### PR TITLE
feat(mcp): flag thin/ghost web-page sources on source_wait (#1698)

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -68,6 +68,11 @@ _DEFAULT_DRIVE_MIME = "google-doc"
 #: conservative — advisory only, never a rejection. See :func:`_thin_content_warning`.
 _THIN_SOURCE_CHAR_THRESHOLD = 100
 
+#: Per-source budget for the advisory thin-content body fetch. The check is
+#: best-effort and must not let ``source_wait`` overrun its own ``timeout`` waiting
+#: on a slow ``GET_SOURCE`` — a fetch that exceeds this degrades to no warning.
+_THIN_SOURCE_FETCH_TIMEOUT_SECONDS = 5.0
+
 
 def _source_view(source: Any) -> dict[str, Any]:
     """Serialize a Source with agent-readable string labels added.
@@ -314,12 +319,10 @@ def register(mcp: Any) -> None:
         that did become ready.
 
         A READY **web-page** entry may carry a non-blocking ``warning`` when its
-        indexed text is suspiciously thin (little/no extractable content) — a likely
-        dead link / soft-404 / paywalled "ghost source" that add-time status cannot
-        catch (a soft-404 serves HTTP 200). It is advisory only: the source is still
-        READY and still counts as ``ok``; verify the page with ``source_get_content``.
-        Only web-page sources are checked — short pasted text / transcripts are never
-        flagged.
+        indexed text is suspiciously thin — a likely dead link / soft-404 / paywalled
+        "ghost source" add-time status can't catch. Advisory only (still READY, still
+        ``ok``; verify with ``source_get_content``); short pasted text / transcripts
+        are never flagged.
 
         A single-source ``source`` ref that does not resolve (e.g. an unknown title)
         still raises NOT_FOUND before the wait — that is an input error, distinct
@@ -916,21 +919,21 @@ async def _annotate_thin_warnings(
 ) -> None:
     """Attach a thin-content ``warning`` to each ready web-page view, in place.
 
-    Fetches the indexed body for the ready web-page sources concurrently (reads;
-    the client already caps in-flight RPCs via its semaphore). Non-web-page sources
-    never incur a fetch (:func:`_thin_content_warning` returns ``None`` immediately
-    for them).
-
-    Drives explicit tasks and, on any escape (e.g. a propagating ``CancelledError``
-    — :func:`_thin_content_warning` swallows ``Exception`` but not ``BaseException``),
-    cancels + drains the still-running sibling fetches before re-raising, so a
-    cancelled wait never leaks a coroutine. Mirrors :func:`_wait_all_sources`.
+    Fetches the indexed body for the ready web-page sources concurrently (reads,
+    capped by the client's RPC semaphore); non-web-page sources are filtered out up
+    front so they never schedule a no-op task. Drives explicit tasks and, on any
+    escape (e.g. a propagating ``CancelledError``), cancels + drains the still-running
+    sibling fetches before re-raising — no leaked coroutine. Mirrors
+    :func:`_wait_all_sources`.
     """
-    if not ready_pairs:
+    web_page_pairs = [
+        (view, source) for view, source in ready_pairs if source.kind == SourceType.WEB_PAGE
+    ]
+    if not web_page_pairs:
         return
     tasks = [
         asyncio.create_task(_thin_content_warning(client, notebook_id, source))
-        for _view, source in ready_pairs
+        for _view, source in web_page_pairs
     ]
     try:
         warnings = await asyncio.gather(*tasks)
@@ -940,7 +943,7 @@ async def _annotate_thin_warnings(
                 task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         raise
-    for (view, _source), warning in zip(ready_pairs, warnings, strict=True):
+    for (view, _source), warning in zip(web_page_pairs, warnings, strict=True):
         if warning is not None:
             view["warning"] = warning
 
@@ -951,33 +954,31 @@ async def _thin_content_warning(
     """Return a content-sanity warning for a READY web-page source, else ``None``.
 
     A dead link / soft-404 / paywalled page is often ingested as a READY source
-    with little or no extractable text — a "ghost source" that the add-time status
-    cannot catch (a soft-404 serves HTTP 200). When such a READY ``web_page`` source
-    has fewer than :data:`_THIN_SOURCE_CHAR_THRESHOLD` characters of indexed text,
-    flag it so an agent can verify rather than trust it.
-
-    Scope + safety:
-
-    * **web-page only** — text / file / drive / youtube sources are skipped:
-      legitimately short pasted text or a short transcript must NEVER be flagged.
-    * **best-effort** — the body fetch reuses the same ``GET_SOURCE`` the
-      ``source_get_content`` tool issues; any failure degrades to ``None`` so the
-      sanity check can never break a wait. (``except Exception``, not
-      ``BaseException``, so ``CancelledError`` still propagates.)
-    * **never rejects** — it only annotates; the source stays READY.
+    with little/no extractable text — a "ghost source" add-time status can't catch
+    (a soft-404 serves HTTP 200). Such a ``web_page`` source under
+    :data:`_THIN_SOURCE_CHAR_THRESHOLD` chars of indexed text is flagged so an agent
+    can verify rather than trust it. **web-page only** (short pasted text /
+    transcripts are legitimate, never flagged; callers also pre-filter).
+    **best-effort**: the body fetch reuses ``source_get_content``'s ``GET_SOURCE``,
+    bounded by :data:`_THIN_SOURCE_FETCH_TIMEOUT_SECONDS`; ANY failure (timeout,
+    transport, unexpected shape) degrades to ``None`` so it can never break a wait
+    (``except Exception`` — ``CancelledError`` still propagates). **Never rejects.**
     """
     if not source.is_ready or source.kind != SourceType.WEB_PAGE:
         return None
     try:
-        result = await content_core.execute_source_fulltext(
-            client,
-            content_core.SourceFulltextPlan(
-                notebook_id=notebook_id, source_id=source.id, output_format="text"
+        result = await asyncio.wait_for(
+            content_core.execute_source_fulltext(
+                client,
+                content_core.SourceFulltextPlan(
+                    notebook_id=notebook_id, source_id=source.id, output_format="text"
+                ),
             ),
+            timeout=_THIN_SOURCE_FETCH_TIMEOUT_SECONDS,
         )
+        char_count = result.fulltext.char_count
     except Exception:  # noqa: BLE001 - sanity check must never break a wait
         return None
-    char_count = result.fulltext.char_count
     if char_count >= _THIN_SOURCE_CHAR_THRESHOLD:
         return None
     return (

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -38,7 +38,7 @@ from ...exceptions import (
     SourceTimeoutError,
     ValidationError,
 )
-from ...types import source_status_to_str
+from ...types import SourceType, source_status_to_str
 from ...urls import is_youtube_url
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -61,6 +61,12 @@ _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
 #: The default Drive MIME choice when the caller does not specify one.
 _DEFAULT_DRIVE_MIME = "google-doc"
+
+#: A READY ``web_page`` source whose indexed text is shorter than this many
+#: characters gets a non-blocking content-sanity ``warning`` on ``source_wait``
+#: (likely a dead link / soft-404 / paywall "ghost source"). Deliberately
+#: conservative — advisory only, never a rejection. See :func:`_thin_content_warning`.
+_THIN_SOURCE_CHAR_THRESHOLD = 100
 
 
 def _source_view(source: Any) -> dict[str, Any]:
@@ -307,6 +313,14 @@ def register(mcp: Any) -> None:
         **partial progress** — a slow or failed source no longer discards the ones
         that did become ready.
 
+        A READY **web-page** entry may carry a non-blocking ``warning`` when its
+        indexed text is suspiciously thin (little/no extractable content) — a likely
+        dead link / soft-404 / paywalled "ghost source" that add-time status cannot
+        catch (a soft-404 serves HTTP 200). It is advisory only: the source is still
+        READY and still counts as ``ok``; verify the page with ``source_get_content``.
+        Only web-page sources are checked — short pasted text / transcripts are never
+        flagged.
+
         A single-source ``source`` ref that does not resolve (e.g. an unknown title)
         still raises NOT_FOUND before the wait — that is an input error, distinct
         from a resolved source the backend reports missing/failed/slow (which lands
@@ -330,12 +344,12 @@ def register(mcp: Any) -> None:
                         interval=interval,
                     ),
                 )
-                return _aggregate_wait_outcomes(nb_id, [outcome])
+                return await _aggregate_wait_outcomes(client, nb_id, [outcome])
             sources = await client.sources.list(nb_id)
             outcomes = await _wait_all_sources(
                 client, nb_id, [s.id for s in sources], timeout=timeout, interval=interval
             )
-            return _aggregate_wait_outcomes(nb_id, outcomes)
+            return await _aggregate_wait_outcomes(client, nb_id, outcomes)
 
     @mcp.tool
     async def source_add(
@@ -385,7 +399,9 @@ def register(mcp: Any) -> None:
         only AFTER processing. Confirm the outcome with ``source_wait`` or
         ``source_list(status="error")``. When the add response ALREADY reflects a
         failed import, ``source_add`` flags it inline (``status_label="error"`` plus
-        a top-level ``warning``) instead of looking like a clean add.
+        a top-level ``warning``) instead of looking like a clean add. ``source_wait``
+        additionally flags a READY web page whose fetched text is suspiciously thin
+        (a likely dead link / soft-404 / paywall) with a per-source ``warning``.
 
         **Batch mode** — pass ``urls`` (a list of **http/https URLs**, YouTube links
         included) to add many in one call instead of one round-trip each. Each entry
@@ -840,8 +856,10 @@ def _wait_bucket_entry(
     return {"source_id": error.source_id, "error": str(error)}
 
 
-def _aggregate_wait_outcomes(
-    notebook_id: str, outcomes: list[wait_core.SourceWaitOutcome]
+async def _aggregate_wait_outcomes(
+    client: NotebookLMClient,
+    notebook_id: str,
+    outcomes: list[wait_core.SourceWaitOutcome],
 ) -> dict[str, Any]:
     """Project per-source wait outcomes onto the unified aggregate wire shape.
 
@@ -850,14 +868,25 @@ def _aggregate_wait_outcomes(
     missing, so the all-sources mode reports partial progress instead of discarding
     the sources that did become ready. ``ok`` is ``True`` iff nothing landed in an
     error bucket.
+
+    READY web-page entries are additionally annotated with a non-blocking
+    content-sanity ``warning`` when their indexed text is suspiciously thin (a
+    likely dead link / soft-404 / paywall ghost source) — see
+    :func:`_annotate_thin_warnings`. The warning is purely advisory: a thin source
+    is still READY and the wait is still ``ok``.
     """
     ready: list[dict[str, Any]] = []
+    # Pair each ready view with its Source so the thin-content sanity check can
+    # read the kind + fetch the body without re-resolving.
+    ready_pairs: list[tuple[dict[str, Any], Source]] = []
     timed_out: list[dict[str, str]] = []
     failed: list[dict[str, str]] = []
     not_found: list[dict[str, str]] = []
     for outcome in outcomes:
         if isinstance(outcome, wait_core.SourceWaitReady):
-            ready.append(_source_view(outcome.source))
+            view = _source_view(outcome.source)
+            ready.append(view)
+            ready_pairs.append((view, outcome.source))
         elif isinstance(outcome, wait_core.SourceWaitTimeout):
             timed_out.append(_wait_bucket_entry(outcome.error))
         elif isinstance(outcome, wait_core.SourceWaitProcessingError):
@@ -869,6 +898,7 @@ def _aggregate_wait_outcomes(
             # would surface as a type error AND fail loudly at runtime rather than
             # being silently dropped from every bucket.
             raise AssertionError(f"unhandled SourceWaitOutcome: {outcome!r}")
+    await _annotate_thin_warnings(client, notebook_id, ready_pairs)
     return {
         "notebook_id": notebook_id,
         "ok": not (timed_out or failed or not_found),
@@ -877,3 +907,81 @@ def _aggregate_wait_outcomes(
         "failed": failed,
         "not_found": not_found,
     }
+
+
+async def _annotate_thin_warnings(
+    client: NotebookLMClient,
+    notebook_id: str,
+    ready_pairs: list[tuple[dict[str, Any], Source]],
+) -> None:
+    """Attach a thin-content ``warning`` to each ready web-page view, in place.
+
+    Fetches the indexed body for the ready web-page sources concurrently (reads;
+    the client already caps in-flight RPCs via its semaphore). Non-web-page sources
+    never incur a fetch (:func:`_thin_content_warning` returns ``None`` immediately
+    for them).
+
+    Drives explicit tasks and, on any escape (e.g. a propagating ``CancelledError``
+    — :func:`_thin_content_warning` swallows ``Exception`` but not ``BaseException``),
+    cancels + drains the still-running sibling fetches before re-raising, so a
+    cancelled wait never leaks a coroutine. Mirrors :func:`_wait_all_sources`.
+    """
+    if not ready_pairs:
+        return
+    tasks = [
+        asyncio.create_task(_thin_content_warning(client, notebook_id, source))
+        for _view, source in ready_pairs
+    ]
+    try:
+        warnings = await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+    for (view, _source), warning in zip(ready_pairs, warnings, strict=True):
+        if warning is not None:
+            view["warning"] = warning
+
+
+async def _thin_content_warning(
+    client: NotebookLMClient, notebook_id: str, source: Source
+) -> str | None:
+    """Return a content-sanity warning for a READY web-page source, else ``None``.
+
+    A dead link / soft-404 / paywalled page is often ingested as a READY source
+    with little or no extractable text — a "ghost source" that the add-time status
+    cannot catch (a soft-404 serves HTTP 200). When such a READY ``web_page`` source
+    has fewer than :data:`_THIN_SOURCE_CHAR_THRESHOLD` characters of indexed text,
+    flag it so an agent can verify rather than trust it.
+
+    Scope + safety:
+
+    * **web-page only** — text / file / drive / youtube sources are skipped:
+      legitimately short pasted text or a short transcript must NEVER be flagged.
+    * **best-effort** — the body fetch reuses the same ``GET_SOURCE`` the
+      ``source_get_content`` tool issues; any failure degrades to ``None`` so the
+      sanity check can never break a wait. (``except Exception``, not
+      ``BaseException``, so ``CancelledError`` still propagates.)
+    * **never rejects** — it only annotates; the source stays READY.
+    """
+    if not source.is_ready or source.kind != SourceType.WEB_PAGE:
+        return None
+    try:
+        result = await content_core.execute_source_fulltext(
+            client,
+            content_core.SourceFulltextPlan(
+                notebook_id=notebook_id, source_id=source.id, output_format="text"
+            ),
+        )
+    except Exception:  # noqa: BLE001 - sanity check must never break a wait
+        return None
+    char_count = result.fulltext.char_count
+    if char_count >= _THIN_SOURCE_CHAR_THRESHOLD:
+        return None
+    return (
+        f"little/no text extracted ({char_count} chars) — may be empty, "
+        "not-yet-indexed, a soft-404/dead link, blocked, or paywalled; "
+        "verify with source_get_content."
+    )

--- a/tests/cassettes/sources_wait.yaml
+++ b/tests/cassettes/sources_wait.yaml
@@ -1,0 +1,2047 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        OSID=SCRUBBED; __Secure-OSID=SCRUBBED; SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED;
+        __Secure-3PSIDCC=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: GET
+    uri: https://notebooklm.google.com/
+  response:
+    body:
+      string: "<!doctype html><html lang=\"en\" dir=\"ltr\"><head><base href=\"https://notebooklm.google.com/\"><link
+        rel=\"preconnect\" href=\"//www.gstatic.com\"><meta name=\"referrer\" content=\"origin\"><title>Google
+        NotebookLM</title><link rel=\"canonical\" href=\"https://notebooklm.google.com/\"><meta
+        name=\"description\" content=\"Use the power of AI for quick summarization
+        and note taking, NotebookLM is your powerful virtual research assistant rooted
+        in information you can trust.\"><meta property=\"og:title\" content=\"Google
+        NotebookLM | Note Taking &amp; Research Assistant Powered by AI\"><meta property=\"og:image\"
+        content=\"https://notebooklm.google.com/_/static/branding/v5/og/notebook_lm_share.png\"><meta
+        property=\"og:description\" content=\"Use the power of AI for quick summarization
+        and note taking, NotebookLM is your powerful virtual research assistant rooted
+        in information you can trust.\"><meta property=\"og:url\" content=\"https://notebooklm.google.com/\"><meta
+        property=\"og:image:width\" content=\"2400\"><meta property=\"og:image:height\"
+        content=\"1254\"><meta property=\"og:image:alt\" content=\"Google NotebookLM\"><meta
+        property=\"og:type\" content=\"website\"><meta name=\"twitter:card\" content=\"summary_large_image\"><meta
+        name=\"viewport\" content=\"width=device-width, initial-scale=1, interactive-widget=resizes-content\"><meta
+        name=\"theme-color\" media=\"(prefers-color-scheme: light)\" content=\"#000000\"><meta
+        name=\"theme-color\" media=\"(prefers-color-scheme: dark)\" content=\"#ffffff\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon.svg\"
+        media=\"(prefers-color-scheme: light)\"><link rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" media=\"(prefers-color-scheme: light)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" media=\"(prefers-color-scheme: light)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon.svg\"
+        media=\"(prefers-color-scheme: dark)\"><link rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" media=\"(prefers-color-scheme: dark)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" media=\"(prefers-color-scheme: dark)\" type=\"image/png\"><link
+        rel=\"apple-touch-icon\" href=\"/_/static/branding/v5/light_mode/favicon/apple-touch-icon.png\"
+        sizes=\"180x180\" media=\"(prefers-color-scheme: light)\"><link rel=\"apple-touch-icon\"
+        href=\"/_/static/branding/v5/dark_mode/favicon/apple-touch-icon.png\" sizes=\"180x180\"
+        media=\"(prefers-color-scheme: dark)\"><link rel=\"manifest\" crossorigin=\"use-credentials\"
+        href=\"/_/static/branding/v5/manifest.json\"><link rel=\"preload\" href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.-t-Z0Dl0T4A.es5.O/d=1/excm=_b/ed=1/dg=0/wt=2/ujg=1/rs=ANnj5bFcBtIFXHnbvEejJmlA-A_g3vdCGg/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;Uvc8o:VDovNc;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb;lOO0Vd:OTA3Ae;qafBPd:ovKuLd/dti=1/m=_b\"
+        as=\"script\" nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\"><link rel=\"preload\" href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.-t-Z0Dl0T4A.es5.O/ck=boq-labs-tailwind.LabsTailwindUi.RbLx_Ag-LLY.L.X.O/d=1/exm=_b/excm=_b/ed=1/wt=2/ujg=1/rs=ANnj5bGqFyyKvs12NagKDtfe1xerqbQ8mw/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;Uvc8o:VDovNc;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb;lOO0Vd:OTA3Ae;qafBPd:ovKuLd/dti=1/m=Ai5g0d\"
+        as=\"script\" nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\"><script data-id=\"_gd\" nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">window.WIZ_global_data
+        = {\"AfY8Hf\":true,\"B8SWKb\":\"SCRUBBED_API_KEY\",\"DpimGf\":false,\"EP1ykd\":[\"/_/*\",\"/accounts/*\"],\"FdrFJe\":\"SCRUBBED_SESSION\",\"HiPsbb\":1,\"IkJAZb\":false,\"Im6cmf\":\"/_/LabsTailwindUi\",\"Jlqnmf\":\"prod\",\"KjTSIf\":\"boq_labs-tailwind-frontend_20260111.16_p0\",\"LoQv7e\":true,\"MT7f9b\":[],\"MUE6Ne\":\"LabsTailwindUi\",\"PMF0Je\":true,\"QGcrse\":\"SCRUBBED_CLIENT_ID\",\"QrtxK\":\"0\",\"S06Grb\":\"SCRUBBED_USER_ID\",\"S6lZl\":96797242,\"SNlM0e\":\"SCRUBBED_CSRF\",\"TSDtV\":\"%.@.[[null,[[45733487,null,false,null,null,null,\\\"BPaxWc\\\"],[45738250,null,false,null,null,null,\\\"sCzZJe\\\"],[45740073,null,false,null,null,null,\\\"wfPPIc\\\"],[45724026,null,null,null,null,null,\\\"czcnaf\\\",[\\\"[]\\\"]],[45684592,null,true,null,null,null,\\\"SpzUSd\\\"],[45716486,null,false,null,null,null,\\\"r0wcHb\\\"],[45719156,null,true,null,null,null,\\\"tjmSkf\\\"],[45698799,null,false,null,null,null,\\\"M8rvMd\\\"],[45722390,null,true,null,null,null,\\\"PZCQFc\\\"],[45715358,null,null,null,null,null,\\\"KMlRwd\\\",[\\\"[[\\\\\\\"png\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpg\\\\\\\"]]\\\"]],[45735128,null,true,null,null,null,\\\"wXeNQc\\\"],[45686503,null,false,null,null,null,\\\"humjFc\\\"],[45743169,null,false,null,null,null,\\\"RMhfuf\\\"],[45747054,null,true,null,null,null,\\\"gPuegc\\\"],[45708268,null,null,null,null,null,\\\"Nlyzuf\\\",[\\\"[[\\\\\\\"71669a91-d5f0-4298-913e-9193178ec62c\\\\\\\",\\\\\\\"62e5c8db-3dd2-407c-8d19-32ae4ae799db\\\\\\\"]]\\\"]],[45715763,null,false,null,null,null,\\\"G9xxqd\\\"],[45648591,null,true,null,null,null,\\\"Mlxxm\\\"],[45728278,null,true,null,null,null,\\\"YyUfHb\\\"],[45678449,null,true,null,null,null,\\\"yGxKIb\\\"],[45728059,null,false,null,null,null,\\\"Ml1gbd\\\"],[45701857,null,false,null,null,null,\\\"PTXWhe\\\"],[45724582,null,true,null,null,null,\\\"WNQ6ce\\\"],[45656575,null,null,null,null,null,\\\"HFmJ5b\\\",[\\\"[[\\\\\\\"3g2\\\\\\\",\\\\\\\"3gp\\\\\\\",\\\\\\\"aac\\\\\\\",\\\\\\\"aif\\\\\\\",\\\\\\\"aifc\\\\\\\",\\\\\\\"aiff\\\\\\\",\\\\\\\"amr\\\\\\\",\\\\\\\"au\\\\\\\",\\\\\\\"avi\\\\\\\",\\\\\\\"cda\\\\\\\",\\\\\\\"m4a\\\\\\\",\\\\\\\"mid\\\\\\\",\\\\\\\"mp3\\\\\\\",\\\\\\\"mp4\\\\\\\",\\\\\\\"mpeg\\\\\\\",\\\\\\\"ogg\\\\\\\",\\\\\\\"opus\\\\\\\",\\\\\\\"ra\\\\\\\",\\\\\\\"ram\\\\\\\",\\\\\\\"snd\\\\\\\",\\\\\\\"wav\\\\\\\",\\\\\\\"wma\\\\\\\"]]\\\"]],[45732206,null,true,null,null,null,\\\"ghZtJe\\\"],[45688086,null,true,null,null,null,\\\"hhpXGe\\\"],[45707305,null,true,null,null,null,\\\"KXRoSc\\\"],[45685058,null,true,null,null,null,\\\"Bw7zDb\\\"],[45723912,5000,null,null,null,null,\\\"Vg0Jae\\\"],[45674765,null,true,null,null,null,\\\"j6Vjze\\\"],[45725988,null,true,null,null,null,\\\"yiQAJb\\\"],[45732207,null,null,null,\\\"2025-10-27\\\",null,\\\"U3MPQe\\\"],[45678177,null,true,null,null,null,\\\"kHU30e\\\"],[45693667,null,true,null,null,null,\\\"xrCHrf\\\"],[45740925,50,null,null,null,null,\\\"bu25wf\\\"],[45727858,null,true,null,null,null,\\\"FbwoGf\\\"],[45478345,null,false,null,null,null,\\\"Lwxhzb\\\"],[45702188,null,true,null,null,null,\\\"wzTuh\\\"],[45668974,null,false,null,null,null,\\\"CNhZ7\\\"],[45651050,null,true,null,null,null,\\\"ck2VTe\\\"],[45716146,null,true,null,null,null,\\\"ilD2hf\\\"],[45686324,null,false,null,null,null,\\\"oTEdQe\\\"],[45741650,null,null,null,\\\"public\\\",null,\\\"IIvT6\\\"],[45707709,null,null,null,null,null,\\\"UldEOb\\\",[\\\"[[\\\\\\\"af\\\\\\\",\\\\\\\"am\\\\\\\",\\\\\\\"ar_001\\\\\\\",\\\\\\\"ar_eg\\\\\\\",\\\\\\\"az\\\\\\\",\\\\\\\"be\\\\\\\",\\\\\\\"bg\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"ca\\\\\\\",\\\\\\\"ceb\\\\\\\",\\\\\\\"cs\\\\\\\",\\\\\\\"da\\\\\\\",\\\\\\\"de\\\\\\\",\\\\\\\"el\\\\\\\",\\\\\\\"en\\\\\\\",\\\\\\\"es\\\\\\\",\\\\\\\"es_419\\\\\\\",\\\\\\\"es_MX\\\\\\\",\\\\\\\"et\\\\\\\",\\\\\\\"eu\\\\\\\",\\\\\\\"fa\\\\\\\",\\\\\\\"fi\\\\\\\",\\\\\\\"fil\\\\\\\",\\\\\\\"fr\\\\\\\",\\\\\\\"fr_CA\\\\\\\",\\\\\\\"gl\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"hi\\\\\\\",\\\\\\\"hr\\\\\\\",\\\\\\\"ht\\\\\\\",\\\\\\\"hu\\\\\\\",\\\\\\\"hy\\\\\\\",\\\\\\\"id\\\\\\\",\\\\\\\"is\\\\\\\",\\\\\\\"it\\\\\\\",\\\\\\\"iw\\\\\\\",\\\\\\\"ja\\\\\\\",\\\\\\\"jv\\\\\\\",\\\\\\\"ka\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ko\\\\\\\",\\\\\\\"kok\\\\\\\",\\\\\\\"la\\\\\\\",\\\\\\\"lt\\\\\\\",\\\\\\\"lv\\\\\\\",\\\\\\\"mai\\\\\\\",\\\\\\\"mk\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"ms\\\\\\\",\\\\\\\"my\\\\\\\",\\\\\\\"nb_NO\\\\\\\",\\\\\\\"ne\\\\\\\",\\\\\\\"nl_NL\\\\\\\",\\\\\\\"nn_NO\\\\\\\",\\\\\\\"or\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"pl\\\\\\\",\\\\\\\"ps\\\\\\\",\\\\\\\"pt_BR\\\\\\\",\\\\\\\"pt_PT\\\\\\\",\\\\\\\"ro\\\\\\\",\\\\\\\"ru\\\\\\\",\\\\\\\"sd\\\\\\\",\\\\\\\"si\\\\\\\",\\\\\\\"sk\\\\\\\",\\\\\\\"sl\\\\\\\",\\\\\\\"sq\\\\\\\",\\\\\\\"sr\\\\\\\",\\\\\\\"sv\\\\\\\",\\\\\\\"sw\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\",\\\\\\\"th\\\\\\\",\\\\\\\"tr\\\\\\\",\\\\\\\"uk\\\\\\\",\\\\\\\"ur\\\\\\\",\\\\\\\"vi\\\\\\\",\\\\\\\"zh_Hans\\\\\\\",\\\\\\\"zh_Hant\\\\\\\"]]\\\"]],[45724540,null,false,null,null,null,\\\"kneAIc\\\"],[45730504,null,false,null,null,null,\\\"r4LEJf\\\"],[45724092,null,false,null,null,null,\\\"bfDVEc\\\"],[45641801,null,true,null,null,null,\\\"JeSsGe\\\"],[45727376,null,true,null,null,null,\\\"uVzPte\\\"],[45674022,null,true,null,null,null,\\\"GJ0Fbc\\\"],[45723410,null,false,null,null,null,\\\"LRVRZ\\\"],[105963886,null,false,null,null,null,\\\"HBjKGb\\\"],[45644621,null,true,null,null,null,\\\"lDhe7d\\\"],[45692441,null,true,null,null,null,\\\"HeeGbc\\\"],[45724220,10,null,null,null,null,\\\"ncg6Ve\\\"],[45651720,null,true,null,null,null,\\\"I3MBz\\\"],[45725687,null,true,null,null,null,\\\"Sevrrc\\\"],[45650923,null,true,null,null,null,\\\"MOu1Rc\\\"],[45681923,null,false,null,null,null,\\\"kEv01e\\\"],[45731113,null,null,null,null,null,\\\"ZI9cc\\\",[\\\"[[\\\\\\\"png\\\\\\\",\\\\\\\"jpg\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpe\\\\\\\",\\\\\\\"avif\\\\\\\",\\\\\\\"bmp\\\\\\\",\\\\\\\"gif\\\\\\\",\\\\\\\"ico\\\\\\\",\\\\\\\"jp2\\\\\\\",\\\\\\\"webp\\\\\\\",\\\\\\\"tif\\\\\\\",\\\\\\\"tiff\\\\\\\",\\\\\\\"heic\\\\\\\",\\\\\\\"heif\\\\\\\"]]\\\"]],[45656736,null,false,null,null,null,\\\"rKqRdd\\\"],[45751177,null,false,null,null,null,\\\"toafIc\\\"],[45732203,null,true,null,null,null,\\\"kSBWQ\\\"],[45669748,null,false,null,null,null,\\\"S4swcd\\\"],[45732204,null,true,null,null,null,\\\"pPHMCb\\\"],[45662544,null,true,null,null,null,\\\"t6ww0\\\"],[45687890,10000,null,null,null,null,\\\"uOwq4d\\\"],[45723756,null,true,null,null,null,\\\"yZTigd\\\"],[45739154,null,true,null,null,null,\\\"XF97Pb\\\"],[45727973,null,false,null,null,null,\\\"joHIze\\\"],[45742067,null,false,null,null,null,\\\"DbKd8\\\"],[45723390,null,true,null,null,null,\\\"E9Gv8e\\\"],[45738479,null,true,null,null,null,\\\"Ab1vp\\\"],[45650876,null,false,null,null,null,\\\"YnQp8e\\\"],[45725987,null,false,null,null,null,\\\"iDsH1e\\\"],[45655118,null,true,null,null,null,\\\"gRPr0e\\\"],[45652801,null,true,null,null,null,\\\"LioP4d\\\"],[45725970,null,false,null,null,null,\\\"sPU3yb\\\"],[45623261,null,false,null,null,null,\\\"e25Ryd\\\"],[45723440,null,true,null,null,null,\\\"f2iaWd\\\"],[45643362,null,true,null,null,null,\\\"doKTK\\\"],[105739227,null,false,null,null,null,\\\"RmLbJe\\\"],[45725063,null,true,null,null,null,\\\"dVxE3e\\\"],[45699383,null,false,null,null,null,\\\"WB61ic\\\"],[45740924,5,null,null,null,null,\\\"IvF6ie\\\"],[45691822,null,true,null,null,null,\\\"y2K6ib\\\"],[45664693,null,true,null,null,null,\\\"QXpeld\\\"],[45738317,null,null,null,null,null,\\\"eVvEMd\\\",[\\\"[[\\\\\\\"avif\\\\\\\",\\\\\\\"bmp\\\\\\\",\\\\\\\"gif\\\\\\\",\\\\\\\"ico\\\\\\\",\\\\\\\"jp2\\\\\\\",\\\\\\\"png\\\\\\\",\\\\\\\"webp\\\\\\\",\\\\\\\"tif\\\\\\\",\\\\\\\"tiff\\\\\\\",\\\\\\\"heic\\\\\\\",\\\\\\\"heif\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpg\\\\\\\",\\\\\\\"jpe\\\\\\\"]]\\\"]],[45743134,null,true,null,null,null,\\\"Iv2Hxe\\\"],[45749382,null,false,null,null,null,\\\"aartMe\\\"],[45746103,2000,null,null,null,null,\\\"XGM6Xe\\\"],[45682203,null,true,null,null,null,\\\"WFSam\\\"],[45739220,null,true,null,null,null,\\\"ZWjLyb\\\"],[45716774,null,false,null,null,null,\\\"rgA9If\\\"],[45721095,null,true,null,null,null,\\\"ywzYTd\\\"],[45673657,null,false,null,null,null,\\\"BdrTcf\\\"],[45724487,null,true,null,null,null,\\\"WG0tGf\\\"],[45746551,null,false,null,null,null,\\\"qMcOyc\\\"],[45728277,null,true,null,null,null,\\\"yVqdQ\\\"],[45700002,null,true,null,null,null,\\\"KgtOgd\\\"],[45696585,null,null,null,null,null,\\\"wRJHtc\\\",[\\\"[[\\\\\\\"ar_eg\\\\\\\",\\\\\\\"ar_001\\\\\\\"]]\\\"]],[45736238,null,true,null,null,null,\\\"qix6kb\\\"],[45716076,null,false,null,null,null,\\\"qN5Ni\\\"],[45750247,null,false,null,null,null,\\\"eyUGmb\\\"],[45736793,null,false,null,null,null,\\\"SjmdKb\\\"],[45626329,10000,null,null,null,null,\\\"xAdyb\\\"],[45732982,null,true,null,null,null,\\\"RNnPXd\\\"],[45741610,null,false,null,null,null,\\\"D6eTJ\\\"],[45682327,null,false,null,null,null,\\\"DcJcid\\\"],[45712306,null,true,null,null,null,\\\"NZrIV\\\"],[45715833,null,null,null,\\\"2025-09-03\\\",null,\\\"zXsjTc\\\"],[45678526,null,false,null,null,null,\\\"TSpMx\\\"],[45711140,null,true,null,null,null,\\\"Fp3bic\\\"],[45739119,null,false,null,null,null,\\\"u3PAZ\\\"],[45739128,null,true,null,null,null,\\\"bRZrYe\\\"],[45646319,null,false,null,null,null,\\\"XDSRxb\\\"],[45723173,null,false,null,null,null,\\\"xsupAd\\\"],[45740074,null,true,null,null,null,\\\"bhCwDf\\\"],[45642474,null,false,null,null,null,\\\"e4pHkf\\\"],[45750354,null,false,null,null,null,\\\"Pxrbt\\\"],[45620149,null,true,null,null,null,\\\"pbA7cd\\\"],[45724908,null,null,null,\\\"2025-09-19\\\",null,\\\"xFVBIb\\\"],[45677551,null,true,null,null,null,\\\"FOlkXb\\\"],[45643552,null,false,null,null,null,\\\"AVCDDf\\\"],[45743229,null,false,null,null,null,\\\"IdVLAf\\\"],[45741588,null,true,null,null,null,\\\"QVPuEd\\\"],[45634044,null,false,null,null,null,\\\"k3zu1d\\\"],[105739228,null,null,null,null,null,\\\"lJ7Wub\\\",[\\\"[[1]]\\\"]],[45745566,null,false,null,null,null,\\\"x9hO9d\\\"],[45647693,null,null,null,null,null,\\\"LykTQb\\\",[\\\"[[\\\\\\\"google.com\\\\\\\",\\\\\\\".edu\\\\\\\",\\\\\\\".org\\\\\\\",\\\\\\\".net\\\\\\\",\\\\\\\".jp\\\\\\\",\\\\\\\".br\\\\\\\",\\\\\\\".tw\\\\\\\"]]\\\"]],[45667158,null,true,null,null,null,\\\"o9omF\\\"],[45739834,null,false,null,null,null,\\\"wpiqm\\\"],[45723955,null,false,null,null,null,\\\"eBBjmf\\\"],[45691662,null,true,null,null,null,\\\"EXhW4b\\\"],[45724967,null,true,null,null,null,\\\"vZRBce\\\"],[45740290,null,null,null,null,null,\\\"Adr4wd\\\",[\\\"[]\\\"]],[45665026,null,null,null,\\\"\\\",null,\\\"r5O8Ze\\\"],[45724355,null,true,null,null,null,\\\"rWadk\\\"],[45732534,null,true,null,null,null,\\\"i09X8c\\\"],[45678961,null,true,null,null,null,\\\"QjI7hd\\\"],[45678578,null,true,null,null,null,\\\"soQo1d\\\"],[45645925,50,null,null,null,null,\\\"wv29ce\\\"],[45687600,1,null,null,null,null,\\\"sAL5Je\\\"],[45749515,null,false,null,null,null,\\\"aMVXWe\\\"],[45693251,null,true,null,null,null,\\\"pPbgEf\\\"],[45747063,null,false,null,null,null,\\\"lvXPvb\\\"],[45732205,null,true,null,null,null,\\\"U2Sved\\\"],[45718005,null,true,null,null,null,\\\"kiJI4c\\\"],[45735679,null,false,null,null,null,\\\"sOvZBf\\\"],[45738347,null,true,null,null,null,\\\"xHqDbe\\\"],[45429920,null,false,null,null,null,\\\"E914fb\\\"],[45681212,null,true,null,null,null,\\\"DiGvhc\\\"],[45739226,null,false,null,null,null,\\\"SkzECe\\\"],[45693482,null,true,null,null,null,\\\"EW61Ce\\\"],[45644274,20,null,null,null,null,\\\"aMs4Gb\\\"],[45675685,null,true,null,null,null,\\\"x9cXUb\\\"],[45459555,null,false,null,null,null,\\\"Imeoqb\\\"],[45742581,null,true,null,null,null,\\\"RIBLyb\\\"],[45694769,null,true,null,null,null,\\\"beJTsd\\\"],[45640342,null,true,null,null,null,\\\"gIFZhc\\\"],[45667300,null,false,null,null,null,\\\"inaRw\\\"],[45724364,null,true,null,null,null,\\\"gILkWb\\\"],[45696014,null,true,null,null,null,\\\"Vap7Vc\\\"],[45646880,null,true,null,null,null,\\\"rKvLob\\\"],[45626328,10,null,null,null,null,\\\"I1V8ie\\\"],[45696584,null,true,null,null,null,\\\"Cmvzne\\\"],[45638708,null,null,null,\\\"71669a91-d5f0-4298-913e-9193178ec62c\\\",null,\\\"iQoIFf\\\"],[45709616,null,true,null,null,null,\\\"ypJDU\\\"],[45727267,null,true,null,null,null,\\\"NHdRE\\\"],[45734729,null,false,null,null,null,\\\"Pe6YZb\\\"],[45673126,null,true,null,null,null,\\\"aM63X\\\"],[45622893,null,true,null,null,null,\\\"ZKtzR\\\"],[45692861,null,true,null,null,null,\\\"UvMGC\\\"],[45735506,null,false,null,null,null,\\\"DLUCGe\\\"],[45681006,null,true,null,null,null,\\\"WF6tob\\\"],[45460035,null,true,null,null,null,\\\"i6PDjc\\\"],[45630645,1,null,null,null,null,\\\"N5wbdc\\\"],[45699449,null,null,null,\\\"953b658a-579b-4b3c-b280-43b3781babf3\\\",null,\\\"Uhlwjf\\\"],[45747536,null,false,null,null,null,\\\"F67Xyc\\\"],[105739229,null,null,null,null,null,\\\"NAKK1\\\",[\\\"[]\\\"]],[45679330,null,false,null,null,null,\\\"WEMP6e\\\"],[45694287,null,false,null,null,null,\\\"ytDzle\\\"],[45741764,null,true,null,null,null,\\\"Y2scZ\\\"],[45740989,3000,null,null,null,null,\\\"SXDqEe\\\"],[45696586,null,null,null,null,null,\\\"hGwUE\\\",[\\\"[[\\\\\\\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629
+        (\u0627\u0644\u0639\u0627\u0645\u064A\u0629 \u0627\u0644\u0645\u0635\u0631\u064A\u0629)\\\\\\\",\\\\\\\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629\\\\\\\"]]\\\"]],[45725774,null,false,null,null,null,\\\"J3X1uc\\\"],[45722636,null,false,null,null,null,\\\"sETgKe\\\"],[45723322,null,true,null,null,null,\\\"vSpvBb\\\"],[45639131,null,null,null,null,null,\\\"lSt5Ue\\\",[\\\"[]\\\"]],[45696007,null,true,null,null,null,\\\"hsNESc\\\"],[45650134,null,null,null,\\\"f7607d7a-584c-4f35-96fc-f6815c573a6c\\\",null,\\\"KqZKAb\\\"],[45733865,null,true,null,null,null,\\\"jKONzf\\\"],[45623036,null,true,null,null,null,\\\"uBTtH\\\"],[45651102,null,true,null,null,null,\\\"AQmbKc\\\"],[45700001,null,true,null,null,null,\\\"kQFRdd\\\"],[45714669,null,true,null,null,null,\\\"nmpRPe\\\"],[45723127,null,true,null,null,null,\\\"zKGNYc\\\"],[45723296,null,true,null,null,null,\\\"R8Ib9c\\\"],[45545417,null,true,null,null,null,\\\"tqnO1\\\"],[45683036,null,true,null,null,null,\\\"IBjb7d\\\"],[45716490,null,null,null,null,null,\\\"raFU8e\\\",[\\\"[[\\\\\\\"hi\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\"]]\\\"]],[45735534,null,false,null,null,null,\\\"nw6yvc\\\"],[45684106,null,true,null,null,null,\\\"j23Rxe\\\"],[45718806,null,false,null,null,null,\\\"pELJSc\\\"],[45730877,null,false,null,null,null,\\\"rBvXZd\\\"],[45741605,null,null,null,\\\"2025-10-27\\\",null,\\\"eVX7gb\\\"],[45674863,null,true,null,null,null,\\\"Rb5Ckd\\\"],[45478346,null,false,null,null,null,\\\"YnbJfb\\\"],[45642683,null,false,null,null,null,\\\"NTEHXd\\\"],[45720120,null,true,null,null,null,\\\"nbeCbd\\\"],[45461691,null,null,null,null,null,\\\"ws98Dd\\\",[\\\"[[\\\\\\\"application/vnd.google-apps.document\\\\\\\",\\\\\\\"application/vnd.google-apps.presentation\\\\\\\",\\\\\\\"application/pdf\\\\\\\",\\\\\\\"application/vnd.google-apps.spreadsheet\\\\\\\",\\\\\\\"application/vnd.openxmlformats-officedocument.wordprocessingml.document\\\\\\\"]]\\\"]],[45732186,null,true,null,null,null,\\\"fUrPrf\\\"],[45707150,null,true,null,null,null,\\\"yE41Cd\\\"],[45696727,null,false,null,null,null,\\\"A1a0Nd\\\"],[45718016,null,true,null,null,null,\\\"gdUu3d\\\"],[45723899,null,false,null,null,null,\\\"RczE3\\\"],[45691118,null,true,null,null,null,\\\"U1L54d\\\"],[45714592,null,true,null,null,null,\\\"eSw7ae\\\"],[45683617,null,false,null,null,null,\\\"zGScr\\\"],[45737496,null,true,null,null,null,\\\"UrGmDc\\\"],[45657965,null,true,null,null,null,\\\"ncR2Ld\\\"],[45687798,null,null,null,null,null,\\\"M2O21b\\\",[\\\"[[\\\\\\\"af\\\\\\\",\\\\\\\"am\\\\\\\",\\\\\\\"ar_001\\\\\\\",\\\\\\\"ar_eg\\\\\\\",\\\\\\\"az\\\\\\\",\\\\\\\"be\\\\\\\",\\\\\\\"bg\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"ca\\\\\\\",\\\\\\\"ceb\\\\\\\",\\\\\\\"cs\\\\\\\",\\\\\\\"da\\\\\\\",\\\\\\\"de\\\\\\\",\\\\\\\"el\\\\\\\",\\\\\\\"en\\\\\\\",\\\\\\\"es\\\\\\\",\\\\\\\"es_419\\\\\\\",\\\\\\\"es_MX\\\\\\\",\\\\\\\"et\\\\\\\",\\\\\\\"eu\\\\\\\",\\\\\\\"fa\\\\\\\",\\\\\\\"fi\\\\\\\",\\\\\\\"fil\\\\\\\",\\\\\\\"fr\\\\\\\",\\\\\\\"fr_CA\\\\\\\",\\\\\\\"gl\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"hi\\\\\\\",\\\\\\\"hr\\\\\\\",\\\\\\\"ht\\\\\\\",\\\\\\\"hu\\\\\\\",\\\\\\\"hy\\\\\\\",\\\\\\\"id\\\\\\\",\\\\\\\"is\\\\\\\",\\\\\\\"it\\\\\\\",\\\\\\\"iw\\\\\\\",\\\\\\\"ja\\\\\\\",\\\\\\\"jv\\\\\\\",\\\\\\\"ka\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ko\\\\\\\",\\\\\\\"kok\\\\\\\",\\\\\\\"la\\\\\\\",\\\\\\\"lt\\\\\\\",\\\\\\\"lv\\\\\\\",\\\\\\\"mai\\\\\\\",\\\\\\\"mk\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"ms\\\\\\\",\\\\\\\"my\\\\\\\",\\\\\\\"nb_NO\\\\\\\",\\\\\\\"ne\\\\\\\",\\\\\\\"nl_NL\\\\\\\",\\\\\\\"nn_NO\\\\\\\",\\\\\\\"or\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"pl\\\\\\\",\\\\\\\"ps\\\\\\\",\\\\\\\"pt_BR\\\\\\\",\\\\\\\"pt_PT\\\\\\\",\\\\\\\"ro\\\\\\\",\\\\\\\"ru\\\\\\\",\\\\\\\"sd\\\\\\\",\\\\\\\"si\\\\\\\",\\\\\\\"sk\\\\\\\",\\\\\\\"sl\\\\\\\",\\\\\\\"sq\\\\\\\",\\\\\\\"sr\\\\\\\",\\\\\\\"sv\\\\\\\",\\\\\\\"sw\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\",\\\\\\\"th\\\\\\\",\\\\\\\"tr\\\\\\\",\\\\\\\"uk\\\\\\\",\\\\\\\"ur\\\\\\\",\\\\\\\"vi\\\\\\\",\\\\\\\"zh_Hans\\\\\\\",\\\\\\\"zh_Hant\\\\\\\"]]\\\"]],[45667340,null,false,null,null,null,\\\"mhlPVb\\\"],[45726393,null,false,null,null,null,\\\"dFJRwf\\\"],[45477865,null,true,null,null,null,\\\"p9oeJc\\\"],[45744638,null,true,null,null,null,\\\"fsg7Cb\\\"],[45740532,null,false,null,null,null,\\\"zKRa0\\\"],[45717748,null,false,null,null,null,\\\"bomvXb\\\"],[45683096,null,false,null,null,null,\\\"SuFLEb\\\"],[45491609,null,false,null,null,null,\\\"DpoYPc\\\"],[45732022,null,true,null,null,null,\\\"QQKUfb\\\"],[45716515,null,true,null,null,null,\\\"b4dT9e\\\"],[45715089,null,true,null,null,null,\\\"T6tAvf\\\"],[45684753,null,false,null,null,null,\\\"ywxfCd\\\"],[45731112,null,null,null,null,null,\\\"RmGjKd\\\",[\\\"[[\\\\\\\"3g2\\\\\\\",\\\\\\\"3gp\\\\\\\",\\\\\\\"aac\\\\\\\",\\\\\\\"aif\\\\\\\",\\\\\\\"aifc\\\\\\\",\\\\\\\"aiff\\\\\\\",\\\\\\\"amr\\\\\\\",\\\\\\\"au\\\\\\\",\\\\\\\"avi\\\\\\\",\\\\\\\"cda\\\\\\\",\\\\\\\"m4a\\\\\\\",\\\\\\\"mid\\\\\\\",\\\\\\\"midi\\\\\\\",\\\\\\\"mp3\\\\\\\",\\\\\\\"mp4\\\\\\\",\\\\\\\"mpeg\\\\\\\",\\\\\\\"ogg\\\\\\\",\\\\\\\"opus\\\\\\\",\\\\\\\"ra\\\\\\\",\\\\\\\"ram\\\\\\\",\\\\\\\"snd\\\\\\\",\\\\\\\"wav\\\\\\\",\\\\\\\"weba\\\\\\\",\\\\\\\"wma\\\\\\\"]]\\\"]],[45623264,null,false,null,null,null,\\\"r1lBY\\\"],[45727591,null,true,null,null,null,\\\"ygidy\\\"],[45728338,null,false,null,null,null,\\\"wma0md\\\"],[45734733,null,true,null,null,null,\\\"V5bj7\\\"],[45722828,null,false,null,null,null,\\\"bbwVdc\\\"],[45719885,null,false,null,null,null,\\\"YHdrU\\\"],[45696338,null,true,null,null,null,\\\"lJ1Uyd\\\"],[45724529,null,true,null,null,null,\\\"xYPCFf\\\"],[45745829,null,false,null,null,null,\\\"wRuQ3b\\\"],[105788761,null,true,null,null,null,\\\"mQeJ7d\\\"],[45689034,null,false,null,null,null,\\\"rDyR6c\\\"],[45703804,null,true,null,null,null,\\\"aW5U0\\\"],[45680123,null,true,null,null,null,\\\"DGuzo\\\"],[45658718,null,true,null,null,null,\\\"e9CJhe\\\"],[45730447,null,true,null,null,null,\\\"FQyCl\\\"],[45723784,5000,null,null,null,null,\\\"PJ8nYd\\\"],[45750328,null,false,null,null,null,\\\"YlIlw\\\"],[45743839,null,false,null,null,null,\\\"pnWyHf\\\"],[45727720,null,true,null,null,null,\\\"vD09Ne\\\"],[45719155,null,true,null,null,null,\\\"YVpG5e\\\"],[45751068,null,false,null,null,null,\\\"dpCKWd\\\"],[45667626,null,true,null,null,null,\\\"GQQefc\\\"],[45736777,null,false,null,null,null,\\\"RyJDpe\\\"]],\\\"CAMSdx1yjcK5KRbIgyAGrNgFBqT6DgaqrwUGs9uNBgaJpqoFBonDBgbdrAQG5hUGyfwGBqc4BtAMBtY5BoAxBsgiBq0pBrkOFo6RBgaz4AYGuncExTIGhLcGwQ8GhCoGpykGt54FpAzaPgS8PQSqxQYG+RYBik4GikEC\\\"]]]\",\"UUFaWc\":\"%.@.null,1000,2]\",\"VqImj\":\"SCRUBBED_API_KEY\",\"Vvafkd\":false,\"W3Yyqf\":\"SCRUBBED_USER_ID\",\"WZsZ1e\":\"Sv-w1gimDu8odYVP/ARcfbasl4NNZ5HaKj\",\"b5W2zf\":\"default_LabsTailwindUi\",\"cEM4oc\":\"prod\",\"cfb2h\":\"boq_labs-tailwind-frontend_20260111.16_p0\",\"eptZe\":\"/_/LabsTailwindUi/\",\"fPDxwd\":[97493660,105739272],\"fWyqL\":false,\"gGcLoe\":true,\"hsFLT\":\"%.@.null,1000,2]\",\"iCzhFc\":false,\"iQJtYd\":\"SCRUBBED_PROJECT_ID\",\"k76Vlc\":[\"G-W0LDH41ZCB\"],\"mXaIFf\":true,\"nQyAE\":{},\"oPEP7c\":\"SCRUBBED_EMAIL\",\"p9hQne\":\"https://www.gstatic.com/_/boq-labs-tailwind/_/r/\",\"qDCSke\":\"SCRUBBED_USER_ID\",\"qwAQke\":\"LabsTailwindUi\",\"rtQCxc\":300,\"u4g7r\":\"%.@.null,1,2]\",\"vJQk6\":false,\"wAdwcc\":\"https://docs.google.com/picker\",\"xnI9P\":true,\"xwAfE\":true,\"y2FhP\":\"prod\",\"yFnxrf\":1957,\"zChJod\":\"%.@.]\",\"zgYTbd\":false};</script><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">window[\"_F_toggles_default_LabsTailwindUi\"]
+        = [0x60800, ];</script><script nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\"></script><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">var _F_cssRowKey = 'boq-labs-tailwind.LabsTailwindUi.RbLx_Ag-LLY.L.X.O';var
+        _F_combinedSignature = 'ANnj5bGqFyyKvs12NagKDtfe1xerqbQ8mw';function _DumpException(e)
+        {throw e;}</script><style data-href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/ss/k=boq-labs-tailwind.LabsTailwindUi.RbLx_Ag-LLY.L.X.O/am=AAgG/d=1/ed=1/rs=ANnj5bGzT5Jahv5to6Yt3_S9bUUvvGJ93w/m=_b\"
+        nonce=\"1Vi3CGjD1-dukIf8_w25kg\">.boqHighlightVe [jslog]{-webkit-box-shadow:0
+        0 0 5px #7fffd4;box-shadow:0 0 0 5px #7fffd4}.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{font-size:1rem;line-height:1.5;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;-webkit-align-content:center;align-content:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-align-self:flex-start;align-self:flex-start;border:1px
+        solid transparent;border-radius:48px;display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;font-family:\"Google Sans\",Arial,Helvetica,sans-serif;font-weight:500;-webkit-justify-content:space-around;justify-content:space-around;letter-spacing:.5px;margin:8px
+        0;max-width:380px;min-height:48px;min-width:96px;overflow:hidden;padding:12px
+        24px 12px 24px;text-align:center;text-decoration:none;-webkit-transition:background-color
+        .2s,color .2s,-webkit-box-shadow .2s;transition:background-color .2s,color
+        .2s,-webkit-box-shadow .2s;transition:background-color .2s,box-shadow .2s,color
+        .2s;transition:background-color .2s,box-shadow .2s,color .2s,-webkit-box-shadow
+        .2s;vertical-align:middle}[lang=ar] .glue-cookie-notification-bar__accept,[lang=ar]
+        .glue-cookie-notification-bar__reject{font-family:\"Google Sans\",\"Google
+        Sans Arabic\",Arial,Helvetica,sans-serif}[lang=ja] .glue-cookie-notification-bar__accept,[lang=ja]
+        .glue-cookie-notification-bar__reject{font-family:\"Google Sans\",\"Google
+        Sans Japanese\",\"Noto Sans JP\",Arial,Helvetica,sans-serif}[lang=ko] .glue-cookie-notification-bar__accept,[lang=ko]
+        .glue-cookie-notification-bar__reject{font-family:\"Google Sans\",\"Google
+        Sans Korean\",\"Noto Sans KR\",Arial,Helvetica,sans-serif}[lang=zh-CN] .glue-cookie-notification-bar__accept,[lang=zh-CN]
+        .glue-cookie-notification-bar__reject{font-family:\"Google Sans\",\"Google
+        Sans Simplified Chinese\",\"Noto Sans SC\",Arial,Helvetica,sans-serif}[lang=zh-TW]
+        .glue-cookie-notification-bar__accept,[lang=zh-TW] .glue-cookie-notification-bar__reject{font-family:\"Google
+        Sans\",\"Google Sans Traditional Chinese\",\"Noto Sans TC\",Arial,Helvetica,sans-serif}@media
+        (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{-webkit-transition:none;transition:none}}.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{outline:2px
+        solid transparent;-webkit-transition:none;transition:none}.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{background-color:#1a73e8;color:#fff}@media
+        (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{forced-color-adjust:none;background:buttonText;border-color:buttonFace;color:buttonFace}.glue-cookie-notification-bar__accept
+        svg,.glue-cookie-notification-bar__reject svg{fill:buttonFace}}.glue-cookie-notification-bar__accept:visited,.glue-cookie-notification-bar__reject:visited{background-color:#1a73e8;color:#fff}@media
+        (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:visited,.glue-cookie-notification-bar__reject:visited{forced-color-adjust:none;background:buttonText;border-color:buttonFace;color:buttonFace}.glue-cookie-notification-bar__accept:visited
+        svg,.glue-cookie-notification-bar__reject:visited svg{fill:buttonFace}}.glue-cookie-notification-bar__accept:hover,.glue-cookie-notification-bar__reject:hover{background-color:#185abc;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15)}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:hover,.glue-cookie-notification-bar__reject:hover{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText}.glue-cookie-notification-bar__accept:hover
+        svg,.glue-cookie-notification-bar__reject:hover svg{fill:buttonText}}.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{background-color:#185abc;border-color:#fff;-webkit-box-shadow:0
+        0 0 2px #185abc;box-shadow:0 0 0 2px #185abc}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText;outline:2px
+        solid highlight}.glue-cookie-notification-bar__accept:focus svg,.glue-cookie-notification-bar__reject:focus
+        svg{fill:buttonText}}.glue-cookie-notification-bar__accept:active,.glue-cookie-notification-bar__reject:active{background-color:#185abc;border:1px
+        solid transparent;-webkit-box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0 2px 6px
+        2px rgba(60,64,67,.15);box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0 2px 6px
+        2px rgba(60,64,67,.15)}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:active,.glue-cookie-notification-bar__reject:active{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText}.glue-cookie-notification-bar__accept:active
+        svg,.glue-cookie-notification-bar__reject:active svg{fill:buttonText}}.glue-cookie-notification-bar__more{background:transparent;border-radius:4px;color:#1a73e8;display:inline;overflow:hidden;text-decoration:underline;-webkit-transition:background-color
+        .2s,color .2s;transition:background-color .2s,color .2s}.glue-cookie-notification-bar__more:hover,.glue-cookie-notification-bar__more:active,.glue-cookie-notification-bar__more:focus{color:#174ea6}.glue-cookie-notification-bar__more:visited{color:#681da8}.glue-cookie-notification-bar__more:hover,.glue-cookie-notification-bar__more:focus,.glue-cookie-notification-bar__more:active{cursor:pointer;outline:none}.glue-cookie-notification-bar__more:hover{background-color:rgba(26,115,232,.04)}.glue-cookie-notification-bar__more:focus{outline:2px
+        solid transparent;background-color:rgba(26,115,232,.12);-webkit-box-shadow:0
+        0 0 2px #1a73e8;box-shadow:0 0 0 2px #1a73e8;z-index:1}.glue-cookie-notification-bar__more:active{background-color:rgba(26,115,232,.1);-webkit-box-shadow:none;box-shadow:none;outline:auto
+        2px Highlight;outline:auto 5px -webkit-focus-ring-color}.glue-cookie-notification-bar__more
+        img{border:0}.glue-cookie-notification-bar{-webkit-box-shadow:0 2px 3px 0
+        rgba(60,64,67,.3),0 6px 10px 4px rgba(60,64,67,.15);box-shadow:0 2px 3px 0
+        rgba(60,64,67,.3),0 6px 10px 4px rgba(60,64,67,.15);background:#fff;bottom:0;-webkit-box-sizing:border-box;box-sizing:border-box;display:grid;font-size:1rem;grid-gap:8px;grid-template-columns:auto
+        auto;left:0;padding:8px;position:fixed;width:100%;z-index:1000}.glue-cookie-notification-bar[aria-hidden=true]{display:none}@media
+        (min-width:600px){.glue-cookie-notification-bar{grid-template-columns:1fr
+        auto;justify-items:flex-end}}@media (min-width:1024px){.glue-cookie-notification-bar{grid-template-columns:1fr
+        auto auto}}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar{border-top:1px
+        solid transparent}}@media print{.glue-cookie-notification-bar{display:none}}.glue-cookie-notification-bar__text{font-family:\"Google
+        Sans Text\",\"Roboto\",Arial,Helvetica,sans-serif;font-size:1.125em;line-height:1.5555555556;font-weight:400;letter-spacing:normal;align-self:center;color:#5f6368;grid-column:span
+        2;justify-self:flex-start;margin:0;padding:4px 12px}[lang=ar] .glue-cookie-notification-bar__text{font-family:\"Google
+        Sans Text\",\"Google Sans Arabic\",\"Roboto\",Arial,Helvetica,sans-serif}[lang=ja]
+        .glue-cookie-notification-bar__text{font-family:\"Google Sans Text\",\"Google
+        Sans Japanese\",\"Noto Sans JP\",\"Roboto\",Arial,Helvetica,sans-serif}[lang=ko]
+        .glue-cookie-notification-bar__text{font-family:\"Google Sans Text\",\"Google
+        Sans Korean\",\"Noto Sans KR\",\"Roboto\",Arial,Helvetica,sans-serif}[lang=zh-CN]
+        .glue-cookie-notification-bar__text{font-family:\"Google Sans Text\",\"Google
+        Sans Simplified Chinese\",\"Noto Sans SC\",\"Roboto\",Arial,Helvetica,sans-serif}[lang=zh-TW]
+        .glue-cookie-notification-bar__text{font-family:\"Google Sans Text\",\"Google
+        Sans Traditional Chinese\",\"Noto Sans TC\",\"Roboto\",Arial,Helvetica,sans-serif}@media
+        (min-width:1024px){.glue-cookie-notification-bar__text{grid-column:span 1}}.glue-cookie-notification-bar__text,.glue-cookie-notification-bar__text
+        *{-moz-osx-font-smoothing:initial;-webkit-font-smoothing:initial;text-rendering:auto}.glue-cookie-notification-bar__more{border-bottom:0;font-weight:inherit;letter-spacing:inherit}.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{font-size:1em;cursor:pointer;margin:auto
+        0 0;max-width:unset}.glue-cookie-notification-bar__accept:last-child{grid-column:span
+        2}.glue-cookie-notification-bar-control[aria-hidden=true]{display:none}button.glue-cookie-notification-bar-control.glue-footer__link{-moz-appearance:none;-webkit-appearance:none;appearance:none;border:0;border-radius:4px;padding:0}@media
+        (-ms-high-contrast:active),(forced-colors:active){button.glue-cookie-notification-bar-control.glue-footer__link{color:linkText}button.glue-cookie-notification-bar-control.glue-footer__link:focus{outline:2px
+        solid transparent}}.glue-footer__global-links-list-item[aria-hidden=true],.h-c-footer__global-links-list-item[aria-hidden=true]{display:none}.picker-api-container,.picker-iframe-container{height:100%;width:100%;position:relative}.picker-close-button{position:absolute;z-index:100;top:12px;right:14px;width:36px;height:36px;border-radius:18px;border-width:0;background-color:rgba(0,0,0,0)}.picker-close-button:hover{background-color:rgba(60,64,67,.04)}.picker-close-button:active{background-color:rgba(60,64,67,.12)}.picker-close-button-svg{fill:#616161}.content-library
+        .picker-close-button-svg{color:var(--dt-on-neutral-container,rgb(60,64,67))}.content-library
+        .picker-loading-container{position:absolute;height:100%;width:100%;background-color:var(--dt-surface-container,#fff);-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:space-evenly;-webkit-justify-content:space-evenly;justify-content:space-evenly;display:none}.content-library.loading
+        .picker-loading-container{display:-webkit-box;display:-webkit-flex;display:flex;background-color:#f0f4f9}.content-library.loading
+        .picker-iframe-container,.content-library.loaded .picker-loading-container,.content-library.loading-timed-out
+        .picker-loading-container{display:none}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressWrapper{position:relative}.javascriptMaterialdesignGm3WizCircularProgressCircularProgress{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;line-height:0;overflow:hidden}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressContainer{position:absolute;width:100%;height:100%;-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressCircleGraphic{height:100%;width:100%;fill:transparent}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke:var(--yPTsAb,var(--gm3-sys-color-primary,#0b57d0));stroke-width:var(--EscQs,4px);stroke-linecap:round}@media
+        (forced-colors:active){.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke:CanvasText}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke:var(--Sewh0e,var(--gm3-sys-color-secondary-container,#c2e7ff));stroke-width:var(--EscQs,4px);stroke-linecap:round}@media
+        (forced-colors:active){.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke:Canvas;stroke-width:calc(var(--EscQs,
+        4px) - 2px);-webkit-filter:drop-shadow(-1px 0 0 CanvasText) drop-shadow(1px
+        0 0 CanvasText) drop-shadow(0 -1px 0 CanvasText) drop-shadow(0 1px 0 CanvasText);filter:drop-shadow(-1px
+        0 0 CanvasText) drop-shadow(1px 0 0 CanvasText) drop-shadow(0 -1px 0 CanvasText)
+        drop-shadow(0 1px 0 CanvasText)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressUnopened
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressAlmostComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressClosed
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressClosed
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke-width:0}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate{-webkit-animation:gm3-cpi-rotate
+        6s linear infinite;animation:gm3-cpi-rotate 6s linear infinite}@-webkit-keyframes
+        gm3-cpi-rotate{from{-webkit-transform:rotate(-90deg);transform:rotate(-90deg)}to{-webkit-transform:rotate(990deg);transform:rotate(990deg)}}@keyframes
+        gm3-cpi-rotate{from{-webkit-transform:rotate(-90deg);transform:rotate(-90deg)}to{-webkit-transform:rotate(990deg);transform:rotate(990deg)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressContainer{-webkit-animation:gm3-cpi-container-rotate
+        6s ease infinite;animation:gm3-cpi-container-rotate 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-container-rotate{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}8.3333333333%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}25%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}33.3333333333%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}50%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}58.3333333333%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}75%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}83.3333333333%{-webkit-transform:rotate(1turn);transform:rotate(1turn)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        gm3-cpi-container-rotate{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}8.3333333333%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}25%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}33.3333333333%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}50%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}58.3333333333%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}75%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}83.3333333333%{-webkit-transform:rotate(1turn);transform:rotate(1turn)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgress{height:calc(var(--EkrYwf,
+        40px));width:calc(var(--EkrYwf, 40px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{-webkit-transition:stroke-dasharray
+        .5s 0ms cubic-bezier(0,0,.2,1),stroke-width .25s 0ms cubic-bezier(.4,0,.6,1);transition:stroke-dasharray
+        .5s 0ms cubic-bezier(0,0,.2,1),stroke-width .25s 0ms cubic-bezier(.4,0,.6,1);cx:calc(var(--EkrYwf,
+        40px)/2);cy:calc(var(--EkrYwf, 40px)/2);r:calc((var(--EkrYwf, 40px) - var(--EscQs,
+        4px))/2);stroke-dasharray:calc(var(--progress-value, 0)*(6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px)) - var(--EscQs, 4px)) calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - var(--progress-value, 0)*(6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px)) + var(--EscQs, 4px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{-webkit-transition:stroke-dasharray
+        .5s 0ms cubic-bezier(0,0,.2,1),stroke-dashoffset .5s 0ms cubic-bezier(0,0,.2,1),stroke-width
+        .25s 0ms cubic-bezier(.4,0,.6,1);transition:stroke-dasharray .5s 0ms cubic-bezier(0,0,.2,1),stroke-dashoffset
+        .5s 0ms cubic-bezier(0,0,.2,1),stroke-width .25s 0ms cubic-bezier(.4,0,.6,1);cx:calc(var(--EkrYwf,
+        40px)/2);cy:calc(var(--EkrYwf, 40px)/2);r:calc((var(--EkrYwf, 40px) - var(--EscQs,
+        4px))/2);stroke-dasharray:min((1 - var(--progress-value,0)) * (6.2831852 *
+        (var(--EkrYwf,40px) - var(--EscQs,4px))/2 - var(--XJrZW,4px)) - var(--XJrZW,4px)
+        - var(--EscQs,4px),6.2831852 * (var(--EkrYwf,40px) - var(--EscQs,4px))/2 -
+        var(--XJrZW,4px) - var(--XJrZW,4px) - 2 * var(--EscQs,4px)) calc(6.2831852
+        * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - min((1 - var(--progress-value,
+        0)) * (6.2831852 * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW,
+        4px)) - var(--XJrZW, 4px) - var(--EscQs, 4px), 6.2831852 * (var(--EkrYwf,
+        40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW, 4px) - var(--XJrZW, 4px) - 2
+        * var(--EscQs, 4px)));stroke-dashoffset:calc(min((1 - var(--progress-value,
+        0)) * (6.2831852 * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW,
+        4px)) - var(--XJrZW, 4px) - var(--EscQs, 4px), 6.2831852 * (var(--EkrYwf,
+        40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW, 4px) - var(--XJrZW, 4px) - 2
+        * var(--EscQs, 4px)) + var(--XJrZW, 4px) + var(--EscQs, 4px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke-dasharray:calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2)}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressUnopened
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke-dasharray:calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2) 0}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{-webkit-animation:gm3-cpi-active-grow
+        6s ease infinite;animation:gm3-cpi-active-grow 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-active-grow{from{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}}@keyframes
+        gm3-cpi-active-grow{from{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{-webkit-animation:gm3-cpi-track-grow
+        6s ease infinite;animation:gm3-cpi-track-grow 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-track-grow{from{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px) - var(--EscQs,
+        4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 + var(--XJrZW, 4px)
+        + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px) - var(--EscQs,
+        4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}}@keyframes gm3-cpi-track-grow{from{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}}.mdc-circular-progress__determinate-circle,.mdc-circular-progress__indeterminate-circle-graphic{stroke:#6200ee;stroke:var(--mdc-theme-primary,#6200ee)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.mdc-circular-progress__determinate-circle,.mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.mdc-circular-progress__determinate-track{stroke:transparent}@-webkit-keyframes
+        mdc-circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        mdc-circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@-webkit-keyframes
+        mdc-circular-progress-spinner-layer-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}100%{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@keyframes
+        mdc-circular-progress-spinner-layer-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}100%{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@-webkit-keyframes
+        mdc-circular-progress-color-1-fade-in-out{from{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@keyframes
+        mdc-circular-progress-color-1-fade-in-out{from{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@-webkit-keyframes
+        mdc-circular-progress-color-2-fade-in-out{from{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-2-fade-in-out{from{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-color-3-fade-in-out{from{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-3-fade-in-out{from{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-color-4-fade-in-out{from{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-4-fade-in-out{from{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-left-spin{from{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@keyframes
+        mdc-circular-progress-left-spin{from{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@-webkit-keyframes
+        mdc-circular-progress-right-spin{from{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}50%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}to{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}}@keyframes
+        mdc-circular-progress-right-spin{from{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}50%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}to{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}}.mdc-circular-progress{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;direction:ltr;line-height:0;overflow:hidden;-webkit-transition:opacity
+        .25s 0ms cubic-bezier(.4,0,.6,1);transition:opacity .25s 0ms cubic-bezier(.4,0,.6,1)}.mdc-circular-progress__determinate-container,.mdc-circular-progress__indeterminate-circle-graphic,.mdc-circular-progress__indeterminate-container,.mdc-circular-progress__spinner-layer{position:absolute;width:100%;height:100%}.mdc-circular-progress__determinate-container{-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.mdc-circular-progress__indeterminate-container{font-size:0;letter-spacing:0;white-space:nowrap;opacity:0}.mdc-circular-progress__determinate-circle-graphic,.mdc-circular-progress__indeterminate-circle-graphic{fill:transparent}.mdc-circular-progress__determinate-circle{-webkit-transition:stroke-dashoffset
+        .5s 0ms cubic-bezier(0,0,.2,1);transition:stroke-dashoffset .5s 0ms cubic-bezier(0,0,.2,1)}.mdc-circular-progress__gap-patch{position:absolute;top:0;left:47.5%;-webkit-box-sizing:border-box;box-sizing:border-box;width:5%;height:100%;overflow:hidden}.mdc-circular-progress__gap-patch
+        .mdc-circular-progress__indeterminate-circle-graphic{left:-900%;width:2000%;-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg)}.mdc-circular-progress__circle-clipper{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;width:50%;height:100%;overflow:hidden}.mdc-circular-progress__circle-clipper
+        .mdc-circular-progress__indeterminate-circle-graphic{width:200%}.mdc-circular-progress__circle-right
+        .mdc-circular-progress__indeterminate-circle-graphic{left:-100%}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__determinate-container{opacity:0}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__indeterminate-container{opacity:1}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__indeterminate-container{-webkit-animation:mdc-circular-progress-container-rotate
+        1.5682352941176s linear infinite;animation:mdc-circular-progress-container-rotate
+        1.5682352941176s linear infinite}.mdc-circular-progress--indeterminate .mdc-circular-progress__spinner-layer{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-1{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-1-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-1-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-2{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-2-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-2-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-3{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-3-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-3-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-4{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-4-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-4-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__circle-left .mdc-circular-progress__indeterminate-circle-graphic{-webkit-animation:mdc-circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__circle-right .mdc-circular-progress__indeterminate-circle-graphic{-webkit-animation:mdc-circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--closed{opacity:0}.GmCircularProgress{position:relative}.GmCircularProgress
+        .mdc-circular-progress__determinate-circle,.GmCircularProgress .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(66,133,244)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__determinate-circle,.GmCircularProgress .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-1 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(66,133,244)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-1 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-2 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(234,67,53)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-2 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-3 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(251,188,4)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-3 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-4 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(52,168,83)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-4 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__accessible-label{height:100%;width:100%;position:absolute;opacity:0;overflow:hidden;z-index:-1}.materialdesignWizIconSvgsSvgIcon{fill:currentColor;-webkit-flex-shrink:0;flex-shrink:0}[dir=rtl]
+        .materialdesignWizIconSvgsRtlIcon{-webkit-transform:scaleX(-1);-ms-transform:scaleX(-1);transform:scaleX(-1)}.peopleKitStyleGm3{--pkw-background:var(--gm3-sys-color-background,#fff);--pkw-outline:var(--gm3-sys-color-outline,#747775);--pkw-outline-variant:var(--gm3-sys-color-outline-variant,#c4c7c5);--pkw-scrim:rgba(0,0,0,0.32);--pkw-primary:var(--gm3-sys-color-primary,#0b57d0);--pkw-secondary-container:var(--gm3-sys-color-secondary-container,#c2e7ff);--pkw-on-secondary-container:var(--gm3-sys-color-on-secondary-container,#001d35);--pkw-error:var(--gm3-sys-color-error,#b3261e);--pkw-on-error:var(--gm3-sys-color-on-error,#fff);--pkw-error-container:var(--gm3-sys-color-error-container,#f9dedc);--pkw-error-container-low:rgb(255,237,234);--pkw-on-error-container:var(--gm3-sys-color-on-error-container,#410e0b);--pkw-caution:rgb(125,88,0);--pkw-caution-container:rgb(255,222,169);--pkw-caution-container-low:rgb(255,239,212);--pkw-on-caution-container:rgb(39,25,0);--pkw-on-surface:var(--gm3-sys-color-on-surface,#1f1f1f);--pkw-on-surface-variant:var(--gm3-sys-color-on-surface-variant,#444746);--pkw-surface-container:var(--gm3-sys-color-surface-container,#f0f4f9);--pkw-surface-container-high:var(--gm3-sys-color-surface-container-high,#e9eef6);--pkw-inverse-surface:var(--gm3-sys-color-inverse-surface,#303030);--pkw-inverse-on-surface:var(--gm3-sys-color-inverse-on-surface,#f2f2f2)}.peoplekitThemeDark
+        .peopleKitStyleGm3{--pkw-background:var(--gm3-sys-color-background,#131314);--pkw-outline:var(--gm3-sys-color-outline,#8e918f);--pkw-outline-variant:var(--gm3-sys-color-outline-variant,#444746);--pkw-scrim:rgba(0,0,0,0.32);--pkw-primary:var(--gm3-sys-color-primary,#a8c7fa);--pkw-secondary-container:var(--gm3-sys-color-secondary-container,#004a77);--pkw-on-secondary-container:var(--gm3-sys-color-on-secondary-container,#c2e7ff);--pkw-error:var(--gm3-sys-color-error,#f2b8b5);--pkw-on-error:var(--gm3-sys-color-on-error,#601410);--pkw-error-container:var(--gm3-sys-color-error-container,#8c1d18);--pkw-error-container-low:rgb(65,0,1);--pkw-on-error-container:var(--gm3-sys-color-on-error-container,#f9dedc);--pkw-caution:rgb(255,186,40);--pkw-caution-container:rgb(94,65,0);--pkw-caution-container-low:rgb(80,55,0);--pkw-on-caution-container:rgb(255,222,169);--pkw-on-surface:var(--gm3-sys-color-on-surface,#e3e3e3);--pkw-on-surface-variant:var(--gm3-sys-color-on-surface-variant,#c4c7c5);--pkw-surface-container:var(--gm3-sys-color-surface-container,#1e1f20);--pkw-surface-container-high:var(--gm3-sys-color-surface-container-high,#282a2c);--pkw-inverse-surface:var(--gm3-sys-color-inverse-surface,#e3e3e3);--pkw-inverse-on-surface:var(--gm3-sys-color-inverse-on-surface,#303030)}.peoplekitComponentsAvatarImplAvatarContainer{position:relative}.peoplekitComponentsAvatarImplAvatar{border-radius:50%;outline:1px
+        solid transparent;overflow:hidden}.peoplekitComponentsAvatarImplBadgeIconImage{margin:auto;display:block;height:100%;width:100%}.peoplekitComponentsAvatarImplAvatarBadge{position:absolute;bottom:0;right:0;display:none;height:30%;width:30%;min-height:30%;min-width:30%;-o-object-fit:cover;object-fit:cover;overflow:hidden}.peoplekitComponentsAvatarImplAvatarBadge.visible{display:inline}.isSelected
+        .peoplekitComponentsAvatarImplAvatarBadge{display:none}.peoplekitComponentsAvatarImplContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;height:inherit;width:inherit}.peoplekitComponentsAvatarImplColumn{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-flex:1;-webkit-flex:1;flex:1;overflow:hidden;height:inherit;-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch}.peoplekitComponentsAvatarImplRow{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:1;-webkit-flex:1;flex:1;overflow:hidden}.peoplekitComponentsAvatarImplDivider{margin:1px}.peoplekitComponentsAvatarImplImageRoot{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-flex:1;-webkit-flex:auto;flex:auto;-webkit-box-align:center;-webkit-align-items:center;align-items:center;justify-items:center;-webkit-transition:background
+        50ms ease-in-out;transition:background 50ms ease-in-out}.peoplekitComponentsAvatarImplImageRoot.isLoading{background-clip:padding-box;background-color:var(--pkw-on-surface-variant,rgb(189,193,198))}.peoplekitComponentsAvatarImplDefaultAvatarImage{display:none}.isNotLoaded
+        .peoplekitComponentsAvatarImplDefaultAvatarImage{display:block;fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .isNotLoaded .peoplekitComponentsAvatarImplDefaultAvatarImage{fill:var(--pkw-on-surface-variant,rgb(154,160,166))}.peoplekitComponentsAvatarImplImage{opacity:1;display:block;-webkit-transition:opacity
+        50ms ease-in-out;transition:opacity 50ms ease-in-out}.isLoading .peoplekitComponentsAvatarImplImage{opacity:0}.isNotLoaded
+        .peoplekitComponentsAvatarImplImage{display:none}.peoplekitComponentsChipChip{background:var(--pkw-background,#fff);border-radius:50vh;-webkit-box-shadow:0
+        0 0 1px var(--pkw-outline,rgb(218,220,224)) inset;box-shadow:0 0 0 1px var(--pkw-outline,rgb(218,220,224))
+        inset;color:var(--pkw-on-surface-variant,rgb(95,99,104));cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;display:inline-block;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin:4px;min-width:1px;outline:1px
+        solid transparent;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitComponentsChipChip:hover{background:var(--pkw-background,rgb(248,249,250));color:var(--pkw-on-surface-variant,rgb(32,33,36))}.peoplekitComponentsChipChip.isActive{background:var(--pkw-secondary-container,rgb(232,240,254));-webkit-box-shadow:none;box-shadow:none;color:var(--pkw-on-secondary-container,rgb(25,103,210));outline-width:2px}.peoplekitComponentsChipChip.isActive:hover{background:var(--pkw-secondary-container,rgb(210,227,252));color:var(--pkw-on-secondary-container,rgb(23,78,166))}.peoplekitComponentsChipChip.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-primary,rgb(102,157,246)) inset;box-shadow:0 0 0 2px var(--pkw-primary,rgb(102,157,246))
+        inset;outline-width:3px}.peoplekitComponentsChipChip.isWarning{background:var(--pkw-caution-container-low,rgb(254,247,224));-webkit-box-shadow:0
+        0 0 1px var(--pkw-caution,rgb(251,188,4)) inset;box-shadow:0 0 0 1px var(--pkw-caution,rgb(251,188,4))
+        inset;color:var(--pkw-caution,rgb(95,99,104))}.peoplekitComponentsChipChip.isWarning.isActive{background:var(--pkw-caution-container,rgb(253,214,99));color:var(--pkw-on-caution-container,rgb(60,64,67));-webkit-box-shadow:none;box-shadow:none}.peoplekitComponentsChipChip.isWarning.isActive:hover{background:var(--pkw-caution-container,rgb(252,201,52));color:var(--pkw-on-caution-container,rgb(32,33,36))}.peoplekitComponentsChipChip.isWarning.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-on-caution-container,rgb(32,33,36)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-caution-container,rgb(32,33,36)) inset}.peoplekitComponentsChipChip.isWarning:hover{background:var(--pkw-caution-container,rgb(254,239,195));color:var(--pkw-caution,rgb(32,33,36))}.peoplekitComponentsChipChip.isError{background:var(--pkw-error-container-low,#fff);-webkit-box-shadow:0
+        0 0 1px var(--pkw-error,rgb(234,67,53)) inset;box-shadow:0 0 0 1px var(--pkw-error,rgb(234,67,53))
+        inset;color:var(--pkw-error,rgb(197,34,31))}.peoplekitComponentsChipChip.isError.isActive{background:var(--pkw-error-container,rgba(217,48,37,.2));color:var(--pkw-on-error-container,rgb(165,14,14));-webkit-box-shadow:none;box-shadow:none}.peoplekitComponentsChipChip.isError.isActive:hover{background:var(--pkw-error-container,rgba(217,48,37,.24));color:var(--pkw-on-error-container,rgb(165,14,14))}.peoplekitComponentsChipChip.isError.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-on-error-container,rgb(165,14,14)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-error-container,rgb(165,14,14)) inset}.peoplekitComponentsChipChip.isError:hover{background:var(--pkw-error-container,rgb(250,210,207));color:var(--pkw-error,rgb(165,14,14))}.peoplekitComponentsChipChip.isDragged,.peoplekitComponentsChipChip.isDragged.isError,.peoplekitComponentsChipChip.isDragged.isWarning,.peoplekitComponentsChipChip.isDragged.isActive,.peoplekitComponentsChipChip.isDragged.isSpotlit{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitComponentsChipChip.isDragged.isError
+        .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isActive
+        .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isActive .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged
+        .mdc-elevation-overlay{opacity:0}.peoplekitComponentsChipChip.isDragged.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15)}.peoplekitComponentsChipChip.isDisabled,.peoplekitComponentsChipChip.isDisabled:hover{cursor:default;opacity:.5}.peoplekitComponentsChipChip.isDeletionDisabled
+        .peoplekitComponentsChipDeleteButton{display:none}.peoplekitThemeDark .peoplekitComponentsChipChip{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);border-radius:50vh;-webkit-box-shadow:0
+        0 0 1px var(--pkw-outline,rgb(95,99,104)) inset;box-shadow:0 0 0 1px var(--pkw-outline,rgb(95,99,104))
+        inset;color:var(--pkw-on-surface-variant,rgb(154,160,166));cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;display:inline-block;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin:4px;min-width:1px;outline:1px
+        solid transparent;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.04),rgba(232,234,237,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface-variant,rgb(232,234,237))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isActive{background:var(--pkw-secondary-container,linear-gradient(0deg,rgba(138,180,248,.24),rgba(138,180,248,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:none;box-shadow:none;color:var(--pkw-on-secondary-container,rgb(210,227,252));outline-width:2px}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isActive:hover{background:var(--pkw-secondary-container,linear-gradient(0deg,rgba(138,180,248,.32),rgba(138,180,248,.32)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-secondary-container,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isSpotlit{-webkit-box-shadow:0 0 0 2px var(--pkw-primary,rgb(174,203,250))
+        inset;box-shadow:0 0 0 2px var(--pkw-primary,rgb(174,203,250)) inset;outline-width:3px}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning{background:var(--pkw-caution-container-low,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:0
+        0 0 1px var(--pkw-caution,rgb(253,214,99)) inset;box-shadow:0 0 0 1px var(--pkw-caution,rgb(253,214,99))
+        inset;color:var(--pkw-caution,rgb(253,214,99))}.peoplekitThemeDark .peoplekitComponentsChipChip.isWarning.isActive{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.24),rgba(253,214,99,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-caution-container,rgb(254,239,195));-webkit-box-shadow:none;box-shadow:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning.isActive:hover{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.36),rgba(253,214,99,.36)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-caution-container,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning.isSpotlit{-webkit-box-shadow:0 0 0
+        2px var(--pkw-on-caution-container,rgb(232,234,237)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-caution-container,rgb(232,234,237)) inset}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning:hover{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.04),rgba(253,214,99,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-caution,rgb(254,239,195))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError{background:var(--pkw-error-container-low,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:0
+        0 0 1px var(--pkw-error,rgb(242,139,130)) inset;box-shadow:0 0 0 1px var(--pkw-error,rgb(242,139,130))
+        inset;color:var(--pkw-error,rgb(242,139,130))}.peoplekitThemeDark .peoplekitComponentsChipChip.isError.isActive{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.24),rgba(242,139,130,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-error-container,rgb(250,210,207));-webkit-box-shadow:none;box-shadow:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError.isActive:hover{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.36),rgba(242,139,130,.36)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-error-container,rgb(252,232,230))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError.isSpotlit{-webkit-box-shadow:0 0 0 2px
+        var(--pkw-on-error-container,rgb(250,210,207)) inset;box-shadow:0 0 0 2px
+        var(--pkw-on-error-container,rgb(250,210,207)) inset}.peoplekitThemeDark .peoplekitComponentsChipChip.isError:hover{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.04),rgba(242,139,130,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-error,rgb(250,210,207))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isWarning,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isSpotlit{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isActive .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15)}.peoplekitThemeDark .peoplekitComponentsChipChip.isDisabled,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDisabled:hover{cursor:default;opacity:.5}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDeletionDisabled .peoplekitComponentsChipDeleteButton{display:none}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip{position:relative}.peopleKitStyleGm3 .peoplekitComponentsChipChip::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50vh;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsChipChip::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isActive:hover::before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isWarning:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isWarning.isActive:hover::before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isError:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isError.isActive:hover::before{opacity:.1}.peoplekitComponentsChipChipRow{-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;padding:2px}.peoplekitComponentsChipLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipCenter{-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:1;-webkit-flex:auto;flex:auto;justify-items:stretch;overflow:hidden}.peoplekitComponentsChipRight{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipLabelContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin-left:8px;margin-right:8px;overflow:hidden}.peoplekitComponentsChipLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipLabel{letter-spacing:.0214285714em;font-family:Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;line-height:unset;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:-webkit-box;display:-webkit-flex;display:flex}.peopleKitStyleGm3
+        .peoplekitComponentsChipLabel{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsChipDisambiguationLabel.hasDisambiguationLabel{margin-left:4px}.peoplekitComponentsChipDisplayLabel{-webkit-box-flex:1;-webkit-flex:1
+        0 auto;flex:1 0 auto;overflow:hidden;text-overflow:ellipsis;max-width:100%}.peoplekitComponentsChipDisambiguationLabel{overflow:hidden;text-overflow:ellipsis}.peoplekitComponentsChipAvatar{position:relative}.peoplekitComponentsChipAvatarContainer{height:inherit;width:inherit;position:relative}.peoplekitComponentsChipAvatarExclamationOverlay{border-radius:50%;height:100%;left:0;outline:1px
+        solid transparent;position:absolute;top:0;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center}.peoplekitComponentsChipAvatarExclamationOverlay.isError{background-color:var(--pkw-error,rgb(197,34,31))}.peoplekitThemeDark
+        .peoplekitComponentsChipAvatarExclamationOverlay.isError{background-color:var(--pkw-error,rgb(242,139,130))}.peoplekitComponentsChipExclamationIcon{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;height:85%;width:85%}.peoplekitComponentsChipExclamationIcon.isError{fill:var(--pkw-on-error,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipExclamationIcon.isError{fill:var(--pkw-on-error,rgb(32,33,36))}@media
+        (forced-colors:active){.peoplekitComponentsChipExclamationIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsChipDeleteButton{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;height:100%;max-height:24px;margin-left:-3px;margin-right:1px;width:24px;z-index:1}.peoplekitComponentsChipDeleteIcon{display:block;fill:currentcolor;margin:0
+        auto}.peoplekitComponentsChipPlaceholderAvatarPlaceholder{border-radius:50%;background-color:var(--pkw-secondary-fixed-dim,rgb(174,203,250))}.peoplekitComponentsChipPlaceholderLabelPlaceholder{-webkit-align-self:center;align-self:center;background-color:var(--pkw-secondary-fixed-dim,rgb(174,203,250));border-radius:8px;height:16px;margin-left:8px;margin-right:8px;width:150px}.peoplekitComponentsChipPlaceholderShimmer{-webkit-animation:fadeinout
+        1.4s cubic-bezier(.5,0,.5,1) infinite;animation:fadeinout 1.4s cubic-bezier(.5,0,.5,1)
+        infinite}@-webkit-keyframes fadeinout{0%{opacity:.75}50%{opacity:1}100%{opacity:.75}}@keyframes
+        fadeinout{0%{opacity:.75}50%{opacity:1}100%{opacity:.75}}.peoplekitComponentsTooltipImplTooltip{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;background-color:var(--pkw-inverse-surface,rgb(60,64,67));color:var(--pkw-inverse-on-surface,rgb(241,243,244));border-radius:5px;-webkit-box-sizing:border-box;box-sizing:border-box;font-weight:bold;line-height:16px;min-width:40px;max-width:200px;min-height:24px;max-height:40vh;overflow:hidden;padding:4px
+        8px;position:absolute;outline:1px solid transparent;text-align:center;width:-webkit-max-content;width:-moz-max-content;width:max-content;z-index:9}.peoplekitThemeDark
+        .peoplekitComponentsTooltipImplTooltip{background-color:var(--pkw-inverse-surface,rgb(60,64,67));color:var(--pkw-inverse-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsTooltipImplTooltip{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem;border-radius:4px}.peoplekitComponentsButtonIconIconButton{background:none;border:none;border-radius:50%;cursor:pointer}.peoplekitComponentsButtonIconIconButton:hover{background-color:var(--pkw-background,rgb(218,220,224))}.peoplekitComponentsButtonIconIconButton:active{background-color:var(--pkw-background,rgb(189,193,198))}.peoplekitComponentsButtonIconIconButton::-moz-focus-inner{border:0}.peoplekitComponentsButtonIconIconButton.isFocused{background-color:var(--pkw-background,rgb(218,220,224));outline:3px
+        solid transparent}.peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity{height:40px;padding:8px;width:40px}.peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:24px;width:24px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity{height:32px;padding:6px;width:32px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:20px;width:20px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity{height:28px;padding:5px;width:28px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:18px;width:18px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton{background:none;border:none;border-radius:50%;cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton:hover{background-color:var(--pkw-background,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton:active{background-color:var(--pkw-background,rgb(128,134,139))}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton::-moz-focus-inner{border:0}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.isFocused{background-color:var(--pkw-background,rgb(95,99,104));outline:3px
+        solid transparent}.peoplekitThemeDark .peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity{height:40px;padding:8px;width:40px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity .peoplekitComponentsButtonIconAdaptableIcon{height:24px;width:24px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity{height:32px;padding:6px;width:32px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:20px;width:20px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity{height:28px;padding:5px;width:28px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity .peoplekitComponentsButtonIconAdaptableIcon{height:18px;width:18px}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsButtonIconIconButton::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton:hover::before{opacity:.16}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton:active::before{opacity:.2}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton.isFocused::before{opacity:.2}@media
+        (forced-colors:none){.peopleKitStyleGm3 .peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0)
+        saturate(100%) invert(25%) sepia(11%) saturate(129%) hue-rotate(109deg) brightness(93%)
+        contrast(86%);filter:brightness(0) saturate(100%) invert(25%) sepia(11%) saturate(129%)
+        hue-rotate(109deg) brightness(93%) contrast(86%)}.peoplekitThemeDark .peopleKitStyleGm3
+        .peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0) saturate(100%)
+        invert(88%) sepia(2%) saturate(246%) hue-rotate(87deg) brightness(92%) contrast(88%);filter:brightness(0)
+        saturate(100%) invert(88%) sepia(2%) saturate(246%) hue-rotate(87deg) brightness(92%)
+        contrast(88%)}}@media (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsResultlistitemResultListItem{background:var(--pkw-background,#fff);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;cursor:pointer}.peoplekitComponentsResultlistitemResultListItem:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsResultlistitemResultListItem:hover
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgb(241,243,244))}.peoplekitComponentsResultlistitemResultListItem.isActive{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitComponentsResultlistitemResultListItem.isActive
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgb(241,243,244))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem:hover .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isActive{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsResultlistitemResultListItem.isActive
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsResultlistitemResultListItem::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.isActive::before{opacity:.1}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity{min-height:64px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:0;font-weight:400}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:24px;height:24px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:25px;height:25px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding:8px 16px}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity{min-height:72px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity{min-height:52px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;line-height:1.25rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;font-size:.75rem;letter-spacing:.025em;font-weight:400;line-height:1rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:19px;height:19px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:20px;height:20px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding-left:12px;padding-right:12px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity{min-height:44px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;line-height:1.125}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;line-height:.875rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:17px;height:17px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:20px;height:20px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding-left:12px;padding-right:12px}.peoplekitComponentsResultlistitemResultListItem.isDisabled{cursor:default}.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemLabel,.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface,rgb(60,64,67));opacity:.38}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isDisabled .peoplekitComponentsResultlistitemLabel,.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isDisabled .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface,rgb(232,234,237))}.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemAvatar{opacity:.5}.peoplekitComponentsResultlistitemResultListItem.isSelected
+        .peoplekitComponentsResultlistitemAvatarSelectionOverlay{opacity:1;-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1)}.peoplekitComponentsResultlistitemResultListItem.isOutOfOffice{background-color:var(--pkw-caution-container-low,papayawhip)}.peoplekitComponentsResultlistitemResultListItemRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap}.peoplekitComponentsResultlistitemLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsResultlistitemCenter{-webkit-box-flex:1;-webkit-flex:auto;flex:auto;overflow:hidden}.peoplekitComponentsResultlistitemRight{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsResultlistitemLabelContainer{-webkit-align-content:flex-start;align-content:flex-start;-webkit-box-align:start;-webkit-align-items:flex-start;align-items:flex-start;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;margin-right:0}.peopleKitStyleGm3 .peoplekitComponentsResultlistitemLabelContainer{margin-left:16px}.peoplekitComponentsResultlistitemLabelContainer{margin-left:12px}.peoplekitComponentsResultlistitemLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;width:100%}.peoplekitComponentsResultlistitemLabel{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitComponentsResultlistitemLabelText{color:var(--pkw-on-surface,rgb(60,64,67));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemLabelText{color:var(--pkw-on-surface,rgb(232,234,237))}.peoplekitComponentsResultlistitemTags{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-align:center;-webkit-align-items:center;align-items:center}.peoplekitComponentsResultlistitemSublabel{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface-variant,rgb(95,99,104));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peoplekitComponentsResultlistitemAvatar{position:relative}.peoplekitComponentsResultlistitemAvatarContainer{height:inherit;width:inherit;position:relative}.peoplekitComponentsResultlistitemAvatarSelectionOverlay{background-color:var(--pkw-primary,rgb(26,115,232));border-radius:50%;height:100%;left:0;opacity:0;outline:1px
+        solid transparent;position:absolute;top:0;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);-webkit-transition:-webkit-transform
+        .15s ease-out;transition:-webkit-transform .15s ease-out;transition:transform
+        .15s ease-out;transition:transform .15s ease-out,-webkit-transform .15s ease-out;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemAvatarSelectionOverlay{background-color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsResultlistitemWhiteCheck{fill:var(--pkw-background,#fff);display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemWhiteCheck{fill:var(--pkw-background,rgb(32,33,36))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsResultlistitemWhiteCheck{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsResultlistitemWhiteCheck{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsResultlistitemOutOfOffice{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(95,99,104));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:none}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemOutOfOffice{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemOutOfOffice{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemMetaIcon{margin-left:16px}.peoplekitComponentsResultlistitemMetaIcon[src=\"\"]{display:none}.peoplekitComponentsListImplList{list-style:none;margin:0;padding:0}.peoplekitComponentsListImplList:focus{outline:none}.peoplekitComponentsResultListCoreGroupSectionListContainer{overflow:hidden;-webkit-transform-origin:top;-ms-transform-origin:top;transform-origin:top;-webkit-transition:all
+        .5s cubic-bezier(.05,.7,.1,1);transition:all .5s cubic-bezier(.05,.7,.1,1)}.peoplekitComponentsResultListCoreGroupSectionListContainer.collapsed{height:0;-webkit-transform:scaleY(0);-ms-transform:scaleY(0);transform:scaleY(0);-webkit-transition:all
+        .2s cubic-bezier(.3,0,.8,.15);transition:all .2s cubic-bezier(.3,0,.8,.15)}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active{background:var(--pkw-background,rgba(10,10,10,.12))}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.rotate{-webkit-transform:rotate(-180deg);-ms-transform:rotate(-180deg);transform:rotate(-180deg)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.rotate{-webkit-transform:rotate(-180deg);-ms-transform:rotate(-180deg);transform:rotate(-180deg)}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active::before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit::before{opacity:.1}.peoplekitComponentsGroupingHeaderCollapsibleChevron{fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevron{fill:var(--pkw-on-surface-variant,rgb(241,243,244))}.peoplekitComponentsButtonLabelLabelButton{font-family:\"Google
+        Sans\",Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500;-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:none;border:none;border-radius:4px;color:var(--pkw-primary,rgb(26,115,232));display:-webkit-box;display:-webkit-flex;display:flex;height:36px;line-height:unset;outline:1px
+        solid transparent;padding:0 8px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitComponentsButtonLabelLabelButton:hover{background-color:var(--pkw-surface-container-high,rgba(26,115,232,.04));color:var(--pkw-primary,rgb(23,78,166));cursor:pointer}.peoplekitComponentsButtonLabelLabelButton:focus{background-color:var(--pkw-surface-container-high,rgba(26,115,232,.12));color:var(--pkw-primary,rgb(23,78,166));cursor:pointer;outline-width:3px}.peoplekitComponentsButtonLabelLabelButton::-moz-focus-inner{border:0}.peoplekitComponentsButtonLabelLabelButton.isDisabled{color:var(--pkw-on-surface,rgb(60,64,67));opacity:.38}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton{-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:none;border:none;border-radius:4px;color:var(--pkw-primary,rgb(138,180,248));display:-webkit-box;display:-webkit-flex;display:flex;height:36px;line-height:unset;outline:1px
+        solid transparent;padding:0 8px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton:hover{background-color:var(--pkw-surface-container-high,rgba(138,180,248,.04));color:var(--pkw-primary,rgb(210,227,252));cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton:focus{background-color:var(--pkw-surface-container-high,rgba(138,180,248,.12));color:var(--pkw-primary,rgb(210,227,252));cursor:pointer;outline-width:3px}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton::-moz-focus-inner{border:0}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton.isDisabled{color:var(--pkw-on-surface,rgb(232,234,237));opacity:.38}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;border-radius:20px;height:40px;padding:0
+        24px;position:relative}.peopleKitStyleGm3 .peoplekitComponentsButtonLabelLabelButton::before{background:var(--pkw-primary,var(--gm3-sys-color-primary,#0b57d0));border-radius:20px;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsButtonLabelLabelButton::before{background:var(--pkw-primary,var(--gm3-sys-color-primary,#a8c7fa))}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton:focus::before{opacity:.1}.peoplekitComponentsDialogImplScrim{background:var(--pkw-scrim,rgba(32,33,36,.6));-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-sizing:border-box;box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:flex;height:100%;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;left:0;position:fixed;top:0;width:100%;z-index:999999}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplScrim{background:var(--pkw-scrim,rgba(32,33,36,.6))}.peoplekitComponentsDialogImplDialog{border-width:0;-webkit-box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);background:var(--pkw-surface-container-high,#fff);text-wrap-mode:wrap;border-radius:8px;max-width:300px;outline:1px
+        solid transparent;overflow:hidden}.peoplekitComponentsDialogImplDialog .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplDialog{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsDialogImplDialog.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);border-radius:28px;padding:24px}.peoplekitComponentsDialogImplAvatarHeader{background:var(--pkw-surface-container-high,#fff);border-bottom:1px
+        solid var(--pkw-outline-variant,rgb(218,220,224));display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;padding:12px}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplAvatarHeader{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);border-bottom:1px
+        solid var(--pkw-outline-variant,rgb(128,134,139))}.peopleKitStyleGm3 .peoplekitComponentsDialogImplAvatarHeader{padding:0
+        0 8px}.peoplekitComponentsDialogImplTextHeader{font-family:\"Google Sans\",Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:500;background:var(--pkw-surface-container-high,#fff);color:var(--pkw-on-surface,rgb(32,33,36));margin:24px
+        24px 20px}.peoplekitThemeDark .peoplekitComponentsDialogImplTextHeader{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplTextHeader{font-family:Google Sans,Google Sans,Roboto,Arial,sans-serif;font-size:1.5rem;font-weight:400;letter-spacing:0;line-height:2rem;margin:0}.peoplekitComponentsDialogImplHeaderRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap}.peoplekitComponentsDialogImplLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsDialogImplCenter{-webkit-box-flex:1;-webkit-flex:auto;flex:auto;overflow:hidden}.peoplekitComponentsDialogImplAvatar{position:relative}.peoplekitComponentsDialogImplAvatarContainer{height:inherit;position:relative;width:inherit}.peoplekitComponentsDialogImplLabelContainer{-webkit-align-content:flex-start;align-content:flex-start;-webkit-box-align:start;-webkit-align-items:flex-start;align-items:flex-start;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;margin-left:12px;margin-right:0}.peoplekitComponentsDialogImplLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;width:100%}.peoplekitComponentsDialogImplLabel{font-family:\"Google
+        Sans\",Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500;color:var(--pkw-on-surface,rgb(32,33,36));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplLabel{color:var(--pkw-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplLabel{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsDialogImplSublabel{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(60,64,67));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplSublabel{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:500;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsDialogImplContent{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(60,64,67));margin:24px
+        24px 20px}.peoplekitThemeDark .peoplekitComponentsDialogImplContent{color:var(--pkw-on-surface-variant,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplContent{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem;margin:0;padding-top:16px;padding-bottom:24px}.peoplekitComponentsDialogImplActions{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:end;-webkit-justify-content:flex-end;justify-content:flex-end;padding:8px}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplActions{padding:0}.peoplekitComponentsDialogImplActionDivider{width:8px}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active{background:var(--pkw-background,rgba(10,10,10,.12))}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderInfoInfoIconContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderInfoInfoIconContainer{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderInfoInfoIconContainer::before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover::before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active::before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit::before{opacity:.1}.peoplekitComponentsGroupingHeaderInfoLearnMoreLink{color:var(--pkw-primary,rgb(26,115,232));text-decoration:underline}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoLearnMoreLink{color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsGroupingHeaderInfoLearnMoreLink:visited{color:var(--pkw-primary,rgb(26,115,232))}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoLearnMoreLink:visited{color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsGroupingHeaderInfoInfoIcon{fill:var(--pkw-on-surface-variant,rgb(95,99,104));height:16px;padding:5px;width:16px}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIcon{fill:var(--pkw-on-surface-variant,rgb(241,243,244))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsGroupingHeaderInfoInfoIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsGroupingHeaderInfoInfoIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsGroupingHeaderGroupingHeader{background:var(--pkw-background,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderGroupingHeader{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsGroupingHeaderGroupingHeaderRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;padding-left:16px;padding-right:16px}.peoplekitComponentsGroupingHeaderHeader{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.6875rem;letter-spacing:.0727272727em;font-weight:500;text-transform:uppercase;color:var(--pkw-on-surface-variant,rgb(95,99,104));padding-bottom:11px;padding-top:13px}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderHeader{color:var(--pkw-on-surface-variant,rgb(241,243,244))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderHeader{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;text-transform:none;padding:6px
+        0}.peoplekitComponentsGroupingHeaderAction{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1}.peoplekitComponentsGroupingHeaderActionRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between}.peoplekitComponentsGroupingHeaderLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsGroupingHeaderRight{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;margin-left:16px;margin-right:4px}.peoplekitComponentsTagTag{background:rgb(241,243,244);color:rgb(32,33,36);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-align:center;-webkit-align-items:center;align-items:center;margin-left:8px;border-radius:4px;outline:1px
+        solid transparent;overflow:hidden;position:relative}.peoplekitComponentsTagTag.isWarning{background:#fbbc04;color:rgb(32,33,36)}.peopleKitStyleGm3
+        .peoplekitComponentsTagTag{background:var(--gm3-sys-color-surface-container-high,#e9eef6);color:var(--gm3-sys-color-on-surface-variant,#444746)}.peopleKitStyleGm3
+        .peoplekitComponentsTagTag.isWarning{background:#ffbb29;color:var(--gm3-sys-color-on-surface,#1f1f1f)}@media
+        (forced-colors:none){.peopleKitStyleGm3 .peoplekitComponentsTagIcon.isWarning{-webkit-filter:brightness(0)
+        saturate(100%) invert(0) sepia(7%) saturate(1357%) hue-rotate(335deg) brightness(112%)
+        contrast(76%);filter:brightness(0) saturate(100%) invert(0) sepia(7%) saturate(1357%)
+        hue-rotate(335deg) brightness(112%) contrast(76%)}}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagTag{height:20px;min-width:20px}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagTag,.workspaceMaterialCompactDensity .peoplekitComponentsTagTag{height:16px;min-width:16px}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagIcon{width:16px;height:16px;margin-left:2px;font-size:16px}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagIcon,.workspaceMaterialCompactDensity .peoplekitComponentsTagIcon{width:14px;height:14px;margin-left:1px;font-size:14px}.peoplekitComponentsTagUnrollingAltText{max-width:0;overflow:hidden;-webkit-transition:max-width
+        .3s;transition:max-width .3s}.peoplekitComponentsTagTag:hover .peoplekitComponentsTagUnrollingAltText{max-width:1000px}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsTagIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}.peoplekitComponentsTagText{margin-left:4px;margin-right:4px}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.workspaceMaterialCompactDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400}.workspaceMaterialCompactDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemDisabledDisableReasonContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex}.peoplekitComponentsResultlistitemDisabledTextIndicator{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400;color:var(--pkw-on-surface,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledTextIndicator{color:var(--pkw-on-surface,#fff)}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemDisabledTextIndicator{font-family:Google
+        Sans Text,Google Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:0;font-weight:400}.peoplekitComponentsResultlistitemDisabledIconIndicator{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;background:var(--pkw-background,rgb(241,243,244));border-radius:50px;width:32px;height:32px;margin-left:16px;margin-right:4px}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peoplekitComponentsResultlistitemDisabledSelectedIcon{fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledSelectedIcon{fill:var(--pkw-on-surface-variant,rgb(232,234,237))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsResultlistitemDisabledSelectedIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsResultlistitemDisabledSelectedIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitUiResultlistHeader{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.6875rem;letter-spacing:.0727272727em;font-weight:500;text-transform:uppercase;background:var(--pkw-background,#fff);color:var(--pkw-on-surface-variant,rgb(95,99,104));padding-bottom:12px;padding-left:16px;padding-top:12px}.peoplekitThemeDark
+        .peoplekitUiResultlistHeader{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface-variant,rgb(241,243,244))}.peopleKitStyleGm3
+        .peoplekitUiResultlistHeader{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;text-transform:none}.peoplekitComponentsAutocompleteInlineContainer{background:var(--pkw-background,#fff);height:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsAutocompleteInlineContainer{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineListContainer,.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineNoResultsContainer{display:none}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center;height:100%}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress::before{-webkit-box-flex:1;-webkit-flex:auto;flex:auto}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress::after{-webkit-box-flex:1;-webkit-flex:auto;flex:auto}.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineListContainer,.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineCircularProgress{display:none}.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineNoResultsContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:start;-webkit-justify-content:flex-start;justify-content:flex-start;-webkit-box-align:center;-webkit-align-items:center;align-items:center;height:100%;overflow:auto}.peoplekitComponentsAutocompleteInlineListContainer{height:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;overflow:hidden}.peoplekitComponentsAutocompleteInlineCircularProgress,.peoplekitComponentsAutocompleteInlineNoResultsContainer{display:none}.peoplekitComponentsCircularprogressCircularProgress{display:inline-block;height:40px;position:relative;width:40px;direction:ltr}.peoplekitComponentsCircularprogressMessageContainer{height:0;overflow:hidden;position:absolute;width:0}.peoplekitComponentsCircularprogressCircularProgressContainer{width:100%;height:100%}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressContainer{-webkit-animation:circular-progress-container-rotate
+        1568ms linear infinite;animation:circular-progress-container-rotate 1568ms
+        linear infinite}.peoplekitComponentsCircularprogressCircularProgressLayer{height:100%;opacity:0;position:absolute;width:100%}.peoplekitComponentsCircularprogressColorOne{border-color:#4285f4}.peoplekitComponentsCircularprogressColorTwo{border-color:#ea4335}.peoplekitComponentsCircularprogressColorThree{border-color:#fbbc04}.peoplekitComponentsCircularprogressColorFour{border-color:#34a853}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorOne{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-blue-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-blue-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorTwo{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-red-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-red-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorThree{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-yellow-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-yellow-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorFour{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-green-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-green-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressGapPatch{position:absolute;-webkit-box-sizing:border-box;box-sizing:border-box;top:0;left:45%;width:10%;height:100%;overflow:hidden;border-color:inherit}.peoplekitComponentsCircularprogressGapPatch
+        .peoplekitComponentsCircularprogressCircle{width:1000%;left:-450%}.peoplekitComponentsCircularprogressCircleClipper{display:inline-block;position:relative;width:50%;height:100%;overflow:hidden;border-color:inherit}.peoplekitComponentsCircularprogressCircleClipper
+        .peoplekitComponentsCircularprogressCircle{width:200%}.peoplekitComponentsCircularprogressCircle{position:absolute;top:0;right:0;bottom:0;left:0;-webkit-box-sizing:border-box;box-sizing:border-box;height:100%;border-width:3px;border-style:solid;border-color:inherit;border-bottom-color:transparent;border-radius:50%;-webkit-animation:none;animation:none}.peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressLeft
+        .peoplekitComponentsCircularprogressCircle{border-right-color:transparent;-webkit-transform:rotate(129deg);-ms-transform:rotate(129deg);transform:rotate(129deg)}.peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressRight
+        .peoplekitComponentsCircularprogressCircle{left:-100%;border-left-color:transparent;-webkit-transform:rotate(-129deg);-ms-transform:rotate(-129deg);transform:rotate(-129deg)}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressLeft
+        .peoplekitComponentsCircularprogressCircle{-webkit-animation:circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressRight
+        .peoplekitComponentsCircularprogressCircle{-webkit-animation:circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isWarmdown
+        .peoplekitComponentsCircularprogressCircularProgressContainer{-webkit-animation:circular-progress-container-rotate
+        1568ms linear infinite,circular-progress-fade-out .4s cubic-bezier(.4,0,.2,1);animation:circular-progress-container-rotate
+        1568ms linear infinite,circular-progress-fade-out .4s cubic-bezier(.4,0,.2,1)}@-webkit-keyframes
+        circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@-webkit-keyframes
+        circular-progress-fill-unfill-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@keyframes
+        circular-progress-fill-unfill-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@-webkit-keyframes
+        circular-progress-blue-fade-in-out{from{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}100%{opacity:.99}}@keyframes
+        circular-progress-blue-fade-in-out{from{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}100%{opacity:.99}}@-webkit-keyframes
+        circular-progress-red-fade-in-out{from{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}}@keyframes
+        circular-progress-red-fade-in-out{from{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}}@-webkit-keyframes
+        circular-progress-yellow-fade-in-out{from{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}}@keyframes
+        circular-progress-yellow-fade-in-out{from{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}}@-webkit-keyframes
+        circular-progress-green-fade-in-out{from{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}100%{opacity:0}}@keyframes
+        circular-progress-green-fade-in-out{from{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}100%{opacity:0}}@-webkit-keyframes
+        circular-progress-left-spin{from{-webkit-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);transform:rotate(-5deg)}to{-webkit-transform:rotate(130deg);transform:rotate(130deg)}}@keyframes
+        circular-progress-left-spin{from{-webkit-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);transform:rotate(-5deg)}to{-webkit-transform:rotate(130deg);transform:rotate(130deg)}}@-webkit-keyframes
+        circular-progress-right-spin{from{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);transform:rotate(5deg)}to{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}}@keyframes
+        circular-progress-right-spin{from{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);transform:rotate(5deg)}to{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}}@-webkit-keyframes
+        circular-progress-fade-out{from{opacity:.99}to{opacity:0}}@keyframes circular-progress-fade-out{from{opacity:.99}to{opacity:0}}.peoplekitComponentsScrollboxScrollbar{border:none;outline:none;overflow:auto}.peoplekitComponentsNoResultsMessageNoResultsMessage{color:var(--pkw-on-surface,rgb(95,99,104));padding:2em;text-align:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center}.peoplekitThemeDark
+        .peoplekitComponentsNoResultsMessageNoResultsMessage{color:var(--pkw-on-surface,rgb(154,160,166))}.peoplekitComponentsNoResultsMessageHeader{font-family:\"Google
+        Sans\",Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:500}.peopleKitStyleGm3
+        .peoplekitComponentsNoResultsMessageHeader{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:1rem;font-weight:500;letter-spacing:0;line-height:1.5rem}.peoplekitComponentsNoResultsMessageExplanation{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsNoResultsMessageExplanation{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsNoResultsMessageLearnMoreLink{color:inherit;text-decoration:underline;white-space:nowrap}.peoplekitComponentsAutocompletePopupContainer{border-width:0;-webkit-box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);background:var(--pkw-background,#fff);border-radius:4px;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;outline:2px
+        solid transparent;padding-bottom:8px;padding-top:8px;position:absolute;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;z-index:999999}.peoplekitComponentsAutocompletePopupContainer
+        .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark .peoplekitComponentsAutocompletePopupContainer{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peopleKitStyleGm3
+        .peoplekitComponentsAutocompletePopupContainer{-webkit-box-shadow:0 2px 6px
+        2px rgba(0,0,0,.15),0 1px 2px 0 rgba(0,0,0,.3);box-shadow:0 2px 6px 2px rgba(0,0,0,.15),0
+        1px 2px 0 rgba(0,0,0,.3)}.picker-api-container,.picker-iframe-container{height:100%;width:100%;position:relative}.picker-close-button{position:absolute;z-index:100;top:12px;right:14px;width:36px;height:36px;border-radius:18px;border-width:0;background-color:rgba(0,0,0,0)}.picker-close-button:hover{background-color:rgba(60,64,67,.04)}.picker-close-button:active{background-color:rgba(60,64,67,.12)}.picker-close-button-svg{fill:#616161}.content-library
+        .picker-close-button-svg{color:var(--dt-on-neutral-container,rgb(60,64,67))}.content-library
+        .picker-loading-container{position:absolute;height:100%;width:100%;background-color:var(--dt-surface-container,#fff);-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:space-evenly;-webkit-justify-content:space-evenly;justify-content:space-evenly;display:none}.content-library.loading
+        .picker-loading-container{display:-webkit-box;display:-webkit-flex;display:flex;background-color:#f0f4f9}.content-library.loading
+        .picker-iframe-container,.content-library.loaded .picker-loading-container,.content-library.loading-timed-out
+        .picker-loading-container{display:none}.goog-modalpopup,.modal-dialog{-webkit-box-shadow:0
+        4px 16px rgba(0,0,0,.2);box-shadow:0 4px 16px rgba(0,0,0,.2);background:#fff;background-clip:padding-box;border:1px
+        solid #acacac;border:1px solid rgba(0,0,0,.333);outline:0;position:absolute}.goog-modalpopup-bg,.modal-dialog-bg{background:#fff;left:0;position:absolute;top:0}div.goog-modalpopup-bg,div.modal-dialog-bg{filter:alpha(opacity=75);opacity:.75}.modal-dialog{color:#000;padding:30px
+        42px}.modal-dialog-title{background-color:#fff;color:#000;cursor:default;font-size:16px;font-weight:normal;line-height:24px;margin:0
+        0 16px}.modal-dialog-title-close{height:11px;opacity:.7;padding:17px;position:absolute;right:0;top:0;width:11px}.modal-dialog-title-close::after{content:\"\";background:url(https://ssl.gstatic.com/ui/v1/dialog/close-x.png);position:absolute;height:11px;width:11px;right:17px}.modal-dialog-title-close:hover{opacity:1}.modal-dialog-content{background-color:#fff;line-height:1.4em;word-wrap:break-word}.modal-dialog-buttons{margin-top:16px}.modal-dialog-buttons
+        button{border-radius:2px;background-color:#f5f5f5;background-image:-webkit-linear-gradient(top,#f5f5f5,#f1f1f1);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#f5f5f5),to(#f1f1f1));background-image:linear-gradient(top,#f5f5f5,#f1f1f1);border:1px
+        solid #dcdcdc;border:1px solid rgba(0,0,0,.1);color:#444;cursor:default;font-family:inherit;font-size:11px;font-weight:bold;height:29px;line-height:27px;margin:0
+        16px 0 0;min-width:72px;outline:0;padding:0 8px}.modal-dialog-buttons button:hover,.modal-dialog-buttons
+        button:active{-webkit-box-shadow:0 1px 1px rgba(0,0,0,.1);box-shadow:0 1px
+        1px rgba(0,0,0,.1);background-color:#f8f8f8;background-image:-webkit-linear-gradient(top,#f8f8f8,#f1f1f1);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#f8f8f8),to(#f1f1f1));background-image:linear-gradient(top,#f8f8f8,#f1f1f1);border:1px
+        solid #c6c6c6;color:#333}.modal-dialog-buttons button:active{-webkit-box-shadow:inset
+        0 1px 2px rgba(0,0,0,.1);box-shadow:inset 0 1px 2px rgba(0,0,0,.1)}.modal-dialog-buttons
+        button:focus{border:1px solid #4d90fe}.modal-dialog-buttons button[disabled]{-webkit-box-shadow:none;box-shadow:none;background:#fff;background-image:none;border:1px
+        solid #f3f3f3;border:1px solid rgba(0,0,0,.05);color:#b8b8b8}.modal-dialog-buttons
+        .goog-buttonset-action{background-color:#4d90fe;background-image:-webkit-linear-gradient(top,#4d90fe,#4787ed);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#4d90fe),to(#4787ed));background-image:linear-gradient(top,#4d90fe,#4787ed);border:1px
+        solid #3079ed;color:#fff}.modal-dialog-buttons .goog-buttonset-action:hover,.modal-dialog-buttons
+        .goog-buttonset-action:active{background-color:#357ae8;background-image:-webkit-linear-gradient(to
+        bottom,#4d90fe,#357ae8);background-image:-webkit-gradient(linear,left top,left
+        bottom,from(#4d90fe),to(#357ae8));background-image:-webkit-linear-gradient(top,#4d90fe,#357ae8);background-image:linear-gradient(to
+        bottom,#4d90fe,#357ae8);border:1px solid #2f5bb7;color:#fff}.modal-dialog-buttons
+        .goog-buttonset-action:active{-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,.3);box-shadow:inset
+        0 1px 2px rgba(0,0,0,.3)}.modal-dialog-buttons .goog-buttonset-action:focus{-webkit-box-shadow:inset
+        0 0 0 1px #fff;box-shadow:inset 0 0 0 1px #fff;border:1px solid #fff;border:rgba(0,0,0,0)
+        solid 1px;outline:1px solid #4d90fe;outline:rgba(0,0,0,0) 0}.modal-dialog-buttons
+        .goog-buttonset-action[disabled]{-webkit-box-shadow:none;box-shadow:none;background:#4d90fe;color:#fff;filter:alpha(opacity=50);opacity:.5}.jfk-alert,.jfk-confirm,.jfk-prompt{width:512px}.google-picker.modal-dialog{background-color:var(--dt-background,#fff);border:none;padding:0;-webkit-transition:top
+        .5s ease-in-out;transition:top .5s ease-in-out;z-index:1004;border-radius:8px;-webkit-box-shadow:0
+        4px 8px 3px rgba(60,64,67,.15),0 1px 3px rgba(60,64,67,.3);box-shadow:0 4px
+        8px 3px rgba(60,64,67,.15),0 1px 3px rgba(60,64,67,.3);overflow:hidden;right:auto;bottom:auto}.google-picker.modal-dialog
+        .picker-close-button{top:20px;right:18px}.google-picker.modal-dialog-bg{background-color:var(--dt-scrim,rgba(32,33,36,.6));z-index:1003;border:none;bottom:auto;right:auto}.google-picker.transparent-picker.modal-dialog{background-color:transparent;border:none;-webkit-box-shadow:none;box-shadow:none;padding:0}.google-picker.transparent-picker.modal-dialog-content{background-color:transparent}.note-card
+        .ql-indent-1:not(.ql-direction-rtl){-webkit-margin-start:27px;margin-inline-start:27px}.note-card
+        .ql-indent-1.ql-direction-rtl.ql-align-right{-webkit-margin-end:27px;margin-inline-end:27px}.note-card
+        li.ql-indent-1.ql-direction-rtl.ql-align-right{-webkit-margin-end:40px;margin-inline-end:40px}.note-card
+        li.ql-indent-1:not(.ql-direction-rtl){-webkit-margin-start:40px;margin-inline-start:40px}.note-card
+        .ql-indent-2:not(.ql-direction-rtl){-webkit-margin-start:54px;margin-inline-start:54px}.note-card
+        .ql-indent-2.ql-direction-rtl.ql-align-right{-webkit-margin-end:54px;margin-inline-end:54px}.note-card
+        li.ql-indent-2.ql-direction-rtl.ql-align-right{-webkit-margin-end:80px;margin-inline-end:80px}.note-card
+        li.ql-indent-2:not(.ql-direction-rtl){-webkit-margin-start:80px;margin-inline-start:80px}.note-card
+        .ql-indent-3:not(.ql-direction-rtl){-webkit-margin-start:81px;margin-inline-start:81px}.note-card
+        .ql-indent-3.ql-direction-rtl.ql-align-right{-webkit-margin-end:81px;margin-inline-end:81px}.note-card
+        li.ql-indent-3.ql-direction-rtl.ql-align-right{-webkit-margin-end:120px;margin-inline-end:120px}.note-card
+        li.ql-indent-3:not(.ql-direction-rtl){-webkit-margin-start:120px;margin-inline-start:120px}.note-card
+        .ql-indent-4:not(.ql-direction-rtl){-webkit-margin-start:108px;margin-inline-start:108px}.note-card
+        .ql-indent-4.ql-direction-rtl.ql-align-right{-webkit-margin-end:108px;margin-inline-end:108px}.note-card
+        li.ql-indent-4.ql-direction-rtl.ql-align-right{-webkit-margin-end:160px;margin-inline-end:160px}.note-card
+        li.ql-indent-4:not(.ql-direction-rtl){-webkit-margin-start:160px;margin-inline-start:160px}.note-card
+        .ql-indent-5:not(.ql-direction-rtl){-webkit-margin-start:135px;margin-inline-start:135px}.note-card
+        .ql-indent-5.ql-direction-rtl.ql-align-right{-webkit-margin-end:135px;margin-inline-end:135px}.note-card
+        li.ql-indent-5.ql-direction-rtl.ql-align-right{-webkit-margin-end:200px;margin-inline-end:200px}.note-card
+        li.ql-indent-5:not(.ql-direction-rtl){-webkit-margin-start:200px;margin-inline-start:200px}.note-card
+        .ql-indent-6:not(.ql-direction-rtl){-webkit-margin-start:162px;margin-inline-start:162px}.note-card
+        .ql-indent-6.ql-direction-rtl.ql-align-right{-webkit-margin-end:162px;margin-inline-end:162px}.note-card
+        li.ql-indent-6.ql-direction-rtl.ql-align-right{-webkit-margin-end:240px;margin-inline-end:240px}.note-card
+        li.ql-indent-6:not(.ql-direction-rtl){-webkit-margin-start:240px;margin-inline-start:240px}.note-card
+        .ql-indent-7:not(.ql-direction-rtl){-webkit-margin-start:189px;margin-inline-start:189px}.note-card
+        .ql-indent-7.ql-direction-rtl.ql-align-right{-webkit-margin-end:189px;margin-inline-end:189px}.note-card
+        li.ql-indent-7.ql-direction-rtl.ql-align-right{-webkit-margin-end:280px;margin-inline-end:280px}.note-card
+        li.ql-indent-7:not(.ql-direction-rtl){-webkit-margin-start:280px;margin-inline-start:280px}.note-card
+        .ql-indent-8:not(.ql-direction-rtl){-webkit-margin-start:216px;margin-inline-start:216px}.note-card
+        .ql-indent-8.ql-direction-rtl.ql-align-right{-webkit-margin-end:216px;margin-inline-end:216px}.note-card
+        li.ql-indent-8.ql-direction-rtl.ql-align-right{-webkit-margin-end:320px;margin-inline-end:320px}.note-card
+        li.ql-indent-8:not(.ql-direction-rtl){-webkit-margin-start:320px;margin-inline-start:320px}.note-card
+        .ql-indent-9:not(.ql-direction-rtl){-webkit-margin-start:243px;margin-inline-start:243px}.note-card
+        .ql-indent-9.ql-direction-rtl.ql-align-right{-webkit-margin-end:243px;margin-inline-end:243px}.note-card
+        li.ql-indent-9.ql-direction-rtl.ql-align-right{-webkit-margin-end:360px;margin-inline-end:360px}.note-card
+        li.ql-indent-9:not(.ql-direction-rtl){-webkit-margin-start:360px;margin-inline-start:360px}:where(:root):root{--icon-secondary:#545d7e;--on-surface-de-emphasis:#545d7e;--on-surface-emphasis:#001d35;--surface-container-high:#d3e3fd;--surface-container:#ebf1ff;--internal-only-debug-background:#f26722;--scrollbar-thumb-background:#dde1eb;--scrollbar-track:#d6dbe2;--v2-action-chip-text-color:#202124;--v2-chat-background:rgba(31,31,31,0.12);--v2-chat-blur:blur(30px);--v2-chat-save-note:#e9edf3;--v2-chip-alternative-border:#fff;--v2-divider:#d6dbe2;--v2-dynamic-action-chip-background-color:#abc8fa;--v2-icon-primary:#abc8fa;--v2-icon-secondary-variant:#ffa500;--v2-icon-secondary:#404144;--v2-link-primary:#1b4b9f;--v2-note-border:#dde1eb;--v2-note-citation-on-surface:#47484c;--v2-note-citation-surface:rgba(31,31,31,0.1215686275);--v2-note-citation-warning-on-surface:#fcdf47;--v2-note-citation-warning-surface:rgb(251,188,4);--v2-note-on-saved:#6ea2ff;--v2-note-on-written:#2ba640;--v2-note-pin-background:#5f5d6c;--v2-note-saved:#f2f6fa;--v2-note-text:#131314;--v2-note-written:#f2f6fa;--v2-on-primary:#1f1f1f;--v2-on-source-guide:#234776;--v2-on-source-viewer:#1f1f1f;--v2-on-surface-de-emphasis:#535559;--v2-on-surface-deep-de-emphasis:#585b60;--v2-on-surface-emphasis:#1f1f1f;--v2-on-surface:#47484c;--v2-on-tooltip:#fff;--v2-primary:#abc8fa;--v2-project-button-action-button-border:#8c8c8c;--v2-project-button-emoji-background-color:#fff;--v2-settings-button-background:#eef0f1;--v2-share-button-background:#c2e7ff;--v2-source-error-hover:#ff9a98;--v2-source-error:#ffcccb;--v2-source-guide-chip-text:#234776;--v2-source-guide-chip:rgba(35,71,118,0.15);--v2-source-guide-label:#234776;--v2-source-guide-text:#47484c;--v2-source-guide:#d6e5ff;--v2-source-viewer:#fff;--v2-surface-container-high:#e3e8ee;--v2-surface-container-low:#cdd2d9;--v2-surface-container-variant:#e5ebf2;--v2-surface-container:#dce1e8;--v2-surface:#f7fbff;--v2-table-border-color:#cdd2d9;--v2-text-highlighter:#eadef9;--v2-tooltip:#347af2;--v3-action-button-text-color:#5f6368;--v3-advanced-settings-border-color:#c4c7c5;--v3-analytics-dashboard-card-color:#f2f4f7;--v3-analytics-icon-background-end:rgba(217,101,112,0.3);--v3-analytics-icon-background-middle:rgba(155,114,203,0.3);--v3-analytics-icon-background-start:rgba(66,133,244,0.3);--v3-analytics-icon-color:#234776;--v3-audio-button-background:#c6d5f4;--v3-audio-overview-icon-background:#ebf1fd;--v3-black:#252526;--v3-chat-container-inset-shadow:#dee3ea;--v3-code-background-color:#c4c7c5;--v3-code-color:#282a2c;--v3-configure-settings-description-text-color:#666;--v3-configure-settings-entrypoint-button-color:#141415;--v3-configure-settings-save-background-color:#e4eaf3;--v3-create-new-homepage-plus-update-background:#000;--v3-create-new-homepage-plus-update-onboarding-splash-background:#fff;--v3-create-new-homepage-plus-update-onboarding-splash-icon-background:#edeffa;--v3-create-new-homepage-plus-update-onboarding-splash-text-color:#4a4b4d;--v3-create-new-homepage-plus-update-text-color:#fff;--v3-customize-guidebooks-border-color:rgba(0,0,0,0.2);--v3-customize-guidebooks-option-background:#f2f4f7;--v3-follow-up-button-background:#dce1e8;--v3-homepage-empty-project-icon-color:#4259ff;--v3-image-source-icon-color:#db372d;--v3-inline-citation-background-color:#d7d6dd;--v3-inline-citation-color:#5d6172;--v3-manage-guidebooks-tab-label-color:#065fd4;--v3-mindmap-button-color:#802272;--v3-mindmap-dialog-background:#fff;--v3-mindmap-zoom-background:#edeffa;--v3-mindmap-zoom-border-color:#dde1eb;--v3-mindmap-zoom-box-shadow:rgba(0,0,0,0.2);--v3-note-editor-background:#fff;--v3-note-editor-border-color:#dde1eb;--v3-note-header-background:#f2f6fa;--v3-note-header-chip:rgba(218,220,224,0.16);--v3-notebook-guide-background:#fff;--v3-notebook-guide-button-color:#4966ff;--v3-notebook-guide-error-text-color:#7f7f7f;--v3-notebook-guide-generate-button-background-disabled:#e0e0e0;--v3-notebook-guide-generate-button-background-hover:#b8bdc6;--v3-notebook-guide-generate-button-background:#eff2f7;--v3-notebook-guide-generate-button-text-color:#234776;--v3-notebook-guide-generate-icon-color:#000;--v3-notebook-guide-idea-icon-disabled-color:#a4a4a4;--v3-notebook-guide-text-color:#47484c;--v3-notebook-guide-trigger-button-color:#3885ef;--v3-onboarding-splash-background:#fff;--v3-onboarding-splash-icon-bg-border-color:rgba(0,0,0,0.2);--v3-onboarding-splash-icon-bg:rgba(234,234,234,0.4);--v3-pdf-source-icon-color:#ea4335;--v3-pill-border-color:#dde1eb;--v3-pill-selected-background:#edeffa;--v3-pro-badge-homepage-background:#f0f4f9;--v3-pro-badge-notebook-background:#fff;--v3-pro-badge-text-color:#575b5f;--v3-scroll-carousel-button-color:#fff;--v3-see-all-notebooks-label-color:#1b1b1c;--v3-share-dialog-icon-background:#f2f4f7;--v3-share-dialog-icon-color:#4a4b4d;--v3-share-dialog-public-access-icon-background:#e1f1e5;--v3-share-dialog-public-access-icon-color:#0f5223;--v3-share-dialog-subheader-color:#252526;--v3-share-form-border-color:#dde1eb;--v3-share-form-description-color:#5f6368;--v3-sheets-source-icon-color:#34a853;--v3-shimmer-color:#c6d5f4;--v3-slides-source-icon-color:#fbbc05;--v3-source-guide-er-disclaimer-background:rgb(229,213,244);--v3-source-icon-color:#71a5ff;--v3-three-panel-action-background:#4259ff;--v3-three-panel-action-text-color:#f7fbff;--v3-three-panel-toggle-track-color:#edeffa;--v3-upload-files-button-background:#fff;--v3-upload-sources-text:#909090;--v3-youtube-source-icon-color:#f00}.dark-theme{--icon-secondary:#c3c6d6;--on-surface-de-emphasis:#c3c6d6;--on-surface-emphasis:#eef0ff;--surface-container-high:#3a3f50;--surface-container:#2c303d;--internal-only-debug-background:#f26722;--mat-snack-bar-button-color:#e3e3e3;--primary-neutral:#a8c7fa;--scrollbar-thumb-background:rgba(255,255,255,0.1);--scrollbar-track:#1f1f1f;--v2-action-chip-text-color:#202124;--v2-chat-background:rgba(31,31,31,0.5);--v2-chat-blur:blur(60px);--v2-chat-save-note:#2a2a2a;--v2-chip-alternative-border:rgb(218,220,224);--v2-divider:#28292a;--v2-dynamic-action-chip-background-color:#abc8fa;--v2-icon-primary:#fff;--v2-icon-secondary-variant:#9aa0a6;--v2-icon-secondary:#e8eaed;--v2-link-primary:var(--v2-primary);--v2-note-border:#37383b;--v2-note-citation-on-surface:#9e9e9e;--v2-note-citation-surface:#1f1f1f;--v2-note-citation-warning-on-surface:#fcdf47;--v2-note-citation-warning-surface:rgba(251,188,4,0.6);--v2-note-on-saved:#8ab4f8;--v2-note-on-written:#2ba640;--v2-note-pin-background:#5f5d6c;--v2-note-saved:#333438;--v2-note-text:#e8e8e8;--v2-note-written:#333438;--v2-on-primary:#1f1f1f;--v2-on-source-guide:#234776;--v2-on-source-viewer:#fff;--v2-on-surface-de-emphasis:#bdc1c6;--v2-on-surface-deep-de-emphasis:#9aa0a6;--v2-on-surface-emphasis:#fff;--v2-on-surface:#e8eaed;--v2-on-tooltip:#1f1f1f;--v2-primary:#abc8fa;--v2-project-button-action-button-border:#404144;--v2-project-button-emoji-background-color:#1f1f1f;--v2-settings-button-background:#9a9a9a;--v2-share-button-background:#c2e7ff;--v2-source-error-hover:#f00;--v2-source-error:#ff4c4c;--v2-source-guide-chip-text:#abc8fa;--v2-source-guide-chip:rgba(209,229,255,0.15);--v2-source-guide-label:#abc8fa;--v2-source-guide-text:#c0d6f2;--v2-source-guide:#1a1d22;--v2-source-viewer:#333435;--v2-surface-container-high:#131314;--v2-surface-container-low:#28292a;--v2-surface-container-variant:#404144;--v2-surface-container:#333435;--v2-surface:#1f1f1f;--v2-table-border-color:#e8eaed;--v2-text-highlighter:#61597b;--v2-tooltip:#71a5ff;--v3-action-button-text-color:#e8eaed;--v3-advanced-settings-border-color:#404144;--v3-analytics-dashboard-card-color:#22262b;--v3-analytics-icon-background-end:rgba(217,101,112,0.7);--v3-analytics-icon-background-middle:rgba(155,114,203,0.7);--v3-analytics-icon-background-start:rgba(66,133,244,0.7);--v3-analytics-icon-color:#dde1eb;--v3-audio-button-background:#1a73e8;--v3-audio-overview-icon-background:#393b3e;--v3-black:#e6e6e6;--v3-chat-container-inset-shadow:#000;--v3-code-background-color:#282a2c;--v3-code-color:#c4c7c5;--v3-configure-settings-description-text-color:#d4d4d4;--v3-configure-settings-entrypoint-button-color:#f7fbff;--v3-configure-settings-save-background-color:#1f1f1f;--v3-create-new-homepage-plus-update-background:#e6e6e6;--v3-create-new-homepage-plus-update-onboarding-splash-background:#1a1d22;--v3-create-new-homepage-plus-update-onboarding-splash-icon-background:#262b41;--v3-create-new-homepage-plus-update-onboarding-splash-text-color:#b3b3b3;--v3-create-new-homepage-plus-update-text-color:#1a1d22;--v3-customize-guidebooks-border-color:rgba(0,0,0,0.2);--v3-customize-guidebooks-option-background:#9a9a9a;--v3-follow-up-button-background:#3b3f47;--v3-homepage-empty-project-icon-color:#c3caff;--v3-image-source-icon-color:#db372d;--v3-inline-citation-background-color:#484b54;--v3-inline-citation-color:#d3daff;--v3-manage-guidebooks-tab-label-color:#c2e7ff;--v3-mindmap-button-color:#f0cceb;--v3-mindmap-dialog-background:#333438;--v3-mindmap-zoom-background:#262b41;--v3-mindmap-zoom-border-color:#37383b;--v3-mindmap-zoom-box-shadow:rgba(0,0,0,0.2);--v3-note-editor-background:#333438;--v3-note-editor-border-color:#37383b;--v3-note-header-background:#46484e;--v3-note-header-chip:rgba(218,220,224,0.16);--v3-notebook-guide-background:#252525;--v3-notebook-guide-button-color:#6cb7fc;--v3-notebook-guide-error-text-color:#cbcbcb;--v3-notebook-guide-generate-button-background-disabled:#2e2f31;--v3-notebook-guide-generate-button-background-hover:#454950;--v3-notebook-guide-generate-button-background:#3b3f47;--v3-notebook-guide-generate-button-text-color:#fff;--v3-notebook-guide-generate-icon-color:#d6dce6;--v3-notebook-guide-idea-icon-disabled-color:#737477;--v3-notebook-guide-text-color:#d6dce6;--v3-notebook-guide-trigger-button-color:#3885ef;--v3-onboarding-splash-background:rgb(43,43,43);--v3-onboarding-splash-icon-bg-border-color:#fff;--v3-onboarding-splash-icon-bg:rgba(234,234,234,0.1);--v3-pdf-source-icon-color:#ea4335;--v3-pill-border-color:#37383b;--v3-pill-selected-background:#2f334b;--v3-pro-badge-homepage-background:#282a2c;--v3-pro-badge-notebook-background:#22262b;--v3-pro-badge-text-color:#a2a9b0;--v3-scroll-carousel-button-color:#1a1d22;--v3-see-all-notebooks-label-color:#f2f2f2;--v3-share-dialog-icon-background:#22262b;--v3-share-dialog-icon-color:#b3b3b3;--v3-share-dialog-public-access-icon-background:#e1f1e5;--v3-share-dialog-public-access-icon-color:#0f5223;--v3-share-dialog-subheader-color:#e6e6e6;--v3-share-form-border-color:#37383b;--v3-share-form-description-color:#9aa0a6;--v3-shimmer-color:#1a73e8;--v3-slides-source-icon-color:#fbbc05;--v3-source-guide-er-disclaimer-background:#28292a;--v3-source-icon-color:#71a5ff;--v3-three-panel-action-background:#4259ff;--v3-three-panel-action-text-color:#f7fbff;--v3-three-panel-toggle-track-color:#dde1eb;--v3-upload-files-button-background:#333232;--v3-upload-sources-text:#909090;--v3-youtube-source-icon-color:#f00}html,body{isolation:isolate;margin-block:0;margin-inline:0;block-size:100%}::-webkit-scrollbar{inline-size:12px}::-webkit-scrollbar-corner{background:transparent}::-webkit-scrollbar-thumb{background-color:var(--scrollbar-thumb-background);border-start-start-radius:20px;border-start-end-radius:20px;border-end-start-radius:20px;border-end-end-radius:20px;border-block:3px
+        solid transparent;border-inline:3px solid transparent;background-clip:content-box}.boqOnegoogleliteOgbOneGoogleBar{position:absolute;inset-inline-end:.5rem;block-size:4rem;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;z-index:999}strong{font-weight:600}.rounded-bottom-sheet
+        mat-bottom-sheet-container{border-start-start-radius:1rem;border-start-end-radius:1rem}.bottom-sheet-overflow-hidden
+        mat-bottom-sheet-container{overflow:hidden}h1,.mat-display-large{font:var(--mat-sys-display-large);letter-spacing:var(--mat-sys-display-large-tracking);margin-inline:0;margin-block:0
+        .5em}h2,.mat-display-medium{font:var(--mat-sys-display-medium);letter-spacing:var(--mat-sys-display-medium-tracking);margin-inline:0;margin-block:0
+        .5em}h3,.mat-display-small{font:var(--mat-sys-display-small);letter-spacing:var(--mat-sys-display-small-tracking);margin-inline:0;margin-block:0
+        .5em}h4,.mat-headline-large{font:var(--mat-sys-headline-large);letter-spacing:var(--mat-sys-headline-large-tracking);margin-inline:0;margin-block:0
+        .5em}h5,.mat-headline-medium{font:var(--mat-sys-headline-medium);letter-spacing:var(--mat-sys-headline-medium-tracking);margin-inline:0;margin-block:0
+        .5em}h6,.mat-headline-small{font:var(--mat-sys-headline-small);letter-spacing:var(--mat-sys-headline-small-tracking);margin-inline:0;margin-block:0
+        .5em}.mat-title-xlarge{font:var(--mat-sys-title-large);letter-spacing:var(--mat-sys-title-large-tracking);font-size:1.75rem;line-height:2.25rem}.mat-title-large{font:var(--mat-sys-title-large);letter-spacing:var(--mat-sys-title-large-tracking);line-height:2.25rem}.mat-title-medium{font:var(--mat-sys-title-medium);letter-spacing:var(--mat-sys-title-medium-tracking);line-height:2rem;font-weight:500}.mat-title-small{font:var(--mat-sys-title-small);letter-spacing:var(--mat-sys-title-small-tracking);line-height:1.5rem;font-weight:500}.mat-body-large{font:var(--mat-sys-body-large);letter-spacing:var(--mat-sys-body-large-tracking)}.mat-body-large
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-medium{font:var(--mat-sys-body-medium);letter-spacing:var(--mat-sys-body-medium-tracking);line-height:1.5rem}.mat-body-medium
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-medium-condensed{font:var(--mat-sys-body-medium);letter-spacing:var(--mat-sys-body-medium-tracking)}.mat-body-medium-condensed
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-small{font:var(--mat-sys-body-small);letter-spacing:var(--mat-sys-body-small-tracking);line-height:1.25rem}.mat-body-small
+        p{margin-inline:0;margin-block:0 .75em}.mat-label-xlarge{font:var(--mat-sys-label-large);letter-spacing:var(--mat-sys-label-large-tracking);font-size:1rem;line-height:1.5rem;font-weight:500}.mat-label-large{font:var(--mat-sys-label-large);letter-spacing:var(--mat-sys-label-large-tracking);font-weight:400}.mat-label-medium{font:var(--mat-sys-label-medium);letter-spacing:var(--mat-sys-label-medium-tracking)}.mat-label-small{font:var(--mat-sys-label-small);letter-spacing:var(--mat-sys-label-small-tracking)}:where(:root):root{--xap-color-surface:var(--mat-sys-surface);--xap-color-on-surface:var(--mat-sys-on-surface);background:var(--mat-sys-background);color:var(--mat-sys-on-background);--mat-sys-background:#fff;--mat-sys-error:#b3261e;--mat-sys-error-container:#f9dedc;--mat-sys-inverse-on-surface:#f2f2f2;--mat-sys-inverse-primary:#a8c7fa;--mat-sys-inverse-surface:#303030;--mat-sys-on-background:#1f1f1f;--mat-sys-on-error:#fff;--mat-sys-on-error-container:#8c1d18;--mat-sys-on-primary:#fff;--mat-sys-on-primary-container:#0842a0;--mat-sys-on-primary-fixed:#041e49;--mat-sys-on-primary-fixed-variant:#0842a0;--mat-sys-on-secondary:#fff;--mat-sys-on-secondary-container:#004a77;--mat-sys-on-secondary-fixed:#001d35;--mat-sys-on-secondary-fixed-variant:#004a77;--mat-sys-on-surface:#1f1f1f;--mat-sys-on-surface-variant:#444746;--mat-sys-on-tertiary:#fff;--mat-sys-on-tertiary-container:#0842a0;--mat-sys-on-tertiary-fixed:#041e49;--mat-sys-on-tertiary-fixed-variant:#0842a0;--mat-sys-outline:#747775;--mat-sys-outline-variant:#c4c7c5;--mat-sys-primary:#0b57d0;--mat-sys-primary-container:#d3e3fd;--mat-sys-primary-fixed:#d3e3fd;--mat-sys-primary-fixed-dim:#a8c7fa;--mat-sys-scrim:#000;--mat-sys-secondary:#00639b;--mat-sys-secondary-container:#c2e7ff;--mat-sys-secondary-fixed:#c2e7ff;--mat-sys-secondary-fixed-dim:#7fcfff;--mat-sys-shadow:#000;--mat-sys-surface:#fff;--mat-sys-surface-bright:#fff;--mat-sys-surface-container:#f0f4f9;--mat-sys-surface-container-high:#e9eef6;--mat-sys-surface-container-highest:#dde3ea;--mat-sys-surface-container-low:#f8fafd;--mat-sys-surface-container-lowest:#fff;--mat-sys-surface-dim:#d3dbe5;--mat-sys-surface-tint:#6991d6;--mat-sys-surface-variant:#e1e3e1;--mat-sys-tertiary:#0b57d0;--mat-sys-tertiary-container:#d3e3fd;--mat-sys-tertiary-fixed:#d3e3fd;--mat-sys-tertiary-fixed-dim:#a8c7fa;--mat-sys-info:#1157ce;--mat-sys-on-info:#fff;--mat-sys-info-container:#d0e4ff;--mat-sys-on-info-container:#04409f;--mat-sys-success:#006c35;--mat-sys-on-success:#fff;--mat-sys-success-container:#beefbb;--mat-sys-on-success-container:#00522c;--mat-sys-warning:#8f4e06;--mat-sys-on-warning:#fff;--mat-sys-warning-container:#ffe07c;--mat-sys-on-warning-container:#6d3a01;--mat-sys-link:#1157ce;--mat-sys-link-hover:#04409f;--mat-sys-link-visited:#7438d2;--mat-sys-neutral-variant20:#2d312f;--mat-sys-neutral10:#1f1f1f;--mat-sys-level0:0px
+        0px 0px 0px rgba(0,0,0,0.2),0px 0px 0px 0px rgba(0,0,0,0.14),0px 0px 0px 0px
+        rgba(0,0,0,0.12);--mat-sys-level1:0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px
+        1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);--mat-sys-level2:0px
+        3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px
+        0px rgba(0,0,0,0.12);--mat-sys-level3:0px 3px 5px -1px rgba(0,0,0,0.2),0px
+        6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);--mat-sys-level4:0px
+        5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px
+        2px rgba(0,0,0,0.12);--mat-sys-level5:0px 7px 8px -4px rgba(0,0,0,0.2),0px
+        12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);--mat-sys-body-large:400
+        1rem/1.5rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-large-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-large-line-height:1.5rem;--mat-sys-body-large-size:1rem;--mat-sys-body-large-tracking:0;--mat-sys-body-large-weight:400;--mat-sys-body-medium:400
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-medium-line-height:1.25rem;--mat-sys-body-medium-size:0.875rem;--mat-sys-body-medium-tracking:0;--mat-sys-body-medium-weight:400;--mat-sys-body-small:400
+        0.75rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-small-line-height:1rem;--mat-sys-body-small-size:0.75rem;--mat-sys-body-small-tracking:0.006rem;--mat-sys-body-small-weight:400;--mat-sys-display-large:400
+        3.562rem/4rem Google Sans;--mat-sys-display-large-font:Google Sans;--mat-sys-display-large-line-height:4rem;--mat-sys-display-large-size:3.562rem;--mat-sys-display-large-tracking:0;--mat-sys-display-large-weight:400;--mat-sys-display-medium:400
+        2.812rem/3.25rem Google Sans;--mat-sys-display-medium-font:Google Sans;--mat-sys-display-medium-line-height:3.25rem;--mat-sys-display-medium-size:2.812rem;--mat-sys-display-medium-tracking:0;--mat-sys-display-medium-weight:400;--mat-sys-display-small:400
+        2.25rem/2.75rem Google Sans;--mat-sys-display-small-font:Google Sans;--mat-sys-display-small-line-height:2.75rem;--mat-sys-display-small-size:2.25rem;--mat-sys-display-small-tracking:0;--mat-sys-display-small-weight:400;--mat-sys-headline-large:400
+        2rem/2.5rem Google Sans;--mat-sys-headline-large-font:Google Sans;--mat-sys-headline-large-line-height:2.5rem;--mat-sys-headline-large-size:2rem;--mat-sys-headline-large-tracking:0;--mat-sys-headline-large-weight:400;--mat-sys-headline-medium:400
+        1.75rem/2.25rem Google Sans;--mat-sys-headline-medium-font:Google Sans;--mat-sys-headline-medium-line-height:2.25rem;--mat-sys-headline-medium-size:1.75rem;--mat-sys-headline-medium-tracking:0;--mat-sys-headline-medium-weight:400;--mat-sys-headline-small:400
+        1.5rem/2rem Google Sans;--mat-sys-headline-small-font:Google Sans;--mat-sys-headline-small-line-height:2rem;--mat-sys-headline-small-size:1.5rem;--mat-sys-headline-small-tracking:0;--mat-sys-headline-small-weight:400;--mat-sys-label-large:500
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-large-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-large-line-height:1.25rem;--mat-sys-label-large-size:0.875rem;--mat-sys-label-large-tracking:0;--mat-sys-label-large-weight:500;--mat-sys-label-large-weight-prominent:700;--mat-sys-label-medium:500
+        0.75rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-medium-line-height:1rem;--mat-sys-label-medium-size:0.75rem;--mat-sys-label-medium-tracking:0.006rem;--mat-sys-label-medium-weight:500;--mat-sys-label-medium-weight-prominent:700;--mat-sys-label-small:500
+        0.688rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-small-line-height:1rem;--mat-sys-label-small-size:0.688rem;--mat-sys-label-small-tracking:0.006rem;--mat-sys-label-small-weight:500;--mat-sys-title-large:400
+        1.375rem/1.75rem Google Sans;--mat-sys-title-large-font:Google Sans;--mat-sys-title-large-line-height:1.75rem;--mat-sys-title-large-size:1.375rem;--mat-sys-title-large-tracking:0;--mat-sys-title-large-weight:400;--mat-sys-title-medium:500
+        1rem/1.5rem Google Sans Text,Google Sans,sans-serif;--mat-sys-title-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-title-medium-line-height:1.5rem;--mat-sys-title-medium-size:1rem;--mat-sys-title-medium-tracking:0;--mat-sys-title-medium-weight:500;--mat-sys-title-small:500
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-title-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-title-small-line-height:1.25rem;--mat-sys-title-small-size:0.875rem;--mat-sys-title-small-tracking:0;--mat-sys-title-small-weight:500;--mat-sys-corner-extra-large:28px;--mat-sys-corner-extra-large-top:28px
+        28px 0 0;--mat-sys-corner-extra-small:4px;--mat-sys-corner-extra-small-top:4px
+        4px 0 0;--mat-sys-corner-full:9999px;--mat-sys-corner-large:16px;--mat-sys-corner-large-end:0
+        16px 16px 0;--mat-sys-corner-large-start:16px 0 0 16px;--mat-sys-corner-large-top:16px
+        16px 0 0;--mat-sys-corner-medium:12px;--mat-sys-corner-none:0;--mat-sys-corner-small:8px;--mat-sys-dragged-state-layer-opacity:0.16;--mat-sys-focus-state-layer-opacity:0.12;--mat-sys-hover-state-layer-opacity:0.08;--mat-sys-pressed-state-layer-opacity:0.12;--nlm-grey-0:#000;--nlm-grey-5:undefined;--nlm-grey-10:#1b1b1c;--nlm-grey-20:#303030;--nlm-grey-30:#474747;--nlm-grey-40:#5e5e5e;--nlm-grey-50:#777;--nlm-grey-60:#919191;--nlm-grey-70:#ababab;--nlm-grey-80:#c7c7c7;--nlm-grey-90:#e3e3e3;--nlm-grey-95:#f2f2f2;--nlm-grey-98:#f9f9f9;--nlm-grey-99:undefined;--nlm-grey-100:#fff;--nlm-blue-0:undefined;--nlm-blue-2:#17181c;--nlm-blue-5:#1d1e26;--nlm-blue-10:#232740;--nlm-blue-20:#2a3163;--nlm-blue-30:#2f3a8e;--nlm-blue-40:#384acf;--nlm-blue-50:#4259ff;--nlm-blue-60:#596cf7;--nlm-blue-70:#7c8bf3;--nlm-blue-80:#94a0f4;--nlm-blue-90:#c3cafc;--nlm-blue-95:#dbdfff;--nlm-blue-98:#edeffa;--nlm-blue-99:undefined;--nlm-blue-100:#fff;--nlm-green-0:undefined;--nlm-green-5:undefined;--nlm-green-10:undefined;--nlm-green-20:undefined;--nlm-green-30:undefined;--nlm-green-40:undefined;--nlm-green-50:#45ec6d;--nlm-green-60:#6df88e;--nlm-green-70:#9efab4;--nlm-green-80:#cefdd9;--nlm-green-90:undefined;--nlm-green-95:undefined;--nlm-green-98:undefined;--nlm-green-99:undefined;--nlm-green-100:#fff;--nlm-brand-black:#000;--nlm-brand-white:#fff;--nlm-brand-green:#45ec6d;--nlm-brand-blue:#4259ff;--nlm-brand-dark-blue:#2f334b;--nlm-red-50:#db372d;--nlm-ctas-buttons-primary:var(--nlm-blue-50);--nlm-ctas-buttons-tertiary:var(--nlm-fills-surface-panel);--nlm-text-cta-text-primary:var(--nlm-brand-white);--nlm-text-cta-text-secondary:var(--nlm-fills-surface-landing);--nlm-text-cta-text-tertiary:var(--nlm-text-titles-and-labels);--nlm-icons-default:var(--nlm-text-titles-and-labels);--nlm-icons-blue:#3271ea;--nlm-icons-yellow:#fcbd00;--nlm-icons-red:#f55e57;--nlm-icons-pink:#b741ff;--nlm-states-on-tertiary-hover:rgba(66,89,255,0.08);--nlm-states-on-tertiary-focus:rgba(66,89,255,0.1);--nlm-pastel-purple:#edeffa;--nlm-pastel-green:#e1f1e5;--nlm-pastel-yellow:#f2f2e8;--nlm-pastel-orange:#f7edeb;--nlm-pastel-pink:#f0e9ef;--nlm-pastel-blue:#e7f0fa;--nlm-fills-surface-panel:var(--nlm-brand-white);--nlm-fills-surface-panel-transparent-70:rgba(255,255,255,0.7);--nlm-fills-surface-panel-transparent-80:rgba(255,255,255,0.8);--nlm-fills-surface-page:var(--nlm-blue-98);--nlm-fills-surface-page-grey:var(--nlm-grey-98);--nlm-fills-surface-landing:var(--nlm-brand-white);--nlm-fills-ui-blue-fill:var(--nlm-blue-98);--nlm-fills-ui-grey-fill:var(--nlm-grey-95);--nlm-fills-ui-light-grey-fill:var(--nlm-grey-98);--nlm-fills-x-icon:#f2f4f7;--nlm-fills-scrim:rgba(0,0,0,0.32);--nlm-ctas-buttons-secondary:var(--nlm-brand-black);--nlm-ctas-buttons-pill:var(--nlm-blue-98);--nlm-text-secondary-text:var(--nlm-grey-40);--nlm-text-titles-and-labels:var(--nlm-grey-10);--nlm-text-body-text:var(--nlm-grey-20);--nlm-text-ghost-text:var(--nlm-grey-50);--nlm-stroke-default:#dde1eb;--nlm-stroke-focus:var(--nlm-grey-60);--nlm-strong-focus-indicator:var(--nlm-ctas-buttons-primary);--nlm-states-on-primary-hover:rgba(0,0,0,0.08);--nlm-states-on-primary-focus:rgba(0,0,0,0.1);--nlm-states-on-secondary-hover:rgba(255,255,255,0.08);--nlm-states-on-secondary-focus:rgba(255,255,255,0.1);--nlm-states-surface-panel-0:rgba(255,255,255,0);--nlm-states-tile-edit-button-hover:rgba(0,0,0,0.16);--nlm-states-tile-edit-button-focus:rgba(0,0,0,0.18);--nlm-tiles-blue:#edeffa;--nlm-tiles-cyan:#def1f7;--nlm-tiles-pink:#f0e9ef;--nlm-tiles-green:#e1f1e5;--nlm-tiles-yellow:#f2f2e8;--nlm-tiles-orange:#f7edeb;--nlm-tiles-grey:#f2f2f2;--nlm-tiles-on-blue:#224484;--nlm-tiles-on-cyan:#056a95;--nlm-tiles-on-pink:#802272;--nlm-tiles-on-green:#0f5223;--nlm-tiles-on-yellow:#796731;--nlm-tiles-on-orange:#8c2e2a;--nlm-tiles-on-grey:#f2f2f2;--nlm-tiles-on-blue-opacity:rgba(34,68,132,0.08);--nlm-tiles-on-green-opacity:rgba(15,82,35,0.08);--nlm-tiles-on-pink-opacity:rgba(128,34,114,0.08);--nlm-tiles-on-yellow-opacity:rgba(121,103,49,0.08);--nlm-tiles-on-orange-opacity:rgba(140,46,42,0.08);--nlm-tiles-on-grey-opacity:rgba(242,242,242,0.08);--nlm-tiles-on-cyan-opacity:rgba(26,81,99,0.08);--nlm-brand-light-blue:#edeffa;--nlm-loading-shimmer-highlight:#edeffa;--nlm-loading-shimmer-general:transparent;--mat-focus-indicator-border-color:var(--nlm-strong-focus-indicator);--mat-focus-indicator-display:block;--mat-sys-background:var(--nlm-fills-surface-landing);--mat-sys-on-background:var(--nlm-text-body-text);--mat-dialog-container-max-width:90vw;--mat-dialog-container-shape:1rem}:where(:root):root
+        .mat-icon.filled{font-variation-settings:\"FILL\" 1}:where(:root):root .mat-mdc-standard-chip
+        .mdc-evolution-chip__cell--primary,:where(:root):root .mat-mdc-standard-chip
+        .mdc-evolution-chip__action--primary,:where(:root):root .mat-mdc-standard-chip
+        .mat-mdc-chip-action-label{overflow:visible}:where(:root):root .xap-inline-dialog-container{-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);background:var(--xap-color-surface);color:var(--xap-color-on-surface)}:where(:root):root
+        .xap-inline-dialog-container:focus{outline-color:var(--xap-color-outline,#202124)}:where(:root):root
+        .xap-inline-dialog-container .xap-dialog-layout .xap-dialog-layout-content{max-height:none}@media
+        (forced-colors:active){:where(:root):root .xap-inline-dialog-container{outline:2px
+        solid;outline-color:var(--xap-color-outline,black)}:where(:root):root .xap-inline-dialog-container:focus{outline:3px
+        dashed}}.dark-theme{--xap-color-surface:var(--mat-sys-surface);--xap-color-on-surface:var(--mat-sys-on-surface);background:var(--mat-sys-background);color:var(--mat-sys-on-background);--mat-sys-background:#131314;--mat-sys-error:#f2b8b5;--mat-sys-error-container:#8c1d18;--mat-sys-inverse-on-surface:#303030;--mat-sys-inverse-primary:#0b57d0;--mat-sys-inverse-surface:#e3e3e3;--mat-sys-on-background:#e3e3e3;--mat-sys-on-error:#601410;--mat-sys-on-error-container:#f9dedc;--mat-sys-on-primary:#062e6f;--mat-sys-on-primary-container:#d3e3fd;--mat-sys-on-primary-fixed:#041e49;--mat-sys-on-primary-fixed-variant:#0842a0;--mat-sys-on-secondary:#035;--mat-sys-on-secondary-container:#c2e7ff;--mat-sys-on-secondary-fixed:#001d35;--mat-sys-on-secondary-fixed-variant:#004a77;--mat-sys-on-surface:#e3e3e3;--mat-sys-on-surface-variant:#c4c7c5;--mat-sys-on-tertiary:#062e6f;--mat-sys-on-tertiary-container:#d3e3fd;--mat-sys-on-tertiary-fixed:#041e49;--mat-sys-on-tertiary-fixed-variant:#0842a0;--mat-sys-outline:#8e918f;--mat-sys-outline-variant:#444746;--mat-sys-primary:#a8c7fa;--mat-sys-primary-container:#0842a0;--mat-sys-primary-fixed:#d3e3fd;--mat-sys-primary-fixed-dim:#a8c7fa;--mat-sys-scrim:#000;--mat-sys-secondary:#7fcfff;--mat-sys-secondary-container:#004a77;--mat-sys-secondary-fixed:#c2e7ff;--mat-sys-secondary-fixed-dim:#7fcfff;--mat-sys-shadow:#000;--mat-sys-surface:#131314;--mat-sys-surface-bright:#37393b;--mat-sys-surface-container:#1e1f20;--mat-sys-surface-container-high:#282a2c;--mat-sys-surface-container-highest:#333537;--mat-sys-surface-container-low:#1b1b1b;--mat-sys-surface-container-lowest:#0e0e0e;--mat-sys-surface-dim:#131313;--mat-sys-surface-tint:#d1e1ff;--mat-sys-surface-variant:#444746;--mat-sys-tertiary:#a8c7fa;--mat-sys-tertiary-container:#0842a0;--mat-sys-tertiary-fixed:#d3e3fd;--mat-sys-tertiary-fixed-dim:#a8c7fa;--mat-sys-info:#a1c9ff;--mat-sys-on-info:#012c6f;--mat-sys-info-container:#04409f;--mat-sys-on-info-container:#d0e4ff;--mat-sys-success:#80da88;--mat-sys-on-success:#00381f;--mat-sys-success-container:#00522c;--mat-sys-on-success-container:#beefbb;--mat-sys-warning:#fcbd00;--mat-sys-on-warning:#4d2600;--mat-sys-warning-container:#6d3a01;--mat-sys-on-warning-container:#ffe07c;--mat-sys-link:#a1c9ff;--mat-sys-link-hover:#d0e4ff;--mat-sys-link-visited:#d9bafd;--mat-sys-neutral-variant20:#2d312f;--mat-sys-neutral10:#1f1f1f;--mat-sys-level0:0px
+        0px 0px 0px rgba(0,0,0,0.2),0px 0px 0px 0px rgba(0,0,0,0.14),0px 0px 0px 0px
+        rgba(0,0,0,0.12);--mat-sys-level1:0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px
+        1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);--mat-sys-level2:0px
+        3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px
+        0px rgba(0,0,0,0.12);--mat-sys-level3:0px 3px 5px -1px rgba(0,0,0,0.2),0px
+        6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);--mat-sys-level4:0px
+        5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px
+        2px rgba(0,0,0,0.12);--mat-sys-level5:0px 7px 8px -4px rgba(0,0,0,0.2),0px
+        12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);--mat-sys-body-large:400
+        1rem/1.5rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-large-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-large-line-height:1.5rem;--mat-sys-body-large-size:1rem;--mat-sys-body-large-tracking:0;--mat-sys-body-large-weight:400;--mat-sys-body-medium:400
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-medium-line-height:1.25rem;--mat-sys-body-medium-size:0.875rem;--mat-sys-body-medium-tracking:0;--mat-sys-body-medium-weight:400;--mat-sys-body-small:400
+        0.75rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-body-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-body-small-line-height:1rem;--mat-sys-body-small-size:0.75rem;--mat-sys-body-small-tracking:0.006rem;--mat-sys-body-small-weight:400;--mat-sys-display-large:400
+        3.562rem/4rem Google Sans;--mat-sys-display-large-font:Google Sans;--mat-sys-display-large-line-height:4rem;--mat-sys-display-large-size:3.562rem;--mat-sys-display-large-tracking:0;--mat-sys-display-large-weight:400;--mat-sys-display-medium:400
+        2.812rem/3.25rem Google Sans;--mat-sys-display-medium-font:Google Sans;--mat-sys-display-medium-line-height:3.25rem;--mat-sys-display-medium-size:2.812rem;--mat-sys-display-medium-tracking:0;--mat-sys-display-medium-weight:400;--mat-sys-display-small:400
+        2.25rem/2.75rem Google Sans;--mat-sys-display-small-font:Google Sans;--mat-sys-display-small-line-height:2.75rem;--mat-sys-display-small-size:2.25rem;--mat-sys-display-small-tracking:0;--mat-sys-display-small-weight:400;--mat-sys-headline-large:400
+        2rem/2.5rem Google Sans;--mat-sys-headline-large-font:Google Sans;--mat-sys-headline-large-line-height:2.5rem;--mat-sys-headline-large-size:2rem;--mat-sys-headline-large-tracking:0;--mat-sys-headline-large-weight:400;--mat-sys-headline-medium:400
+        1.75rem/2.25rem Google Sans;--mat-sys-headline-medium-font:Google Sans;--mat-sys-headline-medium-line-height:2.25rem;--mat-sys-headline-medium-size:1.75rem;--mat-sys-headline-medium-tracking:0;--mat-sys-headline-medium-weight:400;--mat-sys-headline-small:400
+        1.5rem/2rem Google Sans;--mat-sys-headline-small-font:Google Sans;--mat-sys-headline-small-line-height:2rem;--mat-sys-headline-small-size:1.5rem;--mat-sys-headline-small-tracking:0;--mat-sys-headline-small-weight:400;--mat-sys-label-large:500
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-large-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-large-line-height:1.25rem;--mat-sys-label-large-size:0.875rem;--mat-sys-label-large-tracking:0;--mat-sys-label-large-weight:500;--mat-sys-label-large-weight-prominent:700;--mat-sys-label-medium:500
+        0.75rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-medium-line-height:1rem;--mat-sys-label-medium-size:0.75rem;--mat-sys-label-medium-tracking:0.006rem;--mat-sys-label-medium-weight:500;--mat-sys-label-medium-weight-prominent:700;--mat-sys-label-small:500
+        0.688rem/1rem Google Sans Text,Google Sans,sans-serif;--mat-sys-label-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-label-small-line-height:1rem;--mat-sys-label-small-size:0.688rem;--mat-sys-label-small-tracking:0.006rem;--mat-sys-label-small-weight:500;--mat-sys-title-large:400
+        1.375rem/1.75rem Google Sans;--mat-sys-title-large-font:Google Sans;--mat-sys-title-large-line-height:1.75rem;--mat-sys-title-large-size:1.375rem;--mat-sys-title-large-tracking:0;--mat-sys-title-large-weight:400;--mat-sys-title-medium:500
+        1rem/1.5rem Google Sans Text,Google Sans,sans-serif;--mat-sys-title-medium-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-title-medium-line-height:1.5rem;--mat-sys-title-medium-size:1rem;--mat-sys-title-medium-tracking:0;--mat-sys-title-medium-weight:500;--mat-sys-title-small:500
+        0.875rem/1.25rem Google Sans Text,Google Sans,sans-serif;--mat-sys-title-small-font:Google
+        Sans Text,Google Sans,sans-serif;--mat-sys-title-small-line-height:1.25rem;--mat-sys-title-small-size:0.875rem;--mat-sys-title-small-tracking:0;--mat-sys-title-small-weight:500;--mat-sys-corner-extra-large:28px;--mat-sys-corner-extra-large-top:28px
+        28px 0 0;--mat-sys-corner-extra-small:4px;--mat-sys-corner-extra-small-top:4px
+        4px 0 0;--mat-sys-corner-full:9999px;--mat-sys-corner-large:16px;--mat-sys-corner-large-end:0
+        16px 16px 0;--mat-sys-corner-large-start:16px 0 0 16px;--mat-sys-corner-large-top:16px
+        16px 0 0;--mat-sys-corner-medium:12px;--mat-sys-corner-none:0;--mat-sys-corner-small:8px;--mat-sys-dragged-state-layer-opacity:0.16;--mat-sys-focus-state-layer-opacity:0.12;--mat-sys-hover-state-layer-opacity:0.08;--mat-sys-pressed-state-layer-opacity:0.12;--nlm-ctas-buttons-primary:var(--nlm-blue-50);--nlm-ctas-buttons-tertiary:var(--nlm-fills-surface-panel);--nlm-text-cta-text-primary:var(--nlm-brand-white);--nlm-text-cta-text-secondary:var(--nlm-fills-surface-landing);--nlm-text-cta-text-tertiary:var(--nlm-text-titles-and-labels);--nlm-icons-default:var(--nlm-text-titles-and-labels);--nlm-icons-blue:#3271ea;--nlm-icons-yellow:#fcbd00;--nlm-icons-red:#f55e57;--nlm-icons-pink:#b741ff;--nlm-states-on-tertiary-hover:rgba(66,89,255,0.08);--nlm-states-on-tertiary-focus:rgba(66,89,255,0.1);--nlm-pastel-purple:#20222d;--nlm-pastel-green:#1e2520;--nlm-pastel-yellow:#29291d;--nlm-pastel-orange:#29201e;--nlm-pastel-pink:#291f28;--nlm-pastel-blue:#20272d;--nlm-fills-surface-panel:#22262b;--nlm-fills-surface-panel-transparent-70:rgba(34,38,43,0.7);--nlm-fills-surface-panel-transparent-80:rgba(34,38,43,0.8);--nlm-fills-surface-page:#1a1d22;--nlm-fills-surface-page-grey:#1a1d22;--nlm-fills-surface-landing:var(--nlm-fills-surface-panel);--nlm-fills-ui-blue-fill:var(--nlm-fills-surface-page);--nlm-fills-ui-grey-fill:#3e4a59;--nlm-fills-ui-light-grey-fill:#1a1d22;--nlm-fills-x-icon:#22262b;--nlm-fills-scrim:rgba(0,0,0,0.6);--nlm-ctas-buttons-secondary:var(--nlm-grey-100);--nlm-ctas-buttons-pill:var(--nlm-blue-90);--nlm-text-secondary-text:var(--nlm-grey-70);--nlm-text-titles-and-labels:var(--nlm-grey-95);--nlm-text-body-text:var(--nlm-grey-80);--nlm-text-ghost-text:var(--nlm-grey-60);--nlm-stroke-default:#37383b;--nlm-stroke-focus:var(--nlm-grey-40);--nlm-strong-focus-indicator:#c3cafc;--nlm-states-on-primary-hover:rgba(255,255,255,0.08);--nlm-states-on-primary-focus:rgba(255,255,255,0.1);--nlm-states-on-secondary-hover:rgba(0,0,0,0.08);--nlm-states-on-secondary-focus:rgba(0,0,0,0.1);--nlm-states-surface-panel-0:rgba(34,38,43,0);--nlm-states-tile-edit-button-hover:rgba(255,255,255,0.16);--nlm-states-tile-edit-button-focus:rgba(255,255,255,0.18);--nlm-tiles-blue:#32343e;--nlm-tiles-cyan:#32383e;--nlm-tiles-pink:#3a3139;--nlm-tiles-green:#303632;--nlm-tiles-yellow:#3a3a2f;--nlm-tiles-orange:#3a3230;--nlm-tiles-on-blue:#d4dafa;--nlm-tiles-on-cyan:#c9eff0;--nlm-tiles-on-pink:#f0cceb;--nlm-tiles-on-green:#cdf1d6;--nlm-tiles-on-yellow:#f2f2ce;--nlm-tiles-on-orange:#f7d8d2;--nlm-tiles-on-blue-opacity:rgba(212,218,250,0.08);--nlm-tiles-on-green-opacity:rgba(205,241,214,0.08);--nlm-tiles-on-pink-opacity:rgba(240,204,235,0.08);--nlm-tiles-on-yellow-opacity:rgba(242,242,206,0.08);--nlm-tiles-on-orange-opacity:rgba(247,216,210,0.08);--nlm-tiles-on-grey-opacity:rgba(62,74,89,0.08);--nlm-tiles-on-cyan-opacity:rgba(201,239,240,0.08);--nlm-brand-light-blue:#2f334b;--nlm-loading-shimmer-highlight:#2f334b;--nlm-loading-shimmer-general:transparent;--mat-focus-indicator-border-color:var(--nlm-strong-focus-indicator);--mat-focus-indicator-display:block;--mat-sys-background:var(--nlm-fills-surface-landing);--mat-sys-on-background:var(--nlm-text-body-text)}.dark-theme
+        .mat-mdc-standard-chip .mdc-evolution-chip__cell--primary,.dark-theme .mat-mdc-standard-chip
+        .mdc-evolution-chip__action--primary,.dark-theme .mat-mdc-standard-chip .mat-mdc-chip-action-label{overflow:visible}.dark-theme
+        .xap-inline-dialog-container{-webkit-box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0
+        1px 3px 1px rgba(60,64,67,.15);box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0
+        1px 3px 1px rgba(60,64,67,.15);background:var(--xap-color-surface);color:var(--xap-color-on-surface)}.dark-theme
+        .xap-inline-dialog-container:focus{outline-color:var(--xap-color-outline,#202124)}.dark-theme
+        .xap-inline-dialog-container .xap-dialog-layout .xap-dialog-layout-content{max-height:none}@media
+        (forced-colors:active){.dark-theme .xap-inline-dialog-container{outline:2px
+        solid;outline-color:var(--xap-color-outline,black)}.dark-theme .xap-inline-dialog-container:focus{outline:3px
+        dashed}}sentinel{}</style><style data-font-stylesheet nonce=\"1Vi3CGjD1-dukIf8_w25kg\">@font-face{font-family:'Roboto';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxP.ttf)format('truetype');}@font-face{font-family:'Roboto';font-style:normal;font-weight:500;src:url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmEU9fBBc9.ttf)format('truetype');}@font-face{font-family:'Google
+        Material Icons';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlematerialicons/v144/Gw6kwdfw6UnXLJCcmafZyFRXb3BL9rvi0QZG3g.otf)format('opentype');}.google-material-icons{font-family:'Google
+        Material Icons';font-weight:normal;font-style:normal;font-size:24px;line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;}@font-face{font-family:'Google
+        Sans Display';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesansdisplay/v13/ea8FacM9Wef3EJPWRrHjgE4B6CnlZxHVDv79pA.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrwEIJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhX9RFD48TE63OOYKtrwEIJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:500;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrw2IJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:500;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhX9RFD48TE63OOYKtrw2IJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:600;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrzaJ5llpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:600;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhX9RFD48TE63OOYKtrzaJ5llpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:700;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrzjJ5llpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:700;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhX9RFD48TE63OOYKtrzjJ5llpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Symbols';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesymbols/v385/HhzMU5Ak9u-oMExPeInvcuEmPosC9zyteYEFU68cPrjdKM1XLPTxlGmzczpgWvF1d8Yp7AudBnt3CPar1JFWjoLAUv3G-tSNljixIIGUsC62cYrKiAk.ttf)format('truetype');}@font-face{font-family:'Google
+        Symbols';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesymbols/v385/HhzMU5Ak9u-oMExPeInvcuEmPosC9zyteYEFU68cvofdKM1XLPTxlGmzczpgWvF1d8Yp7AudBnt3CPar1JFWjoLAUv3G-tSNljixIIGUsC62cYrKiAk.ttf)format('truetype');}.google-symbols{font-family:'Google
+        Symbols';font-weight:normal;font-style:normal;font-size:24px;line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;}</style><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">(window.dataLayer=window.dataLayer||[]).push({'gtm.start':new
+        Date().getTime(),event:'gtm.js'});</script><script async src=\"https://www.googletagmanager.com/gtm.js?id=GTM-WQ7LTQ58\"
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\"></script><style nonce=\"1Vi3CGjD1-dukIf8_w25kg\">.gb_yb{font:13px/27px
+        Roboto,Arial,sans-serif;z-index:986}.gb_R{display:none}.gb_Q{-webkit-background-size:32px
+        32px;background-size:32px 32px;border:0;border-radius:50%;display:block;margin:0px;position:relative;height:32px;width:32px;z-index:0}.gb_kb{background-color:#e8f0fe;border:1px
+        solid rgba(32,33,36,.08);position:relative}.gb_kb.gb_Q{height:30px;width:30px}.gb_kb.gb_Q:hover,.gb_kb.gb_Q:active{-webkit-box-shadow:none;box-shadow:none}.gb_lb{background:#fff;border:none;border-radius:50%;bottom:2px;-webkit-box-shadow:0px
+        1px 2px 0px rgba(60,64,67,0.3),0px 1px 3px 1px rgba(60,64,67,0.15);box-shadow:0px
+        1px 2px 0px rgba(60,64,67,0.3),0px 1px 3px 1px rgba(60,64,67,0.15);height:14px;margin:2px;position:absolute;right:0;width:14px;line-height:normal;z-index:1}.gb_mb{color:#1f71e7;font:400
+        22px/32px Google Sans,Roboto,Helvetica,Arial,sans-serif;text-align:center;text-transform:uppercase}@media
+        (-webkit-min-device-pixel-ratio:1.25),(min-device-pixel-ratio:1.25),(min-resolution:1.25dppx){.gb_Q::before,.gb_nb::before{display:inline-block;-webkit-transform:scale(.5);-ms-transform:scale(.5);transform:scale(.5);-webkit-transform-origin:left
+        0;-ms-transform-origin:left 0;transform-origin:left 0}.gb_4 .gb_nb::before{-webkit-transform:scale(scale(.416666667));-ms-transform:scale(scale(.416666667));transform:scale(scale(.416666667))}}.gb_Q:hover,.gb_Q:focus{-webkit-box-shadow:0
+        1px 0 rgba(0,0,0,.15);box-shadow:0 1px 0 rgba(0,0,0,.15)}.gb_Q:active{-webkit-box-shadow:inset
+        0 2px 0 rgba(0,0,0,.15);box-shadow:inset 0 2px 0 rgba(0,0,0,.15)}.gb_Q:active::after{background:rgba(0,0,0,.1);border-radius:50%;content:\"\";display:block;height:100%}.gb_ob{cursor:pointer;line-height:40px;min-width:30px;opacity:.75;overflow:hidden;vertical-align:middle;text-overflow:ellipsis}.gb_B.gb_ob{width:auto}.gb_ob:hover,.gb_ob:focus{opacity:.85}.gb_pb
+        .gb_ob,.gb_pb .gb_qb{line-height:26px}#gb#gb.gb_pb a.gb_ob,.gb_pb .gb_qb{font-size:11px;height:auto}.gb_rb{border-top:4px
+        solid #000;border-left:4px dashed transparent;border-right:4px dashed transparent;display:inline-block;margin-left:6px;opacity:.75;vertical-align:middle}.gb_0a:hover
+        .gb_rb{opacity:.85}.gb_Xa>.gb_z{padding:3px 3px 3px 4px}.gb_sb.gb_jb{color:#fff}.gb_2
+        .gb_ob,.gb_2 .gb_rb{opacity:1}#gb#gb.gb_2.gb_2 a.gb_ob,#gb#gb .gb_2.gb_2 a.gb_ob{color:#fff}.gb_2.gb_2
+        .gb_rb{border-top-color:#fff;opacity:1}.gb_la .gb_Q:hover,.gb_2 .gb_Q:hover,.gb_la
+        .gb_Q:focus,.gb_2 .gb_Q:focus{-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.15),0
+        1px 2px rgba(0,0,0,0.2);box-shadow:0 1px 0 rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.2)}.gb_tb
+        .gb_z,.gb_ub .gb_z{position:absolute;right:1px}.gb_z.gb_1,.gb_vb.gb_1,.gb_0a.gb_1{-webkit-box-flex:0;-webkit-flex:0
+        1 auto;flex:0 1 auto}.gb_wb.gb_xb .gb_ob{width:30px!important}.gb_P{height:40px;position:absolute;right:-5px;top:-5px;width:40px}.gb_yb
+        .gb_P,.gb_zb .gb_P{right:0;top:0}a.gb_Va{border-radius:100px;background:#0b57d0;background:var(--gm3-sys-color-primary,#0b57d0);-webkit-box-sizing:border-box;box-sizing:border-box;color:#fff;color:var(--gm3-sys-color-on-primary,#fff);display:inline-block;font-size:14px;font-weight:500;min-height:40px;outline:none;padding:10px
+        24px;text-align:center;text-decoration:none;white-space:normal;line-height:18px;position:relative}a.gb_Wa{border-radius:100px;border:1px
+        solid;border-color:#747775;border-color:var(--gm3-sys-color-outline,#747775);background:none;-webkit-box-sizing:border-box;box-sizing:border-box;color:#0b57d0;color:var(--gm3-sys-color-primary,#0b57d0);display:inline-block;font-size:14px;font-weight:500;min-height:40px;outline:none;padding:10px
+        24px;text-align:center;text-decoration:none;white-space:normal;line-height:18px;position:relative}.gb_1a.gb_H
+        a.gb_Va,.gb_2a.gb_H a.gb_Va,.gb_3a.gb_H a.gb_Va{background:#c2e7ff;background:var(--gm3-sys-color-secondary-fixed,#c2e7ff);color:#001d35;color:var(--gm3-sys-color-on-secondary-fixed,#001d35)}.gb_Ha.gb_H
+        a.gb_Wa{color:#a8c7fa;color:var(--gm3-sys-color-primary,#a8c7fa)}a.gb_Od{padding:10px
+        12px;margin:12px 16px 12px 10px;min-width:85px}@media (max-width:640px){a.gb_Od{min-width:75px}}.gb_Ha,.gb_Dd{font-family:\"Google
+        Sans Text\",Roboto,Helvetica,Arial,sans-serif;font-style:normal}.gb_Ha.gb_1a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_1a.gb_Pd{background:#fff;background:var(--og-bar-background,var(--gm3-sys-color-background,#fff))}.gb_Ha.gb_1a
+        .gb_pd.gb_qd,.gb_Ha.gb_1a a.gb_Z,.gb_Ha.gb_1a span.gb_Z{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_1a
+        .gb_rd .gb_Qd,.gb_Ha.gb_1a .gb_id .gb_Qd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_1a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.gb_Ha svg,.gb_Ha.gb_1a
+        svg,.gb_Ha.gb_H svg{color:white}}.gb_Ha.gb_H.gb_1a{color:#e3e3e3;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_1a.gb_Pd{background:transparent}.gb_Ha.gb_H.gb_1a
+        .gb_pd.gb_qd,.gb_Ha.gb_H.gb_1a a.gb_Z,.gb_Ha.gb_H.gb_1a span.gb_Z{color:#e3e3e3;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_1a
+        .gb_rd .gb_Qd,.gb_Ha.gb_H.gb_1a .gb_id .gb_Qd{color:#e3e3e3;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_1a
+        svg{color:#c4c7c5;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.gb_Ha.gb_H.gb_1a.gb_Pd{background:#1f1f1f;background:var(--og-bar-background,var(--gm3-sys-color-background,#131314))}.gb_Ha.gb_2a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_2a.gb_Pd{background:#e9eef6;background:var(--og-bar-background,var(--gm3-sys-color-surface-container-high,#e9eef6))}.gb_Ha.gb_2a
+        .gb_pd.gb_qd,.gb_Ha.gb_2a a.gb_Z,.gb_Ha.gb_2a span.gb_Z{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_2a
+        .gb_rd .gb_Qd,.gb_Ha.gb_2a .gb_id .gb_Qd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_2a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}.gb_Ha.gb_H.gb_2a{color:#e3e3e3;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_2a.gb_Pd{background:#282a2c;background:var(--og-bar-background,var(--gm3-sys-color-surface-container-high,#282a2c))}.gb_Ha.gb_H.gb_2a
+        .gb_pd.gb_qd,.gb_Ha.gb_H.gb_2a a.gb_Z,.gb_Ha.gb_H.gb_2a span.gb_Z{color:#e3e3e3;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_2a
+        .gb_rd .gb_Qd,.gb_Ha.gb_H.gb_2a .gb_id .gb_Qd{color:#e3e3e3;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ha.gb_H.gb_2a
+        svg{color:#c4c7c5;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.gb_Ha.gb_3a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_3a.gb_Pd{background:transparent}.gb_Ha.gb_3a
+        .gb_pd.gb_qd,.gb_Ha.gb_3a a.gb_Z,.gb_Ha.gb_3a span.gb_Z{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_3a
+        .gb_rd .gb_Qd,.gb_Ha.gb_3a .gb_id .gb_Qd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ha.gb_3a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}.gb_Ha.gb_3a.gb_H.gb_Pd{background:transparent}.gb_Ha.gb_3a.gb_H
+        .gb_pd.gb_qd,.gb_Ha.gb_3a.gb_H a.gb_Z,.gb_Ha.gb_3a.gb_H span.gb_Z{color:white;color:var(--og-theme-color,white)}.gb_Ha.gb_3a.gb_H
+        .gb_rd .gb_Qd,.gb_Ha.gb_3a.gb_H .gb_id .gb_Qd{color:white;color:var(--og-theme-color,white)}.gb_Ha.gb_3a.gb_H
+        svg{color:white;color:var(--og-theme-color,white)}.gb_Ha a.gb_Z,.gb_Ha span.gb_Z{text-decoration:none}.gb_pd{font-family:Google
+        Sans,Roboto,Helvetica,Arial,sans-serif;font-size:20px;font-weight:400;letter-spacing:.25px;line-height:48px;margin-bottom:2px;opacity:1;overflow:hidden;padding-left:16px;position:relative;text-overflow:ellipsis;vertical-align:middle;top:2px;white-space:nowrap;-webkit-box-flex:1;-webkit-flex:1
+        1 auto;flex:1 1 auto}.gb_ud{display:none}.gb_Ha.gb_9a .gb_pd{margin-bottom:0}.gb_rd.gb_sd
+        .gb_pd{padding-left:4px}.gb_Ha.gb_9a .gb_td{position:relative;top:-2px}.gb_Ha{min-width:160px;position:relative}.gb_Ha.gb_ad{min-width:120px}.gb_Ha.gb_Rd
+        .gb_Sd{display:none}.gb_Ha.gb_Rd .gb_Kd{height:56px}header.gb_Ha{display:block}.gb_Ha
+        svg{fill:currentColor}.gb_Td{position:fixed;top:0;width:100%}.gb_Ud{-webkit-box-shadow:0
+        4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2);box-shadow:0
+        4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2)}.gb_Vd{height:64px}.gb_Kd{-webkit-box-sizing:border-box;box-sizing:border-box;position:relative;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;min-width:-webkit-min-content;min-width:-moz-min-content;min-width:min-content}.gb_Ha:not(.gb_9a)
+        .gb_Kd{padding:8px}.gb_Ha:not(.gb_9a) .gb_Kd a.gb_Wd{margin:12px 8px 12px
+        10px}.gb_Ha.gb_Xd .gb_Kd{-webkit-box-flex:1;-webkit-flex:1 0 auto;flex:1 0
+        auto}.gb_Ha .gb_Kd.gb_Ld.gb_Zd{min-width:0}.gb_Ha.gb_9a .gb_Kd{padding:4px;padding-left:8px;min-width:0}.gb_Ha.gb_9a
+        .gb_Kd a.gb_Wd{margin:12px 8px 12px 10px}.gb_Sd{height:48px;vertical-align:middle;white-space:nowrap;-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.gb_0d>.gb_Sd{display:table-cell;width:100%}.gb_rd{padding-right:25px;-webkit-box-sizing:border-box;box-sizing:border-box;-webkit-box-flex:1;-webkit-flex:1
+        0 auto;flex:1 0 auto}.gb_Ha.gb_9a .gb_rd{padding-right:14px}.gb_1d{-webkit-box-flex:1;-webkit-flex:1
+        1 100%;flex:1 1 100%}.gb_1d>:only-child{display:inline-block}.gb_2d.gb_jd{padding-left:4px}.gb_2d.gb_3d,.gb_Ha.gb_Xd
+        .gb_2d,.gb_Ha.gb_9a:not(.gb_Dd) .gb_2d{padding-left:0}.gb_Ha.gb_9a .gb_2d.gb_3d{padding-right:0}.gb_Ha.gb_9a
+        .gb_2d.gb_3d .gb_Xa{margin-left:10px}.gb_jd{display:inline}.gb_Ha.gb_dd .gb_2d.gb_4d,.gb_Ha.gb_Dd
+        .gb_2d.gb_4d{padding-left:2px}.gb_pd{display:inline-block}.gb_2d{-webkit-box-sizing:border-box;box-sizing:border-box;height:48px;padding:0
+        4px;padding-left:5px;-webkit-box-flex:0;-webkit-flex:0 0 auto;flex:0 0 auto;-webkit-box-pack:end;-webkit-justify-content:flex-end;justify-content:flex-end}.gb_Dd{height:48px}.gb_Ha.gb_Dd{min-width:auto}.gb_Dd
+        .gb_2d{float:right;padding-left:32px;padding-left:var(--og-bar-parts-side-padding,32px)}.gb_Dd
+        .gb_2d.gb_5d{padding-left:0}.gb_6d{font-size:14px;max-width:200px;overflow:hidden;padding:0
+        12px;text-overflow:ellipsis;white-space:nowrap;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text;user-select:text}.gb_a
+        a,.gb_6c a{color:inherit}.gb_qd{text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.gb_qd{opacity:1}.gb_7d{position:relative}.gb_M{font-family:arial,sans-serif;line-height:normal;padding-right:15px}.gb_0{display:inline-block;padding-left:15px}.gb_0
+        .gb_Z{display:inline-block;line-height:24px;vertical-align:middle}.gb_8d{text-align:left}.gb_K{display:none}@media
+        screen and (max-width:319px){.gb_Kd .gb_J{display:none;visibility:hidden}}.gb_J
+        .gb_B,.gb_J .gb_B:hover,.gb_J .gb_B:focus{opacity:1}.gb_L{display:none}.gb_S{display:none!important}.gb_jb{visibility:hidden}@media
+        screen and (max-width:319px){.gb_Kd:not(.gb_Ld) .gb_J{display:none;visibility:hidden}}.gb_vd{display:inline-block;vertical-align:middle}.gb_wd
+        .gb_R{bottom:-3px;right:-5px}@if (RTL_LANG){.gb_wd .gb_R{left:-5px}}.gb_vd:first-child{padding-left:0}.gb_D{position:relative}.gb_B{display:inline-block;outline:none;vertical-align:middle;border-radius:50%;-webkit-box-sizing:border-box;box-sizing:border-box;height:40px;width:40px}.gb_B,#gb#gb
+        a.gb_B{cursor:pointer;text-decoration:none}.gb_B,a.gb_B{color:#000}x:-o-prefocus{border-bottom-color:#ccc}.gb_ma{background:#fff;border:1px
+        solid #ccc;border-color:rgba(0,0,0,.2);color:#000;-webkit-box-shadow:0 2px
+        10px rgba(0,0,0,.2);box-shadow:0 2px 10px rgba(0,0,0,.2);display:none;outline:none;overflow:hidden;position:absolute;right:0;top:54px;-webkit-animation:gb__a
+        .2s;animation:gb__a .2s;border-radius:2px;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text;user-select:text}.gb_vd.gb_5a
+        .gb_ma,.gb_5a.gb_ma{display:block}.gb_Ad{position:absolute;right:0;top:54px;z-index:-1}.gb_pb
+        .gb_ma{margin-top:-10px}.gb_vd:first-child{padding-left:4px}.gb_Ha.gb_Bd .gb_vd:first-child{padding-left:0}.gb_Cd{position:relative}.gb_id
+        .gb_Cd,.gb_Dd .gb_Cd{float:right}.gb_B{padding:8px;cursor:pointer}.gb_Fd button
+        svg,.gb_B{border-radius:50%}.gb_vd{padding:4px}.gb_Ha.gb_Bd .gb_vd{padding:4px
+        2px}.gb_Ha.gb_Bd .gb_z.gb_vd{padding-left:6px}.gb_ma{z-index:991;line-height:normal}.gb_ma.gb_Id{left:0;right:auto}@media
+        (max-width:350px){.gb_ma.gb_Id{left:0}}.gb_Jd .gb_ma{top:56px}.gb_z .gb_B{padding:4px}.gb_T{display:none}.gb_0a:not(.gb_Wd){position:relative}.gb_be::after{content:\"\";border:1px
+        solid #202124;opacity:.13;position:absolute;top:4px;left:4px;border-radius:50%;width:30px;height:30px}.gb_Xa{-webkit-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:inline-block;height:48px;overflow:hidden;outline:none;padding:7px
+        0 0 16px;vertical-align:middle;width:142px;border-radius:28px;background-color:transparent;border:1px
+        solid;position:relative}.gb_Xa .gb_0a{width:32px;height:32px;padding:0}.gb_Xa
+        .gb_R{bottom:-2px;right:-4px}.gb_1a .gb_Xa,.gb_2a .gb_Xa{border-color:#747775;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#747775))}.gb_1a.gb_H
+        .gb_Xa,.gb_2a.gb_H .gb_Xa{border-color:#8e918f;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#8e918f))}.gb_3a
+        .gb_Xa{border-color:#747775;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#747775))}.gb_3a.gb_H
+        .gb_Xa{border-color:#e3e3e3;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_4a{display:inherit}.gb_Xa
+        .gb_4a{background:#fff;border-radius:6px;display:inline-block;left:15px;position:static;padding:2px;top:-1px;height:32px;-webkit-box-sizing:border-box;box-sizing:border-box;width:78px}.gb_6a{text-align:center}.gb_6a.gb_7a{background-color:#f1f3f4}.gb_6a
+        .gb_8a{vertical-align:middle;max-height:28px;max-width:74px}.gb_Ha .gb_Xa
+        .gb_z.gb_vd{padding:0;margin-right:9px;float:right}.gb_Ha:not(.gb_9a) .gb_Xa{margin-left:10px;margin-right:4px}.gb_Xa
+        .gb_be::after{left:0;top:0}@media screen and (max-width:480px){.gb_Xa .gb_4a{display:none}.gb_Xa{border:none;border-radius:50%;height:40px;margin:4px;outline:1px
+        solid transparent;padding:0;width:40px}.gb_Ha .gb_Xa .gb_z.gb_vd{padding:4px;margin-right:0}}sentinel{}</style><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">;this.gbar_={CONFIG:[[[0,\"www.gstatic.com\",\"og.qtm.en_US.lgb6SdZ3Qec.es5.O\",\"com\",\"en\",\"666\",0,[4,2,\"\",\"\",\"\",\"854989827\",\"0\"],null,\"nE1macfxLOe0ptQPjarXgAo\",null,0,\"og.qtm.K3HqY6n_LHE.L.X.O\",\"AA2YrTuBgFgtk-JdfmMBlHc0qvWJrt15cg\",\"AA2YrTtI_kjIAbOvcleZlrzvboqdy3B4Dw\",\"\",2,1,200,\"USA\",null,null,\"269\",\"666\",1,null,null,96797242,null,0,0],null,[1,0.1000000014901161,2,1],null,[1,0,0,null,\"0\",\"SCRUBBED_EMAIL@example.com\",\"\",\"AFiauXGKiarolFIxzfaEK5E0hyBKUzYNhUjBSjp1ncFRcmYv57hiUkok4e3rmyvsLXUIcV7c_x8-o1OKsa7H3qj9zOoUgn_67g\",0,0,null,\"\"],[0,0,\"\",1,0,0,0,0,0,0,null,0,0,null,0,0,null,null,0,0,0,\"\",\"\",\"\",\"\",\"\",\"\",null,0,0,0,0,0,null,null,null,\"rgba(32,33,36,1)\",\"rgba(255,255,255,1)\",0,0,1,null,null,null,0],[\"%1$s
+        (default)\",\"Brand account\",1,\"%1$s (delegated)\",1,null,83,\"/?authuser=$authuser\\u0026pageId=$pageId\",null,null,null,1,\"https://accounts.google.com/ListAccounts?authuser=0\\u0026listPages=1\\u0026fwput=10\\u0026rdr=2\\u0026pid=666\\u0026gpsia=1\\u0026source=ogb\\u0026atic=1\\u0026mo=1\\u0026mn=1\\u0026hl=en\\u0026ts=1097\",0,\"dashboard\",null,null,null,null,\"Profile\",\"\",1,null,\"Signed
+        out\",\"https://accounts.google.com/AccountChooser?source=ogb\\u0026continue=$continue\\u0026Email=$email\\u0026ec=GAhAmgU\",\"https://accounts.google.com/RemoveLocalAccount?source=ogb\",\"Remove\",\"Sign
+        in\",0,1,1,0,1,0,0,null,null,null,\"Session expired\",null,null,null,\"Visitor\",null,\"Default\",\"Delegated\",\"Sign
+        out of all accounts\",0,null,null,0,null,null,\"myaccount.google.com\",\"https\",0,1,0],null,[\"1\",\"gci_91f30755d6a6b787dcc2a4062e6e9824.js\",\"googleapis.client:gapi.iframes\",\"0\",\"en\"],null,null,null,null,[\"m;/_/scs/abc-static/_/js/k=gapi.gapi.en.FZb77tO2YW4.O/d=1/rs=AHpOoo8lqavmo6ayfVxZovyDiP6g3TOVSQ/m=__features__\",\"https://apis.google.com\",\"\",\"\",\"1\",\"\",null,1,\"es_plusone_gc_20251208.0_p0\",\"en\",null,0],[0.009999999776482582,\"com\",\"666\",[null,\"\",\"0\",null,1,5184000,null,null,\"\",null,null,null,null,null,0,null,0,null,1,0,0,0,null,null,0,0,null,0,0,0,0,0],null,null,null,0],[1,null,null,27043,666,\"USA\",\"en\",\"854989827.0\",8,null,1,0,null,null,null,null,\"3700949,105109531,105109534,105140909,105140912,115517798,115517801,116221146,116221148\",null,null,null,\"nE1macfxLOe0ptQPjarXgAo\",0,0,0,null,2,5,\"gh\",193,0,0,null,null,1,96797242,0,0],[[null,null,null,\"https://www.gstatic.com/og/_/js/k=og.qtm.en_US.lgb6SdZ3Qec.es5.O/rt=j/m=qabr,qgl,q_dnp,qdid,qbd,qapid,qads,qrcd,q_dg/exm=qaaw,qadd,qaid,qein,qhaw,qhba,qhbr,qhch,qhga,qhid,qhin/d=1/ed=1/rs=AA2YrTuBgFgtk-JdfmMBlHc0qvWJrt15cg\"],[null,null,null,\"https://www.gstatic.com/og/_/ss/k=og.qtm.K3HqY6n_LHE.L.X.O/m=qdid,qba,d_b_gm3,d_wi_gm3,d_lo_gm3/excm=qaaw,qadd,qaid,qein,qhaw,qhba,qhbr,qhch,qhga,qhid,qhin/d=1/ed=1/ct=zgms/rs=AA2YrTtI_kjIAbOvcleZlrzvboqdy3B4Dw\"]],null,null,null,null,null,[[\"mousedown\",\"touchstart\",\"touchmove\",\"wheel\",\"keydown\"],300000],[[null,null,null,\"https://accounts.google.com/RotateCookiesPage\"],3,null,null,null,0,1]]],};this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\n_._F_toggles_initialize=function(a){(typeof globalThis!==\"undefined\"?globalThis:typeof
+        self!==\"undefined\"?self:this)._F_toggles_gbar_=a||[]};(0,_._F_toggles_initialize)([]);\n/*\n\n
+        Copyright The Closure Library Authors.\n SPDX-License-Identifier: Apache-2.0\n*/\nvar
+        ia,oa,qa,ua,wa,xa,La,Ma,eb,hb,jb,ob,kb,rb,wb,Ib,Jb,Kb,Lb,Mb,Ub,Vb,Xb,Yb;_.aa=function(a,b){if(Error.captureStackTrace)Error.captureStackTrace(this,_.aa);else{var
+        c=Error().stack;c&&(this.stack=c)}a&&(this.message=String(a));b!==void 0&&(this.cause=b)};_.ba=function(a){a.Km=!0;return
+        a};\n_.ha=function(a){var b=a;if(ca(b)){if(!/^\\s*(?:-?[1-9]\\d*|0)?\\s*$/.test(b))throw
+        Error(String(b));}else if(da(b)&&!Number.isSafeInteger(b))throw Error(String(b));return
+        ea?BigInt(a):a=fa(a)?a?\"1\":\"0\":ca(a)?a.trim()||\"0\":String(a)};ia=function(a,b){if(a.length>b.length)return!1;if(a.length<b.length||a===b)return!0;for(var
+        c=0;c<a.length;c++){var d=a[c],e=b[c];if(d>e)return!1;if(d<e)return!0}};_.ja=function(a){_.t.setTimeout(function(){throw
+        a;},0)};\n_.la=function(){return _.ka().toLowerCase().indexOf(\"webkit\")!=-1};_.ka=function(){var
+        a=_.t.navigator;return a&&(a=a.userAgent)?a:\"\"};oa=function(a){if(!ma||!na)return!1;for(var
+        b=0;b<na.brands.length;b++){var c=na.brands[b].brand;if(c&&c.indexOf(a)!=-1)return!0}return!1};_.pa=function(a){return
+        _.ka().indexOf(a)!=-1};qa=function(){return ma?!!na&&na.brands.length>0:!1};_.ra=function(){return
+        qa()?!1:_.pa(\"Opera\")};_.sa=function(){return qa()?!1:_.pa(\"Trident\")||_.pa(\"MSIE\")};\n_.ta=function(){return
+        _.pa(\"Firefox\")||_.pa(\"FxiOS\")};_.va=function(){return _.pa(\"Safari\")&&!(ua()||(qa()?0:_.pa(\"Coast\"))||_.ra()||(qa()?0:_.pa(\"Edge\"))||(qa()?oa(\"Microsoft
+        Edge\"):_.pa(\"Edg/\"))||(qa()?oa(\"Opera\"):_.pa(\"OPR\"))||_.ta()||_.pa(\"Silk\")||_.pa(\"Android\"))};ua=function(){return
+        qa()?oa(\"Chromium\"):(_.pa(\"Chrome\")||_.pa(\"CriOS\"))&&!(qa()?0:_.pa(\"Edge\"))||_.pa(\"Silk\")};wa=function(){return
+        ma?!!na&&!!na.platform:!1};xa=function(){return _.pa(\"iPhone\")&&!_.pa(\"iPod\")&&!_.pa(\"iPad\")};\n_.ya=function(){return
+        xa()||_.pa(\"iPad\")||_.pa(\"iPod\")};_.za=function(){return wa()?na.platform===\"macOS\":_.pa(\"Macintosh\")};_.Ba=function(a,b){return(0,_.Aa)(a,b)>=0};_.Ca=function(a,b,c){return
+        typeof Symbol===\"function\"&&typeof Symbol()===\"symbol\"?(c===void 0?0:c)&&Symbol.for&&a?Symbol.for(a):a!=null?Symbol(a):Symbol():b};_.Ga=function(a,b){_.Da||_.v
+        in a||Ea(a,Fa);a[_.v]|=b};_.Ha=function(a,b){_.Da||_.v in a||Ea(a,Fa);a[_.v]=b};\n_.Ja=function(a,b){return
+        b===void 0?a.j!==Ia&&!!(2&(a.J[_.v]|0)):!!(2&b)&&a.j!==Ia};La=function(a){return
+        a};Ma=function(a,b){a.__closure__error__context__984382||(a.__closure__error__context__984382={});a.__closure__error__context__984382.severity=b};_.Na=function(a){a=Error(a);Ma(a,\"warning\");return
+        a};_.Pa=function(a,b){if(a!=null){var c;var d=(c=Oa)!=null?c:Oa={};c=d[a]||0;c>=b||(d[a]=c+1,a=Error(),Ma(a,\"incident\"),_.ja(a))}};\n_.Ra=function(a){if(typeof
+        a!==\"boolean\")throw Error(\"y`\"+_.Qa(a)+\"`\"+a);return a};_.Sa=function(a){if(a==null||typeof
+        a===\"boolean\")return a;if(typeof a===\"number\")return!!a};_.Ua=function(a){if(!(0,_.Ta)(a))throw
+        _.Na(\"enum\");return a|0};_.Va=function(a){if(typeof a!==\"number\")throw
+        _.Na(\"int32\");if(!(0,_.Ta)(a))throw _.Na(\"int32\");return a|0};_.Wa=function(a){if(a!=null&&typeof
+        a!==\"string\")throw Error();return a};_.Xa=function(a){return a==null||typeof
+        a===\"string\"?a:void 0};\n_.$a=function(a,b,c){if(a!=null&&a[_.Ya]===_.Za)return
+        a;if(Array.isArray(a)){var d=a[_.v]|0;c=d|c&32|c&2;c!==d&&_.Ha(a,c);return
+        new b(a)}};_.cb=function(a){var b=_.ab(_.bb);return b?a[b]:void 0};eb=function(a,b){b<100||_.Pa(db,1)};\nhb=function(a,b,c,d){var
+        e=d!==void 0;d=!!d;var f=_.ab(_.bb),g;!e&&_.Da&&f&&(g=a[f])&&g.Md(eb);f=[];var
+        h=a.length;g=4294967295;var k=!1,m=!!(b&64),n=m?b&128?0:-1:void 0;if(!(b&1)){var
+        p=h&&a[h-1];p!=null&&typeof p===\"object\"&&p.constructor===Object?(h--,g=h):p=void
+        0;if(m&&!(b&128)&&!e){k=!0;var q;g=((q=fb)!=null?q:La)(g-n,n,a,p,void 0)+n}}b=void
+        0;for(q=0;q<h;q++){var r=a[q];if(r!=null&&(r=c(r,d))!=null)if(m&&q>=g){var
+        u=q-n,w=void 0;((w=b)!=null?w:b={})[u]=r}else f[q]=r}if(p)for(var B in p)h=p[B],\nh!=null&&(h=c(h,d))!=null&&(q=+B,r=void
+        0,m&&!Number.isNaN(q)&&(r=q+n)<g?f[r]=h:(q=void 0,((q=b)!=null?q:b={})[B]=h));b&&(k?f.push(b):f[g]=b);e&&_.ab(_.bb)&&(a=_.cb(a))&&\"function\"==typeof
+        _.gb&&a instanceof _.gb&&(f[_.bb]=a.i());return f};\njb=function(a){switch(typeof
+        a){case \"number\":return Number.isFinite(a)?a:\"\"+a;case \"bigint\":return(0,_.ib)(a)?Number(a):\"\"+a;case
+        \"boolean\":return a?1:0;case \"object\":if(Array.isArray(a)){var b=a[_.v]|0;return
+        a.length===0&&b&1?void 0:hb(a,b,jb)}if(a!=null&&a[_.Ya]===_.Za)return kb(a);if(\"function\"==typeof
+        _.lb&&a instanceof _.lb)return a.j();return}return a};ob=function(a,b){if(b){fb=b==null||b===La||b[mb]!==nb?La:b;try{return
+        kb(a)}finally{fb=void 0}}return kb(a)};\nkb=function(a){a=a.J;return hb(a,a[_.v]|0,jb)};_.x=function(a,b,c){return
+        _.pb(a,b,c,2048)};\n_.pb=function(a,b,c,d){d=d===void 0?0:d;if(a==null){var
+        e=32;c?(a=[c],e|=128):a=[];b&&(e=e&-16760833|(b&1023)<<14)}else{if(!Array.isArray(a))throw
+        Error(\"z\");e=a[_.v]|0;if(qb&&1&e)throw Error(\"A\");2048&e&&!(2&e)&&rb();if(e&256)throw
+        Error(\"B\");if(e&64)return(e|d)!==e&&_.Ha(a,e|d),a;if(c&&(e|=128,c!==a[0]))throw
+        Error(\"C\");a:{c=a;e|=64;var f=c.length;if(f){var g=f-1,h=c[g];if(h!=null&&typeof
+        h===\"object\"&&h.constructor===Object){b=e&128?0:-1;g-=b;if(g>=1024)throw
+        Error(\"E\");for(var k in h)f=+k,f<g&&\n(c[f+b]=h[k],delete h[k]);e=e&-16760833|(g&1023)<<14;break
+        a}}if(b){k=Math.max(b,f-(e&128?0:-1));if(k>1024)throw Error(\"F\");e=e&-16760833|(k&1023)<<14}}}_.Ha(a,e|64|d);return
+        a};rb=function(){if(qb)throw Error(\"D\");_.Pa(sb,5)};\nwb=function(a,b){if(typeof
+        a!==\"object\")return a;if(Array.isArray(a)){var c=a[_.v]|0;a.length===0&&c&1?a=void
+        0:c&2||(!b||4096&c||16&c?a=_.tb(a,c,!1,b&&!(c&16)):(_.Ga(a,34),c&4&&Object.freeze(a)));return
+        a}if(a!=null&&a[_.Ya]===_.Za)return b=a.J,c=b[_.v]|0,_.Ja(a,c)?a:_.ub(a,b,c)?_.vb(a,b):_.tb(b,c);if(\"function\"==typeof
+        _.lb&&a instanceof _.lb)return a};_.vb=function(a,b,c){a=new a.constructor(b);c&&(a.j=Ia);a.o=Ia;return
+        a};\n_.tb=function(a,b,c,d){d!=null||(d=!!(34&b));a=hb(a,b,wb,d);d=32;c&&(d|=2);b=b&16769217|d;_.Ha(a,b);return
+        a};_.xb=function(a){var b=a.J,c=b[_.v]|0;return _.Ja(a,c)?_.ub(a,b,c)?_.vb(a,b,!0):new
+        a.constructor(_.tb(b,c,!1)):a};_.yb=function(a){if(a.j!==Ia)return!1;var b=a.J;b=_.tb(b,b[_.v]|0);_.Ga(b,2048);a.J=b;a.j=void
+        0;a.o=void 0;return!0};_.zb=function(a){if(!_.yb(a)&&_.Ja(a,a.J[_.v]|0))throw
+        Error();};_.Ab=function(a,b){b===void 0&&(b=a[_.v]|0);b&32&&!(b&4096)&&_.Ha(a,b|4096)};\n_.ub=function(a,b,c){return
+        c&2?!0:c&32&&!(c&4096)?(_.Ha(b,c|2),a.j=Ia,!0):!1};_.Bb=function(a,b,c,d,e){var
+        f=c+(e?0:-1),g=a.length-1;if(g>=1+(e?0:-1)&&f>=g){var h=a[g];if(h!=null&&typeof
+        h===\"object\"&&h.constructor===Object)return h[c]=d,b}if(f<=g)return a[f]=d,b;if(d!==void
+        0){var k;g=((k=b)!=null?k:b=a[_.v]|0)>>14&1023||536870912;c>=g?d!=null&&(f={},a[g+(e?0:-1)]=(f[c]=d,f)):a[f]=d}return
+        b};\n_.Db=function(a,b,c,d,e){var f=!1;d=_.Cb(a,d,e,function(g){var h=_.$a(g,c,b);f=h!==g&&h!=null;return
+        h});if(d!=null)return f&&!_.Ja(d)&&_.Ab(a,b),d};_.Eb=function(){var a=function(){throw
+        Error();};Object.setPrototypeOf(a,a.prototype);return a};_.Fb=function(a,b){return
+        a!=null?!!a:!!b};_.y=function(a,b){b==void 0&&(b=\"\");return a!=null?a:b};_.Gb=function(a,b,c){for(var
+        d in a)b.call(c,a[d],d,a)};_.Hb=function(a){for(var b in a)return!1;return!0};\nIb=typeof
+        Object.create==\"function\"?Object.create:function(a){var b=function(){};b.prototype=a;return
+        new b};Jb=typeof Object.defineProperties==\"function\"?Object.defineProperty:function(a,b,c){if(a==Array.prototype||a==Object.prototype)return
+        a;a[b]=c.value;return a};\nKb=function(a){a=[\"object\"==typeof globalThis&&globalThis,a,\"object\"==typeof
+        window&&window,\"object\"==typeof self&&self,\"object\"==typeof global&&global];for(var
+        b=0;b<a.length;++b){var c=a[b];if(c&&c.Math==Math)return c}throw Error(\"a\");};Lb=Kb(this);Mb=\"Int8
+        Uint8 Uint8Clamped Int16 Uint16 Int32 Uint32 Float32 Float64\".split(\" \");Lb.BigInt64Array&&(Mb.push(\"BigInt64\"),Mb.push(\"BigUint64\"));\nvar
+        Ob=function(a,b){if(b)for(var c=0;c<Mb.length;c++)Nb(Mb[c]+\"Array.prototype.\"+a,b)},Pb=function(a,b){b&&Nb(a,b)},Nb=function(a,b){var
+        c=Lb;a=a.split(\".\");for(var d=0;d<a.length-1;d++){var e=a[d];if(!(e in c))return;c=c[e]}a=a[a.length-1];d=c[a];b=b(d);b!=d&&b!=null&&Jb(c,a,{configurable:!0,writable:!0,value:b})},Qb;\nif(typeof
+        Object.setPrototypeOf==\"function\")Qb=Object.setPrototypeOf;else{var Rb;a:{var
+        Sb={a:!0},Tb={};try{Tb.__proto__=Sb;Rb=Tb.a;break a}catch(a){}Rb=!1}Qb=Rb?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw
+        new TypeError(\"b`\"+a);return a}:null}Ub=Qb;\n_.z=function(a,b){a.prototype=Ib(b.prototype);a.prototype.constructor=a;if(Ub)Ub(a,b);else
+        for(var c in b)if(c!=\"prototype\")if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else
+        a[c]=b[c];a.X=b.prototype};Vb=function(a){var b=0;return function(){return
+        b<a.length?{done:!1,value:a[b++]}:{done:!0}}};\n_.A=function(a){var b=typeof
+        Symbol!=\"undefined\"&&Symbol.iterator&&a[Symbol.iterator];if(b)return b.call(a);if(typeof
+        a.length==\"number\")return{next:Vb(a)};throw Error(\"c`\"+String(a));};Xb=function(a,b){return
+        Object.prototype.hasOwnProperty.call(a,b)};Yb=typeof Object.assign==\"function\"?Object.assign:function(a,b){if(a==null)throw
+        new TypeError(\"d\");a=Object(a);for(var c=1;c<arguments.length;c++){var d=arguments[c];if(d)for(var
+        e in d)Xb(d,e)&&(a[e]=d[e])}return a};\nPb(\"Object.assign\",function(a){return
+        a||Yb});Pb(\"globalThis\",function(a){return a||Lb});Pb(\"Reflect.setPrototypeOf\",function(a){return
+        a?a:Ub?function(b,c){try{return Ub(b,c),!0}catch(d){return!1}}:null});\nPb(\"Symbol\",function(a){if(a)return
+        a;var b=function(f,g){this.i=f;Jb(this,\"description\",{configurable:!0,writable:!0,value:g})};b.prototype.toString=function(){return
+        this.i};var c=\"jscomp_symbol_\"+(Math.random()*1E9>>>0)+\"_\",d=0,e=function(f){if(this
+        instanceof e)throw new TypeError(\"g\");return new b(c+(f||\"\")+\"_\"+d++,f)};return
+        e});Pb(\"Symbol.iterator\",function(a){if(a)return a;a=Symbol(\"h\");Jb(Array.prototype,a,{configurable:!0,writable:!0,value:function(){return
+        Zb(Vb(this))}});return a});\nvar Zb=function(a){a={next:a};a[Symbol.iterator]=function(){return
+        this};return a};\nPb(\"Promise\",function(a){function b(){this.i=null}function
+        c(g){return g instanceof e?g:new e(function(h){h(g)})}if(a)return a;b.prototype.j=function(g){if(this.i==null){this.i=[];var
+        h=this;this.o(function(){h.A()})}this.i.push(g)};var d=Lb.setTimeout;b.prototype.o=function(g){d(g,0)};b.prototype.A=function(){for(;this.i&&this.i.length;){var
+        g=this.i;this.i=[];for(var h=0;h<g.length;++h){var k=g[h];g[h]=null;try{k()}catch(m){this.v(m)}}}this.i=null};b.prototype.v=function(g){this.o(function(){throw
+        g;\n})};var e=function(g){this.i=0;this.o=void 0;this.j=[];this.C=!1;var h=this.v();try{g(h.resolve,h.reject)}catch(k){h.reject(k)}};e.prototype.v=function(){function
+        g(m){return function(n){k||(k=!0,m.call(h,n))}}var h=this,k=!1;return{resolve:g(this.Y),reject:g(this.A)}};e.prototype.Y=function(g){if(g===this)this.A(new
+        TypeError(\"i\"));else if(g instanceof e)this.M(g);else{a:switch(typeof g){case
+        \"object\":var h=g!=null;break a;case \"function\":h=!0;break a;default:h=!1}h?this.K(g):this.B(g)}};e.prototype.K=\nfunction(g){var
+        h=void 0;try{h=g.then}catch(k){this.A(k);return}typeof h==\"function\"?this.N(h,g):this.B(g)};e.prototype.A=function(g){this.D(2,g)};e.prototype.B=function(g){this.D(1,g)};e.prototype.D=function(g,h){if(this.i!=0)throw
+        Error(\"j`\"+g+\"`\"+h+\"`\"+this.i);this.i=g;this.o=h;this.i===2&&this.L();this.F()};e.prototype.L=function(){var
+        g=this;d(function(){if(g.G()){var h=Lb.console;typeof h!==\"undefined\"&&h.error(g.o)}},1)};e.prototype.G=function(){if(this.C)return!1;var
+        g=Lb.CustomEvent,h=Lb.Event,\nk=Lb.dispatchEvent;if(typeof k===\"undefined\")return!0;typeof
+        g===\"function\"?g=new g(\"unhandledrejection\",{cancelable:!0}):typeof h===\"function\"?g=new
+        h(\"unhandledrejection\",{cancelable:!0}):(g=Lb.document.createEvent(\"CustomEvent\"),g.initCustomEvent(\"unhandledrejection\",!1,!0,g));g.promise=this;g.reason=this.o;return
+        k(g)};e.prototype.F=function(){if(this.j!=null){for(var g=0;g<this.j.length;++g)f.j(this.j[g]);this.j=null}};var
+        f=new b;e.prototype.M=function(g){var h=this.v();g.Jd(h.resolve,h.reject)};\ne.prototype.N=function(g,h){var
+        k=this.v();try{g.call(h,k.resolve,k.reject)}catch(m){k.reject(m)}};e.prototype.then=function(g,h){function
+        k(q,r){return typeof q==\"function\"?function(u){try{m(q(u))}catch(w){n(w)}}:r}var
+        m,n,p=new e(function(q,r){m=q;n=r});this.Jd(k(g,m),k(h,n));return p};e.prototype.catch=function(g){return
+        this.then(void 0,g)};e.prototype.Jd=function(g,h){function k(){switch(m.i){case
+        1:g(m.o);break;case 2:h(m.o);break;default:throw Error(\"k`\"+m.i);}}var m=this;this.j==null?f.j(k):\nthis.j.push(k);this.C=!0};e.resolve=c;e.reject=function(g){return
+        new e(function(h,k){k(g)})};e.race=function(g){return new e(function(h,k){for(var
+        m=_.A(g),n=m.next();!n.done;n=m.next())c(n.value).Jd(h,k)})};e.all=function(g){var
+        h=_.A(g),k=h.next();return k.done?c([]):new e(function(m,n){function p(u){return
+        function(w){q[u]=w;r--;r==0&&m(q)}}var q=[],r=0;do q.push(void 0),r++,c(k.value).Jd(p(q.length-1),n),k=h.next();while(!k.done)})};return
+        e});\nvar $b=function(a,b,c){if(a==null)throw new TypeError(\"l`\"+c);if(b
+        instanceof RegExp)throw new TypeError(\"m`\"+c);return a+\"\"};Pb(\"String.prototype.startsWith\",function(a){return
+        a?a:function(b,c){var d=$b(this,b,\"startsWith\"),e=d.length,f=b.length;c=Math.max(0,Math.min(c|0,d.length));for(var
+        g=0;g<f&&c<e;)if(d[c++]!=b[g++])return!1;return g>=f}});Pb(\"Object.setPrototypeOf\",function(a){return
+        a||Ub});Pb(\"Symbol.dispose\",function(a){return a?a:Symbol(\"n\")});\nPb(\"WeakMap\",function(a){function
+        b(){}function c(k){var m=typeof k;return m===\"object\"&&k!==null||m===\"function\"}function
+        d(k){if(!Xb(k,f)){var m=new b;Jb(k,f,{value:m})}}function e(k){var m=Object[k];m&&(Object[k]=function(n){if(n
+        instanceof b)return n;Object.isExtensible(n)&&d(n);return m(n)})}if(function(){if(!a||!Object.seal)return!1;try{var
+        k=Object.seal({}),m=Object.seal({}),n=new a([[k,2],[m,3]]);if(n.get(k)!=2||n.get(m)!=3)return!1;n.delete(k);n.set(m,4);return!n.has(k)&&n.get(m)==4}catch(p){return!1}}())return
+        a;\nvar f=\"$jscomp_hidden_\"+Math.random();e(\"freeze\");e(\"preventExtensions\");e(\"seal\");var
+        g=0,h=function(k){this.i=(g+=Math.random()+1).toString();if(k){k=_.A(k);for(var
+        m;!(m=k.next()).done;)m=m.value,this.set(m[0],m[1])}};h.prototype.set=function(k,m){if(!c(k))throw
+        Error(\"o\");d(k);if(!Xb(k,f))throw Error(\"p`\"+k);k[f][this.i]=m;return
+        this};h.prototype.get=function(k){return c(k)&&Xb(k,f)?k[f][this.i]:void 0};h.prototype.has=function(k){return
+        c(k)&&Xb(k,f)&&Xb(k[f],this.i)};h.prototype.delete=function(k){return c(k)&&\nXb(k,f)&&Xb(k[f],this.i)?delete
+        k[f][this.i]:!1};return h});\nPb(\"Map\",function(a){if(function(){if(!a||typeof
+        a!=\"function\"||!a.prototype.entries||typeof Object.seal!=\"function\")return!1;try{var
+        h=Object.seal({x:4}),k=new a(_.A([[h,\"s\"]]));if(k.get(h)!=\"s\"||k.size!=1||k.get({x:4})||k.set({x:4},\"t\")!=k||k.size!=2)return!1;var
+        m=k.entries(),n=m.next();if(n.done||n.value[0]!=h||n.value[1]!=\"s\")return!1;n=m.next();return
+        n.done||n.value[0].x!=4||n.value[1]!=\"t\"||!m.next().done?!1:!0}catch(p){return!1}}())return
+        a;var b=new WeakMap,c=function(h){this[0]={};this[1]=\nf();this.size=0;if(h){h=_.A(h);for(var
+        k;!(k=h.next()).done;)k=k.value,this.set(k[0],k[1])}};c.prototype.set=function(h,k){h=h===0?0:h;var
+        m=d(this,h);m.list||(m.list=this[0][m.id]=[]);m.entry?m.entry.value=k:(m.entry={next:this[1],yb:this[1].yb,head:this[1],key:h,value:k},m.list.push(m.entry),this[1].yb.next=m.entry,this[1].yb=m.entry,this.size++);return
+        this};c.prototype.delete=function(h){h=d(this,h);return h.entry&&h.list?(h.list.splice(h.index,1),h.list.length||delete
+        this[0][h.id],h.entry.yb.next=\nh.entry.next,h.entry.next.yb=h.entry.yb,h.entry.head=null,this.size--,!0):!1};c.prototype.clear=function(){this[0]={};this[1]=this[1].yb=f();this.size=0};c.prototype.has=function(h){return!!d(this,h).entry};c.prototype.get=function(h){return(h=d(this,h).entry)&&h.value};c.prototype.entries=function(){return
+        e(this,function(h){return[h.key,h.value]})};c.prototype.keys=function(){return
+        e(this,function(h){return h.key})};c.prototype.values=function(){return e(this,function(h){return
+        h.value})};c.prototype.forEach=\nfunction(h,k){for(var m=this.entries(),n;!(n=m.next()).done;)n=n.value,h.call(k,n[1],n[0],this)};c.prototype[Symbol.iterator]=c.prototype.entries;var
+        d=function(h,k){var m=k&&typeof k;m==\"object\"||m==\"function\"?b.has(k)?m=b.get(k):(m=\"\"+
+        ++g,b.set(k,m)):m=\"p_\"+k;var n=h[0][m];if(n&&Xb(h[0],m))for(h=0;h<n.length;h++){var
+        p=n[h];if(k!==k&&p.key!==p.key||k===p.key)return{id:m,list:n,index:h,entry:p}}return{id:m,list:n,index:-1,entry:void
+        0}},e=function(h,k){var m=h[1];return Zb(function(){if(m){for(;m.head!=\nh[1];)m=m.yb;for(;m.next!=m.head;)return
+        m=m.next,{done:!1,value:k(m)};m=null}return{done:!0,value:void 0}})},f=function(){var
+        h={};return h.yb=h.next=h.head=h},g=0;return c});\nPb(\"Set\",function(a){if(function(){if(!a||typeof
+        a!=\"function\"||!a.prototype.entries||typeof Object.seal!=\"function\")return!1;try{var
+        c=Object.seal({x:4}),d=new a(_.A([c]));if(!d.has(c)||d.size!=1||d.add(c)!=d||d.size!=1||d.add({x:4})!=d||d.size!=2)return!1;var
+        e=d.entries(),f=e.next();if(f.done||f.value[0]!=c||f.value[1]!=c)return!1;f=e.next();return
+        f.done||f.value[0]==c||f.value[0].x!=4||f.value[1]!=f.value[0]?!1:e.next().done}catch(g){return!1}}())return
+        a;var b=function(c){this.i=new Map;if(c){c=\n_.A(c);for(var d;!(d=c.next()).done;)this.add(d.value)}this.size=this.i.size};b.prototype.add=function(c){c=c===0?0:c;this.i.set(c,c);this.size=this.i.size;return
+        this};b.prototype.delete=function(c){c=this.i.delete(c);this.size=this.i.size;return
+        c};b.prototype.clear=function(){this.i.clear();this.size=0};b.prototype.has=function(c){return
+        this.i.has(c)};b.prototype.entries=function(){return this.i.entries()};b.prototype.values=function(){return
+        this.i.values()};b.prototype.keys=b.prototype.values;\nb.prototype[Symbol.iterator]=b.prototype.values;b.prototype.forEach=function(c,d){var
+        e=this;this.i.forEach(function(f){return c.call(d,f,f,e)})};return b});Pb(\"Array.from\",function(a){return
+        a?a:function(b,c,d){c=c!=null?c:function(h){return h};var e=[],f=typeof Symbol!=\"undefined\"&&Symbol.iterator&&b[Symbol.iterator];if(typeof
+        f==\"function\"){b=f.call(b);for(var g=0;!(f=b.next()).done;)e.push(c.call(d,f.value,g++))}else
+        for(f=b.length,g=0;g<f;g++)e.push(c.call(d,b[g],g));return e}});\nPb(\"Object.entries\",function(a){return
+        a?a:function(b){var c=[],d;for(d in b)Xb(b,d)&&c.push([d,b[d]]);return c}});Pb(\"Number.isFinite\",function(a){return
+        a?a:function(b){return typeof b!==\"number\"?!1:!isNaN(b)&&b!==Infinity&&b!==-Infinity}});Pb(\"Number.MAX_SAFE_INTEGER\",function(){return
+        9007199254740991});Pb(\"Number.MIN_SAFE_INTEGER\",function(){return-9007199254740991});Pb(\"Number.isInteger\",function(a){return
+        a?a:function(b){return Number.isFinite(b)?b===Math.floor(b):!1}});\nPb(\"Number.isSafeInteger\",function(a){return
+        a?a:function(b){return Number.isInteger(b)&&Math.abs(b)<=Number.MAX_SAFE_INTEGER}});Pb(\"Object.is\",function(a){return
+        a?a:function(b,c){return b===c?b!==0||1/b===1/c:b!==b&&c!==c}});Pb(\"Array.prototype.includes\",function(a){return
+        a?a:function(b,c){var d=this;d instanceof String&&(d=String(d));var e=d.length;c=c||0;for(c<0&&(c=Math.max(c+e,0));c<e;c++){var
+        f=d[c];if(f===b||Object.is(f,b))return!0}return!1}});\nPb(\"String.prototype.includes\",function(a){return
+        a?a:function(b,c){return $b(this,b,\"includes\").indexOf(b,c||0)!==-1}});var
+        ac=function(a,b){a instanceof String&&(a+=\"\");var c=0,d=!1,e={next:function(){if(!d&&c<a.length){var
+        f=c++;return{value:b(f,a[f]),done:!1}}d=!0;return{done:!0,value:void 0}}};e[Symbol.iterator]=function(){return
+        e};return e};Pb(\"Array.prototype.entries\",function(a){return a?a:function(){return
+        ac(this,function(b,c){return[b,c]})}});\nPb(\"Math.trunc\",function(a){return
+        a?a:function(b){b=Number(b);if(isNaN(b)||b===Infinity||b===-Infinity||b===0)return
+        b;var c=Math.floor(Math.abs(b));return b<0?-c:c}});Pb(\"Array.prototype.find\",function(a){return
+        a?a:function(b,c){a:{var d=this;d instanceof String&&(d=String(d));for(var
+        e=d.length,f=0;f<e;f++){var g=d[f];if(b.call(c,g,f,d)){b=g;break a}}b=void
+        0}return b}});Pb(\"Object.values\",function(a){return a?a:function(b){var
+        c=[],d;for(d in b)Xb(b,d)&&c.push(b[d]);return c}});\nPb(\"Number.isNaN\",function(a){return
+        a?a:function(b){return typeof b===\"number\"&&isNaN(b)}});Pb(\"Array.prototype.keys\",function(a){return
+        a?a:function(){return ac(this,function(b){return b})}});Pb(\"Array.prototype.values\",function(a){return
+        a?a:function(){return ac(this,function(b,c){return c})}});\nPb(\"Array.prototype.fill\",function(a){return
+        a?a:function(b,c,d){var e=this.length||0;c<0&&(c=Math.max(0,e+c));if(d==null||d>e)d=e;d=Number(d);d<0&&(d=Math.max(0,e+d));for(c=Number(c||0);c<d;c++)this[c]=b;return
+        this}});Ob(\"fill\",function(a){return a?a:Array.prototype.fill});Pb(\"Promise.prototype.finally\",function(a){return
+        a?a:function(b){return this.then(function(c){return Promise.resolve(b()).then(function(){return
+        c})},function(c){return Promise.resolve(b()).then(function(){throw c;})})}});\nPb(\"Array.prototype.flat\",function(a){return
+        a?a:function(b){b=b===void 0?1:b;var c=[];Array.prototype.forEach.call(this,function(d){Array.isArray(d)&&b>0?(d=Array.prototype.flat.call(d,b-1),c.push.apply(c,d)):c.push(d)});return
+        c}});var dc,ec,ic,jc;_.bc=_.bc||{};_.t=this||self;dc=function(a,b){var c=_.cc(\"WIZ_global_data.oxN3nb\");a=c&&c[a];return
+        a!=null?a:b};ec=_.t._F_toggles_gbar_||[];_.cc=function(a,b){a=a.split(\".\");b=b||_.t;for(var
+        c=0;c<a.length;c++)if(b=b[a[c]],b==null)return null;return b};_.Qa=function(a){var
+        b=typeof a;return b!=\"object\"?b:a?Array.isArray(a)?\"array\":b:\"null\"};_.fc=function(a){var
+        b=typeof a;return b==\"object\"&&a!=null||b==\"function\"};_.hc=\"closure_uid_\"+(Math.random()*1E9>>>0);\nic=function(a,b,c){return
+        a.call.apply(a.bind,arguments)};jc=function(a,b,c){if(!a)throw Error();if(arguments.length>2){var
+        d=Array.prototype.slice.call(arguments,2);return function(){var e=Array.prototype.slice.call(arguments);Array.prototype.unshift.apply(e,d);return
+        a.apply(b,e)}}return function(){return a.apply(b,arguments)}};_.C=function(a,b,c){_.C=Function.prototype.bind&&Function.prototype.bind.toString().indexOf(\"native
+        code\")!=-1?ic:jc;return _.C.apply(null,arguments)};\n_.kc=function(a,b){var
+        c=Array.prototype.slice.call(arguments,1);return function(){var d=c.slice();d.push.apply(d,arguments);return
+        a.apply(this,d)}};_.D=function(a,b){a=a.split(\".\");for(var c=_.t,d;a.length&&(d=a.shift());)a.length||b===void
+        0?c[d]&&c[d]!==Object.prototype[d]?c=c[d]:c=c[d]={}:c[d]=b};_.ab=function(a){return
+        a};\n_.E=function(a,b){function c(){}c.prototype=b.prototype;a.X=b.prototype;a.prototype=new
+        c;a.prototype.constructor=a;a.Bm=function(d,e,f){for(var g=Array(arguments.length-2),h=2;h<arguments.length;h++)g[h-2]=arguments[h];return
+        b.prototype[e].apply(d,g)}};_.E(_.aa,Error);_.aa.prototype.name=\"CustomError\";var
+        lc=!!(ec[0]>>17&1),mc=!!(ec[0]&4096),nc=!!(ec[0]>>18&1),oc=!!(ec[0]&256),pc=!!(ec[0]&32),qc=!!(ec[0]&1024);var
+        sc,ma,qb;sc=dc(1,!0);ma=lc?nc:dc(610401301,!1);qb=lc?mc||!oc:dc(748402147,!0);_.tc=lc?mc||!pc:dc(824648567,!0);_.uc=lc?mc||!qc:dc(824656860,sc);_.wc=_.ba(function(a){return
+        a!==null&&a!==void 0});var da=_.ba(function(a){return typeof a===\"number\"}),ca=_.ba(function(a){return
+        typeof a===\"string\"}),fa=_.ba(function(a){return typeof a===\"boolean\"});var
+        ea=typeof _.t.BigInt===\"function\"&&typeof _.t.BigInt(0)===\"bigint\";var
+        zc,xc,Ac,yc;_.ib=_.ba(function(a){return ea?a>=xc&&a<=yc:a[0]===\"-\"?ia(a,zc):ia(a,Ac)});zc=Number.MIN_SAFE_INTEGER.toString();xc=ea?BigInt(Number.MIN_SAFE_INTEGER):void
+        0;Ac=Number.MAX_SAFE_INTEGER.toString();yc=ea?BigInt(Number.MAX_SAFE_INTEGER):void
+        0;_.Bc=typeof Uint8Array.prototype.slice===\"function\";_.Cc=typeof TextDecoder!==\"undefined\";_.Dc=typeof
+        String.prototype.isWellFormed===\"function\";_.Ec=typeof TextEncoder!==\"undefined\";_.Fc=String.prototype.trim?function(a){return
+        a.trim()}:function(a){return/^[\\s\\xa0]*([\\s\\S]*?)[\\s\\xa0]*$/.exec(a)[1]};var
+        na,Gc=_.t.navigator;na=Gc?Gc.userAgentData||null:null;_.Aa=Array.prototype.indexOf?function(a,b){return
+        Array.prototype.indexOf.call(a,b,void 0)}:function(a,b){if(typeof a===\"string\")return
+        typeof b!==\"string\"||b.length!=1?-1:a.indexOf(b,0);for(var c=0;c<a.length;c++)if(c
+        in a&&a[c]===b)return c;return-1};_.Hc=Array.prototype.forEach?function(a,b,c){Array.prototype.forEach.call(a,b,c)}:function(a,b,c){for(var
+        d=a.length,e=typeof a===\"string\"?a.split(\"\"):a,f=0;f<d;f++)f in e&&b.call(c,e[f],f,a)};\n_.Ic=Array.prototype.filter?function(a,b,c){return
+        Array.prototype.filter.call(a,b,c)}:function(a,b,c){for(var d=a.length,e=[],f=0,g=typeof
+        a===\"string\"?a.split(\"\"):a,h=0;h<d;h++)if(h in g){var k=g[h];b.call(c,k,h,a)&&(e[f++]=k)}return
+        e};_.Jc=Array.prototype.map?function(a,b,c){return Array.prototype.map.call(a,b,c)}:function(a,b,c){for(var
+        d=a.length,e=Array(d),f=typeof a===\"string\"?a.split(\"\"):a,g=0;g<d;g++)g
+        in f&&(e[g]=b.call(c,f[g],g,a));return e};\n_.Kc=Array.prototype.some?function(a,b){return
+        Array.prototype.some.call(a,b,void 0)}:function(a,b){for(var c=a.length,d=typeof
+        a===\"string\"?a.split(\"\"):a,e=0;e<c;e++)if(e in d&&b.call(void 0,d[e],e,a))return!0;return!1};_.Lc=function(a){_.Lc[\"
+        \"](a);return a};_.Lc[\" \"]=function(){};var Yc;_.Mc=_.ra();_.Nc=_.sa();_.Oc=_.pa(\"Edge\");_.Pc=_.pa(\"Gecko\")&&!(_.la()&&!_.pa(\"Edge\"))&&!(_.pa(\"Trident\")||_.pa(\"MSIE\"))&&!_.pa(\"Edge\");_.Qc=_.la()&&!_.pa(\"Edge\");_.Rc=_.za();_.Sc=wa()?na.platform===\"Windows\":_.pa(\"Windows\");_.Tc=wa()?na.platform===\"Android\":_.pa(\"Android\");_.Uc=xa();_.Vc=_.pa(\"iPad\");_.Wc=_.pa(\"iPod\");_.Xc=_.ya();\na:{var
+        Zc=\"\",$c=function(){var a=_.ka();if(_.Pc)return/rv:([^\\);]+)(\\)|;)/.exec(a);if(_.Oc)return/Edge\\/([\\d\\.]+)/.exec(a);if(_.Nc)return/\\b(?:MSIE|rv)[:
+        ]([^\\);]+)(\\)|;)/.exec(a);if(_.Qc)return/WebKit\\/(\\S+)/.exec(a);if(_.Mc)return/(?:Version)[
+        \\/]?(\\S+)/.exec(a)}();$c&&(Zc=$c?$c[1]:\"\");if(_.Nc){var ad,bd=_.t.document;ad=bd?bd.documentMode:void
+        0;if(ad!=null&&ad>parseFloat(Zc)){Yc=String(ad);break a}}Yc=Zc}_.cd=Yc;_.ed=_.ta();_.fd=xa()||_.pa(\"iPod\");_.gd=_.pa(\"iPad\");_.hd=_.pa(\"Android\")&&!(ua()||_.ta()||_.ra()||_.pa(\"Silk\"));_.id=ua();_.jd=_.va()&&!_.ya();_.kd=typeof
+        Uint8Array!==\"undefined\";_.ld=!_.Nc&&typeof btoa===\"function\";var md,db,sb,mb;_.Da=typeof
+        Symbol===\"function\"&&typeof Symbol()===\"symbol\";md=_.Ca(\"jas\",void 0,!0);_.bb=_.Ca(void
+        0,Symbol());_.nd=_.Ca(void 0,\"0ub\");db=_.Ca(void 0,\"0ubs\");_.od=_.Ca(void
+        0,\"0ubsb\");sb=_.Ca(void 0,\"0actk\");_.Ya=_.Ca(\"m_m\",\"Pm\",!0);mb=_.Ca(void
+        0,\"vps\");_.pd=_.Ca();var Fa,Ea,rd;Fa={dk:{value:0,configurable:!0,writable:!0,enumerable:!1}};Ea=Object.defineProperties;_.v=_.Da?md:\"dk\";rd=[];_.Ha(rd,7);_.qd=Object.freeze(rd);var
+        Ia;_.Za={};Ia={};_.sd=Object.freeze({});var nb={};var Oa=void 0;_.td=typeof
+        BigInt===\"function\"?BigInt.asIntN:void 0;_.ud=Number.isSafeInteger;_.Ta=Number.isFinite;_.vd=Math.trunc;var
+        fb;_.wd=_.ha(0);_.xd={};_.yd=function(a,b,c,d,e){b=_.Cb(a.J,b,c,e);if(b!==null||d&&a.o!==Ia)return
+        b};_.Cb=function(a,b,c,d){if(b===-1)return null;var e=b+(c?0:-1),f=a.length-1;if(!(f<1+(c?0:-1))){if(e>=f){var
+        g=a[f];if(g!=null&&typeof g===\"object\"&&g.constructor===Object){c=g[b];var
+        h=!0}else if(e===f)c=g;else return}else c=a[e];if(d&&c!=null){d=d(c);if(d==null)return
+        d;if(!Object.is(d,c))return h?g[b]=d:a[e]=d,d}return c}};_.zd=function(a,b,c,d){_.zb(a);var
+        e=a.J;_.Bb(e,e[_.v]|0,b,c,d);return a};\n_.F=function(a,b,c,d){var e=a.J,f=e[_.v]|0;b=_.Db(e,f,b,c,d);if(b==null)return
+        b;f=e[_.v]|0;if(!_.Ja(a,f)){var g=_.xb(b);g!==b&&(_.yb(a)&&(e=a.J,f=e[_.v]|0),b=g,f=_.Bb(e,f,c,b,d),_.Ab(e,f))}return
+        b};_.H=function(a,b,c){c==null&&(c=void 0);_.zd(a,b,c);c&&!_.Ja(c)&&_.Ab(a.J);return
+        a};_.J=function(a,b,c,d){c=c===void 0?!1:c;var e;return(e=_.Sa(_.yd(a,b,d)))!=null?e:c};_.K=function(a,b,c,d){c=c===void
+        0?\"\":c;var e;return(e=_.Xa(_.yd(a,b,d)))!=null?e:c};_.L=function(a,b,c){return
+        _.Xa(_.yd(a,b,c,_.xd))};\n_.M=function(a,b,c,d){return _.zd(a,b,c==null?c:_.Ra(c),d)};_.O=function(a,b,c){return
+        _.zd(a,b,c==null?c:_.Va(c))};_.P=function(a,b,c,d){return _.zd(a,b,_.Wa(c),d)};_.Q=function(a,b,c,d){return
+        _.zd(a,b,c==null?c:_.Ua(c),d)};_.R=function(a,b,c){this.J=_.x(a,b,c)};_.R.prototype.toJSON=function(){return
+        ob(this)};_.R.prototype.va=function(a){return JSON.stringify(ob(this,a))};_.R.prototype[_.Ya]=_.Za;_.R.prototype.toString=function(){return
+        this.J.toString()};_.Ad=_.Eb();_.Bd=_.Eb();_.Cd=_.Eb();_.Dd=Symbol();var Ed=function(a){this.J=_.x(a)};_.z(Ed,_.R);_.Fd=function(a){this.J=_.x(a)};_.z(_.Fd,_.R);_.Fd.prototype.vd=function(a){return
+        _.O(this,3,a)};_.Gd=function(a){this.J=_.x(a)};_.z(_.Gd,_.R);_.S=function(){this.Ba=this.Ba;this.Y=this.Y};_.S.prototype.Ba=!1;_.S.prototype.isDisposed=function(){return
+        this.Ba};_.S.prototype.dispose=function(){this.Ba||(this.Ba=!0,this.P())};_.S.prototype[Symbol.dispose]=function(){this.dispose()};_.S.prototype.P=function(){if(this.Y)for(;this.Y.length;)this.Y.shift()()};var
+        Hd=function(a){_.S.call(this);this.o=a;this.i=[];this.j={}};_.z(Hd,_.S);Hd.prototype.resolve=function(a){var
+        b=this.o;a=a.split(\".\");for(var c=a.length,d=0;d<c;++d)if(b[a[d]])b=b[a[d]];else
+        return null;return b instanceof Function?b:null};Hd.prototype.ub=function(){for(var
+        a=this.i.length,b=this.i,c=[],d=0;d<a;++d){var e=b[d].i(),f=this.resolve(e);if(f&&f!=this.j[e])try{b[d].ub(f)}catch(g){}else
+        c.push(b[d])}this.i=c.concat(b.slice(a))};var Jd=function(a){_.S.call(this);this.o=a;this.A=this.i=null;this.v=0;this.B={};this.j=!1;a=window.navigator.userAgent;a.indexOf(\"MSIE\")>=0&&a.indexOf(\"Trident\")>=0&&(a=/\\b(?:MSIE|rv)[:
+        ]([^\\);]+)(\\)|;)/.exec(a))&&a[1]&&parseFloat(a[1])<9&&(this.j=!0)};_.z(Jd,_.S);Jd.prototype.C=function(a,b){this.i=b;this.A=a;b.preventDefault?b.preventDefault():b.returnValue=!1};_.Kd=function(a){this.J=_.x(a)};_.z(_.Kd,_.R);var
+        Ld=function(a){this.J=_.x(a)};_.z(Ld,_.R);var Nd=function(){var a=Md;this.i=null;_.J(a,4,!0)};Nd.prototype.log=function(a,b,c){c=c===void
+        0?new _.Fd:c;_.Od(this,a,98,c)};_.Od=function(a,b,c,d){c=c===void 0?98:c;d=d===void
+        0?new _.Fd:d;if(a.i){var e=new Ed;_.P(e,1,b.message);_.P(e,2,b.stack);_.O(e,3,b.lineNumber);_.Q(e,5,1);_.H(d,40,e);a.i.log(c,d)}};_.Pd=function(a){this.i=a;this.j=void
+        0;this.o=[]};_.Pd.prototype.then=function(a,b,c){this.o.push(new Qd(a,b,c));Rd(this)};_.Pd.prototype.resolve=function(a){if(this.i!==void
+        0||this.j!==void 0)throw Error(\"J\");this.i=a;Rd(this)};_.Pd.prototype.reject=function(a){if(this.i!==void
+        0||this.j!==void 0)throw Error(\"J\");this.j=a;Rd(this)};var Rd=function(a){if(a.o.length>0){var
+        b=a.i!==void 0,c=a.j!==void 0;if(b||c){b=b?a.v:a.A;c=a.o;a.o=[];try{_.Hc(c,b,a)}catch(d){console.error(d)}}}};\n_.Pd.prototype.v=function(a){a.j&&a.j.call(a.i,this.i)};_.Pd.prototype.A=function(a){a.o&&a.o.call(a.i,this.j)};var
+        Qd=function(a,b,c){this.j=a;this.o=b;this.i=c};_.Sd=function(a){var b=\"bc\";if(a.bc&&a.hasOwnProperty(b))return
+        a.bc;b=new a;return a.bc=b};_.T=function(){this.v=new _.Pd;this.i=new _.Pd;this.D=new
+        _.Pd;this.B=new _.Pd;this.C=new _.Pd;this.A=new _.Pd;this.o=new _.Pd;this.j=new
+        _.Pd;this.F=new _.Pd;this.G=new _.Pd};_.l=_.T.prototype;_.l.fj=function(){return
+        this.v};_.l.nj=function(){return this.i};_.l.xj=function(){return this.D};_.l.mj=function(){return
+        this.B};_.l.vj=function(){return this.C};_.l.kj=function(){return this.A};_.l.Yi=function(){return
+        this.o};_.l.Xi=function(){return this.j};_.l.oj=function(){return this.F};_.T.i=function(){return
+        _.Sd(_.T)};var Td=function(a){this.J=_.x(a)};_.z(Td,_.R);_.Vd=function(){return
+        _.F(_.Ud,_.Gd,5)};var Wd;window.gbar_&&window.gbar_.CONFIG?Wd=window.gbar_.CONFIG[0]||{}:Wd=[];_.Ud=new
+        Td(Wd);var Md;Md=_.F(_.Ud,Ld,3)||new Ld;_.Xd=new Nd;_.D(\"gbar_._DumpException\",function(a){_.Xd?_.Xd.log(a):console.error(a)});_.Yd=new
+        Jd(_.Xd);_.Zd=function(){this.i={};this.j={}};_.ae=function(a,b){var c=_.Zd.i();if(a
+        in c.i){if(c.i[a]!=b)throw new $d(a);}else{c.i[a]=b;if(b=c.j[a])for(var d=0,e=b.length;d<e;d++){var
+        f=b[d],g=c.i;delete f.i[a];if(_.Hb(f.i)){for(var h=f.j.length,k=Array(h),m=0;m<h;m++)k[m]=g[f.j[m]];f.o.apply(f.v,k)}}delete
+        c.j[a]}};_.Zd.i=function(){return _.Sd(_.Zd)};_.be=function(){_.aa.call(this)};_.z(_.be,_.aa);var
+        $d=function(){_.aa.call(this)};_.z($d,_.be);_.D(\"gbar.A\",_.Pd);_.Pd.prototype.aa=_.Pd.prototype.then;_.D(\"gbar.B\",_.T);_.T.prototype.ba=_.T.prototype.nj;_.T.prototype.bb=_.T.prototype.xj;_.T.prototype.bd=_.T.prototype.vj;_.T.prototype.bf=_.T.prototype.fj;_.T.prototype.bg=_.T.prototype.mj;_.T.prototype.bh=_.T.prototype.kj;_.T.prototype.bj=_.T.prototype.Yi;_.T.prototype.bk=_.T.prototype.Xi;_.T.prototype.bl=_.T.prototype.oj;_.D(\"gbar.a\",_.T.i());window.gbar&&window.gbar.ap&&window.gbar.ap(window.gbar.a);var
+        ce=new Hd(window);_.ae(\"api\",ce);\nvar de=_.Vd()||new _.Gd,ee=window,fe=_.y(_.L(de,8));ee.__PVT=fe;_.ae(\"eq\",_.Yd);\n}catch(e){_._DumpException(e)}\ntry{\n_.ge=function(a){this.J=_.x(a)};_.z(_.ge,_.R);\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        he=function(a){this.J=_.x(a)};_.z(he,_.R);var ie=function(){_.S.call(this);this.j=[];this.i=[]};_.z(ie,_.S);ie.prototype.o=function(a,b){this.j.push({features:a,options:b!=null?b:null})};ie.prototype.init=function(a,b,c){window.gapi={};var
+        d=window.___jsl={};d.h=_.y(_.L(a,1));_.Sa(_.yd(a,12))!=null&&(d.dpo=_.Fb(_.J(a,12)));d.ms=_.y(_.L(a,2));d.m=_.y(_.L(a,3));d.l=[];_.K(b,1)&&(a=_.L(b,3))&&this.i.push(a);_.K(c,1)&&(c=_.L(c,2))&&this.i.push(c);_.D(\"gapi.load\",(0,_.C)(this.o,this));return
+        this};var je=_.F(_.Ud,_.Kd,14);if(je){var ke=_.F(_.Ud,_.ge,9)||new _.ge,le=new
+        he,me=new ie;me.init(je,ke,le);_.ae(\"gs\",me)};\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><script type=\"application/ld+json\" nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">\n{\n
+        \ \"@context\" : \"https://schema.org\",\n  \"@type\" : \"WebSite\",\n  \"name\"
+        : \"Google NotebookLM\",\n  \"url\" : \"https://notebooklm.google/\"\n}\n</script><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">var AF_initDataKeys = []; var AF_dataServiceRequests
+        = {}; var AF_initDataChunkQueue = []; var AF_initDataCallback; var AF_initDataInitializeCallback;
+        if (AF_initDataInitializeCallback) {AF_initDataInitializeCallback(AF_initDataKeys,
+        AF_initDataChunkQueue, AF_dataServiceRequests);}if (!AF_initDataCallback)
+        {AF_initDataCallback = function(chunk) {AF_initDataChunkQueue.push(chunk);};}</script></head><body><!--
+        Google Tag Manager (noscript) --><noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-WQ7LTQ58\"
+        height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript><!--
+        End Google Tag Manager (noscript) --></body><div class=\"boqOnegoogleliteOgbOneGoogleBar\"><div
+        class=\"gb_Ha gb_Dd gb_yb gb_e gb_3a\" id=\"gb\"><div class=\"gb_2d gb_wb
+        gb_Sd\" ng-non-bindable=\"\" data-ogsr-up=\"\"><div class=\"gb_Cd\"><div class=\"gb_jd\"><div
+        class=\"gb_J gb_vd gb_1\" data-ogsr-alt=\"\" id=\"gbwa\"><div class=\"gb_D\"><a
+        class=\"gb_B\" aria-label=\"Google apps\" href=\"https://www.google.com/intl/en/about/products\"
+        aria-expanded=\"false\" role=\"button\" tabindex=\"0\"><svg class=\"gb_F\"
+        focusable=\"false\" viewbox=\"0 0 24 24\"><path d=\"M6,8c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,20c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9
+        -2,2 0.9,2 2,2zM6,20c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM6,14c1.1,0
+        2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,14c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2zM16,6c0,1.1 0.9,2 2,2s2,-0.9 2,-2 -0.9,-2 -2,-2
+        -2,0.9 -2,2zM12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,14c1.1,0
+        2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,20c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2z\"></path><image src=\"https://ssl.gstatic.com/gb/images/bar/al-icon.png\"
+        alt=\"\" height=\"24\" width=\"24\" style=\"border:none;display:none \\9\"></image></svg></a></div></div></div><div
+        class=\"gb_z gb_vd gb_Qf gb_1\"><div class=\"gb_D gb_vb gb_Qf gb_1\"><a class=\"gb_B
+        gb_0a gb_1\" aria-expanded=\"false\" aria-label=\"Google Account: SCRUBBED_NAME
+        \ &#10;(SCRUBBED_EMAIL@example.com)\" href=\"https://accounts.google.com/SignOutOptions?hl=en&amp;continue=https://notebooklm.google.com/&amp;ec=GBRAmgU\"
+        tabindex=\"0\" role=\"button\"><div class=\"gb_P\"><svg focusable=\"false\"
+        height=\"40px\" version=\"1.1\" viewbox=\"0 0 40 40\" width=\"40px\" xml:space=\"preserve\"
+        xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        style=\"opacity:1.0\"><path d=\"M4.02,28.27C2.73,25.8,2,22.98,2,20c0-2.87,0.68-5.59,1.88-8l-1.72-1.04C0.78,13.67,0,16.75,0,20c0,3.31,0.8,6.43,2.23,9.18L4.02,28.27z\"
+        fill=\"#F6AD01\"></path><path d=\"M32.15,33.27C28.95,36.21,24.68,38,20,38c-6.95,0-12.98-3.95-15.99-9.73l-1.79,0.91C5.55,35.61,12.26,40,20,40c5.2,0,9.93-1.98,13.48-5.23L32.15,33.27z\"
+        fill=\"#249A41\"></path><path d=\"M33.49,34.77C37.49,31.12,40,25.85,40,20c0-5.86-2.52-11.13-6.54-14.79l-1.37,1.46C35.72,9.97,38,14.72,38,20c0,5.25-2.26,9.98-5.85,13.27L33.49,34.77z\"
+        fill=\"#3174F1\"></path><path d=\"M20,2c4.65,0,8.89,1.77,12.09,4.67l1.37-1.46C29.91,1.97,25.19,0,20,0l0,0C12.21,0,5.46,4.46,2.16,10.96L3.88,12C6.83,6.08,12.95,2,20,2\"
+        fill=\"#E92D18\"></path></svg></div><span class=\"gb_be\"><img class=\"gb_Q
+        gbii\" src=\"SCRUBBED_AVATAR_URL\" srcset=\"SCRUBBED_AVATAR_URL 1x, SCRUBBED_AVATAR_URL
+        2x \" alt=\"\" aria-hidden=\"true\" data-noaft=\"\"></span><div class=\"gb_R
+        gb_S\" aria-hidden=\"true\"><svg class=\"gb_La\" height=\"14\" viewBox=\"0
+        0 14 14\" width=\"14\" xmlns=\"http://www.w3.org/2000/svg\"><circle class=\"gb_Ma\"
+        cx=\"7\" cy=\"7\" r=\"7\"></circle><path class=\"gb_Oa\" d=\"M6 10H8V12H6V10ZM6
+        2H8V8H6V2Z\"></path></svg></div></a></div><div class=\"gb_Ab gb_ma gb_4 gb_Bb\"
+        aria-label=\"Account Information\" aria-hidden=\"true\"><div class=\"gb_Kb\"><div
+        class=\"gb_Lb\"><img class=\"gb_nb gbip gb_Pb gb_Sb\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
+        data-src=\"SCRUBBED_AVATAR_URL\" data-srcset=\"SCRUBBED_AVATAR_URL 1x, SCRUBBED_AVATAR_URL
+        2x \" title=\"Profile\" alt=\"\" aria-hidden=\"true\"><div class=\"gb_Hc\"><svg
+        height=\"88\" width=\"88\" focusable=\"false\" version=\"1.1\" viewbox=\"0
+        0 108 108\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        style=\"opacity:1.0\"><path d=\"M3,54c0-8.21,1.95-15.96,5.4-22.83l-2.62-1.32c-3.67,7.29-5.74,15.51-5.74,24.23
+        c0,9.01,2.22,17.49,6.12,24.96l2.66-1.4C5.11,70.56,3,62.53,3,54z\" fill=\"#F6AD01\"></path><path
+        d=\"M90.22,94.16l-2.07-2.28C79.11,100.03,67.13,105,54,105c-19.64,0-36.67-11.1-45.19-27.37l-2.66,1.4
+        c8.53,16.34,25.17,27.76,44.58,28.93h6.6C69.95,107.21,81.4,102.12,90.22,94.16z\"
+        fill=\"#249A41\"></path><path d=\"M108,52.89c-0.33-15.31-7.02-29.05-17.55-38.68l-2.01,2.17C98.61,25.71,105,39.11,105,54
+        c0,15.03-6.51,28.54-16.85,37.88l2.07,2.28c10.66-9.63,17.45-23.47,17.78-38.89V52.89z\"
+        fill=\"#3174F1\"></path><path d=\"M8.43,31.11C16.81,14.44,34.07,3,54,3c13.28,0,25.36,5.08,34.44,13.39l2.01-2.17
+        C80.85,5.44,68.06,0.08,54.03,0.08C32.95,0.08,14.7,12.17,5.8,29.79L8.43,31.11z\"
+        fill=\"#E92D18\"></path></svg></div><div class=\"gb_Tb gb_Pb\"><a class=\"gb_Ub
+        gb_vf gb_Pb gb_Af\" aria-label=\"Change profile picture.\" href=\"https://myaccount.google.com/?utm_source=OGB\"
+        target=\"_blank\"><svg class=\"gb_Vb\" enable-background=\"new 0 0 24 24\"
+        focusable=\"false\" height=\"26\" viewbox=\"0 0 24 24\" width=\"18\" xml:space=\"preserve\"
+        xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path
+        d=\"M20 5h-3.17L15 3H9L7.17 5H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0
+        2-.9 2-2V7c0-1.1-.9-2-2-2zm0 14H4V7h16v12zM12 9c-2.21 0-4 1.79-4 4s1.79 4
+        4 4 4-1.79 4-4-1.79-4-4-4z\"></path></svg></a></div></div><div class=\"gb_Mb\"><div
+        class=\"gb_Wb gb_g\">SCRUBBED_NAME</div><div class=\"gb_Xb\">SCRUBBED_EMAIL@example.com</div><a
+        class=\"gb_2b gb_wf gbp1 gb_Md gb_Ed\" href=\"https://myaccount.google.com/?utm_source=OGB&amp;utm_medium=act\"
+        target=\"_blank\">Manage your Google Account</a></div></div><div class=\"gb_m
+        gb_ec\"><div class=\"gb_Cf gb_Ic gb_S\"><div class=\"gb_Jc\"></div></div><div
+        class=\"gb_zf gb_gc gb_S\" aria-hidden=\"true\"><a class=\"gb_fc gb_pc\" aria-hidden=\"true\"
+        href=\"/?authuser=0\" target=\"_blank\"><img class=\"gb_rc gb_Pb\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
+        data-src=\"SCRUBBED_AVATAR_URL\" alt=\"\" aria-hidden=\"true\"><div class=\"gb_ic\"><div><div
+        class=\"gb_wc\">Default</div></div><div class=\"gb_tc\">SCRUBBED_NAME</div><div
+        class=\"gb_vc\">SCRUBBED_EMAIL@example.com</div></div></a></div><div class=\"gb_8b\"
+        aria-hidden=\"true\"><svg class=\"gb_9b\" focusable=\"false\" height=\"20\"
+        viewbox=\"0 0 20 20\" width=\"20\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path d=\"M0 0h20v20H0V0z\" fill=\"none\"></path><path
+        d=\"M6.18 7L10 10.82 13.82 7 15 8.17l-5 5-5-5z\"></path></svg></div><a class=\"gb_yc
+        gb_S gb_jc\" href=\"https://myaccount.google.com/brandaccounts?authuser=0&amp;continue=https://notebooklm.google.com/&amp;service=/%3Fauthuser%3D%24authuser%26pageId%3D%24pageId\"
+        aria-hidden=\"true\"><div class=\"gb_zc\"><svg focusable=\"false\" height=\"20\"
+        viewbox=\"0 0 24 24\" width=\"20\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path d=\"M19 3H5c-1.11 0-2 .9-2
+        2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 2v10.79C16.52 14.37
+        13.23 14 12 14s-4.52.37-7 1.79V5h14zM5 19v-.77C6.74 16.66 10.32 16 12 16s5.26.66
+        7 2.23V19H5zm7-6c1.94 0 3.5-1.56 3.5-3.5S13.94 6 12 6 8.5 7.56 8.5 9.5 10.06
+        13 12 13zm0-5c.83 0 1.5.67 1.5 1.5S12.83 11 12 11s-1.5-.67-1.5-1.5S11.17 8
+        12 8z\" fill=\"#5F6368\"></path><path d=\"M0 0h24v24H0V0z\" fill=\"none\"></path></svg></div><div
+        class=\"gb_Bc gb_Cc\">All Brand accounts</div><svg class=\"gb_Dc\" focusable=\"false\"
+        height=\"24\" viewbox=\"0 0 24 24\" width=\"24\" xmlns=\"http://www.w3.org/2000/svg\"><path
+        d=\"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z\" fill=\"#5F6368\"></path><path
+        d=\"M0 0h24v24H0z\" fill=\"none\"></path></svg></a></div><div class=\"gb_kc\"
+        tabindex=\"-1\"><a class=\"gb_5b gb_sf\" href=\"https://accounts.google.com/AddSession?continue=https://notebooklm.google.com/&amp;ec=GAlAmgU\"
+        target=\"_blank\"><div class=\"gb_6b\"><svg class=\"gb_7b\" enable-background=\"new
+        0 0 24 24\" focusable=\"false\" height=\"20\" viewbox=\"0 0 24 24\" width=\"20\"
+        xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path
+        d=\"M9 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0-6c1.1 0 2
+        .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0 7c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4zm6
+        5H3v-.99C3.2 16.29 6.3 15 9 15s5.8 1.29 6 2v1zm3-4v-3h-3V9h3V6h2v3h3v2h-3v3h-2z\"></path></svg></div><div
+        class=\"gb_ac\">Add another account</div></a></div><div class=\"gb_tf gb_bc\"><a
+        class=\"gb_cc gb_xf gb_Ff gb_Md gb_Ed\" id=\"gb_71\" href=\"https://accounts.google.com/Logout?ec=GAdAmgU\"
+        target=\"_top\">Sign out</a></div><div class=\"gb_uf gb_3b\"><a class=\"gb_4b
+        gb_t\" href=\"https://policies.google.com/privacy?hl=en\" target=\"_blank\">Privacy
+        Policy</a><span class=\"gb_sb\" aria-hidden=\"true\">&bull;</span><a class=\"gb_4b
+        gb_x\" href=\"https://myaccount.google.com/termsofservice?hl=en\" target=\"_blank\">Terms
+        of Service</a></div></div></div></div></div></div></div><script nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\n_.oe=function(a,b,c){if(!a.j)if(c instanceof Array){c=_.A(c);for(var
+        d=c.next();!d.done;d=c.next())_.oe(a,b,d.value)}else{d=(0,_.C)(a.C,a,b);var
+        e=a.v+c;a.v++;b.dataset.eqid=e;a.B[e]=d;b&&b.addEventListener?b.addEventListener(c,d,!1):b&&b.attachEvent?b.attachEvent(\"on\"+c,d):a.o.log(Error(\"H`\"+b))}};\n}catch(e){_._DumpException(e)}\ntry{\n_.pe=function(){if(!_.t.addEventListener||!Object.defineProperty)return!1;var
+        a=!1,b=Object.defineProperty({},\"passive\",{get:function(){a=!0}});try{var
+        c=function(){};_.t.addEventListener(\"test\",c,b);_.t.removeEventListener(\"test\",c,b)}catch(d){}return
+        a}();\n}catch(e){_._DumpException(e)}\ntry{\nvar qe=document.querySelector(\".gb_J
+        .gb_B\"),re=document.querySelector(\"#gb.gb_ad\");qe&&!re&&_.oe(_.Yd,qe,\"click\");\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        ci=function(a){_.S.call(this);this.B=a;this.v=null;this.o={};this.C={};this.i={};this.j=null};_.z(ci,_.S);_.di=function(a){if(a.v)return
+        a.v;for(var b in a.i)if(a.i[b].Ie()&&a.i[b].lb())return a.i[b];return null};ci.prototype.A=function(a){this.i[a]&&(_.di(this)&&_.di(this).Bc()==a||this.i[a].Dd(!0))};ci.prototype.Ua=function(a){this.j=a;for(var
+        b in this.i)this.i[b].Ie()&&this.i[b].Ua(a)};_.ei=function(a,b){a.i[b.Bc()]=b};ci.prototype.Wb=function(a){return
+        a in this.i?this.i[a]:null};var fi=new ci(_.Xd);_.ae(\"dd\",fi);\n}catch(e){_._DumpException(e)}\ntry{\n_.xj=function(a,b){return
+        _.M(a,36,b)};\n}catch(e){_._DumpException(e)}\ntry{\nvar yj=document.querySelector(\".gb_z
+        .gb_B\"),zj=document.querySelector(\"#gb.gb_ad\");yj&&!zj&&_.oe(_.Yd,yj,\"click\");\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><body><labs-tailwind-root></labs-tailwind-root></body><script
+        src=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.-t-Z0Dl0T4A.es5.O/d=1/excm=_b/ed=1/dg=0/wt=2/ujg=1/rs=ANnj5bFcBtIFXHnbvEejJmlA-A_g3vdCGg/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;Uvc8o:VDovNc;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb;lOO0Vd:OTA3Ae;qafBPd:ovKuLd/dti=1/m=_b\"
+        id=\"base-js\" nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\"></script></body></html><script
+        nonce=\"qcWPQEhpM4rdLKEpt2i6QQ\">this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\nvar xe=function(){_.aa.call(this)};_.z(xe,_.be);_.ye=function(a,b){if(b
+        in a.i)return a.i[b];throw new xe(b);};_.ze=function(a){return _.ye(_.Zd.i(),a)};\n}catch(e){_._DumpException(e)}\ntry{\n/*\n\n
+        Copyright Google LLC\n SPDX-License-Identifier: Apache-2.0\n*/\nvar Ce,De;_.Ae=function(a){var
+        b=a.length;if(b>0){for(var c=Array(b),d=0;d<b;d++)c[d]=a[d];return c}return[]};Ce=function(a){return
+        new _.Be(function(b){return b.substr(0,a.length+1).toLowerCase()===a+\":\"})};De=0;_.Ee=function(a){return
+        Object.prototype.hasOwnProperty.call(a,_.hc)&&a[_.hc]||(a[_.hc]=++De)};_.Fe=globalThis.trustedTypes;_.Ge=function(a){this.i=a};_.Ge.prototype.toString=function(){return
+        this.i};_.He=new _.Ge(\"about:invalid#zClosurez\");_.Be=function(a){this.ek=a};_.Ie=[Ce(\"data\"),Ce(\"http\"),Ce(\"https\"),Ce(\"mailto\"),Ce(\"ftp\"),new
+        _.Be(function(a){return/^[^:]*([/?#]|$)/.test(a)})];_.Je=function(a){this.i=a};_.Je.prototype.toString=function(){return
+        this.i+\"\"};_.Ke=new _.Je(_.Fe?_.Fe.emptyHTML:\"\");\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        Qe,bf,ef,Pe,Re;_.Le=function(a){return/^[\\s\\xa0]*$/.test(a)};_.Me=function(a){return
+        a==null?a:(0,_.Ta)(a)?a|0:void 0};_.Ne=function(a){if(a==null)return a;if(typeof
+        a===\"string\"&&a)a=+a;else if(typeof a!==\"number\")return;return(0,_.Ta)(a)?a|0:void
+        0};_.Oe=function(a,b){return a.lastIndexOf(b,0)==0};Qe=function(){var a=null;if(!Pe)return
+        a;try{var b=function(c){return c};a=Pe.createPolicy(\"ogb-qtm#html\",{createHTML:b,createScript:b,createScriptURL:b})}catch(c){}return
+        a};\n_.Se=function(){Re===void 0&&(Re=Qe());return Re};_.Ue=function(a){var
+        b=_.Se();a=b?b.createScriptURL(a):a;return new _.Te(a)};_.Ve=function(a){if(a
+        instanceof _.Te)return a.i;throw Error(\"L\");};_.Xe=function(a){if(We.test(a))return
+        a};_.Ye=function(a){if(a instanceof _.Ge)if(a instanceof _.Ge)a=a.i;else throw
+        Error(\"L\");else a=_.Xe(a);return a};\n_.Ze=function(a,b){b=b===void 0?document:b;var
+        c,d;b=(d=(c=b).querySelector)==null?void 0:d.call(c,a+\"[nonce]\");return
+        b==null?\"\":b.nonce||b.getAttribute(\"nonce\")||\"\"};_.$e=function(a,b,c,d){return
+        _.Me(_.yd(a,b,c,d))};_.U=function(a,b,c){return _.Sa(_.yd(a,b,c,_.xd))};_.af=function(a,b){return
+        _.Ne(_.yd(a,b,void 0,_.xd))};bf=function(a){this.J=_.x(a)};_.z(bf,_.R);bf.prototype.Mb=function(a){return
+        _.P(this,24,a)};_.cf=function(){return _.F(_.Ud,bf,1)};\n_.df=function(a){var
+        b=_.Qa(a);return b==\"array\"||b==\"object\"&&typeof a.length==\"number\"};Pe=_.Fe;_.Te=function(a){this.i=a};_.Te.prototype.toString=function(){return
+        this.i+\"\"};var We=/^\\s*(?!javascript:)(?:[\\w+.-]+:|[^:/?#]*(?:[/?#]|$))/i;var
+        lf,pf,ff;_.hf=function(a){return a?new ff(_.gf(a)):ef||(ef=new ff)};_.jf=function(a,b){return
+        typeof b===\"string\"?a.getElementById(b):b};_.V=function(a,b){var c=b||document;c.getElementsByClassName?a=c.getElementsByClassName(a)[0]:(c=document,a=a?(b||c).querySelector(a?\".\"+a:\"\"):_.kf(c,\"*\",a,b)[0]||null);return
+        a||null};_.kf=function(a,b,c,d){a=d||a;return(b=b&&b!=\"*\"?String(b).toUpperCase():\"\")||c?a.querySelectorAll(b+(c?\".\"+c:\"\")):a.getElementsByTagName(\"*\")};\n_.mf=function(a,b){_.Gb(b,function(c,d){d==\"style\"?a.style.cssText=c:d==\"class\"?a.className=c:d==\"for\"?a.htmlFor=c:lf.hasOwnProperty(d)?a.setAttribute(lf[d],c):_.Oe(d,\"aria-\")||_.Oe(d,\"data-\")?a.setAttribute(d,c):a[d]=c})};lf={cellpadding:\"cellPadding\",cellspacing:\"cellSpacing\",colspan:\"colSpan\",frameborder:\"frameBorder\",height:\"height\",maxlength:\"maxLength\",nonce:\"nonce\",role:\"role\",rowspan:\"rowSpan\",type:\"type\",usemap:\"useMap\",valign:\"vAlign\",width:\"width\"};\n_.nf=function(a){return
+        a?a.defaultView:window};_.qf=function(a,b){var c=b[1],d=_.of(a,String(b[0]));c&&(typeof
+        c===\"string\"?d.className=c:Array.isArray(c)?d.className=c.join(\" \"):_.mf(d,c));b.length>2&&pf(a,d,b);return
+        d};\npf=function(a,b,c){function d(h){h&&b.appendChild(typeof h===\"string\"?a.createTextNode(h):h)}for(var
+        e=2;e<c.length;e++){var f=c[e];if(!_.df(f)||_.fc(f)&&f.nodeType>0)d(f);else{a:{if(f&&typeof
+        f.length==\"number\"){if(_.fc(f)){var g=typeof f.item==\"function\"||typeof
+        f.item==\"string\";break a}if(typeof f===\"function\"){g=typeof f.item==\"function\";break
+        a}}g=!1}_.Hc(g?_.Ae(f):f,d)}}};_.rf=function(a){return _.of(document,a)};\n_.of=function(a,b){b=String(b);a.contentType===\"application/xhtml+xml\"&&(b=b.toLowerCase());return
+        a.createElement(b)};_.sf=function(a){for(var b;b=a.firstChild;)a.removeChild(b)};_.tf=function(a){return
+        a&&a.parentNode?a.parentNode.removeChild(a):null};_.uf=function(a,b){if(!a||!b)return!1;if(a.contains&&b.nodeType==1)return
+        a==b||a.contains(b);if(typeof a.compareDocumentPosition!=\"undefined\")return
+        a==b||!!(a.compareDocumentPosition(b)&16);for(;b&&a!=b;)b=b.parentNode;return
+        b==a};\n_.gf=function(a){return a.nodeType==9?a:a.ownerDocument||a.document};ff=function(a){this.i=a||_.t.document||document};_.l=ff.prototype;_.l.H=function(a){return
+        _.jf(this.i,a)};_.l.Pa=function(a,b,c){return _.qf(this.i,arguments)};_.l.appendChild=function(a,b){a.appendChild(b)};_.l.uf=_.sf;_.l.Zg=_.tf;_.l.Yg=_.uf;\n}catch(e){_._DumpException(e)}\ntry{\n_.Ej=function(a){var
+        b=_.Ze(\"script\",a.ownerDocument);b&&a.setAttribute(\"nonce\",b)};_.Fj=function(a){if(!a)return
+        null;a=_.L(a,4);var b;a===null||a===void 0?b=null:b=_.Ue(a);return b};_.Gj=function(a,b,c){a=a.J;return
+        _.Db(a,a[_.v]|0,b,c)!==void 0};_.Hj=function(a){this.J=_.x(a)};_.z(_.Hj,_.R);_.Ij=function(){for(var
+        a=Number(this),b=[],c=a;c<arguments.length;c++)b[c-a]=arguments[c];return
+        b};_.Jj=function(a,b){return(b||document).getElementsByTagName(String(a))};\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        Lj=function(a,b,c){a<b?Kj(a+1,b):_.Xd.log(Error(\"ja`\"+a+\"`\"+b),{url:c})},Kj=function(a,b){if(Mj){var
+        c=_.rf(\"SCRIPT\");c.async=!0;c.type=\"text/javascript\";c.charset=\"UTF-8\";c.src=_.Ve(Mj);_.Ej(c);c.onerror=_.kc(Lj,a,b,c.src);_.Jj(\"HEAD\")[0].appendChild(c)}},Nj=function(a){this.J=_.x(a)};_.z(Nj,_.R);var
+        Oj=_.F(_.Ud,Nj,17)||new Nj,Pj,Mj=(Pj=_.F(Oj,_.Hj,1))?_.Fj(Pj):null,Qj,Rj=(Qj=_.F(Oj,_.Hj,2))?_.Fj(Qj):null,Sj=function(){Kj(1,2);if(Rj){var
+        a=_.rf(\"LINK\");a.setAttribute(\"type\",\"text/css\");a.href=_.Ve(Rj).toString();a.rel=\"stylesheet\";var
+        b=_.Ze(\"style\",document);b&&a.setAttribute(\"nonce\",b);_.Jj(\"HEAD\")[0].appendChild(a)}};(function(){var
+        a=_.cf();if(_.U(a,18))Sj();else{var b=_.af(a,19)||0;window.addEventListener(\"load\",function(){window.setTimeout(Sj,b)})}})();\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><div ng-non-bindable=\"\"><div class=\"gb_L\">Google
+        apps</div><div class=\"gb_T\"><div class=\"gb_Rc\"><div>Google Account</div><div
+        class=\"gb_g\">SCRUBBED_NAME</div><div>SCRUBBED_EMAIL@example.com</div><div
+        class=\"gb_Sc\"></div></div></div></div>"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Security-Policy:
+      - script-src 'report-sample' 'nonce-qcWPQEhpM4rdLKEpt2i6QQ' 'unsafe-inline';object-src
+        'none';base-uri 'self';report-uri /_/LabsTailwindUi/cspreport;worker-src 'self'
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - text/html; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Tue, 13 Jan 2026 13:50:20 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Wed, 15-Jul-2026 13:50:20 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:20 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '258473'
+      reporting-endpoints:
+      - default="/_/LabsTailwindUi/web-reports?context=eJwNyMErg2EcB_A1np95I5odWC1ymFm29q7MIhFZaXved0cl1tbQ2ryb7ZVwtdKSi4Ow07Qk_4ATN00r00Lb2i7kJgcHKWW-h8_lI1xrrYJR47EYNenqAzuGK6XEMrkSy4I4UGazkOx9YnvwtVNhht0KC7VVmQof4Sr7hFNDjWVh-qjOZiAx1GBJuHhusktwm700DvP7XvKCedlHFsis-egAFt99tAR_rZw0jFNF4FSDESsnO7jmOLlBt8BJgNE4pzH4TuFUTvpbTga4d0pUhPaoRJ3wmJaoDC8NiUyvEvXD-Y9EebjrkqkA21mZTDmZfm9kasJEXaYpWJ_0UxwUj582oSXqJwY9h37qA32HLnt2UqTuwlu-oR0cDsU3ArFgKGVTg5HYVkQJ21aTcUVdUcIBp8PpcoiiaBddgYTjH3GyfF0"
+      x-ua-compatible:
+      - IE=edge
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312220727&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        OSID=SCRUBBED; __Secure-OSID=SCRUBBED; SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED;
+        __Secure-3PSIDCC=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=rLM1Ne&source-path=%2Fnotebook%2Fc3f6285f-1709-44c4-9cd6-e95cf0ea4f5e&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n3132\n[[\"wrb.fr\",\"rLM1Ne\",\"[[\\\"READ ONLY: Learn Claude
+        Code \\\\u0026 AI Agents for High School Students\\\",[[[\\\"a474cd35-6c21-4e72-94a0-c38b5491b449\\\"],\\\"GitHub
+        - shareAI-lab/learn-claude-code: How can we build a true AI agent? Like Claude
+        Code.\\\",[null,1105,[1768268904,969842000],[\\\"59732f07-bb2d-4c52-982c-f30a405ee2c2\\\",[1768268904,722716000]],5,null,1,[\\\"https://github.com/shareAI-lab/learn-claude-code\\\"]],[null,2]],[[\\\"735fcfef-9fbd-4c89-9789-6a9760587bec\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v3-subagent-mechanism.md\\\",[null,649,[1768268936,841702000],[\\\"353e2480-1ab2-4f10-b4ef-33d4fd931e21\\\",[1768268936,552638000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v3-subagent-mechanism.md\\\"]],[null,2]],[[\\\"4d3f7b07-e9e6-43d3-ab8b-184fa27a9f1e\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v4-skills-mechanism.md\\\",[null,1894,[1768268939,620097000],[\\\"63170d6b-f335-4f62-ba95-8f9455c2466b\\\",[1768268939,269895000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v4-skills-mechanism.md\\\"]],[null,2]],[[\\\"a5ec927b-12eb-45d1-989f-12eb3db4ce53\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v0_bash_agent.py\\\",[null,781,[1768268914,461842000],[\\\"21de4c3f-3323-4563-8307-3749f6c39616\\\",[1768268914,116348000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v0_bash_agent.py\\\"]],[null,2]],[[\\\"c361a555-5c2d-42e2-94d0-a65da95be660\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v1_basic_agent.py\\\",[null,1452,[1768268917,15523000],[\\\"a6cbd772-2811-499f-bc31-6dd0b74ca7fd\\\",[1768268916,689238000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v1_basic_agent.py\\\"]],[null,2]],[[\\\"48f71a82-08d3-46fa-a37f-d657fb2f0723\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v2_todo_agent.py\\\",[null,1702,[1768268919,610537000],[\\\"a65b88ec-b154-4633-8c74-b2487b30c1e5\\\",[1768268919,248383000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v2_todo_agent.py\\\"]],[null,2]],[[\\\"d6ce2ec3-f98a-4529-acd5-08bff271cb3b\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v3_subagent.py\\\",[null,1967,[1768268922,541555000],[\\\"a719762f-4b05-4c77-bb72-eab7a603b4a6\\\",[1768268922,151851000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v3_subagent.py\\\"]],[null,2]],[[\\\"ef358221-3904-4dbc-be6f-e1e8dea63954\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v4_skills_agent.py\\\",[null,2410,[1768268925,379830000],[\\\"f3afdf07-2d63-404f-84d5-955eadba6d91\\\",[1768268925,17659000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v4_skills_agent.py\\\"]],[null,2]]],\\\"c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e\\\",\\\"\U0001F916\\\",null,[1,true,true,null,null,[1768312221,10640000],1,false,[1768268884,276629000],null,null,null,true,true,1,false],null,null,[false],[true,true,true],[6,500,300,500000]]]\",null,null,null,\"generic\"]]\n55\n[[\"di\",158],[\"af.httprm\",158,\"3194215724454271462\",10]]\n24\n[[\"e\",4,null,null,3231]]\n"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Tue, 13 Jan 2026 13:50:20 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Wed, 15-Jul-2026 13:50:20 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '3231'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '199'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        OSID=SCRUBBED; __Secure-OSID=SCRUBBED; SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED;
+        __Secure-3PSIDCC=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=rLM1Ne&source-path=%2Fnotebook%2Fc3f6285f-1709-44c4-9cd6-e95cf0ea4f5e&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n3133\n[[\"wrb.fr\",\"rLM1Ne\",\"[[\\\"READ ONLY: Learn Claude
+        Code \\\\u0026 AI Agents for High School Students\\\",[[[\\\"a474cd35-6c21-4e72-94a0-c38b5491b449\\\"],\\\"GitHub
+        - shareAI-lab/learn-claude-code: How can we build a true AI agent? Like Claude
+        Code.\\\",[null,1105,[1768268904,969842000],[\\\"59732f07-bb2d-4c52-982c-f30a405ee2c2\\\",[1768268904,722716000]],5,null,1,[\\\"https://github.com/shareAI-lab/learn-claude-code\\\"]],[null,2]],[[\\\"735fcfef-9fbd-4c89-9789-6a9760587bec\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v3-subagent-mechanism.md\\\",[null,649,[1768268936,841702000],[\\\"353e2480-1ab2-4f10-b4ef-33d4fd931e21\\\",[1768268936,552638000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v3-subagent-mechanism.md\\\"]],[null,2]],[[\\\"4d3f7b07-e9e6-43d3-ab8b-184fa27a9f1e\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v4-skills-mechanism.md\\\",[null,1894,[1768268939,620097000],[\\\"63170d6b-f335-4f62-ba95-8f9455c2466b\\\",[1768268939,269895000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/docs/v4-skills-mechanism.md\\\"]],[null,2]],[[\\\"a5ec927b-12eb-45d1-989f-12eb3db4ce53\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v0_bash_agent.py\\\",[null,781,[1768268914,461842000],[\\\"21de4c3f-3323-4563-8307-3749f6c39616\\\",[1768268914,116348000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v0_bash_agent.py\\\"]],[null,2]],[[\\\"c361a555-5c2d-42e2-94d0-a65da95be660\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v1_basic_agent.py\\\",[null,1452,[1768268917,15523000],[\\\"a6cbd772-2811-499f-bc31-6dd0b74ca7fd\\\",[1768268916,689238000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v1_basic_agent.py\\\"]],[null,2]],[[\\\"48f71a82-08d3-46fa-a37f-d657fb2f0723\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v2_todo_agent.py\\\",[null,1702,[1768268919,610537000],[\\\"a65b88ec-b154-4633-8c74-b2487b30c1e5\\\",[1768268919,248383000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v2_todo_agent.py\\\"]],[null,2]],[[\\\"d6ce2ec3-f98a-4529-acd5-08bff271cb3b\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v3_subagent.py\\\",[null,1967,[1768268922,541555000],[\\\"a719762f-4b05-4c77-bb72-eab7a603b4a6\\\",[1768268922,151851000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v3_subagent.py\\\"]],[null,2]],[[\\\"ef358221-3904-4dbc-be6f-e1e8dea63954\\\"],\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v4_skills_agent.py\\\",[null,2410,[1768268925,379830000],[\\\"f3afdf07-2d63-404f-84d5-955eadba6d91\\\",[1768268925,17659000]],4,null,1,[\\\"https://raw.githubusercontent.com/shareAI-lab/learn-claude-code/main/v4_skills_agent.py\\\"]],[null,2]]],\\\"c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e\\\",\\\"\U0001F916\\\",null,[1,true,true,null,null,[1768312221,635381000],1,false,[1768268884,276629000],null,null,null,true,true,1,false],null,null,[false],[true,true,true],[6,500,300,500000]]]\",null,null,null,\"generic\"]]\n56\n[[\"di\",301],[\"af.httprm\",300,\"-8917822050262652730\",10]]\n24\n[[\"e\",4,null,null,3233]]\n"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Tue, 13 Jan 2026 13:50:21 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Wed, 15-Jul-2026 13:50:21 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:21 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '3233'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22hizoJc%22%2C%22%5B%5B%5C%22a474cd35-6c21-4e72-94a0-c38b5491b449%5C%22%5D%2C%5B2%5D%2C%5B2%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312222253&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '197'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        OSID=SCRUBBED; __Secure-OSID=SCRUBBED; SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED;
+        __Secure-3PSIDCC=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=hizoJc&source-path=%2Fnotebook%2Fc3f6285f-1709-44c4-9cd6-e95cf0ea4f5e&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n65819\n[[\"wrb.fr\",\"hizoJc\",\"[[[\\\"a474cd35-6c21-4e72-94a0-c38b5491b449\\\"],\\\"GitHub
+        - shareAI-lab/learn-claude-code: How can we build a true AI agent? Like Claude
+        Code.\\\",[null,1105,[1768268904,969842000],[\\\"59732f07-bb2d-4c52-982c-f30a405ee2c2\\\",[1768268904,722716000]],5,null,1,[\\\"https://github.com/shareAI-lab/learn-claude-code\\\"],2445],[null,2]],null,null,[[[[0,30,[[[0,15,[\\\"Skip
+        to content\\\",[null,null,null,\\\"\\\"]]],[15,30,[\\\"Navigation Menu\\\"]]],[null,5]]],[30,60,[[[30,39,[\\\"
+        Sign in \\\",[null,null,null,\\\"\\\"]]],[39,60,[\\\"Appearance settings  \\\"]]],[null,1]]],[60,76,[[[60,76,[\\\"AI
+        CODE CREATION\\\"]]],[null,1]]],[76,116,[[[76,116,[\\\"GitHub Copilot Write
+        better code with AI\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[116,162,[[[116,162,[\\\"GitHub
+        Spark Build and deploy intelligent apps\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[162,202,[[[162,202,[\\\"GitHub
+        Models Manage and compare prompts\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[202,241,[[[202,214,[\\\"MCP
+        Registry\\\"]],[214,217,[\\\"New\\\",[]]],[217,241,[\\\"Integrate external
+        tools\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[241,260,[[[241,260,[\\\"DEVELOPER
+        WORKFLOWS\\\"]]],[null,1]]],[260,289,[[[260,289,[\\\"Actions Automate any
+        workflow\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[289,324,[[[289,324,[\\\"Codespaces
+        Instant dev environments\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[324,350,[[[324,350,[\\\"Issues
+        Plan and track work\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[350,381,[[[350,381,[\\\"Code
+        Review Manage code changes\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[381,401,[[[381,401,[\\\"APPLICATION
+        SECURITY\\\"]]],[null,1]]],[401,454,[[[401,454,[\\\"GitHub Advanced Security
+        Find and fix vulnerabilities\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[454,497,[[[454,497,[\\\"Code
+        security Secure your code as you build\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[497,543,[[[497,543,[\\\"Secret
+        protection Stop leaks before they start\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[543,550,[[[543,550,[\\\"EXPLORE\\\"]]],[null,1]]],[550,560,[[[550,560,[\\\"Why
+        GitHub\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[560,573,[[[560,573,[\\\"Documentation\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[573,577,[[[573,577,[\\\"Blog\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[577,586,[[[577,586,[\\\"Changelog\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[586,597,[[[586,597,[\\\"Marketplace\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[597,614,[[[597,614,[\\\"View
+        all features\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"0\\\",0,0,0]]],[614,629,[[[614,629,[\\\"BY
+        COMPANY SIZE\\\"]]],[null,1]]],[629,640,[[[629,640,[\\\"Enterprises\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[640,662,[[[640,662,[\\\"Small
+        and medium teams\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[662,670,[[[662,670,[\\\"Startups\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[670,680,[[[670,680,[\\\"Nonprofits\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[680,691,[[[680,691,[\\\"BY
+        USE CASE\\\"]]],[null,1]]],[691,708,[[[691,708,[\\\"App Modernization\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[708,717,[[[708,717,[\\\"DevSecOps\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[717,723,[[[717,723,[\\\"DevOps\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[723,728,[[[723,728,[\\\"CI/CD\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[728,746,[[[728,746,[\\\"View
+        all use cases\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[746,757,[[[746,757,[\\\"BY
+        INDUSTRY\\\"]]],[null,1]]],[757,767,[[[757,767,[\\\"Healthcare\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[767,785,[[[767,785,[\\\"Financial
+        services\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[785,798,[[[785,798,[\\\"Manufacturing\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[798,808,[[[798,808,[\\\"Government\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[808,827,[[[808,827,[\\\"View
+        all industries\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[827,845,[[[827,845,[\\\"View
+        all solutions\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"0\\\",0,0,0]]],[845,861,[[[845,861,[\\\"EXPLORE
+        BY TOPIC\\\"]]],[null,1]]],[861,863,[[[861,863,[\\\"AI\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[863,883,[[[863,883,[\\\"Software
+        Development\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[883,889,[[[883,889,[\\\"DevOps\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[889,897,[[[889,897,[\\\"Security\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[897,912,[[[897,912,[\\\"View
+        all topics\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[912,927,[[[912,927,[\\\"EXPLORE
+        BY TYPE\\\"]]],[null,1]]],[927,943,[[[927,943,[\\\"Customer stories\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[943,960,[[[943,960,[\\\"Events
+        \\\\u0026 webinars\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[960,976,[[[960,976,[\\\"Ebooks
+        \\\\u0026 reports\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[976,993,[[[976,993,[\\\"Business
+        insights\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[993,1006,[[[993,1006,[\\\"GitHub
+        Skills\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[1006,1024,[[[1006,1024,[\\\"SUPPORT
+        \\\\u0026 SERVICES\\\"]]],[null,1]]],[1024,1037,[[[1024,1037,[\\\"Documentation\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1037,1053,[[[1037,1053,[\\\"Customer
+        support\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[1053,1068,[[[1053,1068,[\\\"Community
+        forum\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[1068,1080,[[[1068,1080,[\\\"Trust
+        center\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[1080,1088,[[[1080,1088,[\\\"Partners\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[1088,1097,[[[1088,1097,[\\\"COMMUNITY\\\"]]],[null,1]]],[1097,1140,[[[1097,1140,[\\\"GitHub
+        Sponsors Fund open source developers\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1140,1148,[[[1140,1148,[\\\"PROGRAMS\\\"]]],[null,1]]],[1148,1160,[[[1148,1160,[\\\"Security
+        Lab\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1160,1180,[[[1160,1180,[\\\"Maintainer
+        Community\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[1180,1191,[[[1180,1191,[\\\"Accelerator\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[1191,1206,[[[1191,1206,[\\\"Archive
+        Program\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[1206,1218,[[[1206,1218,[\\\"REPOSITORIES\\\"]]],[null,1]]],[1218,1224,[[[1218,1224,[\\\"Topics\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1224,1232,[[[1224,1232,[\\\"Trending\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[1232,1243,[[[1232,1243,[\\\"Collections\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[1243,1263,[[[1243,1263,[\\\"ENTERPRISE
+        SOLUTIONS\\\"]]],[null,1]]],[1263,1312,[[[1263,1312,[\\\"Enterprise platform
+        AI-powered developer platform\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1312,1329,[[[1312,1329,[\\\"AVAILABLE
+        ADD-ONS\\\"]]],[null,1]]],[1329,1388,[[[1329,1388,[\\\"GitHub Advanced Security
+        Enterprise-grade security features\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[1388,1437,[[[1388,1437,[\\\"Copilot
+        for Business Enterprise-grade AI features\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[1437,1482,[[[1437,1482,[\\\"Premium
+        Support Enterprise-grade 24/7 support\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[1482,1489,[[[1482,1489,[\\\"Pricing\\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"0\\\",0,0,0]]],[1489,1547,[[[1489,1547,[\\\"Search
+        code, repositories, users, issues, pull requests...\\\"]]],[null,4]]],[1547,1554,[[[1547,1554,[\\\"Clear
+        \ \\\"]]],[null,1]]],[1554,1590,[[[1554,1572,[\\\"Search syntax tips\\\",[null,null,null,\\\"\\\"]]],[1572,1590,[\\\"
+        Provide feedback \\\"]]],[null,4]]],[1590,1658,[[[1590,1658,[\\\"We read every
+        piece of feedback, and take your input very seriously.\\\"]]],[null,1]]],[1658,1674,[[[1658,1674,[\\\"
+        Saved searches \\\"]]],[null,4]]],[1674,1728,[[[1674,1728,[\\\"Use saved searches
+        to filter your results more quickly\\\"]]],[null,5]]],[1728,1785,[[[1728,1770,[\\\"
+        To see all available qualifiers, see our \\\"]],[1770,1783,[\\\"documentation\\\",[null,null,null,\\\"https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax\\\"]]],[1783,1785,[\\\".
+        \\\"]]],[null,1]]],[1785,2130,[[[1785,1794,[\\\" Sign in \\\",[null,null,null,\\\"https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax\\\"]]],[1794,1803,[\\\"
+        Sign up \\\",[null,null,null,\\\"https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax\\\"]]],[1803,1867,[\\\"Appearance
+        settings   You signed in with another tab or window. \\\"]],[1867,1873,[\\\"Reload\\\",[null,null,null,\\\"https://github.com\\\"]]],[1873,1942,[\\\"
+        to refresh your session.   You signed out in another tab or window. \\\"]],[1942,1948,[\\\"Reload\\\",[null,null,null,\\\"https://github.com\\\"]]],[1948,2024,[\\\"
+        to refresh your session.   You switched accounts on another tab or window.
+        \\\"]],[2024,2030,[\\\"Reload\\\",[null,null,null,\\\"https://github.com\\\"]]],[2030,2089,[\\\"
+        to refresh your session.   Dismiss alert   {{ message }}  \\\"]],[2089,2102,[\\\"
+        shareAI-lab \\\",[null,null,null,\\\"https://github.com/shareAI-lab\\\"]]],[2102,2105,[\\\"/
+        \ \\\"]],[2105,2122,[\\\"learn-claude-code\\\",[null,null,null,\\\"\\\"]]],[2122,2130,[\\\"Public
+        \ \\\"]]],[null,1]]],[2130,2199,[[[2130,2144,[\\\"Notifications \\\",[null,null,null,\\\"\\\"]]],[2144,2199,[\\\"You
+        must be signed in to change notification settings  \\\"]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[2199,2211,[[[2199,2211,[\\\"Fork
+        \ 3.3k  \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[2211,2223,[[[2211,2223,[\\\"
+        Star  14k  \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[2223,2276,[[[2223,2276,[\\\"
+        How can we build a true AI agent? Like Claude Code. \\\"]]],[null,1]]],[2276,2283,[[[2276,2283,[\\\"License\\\"]]],[null,6]]],[2283,2420,[[[2283,2296,[\\\"
+        MIT license \\\",[null,null,null,\\\"\\\"]]],[2296,2307,[\\\"14k  stars \\\",[null,null,null,\\\"\\\"]]],[2307,2319,[\\\"3.3k
+        \ forks \\\",[null,null,null,\\\"\\\"]]],[2319,2329,[\\\"Branches  \\\",[null,null,null,\\\"\\\"]]],[2329,2335,[\\\"Tags
+        \ \\\",[null,null,null,\\\"\\\"]]],[2335,2345,[\\\"Activity  \\\",[null,null,null,\\\"\\\"]]],[2345,2351,[\\\"
+        Star \\\",[null,null,null,\\\"\\\"]]],[2351,2365,[\\\"Notifications \\\",[null,null,null,\\\"\\\"]]],[2365,2420,[\\\"You
+        must be signed in to change notification settings  \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"0\\\",0,0,0]]],[2420,2451,[[[2420,2451,[\\\"Additional
+        navigation options  \\\"]]],[null,1]]],[2451,2457,[[[2451,2457,[\\\" Code
+        \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[2457,2465,[[[2457,2465,[\\\"
+        Issues \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[2465,2480,[[[2465,2480,[\\\"
+        Pull requests \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[2480,2489,[[[2480,2489,[\\\"
+        Actions \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"4\\\",1,4,4]]],[2489,2499,[[[2489,2499,[\\\"
+        Projects \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"5\\\",1,5,5]]],[2499,2509,[[[2499,2509,[\\\"
+        Security \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"6\\\",1,6,6]]],[2509,2519,[[[2509,2519,[\\\"
+        Insights \\\",[null,null,null,\\\"\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"7\\\",1,7,7]]],[2519,2548,[[[2519,2548,[\\\"shareAI-lab/learn-claude-code\\\"]]],[null,4]]],[2548,2582,[[[2548,2556,[\\\"Branches\\\",[null,null,null,\\\"\\\"]]],[2556,2560,[\\\"Tags\\\",[null,null,null,\\\"\\\"]]],[2560,2582,[\\\"Open
+        more actions menu\\\"]]],[null,1]]],[2582,2599,[[[2582,2599,[\\\"Folders and
+        files\\\"]]],[null,5]]],[2599,2645,[[[2599,2645,[\\\"Name Name Last commit
+        message Last commit date\\\"]]],[null,1]]],[2645,2658,[[[2645,2658,[\\\"Latest
+        commit\\\"]]],[null,5]]],[2658,2665,[[[2658,2665,[\\\"History\\\"]]],[null,5]]],[2665,3074,[[[2665,2675,[\\\"20
+        Commits\\\",[null,null,null,\\\"\\\"]]],[2675,2683,[\\\"articles\\\",[null,null,null,\\\"\\\"]]],[2683,2691,[\\\"articles\\\",[null,null,null,\\\"\\\"]]],[2691,2695,[\\\"docs\\\",[null,null,null,\\\"\\\"]]],[2695,2699,[\\\"docs\\\",[null,null,null,\\\"\\\"]]],[2699,2705,[\\\"skills\\\",[null,null,null,\\\"\\\"]]],[2705,2711,[\\\"skills\\\",[null,null,null,\\\"\\\"]]],[2711,2723,[\\\".env.example\\\",[null,null,null,\\\"\\\"]]],[2723,2735,[\\\".env.example\\\",[null,null,null,\\\"\\\"]]],[2735,2745,[\\\".gitignore\\\",[null,null,null,\\\"\\\"]]],[2745,2755,[\\\".gitignore\\\",[null,null,null,\\\"\\\"]]],[2755,2762,[\\\"LICENSE\\\",[null,null,null,\\\"\\\"]]],[2762,2769,[\\\"LICENSE\\\",[null,null,null,\\\"\\\"]]],[2769,2778,[\\\"README.md\\\",[null,null,null,\\\"\\\"]]],[2778,2787,[\\\"README.md\\\",[null,null,null,\\\"\\\"]]],[2787,2799,[\\\"README_zh.md\\\",[null,null,null,\\\"\\\"]]],[2799,2811,[\\\"README_zh.md\\\",[null,null,null,\\\"\\\"]]],[2811,2827,[\\\"requirements.txt\\\",[null,null,null,\\\"\\\"]]],[2827,2843,[\\\"requirements.txt\\\",[null,null,null,\\\"\\\"]]],[2843,2859,[\\\"v0_bash_agent.py\\\",[null,null,null,\\\"\\\"]]],[2859,2875,[\\\"v0_bash_agent.py\\\",[null,null,null,\\\"\\\"]]],[2875,2896,[\\\"v0_bash_agent_mini.py\\\",[null,null,null,\\\"\\\"]]],[2896,2917,[\\\"v0_bash_agent_mini.py\\\",[null,null,null,\\\"\\\"]]],[2917,2934,[\\\"v1_basic_agent.py\\\",[null,null,null,\\\"\\\"]]],[2934,2951,[\\\"v1_basic_agent.py\\\",[null,null,null,\\\"\\\"]]],[2951,2967,[\\\"v2_todo_agent.py\\\",[null,null,null,\\\"\\\"]]],[2967,2983,[\\\"v2_todo_agent.py\\\",[null,null,null,\\\"\\\"]]],[2983,2997,[\\\"v3_subagent.py\\\",[null,null,null,\\\"\\\"]]],[2997,3011,[\\\"v3_subagent.py\\\",[null,null,null,\\\"\\\"]]],[3011,3029,[\\\"v4_skills_agent.py\\\",[null,null,null,\\\"\\\"]]],[3029,3047,[\\\"v4_skills_agent.py\\\",[null,null,null,\\\"\\\"]]],[3047,3074,[\\\"Repository
+        files navigation\\\"]]],[null,5]]],[3074,3091,[[[3074,3091,[\\\"Learn Claude
+        Code\\\"]]],[null,4]]],[3091,3271,[[[3091,3101,[\\\"Disclaimer\\\",[true]]],[3101,3149,[\\\":
+        This is an independent educational project by \\\"]],[3149,3160,[\\\"shareAI
+        Lab\\\",[null,null,null,\\\"https://github.com/shareAI-lab\\\"]]],[3160,3271,[\\\".
+        It is not affiliated with, endorsed by, or sponsored by Anthropic. \\\\\\\"Claude
+        Code\\\\\\\" is a trademark of Anthropic.\\\"]]],[null,1]]],[3271,3332,[[[3271,3332,[\\\"Learn
+        how modern AI agents work by building one from scratch.\\\",[true]]]],[null,1]]],[3332,3336,[[[3332,3336,[\\\"\u4E2D\u6587\u6587\u6863\\\",[null,null,null,\\\"https://github.com/shareAI-lab\\\"]]]],[null,1]]],[3336,3354,[[[3336,3354,[\\\"A
+        note to readers:\\\",[true]]]],[null,1]]],[3354,3773,[[[3354,3417,[\\\"We
+        created this repository out of admiration for Claude Code - \\\"]],[3417,3484,[\\\"what
+        we believe to be the most capable AI coding agent in the world\\\",[true]]],[3484,3773,[\\\".
+        Initially, we attempted to reverse-engineer its design through behavioral
+        observation and speculation. The analysis we published was riddled with inaccuracies,
+        unfounded guesses, and technical errors. We deeply apologize to the Claude
+        Code team and anyone who was misled by that content.\\\"]]],[null,1]]],[3773,4078,[[[3773,3874,[\\\"Over
+        the past six months, through building and iterating on real agent systems,
+        our understanding of \\\"]],[3874,3902,[\\\"\\\\\\\"what makes a true AI agent\\\\\\\"\\\",[true]]],[3902,4078,[\\\"
+        has been fundamentally reshaped. We'd like to share these insights with you.
+        All previous speculative content has been removed and replaced with original
+        educational material.\\\"]]],[null,1]]],[4078,4167,[[[4078,4089,[\\\"Works
+        with \\\"]],[4089,4097,[\\\"Kode CLI\\\",[null,null,null,\\\"\\\"]]],[4097,4099,[\\\",
+        \\\"]],[4099,4110,[\\\"Claude Code\\\",[true]]],[4110,4112,[\\\", \\\"]],[4112,4118,[\\\"Cursor\\\",[true]]],[4118,4149,[\\\",
+        and any agent supporting the \\\"]],[4149,4166,[\\\"Agent Skills Spec\\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[4166,4167,[\\\".\\\"]]],[null,1]]],[4167,4180,[[[4167,4180,[\\\"What
+        is this?\\\"]]],[null,5]]],[4180,4278,[[[4180,4278,[\\\"A progressive tutorial
+        that demystifies AI coding agents like Kode, Claude Code, and Cursor Agent.\\\"]]],[null,1]]],[4278,4333,[[[4278,4333,[\\\"5
+        versions, ~1100 lines total, each adding one concept:\\\",[true]]]],[null,1]]],[4333,4595,[[[4333,4380,[\\\"Version
+        \  Lines   What it adds   Core insight  \\\"]],[4380,4382,[\\\"v0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/v0_bash_agent.py\\\"]]],[4382,4424,[\\\"~50
+        \  1 bash tool   Bash is all you need  \\\"]],[4424,4426,[\\\"v1\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/v1_basic_agent.py\\\"]]],[4426,4464,[\\\"~200
+        \  4 core tools   Model as Agent  \\\"]],[4464,4466,[\\\"v2\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/v2_todo_agent.py\\\"]]],[4466,4508,[\\\"~300
+        \  Todo tracking   Explicit planning  \\\"]],[4508,4510,[\\\"v3\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/v3_subagent.py\\\"]]],[4510,4549,[\\\"~450
+        \  Subagents   Divide and conquer  \\\"]],[4549,4551,[\\\"v4\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/v4_skills_agent.py\\\"]]],[4551,4595,[\\\"~550
+        \  Skills   Domain expertise on-demand  \\\"]]],[null,1]]],[4595,4606,[[[4595,4606,[\\\"Quick
+        Start\\\"]]],[null,5]]],[4606,4948,[[[4606,4948,[\\\"pip install anthropic
+        python-dotenv  #  Configure your API  cp .env.example .env  #  Edit .env with
+        your API key   #  Run any version  python v0_bash_agent.py  #  Minimal  python
+        v1_basic_agent.py  #  Core agent loop  python v2_todo_agent.py  #  + Todo
+        planning  python v3_subagent.py  #  + Subagents  python v4_skills_agent.py
+        \ #  + Skills  \\\"]]],[null,1]]],[4948,4964,[[[4948,4964,[\\\"The Core Pattern\\\"]]],[null,5]]],[4964,5001,[[[4964,5001,[\\\"Every
+        coding agent is just this loop:\\\"]]],[null,1]]],[5001,5217,[[[5001,5217,[\\\"while
+        \  True :  response   \\\\u003d   model ( messages ,  tools )  if   response
+        . stop_reason   !\\\\u003d   \\\\\\\"tool_use\\\\\\\" :  return   response
+        . text   results   \\\\u003d   execute ( response . tool_calls )  messages
+        . append ( results )  \\\"]]],[null,1]]],[5217,5292,[[[5217,5292,[\\\"That's
+        it. The model calls tools until done. Everything else is refinement.\\\"]]],[null,1]]],[5292,5306,[[[5292,5306,[\\\"File
+        Structure\\\"]]],[null,5]]],[5306,5762,[[[5306,5762,[\\\"learn-claude-code/
+        \u251C\u2500\u2500 v0_bash_agent.py # ~50 lines: 1 tool, recursive subagents
+        \u251C\u2500\u2500 v0_bash_agent_mini.py # ~16 lines: extreme compression
+        \u251C\u2500\u2500 v1_basic_agent.py # ~200 lines: 4 tools, core loop \u251C\u2500\u2500
+        v2_todo_agent.py # ~300 lines: + TodoManager \u251C\u2500\u2500 v3_subagent.py
+        # ~450 lines: + Task tool, agent registry \u251C\u2500\u2500 v4_skills_agent.py
+        # ~550 lines: + Skill tool, SkillLoader \u251C\u2500\u2500 skills/ # Example
+        skills (for learning) \u2514\u2500\u2500 docs/ # Detailed explanations (EN
+        + ZH) \\\"]]],[null,1]]],[5762,5791,[[[5762,5791,[\\\"Using the Agent Builder
+        Skill\\\"]]],[null,5]]],[5791,5869,[[[5791,5869,[\\\"This repository includes
+        a meta-skill that teaches agents how to build agents:\\\"]]],[null,1]]],[5869,6174,[[[5869,6174,[\\\"#
+        \ Scaffold a new agent project  python skills/agent-builder/scripts/init_agent.py
+        my-agent  #  Or with specific complexity level  python skills/agent-builder/scripts/init_agent.py
+        my-agent --level 0  #  Minimal  python skills/agent-builder/scripts/init_agent.py
+        my-agent --level 1  #  4 tools (default)  \\\"]]],[null,1]]],[6174,6207,[[[6174,6207,[\\\"Install
+        Skills for Production Use\\\"]]],[null,6]]],[6207,6388,[[[6207,6388,[\\\"#
+        \ Kode CLI (recommended)  kode plugins install https://github.com/shareAI-lab/shareAI-skills
+        \ #  Claude Code  claude plugins install https://github.com/shareAI-lab/shareAI-skills
+        \ \\\"]]],[null,1]]],[6388,6458,[[[6388,6392,[\\\"See \\\"]],[6392,6406,[\\\"shareAI-skills\\\",[null,null,null,\\\"https://github.com/shareAI-lab/shareAI-skills\\\"]]],[6406,6458,[\\\"
+        for the full collection of production-ready skills.\\\"]]],[null,1]]],[6458,6470,[[[6458,6470,[\\\"Key
+        Concepts\\\"]]],[null,5]]],[6470,6494,[[[6470,6494,[\\\"v0: Bash is All You
+        Need\\\"]]],[null,6]]],[6494,6564,[[[6494,6564,[\\\"One tool. Recursive self-calls
+        for subagents. Proves the core is tiny.\\\"]]],[null,1]]],[6564,6582,[[[6564,6582,[\\\"v1:
+        Model as Agent\\\"]]],[null,6]]],[6582,6652,[[[6582,6652,[\\\"4 tools (bash,
+        read, write, edit). The complete agent in one function.\\\"]]],[null,1]]],[6652,6675,[[[6652,6675,[\\\"v2:
+        Structured Planning\\\"]]],[null,6]]],[6675,6740,[[[6675,6740,[\\\"Todo tool
+        makes plans explicit. Constraints enable complex tasks.\\\"]]],[null,1]]],[6740,6762,[[[6740,6762,[\\\"v3:
+        Subagent Mechanism\\\"]]],[null,6]]],[6762,6822,[[[6762,6822,[\\\"Task tool
+        spawns isolated child agents. Context stays clean.\\\"]]],[null,1]]],[6822,6842,[[[6822,6842,[\\\"v4:
+        Skills Mechanism\\\"]]],[null,6]]],[6842,6928,[[[6842,6928,[\\\"SKILL.md files
+        provide domain expertise on-demand. Knowledge as a first-class citizen.\\\"]]],[null,1]]],[6928,6938,[[[6928,6938,[\\\"Deep
+        Dives\\\"]]],[null,5]]],[6938,6966,[[[6938,6966,[\\\"Technical tutorials (docs/):\\\",[true]]]],[null,1]]],[6966,7205,[[[6966,6980,[\\\"English
+        \  \u4E2D\u6587  \\\"]],[6980,7004,[\\\"v0: Bash is All You Need\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7004,7017,[\\\"v0:
+        Bash \u5C31\u662F\u4E00\u5207\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7017,7035,[\\\"v1:
+        Model as Agent\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7035,7044,[\\\"v1:
+        \u6A21\u578B\u5373\u4EE3\u7406\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7044,7067,[\\\"v2:
+        Structured Planning\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7067,7076,[\\\"v2:
+        \u7ED3\u6784\u5316\u89C4\u5212\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7076,7098,[\\\"v3:
+        Subagent Mechanism\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7098,7107,[\\\"v3:
+        \u5B50\u4EE3\u7406\u673A\u5236\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7107,7127,[\\\"v4:
+        Skills Mechanism\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7127,7140,[\\\"v4:
+        Skills \u673A\u5236\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7140,7205,[\\\"Original
+        articles (articles/) - Chinese only, social media style:\\\",[true]]]],[null,1]]],[7205,7237,[[[7205,7209,[\\\"v0\u6587\u7AE0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/docs/v0-bash-is-all-you-need.md\\\"]]],[7209,7212,[\\\"
+        | \\\"]],[7212,7216,[\\\"v1\u6587\u7AE0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/articles/v1%E6%96%87%E7%AB%A0.md\\\"]]],[7216,7219,[\\\"
+        | \\\"]],[7219,7223,[\\\"v2\u6587\u7AE0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/articles/v2%E6%96%87%E7%AB%A0.md\\\"]]],[7223,7226,[\\\"
+        | \\\"]],[7226,7230,[\\\"v3\u6587\u7AE0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/articles/v3%E6%96%87%E7%AB%A0.md\\\"]]],[7230,7233,[\\\"
+        | \\\"]],[7233,7237,[\\\"v4\u6587\u7AE0\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/articles/v4%E6%96%87%E7%AB%A0.md\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[7237,7294,[[[7237,7245,[\\\"\u4E0A\u4E0B\u6587\u7F13\u5B58\u7ECF\u6D4E\u5B66\\\",[null,null,null,\\\"https://github.com/shareAI-lab/learn-claude-code/blob/main/articles/v4%E6%96%87%E7%AB%A0.md\\\"]]],[7245,7294,[\\\"
+        - Context Caching Economics for Agent Developers\\\"]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[7294,7310,[[[7294,7310,[\\\"Related
+        Projects\\\"]]],[null,5]]],[7310,7480,[[[7310,7332,[\\\"Repository   Purpose
+        \ \\\"]],[7332,7336,[\\\"Kode\\\",[null,null,null,\\\"https://github.com/shareAI-lab/Kode\\\"]]],[7336,7386,[\\\"Full-featured
+        open source agent CLI (production)  \\\"]],[7386,7400,[\\\"shareAI-skills\\\",[null,null,null,\\\"https://github.com/shareAI-lab/shareAI-skills\\\"]]],[7400,7439,[\\\"Production-ready
+        skills for AI agents  \\\"]],[7439,7456,[\\\"Agent Skills Spec\\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[7456,7480,[\\\"Official
+        specification  \\\"]]],[null,1]]],[7480,7495,[[[7480,7495,[\\\"Use as Template\\\"]]],[null,6]]],[7495,7542,[[[7495,7542,[\\\"Fork
+        and customize for your own agent projects:\\\"]]],[null,1]]],[7542,7692,[[[7542,7692,[\\\"git
+        clone https://github.com/shareAI-lab/learn-claude-code  cd  learn-claude-code
+        \ #  Start from any version level  cp v1_basic_agent.py my_agent.py  \\\"]]],[null,1]]],[7692,7702,[[[7692,7702,[\\\"Philosophy\\\"]]],[null,5]]],[7702,7732,[[[7702,7732,[\\\"The
+        model is 80%. Code is 20%.\\\"]]],[null,1]]],[7732,7913,[[[7732,7913,[\\\"Modern
+        agents like Kode and Claude Code work not because of clever engineering, but
+        because the model is trained to be an agent. Our job is to give it tools and
+        stay out of the way.\\\"]]],[null,1]]],[7913,7920,[[[7913,7920,[\\\"License\\\"]]],[null,5]]],[7920,7923,[[[7920,7923,[\\\"MIT\\\"]]],[null,1]]],[7923,7963,[[[7923,7963,[\\\"Model
+        as Agent. That's the whole secret.\\\",[true]]]],[null,1]]],[7963,7973,[[[7963,7973,[\\\"@baicai003\\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]]],[null,1]]],[7973,7978,[[[7973,7978,[\\\"About\\\"]]],[null,5]]],[7978,8031,[[[7978,8031,[\\\"
+        How can we build a true AI agent? Like Claude Code. \\\"]]],[null,1]]],[8031,8037,[[[8031,8037,[\\\"Topics\\\"]]],[null,6]]],[8037,8076,[[[8037,8044,[\\\"
+        agent \\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[8044,8054,[\\\"
+        teaching \\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[8054,8067,[\\\"
+        claude-code \\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[8067,8076,[\\\"Resources\\\"]]],[null,6]]],[8076,8091,[[[8076,8084,[\\\"
+        Readme \\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[8084,8091,[\\\"License\\\"]]],[null,6]]],[8091,8112,[[[8091,8104,[\\\"
+        MIT license \\\",[null,null,null,\\\"https://github.com/anthropics/agent-skills\\\"]]],[8104,8112,[\\\"
+        Uh oh! \\\"]]],[null,6]]],[8112,8170,[[[8112,8146,[\\\"There was an error
+        while loading. \\\"]],[8146,8169,[\\\"Please reload this page\\\",[null,null,null,\\\"https://github.com\\\"]]],[8169,8170,[\\\".\\\"]]],[null,1]]],[8170,8200,[[[8170,8178,[\\\"Activity\\\",[null,null,null,\\\"https://github.com\\\"]]],[8178,8195,[\\\"Custom
+        properties\\\",[null,null,null,\\\"https://github.com\\\"]]],[8195,8200,[\\\"Stars\\\"]]],[null,6]]],[8200,8217,[[[8200,8203,[\\\"14k\\\",[true]]],[8203,8209,[\\\"
+        stars\\\",[null,null,null,\\\"https://github.com\\\"]]],[8209,8217,[\\\"Watchers\\\"]]],[null,6]]],[8217,8233,[[[8217,8219,[\\\"95\\\",[true]]],[8219,8228,[\\\"
+        watching\\\",[null,null,null,\\\"https://github.com\\\"]]],[8228,8233,[\\\"Forks\\\"]]],[null,6]]],[8233,8277,[[[8233,8237,[\\\"3.3k\\\",[true]]],[8237,8243,[\\\"
+        forks\\\",[null,null,null,\\\"https://github.com\\\"]]],[8243,8262,[\\\" Report
+        repository \\\",[null,null,null,\\\"https://github.com\\\"]]],[8262,8277,[\\\"Contributors
+        \ 3\\\",[null,null,null,\\\"https://github.com\\\"]]]],[null,5]]],[8277,8297,[[[8277,8286,[\\\"CrazyBoyM\\\",[true]]],[8286,8297,[\\\"Xinlu
+        Lai  \\\",[null,null,null,\\\"https://github.com\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[8297,8311,[[[8297,8303,[\\\"claude\\\",[true]]],[8303,8311,[\\\"Claude
+        \ \\\",[null,null,null,\\\"https://github.com\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"2\\\",1,2,2]]],[8311,8336,[[[8311,8322,[\\\"bansalkanav\\\",[true]]],[8322,8336,[\\\"Kanav
+        Bansal  \\\",[null,null,null,\\\"https://github.com\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"3\\\",1,3,3]]],[8336,8345,[[[8336,8345,[\\\"Languages\\\"]]],[null,5]]],[8345,8362,[[[8345,8362,[\\\"Python
+        \  100.0%  \\\",[null,null,null,\\\"https://github.com\\\"]]]],[null,1],null,[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,\\\"1\\\",1,1,1]]],[8362,8407,[[[8362,8407,[\\\"
+        You can\u2019t perform that action at this time. \\\"]]],[null,1]]]]]]]\",null,null,null,\"generic\"]]\n55\n[[\"di\",161],[\"af.httprm\",160,\"-179848079749851432\",10]]\n25\n[[\"e\",4,null,null,65920]]\n"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Tue, 13 Jan 2026 13:50:22 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Wed, 15-Jul-2026 13:50:22 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Wed, 13-Jan-2027 13:50:22 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '65920'
+    status:
+      code: 200
+      message: OK
+
+version: 1

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -17,9 +17,11 @@ Tools covered and the cassette each replays:
 * ``source_get_content`` over ``sources_get_fulltext.yaml`` — consumes BOTH the
   leading ``GET_NOTEBOOK`` (``rLM1Ne``, metadata via ``execute_source_get``) and
   the trailing ``hizoJc`` (``GET_SOURCE``, full text via ``execute_source_fulltext``).
-* ``source_wait`` (single + all) over ``sources_list.yaml`` — the poller probes
-  source status via the same ``GET_NOTEBOOK`` list, and every recorded source is
-  already ``READY`` so it resolves on the first poll.
+* ``source_wait`` (single + all) over ``sources_wait.yaml`` (= ``sources_list.yaml``
+  plus one real ``hizoJc`` ``GET_SOURCE`` interaction) — the poller probes source
+  status via the same ``GET_NOTEBOOK`` list, and every recorded source is already
+  ``READY`` so it resolves on the first poll; the lone web-page source's body is
+  fetched for the #1698 content-sanity check.
 
 Every tool is invoked with a FULL canonical UUID (the cassette's recorded
 notebook/source id) so the resolver takes its full-UUID fast path and never adds
@@ -414,7 +416,7 @@ async def test_mcp_source_get_content_over_vcr() -> None:
 
 
 @pytest.mark.asyncio
-@notebooklm_vcr.use_cassette("sources_list.yaml")
+@notebooklm_vcr.use_cassette("sources_wait.yaml")
 async def test_mcp_source_wait_single_over_vcr() -> None:
     """``source_wait`` (single source) resolves immediately for a READY source.
 
@@ -423,6 +425,14 @@ async def test_mcp_source_wait_single_over_vcr() -> None:
     The recorded source is already ``READY``, so it resolves on the first poll
     and the tool returns the unified aggregate (``ok`` True, the source in
     ``ready``, all error buckets empty).
+
+    The recorded source is a ``web_page``, so the #1698 content-sanity check
+    issues a ``GET_SOURCE`` (``hizoJc``) fetch for it — replayed from
+    ``sources_wait.yaml`` (= ``sources_list.yaml`` plus that one real interaction).
+    Its body is ample (11,819 chars ≫ the thin threshold), so NO ``warning`` is
+    attached: this end-to-end replay confirms a healthy ready page is not flagged.
+    (The per-kind fetch logic — web-page-only, thin → warning — is pinned by the
+    unit tests in ``tests/unit/mcp/test_sources.py``.)
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -448,10 +458,12 @@ async def test_mcp_source_wait_single_over_vcr() -> None:
     assert source["id"] == SOURCES_LIST_SOURCE_ID
     assert source["status"] == 2  # SourceStatus.READY
     assert source["status_label"] == "ready"
+    # The web-page body fetched ample text → no thin-content warning.
+    assert "warning" not in source
 
 
 @pytest.mark.asyncio
-@notebooklm_vcr.use_cassette("sources_list.yaml", allow_playback_repeats=True)
+@notebooklm_vcr.use_cassette("sources_wait.yaml", allow_playback_repeats=True)
 async def test_mcp_source_wait_all_over_vcr() -> None:
     """``source_wait`` (no ``source``) waits for every source in the notebook.
 
@@ -461,6 +473,11 @@ async def test_mcp_source_wait_all_over_vcr() -> None:
     unified aggregate (``ok`` True, the sources in ``ready``, error buckets
     empty). ``allow_playback_repeats`` lets the per-source polls re-match the
     single recorded ``rLM1Ne`` interaction.
+
+    The lone ``web_page`` source triggers the #1698 content-sanity ``GET_SOURCE``
+    (``hizoJc``) fetch (the 7 ``pasted_text`` sources are skipped by the kind gate);
+    its ample body yields no ``warning``. ``sources_wait.yaml`` carries that one
+    extra interaction. (Web-page-only fetching is pinned by the unit tests.)
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -485,3 +502,5 @@ async def test_mcp_source_wait_all_over_vcr() -> None:
     assert SOURCES_LIST_SOURCE_ID in ids
     # Every returned source is READY (the wait only yields ready sources).
     assert all(row["status"] == 2 for row in ready)
+    # The one web_page has ample text → no thin-content warning anywhere.
+    assert all("warning" not in row for row in ready)

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -108,6 +108,33 @@ class FakeFailedSource:
 
 
 @dataclass
+class FakeReadyTextSource:
+    """A READY non-web-page source (pasted text). ``FakeSource`` hardcodes
+    ``kind=WEB_PAGE``; this fake exists so the source_wait thin-content sanity
+    check can prove it NEVER flags (or even fetches) a non-web-page source —
+    legitimately short pasted text / transcripts must not be warned about."""
+
+    id: str
+    title: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return True
+
+    @property
+    def is_error(self) -> bool:
+        return False
+
+    @property
+    def kind(self) -> SourceType:
+        return SourceType.PASTED_TEXT
+
+    @property
+    def status(self) -> SourceStatus:
+        return SourceStatus.READY
+
+
+@dataclass
 class FakeFulltext:
     """Stand-in for ``SourceFulltext`` (what ``client.sources.get_fulltext`` returns)."""
 
@@ -510,6 +537,13 @@ async def test_source_wait_single_source_ready(mcp_call, mock_client) -> None:
     mock_client.sources.wait_until_ready = AsyncMock(
         return_value=FakeSource(id=SRC_ID, title="Ready")
     )
+    # FakeSource is a READY web_page, so the thin-content sanity check fetches its
+    # body; return ample content so NO warning is added (assert below pins the exact
+    # ready row). Without this the fetch would await a bare MagicMock and the
+    # swallowed TypeError would mask the assertion — green for the wrong reason.
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
     sc = result.structured_content
     _assert_aggregate_shape(sc)
@@ -574,6 +608,11 @@ async def test_source_wait_all_sources_all_ready(mcp_call, mock_client) -> None:
     mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
         {SRC_ID: FakeSource(id=SRC_ID, title="A"), SRC2_ID: FakeSource(id=SRC2_ID, title="B")}
     )
+    # Both fakes are READY web_pages → the thin-content check fetches each body;
+    # ample content ⇒ no warning (keeps the ready-id set assertion exact).
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
     result = await mcp_call("source_wait", {"notebook": NB_ID})
     sc = result.structured_content
     _assert_aggregate_shape(sc)
@@ -605,6 +644,11 @@ async def test_source_wait_all_sources_partial_progress(mcp_call, mock_client) -
             missing_id: SourceNotFoundError(missing_id),
         }
     )
+    # The lone ready source is a READY web_page → thin-content check fetches it;
+    # ample content ⇒ no warning, so the ready bucket stays exactly [ready_id].
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
     result = await mcp_call("source_wait", {"notebook": NB_ID})
     sc = result.structured_content
     _assert_aggregate_shape(sc)
@@ -635,6 +679,9 @@ async def test_source_wait_all_sources_forwards_interval(mcp_call, mock_client) 
     """The all-sources branch honors the advertised ``timeout``/``interval`` per source."""
     mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID)])
     mock_client.sources.wait_until_ready = AsyncMock(return_value=FakeSource(id=SRC_ID, title="A"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
     await mcp_call("source_wait", {"notebook": NB_ID, "timeout": 30.0, "interval": 3.0})
     mock_client.sources.wait_until_ready.assert_awaited_once_with(
         NB_ID, SRC_ID, timeout=30.0, initial_interval=3.0
@@ -674,6 +721,129 @@ async def test_source_wait_all_sources_cancels_siblings_on_unexpected_error(
         await mcp_call("source_wait", {"notebook": NB_ID})
     assert sibling_cancelled.is_set(), "slow sibling poller was not cancelled/drained"
     mock_client.sources.wait_for_sources.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# source_wait — thin-content sanity warning (#1698): a READY web_page whose
+# fetched text is suspiciously thin is flagged (likely dead link / soft-404 /
+# paywall ghost source). web-page only; never rejects; best-effort.
+# ---------------------------------------------------------------------------
+
+
+async def test_source_wait_thin_web_page_warns(mcp_call, mock_client) -> None:
+    """A READY web_page with < the thin threshold (100) chars gets a warning,
+    yet stays READY/ok (advisory only)."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Ghost")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="tiny", char_count=4)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert len(sc["ready"]) == 1
+    row = sc["ready"][0]
+    assert row["id"] == SRC_ID
+    assert "warning" in row
+    assert "4 chars" in row["warning"]
+    assert "source_get_content" in row["warning"]
+    mock_client.sources.get_fulltext.assert_awaited_once_with(NB_ID, SRC_ID, output_format="text")
+
+
+async def test_source_wait_ample_web_page_no_warning(mcp_call, mock_client) -> None:
+    """A READY web_page at/above the threshold is not flagged."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Real")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 100, char_count=100)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    assert sc["ready"][0].get("warning") is None
+
+
+async def test_source_wait_zero_char_web_page_warns(mcp_call, mock_client) -> None:
+    """A READY web_page with 0 extracted chars warns too — the wording covers the
+    not-yet-indexed / empty case rather than asserting a false 'dead link'."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Empty")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="", char_count=0)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    row = sc["ready"][0]
+    assert "warning" in row
+    assert "0 chars" in row["warning"]
+    assert "not-yet-indexed" in row["warning"]
+
+
+async def test_source_wait_non_web_page_not_flagged_or_fetched(mcp_call, mock_client) -> None:
+    """A READY non-web-page source (short pasted text) is NEVER flagged, and its
+    body is NEVER fetched — the kind gate protects legitimately short content."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeReadyTextSource(id=SRC_ID, title="Short note")
+    )
+    mock_client.sources.get_fulltext = AsyncMock()
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    assert sc["ready"][0].get("warning") is None
+    mock_client.sources.get_fulltext.assert_not_called()
+
+
+async def test_source_wait_thin_check_fetch_failure_degrades(mcp_call, mock_client) -> None:
+    """A body-fetch failure must NEVER break the wait — it degrades to no warning."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Flaky")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(side_effect=RuntimeError("transport boom"))
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert sc["ready"][0].get("warning") is None
+
+
+async def test_source_wait_all_sources_thin_warning_per_item(mcp_call, mock_client) -> None:
+    """Across the all-sources fan-out: only the thin web_page is flagged; the ample
+    web_page and the non-web-page are not. ``get_fulltext`` is called for the two
+    web_pages only (the pasted-text source is skipped by the kind gate)."""
+    thin_id, ample_id, text_id = SRC_ID, SRC2_ID, "55555555-5555-5555-5555-555555555555"
+    mock_client.sources.list = AsyncMock(
+        return_value=[
+            FakeSource(id=thin_id),
+            FakeSource(id=ample_id),
+            FakeReadyTextSource(id=text_id),
+        ]
+    )
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            thin_id: FakeSource(id=thin_id, title="Ghost"),
+            ample_id: FakeSource(id=ample_id, title="Real"),
+            text_id: FakeReadyTextSource(id=text_id, title="Note"),
+        }
+    )
+
+    def _fulltext(_nb: str, source_id: str, **_kwargs: Any) -> Any:
+        char_count = 5 if source_id == thin_id else 300
+        return FakeFulltext(content="y" * char_count, char_count=char_count)
+
+    mock_client.sources.get_fulltext = AsyncMock(side_effect=_fulltext)
+    result = await mcp_call("source_wait", {"notebook": NB_ID})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    warned = {row["id"]: row.get("warning") for row in sc["ready"]}
+    assert warned[thin_id] is not None and "5 chars" in warned[thin_id]
+    assert warned[ample_id] is None
+    assert warned[text_id] is None
+    # Only the two web_page sources are fetched; the pasted-text source is skipped.
+    fetched_ids = {call.args[1] for call in mock_client.sources.get_fulltext.await_args_list}
+    assert fetched_ids == {thin_id, ample_id}
 
 
 async def test_source_add_text(mcp_call, mock_client) -> None:

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -41,6 +41,10 @@ class FakeSource:
 
     # ``kind``/``status`` are properties (not fields) → mirror real Source: dropped
     # by to_jsonable but read by the tool's _source_view to add string labels.
+    # NOTE: ``kind`` is hardcoded WEB_PAGE, so any source_wait test that lands this in
+    # the ``ready`` bucket triggers the #1698 thin-content fetch — mock
+    # ``client.sources.get_fulltext`` (ample content) or a swallowed error yields a
+    # green-for-the-wrong-reason pass. Use FakeReadyTextSource for a non-web-page READY.
     @property
     def is_ready(self) -> bool:
         return True


### PR DESCRIPTION
## Summary

Closes #1698.

A dead link / soft-404 / paywalled URL is often ingested by NotebookLM as a **READY** source with little or no extractable text — a "ghost source masquerading as success." Add-time status can't catch it (a soft-404 serves HTTP 200), and `#1679`'s add-time failure-signaling only fires on a backend `ERROR`.

This adds a **non-blocking, advisory** content-sanity warning to the MCP `source_wait` tool: when a READY **web-page** source has fewer than a small documented threshold (100) of extracted characters, its `ready` entry gets a per-source `warning`:

> little/no text extracted (N chars) — may be empty, not-yet-indexed, a soft-404/dead link, blocked, or paywalled; verify with source_get_content.

## Why `source_wait` (not at add time)

The original add-time design was investigated and rejected (see issue thread). Established facts:
- The `Source` returned by `source_add` has **no length field**; `char_count` only exists on `SourceFulltext`, via a full `GET_SOURCE` body fetch. There is no cheap metadata count slot (empirically, the row's numeric slots are not char counts).
- URL ingestion is asynchronous, so at add time the content is often unfetched → `char_count` would read 0 → false positives.
- `source_wait` is the documented post-add step and the point where a source reliably reaches READY-with-indexed-content, so the measurement is meaningful there.

## Design

- **web-page only** (`kind == WEB_PAGE`): text / file / drive / youtube are never flagged — legitimately short pasted text or a short transcript must not warn. This also leaves the batch "accepts YouTube" contract untouched.
- **never rejects**: advisory only; the source stays READY and the wait stays `ok`.
- **best-effort**: reuses the same `GET_SOURCE` fulltext fetch the `source_get_content` tool issues; any fetch failure degrades to no warning (`except Exception`, so `CancelledError` still propagates). The concurrent fan-out uses explicit tasks with cancel+drain on escape, mirroring `_wait_all_sources`.
- Indexing-lag-tolerant wording: a 0-char READY page is flagged honestly ("empty, not-yet-indexed, …") rather than asserting a dead link.
- Applies to both single-source and all-sources `source_wait` modes; per-source fetches run concurrently (bounded by the client's existing RPC semaphore).

`_aggregate_wait_outcomes` is now async and annotates the READY web-page entries.

## Tests

- **Unit** (`tests/unit/mcp/test_sources.py`): thin→warn, ample→no-warn, 0-char→warn, non-web-page→no-warn + no fetch, fetch-failure→degrades, and an all-sources per-item test asserting only the two web-page sources are fetched. Existing READY wait tests now mock `get_fulltext` so they pass for the right reason (not via a swallowed error).
- **Integration VCR**: the two `source_wait` tests move to a dedicated `tests/cassettes/sources_wait.yaml` (= `sources_list.yaml` plus one **real** `hizoJc` `GET_SOURCE` interaction copied from `sources_get_fulltext.yaml`), keeping the heavily-shared `sources_list.yaml` pristine. The lone web-page source's ample body (11,819 chars) yields no warning.

## Verification

`uv run mypy src/notebooklm --ignore-missing-imports`, `uv run pre-commit run --all-files`, `uv run python scripts/audit_public_api_compat.py --check-stale`, and the full `uv run pytest` suite all pass locally. No new MCP tool (ceiling-neutral); no public-surface or CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advisory, non-blocking “thin content” warning for READY web-page sources when extracted text is suspiciously low.
  * The warning is included per item; other source types remain unaffected.
* **Bug Fixes**
  * Improved `source_wait` to perform the additional web-page content sanity check and omit the warning if content lookup fails.
* **Tests**
  * Updated unit and VCR integration coverage to validate warning emission, threshold/wording behavior, and that non-web-page sources are not checked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->