### PR TITLE
fix(app): backfill notebook-create timestamps in the transport-neutral core (#1705)

### DIFF
--- a/src/notebooklm/_app/notebooks.py
+++ b/src/notebooklm/_app/notebooks.py
@@ -26,6 +26,7 @@ This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -33,6 +34,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
     from ..types import Notebook, NotebookDescription, NotebookMetadata
+
+logger = logging.getLogger(__name__)
 
 #: Resolves a (possibly partial) notebook id to its full id. The CLI adapter
 #: injects ``cli.resolve.resolve_notebook_id``; it is read off the wrapper at
@@ -61,9 +64,59 @@ async def execute_notebook_create(
     The ``--use`` context switch is a CLI-side side effect (it writes the
     persisted active-notebook pointer), so it stays in the command layer; this
     core only creates the notebook and returns the typed result.
+
+    The returned notebook has its ``created_at`` / ``modified_at`` backfilled
+    best-effort (see :func:`_backfill_create_timestamps`) so every adapter
+    driving this core — CLI ``notebook create --json``, the REST create route,
+    and the MCP ``notebook_create`` tool — surfaces populated timestamps on
+    creation rather than ``null`` (#1705, lifting the MCP-only fix from #1699).
     """
     notebook = await client.notebooks.create(title)
+    await _backfill_create_timestamps(client, notebook)
     return NotebookCreateResult(notebook=notebook)
+
+
+async def _backfill_create_timestamps(
+    client: NotebookLMClient,
+    notebook: Notebook,
+) -> None:
+    """Best-effort: fill ``notebook``'s null ``created_at`` / ``modified_at``.
+
+    ``CREATE_NOTEBOOK`` (``CCqFvf``) returns a notebook whose ``meta[5]`` /
+    ``meta[8]`` timestamp slots are not yet populated, even though
+    ``GET_NOTEBOOK`` / ``notebook_list`` carry them (#1699). Do ONE re-read to
+    backfill just those two keys, skipping it when both are already present (no
+    wasted RPC) or the id is empty (no ``get("")``).
+
+    The fill is PER-KEY and strictly additive: a slot is filled only when the
+    create left it ``None`` AND the re-read has a value, so a populated create
+    timestamp is never touched and a lagging re-read that returns ``None``
+    cannot REGRESS a populated slot back to ``None``. The create already
+    committed server-side, so a re-read failure (eventual-consistency
+    ``NotebookNotFoundError``, a transport blip) degrades to the create
+    timestamps rather than failing the create; ``except Exception`` still lets
+    ``asyncio.CancelledError`` (a ``BaseException``) propagate.
+
+    Mutates ``notebook`` in place — it is the freshly created, unaliased object
+    this core is about to return, so an in-place fill is safe.
+    """
+    if not notebook.id:
+        return
+    if notebook.created_at is not None and notebook.modified_at is not None:
+        return
+    try:
+        fresh = await client.notebooks.get(notebook.id)
+    except Exception:
+        logger.debug(
+            "notebook create: timestamp re-read failed; returning create "
+            "result with unpopulated timestamps",
+            exc_info=True,
+        )
+        return
+    if notebook.created_at is None and fresh.created_at is not None:
+        notebook.created_at = fresh.created_at
+    if notebook.modified_at is None and fresh.modified_at is not None:
+        notebook.modified_at = fresh.modified_at
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -16,7 +16,6 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastmcp import Context
@@ -29,8 +28,6 @@ from .._errors import mcp_errors
 from .._resolve import resolve_notebook
 from ._passthrough import passthrough_notebook_id
 from ._preview import title_for_id
-
-logger = logging.getLogger(__name__)
 
 
 def register(mcp: Any) -> None:
@@ -55,40 +52,13 @@ def register(mcp: Any) -> None:
             # which key the notebook by ``notebook_id`` rather than nesting the
             # record under a ``notebook`` key (#1540). The remaining Notebook
             # fields (title, created_at, sources_count, is_owner, modified_at)
-            # stay at the top level so no metadata is dropped.
+            # stay at the top level so no metadata is dropped. The
+            # created_at/modified_at backfill (#1699) now lives in the
+            # transport-neutral core (``execute_notebook_create``), so CLI / REST
+            # / MCP all get populated timestamps from one place (#1705) — no
+            # adapter-level re-read here.
             record = to_jsonable(result.notebook)
             notebook_id = record.pop("id")
-            # CREATE_NOTEBOOK leaves created_at/modified_at null even though
-            # GET_NOTEBOOK / notebook_list populate them (#1699). Do ONE
-            # best-effort re-read to backfill just those two keys, skipping it
-            # when both are already present (no wasted RPC) or the id is empty
-            # (no ``get("")``). The create result stays authoritative for
-            # id/title/etc. The fill is PER-KEY and strictly additive: a slot is
-            # filled only when the create left it null AND the re-read has a
-            # value, so a populated create timestamp is never touched and a
-            # lagging re-read that returns null cannot REGRESS one back to null.
-            # The create already committed server-side, so a re-read failure
-            # (eventual-consistency NotebookNotFoundError, a transport blip) must
-            # degrade to the create timestamps rather than fail the create;
-            # ``except Exception`` still lets asyncio.CancelledError propagate.
-            if notebook_id and (
-                record.get("created_at") is None or record.get("modified_at") is None
-            ):
-                try:
-                    fresh = to_jsonable(await client.notebooks.get(notebook_id))
-                    # ``to_jsonable`` on the ``Notebook`` dataclass always yields
-                    # a dict; the isinstance guard makes the ``.get`` reads
-                    # explicitly safe regardless.
-                    if isinstance(fresh, dict):
-                        for key in ("created_at", "modified_at"):
-                            if record.get(key) is None and fresh.get(key) is not None:
-                                record[key] = fresh[key]
-                except Exception:
-                    logger.debug(
-                        "notebook_create: timestamp re-read failed; returning "
-                        "create result with unpopulated timestamps",
-                        exc_info=True,
-                    )
             return {"notebook_id": notebook_id, **record}
 
     @mcp.tool(annotations=READ_ONLY)

--- a/tests/unit/app/test_app_notebooks.py
+++ b/tests/unit/app/test_app_notebooks.py
@@ -19,6 +19,7 @@ generic error classification is covered by ``app/test_app_errors.py``).
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -34,6 +35,7 @@ from notebooklm._app.notebooks import (
     execute_notebook_metadata,
     execute_notebook_rename,
 )
+from notebooklm.exceptions import NotebookNotFoundError
 from notebooklm.types import (
     Notebook,
     NotebookDescription,
@@ -53,6 +55,10 @@ async def _resolve_nb(_client, nb_id, *, json_output=False):
     return f"full_{nb_id}"
 
 
+_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+_MODIFIED_AT = datetime(2026, 1, 3, 4, 5, 6, tzinfo=timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # create
 # ---------------------------------------------------------------------------
@@ -61,7 +67,14 @@ async def _resolve_nb(_client, nb_id, *, json_output=False):
 @pytest.mark.asyncio
 async def test_execute_notebook_create_projects_notebook() -> None:
     client = _client()
-    notebook = Notebook(id="nb_new", title="My notebook")
+    # Both timestamps already populated → the best-effort backfill is a no-op
+    # (no wasted GET re-read), so this stays a pure projection assertion.
+    notebook = Notebook(
+        id="nb_new",
+        title="My notebook",
+        created_at=_CREATED_AT,
+        modified_at=_MODIFIED_AT,
+    )
     client.notebooks.create = AsyncMock(return_value=notebook)
 
     result = await execute_notebook_create(client, "My notebook")
@@ -69,6 +82,104 @@ async def test_execute_notebook_create_projects_notebook() -> None:
     assert isinstance(result, NotebookCreateResult)
     assert result.notebook is notebook
     client.notebooks.create.assert_awaited_once_with("My notebook")
+    client.notebooks.get.assert_not_called()
+
+
+# The create RPC (CREATE_NOTEBOOK / CCqFvf) returns null created_at/modified_at;
+# the core does ONE best-effort GET re-read to backfill just those two slots so
+# every adapter (CLI/REST/MCP) surfaces populated timestamps on create (#1705,
+# lifting the MCP-only #1699 fix into the transport-neutral home).
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_create_backfills_null_timestamps() -> None:
+    client = _client()
+    created = Notebook(id="nb_new", title="New", sources_count=0, is_owner=True)
+    client.notebooks.create = AsyncMock(return_value=created)
+    # The GET diverges on every non-timestamp field to prove ONLY the two
+    # timestamp slots are taken from it; the create stays authoritative.
+    client.notebooks.get = AsyncMock(
+        return_value=Notebook(
+            id="nb_new",
+            title="Stale",
+            created_at=_CREATED_AT,
+            sources_count=9,
+            is_owner=False,
+            modified_at=_MODIFIED_AT,
+        )
+    )
+
+    nb = (await execute_notebook_create(client, "New")).notebook
+
+    assert nb.created_at == _CREATED_AT  # backfilled from GET
+    assert nb.modified_at == _MODIFIED_AT  # backfilled from GET
+    assert nb.title == "New"  # from create, not the divergent GET
+    assert nb.sources_count == 0  # from create
+    assert nb.is_owner is True  # from create
+    client.notebooks.get.assert_awaited_once_with("nb_new")
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_create_fills_only_the_null_slot() -> None:
+    """Per-key + additive: a populated create timestamp is never overwritten."""
+    client = _client()
+    created = Notebook(id="nb_new", title="New", created_at=_CREATED_AT)  # modified_at None
+    client.notebooks.create = AsyncMock(return_value=created)
+    client.notebooks.get = AsyncMock(
+        return_value=Notebook(
+            id="nb_new",
+            title="New",
+            created_at=datetime(2099, 1, 1, tzinfo=timezone.utc),  # must NOT win
+            modified_at=_MODIFIED_AT,
+        )
+    )
+
+    nb = (await execute_notebook_create(client, "New")).notebook
+
+    assert nb.created_at == _CREATED_AT  # create's value preserved, GET ignored
+    assert nb.modified_at == _MODIFIED_AT  # only the null slot filled from GET
+    client.notebooks.get.assert_awaited_once_with("nb_new")
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_create_reread_failure_falls_back() -> None:
+    """A failed GET re-read must not fail a successful create (best-effort)."""
+    client = _client()
+    client.notebooks.create = AsyncMock(return_value=Notebook(id="nb_new", title="New"))
+    client.notebooks.get = AsyncMock(side_effect=NotebookNotFoundError("nb_new"))
+
+    nb = (await execute_notebook_create(client, "New")).notebook  # must not raise
+
+    assert nb.created_at is None
+    assert nb.modified_at is None
+    client.notebooks.get.assert_awaited_once_with("nb_new")
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_create_reread_still_null_stays_null() -> None:
+    """If the GET itself still has null timestamps (propagation lag), stay null."""
+    client = _client()
+    client.notebooks.create = AsyncMock(return_value=Notebook(id="nb_new", title="New"))
+    client.notebooks.get = AsyncMock(return_value=Notebook(id="nb_new", title="New"))
+
+    nb = (await execute_notebook_create(client, "New")).notebook
+
+    assert nb.created_at is None
+    assert nb.modified_at is None
+    client.notebooks.get.assert_awaited_once_with("nb_new")
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_create_empty_id_skips_reread() -> None:
+    """No id → no ``get("")``; the create result is returned untouched."""
+    client = _client()
+    client.notebooks.create = AsyncMock(return_value=Notebook(id="", title="New"))
+    client.notebooks.get = AsyncMock()
+
+    nb = (await execute_notebook_create(client, "New")).notebook
+
+    assert nb.created_at is None
+    client.notebooks.get.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -32,11 +32,13 @@ class FakeNotebook:
 
 @dataclass
 class FakeNotebookFull:
-    """A create-result-shaped notebook carrying the metadata the GET re-read adds.
+    """A create-result-shaped notebook mirroring :class:`notebooklm.types.Notebook`.
 
-    Mirrors the real :class:`notebooklm.types.Notebook` field set so
-    ``to_jsonable`` emits the full flat shape (including ``created_at`` /
-    ``modified_at``) the #1699 enrichment surfaces.
+    Carries the full field set so ``to_jsonable`` emits the flat shape (including
+    ``created_at`` / ``modified_at``) the create tool surfaces. The timestamp
+    backfill itself lives in the transport-neutral core (``execute_notebook_create``,
+    #1705) and is unit-tested there; this fake just lets the MCP test assert the
+    tool flattens and surfaces those fields end-to-end.
     """
 
     id: str
@@ -65,20 +67,20 @@ async def test_notebook_list(mcp_call, mock_client) -> None:
     mock_client.notebooks.list.assert_awaited_once_with()
 
 
-async def test_notebook_create_backfills_only_timestamps(mcp_call, mock_client) -> None:
-    """CREATE_NOTEBOOK returns null timestamps (#1699); a single GET re-read
-    backfills ONLY created_at/modified_at.
+async def test_notebook_create_surfaces_backfilled_timestamps(mcp_call, mock_client) -> None:
+    """End-to-end wiring: the tool flattens the create result (#1540) and
+    surfaces the core's timestamp backfill (#1699/#1705) at the top level.
 
-    The create result is authoritative for id/title/sources_count/is_owner — the
-    re-read overwrites just the two timestamp keys, so a divergent GET payload
-    cannot clobber the rest. The flat shape (#1540) exposes the id as
-    ``notebook_id``.
+    The backfill *semantics* (per-key, additive, best-effort fallback) are
+    unit-tested against the core in ``tests/unit/app/test_app_notebooks.py``;
+    here we only assert the MCP tool wires create → core → flat output, exposing
+    the populated ``created_at`` / ``modified_at`` and the id as ``notebook_id``.
     """
     mock_client.notebooks.create = AsyncMock(
         return_value=FakeNotebookFull(id=NB_ID, title="New", sources_count=0, is_owner=True)
     )
-    # GET intentionally diverges on the non-timestamp fields to prove only the
-    # two timestamp keys are taken from it.
+    # The core re-reads via GET to backfill the null create timestamps; the GET
+    # diverges on the non-timestamp fields to prove the create stays authoritative.
     mock_client.notebooks.get = AsyncMock(
         return_value=FakeNotebookFull(
             id=NB_ID,
@@ -93,136 +95,13 @@ async def test_notebook_create_backfills_only_timestamps(mcp_call, mock_client) 
     assert result.structured_content == {
         "notebook_id": NB_ID,
         "title": "New",  # from create, NOT the divergent GET
-        "created_at": CREATED_AT.isoformat(),  # backfilled from GET
+        "created_at": CREATED_AT.isoformat(),  # backfilled by the core
         "sources_count": 0,  # from create
         "is_owner": True,  # from create
-        "modified_at": MODIFIED_AT.isoformat(),  # backfilled from GET
-    }
-    mock_client.notebooks.create.assert_awaited_once_with("New")
-    # The caller needs no follow-up: exactly one internal GET re-read by id.
-    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
-
-
-async def test_notebook_create_reread_failure_falls_back(mcp_call, mock_client) -> None:
-    """A failed GET re-read must not fail a successful create (#1699).
-
-    The create already committed server-side, so the cosmetic timestamp backfill
-    is best-effort: when ``get`` raises (e.g. an eventual-consistency
-    NotebookNotFoundError), the tool returns the create result with its
-    still-null timestamps instead of propagating the error.
-    """
-    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
-    mock_client.notebooks.get = AsyncMock(side_effect=NotebookNotFoundError(NB_ID))
-    result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "title": "New",
-        "created_at": None,
-        "sources_count": 0,
-        "is_owner": True,
-        "modified_at": None,
+        "modified_at": MODIFIED_AT.isoformat(),  # backfilled by the core
     }
     mock_client.notebooks.create.assert_awaited_once_with("New")
     mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
-
-
-async def test_notebook_create_reread_still_null_stays_null(mcp_call, mock_client) -> None:
-    """Best-effort: if GET itself returns still-null timestamps (propagation
-    lag), the output stays null — no worse than today, no error (#1699).
-    """
-    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
-    mock_client.notebooks.get = AsyncMock(return_value=FakeNotebookFull(id=NB_ID, title="New"))
-    result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "title": "New",
-        "created_at": None,
-        "sources_count": 0,
-        "is_owner": True,
-        "modified_at": None,
-    }
-    mock_client.notebooks.create.assert_awaited_once_with("New")
-    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
-
-
-async def test_notebook_create_skips_reread_when_timestamps_present(mcp_call, mock_client) -> None:
-    """No wasted RPC: when CREATE already returns both timestamps, the tool
-    skips the GET re-read entirely (#1699).
-    """
-    mock_client.notebooks.create = AsyncMock(
-        return_value=FakeNotebookFull(
-            id=NB_ID, title="New", created_at=CREATED_AT, modified_at=MODIFIED_AT
-        )
-    )
-    mock_client.notebooks.get = AsyncMock()
-    result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "title": "New",
-        "created_at": CREATED_AT.isoformat(),
-        "sources_count": 0,
-        "is_owner": True,
-        "modified_at": MODIFIED_AT.isoformat(),
-    }
-    mock_client.notebooks.create.assert_awaited_once_with("New")
-    mock_client.notebooks.get.assert_not_awaited()
-
-
-async def test_notebook_create_reread_backfills_missing_without_regressing(
-    mcp_call, mock_client
-) -> None:
-    """Per-key, non-null backfill in a single mixed re-read (#1699).
-
-    The create result carries ``created_at`` but not ``modified_at`` (one null
-    slot fires the re-read guard). The re-read then LAGS — it returns null for
-    the already-populated ``created_at`` while finally supplying
-    ``modified_at``. The populated ``created_at`` must be preserved (the lagging
-    null must NOT regress it), and the missing ``modified_at`` must be
-    backfilled from the re-read — both in the same call, no exception.
-    """
-    mock_client.notebooks.create = AsyncMock(
-        return_value=FakeNotebookFull(
-            id=NB_ID, title="New", created_at=CREATED_AT, modified_at=None
-        )
-    )
-    mock_client.notebooks.get = AsyncMock(
-        return_value=FakeNotebookFull(
-            id=NB_ID, title="New", created_at=None, modified_at=MODIFIED_AT
-        )
-    )
-    result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {
-        "notebook_id": NB_ID,
-        "title": "New",
-        "created_at": CREATED_AT.isoformat(),  # kept; re-read's lagging null ignored
-        "sources_count": 0,
-        "is_owner": True,
-        "modified_at": MODIFIED_AT.isoformat(),  # backfilled from the re-read
-    }
-    mock_client.notebooks.create.assert_awaited_once_with("New")
-    mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
-
-
-async def test_notebook_create_skips_reread_when_id_empty(mcp_call, mock_client) -> None:
-    """No ``get("")`` on a degenerate empty-id create result (#1699).
-
-    ``Notebook.from_api_response`` can parse a malformed row to an empty id; the
-    re-read guard requires a non-empty id, so such a create skips the follow-up
-    entirely rather than issuing a meaningless ``get("")``.
-    """
-    mock_client.notebooks.create = AsyncMock(return_value=FakeNotebookFull(id="", title="New"))
-    mock_client.notebooks.get = AsyncMock()
-    result = await mcp_call("notebook_create", {"title": "New"})
-    assert result.structured_content == {
-        "notebook_id": "",
-        "title": "New",
-        "created_at": None,
-        "sources_count": 0,
-        "is_owner": True,
-        "modified_at": None,
-    }
-    mock_client.notebooks.create.assert_awaited_once_with("New")
-    mock_client.notebooks.get.assert_not_awaited()
 
 
 async def test_notebook_describe_by_id(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary

Fixes #1705.

#1699/#1704 fixed the **MCP** `notebook_create` tool surfacing null `created_at`/`modified_at` on creation via a best-effort `GET_NOTEBOOK` re-read — but the fix was **MCP-adapter-only**, so **CLI** `notebook create --json` and the **REST** create route still returned null timestamps (the same root cause, "only one-third fixed").

This lifts the enrichment into the transport-neutral core `_app.notebooks.execute_notebook_create` (new `_backfill_create_timestamps` helper), so **all three adapters — CLI, REST, MCP — get populated timestamps from one place** (Option 1, the recommended one). The MCP-adapter copy + its now-orphaned `logger` are removed; CLI and REST need no changes (both render straight off `result.notebook`).

## Root cause (confirmed in #1699)

`CREATE_NOTEBOOK` (`CCqFvf`) returns a notebook whose `meta[5]`/`meta[8]` timestamp slots are not yet populated; `GET_NOTEBOOK` / `notebook_list` carry them.

## Behavior (preserved exactly from the MCP version)

- **Per-key + strictly additive:** a slot is filled only when create left it `None` AND the re-read has a value — a populated create timestamp is never overwritten, and a lagging-null re-read cannot regress a populated slot back to `None`.
- **Best-effort:** the create already committed server-side, so a re-read failure (eventual-consistency `NotebookNotFoundError`, a transport blip) degrades to the create timestamps rather than failing the create. `except Exception` still lets `asyncio.CancelledError` propagate.
- **No wasted RPC:** the re-read is skipped when both timestamps are already present or the id is empty.

## Tests

Backfill semantics are now unit-tested at the core in `tests/unit/app/test_app_notebooks.py` (backfill, per-key additivity without regression, re-read-failure fallback, still-null, empty-id skip, both-present skip). The MCP suite (`tests/unit/mcp/test_notebooks.py`) keeps one end-to-end wiring test and defers semantics to the core tests.

## Test plan
- [x] `pytest tests/unit/app/test_app_notebooks.py tests/unit/mcp/test_notebooks.py tests/unit/cli/test_notebook.py tests/unit/cli/test_cli_mcp_parity.py` — green
- [x] Full suite (10501 passed), `mypy src/notebooklm` clean, `ruff` clean
- [x] `_app` transport-neutral boundary intact (`test_app_boundary.py` — only stdlib `logging` added)

## Polish
code-simplifier (clean) + triple review (claude/codex/agy — 0 critical, 0 important) + ultrathink. The one finding (MCP test duplication) is applied. **Deferred findings:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YG1NZU5zNDAX2gWGNubjwi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook creation now better preserves `created_at` and `modified_at` timestamps when they are missing at creation time.
  * If a follow-up lookup fails, notebook creation still succeeds instead of erroring.
  * Created notebook details now return more consistently in API and tool outputs, including timestamp fields when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->