### PR TITLE
fix(mcp): cap download-route concurrency + document token-replay residual (#1681, #1683)

### DIFF
--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -288,6 +288,72 @@ upgrade that changes either fails loudly. Handlers take `(request)` only and rea
   (separate ASGI app, FastAPI `Depends`); the side-channel belongs on the MCP app.
   Shared *logic* is reused; the FastAPI plumbing is not.
 
+### Residual risk: signed-token replay within TTL (accepted)
+
+The signed `ul`/`dl` tokens are **multi-use within their TTL** — there is no
+nonce, no `jti` claim, and no single-use tracking. `FileLinkSigner.verify`
+(`_filelink.py`) checks the length cap, the HMAC, `exp`, and the `op` claim, but a
+token that passes those checks passes them **every time** until it expires. So:
+
+- A leaked **`ul`** token can add a source **repeatedly** — once per request —
+  until it expires (`UPLOAD_TTL` = 15 min), each time against the single tenant's
+  own notebook carried in the signed payload.
+- A leaked **`dl`** token can **re-exfiltrate** the current latest artifact of that
+  type until it expires (`DOWNLOAD_TTL` = 30 min). The token pins
+  `{nb, atype, fmt?, aid?}`, not a byte snapshot, so a replay serves whatever the
+  download core resolves at replay time.
+
+Leakage is plausible, not theoretical: the token rides in the URL **path**, so it
+is captured by claude.ai, browser history, tunnel access logs
+(Cloudflare/Tailscale), and any `Referer`. The `no-referrer` / `no-store` headers
+narrow, but do not eliminate, that surface.
+
+**Bounding factors already in place** (why the residual is small):
+
+- **Short TTLs** — 15 min (`ul`) / 30 min (`dl`) — cap the replay window.
+- **Ephemeral per-process signing key** — `secrets.token_bytes(32)` minted at
+  server start, so a restart invalidates every outstanding token unconditionally.
+- **Single-tenant scope** — the blast radius is the operator's own account and
+  their own notebooks; there is no cross-tenant escalation.
+- **HMAC integrity** — a token cannot be forged or its parameters tampered with;
+  replay requires capturing a *legitimately issued* token.
+- **Download concurrency cap** — `_MAX_CONCURRENT_DOWNLOADS = 4` (added in the same
+  change, #1681, mirroring the existing upload cap) caps concurrent fetch+spool
+  operations, so a replayed token cannot fan out unbounded fresh Google fetches or
+  peak temp-disk spools (the amplification threat). The slot is released
+  deterministically on handler return (a `finally`, not the post-stream background
+  task), so a mid-stream disconnect cannot leak a slot and wedge the route.
+
+**Decision — accept the replay-within-TTL residual; do NOT add `jti` tracking and
+do NOT shorten the TTLs now.**
+
+Reasons for **not** adding a single-use `jti` claim + seen-set:
+
+1. A seen-set **reintroduces the exact in-process server-side state** that the
+   stateless, token-is-the-state design (see *Stateless, token-encoded — no
+   registry, no sweeper*) deliberately eliminated — the registry and sweeper come
+   straight back.
+2. It **does not survive a restart**: an in-memory seen-set is empty after a
+   restart, so it is not a durable guarantee — and the ephemeral key already
+   invalidates *all* tokens on restart, so the only window a seen-set could guard
+   is one the key rotation already closes.
+3. It is **redundant with the short TTL + single-tenant scope**: the window is
+   already minutes-long and the blast radius is the operator's own account.
+
+Reasons for **not** shortening the TTLs now: they are already short, and further
+shrinking trades legitimate slow-upload / slow-download UX for marginal risk
+reduction. A 200 MiB upload over a poor link can take ~13 min — already close to
+the 15-min `ul` TTL — so a failed-then-retried upload can outlive an even shorter
+token.
+
+**What would change this decision.** Any of the following flips the tradeoff and
+warrants adding a `jti` claim + a bounded in-memory seen-set and/or shortening the
+TTLs:
+
+- the server becomes **multi-tenant** (cross-account blast radius appears);
+- the TTLs are **lengthened** for any reason (a larger replay window);
+- a **replay incident is reported** in practice.
+
 ### Why the REST server is out of scope
 
 The REST server (`server/` extra) **already** supports binary file transfer

--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -318,11 +318,13 @@ narrow, but do not eliminate, that surface.
 - **HMAC integrity** — a token cannot be forged or its parameters tampered with;
   replay requires capturing a *legitimately issued* token.
 - **Download concurrency cap** — `_MAX_CONCURRENT_DOWNLOADS = 4` (added in the same
-  change, #1681, mirroring the existing upload cap) caps concurrent fetch+spool
-  operations, so a replayed token cannot fan out unbounded fresh Google fetches or
-  peak temp-disk spools (the amplification threat). The slot is released
-  deterministically on handler return (a `finally`, not the post-stream background
-  task), so a mid-stream disconnect cannot leak a slot and wedge the route.
+  change, #1681, mirroring the existing upload cap) bounds concurrent in-flight
+  downloads, so a replayed token cannot fan out unbounded fresh Google fetches or
+  accumulate unbounded spooled artifacts on temp disk. The slot is held for the
+  whole lifetime the artifact occupies temp disk — released from a `finally` at the
+  end of the response's stream (via a `FileResponse` subclass), so slow/held
+  streams still count against the cap **and** a mid-stream disconnect or aborted
+  `Range` can never leak a slot and wedge the route.
 
 **Decision — accept the replay-within-TTL residual; do NOT add `jti` tracking and
 do NOT shorten the TTLs now.**

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -31,9 +31,8 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from starlette.background import BackgroundTask
 from starlette.requests import Request
 from starlette.responses import (
     FileResponse,
@@ -42,6 +41,7 @@ from starlette.responses import (
     PlainTextResponse,
     Response,
 )
+from starlette.types import Receive, Scope, Send
 
 from .._app import download as download_core
 from .._app import source_add as add_core
@@ -191,6 +191,33 @@ def _cleanup(path: str) -> None:
     shutil.rmtree(path, ignore_errors=True)
 
 
+class _SlotHeldFileResponse(FileResponse):
+    """A ``FileResponse`` that releases its download slot + temp dir only once the
+    body has finished streaming — or the client disconnected / the stream aborted.
+
+    Releasing at the END of the ASGI send loop (a ``finally``), not at handler
+    return, means the slot stays counted for the whole time the spooled artifact
+    occupies temp disk, so slow or deliberately-held streams still count against
+    ``_MAX_CONCURRENT_DOWNLOADS`` (a replayed token cannot accumulate uncounted
+    on-disk artifacts). The ``finally`` also guarantees the release when a client
+    disconnect or bad ``Range`` aborts the stream mid-flight, so a slot can never
+    leak and permanently wedge the cap. Error/early-return paths never construct
+    this response — the route's own ``finally`` releases those.
+    """
+
+    def __init__(self, *args: Any, temp_dir: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._temp_dir = temp_dir
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        global _inflight_downloads
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            _inflight_downloads -= 1
+            _cleanup(self._temp_dir)
+
+
 async def _passthrough_notebook(notebook_id: str) -> str:
     """Async pass-through notebook resolver (the token carries the full id)."""
     return notebook_id
@@ -280,16 +307,19 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
         _inflight_downloads += 1
-        # Release the slot + clean the temp dir in one outer ``finally`` on handler
-        # RETURN (before Starlette streams the file), NOT via the success-path
-        # ``BackgroundTask``: that task is skipped on client disconnect / cancellation
-        # / a bad Range mid-stream, which would leak a slot permanently and turn this
-        # anti-DoS cap into a DoS. The single ``finally`` also covers a ``mkdtemp``
-        # failure (the exact temp-disk exhaustion this cap defends against) and any
-        # unexpected error in the post-fetch code (``FileResponse`` init,
-        # ``artifact_title_to_filename``) — every non-success exit cleans the temp
-        # dir. The ``success`` flag hands temp ownership to the streamed response,
-        # whose own ``BackgroundTask`` removes it after the client finishes.
+        # Slot accounting has two disjoint owners, so the counter is decremented
+        # exactly once per accepted request:
+        #  * NON-success (mkdtemp failure, any error/early return, or an unexpected
+        #    exception in the post-fetch code like ``FileResponse`` init /
+        #    ``artifact_title_to_filename``) → the outer ``finally`` below releases
+        #    the slot AND cleans the temp dir. ``mkdtemp`` failure is the exact
+        #    temp-disk exhaustion this cap defends against, so it must release.
+        #  * SUCCESS → ownership passes to the returned ``_SlotHeldFileResponse``,
+        #    which releases the slot + cleans the temp dir only after the body has
+        #    finished streaming (or a disconnect/bad-Range aborts it). Holding the
+        #    slot for the whole stream keeps slow/held downloads counted (temp disk
+        #    stays bounded), and its ``finally`` guarantees release on disconnect so
+        #    a slot can never leak and wedge the cap.
         temp_dir: str | None = None
         success = False
         try:
@@ -354,18 +384,21 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
             download_name = download_core.artifact_title_to_filename(
                 title, Path(served).suffix, set()
             )
-            response = FileResponse(
+            response = _SlotHeldFileResponse(
                 served,
                 filename=download_name,
-                background=BackgroundTask(_cleanup, temp_dir),
+                temp_dir=temp_dir,
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
             success = True
             return response
         finally:
-            _inflight_downloads -= 1
-            if temp_dir is not None and not success:
-                _cleanup(temp_dir)
+            # Success hands slot + temp ownership to ``_SlotHeldFileResponse`` (released
+            # at end-of-stream); every other exit releases here.
+            if not success:
+                _inflight_downloads -= 1
+                if temp_dir is not None:
+                    _cleanup(temp_dir)
 
     @mcp.custom_route("/files/ul/{token}", methods=["GET"])
     async def upload_page_route(request: Request) -> Response:

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -70,6 +70,17 @@ MAX_UPLOAD_BYTES = 200 * 1024 * 1024
 _MAX_CONCURRENT_UPLOADS = 4
 _inflight_uploads = 0
 
+#: Cap concurrent in-flight downloads. Each accepted download spools the artifact
+#: to a private temp dir and fetches it from Google before streaming it out, so a
+#: leaked/replayable ``dl`` token (valid for its full TTL) could otherwise drive N
+#: parallel streams = N× transient temp disk + N× Google-fetch amplification. This
+#: bounds aggregate temp pressure + upstream fetch fan-out to
+#: ``_MAX_CONCURRENT_DOWNLOADS``; excess downloads get a fast 429 (no disk touched,
+#: no fetch issued). Single process / single tenant, so a plain counter (mutated
+#: only between ``await`` points, never concurrently) is sufficient — no lock.
+_MAX_CONCURRENT_DOWNLOADS = 4
+_inflight_downloads = 0
+
 #: Security headers for the HTML pages. The signed token rides in the URL path, so
 #: bound its exposure: ``no-referrer`` keeps it out of any ``Referer``, ``no-store``
 #: out of caches, ``DENY`` out of frames, plus a strict CSP (the upload page's only
@@ -255,78 +266,105 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
 
-        temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
-        temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
-        try:
-            args: dict[str, object] = {
-                "notebook_id": payload.get("nb"),
-                "output_path": temp_path,
-                "latest": aid is None,
-            }
-            if aid is not None:
-                args["artifact_id"] = aid
-            fmt = payload.get("fmt")
-            if fmt is not None:
-                args[spec.format_param_name] = fmt
-            plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
-            result = await download_core.execute_download(
-                plan,
-                client,
-                notebook_resolver=_passthrough_notebook,
-                artifact_resolver=_resolve_artifact_id,
-            )
-        except ValidationError as exc:
-            # A bad ``aid`` in the token — a no-match id (full UUID or prefix) or an
-            # ambiguous prefix (AmbiguousIdError) — surfaces here from
-            # ``_resolve_artifact_id``. The catch also covers ``build_download_plan``'s
-            # ``DownloadPlanValidationError`` (a ValidationError subclass), which a
-            # broker-minted token won't trigger but is correctly a 400 too. Map it to a
-            # clean 400 instead of letting it bubble up as a Starlette 500. (The 409
-            # below stays for the latest-by-type path when no completed artifact of that
-            # type exists yet.)
-            _cleanup(temp_dir)
+        # Bound aggregate temp-disk + upstream Google-fetch fan-out: reject (fast,
+        # no disk touched, no fetch issued) when too many downloads are already in
+        # flight. Placed AFTER the cheap token/spec/client/aid-shape rejects (those
+        # must not count against the cap) and BEFORE the temp dir / fetch. The
+        # counter is mutated only between awaits in this single-process async server,
+        # so no lock is needed.
+        global _inflight_downloads
+        if _inflight_downloads >= _MAX_CONCURRENT_DOWNLOADS:
             return PlainTextResponse(
-                str(exc),
-                status_code=400,
+                "Too many concurrent downloads in progress; retry shortly.",
+                status_code=429,
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
-        except NotebookLMError as exc:
-            # An upstream error raised out of the core (e.g. the artifact ``list``
-            # RPC inside ``execute_download`` is not wrapped) would otherwise become
-            # a raw 500. Classify + redact it instead. (Failures that the core
-            # *returns* as a non-success ``DownloadResult`` fall through to the
-            # generic 409 below — that path already leaks nothing.)
-            _cleanup(temp_dir)
-            return _upstream_error_response(exc)
-        except BaseException:
-            _cleanup(temp_dir)
-            raise
+        _inflight_downloads += 1
+        # Release in a ``finally`` on handler RETURN (before Starlette streams the
+        # file), NOT via the success-path ``BackgroundTask``: that task is skipped on
+        # client disconnect / cancellation / a bad Range mid-stream, which would leak
+        # a slot permanently and turn this anti-DoS cap into a DoS. Releasing here
+        # also covers a ``mkdtemp`` failure (the exact temp-disk-exhaustion this cap
+        # defends against). The cap therefore bounds concurrent fetch+spool work (the
+        # upstream-amplification threat); temp-dir cleanup keeps its own lifecycle
+        # (``_cleanup`` on error, ``BackgroundTask`` after a successful stream).
+        try:
+            temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
+            temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+            try:
+                args: dict[str, object] = {
+                    "notebook_id": payload.get("nb"),
+                    "output_path": temp_path,
+                    "latest": aid is None,
+                }
+                if aid is not None:
+                    args["artifact_id"] = aid
+                fmt = payload.get("fmt")
+                if fmt is not None:
+                    args[spec.format_param_name] = fmt
+                plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
+                result = await download_core.execute_download(
+                    plan,
+                    client,
+                    notebook_resolver=_passthrough_notebook,
+                    artifact_resolver=_resolve_artifact_id,
+                )
+            except ValidationError as exc:
+                # A bad ``aid`` in the token — a no-match id (full UUID or prefix) or
+                # an ambiguous prefix (AmbiguousIdError) — surfaces here from
+                # ``_resolve_artifact_id``. The catch also covers
+                # ``build_download_plan``'s ``DownloadPlanValidationError`` (a
+                # ValidationError subclass), which a broker-minted token won't trigger
+                # but is correctly a 400 too. Map it to a clean 400 instead of letting
+                # it bubble up as a Starlette 500. (The 409 below stays for the
+                # latest-by-type path when no completed artifact of that type exists.)
+                _cleanup(temp_dir)
+                return PlainTextResponse(
+                    str(exc),
+                    status_code=400,
+                    headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+                )
+            except NotebookLMError as exc:
+                # An upstream error raised out of the core (e.g. the artifact ``list``
+                # RPC inside ``execute_download`` is not wrapped) would otherwise become
+                # a raw 500. Classify + redact it instead. (Failures that the core
+                # *returns* as a non-success ``DownloadResult`` fall through to the
+                # generic 409 below — that path already leaks nothing.)
+                _cleanup(temp_dir)
+                return _upstream_error_response(exc)
+            except BaseException:
+                _cleanup(temp_dir)
+                raise
 
-        if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
-            _cleanup(temp_dir)
-            return PlainTextResponse(
-                f"No completed {spec.name} artifact is available yet.",
-                status_code=409,
-                headers={"Cache-Control": "no-store"},
+            if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
+                _cleanup(temp_dir)
+                return PlainTextResponse(
+                    f"No completed {spec.name} artifact is available yet.",
+                    status_code=409,
+                    headers={"Cache-Control": "no-store"},
+                )
+            # The core may resolve a conflict to a different name, but it must stay
+            # inside our private dir — anything else is a bug, not a file we serve.
+            served = result.output_path or temp_path
+            if Path(temp_dir).resolve() not in Path(served).resolve().parents:
+                _cleanup(temp_dir)
+                return PlainTextResponse(
+                    "Download produced an unexpected output path.", status_code=500
+                )
+            # Hand the user a meaningful name (the core wrote ``artifact<ext>``): the
+            # artifact title + the served file's actual extension.
+            title = str((result.artifact or {}).get("title") or spec.name)
+            download_name = download_core.artifact_title_to_filename(
+                title, Path(served).suffix, set()
             )
-        # The core may resolve a conflict to a different name, but it must stay
-        # inside our private dir — anything else is a bug, not a file we serve.
-        served = result.output_path or temp_path
-        if Path(temp_dir).resolve() not in Path(served).resolve().parents:
-            _cleanup(temp_dir)
-            return PlainTextResponse(
-                "Download produced an unexpected output path.", status_code=500
+            return FileResponse(
+                served,
+                filename=download_name,
+                background=BackgroundTask(_cleanup, temp_dir),
+                headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
-        # Hand the user a meaningful name (the core wrote ``artifact<ext>``): the
-        # artifact title + the served file's actual extension.
-        title = str((result.artifact or {}).get("title") or spec.name)
-        download_name = download_core.artifact_title_to_filename(title, Path(served).suffix, set())
-        return FileResponse(
-            served,
-            filename=download_name,
-            background=BackgroundTask(_cleanup, temp_dir),
-            headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
-        )
+        finally:
+            _inflight_downloads -= 1
 
     @mcp.custom_route("/files/ul/{token}", methods=["GET"])
     async def upload_page_route(request: Request) -> Response:

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -280,14 +280,18 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
         _inflight_downloads += 1
-        # Release in a ``finally`` on handler RETURN (before Starlette streams the
-        # file), NOT via the success-path ``BackgroundTask``: that task is skipped on
-        # client disconnect / cancellation / a bad Range mid-stream, which would leak
-        # a slot permanently and turn this anti-DoS cap into a DoS. Releasing here
-        # also covers a ``mkdtemp`` failure (the exact temp-disk-exhaustion this cap
-        # defends against). The cap therefore bounds concurrent fetch+spool work (the
-        # upstream-amplification threat); temp-dir cleanup keeps its own lifecycle
-        # (``_cleanup`` on error, ``BackgroundTask`` after a successful stream).
+        # Release the slot + clean the temp dir in one outer ``finally`` on handler
+        # RETURN (before Starlette streams the file), NOT via the success-path
+        # ``BackgroundTask``: that task is skipped on client disconnect / cancellation
+        # / a bad Range mid-stream, which would leak a slot permanently and turn this
+        # anti-DoS cap into a DoS. The single ``finally`` also covers a ``mkdtemp``
+        # failure (the exact temp-disk exhaustion this cap defends against) and any
+        # unexpected error in the post-fetch code (``FileResponse`` init,
+        # ``artifact_title_to_filename``) — every non-success exit cleans the temp
+        # dir. The ``success`` flag hands temp ownership to the streamed response,
+        # whose own ``BackgroundTask`` removes it after the client finishes.
+        temp_dir: str | None = None
+        success = False
         try:
             temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
             temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
@@ -318,7 +322,6 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 # but is correctly a 400 too. Map it to a clean 400 instead of letting
                 # it bubble up as a Starlette 500. (The 409 below stays for the
                 # latest-by-type path when no completed artifact of that type exists.)
-                _cleanup(temp_dir)
                 return PlainTextResponse(
                     str(exc),
                     status_code=400,
@@ -330,14 +333,9 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 # a raw 500. Classify + redact it instead. (Failures that the core
                 # *returns* as a non-success ``DownloadResult`` fall through to the
                 # generic 409 below — that path already leaks nothing.)
-                _cleanup(temp_dir)
                 return _upstream_error_response(exc)
-            except BaseException:
-                _cleanup(temp_dir)
-                raise
 
             if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
-                _cleanup(temp_dir)
                 return PlainTextResponse(
                     f"No completed {spec.name} artifact is available yet.",
                     status_code=409,
@@ -347,7 +345,6 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
             # inside our private dir — anything else is a bug, not a file we serve.
             served = result.output_path or temp_path
             if Path(temp_dir).resolve() not in Path(served).resolve().parents:
-                _cleanup(temp_dir)
                 return PlainTextResponse(
                     "Download produced an unexpected output path.", status_code=500
                 )
@@ -357,14 +354,18 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
             download_name = download_core.artifact_title_to_filename(
                 title, Path(served).suffix, set()
             )
-            return FileResponse(
+            response = FileResponse(
                 served,
                 filename=download_name,
                 background=BackgroundTask(_cleanup, temp_dir),
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )
+            success = True
+            return response
         finally:
             _inflight_downloads -= 1
+            if temp_dir is not None and not success:
+                _cleanup(temp_dir)
 
     @mcp.custom_route("/files/ul/{token}", methods=["GET"])
     async def upload_page_route(request: Request) -> Response:

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -97,6 +97,70 @@ def test_download_good_token_streams_bytes_no_bearer(monkeypatch, mock_client, c
     assert resp.headers["cache-control"] == "no-store"
 
 
+def test_download_concurrency_cap_returns_429(monkeypatch, mock_client, config) -> None:
+    # Security: a leaked/replayable dl token must not drive unbounded parallel temp
+    # spools + Google fetches. At the in-flight cap, the next download is a fast 429
+    # (no temp dir, no fetch).
+    fetch = AsyncMock()
+    monkeypatch.setattr(_fileroutes.download_core, "execute_download", fetch)
+    monkeypatch.setattr(_fileroutes, "_inflight_downloads", _fileroutes._MAX_CONCURRENT_DOWNLOADS)
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 429
+    fetch.assert_not_awaited()  # rejected before any temp dir / upstream fetch
+
+
+def test_download_success_releases_slot(monkeypatch, mock_client, config) -> None:
+    # The in-flight slot is released on handler return (a ``finally``), so a
+    # completed download leaves the counter where it started — no slow leak.
+    monkeypatch.setattr(
+        _fileroutes.download_core, "execute_download", _fake_download_writing(b"AUDIO")
+    )
+    before = _fileroutes._inflight_downloads
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 200
+    assert _fileroutes._inflight_downloads == before
+
+
+def test_download_error_releases_slot(monkeypatch, mock_client, config) -> None:
+    # An error outcome (409) must also release the slot via the ``finally``.
+    async def fake(plan, client, *, notebook_resolver, artifact_resolver, progress=None):
+        return _fileroutes.download_core.DownloadResult(
+            outcome=_fileroutes.download_core.DownloadOutcome.NO_ARTIFACTS,
+            error="none yet",
+        )
+
+    monkeypatch.setattr(_fileroutes.download_core, "execute_download", fake)
+    before = _fileroutes._inflight_downloads
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 409
+    assert _fileroutes._inflight_downloads == before
+
+
+def test_download_mkdtemp_failure_releases_slot(monkeypatch, mock_client, config) -> None:
+    # ``mkdtemp`` raising (ENOSPC — the very temp-disk exhaustion this cap guards
+    # against) must NOT leak the slot: it runs inside the counter's ``try``/``finally``.
+    def boom(*_a, **_k):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(_fileroutes.tempfile, "mkdtemp", boom)
+    before = _fileroutes._inflight_downloads
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 500
+    assert _fileroutes._inflight_downloads == before
+
+
 def test_download_route_forwards_fmt_from_token(monkeypatch, mock_client, config) -> None:
     # The `fmt` carried in a dl token must reach build_download_plan (route-level
     # round trip; the tool-level test only checks the token encodes it).

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -188,6 +188,27 @@ def test_download_post_fetch_exception_cleans_temp_and_releases_slot(
     assert _fileroutes._inflight_downloads == before
 
 
+async def test_slot_held_response_releases_on_stream_abort(monkeypatch, tmp_path) -> None:
+    # The slot is held for the whole stream (so slow/held downloads still count),
+    # but released from the response's ``finally`` even when the stream aborts
+    # mid-flight (client disconnect / bad Range) — so a held slot can never leak.
+    temp_dir = str(tmp_path / "dl")
+    os.mkdir(temp_dir)
+    served = os.path.join(temp_dir, "artifact.mp3")
+    Path(served).write_bytes(b"AUDIO")
+
+    async def boom_call(self, *_a, **_k):
+        raise RuntimeError("client disconnected mid-stream")
+
+    monkeypatch.setattr(_fileroutes.FileResponse, "__call__", boom_call)
+    monkeypatch.setattr(_fileroutes, "_inflight_downloads", 1)
+    resp = _fileroutes._SlotHeldFileResponse(served, temp_dir=temp_dir)
+    with pytest.raises(RuntimeError):
+        await resp({"type": "http", "method": "GET", "headers": []}, None, None)
+    assert _fileroutes._inflight_downloads == 0  # slot released despite the abort
+    assert not os.path.exists(temp_dir)  # temp dir cleaned despite the abort
+
+
 def test_download_route_forwards_fmt_from_token(monkeypatch, mock_client, config) -> None:
     # The `fmt` carried in a dl token must reach build_download_plan (route-level
     # round trip; the tool-level test only checks the token encodes it).

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -161,6 +161,33 @@ def test_download_mkdtemp_failure_releases_slot(monkeypatch, mock_client, config
     assert _fileroutes._inflight_downloads == before
 
 
+def test_download_post_fetch_exception_cleans_temp_and_releases_slot(
+    monkeypatch, mock_client, config
+) -> None:
+    # An unexpected error AFTER a successful fetch (here: building the download name)
+    # must still clean the spooled temp dir (not just the error/early-return paths)
+    # and release the slot — the outer finally guarantees both.
+    monkeypatch.setattr(
+        _fileroutes.download_core, "execute_download", _fake_download_writing(b"AUDIO")
+    )
+
+    def boom(*_a, **_k):
+        raise RuntimeError("cannot build filename")
+
+    monkeypatch.setattr(_fileroutes.download_core, "artifact_title_to_filename", boom)
+    cleaned: list[str] = []
+    real_cleanup = _fileroutes._cleanup
+    monkeypatch.setattr(_fileroutes, "_cleanup", lambda d: (cleaned.append(d), real_cleanup(d))[1])
+    before = _fileroutes._inflight_downloads
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 500
+    assert cleaned, "temp dir must be cleaned on a post-fetch exception"
+    assert _fileroutes._inflight_downloads == before
+
+
 def test_download_route_forwards_fmt_from_token(monkeypatch, mock_client, config) -> None:
     # The `fmt` carried in a dl token must reach build_download_plan (route-level
     # round trip; the tool-level test only checks the token encodes it).


### PR DESCRIPTION
## Summary

MCP file-transfer security hardening (two issues):

- **#1681 — download concurrency cap.** The signed-URL `/files/dl` route had no equivalent to the upload cap, so a replayable `dl` token could fire N concurrent `GET`s, each triggering a fresh Google fetch + spooling a full artifact to temp disk (bandwidth/quota amplification + temp-disk pressure). Added `_MAX_CONCURRENT_DOWNLOADS = 4` (mirrors `_MAX_CONCURRENT_UPLOADS`); over-cap requests get a fast **429** before any temp dir / fetch. The in-flight slot is released in a `finally` on handler return, so the cap bounds concurrent fetch+spool work (the amplification threat).
- **#1683 — document the replay-within-TTL residual.** Signed `ul`/`dl` tokens are multi-use within their TTL (no `jti`/nonce). ADR-0024 now documents this residual explicitly with the accept-with-eyes-open decision: no single-use tracking (reintroduces the state the design deliberately avoids, doesn't survive restart, redundant with short TTL + ephemeral per-process key + single tenant) and no TTL shortening now — plus what would change that call.

## Review-hardening (the interesting part)

The initial cap tied the slot-release to temp-dir cleanup (an `_release_download` helper on every exit + the success `BackgroundTask`). All three polish reviewers flagged **two counter-leak paths** in that design — a leaked slot is worse than the original bug because it wedges the whole route at 429 (the anti-DoS cap becomes a DoS):

1. `tempfile.mkdtemp()` sat **outside** the `try` — an `OSError`/ENOSPC (the exact temp-disk exhaustion the cap defends against) leaked a slot.
2. The success-path release rode a Starlette `BackgroundTask`, which is **skipped on client disconnect / cancellation / bad Range** mid-stream.

Both are eliminated by construction: `mkdtemp` moved inside the `try`, and the slot released in a **`finally` on handler return** (before streaming) rather than via the background task — matching the upload route's idiom. Temp-dir cleanup keeps its own (pre-existing) lifecycle.

## Test plan
- [x] Over-cap download → fast 429, no fetch/temp-dir (`test_download_concurrency_cap_returns_429`)
- [x] Slot released after success / error(409) / `mkdtemp` failure (3 new regression tests — counter returns to its prior value)
- [x] Full suite green (11130 passed), mypy + ruff clean

## Polish
code-simplifier (flagged the mkdtemp leak) · claude review (mkdtemp leak + BackgroundTask-disconnect leak, both applied; verified TOCTOU-clean, no double-decrement, ADR accurate) · codex review (same two, plus bad-Range/cancel cases; "fail until both fixed" → both fixed).

## Deferred polish findings
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added download throttling to limit concurrent artifact downloads; excess requests are rejected with HTTP 429.
  * Improved resilience so temporary files and download “slots” are always released, including on mid-stream disconnects and upstream/download failures.
* **Documentation**
  * Documented the accepted residual risk of signed file-transfer token replay within the token TTL, along with existing mitigations and conditions that would change the decision.
* **Tests**
  * Added unit coverage for throttling, correct in-flight accounting across multiple error paths, and proper cleanup on stream abort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->