### PR TITLE
feat(mcp): add note_get + roll title/rename into note_update

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -477,7 +477,7 @@ Wire it into an MCP client with either:
 - `notebooklm mcp install <client>` — auto-writes the server config for `claude-desktop`, `claude-code`, `cursor`, or `windsurf`; or
 - the one-click `.mcpb` desktop bundle built from `desktop-extension/` (Claude Desktop's "Install Extension").
 
-Full usage walkthrough (auth, transports, the 28 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
+Full usage walkthrough (auth, transports, the 29 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
 
 ---
 

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -6,7 +6,7 @@
 > server and its dependencies only arrive with the `mcp` extra.
 
 The MCP server exposes NotebookLM to any [Model Context Protocol](https://modelcontextprotocol.io)
-client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **28 tools** — manage
+client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **29 tools** — manage
 notebooks and sources, chat over a notebook's sources, generate and download studio artifacts,
 and run deep research. It is a thin adapter over the same business logic the CLI uses, so it
 behaves identically to `notebooklm <command>`.
@@ -293,7 +293,7 @@ a single in-flight task.
 | **Notebooks** | `notebook_list` · `notebook_create(title)` · `notebook_describe(notebook)` · `notebook_rename(notebook, new_title)` · `notebook_delete(notebook, confirm)` |
 | **Sources** | `source_list(notebook, status?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports) · `source_get_content(notebook, source, output_format?, max_chars?, offset?)` (metadata **+ full indexed text**, windowable via `max_chars`/`offset` → `content` slice + `truncated` flag, with full `char_count`; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` (a READY web page with thin/empty text, or a short body matching a dead-link / soft-404 boilerplate pattern, carries a non-blocking `warning`) · `source_add(notebook, source_type, ..., allow_internal?)` (single; echoes `kind`/`status_label`, flags a failed import inline with a `warning`) / `source_add(notebook, urls=[...], allow_internal?)` (batch → per-item `results`; a synchronously-ready web-page item may also carry the same content-sanity `warning`) |
 | **Chat** | `chat_ask(notebook, question?, conversation_id?, references?, source_ids?, history?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all; `history`>0 also returns up to N prior `{question, answer}` pairs — omit `question` to recall only) · `chat_configure(notebook, chat_mode?, goal?, response_length?)` (`chat_mode`: default\|learning-guide\|concise\|detailed — a preset, mutually exclusive with `goal`/`response_length`) |
-| **Notes** | `note_create(notebook, title, content)` · `note_list(notebook)` · `note_update(notebook, note, content)` · `note_delete(notebook, note, confirm)` |
+| **Notes** | `note_create(notebook, title, content)` · `note_get(notebook, note)` (one note with full title + content) · `note_list(notebook)` · `note_update(notebook, note, content?, title?)` (content and/or title; title-only = rename) · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` · `artifact_rename(notebook, artifact, new_title)` · `artifact_delete(notebook, artifact, confirm)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` |
 | **Server** | `server_info` — version + local auth health |

--- a/src/notebooklm/mcp/tools/notes.py
+++ b/src/notebooklm/mcp/tools/notes.py
@@ -7,9 +7,10 @@ injected ``resolve_notebook_id`` / ``resolve_note_id`` callables shaped for the
 CLI; since the MCP adapter resolves refs up front it passes the shared
 pass-through resolvers, which return the already-resolved ids unchanged.
 
-Split into verbs (``note_create`` / ``note_list`` / ``note_update`` /
-``note_delete``), NOT an ``action`` enum. ``note_delete`` follows the two-step
-confirm contract; ``note_list`` is read-only.
+Split into verbs (``note_create`` / ``note_get`` / ``note_list`` /
+``note_update`` / ``note_delete``), NOT an ``action`` enum. ``note_delete``
+follows the two-step confirm contract; ``note_get`` / ``note_list`` are
+read-only. ``note_update`` updates content and/or title (title-only = rename).
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -22,6 +23,7 @@ from fastmcp import Context
 
 from ..._app import notes as core
 from ..._app.serialize import to_jsonable
+from ...exceptions import NoteNotFoundError, ValidationError
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client
 from .._errors import mcp_errors
@@ -64,18 +66,62 @@ def register(mcp: Any) -> None:
             notes = await client.notes.list(nb_id)
             return {"notebook_id": nb_id, "notes": to_jsonable(notes)}
 
-    @mcp.tool
-    async def note_update(ctx: Context, notebook: str, note: str, content: str) -> dict[str, Any]:
-        """Update a note's content. Accepts a notebook/note name or ID."""
+    @mcp.tool(annotations=READ_ONLY)
+    async def note_get(ctx: Context, notebook: str, note: str) -> dict[str, Any]:
+        """Fetch a single note with its full title and content.
+
+        Accepts a notebook/note name or ID. ``note_list`` returns the same fields
+        for every note in one call; reach for ``note_get`` when you already have a
+        note ref and want just that one. Raises a not-found error if the note does
+        not exist (e.g. a full-id ref that was deleted).
+        """
         client = get_client(ctx)
         with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            note_id = await resolve_note(client, nb_id, note)
+            result = await core.execute_note_get(
+                client,
+                nb_id,
+                note_id,
+                resolve_notebook_id=passthrough_notebook_id,
+                resolve_note_id=passthrough_child_id,
+            )
+            # ``resolve_note`` raises for an unknown title/prefix, but its
+            # full-UUID fast-path skips the list — so a concrete-but-absent id
+            # reaches here as ``found=False``. Surface the same typed not-found.
+            if not result.found:
+                raise NoteNotFoundError(note_id)
+            return {
+                "notebook_id": result.notebook_id,
+                "note_id": result.note_id,
+                "note": to_jsonable(result.note),
+            }
+
+    @mcp.tool
+    async def note_update(
+        ctx: Context,
+        notebook: str,
+        note: str,
+        content: str | None = None,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a note's content and/or title. Accepts a notebook/note name or ID.
+
+        Supply ``content``, ``title``, or both. Passing only ``title`` renames the
+        note while leaving its body untouched; passing only ``content`` replaces
+        the body and keeps the title. At least one of the two is required.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            if content is None and title is None:
+                raise ValidationError("provide 'content' and/or 'title' to update")
             nb_id = await resolve_notebook(client, notebook)
             note_id = await resolve_note(client, nb_id, note)
             result = await core.execute_note_save(
                 client,
                 nb_id,
                 note_id,
-                title=None,
+                title=title,
                 content=content,
                 resolve_notebook_id=passthrough_notebook_id,
                 resolve_note_id=passthrough_child_id,

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -5,8 +5,8 @@ in-memory FastMCP ``Client``, then pins:
 
 * the EXACT set of tool names — so a tool can't be silently added, removed, or
   renamed without updating this gate;
-* a tool-count ceiling (28) now reached exactly (28/28): the next tool needs a
-  justified ceiling bump;
+* a tool-count ceiling (32) with headroom (29/32): the next few tools are a
+  one-line bump, but an accidental explosion still trips the gate;
 * the ``destructiveHint`` annotation + a ``confirm`` parameter on every
   destructive (delete) tool; and
 * the ``readOnlyHint`` annotation on every read-only tool.
@@ -23,7 +23,7 @@ import pytest
 pytest.importorskip("fastmcp")
 
 
-#: The complete, pinned tool surface. 28 tools across 7 domains. Adding or
+#: The complete, pinned tool surface. 29 tools across 7 domains. Adding or
 #: removing a tool MUST update this set (and the ceiling below if it grows).
 EXPECTED_TOOLS: frozenset[str] = frozenset(
     {
@@ -43,8 +43,9 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         # Chat (2)
         "chat_ask",
         "chat_configure",
-        # Notes (4)
+        # Notes (5)
         "note_create",
+        "note_get",
         "note_list",
         "note_update",
         "note_delete",
@@ -65,10 +66,10 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
     }
 )
 
-#: Tool-count ceiling. The design target is ~25; 28 leaves a little headroom so a
-#: deliberate addition is a one-line bump, but an accidental explosion still
-#: trips the gate.
-TOOL_CEILING = 28
+#: Tool-count ceiling. The design target is ~25; 32 leaves headroom (issue
+#: #1685) so a deliberate addition is a one-line bump, but an accidental
+#: explosion still trips the gate.
+TOOL_CEILING = 32
 
 #: The destructive tools — each carries ``destructiveHint`` AND a ``confirm``
 #: parameter (the both-mode confirmation contract).
@@ -83,6 +84,7 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "notebook_describe",
         "source_list",
         "source_get_content",
+        "note_get",
         "note_list",
         "artifact_list",
         "artifact_status",

--- a/tests/unit/mcp/test_notes.py
+++ b/tests/unit/mcp/test_notes.py
@@ -19,6 +19,7 @@ pytest.importorskip("fastmcp")
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
 from notebooklm.exceptions import NoteNotFoundError  # noqa: E402 - after importorskip guard
+from notebooklm.types import Note  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -60,6 +61,31 @@ async def test_note_list(mcp_call, mock_client) -> None:
     mock_client.notes.list.assert_awaited_once_with(NB_ID)
 
 
+async def test_note_get(mcp_call, mock_client) -> None:
+    # note_get wires get_or_none → _app.execute_note_get → serialized note.
+    # ``execute_note_get`` isinstance-checks the real Note type, so the mock must
+    # return one (a FakeNote would read as found=False).
+    mock_client.notes.get_or_none = AsyncMock(
+        return_value=Note(id=NOTE_ID, notebook_id=NB_ID, title="N1", content="full body")
+    )
+    result = await mcp_call("note_get", {"notebook": NB_ID, "note": NOTE_ID})
+    assert result.structured_content["notebook_id"] == NB_ID
+    assert result.structured_content["note_id"] == NOTE_ID
+    assert result.structured_content["note"]["id"] == NOTE_ID
+    assert result.structured_content["note"]["title"] == "N1"
+    assert result.structured_content["note"]["content"] == "full body"
+    mock_client.notes.get_or_none.assert_awaited_once_with(NB_ID, NOTE_ID)
+
+
+async def test_note_get_not_found_projects_tool_error(mcp_call, mock_client) -> None:
+    # A concrete-but-absent id (full-UUID fast-path skips the list) reaches the
+    # tool as found=False → projected as the typed NOT_FOUND error.
+    mock_client.notes.get_or_none = AsyncMock(return_value=None)
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("note_get", {"notebook": NB_ID, "note": NOTE_ID})
+    assert "NOT_FOUND" in str(excinfo.value)
+
+
 async def test_note_update(mcp_call, mock_client) -> None:
     mock_client.notes.update = AsyncMock(return_value=None)
     result = await mcp_call(
@@ -84,6 +110,36 @@ async def test_note_update_resolves_note_by_name(mcp_call, mock_client) -> None:
     result = await mcp_call("note_update", {"notebook": NB_ID, "note": "My Note", "content": "y"})
     assert result.structured_content["note_id"] == NOTE_ID
     mock_client.notes.update.assert_awaited_once_with(NB_ID, NOTE_ID, content="y", title=None)
+
+
+async def test_note_update_title_only_renames(mcp_call, mock_client) -> None:
+    """Title-only update passes the title through (content stays None = unchanged)."""
+    mock_client.notes.update = AsyncMock(return_value=None)
+    result = await mcp_call("note_update", {"notebook": NB_ID, "note": NOTE_ID, "title": "Renamed"})
+    assert result.structured_content == {
+        "status": "updated",
+        "notebook_id": NB_ID,
+        "note_id": NOTE_ID,
+    }
+    mock_client.notes.update.assert_awaited_once_with(NB_ID, NOTE_ID, content=None, title="Renamed")
+
+
+async def test_note_update_title_and_content(mcp_call, mock_client) -> None:
+    mock_client.notes.update = AsyncMock(return_value=None)
+    await mcp_call(
+        "note_update",
+        {"notebook": NB_ID, "note": NOTE_ID, "content": "body", "title": "T"},
+    )
+    mock_client.notes.update.assert_awaited_once_with(NB_ID, NOTE_ID, content="body", title="T")
+
+
+async def test_note_update_no_fields_errors(mcp_call, mock_client) -> None:
+    """Neither content nor title supplied → validation error, no RPC."""
+    mock_client.notes.update = AsyncMock(return_value=None)
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("note_update", {"notebook": NB_ID, "note": NOTE_ID})
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.notes.update.assert_not_called()
 
 
 async def test_note_delete_without_confirm_previews(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary

Exposes the notes layer's already-existing read + title-update capability over the MCP server. This is **wiring-only** — `client.notes` and `_app.notes` already supported all of it (`get_or_none`, `update(content, title)`, `execute_note_get`, `execute_note_save`); no client/core changes.

- **`note_get(notebook, note)`** — new read-only tool returning one note's full title + content. A concrete-but-absent id (the full-UUID fast-path skips the list, so it reaches the tool as `found=False`) surfaces the standard `NOT_FOUND` error, consistent with `source_get_content`.
- **`note_update`** — `content` and `title` are now both optional. Title-only renames (body untouched), content-only keeps the title, both-`None` is rejected with a `VALIDATION` error before any network call. Additive/backward-compatible (existing `content`-only calls unchanged).
- **Tool-count ceiling 28 → 32** (#1685) and `note_get` registered in the manifest guardrail (`READ_ONLY_TOOLS`).
- Docs updated (tool count 28→29, note table); `note_delete` was already wired (unchanged).

## Test plan

- [x] `note_get` happy path (get → core → serialized note), `note_get` not-found → `NOT_FOUND`
- [x] `note_update` title-only rename, title+content, content-only, both-none → `VALIDATION`
- [x] Manifest guardrail: exact tool set (29), `note_get` read-only, ceiling 32
- [x] Full suite green (11108 passed), mypy clean, ruff clean

## Polish

code-simplifier (0 changes) · claude review (0 findings) · codex review (0 critical; 1 minor applied — pinned the `VALIDATION` code in the no-fields test; its 2 "important" findings were phantom stale-base artifacts, cleared by rebasing onto `origin/main`).

## Deferred polish findings

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only note lookup tool, so notes can now be retrieved directly from the MCP surface.
  * Expanded note editing to support updating a note’s title, content, or both.
* **Bug Fixes**
  * Improved error handling when a requested note is missing.
  * Validation now prevents empty note updates when no changes are provided.
* **Documentation**
  * Updated MCP usage and tool reference docs to reflect the expanded tool set and revised note update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->