### PR TITLE
feat(mcp): add artifact_rename + artifact_delete tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MCP artifact rename & delete tools.** Two new MCP tools close the artifact
+  CRUD gap (the server previously exposed create + read only): `artifact_rename`
+  (title-only update) and `artifact_delete` (destructive, two-step `confirm`).
+  Both accept a notebook/artifact name **or** ID, cover every studio artifact
+  type including both mind-map kinds — note-backed maps route through the note
+  system, interactive maps and regular artifacts through the artifact RPC — over
+  the shared kind-aware `_app.artifacts` cores the CLI already uses. The MCP tool
+  surface is now **28 tools**.
 - **Live-API e2e coverage for the MCP server and the CLI binary.** The nightly
   E2E job now installs `--extra mcp`, so the MCP/CLI layers run against the real
   NotebookLM API once per release instead of being silently `importorskip`-ped.
-  New suites: per-domain MCP tool round-trips plus a 26-tool→test matrix
+  New suites: per-domain MCP tool round-trips plus a 28-tool→test matrix
   (`tests/e2e/test_mcp.py`); the HTTP transport, bearer gate, `.well-known`
   discovery, and signed-URL upload/download routes driven in-process over
   `httpx.ASGITransport` (`tests/e2e/test_mcp_http.py`); live-only contract
@@ -138,7 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Experimental: MCP server** (#1484, opt-in via the `mcp` extra). A
   [Model Context Protocol](https://modelcontextprotocol.io) server exposing
-  NotebookLM to MCP clients (Claude Desktop / Code, Cursor, Windsurf) as 25 tools
+  NotebookLM to MCP clients (Claude Desktop / Code, Cursor, Windsurf) as 28 tools
   across notebooks, sources, chat, notes, studio artifacts, and research — built
   as a transport-neutral sibling adapter over the `_app/` layer (ADR-0021), so it
   behaves identically to the equivalent `notebooklm` CLI command. Run it with the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1178,7 +1178,7 @@ src/notebooklm/
 │   ├── _fileroutes.py           # register_file_routes(mcp, config): the /files/{dl,ul} custom routes mounted on the FastMCP http app (ADR-0024). GET /files/dl streams the artifact (download core → FileResponse, meaningful filename, inside-tempdir assert, BackgroundTask cleanup); GET /files/ul = minimal upload page (file picker + raw-body fetch POST); POST|PUT /files/ul streams request.stream() into a 0600 temp under a running byte cap (real DoS guard) + Content-Length early 413 → neutral source_add core. Signed token is the sole auth (custom routes bypass the bearer gate); HTML pages set no-referrer/no-store/DENY; local _safe_upload_name (no server/ import)
 │   ├── _context.py              # AppState dataclass (client + optional file_transfer) + get_client(ctx) / get_file_transfer(ctx) (lifespan-bound) + get_client_from_app(request) (the guarded private-attr accessor for the bare-Request custom routes)
 │   ├── _errors.py               # Structured tool-error projection (CATEGORY_TABLE/ERROR_CODES/mcp_errors/to_tool_error/tool_error_payload) over _app.errors.classify
-│   ├── _resolve.py              # resolve_notebook/resolve_source/resolve_note — name + partial-id resolution over _app.resolve plus exact-title matching
+│   ├── _resolve.py              # resolve_notebook/resolve_source/resolve_note/resolve_artifact — name + partial-id resolution over _app.resolve plus exact-title matching
 │   ├── _confirm.py              # needs_confirmation() both-mode envelope + READ_ONLY/DESTRUCTIVE ToolAnnotations
 │   ├── _coerce.py               # coerce_list(value) — tolerant list-param normalizer (real list/tuple, JSON-array string, comma string, scalar → list[str]; None stays None for the "all sources" contract); used by artifact_generate/chat_ask source_ids
 │   └── tools/                   # Per-domain tool modules; each exposes register(mcp) wired by server.register_all
@@ -1189,7 +1189,7 @@ src/notebooklm/
 │       ├── sources.py           # source_list/get_content/rename/delete/wait/add over _app.source_* (add: url/text/file/youtube via source_add, drive via source_mutations)
 │       ├── chat.py              # chat_ask (client.chat.ask) + chat_configure (_app.chat.execute_configure)
 │       ├── notes.py             # note_create/list/update/delete over _app.notes
-│       ├── artifacts.py         # artifact_list/generate/status/download (enum dispatch over _app.generate + _app.download; stateless poll via _app.artifacts.poll_artifact)
+│       ├── artifacts.py         # artifact_list/generate/status/download/rename/delete (enum dispatch over _app.generate + _app.download; stateless poll via _app.artifacts.poll_artifact; rename/delete over _app.artifacts kind-aware cores)
 │       ├── research.py          # research_start (client.research.start) + research_status (_app.research.poll_and_classify) + research_import
 │       └── meta.py              # server_info — package version + auth-health over _app.auth_check (no notebook arg)
 ├── rpc/                         # RPC protocol layer

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -477,7 +477,7 @@ Wire it into an MCP client with either:
 - `notebooklm mcp install <client>` — auto-writes the server config for `claude-desktop`, `claude-code`, `cursor`, or `windsurf`; or
 - the one-click `.mcpb` desktop bundle built from `desktop-extension/` (Claude Desktop's "Install Extension").
 
-Full usage walkthrough (auth, transports, the 25 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
+Full usage walkthrough (auth, transports, the 28 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
 
 ---
 

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -6,7 +6,7 @@
 > server and its dependencies only arrive with the `mcp` extra.
 
 The MCP server exposes NotebookLM to any [Model Context Protocol](https://modelcontextprotocol.io)
-client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **25 tools** — manage
+client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **28 tools** — manage
 notebooks and sources, chat over a notebook's sources, generate and download studio artifacts,
 and run deep research. It is a thin adapter over the same business logic the CLI uses, so it
 behaves identically to `notebooklm <command>`.
@@ -195,11 +195,11 @@ bearer-only deploy → the two file tools return a clear "not configured" error
 
 These conventions hold across every tool:
 
-- **Name *or* ID.** Every `notebook`/`source`/`note` argument accepts a human title **or** an ID
-  (full, or a unique prefix). Use the matching `*_list` tool to discover them. An ambiguous name or
-  prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
-- **Destructive tools need confirmation.** `notebook_delete`, `source_delete`, and `note_delete`
-  take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
+- **Name *or* ID.** Every `notebook`/`source`/`note`/`artifact` argument accepts a human title **or**
+  an ID (full, or a unique prefix). Use the matching `*_list` tool to discover them. An ambiguous name
+  or prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
+- **Destructive tools need confirmation.** `notebook_delete`, `source_delete`, `note_delete`, and
+  `artifact_delete` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
   (with the resolved title) and delete **nothing**; call again with `confirm=true` to execute.
 - **Long-running work is non-blocking.** `artifact_generate` returns immediately with a `task_id`;
   poll `artifact_status` until it's complete, then `artifact_download`. Research is the same shape:
@@ -294,11 +294,11 @@ a single in-flight task.
 | **Sources** | `source_list(notebook, status?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` · `source_add(notebook, source_type, ..., allow_internal?)` (single; echoes `kind`/`status_label`, flags a failed import inline with a `warning`) / `source_add(notebook, urls=[...], allow_internal?)` (batch → per-item `results`) |
 | **Chat** | `chat_ask(notebook, question, conversation_id?, references?, source_ids?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all) · `chat_configure(notebook, goal?, response_length?)` |
 | **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
-| **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` |
-| **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` |
+| **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` · `artifact_rename(notebook, artifact, new_title)` · `artifact_delete(notebook, artifact, confirm)` |
+| **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` |
 | **Server** | `server_info` — version + local auth health |
 
-Tools that only read are annotated read-only; the three `*_delete` tools are annotated destructive
+Tools that only read are annotated read-only; the four `*_delete` tools are annotated destructive
 and require `confirm`. A host that honors MCP annotations can auto-allow the read-only calls and
 gate the destructive ones.
 

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -41,6 +41,7 @@ from .._app.resolve import (
     validate_id,
 )
 from ..exceptions import (
+    ArtifactNotFoundError,
     NotebookNotFoundError,
     NoteNotFoundError,
     SourceNotFoundError,
@@ -50,7 +51,13 @@ from ..exceptions import (
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
-__all__ = ["resolve_note", "resolve_notebook", "resolve_source", "resolve_sources"]
+__all__ = [
+    "resolve_artifact",
+    "resolve_note",
+    "resolve_notebook",
+    "resolve_source",
+    "resolve_sources",
+]
 
 #: A token made only of hex digits and dashes routes to the id/prefix path; any
 #: other character (a space, a letter outside ``a-f``, punctuation) routes to the
@@ -65,7 +72,9 @@ def _resolve_by_title(
     token: str,
     items: Sequence[Any],
     *,
-    not_found: type[NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError],
+    not_found: type[
+        NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError | ArtifactNotFoundError
+    ],
 ) -> str:
     """Resolve ``token`` by case-insensitive exact title over ``items``.
 
@@ -97,7 +106,9 @@ def _resolve_by_id_or_prefix(
     token: str,
     items: Sequence[Any],
     *,
-    not_found: type[NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError],
+    not_found: type[
+        NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError | ArtifactNotFoundError
+    ],
 ) -> str:
     """Resolve a hex-ish ``token`` via ``resolve_ref``, mapping no-match to NotFound."""
     try:
@@ -123,7 +134,9 @@ def _resolve_hex(
     token: str,
     items: Sequence[Any],
     *,
-    not_found: type[NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError],
+    not_found: type[
+        NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError | ArtifactNotFoundError
+    ],
 ) -> str:
     """Resolve a hex-ish ``token``, preferring id/prefix but falling back to title.
 
@@ -286,3 +299,39 @@ async def resolve_note(client: NotebookLMClient, notebook_id: str, ref: str) -> 
     if _HEX_ISH.match(ref):
         return _resolve_hex(ref, items, not_found=NoteNotFoundError)
     return _resolve_by_title(ref, items, not_found=NoteNotFoundError)
+
+
+async def resolve_artifact(client: NotebookLMClient, notebook_id: str, ref: str) -> str:
+    """Resolve a studio-artifact reference within a notebook to its id.
+
+    Same matching rules as :func:`resolve_source`, over the notebook's artifact
+    list. ``client.artifacts.list`` MERGES both mind-map backings (interactive +
+    note-backed) under one listing, so a note-backed mind map is resolvable by
+    id / prefix / title here just like any other artifact.
+
+    The full-UUID fast-path returns ``ref`` **verbatim with no list call**: this
+    lets a concrete id (including a note-backed mind-map id, or one missing from a
+    stale list) reach the ``_app`` core, which then routes it by kind.
+
+    Args:
+        client: The lifespan-bound client.
+        notebook_id: The (already-resolved) notebook id the artifact lives in.
+        ref: A full canonical UUID, a hex id prefix, or an exact (case-insensitive)
+            artifact title.
+
+    Returns:
+        The artifact's canonical id.
+
+    Raises:
+        ValidationError: ``ref`` is empty/whitespace.
+        ArtifactNotFoundError: No artifact in the notebook matches ``ref``.
+        AmbiguousIdError: ``ref`` matches more than one artifact by prefix or title.
+    """
+    ref = validate_id(ref, "artifact")
+    # Full UUID fast-path — never list.
+    if FULL_ID_PATTERN.fullmatch(ref):
+        return ref
+    items = await client.artifacts.list(notebook_id)
+    if _HEX_ISH.match(ref):
+        return _resolve_hex(ref, items, not_found=ArtifactNotFoundError)
+    return _resolve_by_title(ref, items, not_found=ArtifactNotFoundError)

--- a/src/notebooklm/mcp/tools/_preview.py
+++ b/src/notebooklm/mcp/tools/_preview.py
@@ -1,9 +1,10 @@
 """Shared helper for the destructive tools' confirmation previews.
 
-The three delete tools (``notebook_delete`` / ``source_delete`` / ``note_delete``)
-build a ``needs_confirmation`` preview that includes the resolved resource's
-title. Each fetches its own domain list (notebooks / sources / notes), but the
-id-to-title match over that list is identical, so it lives here.
+The four delete tools (``notebook_delete`` / ``source_delete`` / ``note_delete`` /
+``artifact_delete``) build a ``needs_confirmation`` preview that includes the
+resolved resource's title. Each fetches its own domain list (notebooks / sources /
+notes / artifacts), but the id-to-title match over that list is identical, so it
+lives here.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """

--- a/src/notebooklm/mcp/tools/artifacts.py
+++ b/src/notebooklm/mcp/tools/artifacts.py
@@ -42,12 +42,13 @@ from ..._app.serialize import to_jsonable
 from ...exceptions import ValidationError
 from ...types import ArtifactType
 from .._coerce import coerce_list
-from .._confirm import READ_ONLY
+from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors
 from .._filelink import DOWNLOAD_TTL, FileTransferConfig
-from .._resolve import resolve_notebook, resolve_sources
+from .._resolve import resolve_artifact, resolve_notebook, resolve_sources
 from ._passthrough import passthrough_notebook_id
+from ._preview import title_for_id
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -700,6 +701,73 @@ def register(mcp: Any) -> None:
                 artifact_resolver=_resolve_artifact_id,
             )
             return to_jsonable(result)
+
+    @mcp.tool
+    async def artifact_rename(
+        ctx: Context, notebook: str, artifact: str, new_title: str
+    ) -> dict[str, Any]:
+        """Rename a studio artifact (title only). Accepts a notebook/artifact name or ID.
+
+        Works for every artifact type — audio, video, slide-deck, quiz,
+        flashcards, infographic, data-table, report, and BOTH mind-map kinds.
+        Note-backed mind maps are renamed through the note system; interactive
+        maps and regular artifacts through the artifact rename RPC. The kind
+        routing is handled by the shared ``_app`` core, so callers need not know
+        which backing an artifact has.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            art_id = await resolve_artifact(client, nb_id, artifact)
+            result = await artifact_core.rename_artifact(client, nb_id, art_id, new_title)
+            return {
+                "status": "renamed",
+                "notebook_id": nb_id,
+                "artifact_id": result.artifact_id,
+                "new_title": result.new_title,
+                "is_mind_map": result.is_mind_map,
+            }
+
+    @mcp.tool(annotations=DESTRUCTIVE)
+    async def artifact_delete(
+        ctx: Context, notebook: str, artifact: str, confirm: bool = False
+    ) -> dict[str, Any]:
+        """Delete a studio artifact (irreversible). Accepts a notebook/artifact name or ID.
+
+        Covers every artifact type, including both mind-map kinds: note-backed
+        maps are *cleared* via the note system (not hard-removed — Google may
+        garbage collect them later), interactive maps and regular artifacts are
+        removed via the artifact delete RPC. The kind routing is handled by the
+        shared ``_app`` core.
+
+        Two-step confirmation: with ``confirm=False`` (default) it returns a
+        ``needs_confirmation`` preview of the resolved artifact without deleting;
+        call again with ``confirm=True`` to perform the delete. Deleting an
+        already-absent full id is idempotent (no error).
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            art_id = await resolve_artifact(client, nb_id, artifact)
+            if not confirm:
+                # Best-effort title for the preview; a full-UUID that is absent
+                # from the list resolves to None, which is fine for the preview.
+                title = title_for_id(await client.artifacts.list(nb_id), art_id)
+                return needs_confirmation(
+                    {
+                        "action": "delete_artifact",
+                        "notebook_id": nb_id,
+                        "artifact_id": art_id,
+                        "title": title,
+                    }
+                )
+            was_note_backed = await artifact_core.delete_artifact(client, nb_id, art_id)
+            return {
+                "status": "deleted",
+                "notebook_id": nb_id,
+                "artifact_id": art_id,
+                "was_note_backed": was_note_backed,
+            }
 
 
 def _generation_payload(

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -188,7 +188,7 @@ class TestMcpNameResolution:
         assert described_upper["notebook_id"] == nb_id
 
 
-# Tool → owning-test matrix. Every one of the 26 registered tools must map to a
+# Tool → owning-test matrix. Every one of the 28 registered tools must map to a
 # test (or a documented owner) so a newly-added tool fails ``test_tool_matrix``
 # until it gains live coverage. ``test_tool_matrix`` asserts this set equals the
 # live manifest.
@@ -220,6 +220,8 @@ TOOL_COVERAGE: dict[str, str] = {
     "artifact_generate": "TestMcpArtifacts.test_generate_report_wiring (variants)",
     "artifact_status": "TestMcpArtifacts.test_generate_report_wiring (variants)",
     "artifact_download": "TestMcpArtifacts.test_download_existing_artifact",
+    "artifact_rename": "tests/unit/mcp/test_artifacts.py (kind-aware rename; no live mutation)",
+    "artifact_delete": "tests/unit/mcp/test_artifacts.py (kind-aware delete; no live mutation)",
     # research
     "research_start": "TestMcpResearch.test_start_status_cancel (variants)",
     "research_status": "TestMcpResearch.test_status_readonly",
@@ -230,7 +232,7 @@ TOOL_COVERAGE: dict[str, str] = {
 
 @requires_auth
 class TestMcpToolMatrix:
-    """Every registered tool is accounted for by a live test (the 26-tool matrix)."""
+    """Every registered tool is accounted for by a live test (the 28-tool matrix)."""
 
     @pytest.mark.asyncio
     @pytest.mark.readonly

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -1071,7 +1071,8 @@ async def test_artifact_rename_not_found_projects_tool_error(mcp_call, mock_clie
         )
     assert "NOT_FOUND" in str(excinfo.value)
     mock_client.artifacts.rename.assert_not_called()
-    _ = ArtifactNotFoundError  # the raw error type is asserted in test_resolve.py
+    # The tool layer asserts the wrapped ToolError/NOT_FOUND; the raw
+    # ArtifactNotFoundError is asserted at the resolver layer in test_resolve.py.
 
 
 # ---------------------------------------------------------------------------
@@ -1090,7 +1091,8 @@ async def test_artifact_delete_confirm_false_previews(mcp_call, mock_client) -> 
     )
     mock_client.artifacts.list = AsyncMock(return_value=[art])
     mock_client.artifacts.delete = AsyncMock()
-    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[])
+    # No list_note_backed mock: the confirm=False path returns the preview before
+    # ever reaching the delete core (which is what probes list_note_backed).
     result = await mcp_call(
         "artifact_delete",
         {"notebook": NB_ID, "artifact": "aaaaaaaa-aaaa"},

--- a/tests/unit/mcp/test_artifacts.py
+++ b/tests/unit/mcp/test_artifacts.py
@@ -25,6 +25,7 @@ from notebooklm._types.artifacts import (  # noqa: E402
     ArtifactStatus,
     ArtifactTypeCode,
 )
+from notebooklm._types.mind_maps import MindMapKind  # noqa: E402
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     ArtifactNotFoundError,
     NotebookNotFoundError,
@@ -83,6 +84,18 @@ class FakeArtifact:
     kind: ArtifactType = ArtifactType.AUDIO
     is_completed: bool = True
     created_at: datetime = field(default_factory=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc))
+
+
+@dataclass
+class FakeMindMap:
+    """Minimal ``MindMap`` stand-in for the rename/delete mind-map probes.
+
+    ``rename_artifact`` reads ``.id`` + ``.kind`` off ``mind_maps.list`` rows;
+    ``delete_artifact`` reads ``.id`` off ``mind_maps.list_note_backed`` rows.
+    """
+
+    id: str
+    kind: MindMapKind = MindMapKind.INTERACTIVE
 
 
 @dataclass
@@ -963,3 +976,228 @@ async def test_artifact_list_notebook_not_found_projects_tool_error(mcp_call, mo
         await mcp_call("artifact_list", {"notebook": "No Such Notebook"})
     assert "NOT_FOUND" in str(excinfo.value)
     _ = NotebookNotFoundError  # imported for symmetry with sibling suites
+
+
+# ---------------------------------------------------------------------------
+# artifact_rename
+# ---------------------------------------------------------------------------
+
+_ART_FULL = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+async def test_artifact_rename_regular_typed_artifact(mcp_call, mock_client) -> None:
+    """A regular artifact resolves via the typed ``Artifact`` list (NOT a dict) and
+    routes to ``artifacts.rename``.
+
+    Regression guard: the resolver must use attribute access (``a.id`` / ``a.title``)
+    on the typed ``Artifact`` objects ``client.artifacts.list`` returns. The earlier
+    dict-shaped helper would ``TypeError`` here. Resolving by a hex prefix exercises
+    the id/prefix path against the typed list.
+    """
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[art])
+    mock_client.mind_maps.list = AsyncMock(return_value=[])
+    mock_client.artifacts.rename = AsyncMock()
+    result = await mcp_call(
+        "artifact_rename",
+        {"notebook": NB_ID, "artifact": "aaaaaaaa-aaaa", "new_title": "Renamed"},
+    )
+    assert result.structured_content == {
+        "status": "renamed",
+        "notebook_id": NB_ID,
+        "artifact_id": _ART_FULL,
+        "new_title": "Renamed",
+        "is_mind_map": False,
+    }
+    mock_client.artifacts.rename.assert_awaited_once_with(
+        NB_ID, _ART_FULL, "Renamed", return_object=False
+    )
+    mock_client.mind_maps.rename.assert_not_called()
+
+
+async def test_artifact_rename_interactive_mind_map_by_title(mcp_call, mock_client) -> None:
+    """A mind map resolved by title routes through ``mind_maps.rename`` (is_mind_map true)."""
+    mm_id = "mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm"
+    mock_client.artifacts.list = AsyncMock(
+        return_value=[FakeArtifact(id=mm_id, title="My Map", kind=ArtifactType.MIND_MAP)]
+    )
+    mock_client.mind_maps.list = AsyncMock(
+        return_value=[FakeMindMap(id=mm_id, kind=MindMapKind.INTERACTIVE)]
+    )
+    mock_client.mind_maps.rename = AsyncMock()
+    result = await mcp_call(
+        "artifact_rename",
+        {"notebook": NB_ID, "artifact": "My Map", "new_title": "Renamed Map"},
+    )
+    assert result.structured_content["is_mind_map"] is True
+    assert result.structured_content["artifact_id"] == mm_id
+    mock_client.mind_maps.rename.assert_awaited_once()
+    mock_client.artifacts.rename.assert_not_called()
+
+
+async def test_artifact_rename_note_backed_mind_map_by_full_uuid(mcp_call, mock_client) -> None:
+    """A full-UUID ref reaches the core unlisted; the core's ``mind_maps.list`` probe
+    finds the note-backed map → ``mind_maps.rename`` with its kind."""
+    mock_client.mind_maps.list = AsyncMock(
+        return_value=[FakeMindMap(id=_ART_FULL, kind=MindMapKind.NOTE_BACKED)]
+    )
+    mock_client.mind_maps.rename = AsyncMock()
+    result = await mcp_call(
+        "artifact_rename",
+        {"notebook": NB_ID, "artifact": _ART_FULL, "new_title": "Renamed"},
+    )
+    assert result.structured_content["is_mind_map"] is True
+    assert result.structured_content["artifact_id"] == _ART_FULL
+    # Full-UUID fast-path: the resolver never lists artifacts.
+    mock_client.artifacts.list.assert_not_called()
+    mock_client.mind_maps.rename.assert_awaited_once()
+    assert mock_client.mind_maps.rename.await_args.kwargs["kind"] == MindMapKind.NOTE_BACKED
+
+
+async def test_artifact_rename_not_found_projects_tool_error(mcp_call, mock_client) -> None:
+    """A prefix/title that matches no artifact projects NOT_FOUND (resolver raises
+    ``ArtifactNotFoundError``, which ``mcp_errors`` maps to a ``ToolError``)."""
+    mock_client.artifacts.list = AsyncMock(return_value=[])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_rename",
+            {"notebook": NB_ID, "artifact": "No Such Artifact", "new_title": "X"},
+        )
+    assert "NOT_FOUND" in str(excinfo.value)
+    mock_client.artifacts.rename.assert_not_called()
+    _ = ArtifactNotFoundError  # the raw error type is asserted in test_resolve.py
+
+
+# ---------------------------------------------------------------------------
+# artifact_delete
+# ---------------------------------------------------------------------------
+
+
+async def test_artifact_delete_confirm_false_previews(mcp_call, mock_client) -> None:
+    """``confirm=False`` returns a ``needs_confirmation`` preview and does NOT delete."""
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[art])
+    mock_client.artifacts.delete = AsyncMock()
+    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[])
+    result = await mcp_call(
+        "artifact_delete",
+        {"notebook": NB_ID, "artifact": "aaaaaaaa-aaaa"},
+    )
+    assert result.structured_content["status"] == "needs_confirmation"
+    preview = result.structured_content["preview"]
+    assert preview["action"] == "delete_artifact"
+    assert preview["artifact_id"] == _ART_FULL
+    assert preview["title"] == "Podcast 1"
+    mock_client.artifacts.delete.assert_not_called()
+    mock_client.notes.delete.assert_not_called()
+
+
+async def test_artifact_delete_regular_confirmed(mcp_call, mock_client) -> None:
+    """``confirm=True`` on a regular artifact hits ``artifacts.delete`` (was_note_backed false)."""
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[art])
+    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[])
+    mock_client.artifacts.delete = AsyncMock()
+    result = await mcp_call(
+        "artifact_delete",
+        {"notebook": NB_ID, "artifact": "aaaaaaaa-aaaa", "confirm": True},
+    )
+    assert result.structured_content == {
+        "status": "deleted",
+        "notebook_id": NB_ID,
+        "artifact_id": _ART_FULL,
+        "was_note_backed": False,
+    }
+    mock_client.artifacts.delete.assert_awaited_once_with(NB_ID, _ART_FULL)
+    mock_client.notes.delete.assert_not_called()
+
+
+async def test_artifact_delete_note_backed_by_full_uuid_confirmed(mcp_call, mock_client) -> None:
+    """A note-backed mind map (full-UUID ref) is cleared via ``notes.delete``
+    (was_note_backed true). The core's probe is ``mind_maps.list_note_backed``."""
+    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[FakeMindMap(id=_ART_FULL)])
+    mock_client.notes.delete = AsyncMock()
+    mock_client.artifacts.delete = AsyncMock()
+    result = await mcp_call(
+        "artifact_delete",
+        {"notebook": NB_ID, "artifact": _ART_FULL, "confirm": True},
+    )
+    assert result.structured_content["was_note_backed"] is True
+    assert result.structured_content["artifact_id"] == _ART_FULL
+    # Full-UUID fast-path: the resolver never lists artifacts.
+    mock_client.artifacts.list.assert_not_called()
+    mock_client.notes.delete.assert_awaited_once_with(NB_ID, _ART_FULL)
+    mock_client.artifacts.delete.assert_not_called()
+
+
+async def test_artifact_delete_note_backed_by_title_confirmed(mcp_call, mock_client) -> None:
+    """A note-backed mind map resolved by title also routes through ``notes.delete``."""
+    mm_id = "mmmmmmmm-mmmm-mmmm-mmmm-mmmmmmmmmmmm"
+    mock_client.artifacts.list = AsyncMock(
+        return_value=[FakeArtifact(id=mm_id, title="My Map", kind=ArtifactType.MIND_MAP)]
+    )
+    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[FakeMindMap(id=mm_id)])
+    mock_client.notes.delete = AsyncMock()
+    mock_client.artifacts.delete = AsyncMock()
+    result = await mcp_call(
+        "artifact_delete",
+        {"notebook": NB_ID, "artifact": "My Map", "confirm": True},
+    )
+    assert result.structured_content["was_note_backed"] is True
+    assert result.structured_content["artifact_id"] == mm_id
+    mock_client.notes.delete.assert_awaited_once_with(NB_ID, mm_id)
+    mock_client.artifacts.delete.assert_not_called()
+
+
+async def test_artifact_delete_absent_full_uuid_is_idempotent(mcp_call, mock_client) -> None:
+    """Deleting an already-absent full UUID is a no-error no-op: the full-UUID
+    fast-path reaches the core unlisted, the note-backed probe misses, and
+    ``artifacts.delete`` (idempotent on missing) runs without raising."""
+    absent = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    mock_client.mind_maps.list_note_backed = AsyncMock(return_value=[])
+    mock_client.artifacts.delete = AsyncMock()
+    result = await mcp_call(
+        "artifact_delete",
+        {"notebook": NB_ID, "artifact": absent, "confirm": True},
+    )
+    assert result.structured_content == {
+        "status": "deleted",
+        "notebook_id": NB_ID,
+        "artifact_id": absent,
+        "was_note_backed": False,
+    }
+    mock_client.artifacts.list.assert_not_called()
+    mock_client.artifacts.delete.assert_awaited_once_with(NB_ID, absent)
+
+
+async def test_artifact_delete_absent_prefix_projects_tool_error(mcp_call, mock_client) -> None:
+    """An absent prefix/title raises at resolve time (NOT_FOUND), never reaching the
+    core — distinct from the idempotent absent-full-UUID case above."""
+    mock_client.artifacts.list = AsyncMock(return_value=[])
+    mock_client.artifacts.delete = AsyncMock()
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "artifact_delete",
+            {"notebook": NB_ID, "artifact": "No Such Artifact", "confirm": True},
+        )
+    assert "NOT_FOUND" in str(excinfo.value)
+    mock_client.artifacts.delete.assert_not_called()
+    mock_client.notes.delete.assert_not_called()

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -3,10 +3,10 @@
 Builds the server (bound to a mock client) and lists its tools through the
 in-memory FastMCP ``Client``, then pins:
 
-* the EXACT set of tool names (the 25 of Phase 2a + 2b plus ``research_cancel``)
-  — so a tool can't be silently added, removed, or renamed without updating this
-  gate;
-* a tool-count ceiling (28) leaving a little headroom over the ~25 design target;
+* the EXACT set of tool names — so a tool can't be silently added, removed, or
+  renamed without updating this gate;
+* a tool-count ceiling (28) now reached exactly (28/28): the next tool needs a
+  justified ceiling bump;
 * the ``destructiveHint`` annotation + a ``confirm`` parameter on every
   destructive (delete) tool; and
 * the ``readOnlyHint`` annotation on every read-only tool.
@@ -23,7 +23,7 @@ import pytest
 pytest.importorskip("fastmcp")
 
 
-#: The complete, pinned tool surface. 26 tools across 7 domains. Adding or
+#: The complete, pinned tool surface. 28 tools across 7 domains. Adding or
 #: removing a tool MUST update this set (and the ceiling below if it grows).
 EXPECTED_TOOLS: frozenset[str] = frozenset(
     {
@@ -48,11 +48,13 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "note_list",
         "note_update",
         "note_delete",
-        # Artifacts (4)
+        # Artifacts (6)
         "artifact_list",
         "artifact_generate",
         "artifact_status",
         "artifact_download",
+        "artifact_rename",
+        "artifact_delete",
         # Research (4)
         "research_start",
         "research_status",
@@ -68,9 +70,11 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
 #: trips the gate.
 TOOL_CEILING = 28
 
-#: The three destructive tools — each carries ``destructiveHint`` AND a
-#: ``confirm`` parameter (the both-mode confirmation contract).
-DESTRUCTIVE_TOOLS: frozenset[str] = frozenset({"notebook_delete", "source_delete", "note_delete"})
+#: The destructive tools — each carries ``destructiveHint`` AND a ``confirm``
+#: parameter (the both-mode confirmation contract).
+DESTRUCTIVE_TOOLS: frozenset[str] = frozenset(
+    {"notebook_delete", "source_delete", "note_delete", "artifact_delete"}
+)
 
 #: Read-only tools — each carries ``readOnlyHint``.
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -136,6 +140,23 @@ async def test_read_only_and_destructive_are_disjoint() -> None:
     assert not (READ_ONLY_TOOLS & DESTRUCTIVE_TOOLS)
     assert READ_ONLY_TOOLS <= EXPECTED_TOOLS
     assert DESTRUCTIVE_TOOLS <= EXPECTED_TOOLS
+
+
+async def test_artifact_rename_is_plain_mutating_tool(tools_by_name) -> None:
+    """``artifact_rename`` mutates but is neither read-only nor destructive.
+
+    A title-only update carries default annotations (no ``readOnlyHint``, no
+    ``destructiveHint``) and no ``confirm`` gate — so it must stay out of both the
+    read-only and destructive pinned sets.
+    """
+    assert "artifact_rename" in tools_by_name
+    assert "artifact_rename" not in READ_ONLY_TOOLS
+    assert "artifact_rename" not in DESTRUCTIVE_TOOLS
+    tool = tools_by_name["artifact_rename"]
+    if tool.annotations is not None:
+        assert not tool.annotations.readOnlyHint
+        assert not tool.annotations.destructiveHint
+    assert "confirm" not in tool.inputSchema.get("properties", {})
 
 
 async def test_artifact_download_advertises_artifact_id_and_format_enum(tools_by_name) -> None:

--- a/tests/unit/mcp/test_resolve.py
+++ b/tests/unit/mcp/test_resolve.py
@@ -21,11 +21,13 @@ pytest.importorskip("fastmcp")
 
 from notebooklm._app.resolve import AmbiguousIdError  # noqa: E402 - after importorskip guard
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    ArtifactNotFoundError,
     NotebookNotFoundError,
     SourceNotFoundError,
     ValidationError,
 )
 from notebooklm.mcp._resolve import (  # noqa: E402 - after importorskip guard
+    resolve_artifact,
     resolve_notebook,
     resolve_source,
     resolve_sources,
@@ -47,10 +49,21 @@ class _Src:
     title: str | None
 
 
-def _client(notebooks: list[_NB] | None = None, sources: list[_Src] | None = None) -> AsyncMock:
+@dataclass
+class _Art:
+    id: str
+    title: str | None
+
+
+def _client(
+    notebooks: list[_NB] | None = None,
+    sources: list[_Src] | None = None,
+    artifacts: list[_Art] | None = None,
+) -> AsyncMock:
     client = AsyncMock()
     client.notebooks.list = AsyncMock(return_value=notebooks or [])
     client.sources.list = AsyncMock(return_value=sources or [])
+    client.artifacts.list = AsyncMock(return_value=artifacts or [])
     return client
 
 
@@ -244,3 +257,63 @@ async def test_sources_whitespace_ref_raises_validation_before_listing() -> None
     with pytest.raises(ValidationError):
         await resolve_sources(client, "nb-1", ["Doc", "   "])
     client.sources.list.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# resolve_artifact
+# --------------------------------------------------------------------------- #
+async def test_artifact_full_uuid_skips_list() -> None:
+    """A full canonical UUID is returned verbatim with no artifact-list call.
+
+    This is load-bearing: a note-backed mind-map id (or one missing from a stale
+    list) must still reach the ``_app`` core for kind routing.
+    """
+    client = _client(artifacts=[_Art(FULL_A, "Podcast")])
+    assert await resolve_artifact(client, "nb-1", FULL_A) == FULL_A
+    client.artifacts.list.assert_not_called()
+
+
+async def test_artifact_prefix_match_lists_within_notebook() -> None:
+    client = _client(artifacts=[_Art("ab0001cdef", "Podcast"), _Art("cd0002abef", "Quiz")])
+    assert await resolve_artifact(client, "nb-1", "ab0001") == "ab0001cdef"
+    client.artifacts.list.assert_awaited_once_with("nb-1")
+
+
+async def test_artifact_title_match() -> None:
+    client = _client(artifacts=[_Art("ab0001cdef", "My Podcast"), _Art("cd0002abef", "Quiz")])
+    assert await resolve_artifact(client, "nb-1", "my podcast") == "ab0001cdef"
+
+
+async def test_artifact_ambiguous_title_raises() -> None:
+    client = _client(artifacts=[_Art("ab0001cdef", "Dup"), _Art("cd0002abef", "dup")])
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_artifact(client, "nb-1", "Dup")
+    assert set(caught.value.candidate_ids) == {"ab0001cdef", "cd0002abef"}
+
+
+async def test_artifact_ambiguous_prefix_raises() -> None:
+    client = _client(artifacts=[_Art("beef0001", "A"), _Art("beef0002", "B")])
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_artifact(client, "nb-1", "beef")
+    assert set(caught.value.candidate_ids) == {"beef0001", "beef0002"}
+
+
+async def test_artifact_no_match_raises_artifact_not_found() -> None:
+    client = _client(artifacts=[_Art("ab0001cdef", "Podcast")])
+    with pytest.raises(ArtifactNotFoundError):
+        await resolve_artifact(client, "nb-1", "Missing Title")
+
+
+async def test_artifact_hex_only_title_falls_back_to_title() -> None:
+    """An artifact whose TITLE is all-hex resolves by name (id/prefix path misses)."""
+    client = _client(artifacts=[_Art("0000aaaa1111", "beef"), _Art("cd0002abef", "Quiz")])
+    assert await resolve_artifact(client, "nb-1", "beef") == "0000aaaa1111"
+
+
+async def test_artifact_whitespace_ref_raises_validation_before_listing() -> None:
+    """An empty/whitespace ref is ``validate_id``-rejected before any list call
+    (sibling-resolver parity)."""
+    client = _client(artifacts=[_Art("ab0001cdef", "Podcast")])
+    with pytest.raises(ValidationError):
+        await resolve_artifact(client, "nb-1", "   ")
+    client.artifacts.list.assert_not_called()


### PR DESCRIPTION
## What & why

The MCP server exposed artifact **create** (`artifact_generate`) and **read** (`artifact_list` / `artifact_status` / `artifact_download`) but no **update** or **delete** — a CRUD gap the CLI already closed. This adds the two missing verbs:

- **`artifact_rename(notebook, artifact, new_title)`** — title-only update; default annotations (mutating, not destructive).
- **`artifact_delete(notebook, artifact, confirm=False)`** — DESTRUCTIVE with the two-step `confirm` flow that `note_delete` / `source_delete` / `notebook_delete` already use.

Both are generic over **every** Studio artifact type, including **both mind-map kinds**: note-backed maps route through the note system, interactive maps and regular artifacts through the artifact RPCs. That kind-routing already lives in the transport-neutral `_app.artifacts` cores (`rename_artifact` / `delete_artifact`) the CLI drives — these tools are thin adapters over them, so no client/core behavior changes.

## How

- **`mcp/_resolve.py`**: new `resolve_artifact`, mirroring `resolve_source` / `resolve_note` exactly — `validate_id` → full-UUID **verbatim** fast-path (no list call) → merged `client.artifacts.list` → hex/title dispatch. The verbatim fast-path is load-bearing: a note-backed mind-map id (or one missing from a stale list) must still reach the core for kind routing. `ArtifactNotFoundError` is threaded through the shared `not_found` unions and `__all__`. The dict-shaped `_resolve_artifact_id` download callback is **not** reused (it would `TypeError` on the typed `Artifact` objects `list` returns).
- **`mcp/tools/artifacts.py`**: the two tools over the existing `_app` cores; `artifact_delete` builds its `needs_confirmation` preview via the shared `title_for_id`.
- Manifest gate `26 → 28` (`artifact_delete` added to `DESTRUCTIVE_TOOLS`; `TOOL_CEILING` unchanged at 28); e2e `TOOL_COVERAGE` matrix; docs (`mcp-guide`, `installation`, `architecture`), `_preview.py` docstring, and `CHANGELOG` all updated.

## Tests

New unit coverage: typed-`Artifact` resolution (TypeError regression guard), interactive + note-backed mind-map routing (by prefix/title **and** full-UUID), confirm-gating, idempotent absent-full-UUID delete vs. NOT_FOUND-at-resolve for an absent prefix/title, and the raw-`ArtifactNotFoundError`-at-resolver vs. `ToolError`/`NOT_FOUND`-at-tool error boundary. Full `tests/unit/mcp/` suite, mypy, ruff, the public-API compat audit, and the doc-freshness gates all pass locally.

Polished via `/polish` (code-simplifier + Claude & Codex review + ultrathink); reviewers found no Critical/Important code issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158QsP9LWmJdfob2491LW3Z

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/teng-lin/notebooklm-py/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools to rename artifacts and delete artifacts.
  * Expanded artifact reference handling to accept IDs, prefixes, and titles (including mind-map-aware behavior).

* **Bug Fixes**
  * Improved destructive-action confirmation flow for artifact deletion.
  * Updated published tool-count documentation and coverage expectations.

* **Tests**
  * Added/updated unit and E2E coverage for artifact rename/delete behavior and artifact resolver edge cases (including not-found and ambiguity handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->