### PR TITLE
feat(mcp): add opt-in account tier/limits to server_info

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -296,7 +296,7 @@ a single in-flight task.
 | **Notes** | `note_create(notebook, title, content)` · `note_get(notebook, note)` (one note with full title + content) · `note_list(notebook)` · `note_update(notebook, note, content?, title?)` (content and/or title; title-only = rename) · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` · `artifact_rename(notebook, artifact, new_title)` · `artifact_delete(notebook, artifact, confirm)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` |
-| **Server** | `server_info` — version + local auth health |
+| **Server** | `server_info(include_account?)` — version + local auth health; `include_account=true` adds an `account` block (tier, plan name, notebook/source limits) for quota pacing (best-effort, needs a live session) |
 
 Tools that only read are annotated read-only; the four `*_delete` tools are annotated destructive
 and require `confirm`. A host that honors MCP annotations can auto-allow the read-only calls and

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -19,6 +19,7 @@ network-free auth-health probe that works even when unauthenticated.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from fastmcp import Context
@@ -59,8 +60,12 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
         return {"available": False, "reason": "not authenticated"}
     client = get_client(ctx)
     try:
-        limits = await client.settings.get_account_limits()
-        tier = await client.settings.get_account_tier()
+        # Two independent reads → run concurrently (repo convention for
+        # independent RPCs). A NotebookLMError from either is still caught below.
+        limits, tier = await asyncio.gather(
+            client.settings.get_account_limits(),
+            client.settings.get_account_tier(),
+        )
     except NotebookLMError as exc:  # degrade, don't sink the whole response
         # Route through the shared scrubber (same chokepoint as every other MCP
         # error): a NotebookLMError on the auth/config path can carry the on-disk

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -10,6 +10,11 @@ round-trip — ``test_fetch`` is off).
 ``server_info`` takes no notebook argument and is read-only. The storage path +
 active profile are resolved via the neutral :mod:`notebooklm.paths` helpers, so
 this module imports NO ``click`` / ``rich`` / ``cli``.
+
+It also accepts an opt-in ``include_account`` flag that adds the account tier +
+notebook/source limits (for an agent to pace against quota). That block requires
+a *live* session, so it is off by default — the default call stays a fast,
+network-free auth-health probe that works even when unauthenticated.
 """
 
 from __future__ import annotations
@@ -20,9 +25,11 @@ from fastmcp import Context
 
 from ... import __version__
 from ..._app.auth_check import AuthCheckPlan, run_auth_check
+from ...exceptions import NotebookLMError
 from ...paths import get_active_profile, get_storage_path
 from .._confirm import READ_ONLY
-from .._errors import mcp_errors
+from .._context import get_client
+from .._errors import mcp_errors, redact
 from ..server import SERVER_NAME
 
 
@@ -37,18 +44,58 @@ def _no_env_auth_json() -> str:
     return ""  # pragma: no cover - unreachable while has_env_auth is False
 
 
+async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]:
+    """Best-effort account tier + limits for quota pacing.
+
+    The local auth probe only proves on-disk storage health, not a live token, so
+    ``include_account`` can still hit an expired session. Rather than sink the
+    whole ``server_info`` response, this degrades to ``available: False`` with a
+    short (scrubbed) reason — keeping the diagnostic useful. ``get_account_tier``
+    always returns an :class:`AccountTier`, but its ``tier`` field is best-effort
+    and may be ``None`` even on success (that is ``available: True`` with
+    ``tier: None``, NOT an error).
+    """
+    if not authenticated:
+        return {"available": False, "reason": "not authenticated"}
+    client = get_client(ctx)
+    try:
+        limits = await client.settings.get_account_limits()
+        tier = await client.settings.get_account_tier()
+    except NotebookLMError as exc:  # degrade, don't sink the whole response
+        # Route through the shared scrubber (same chokepoint as every other MCP
+        # error): a NotebookLMError on the auth/config path can carry the on-disk
+        # storage path, and this tool must never leak the host FS layout to a
+        # (possibly remote) caller. ``redact`` also collapses + length-caps.
+        return {"available": False, "reason": redact(str(exc))}
+    return {
+        "available": True,
+        "tier": tier.tier,
+        "plan_name": tier.plan_name,
+        "notebook_limit": limits.notebook_limit,
+        "source_limit": limits.source_limit,
+    }
+
+
 def register(mcp: Any) -> None:
     """Register the meta tool on ``mcp``."""
 
     @mcp.tool(annotations=READ_ONLY)
-    async def server_info(ctx: Context) -> dict[str, Any]:
+    async def server_info(ctx: Context, include_account: bool = False) -> dict[str, Any]:
         """Report the server version and local authentication health.
 
-        Takes no arguments. Returns the package ``version`` and an ``auth`` block
-        (``authenticated`` / ``storage_exists`` / ``json_valid`` / ``cookies_present``
-        / ``sid_cookie`` / ``profile``). Use it to confirm the server is logged in
-        before driving notebook tools; if ``authenticated`` is false, run
-        ``notebooklm login`` on the server host.
+        Returns the package ``version`` and an ``auth`` block (``authenticated`` /
+        ``storage_exists`` / ``json_valid`` / ``cookies_present`` / ``sid_cookie`` /
+        ``profile``). Use it to confirm the server is logged in before driving
+        notebook tools; if ``authenticated`` is false, run ``notebooklm login`` on
+        the server host.
+
+        Set ``include_account=True`` to also fetch an ``account`` block for quota
+        pacing: ``{available, tier, plan_name, notebook_limit, source_limit}``.
+        This needs a *live* session (two RPCs), so it is off by default — the
+        default call is a fast, network-free probe. When the session is missing or
+        stale the block degrades to ``{available: False, reason: ...}`` rather than
+        failing the whole call; ``tier`` may be ``None`` even when ``available`` is
+        true (it is a best-effort signal).
 
         The absolute on-disk storage path is deliberately **not** returned: it
         leaks the server-host OS username / filesystem layout to any (possibly
@@ -68,7 +115,7 @@ def register(mcp: Any) -> None:
                 json_output=True,
             )
             result = await run_auth_check(plan, read_env_auth_json=_no_env_auth_json)
-            return {
+            info: dict[str, Any] = {
                 "server": SERVER_NAME,
                 "version": __version__,
                 "auth": {
@@ -80,3 +127,6 @@ def register(mcp: Any) -> None:
                     "profile": profile,
                 },
             }
+            if include_account:
+                info["account"] = await _account_block(ctx, authenticated=result.all_passed)
+            return info

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -17,6 +17,30 @@ import pytest
 pytest.importorskip("fastmcp")
 
 from notebooklm import __version__  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import RPCError  # noqa: E402 - after importorskip guard
+from notebooklm.types import AccountLimits, AccountTier  # noqa: E402 - after importorskip guard
+
+from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
+
+
+def _write_authed_storage() -> None:
+    """Write a minimal SID-bearing storage_state.json at the resolved path."""
+    from notebooklm.paths import get_storage_path
+
+    storage_path = get_storage_path()
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "x", "domain": ".google.com"},
+                    {"name": "HSID", "value": "y", "domain": ".google.com"},
+                    {"name": "__Secure-1PSIDTS", "value": "z", "domain": ".google.com"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 async def test_server_info_reports_version(mcp_call, mock_client, tmp_path, monkeypatch) -> None:
@@ -82,3 +106,110 @@ async def test_server_info_does_not_leak_absolute_storage_path(
     # The non-sensitive identity fields are still present.
     assert "profile" in auth
     assert "authenticated" in auth
+
+
+async def test_server_info_default_omits_account(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """Default call (include_account unset) has NO ``account`` key and hits no RPC."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock()
+    mock_client.settings.get_account_tier = AsyncMock()
+    result = await mcp_call("server_info")
+    assert "account" not in result.structured_content
+    mock_client.settings.get_account_limits.assert_not_called()
+    mock_client.settings.get_account_tier.assert_not_called()
+
+
+async def test_server_info_include_account_authenticated(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """include_account=True + live session → account block with tier + limits."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock(
+        return_value=AccountLimits(notebook_limit=100, source_limit=50)
+    )
+    mock_client.settings.get_account_tier = AsyncMock(
+        return_value=AccountTier(tier="NOTEBOOKLM_TIER_PRO", plan_name="Pro")
+    )
+    result = await mcp_call("server_info", {"include_account": True})
+    assert result.structured_content["account"] == {
+        "available": True,
+        "tier": "NOTEBOOKLM_TIER_PRO",
+        "plan_name": "Pro",
+        "notebook_limit": 100,
+        "source_limit": 50,
+    }
+
+
+async def test_server_info_include_account_unauthenticated(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """include_account=True but no storage → degraded, and no RPC is attempted."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "empty"))
+    mock_client.settings.get_account_limits = AsyncMock()
+    mock_client.settings.get_account_tier = AsyncMock()
+    result = await mcp_call("server_info", {"include_account": True})
+    assert result.structured_content["account"] == {
+        "available": False,
+        "reason": "not authenticated",
+    }
+    mock_client.settings.get_account_limits.assert_not_called()
+    mock_client.settings.get_account_tier.assert_not_called()
+
+
+async def test_server_info_include_account_degrades_on_rpc_error(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """A stale session (local auth passes but the RPC fails) degrades gracefully —
+    the account block reports unavailable while version/auth stay intact."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock(side_effect=RPCError("session expired"))
+    mock_client.settings.get_account_tier = AsyncMock()
+    result = await mcp_call("server_info", {"include_account": True})
+    account = result.structured_content["account"]
+    assert account["available"] is False
+    assert "session expired" in account["reason"]
+    # The diagnostic stays useful: version + auth block survive the degradation.
+    assert result.structured_content["version"] == __version__
+    assert result.structured_content["auth"]["authenticated"] is True
+
+
+async def test_server_info_include_account_tier_none_is_available(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """tier RPC is best-effort: a bare AccountTier() (tier None) is available:True,
+    not an error (locks the documented success-with-null-tier contract)."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
+    mock_client.settings.get_account_tier = AsyncMock(return_value=AccountTier())
+    result = await mcp_call("server_info", {"include_account": True})
+    assert result.structured_content["account"] == {
+        "available": True,
+        "tier": None,
+        "plan_name": None,
+        "notebook_limit": None,
+        "source_limit": None,
+    }
+
+
+async def test_server_info_include_account_degraded_reason_is_scrubbed(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """The degraded reason goes through the same scrubber as every other MCP error,
+    so a host filesystem path in the exception never reaches the caller (#1682)."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    leaky = RPCError("auth failed loading /home/secretuser/.notebooklm/storage_state.json")
+    mock_client.settings.get_account_limits = AsyncMock(side_effect=leaky)
+    mock_client.settings.get_account_tier = AsyncMock()
+    result = await mcp_call("server_info", {"include_account": True})
+    reason = result.structured_content["account"]["reason"]
+    assert result.structured_content["account"]["available"] is False
+    # The OS username segment is masked; the rest of the message survives.
+    assert "secretuser" not in reason
+    assert "/home/***/" in reason

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -24,7 +24,11 @@ from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
 
 def _write_authed_storage() -> None:
-    """Write a minimal SID-bearing storage_state.json at the resolved path."""
+    """Write a minimal SID-bearing storage_state.json at the resolved path.
+
+    Resolves the path at call time, so the caller MUST have already pointed
+    ``NOTEBOOKLM_HOME`` at a temp dir (``monkeypatch.setenv``) before calling.
+    """
     from notebooklm.paths import get_storage_path
 
     storage_path = get_storage_path()
@@ -176,6 +180,20 @@ async def test_server_info_include_account_degrades_on_rpc_error(
     # The diagnostic stays useful: version + auth block survive the degradation.
     assert result.structured_content["version"] == __version__
     assert result.structured_content["auth"]["authenticated"] is True
+
+
+async def test_server_info_include_account_degrades_when_tier_rpc_raises(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """The tier RPC failing (not just the limits RPC) also degrades gracefully —
+    the two reads run concurrently, so either one raising must be caught."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
+    mock_client.settings.get_account_tier = AsyncMock(side_effect=RPCError("tier lookup failed"))
+    result = await mcp_call("server_info", {"include_account": True})
+    assert result.structured_content["account"]["available"] is False
+    assert "tier lookup failed" in result.structured_content["account"]["reason"]
 
 
 async def test_server_info_include_account_tier_none_is_available(


### PR DESCRIPTION
## Summary

Folds account **tier + notebook/source limits** into the existing `server_info` tool for quota pacing (#1684 "Settings/language — fold limits/tier into server_info"). **Ceiling-neutral** — an opt-in `include_account` param on the existing tool, no new tool. Wiring-only: `client.settings.get_account_limits()` / `get_account_tier()` already exist.

- **Default unchanged.** `include_account=False` (default) keeps the fast, network-free auth-health probe that works even when unauthenticated — the `account` key is only added when asked.
- **`include_account=True`** adds `account: {available, tier, plan_name, notebook_limit, source_limit}`. It needs a live session (two RPCs), so it:
  - skips the network entirely when the local auth check fails → `{available: False, reason: "not authenticated"}`;
  - degrades to `{available: False, reason}` on any `NotebookLMError` (the local probe only proves storage health, not a live token) rather than sinking the version/auth block;
  - returns `available: True` with `tier: None` when the best-effort tier RPC has no signal.
- **No path leak.** The degraded `reason` is routed through the shared `redact()` chokepoint (the same one every other MCP error uses), so an exception carrying the on-disk `storage_state.json` path can't leak the host FS layout to a remote caller — matching `server_info`'s existing no-path-leak posture (#1682).

## Task
#1684 — MCP coverage expansion (Settings/language tier+limits into `server_info`).

## Test plan
- [x] Default call has no `account` key and makes no RPC (regression guard)
- [x] `include_account=True` authenticated → tier/plan_name/notebook_limit/source_limit
- [x] Unauthenticated → `available:false`, no RPC attempted
- [x] Stale session (RPC raises) → degraded, version/auth block intact
- [x] Degraded reason is scrubbed (host path masked)
- [x] tier-field `None` success path → `available:true`
- [x] Full suite green (11116 passed), mypy + ruff clean

## Polish
code-simplifier (removed a dead `# noqa`) · claude review (**1 important applied** — route the degraded reason through `redact()` to close a host-path leak; +1 minor: added redaction + tier-None tests) · codex review (its "important" `tier=None` crash was a misread — the method always returns an `AccountTier`; added the suggested test + sharpened the docstring anyway).

## Deferred polish findings
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `server_info` now supports an optional `include_account` flag to return best-effort account details (tier, plan name, and notebook/source limits) when available.
* **Bug Fixes**
  * Account details degrade gracefully when session/auth is missing or account RPCs fail, while still returning the core server/version/auth information.
  * Sanitizes degraded error messages to avoid exposing sensitive personal or filesystem details.
* **Documentation**
  * Updated the MCP tool reference to describe the new `include_account` parameter and the resulting `account` block behavior.
* **Tests**
  * Expanded unit test coverage for authenticated, unauthenticated, RPC-failure, and security-scrubbing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->