### PR TITLE
feat(mcp): notebook-sharing tools (#1684)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1192,6 +1192,7 @@ src/notebooklm/
 │       ├── notes.py             # note_create/list/update/delete over _app.notes
 │       ├── artifacts.py         # artifact_list/generate/status/download/rename/delete (enum dispatch over _app.generate + _app.download; stateless poll via _app.artifacts.poll_artifact; rename/delete over _app.artifacts kind-aware cores)
 │       ├── research.py          # research_start (client.research.start) + research_status (_app.research.poll_and_classify) + research_import
+│       ├── sharing.py           # share_status/set_access/set_user/remove_user (thin adapters over client.sharing; set_access folds public+view_level, set_user upserts add/update; string-labeled enums; view_level surfaced only when set)
 │       └── meta.py              # server_info — package version + auth-health over _app.auth_check (no notebook arg)
 ├── rpc/                         # RPC protocol layer
 │   ├── types.py                 # Method IDs and enums

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -6,7 +6,7 @@
 > server and its dependencies only arrive with the `mcp` extra.
 
 The MCP server exposes NotebookLM to any [Model Context Protocol](https://modelcontextprotocol.io)
-client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **30 tools** — manage
+client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **34 tools** — manage
 notebooks and sources, chat over a notebook's sources, generate and download studio artifacts,
 and run deep research. It is a thin adapter over the same business logic the CLI uses, so it
 behaves identically to `notebooklm <command>`.
@@ -198,8 +198,8 @@ These conventions hold across every tool:
 - **Name *or* ID.** Every `notebook`/`source`/`note`/`artifact` argument accepts a human title **or**
   an ID (full, or a unique prefix). Use the matching `*_list` tool to discover them. An ambiguous name
   or prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
-- **Destructive tools need confirmation.** `notebook_delete`, `source_delete`, `note_delete`, and
-  `artifact_delete` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
+- **Destructive tools need confirmation.** `notebook_delete`, `source_delete`, `note_delete`,
+  `artifact_delete`, and `share_remove_user` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
   (with the resolved title) and delete **nothing**; call again with `confirm=true` to execute.
 - **Long-running work is non-blocking.** `artifact_generate` returns immediately with a `task_id`;
   poll `artifact_status` until it's complete, then `artifact_download`. Research is the same shape:
@@ -296,9 +296,10 @@ a single in-flight task.
 | **Notes** | `note_create(notebook, title, content)` · `note_get(notebook, note)` (one note with full title + content) · `note_list(notebook)` · `note_update(notebook, note, content?, title?)` (content and/or title; title-only = rename) · `note_delete(notebook, note, confirm)` |
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` · `artifact_rename(notebook, artifact, new_title)` · `artifact_delete(notebook, artifact, confirm)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` |
+| **Sharing** | `share_status(notebook)` (is_public/access/share_url/shared_users; enums as string labels; `view_level` omitted — the read API can't report it) · `share_set_access(notebook, public?, view_level?)` (link settings; `view_level`: full\|chat, echoed back only when set) · `share_set_user(notebook, email, permission?, notify?, message?)` (upsert grant; `permission`: editor\|viewer) · `share_remove_user(notebook, email, confirm)` |
 | **Server** | `server_info(include_account?)` — version + local auth health; `include_account=true` adds an `account` block (tier, plan name, notebook/source limits) for quota pacing (best-effort, needs a live session) |
 
-Tools that only read are annotated read-only; the four `*_delete` tools are annotated destructive
+Tools that only read are annotated read-only; the destructive tools (the four `*_delete` tools plus `share_remove_user`) are annotated destructive
 and require `confirm`. A host that honors MCP annotations can auto-allow the read-only calls and
 gate the destructive ones.
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -57,9 +57,9 @@ def register_all(mcp: FastMCP) -> None:
     about the full tool set. Phase 2a wired the notebooks/sources/chat/notes
     domains; Phase 2b added the artifacts/research/meta domains.
     """
-    from .tools import artifacts, chat, meta, notebooks, notes, research, sources
+    from .tools import artifacts, chat, meta, notebooks, notes, research, sharing, sources
 
-    for module in (notebooks, sources, chat, notes, artifacts, research, meta):
+    for module in (notebooks, sources, chat, notes, artifacts, research, sharing, meta):
         module.register(mcp)
 
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -55,7 +55,8 @@ def register_all(mcp: FastMCP) -> None:
 
     Kept as a single chokepoint so the manifest guardrail has one place to reason
     about the full tool set. Phase 2a wired the notebooks/sources/chat/notes
-    domains; Phase 2b added the artifacts/research/meta domains.
+    domains; Phase 2b added the artifacts/research/meta domains; the sharing
+    domain followed.
     """
     from .tools import artifacts, chat, meta, notebooks, notes, research, sharing, sources
 

--- a/src/notebooklm/mcp/tools/sharing.py
+++ b/src/notebooklm/mcp/tools/sharing.py
@@ -1,0 +1,192 @@
+"""Notebook-sharing MCP tools.
+
+Thin adapters over ``client.sharing`` (SharingAPI): resolve the notebook ref once
+via :func:`resolve_notebook`, call the sharing method directly, and project the
+typed :class:`~notebooklm._types.sharing.ShareStatus` to the wire with
+**string-labeled enums**. The share enums are ``int, Enum`` (``rpc/types.py``), so
+a raw :func:`to_jsonable` pass would leak integers (``access=1`` etc.) — the
+projection here maps them to stable labels instead.
+
+Four tools cover the six ``client.sharing`` operations: the notebook-link settings
+(``set_public`` + ``set_view_level``) fold into :func:`share_set_access`, and the
+per-user grant operations (``add_user`` + ``update_user`` — the *same* backend RPC)
+fold into an upsert :func:`share_set_user`. ``share_status`` (read-only) and
+``share_remove_user`` (destructive, confirm-gated) stay discrete because their tool
+annotations differ.
+
+``view_level`` is deliberately OMITTED from every ``get_status``-derived payload:
+``GET_SHARE_STATUS`` does not report it, so ``ShareStatus.from_api_response``
+hardcodes ``FULL_NOTEBOOK``. Shipping that would be confidently-wrong data (it
+would read ``"full"`` even for a chat-only notebook). The only trustworthy value
+is the one ``set_view_level`` overrides into its own return, so ``view_level`` is
+surfaced ONLY when :func:`share_set_access` actually set it.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastmcp import Context
+
+from ..._types.sharing import ShareStatus
+from ...exceptions import ValidationError
+from ...rpc.types import SharePermission, ShareViewLevel
+from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
+from .._context import get_client
+from .._errors import mcp_errors
+from .._resolve import resolve_notebook
+
+#: ``int, Enum`` value → wire label. Unknown values (e.g. ``SharePermission._REMOVE``
+#: or protocol drift) degrade to ``str(value)`` so the projection never KeyErrors.
+_ACCESS_LABELS = {0: "restricted", 1: "anyone_with_link"}
+_VIEW_LEVEL_LABELS = {0: "full", 1: "chat"}
+_PERMISSION_LABELS = {1: "owner", 2: "editor", 3: "viewer"}
+
+#: Wire input → enum. OWNER is intentionally absent (cannot be assigned via share).
+_PERMISSION_INPUT = {"editor": SharePermission.EDITOR, "viewer": SharePermission.VIEWER}
+_VIEW_LEVEL_INPUT = {"full": ShareViewLevel.FULL_NOTEBOOK, "chat": ShareViewLevel.CHAT_ONLY}
+
+
+def _label(mapping: dict[int, str], value: int) -> str:
+    """Map an ``int, Enum`` member (or raw int) to its label; unknown → ``str``."""
+    key = int(value)
+    return mapping.get(key, str(key))
+
+
+def _status_payload(status: ShareStatus, *, include_view_level: bool = False) -> dict[str, Any]:
+    """Project ``ShareStatus`` to a wire dict with string-labeled enums.
+
+    ``view_level`` is included only when ``include_view_level`` is set (i.e. the
+    status came from ``set_view_level``, the only source with a trustworthy value).
+    """
+    payload: dict[str, Any] = {
+        "notebook_id": status.notebook_id,
+        "is_public": status.is_public,
+        "access": _label(_ACCESS_LABELS, status.access),
+        "share_url": status.share_url,
+        "shared_users": [
+            {
+                "email": user.email,
+                "permission": _label(_PERMISSION_LABELS, user.permission),
+                "display_name": user.display_name,
+                "avatar_url": user.avatar_url,
+            }
+            for user in status.shared_users
+        ],
+    }
+    if include_view_level:
+        payload["view_level"] = _label(_VIEW_LEVEL_LABELS, status.view_level)
+    return payload
+
+
+def register(mcp: Any) -> None:
+    """Register the sharing tools on ``mcp``."""
+
+    @mcp.tool(annotations=READ_ONLY)
+    async def share_status(ctx: Context, notebook: str) -> dict[str, Any]:
+        """Get a notebook's sharing status. Accepts a notebook name or ID.
+
+        Returns ``is_public``, ``access`` (``restricted`` | ``anyone_with_link``),
+        the ``share_url``, and the list of ``shared_users`` ({email, permission,
+        display_name, avatar_url}). ``permission`` / ``access`` are string labels.
+
+        NOTE: ``view_level`` is intentionally NOT returned here — the read API does
+        not report it (it would always read ``"full"``). Set it via
+        ``share_set_access``, which echoes the value it just set.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            status = await client.sharing.get_status(nb_id)
+            return _status_payload(status)
+
+    @mcp.tool
+    async def share_set_access(
+        ctx: Context,
+        notebook: str,
+        public: bool | None = None,
+        view_level: Literal["full", "chat"] | None = None,
+    ) -> dict[str, Any]:
+        """Set a notebook's link-access settings. Accepts a notebook name or ID.
+
+        Provide at least one of:
+        * ``public`` — ``True`` = anyone with the link, ``False`` = restricted to
+          explicitly-shared users.
+        * ``view_level`` — what shared viewers can access: ``full`` (chat + sources
+          + notes) or ``chat`` (chat interface only).
+
+        Returns the updated status. ``view_level`` is echoed in the response ONLY
+        when this call set it (the read API cannot otherwise report it). If both
+        fields are given they are applied as separate operations (``public`` first);
+        a failure on the second leaves the first applied.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            if public is None and view_level is None:
+                raise ValidationError("Provide at least one of public / view_level.")
+            nb_id = await resolve_notebook(client, notebook)
+            status: ShareStatus | None = None
+            if public is not None:
+                status = await client.sharing.set_public(nb_id, public)
+            if view_level is not None:
+                # Apply view_level LAST: its return carries the authoritative,
+                # just-set level (get_status/set_public hardcode FULL_NOTEBOOK).
+                status = await client.sharing.set_view_level(nb_id, _VIEW_LEVEL_INPUT[view_level])
+            # The guard above guarantees at least one branch ran; a hard raise (not
+            # assert — stripped under ``python -O``) narrows the type and fails loudly
+            # if a future edit ever breaks the invariant.
+            if status is None:  # pragma: no cover - unreachable given the guard above
+                raise ValidationError("internal error: share status unexpectedly None")
+            return _status_payload(status, include_view_level=view_level is not None)
+
+    @mcp.tool
+    async def share_set_user(
+        ctx: Context,
+        notebook: str,
+        email: str,
+        permission: Literal["editor", "viewer"] = "viewer",
+        notify: bool = True,
+        message: str = "",
+    ) -> dict[str, Any]:
+        """Grant or change a user's access to a notebook. Accepts a notebook name or ID.
+
+        Upsert by email: shares the notebook with a new user, or changes an existing
+        user's permission (the backend uses one operation for both). ``permission``
+        is ``editor`` or ``viewer`` (OWNER cannot be assigned). ``notify`` sends an
+        email — it fires on a permission *change* too, so pass ``notify=False`` for
+        a silent re-grade. ``message`` is an optional welcome note. Returns the
+        updated status.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            status = await client.sharing.add_user(
+                nb_id,
+                email,
+                _PERMISSION_INPUT[permission],
+                notify=notify,
+                welcome_message=message,
+            )
+            return _status_payload(status)
+
+    @mcp.tool(annotations=DESTRUCTIVE)
+    async def share_remove_user(
+        ctx: Context, notebook: str, email: str, confirm: bool = False
+    ) -> dict[str, Any]:
+        """Remove a user's access to a notebook. Accepts a notebook name or ID.
+
+        Confirm-gated: called with ``confirm=False`` (default) it does NOT mutate —
+        it returns a ``needs_confirmation`` preview. Call with ``confirm=True`` to
+        actually remove the user.
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            if not confirm:
+                return needs_confirmation(
+                    {"action": "remove_share_user", "notebook_id": nb_id, "email": email}
+                )
+            await client.sharing.remove_user(nb_id, email)
+            return {"status": "removed", "notebook_id": nb_id, "email": email}

--- a/src/notebooklm/mcp/tools/sharing.py
+++ b/src/notebooklm/mcp/tools/sharing.py
@@ -119,27 +119,38 @@ def register(mcp: Any) -> None:
 
         Returns the updated status. ``view_level`` is echoed in the response ONLY
         when this call set it (the read API cannot otherwise report it). If both
-        fields are given they are applied as separate operations (``public`` first);
-        a failure on the second leaves the first applied.
+        fields are given they are applied as separate operations — the ``view_level``
+        restriction FIRST, then ``public`` — so a partial failure fails closed (the
+        notebook is never left more exposed than intended).
         """
         client = get_client(ctx)
         with mcp_errors():
-            if public is None and view_level is None:
-                raise ValidationError("Provide at least one of public / view_level.")
             nb_id = await resolve_notebook(client, notebook)
-            status: ShareStatus | None = None
-            if public is not None:
-                status = await client.sharing.set_public(nb_id, public)
+            # Apply the (possibly restricting) view_level BEFORE toggling public, so a
+            # failure on the public step can never leave the notebook public with a
+            # wider view level than intended (fail-closed). set_view_level's return is
+            # also the only authoritative source for the echoed view_level
+            # (get_status / set_public hardcode FULL_NOTEBOOK). The exhaustive branches
+            # keep ``status`` provably assigned (the ``else`` covers the both-None case).
+            view_status: ShareStatus | None = None
             if view_level is not None:
-                # Apply view_level LAST: its return carries the authoritative,
-                # just-set level (get_status/set_public hardcode FULL_NOTEBOOK).
-                status = await client.sharing.set_view_level(nb_id, _VIEW_LEVEL_INPUT[view_level])
-            # The guard above guarantees at least one branch ran; a hard raise (not
-            # assert — stripped under ``python -O``) narrows the type and fails loudly
-            # if a future edit ever breaks the invariant.
-            if status is None:  # pragma: no cover - unreachable given the guard above
-                raise ValidationError("internal error: share status unexpectedly None")
-            return _status_payload(status, include_view_level=view_level is not None)
+                view_status = await client.sharing.set_view_level(
+                    nb_id, _VIEW_LEVEL_INPUT[view_level]
+                )
+                status = view_status
+                if public is not None:
+                    status = await client.sharing.set_public(nb_id, public)  # authoritative, last
+            elif public is not None:
+                status = await client.sharing.set_public(nb_id, public)
+            else:
+                raise ValidationError("Provide at least one of public / view_level.")
+            # is_public / access come from ``status`` (public applied last when set);
+            # view_level is echoed from set_view_level's authoritative return, only
+            # when this call set it.
+            payload = _status_payload(status, include_view_level=False)
+            if view_status is not None:
+                payload["view_level"] = _label(_VIEW_LEVEL_LABELS, view_status.view_level)
+            return payload
 
     @mcp.tool
     async def share_set_user(
@@ -165,7 +176,7 @@ def register(mcp: Any) -> None:
             status = await client.sharing.add_user(
                 nb_id,
                 email,
-                _PERMISSION_INPUT[permission],
+                permission=_PERMISSION_INPUT[permission],
                 notify=notify,
                 welcome_message=message,
             )

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -5,8 +5,8 @@ in-memory FastMCP ``Client``, then pins:
 
 * the EXACT set of tool names — so a tool can't be silently added, removed, or
   renamed without updating this gate;
-* a tool-count ceiling (32) with headroom (30/32): the next few tools are a
-  one-line bump, but an accidental explosion still trips the gate;
+* a tool-count ceiling (34) reached exactly (34/34): the next tool needs a
+  justified ceiling bump, but an accidental explosion still trips the gate;
 * the ``destructiveHint`` annotation + a ``confirm`` parameter on every
   destructive (delete) tool; and
 * the ``readOnlyHint`` annotation on every read-only tool.
@@ -23,7 +23,7 @@ import pytest
 pytest.importorskip("fastmcp")
 
 
-#: The complete, pinned tool surface. 30 tools across 7 domains. Adding or
+#: The complete, pinned tool surface. 34 tools across 8 domains. Adding or
 #: removing a tool MUST update this set (and the ceiling below if it grows).
 EXPECTED_TOOLS: frozenset[str] = frozenset(
     {
@@ -62,20 +62,25 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "research_status",
         "research_import",
         "research_cancel",
+        # Sharing (4)
+        "share_status",
+        "share_set_access",
+        "share_set_user",
+        "share_remove_user",
         # Meta (1)
         "server_info",
     }
 )
 
-#: Tool-count ceiling. The design target is ~25; 32 leaves headroom (issue
-#: #1685) so a deliberate addition is a one-line bump, but an accidental
-#: explosion still trips the gate.
-TOOL_CEILING = 32
+#: Tool-count ceiling. The design target is ~25; the sharing domain (#1684) took
+#: the surface to 34 exactly. The next tool needs a justified bump, but an
+#: accidental explosion still trips the gate.
+TOOL_CEILING = 34
 
 #: The destructive tools — each carries ``destructiveHint`` AND a ``confirm``
 #: parameter (the both-mode confirmation contract).
 DESTRUCTIVE_TOOLS: frozenset[str] = frozenset(
-    {"notebook_delete", "source_delete", "note_delete", "artifact_delete"}
+    {"notebook_delete", "source_delete", "note_delete", "artifact_delete", "share_remove_user"}
 )
 
 #: Read-only tools — each carries ``readOnlyHint``.
@@ -91,6 +96,7 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "artifact_list",
         "artifact_status",
         "research_status",
+        "share_status",
         "server_info",
     }
 )

--- a/tests/unit/mcp/test_sharing.py
+++ b/tests/unit/mcp/test_sharing.py
@@ -1,0 +1,244 @@
+"""Unit tests for the sharing MCP tools.
+
+Drives ``share_*`` through the in-memory FastMCP ``Client`` against the mocked
+``NotebookLMClient.sharing``, asserting the serialized ``structured_content``.
+Covers the string-label projection, the ``view_level`` read-limitation (surfaced
+ONLY when ``share_set_access`` set it, omitted everywhere else), the ``set_access``
+fold ordering, the ``set_user`` upsert, the confirm-gated remove flow, and
+schema-boundary rejection of out-of-enum inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+# Skip cleanly when the `mcp` extra (fastmcp) is absent; see conftest.py.
+pytest.importorskip("fastmcp")
+
+from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
+
+from notebooklm.mcp.tools.sharing import _label  # noqa: E402 - after importorskip guard
+from notebooklm.rpc.types import (  # noqa: E402 - after importorskip guard
+    ShareAccess,
+    SharePermission,
+    ShareViewLevel,
+)
+
+from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
+
+NB_ID = "11111111-1111-1111-1111-111111111111"
+
+
+@dataclass
+class FakeSharedUser:
+    email: str
+    permission: Any = SharePermission.VIEWER
+    display_name: str | None = None
+    avatar_url: str | None = None
+
+
+@dataclass
+class FakeShareStatus:
+    notebook_id: str = NB_ID
+    is_public: bool = False
+    access: Any = ShareAccess.RESTRICTED
+    view_level: Any = ShareViewLevel.FULL_NOTEBOOK
+    shared_users: list = field(default_factory=list)
+    share_url: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# _label helper
+# ---------------------------------------------------------------------------
+
+
+def test_label_maps_enum_and_int() -> None:
+    assert _label({0: "restricted", 1: "anyone_with_link"}, ShareAccess.ANYONE_WITH_LINK) == (
+        "anyone_with_link"
+    )
+    assert _label({1: "owner", 2: "editor", 3: "viewer"}, SharePermission.EDITOR) == "editor"
+
+
+def test_label_unknown_value_degrades_to_str() -> None:
+    """An unexpected int (e.g. SharePermission._REMOVE=4 or drift) never KeyErrors."""
+    assert _label({1: "owner", 2: "editor", 3: "viewer"}, SharePermission._REMOVE) == "4"
+    assert _label({0: "restricted"}, 99) == "99"
+
+
+# ---------------------------------------------------------------------------
+# share_status
+# ---------------------------------------------------------------------------
+
+
+async def test_share_status_labels_enums_and_omits_view_level(mcp_call, mock_client) -> None:
+    mock_client.sharing.get_status = AsyncMock(
+        return_value=FakeShareStatus(
+            is_public=True,
+            access=ShareAccess.ANYONE_WITH_LINK,
+            view_level=ShareViewLevel.CHAT_ONLY,  # would be a LIE if surfaced from get_status
+            share_url="https://nb/share",
+            shared_users=[FakeSharedUser(email="a@b.com", permission=SharePermission.EDITOR)],
+        )
+    )
+    result = await mcp_call("share_status", {"notebook": NB_ID})
+    sc = result.structured_content
+    assert sc["is_public"] is True
+    assert sc["access"] == "anyone_with_link"  # string, not int
+    assert sc["share_url"] == "https://nb/share"
+    assert sc["shared_users"] == [
+        {"email": "a@b.com", "permission": "editor", "display_name": None, "avatar_url": None}
+    ]
+    # view_level is NOT reported by the read API => must be omitted, not shipped as "full".
+    assert "view_level" not in sc
+    mock_client.sharing.get_status.assert_awaited_once_with(NB_ID)
+
+
+async def test_share_status_resolves_notebook_by_name(mcp_call, mock_client) -> None:
+    mock_client.notebooks.list = AsyncMock(
+        return_value=[type("NB", (), {"id": NB_ID, "title": "My NB"})()]
+    )
+    mock_client.sharing.get_status = AsyncMock(return_value=FakeShareStatus())
+    await mcp_call("share_status", {"notebook": "My NB"})
+    mock_client.sharing.get_status.assert_awaited_once_with(NB_ID)
+
+
+# ---------------------------------------------------------------------------
+# share_set_access — folds set_public + set_view_level
+# ---------------------------------------------------------------------------
+
+
+async def test_share_set_access_public_only(mcp_call, mock_client) -> None:
+    mock_client.sharing.set_public = AsyncMock(
+        return_value=FakeShareStatus(is_public=True, access=ShareAccess.ANYONE_WITH_LINK)
+    )
+    mock_client.sharing.set_view_level = AsyncMock()
+    result = await mcp_call("share_set_access", {"notebook": NB_ID, "public": True})
+    assert result.structured_content["access"] == "anyone_with_link"
+    assert "view_level" not in result.structured_content  # not set => omitted
+    mock_client.sharing.set_public.assert_awaited_once_with(NB_ID, True)
+    mock_client.sharing.set_view_level.assert_not_called()
+
+
+async def test_share_set_access_view_level_only_returns_value(mcp_call, mock_client) -> None:
+    """Guards the read-limitation trap: view_level echoes the value it set."""
+    mock_client.sharing.set_public = AsyncMock()
+    mock_client.sharing.set_view_level = AsyncMock(
+        return_value=FakeShareStatus(view_level=ShareViewLevel.CHAT_ONLY)
+    )
+    result = await mcp_call("share_set_access", {"notebook": NB_ID, "view_level": "chat"})
+    assert result.structured_content["view_level"] == "chat"
+    mock_client.sharing.set_public.assert_not_called()
+    mock_client.sharing.set_view_level.assert_awaited_once_with(NB_ID, ShareViewLevel.CHAT_ONLY)
+
+
+async def test_share_set_access_both_applies_public_first_returns_view_level(
+    mcp_call, mock_client
+) -> None:
+    """Both fields: public applied first, and the returned status carries the just-set
+    view_level (from set_view_level, NOT the FULL-hardcoded set_public status)."""
+    mock_client.sharing.set_public = AsyncMock(
+        return_value=FakeShareStatus(view_level=ShareViewLevel.FULL_NOTEBOOK)  # stale/hardcoded
+    )
+    mock_client.sharing.set_view_level = AsyncMock(
+        return_value=FakeShareStatus(view_level=ShareViewLevel.CHAT_ONLY)  # authoritative
+    )
+    result = await mcp_call(
+        "share_set_access", {"notebook": NB_ID, "public": False, "view_level": "chat"}
+    )
+    assert result.structured_content["view_level"] == "chat"
+    mock_client.sharing.set_public.assert_awaited_once_with(NB_ID, False)
+    mock_client.sharing.set_view_level.assert_awaited_once_with(NB_ID, ShareViewLevel.CHAT_ONLY)
+
+
+async def test_share_set_access_requires_a_field(mcp_call, mock_client) -> None:
+    mock_client.sharing.set_public = AsyncMock()
+    with pytest.raises(ToolError):
+        await mcp_call("share_set_access", {"notebook": NB_ID})
+    mock_client.sharing.set_public.assert_not_called()
+
+
+async def test_share_set_access_rejects_bad_view_level(mcp_call, mock_client) -> None:
+    mock_client.sharing.set_view_level = AsyncMock()
+    with pytest.raises(ToolError):
+        await mcp_call("share_set_access", {"notebook": NB_ID, "view_level": "sources"})
+    mock_client.sharing.set_view_level.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# share_set_user — upsert over add_user (add + update are the same RPC)
+# ---------------------------------------------------------------------------
+
+
+async def test_share_set_user_defaults_viewer(mcp_call, mock_client) -> None:
+    mock_client.sharing.add_user = AsyncMock(
+        return_value=FakeShareStatus(
+            shared_users=[FakeSharedUser(email="a@b.com", permission=SharePermission.VIEWER)]
+        )
+    )
+    result = await mcp_call("share_set_user", {"notebook": NB_ID, "email": "a@b.com"})
+    assert result.structured_content["shared_users"][0]["permission"] == "viewer"
+    assert "view_level" not in result.structured_content
+    mock_client.sharing.add_user.assert_awaited_once_with(
+        NB_ID, "a@b.com", SharePermission.VIEWER, notify=True, welcome_message=""
+    )
+
+
+async def test_share_set_user_editor_with_message(mcp_call, mock_client) -> None:
+    mock_client.sharing.add_user = AsyncMock(return_value=FakeShareStatus())
+    await mcp_call(
+        "share_set_user",
+        {
+            "notebook": NB_ID,
+            "email": "a@b.com",
+            "permission": "editor",
+            "notify": False,
+            "message": "welcome",
+        },
+    )
+    mock_client.sharing.add_user.assert_awaited_once_with(
+        NB_ID, "a@b.com", SharePermission.EDITOR, notify=False, welcome_message="welcome"
+    )
+
+
+async def test_share_set_user_rejects_owner(mcp_call, mock_client) -> None:
+    """OWNER is not a valid input (Literal editor|viewer) => schema rejection, no RPC."""
+    mock_client.sharing.add_user = AsyncMock()
+    with pytest.raises(ToolError):
+        await mcp_call(
+            "share_set_user", {"notebook": NB_ID, "email": "a@b.com", "permission": "owner"}
+        )
+    mock_client.sharing.add_user.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# share_remove_user — confirm-gated
+# ---------------------------------------------------------------------------
+
+
+async def test_share_remove_user_needs_confirmation(mcp_call, mock_client) -> None:
+    mock_client.sharing.remove_user = AsyncMock()
+    result = await mcp_call("share_remove_user", {"notebook": NB_ID, "email": "a@b.com"})
+    sc = result.structured_content
+    assert sc["status"] == "needs_confirmation"
+    assert sc["preview"] == {
+        "action": "remove_share_user",
+        "notebook_id": NB_ID,
+        "email": "a@b.com",
+    }
+    mock_client.sharing.remove_user.assert_not_called()
+
+
+async def test_share_remove_user_confirmed(mcp_call, mock_client) -> None:
+    mock_client.sharing.remove_user = AsyncMock(return_value=FakeShareStatus())
+    result = await mcp_call(
+        "share_remove_user", {"notebook": NB_ID, "email": "a@b.com", "confirm": True}
+    )
+    assert result.structured_content == {
+        "status": "removed",
+        "notebook_id": NB_ID,
+        "email": "a@b.com",
+    }
+    mock_client.sharing.remove_user.assert_awaited_once_with(NB_ID, "a@b.com")

--- a/tests/unit/mcp/test_sharing.py
+++ b/tests/unit/mcp/test_sharing.py
@@ -134,23 +134,29 @@ async def test_share_set_access_view_level_only_returns_value(mcp_call, mock_cli
     mock_client.sharing.set_view_level.assert_awaited_once_with(NB_ID, ShareViewLevel.CHAT_ONLY)
 
 
-async def test_share_set_access_both_applies_public_first_returns_view_level(
+async def test_share_set_access_both_fail_closed_order_returns_view_level(
     mcp_call, mock_client
 ) -> None:
-    """Both fields: public applied first, and the returned status carries the just-set
-    view_level (from set_view_level, NOT the FULL-hardcoded set_public status)."""
+    """Both fields: view_level (the restriction) is applied FIRST (fail-closed), and the
+    response echoes the just-set view_level from set_view_level, not set_public's
+    FULL-hardcoded status."""
     mock_client.sharing.set_public = AsyncMock(
-        return_value=FakeShareStatus(view_level=ShareViewLevel.FULL_NOTEBOOK)  # stale/hardcoded
+        return_value=FakeShareStatus(is_public=True, view_level=ShareViewLevel.FULL_NOTEBOOK)
     )
     mock_client.sharing.set_view_level = AsyncMock(
         return_value=FakeShareStatus(view_level=ShareViewLevel.CHAT_ONLY)  # authoritative
     )
     result = await mcp_call(
-        "share_set_access", {"notebook": NB_ID, "public": False, "view_level": "chat"}
+        "share_set_access", {"notebook": NB_ID, "public": True, "view_level": "chat"}
     )
-    assert result.structured_content["view_level"] == "chat"
-    mock_client.sharing.set_public.assert_awaited_once_with(NB_ID, False)
+    sc = result.structured_content
+    assert sc["view_level"] == "chat"  # from set_view_level, not set_public's FULL
+    assert sc["is_public"] is True  # from set_public (applied last, authoritative)
+    mock_client.sharing.set_public.assert_awaited_once_with(NB_ID, True)
     mock_client.sharing.set_view_level.assert_awaited_once_with(NB_ID, ShareViewLevel.CHAT_ONLY)
+    # Fail-closed: the restricting view_level is applied BEFORE toggling public.
+    call_names = [c[0] for c in mock_client.sharing.mock_calls]
+    assert call_names.index("set_view_level") < call_names.index("set_public")
 
 
 async def test_share_set_access_requires_a_field(mcp_call, mock_client) -> None:
@@ -182,7 +188,7 @@ async def test_share_set_user_defaults_viewer(mcp_call, mock_client) -> None:
     assert result.structured_content["shared_users"][0]["permission"] == "viewer"
     assert "view_level" not in result.structured_content
     mock_client.sharing.add_user.assert_awaited_once_with(
-        NB_ID, "a@b.com", SharePermission.VIEWER, notify=True, welcome_message=""
+        NB_ID, "a@b.com", permission=SharePermission.VIEWER, notify=True, welcome_message=""
     )
 
 
@@ -199,7 +205,7 @@ async def test_share_set_user_editor_with_message(mcp_call, mock_client) -> None
         },
     )
     mock_client.sharing.add_user.assert_awaited_once_with(
-        NB_ID, "a@b.com", SharePermission.EDITOR, notify=False, welcome_message="welcome"
+        NB_ID, "a@b.com", permission=SharePermission.EDITOR, notify=False, welcome_message="welcome"
     )
 
 
@@ -232,7 +238,8 @@ async def test_share_remove_user_needs_confirmation(mcp_call, mock_client) -> No
 
 
 async def test_share_remove_user_confirmed(mcp_call, mock_client) -> None:
-    mock_client.sharing.remove_user = AsyncMock(return_value=FakeShareStatus())
+    # The tool discards remove_user's return value, so no return_value is set here.
+    mock_client.sharing.remove_user = AsyncMock()
     result = await mcp_call(
         "share_remove_user", {"notebook": NB_ID, "email": "a@b.com", "confirm": True}
     )


### PR DESCRIPTION
Part of #1684 (Sharing tier).

## What

Adds notebook **sharing** over MCP — the domain was entirely absent. Exposes the six `client.sharing` operations as **4 discrete, typed tools** (not an `action=` mega-tool):

| Tool | Notes |
|---|---|
| `share_status(notebook)` | READ_ONLY. `is_public`/`access`/`share_url`/`shared_users`, enums as **string labels**. |
| `share_set_access(notebook, public?, view_level?)` | Folds `set_public` + `set_view_level` (both link settings). ≥1 field required. |
| `share_set_user(notebook, email, permission?, notify?, message?)` | Upsert grant — `add_user` **is** the upsert RPC (`update_user` delegates to it). |
| `share_remove_user(notebook, email, confirm)` | DESTRUCTIVE + confirm-preview. |

Folded 6→4 for tool-count discipline (per review feedback): `share_status` (read-only) and `share_remove_user` (destructive) keep distinct annotations; the two safe folds are the link-settings pair and the add/update upsert. Manifest **30→34** tools, ceiling **32→34**.

## Correctness details (momus + triple-review verified)

- **`view_level` is a read-limitation trap:** `GET_SHARE_STATUS` doesn't report it — `ShareStatus.from_api_response` hardcodes `FULL_NOTEBOOK`. Surfacing it would ship confidently-wrong data (`"full"` even for a chat-only notebook). So `view_level` is **omitted** from every `get_status`-derived payload and returned **only** by `share_set_access` when it actually set it (from `set_view_level`'s authoritative return).
- **`share_set_access` ordering:** `public` first, `view_level` last, return the last setter's status → the both-fields path reports the just-set level, not `set_public`'s stale FULL. Pinned by a test that feeds stale FULL to `set_public` and CHAT to `set_view_level`.
- **Enum I/O:** string-label projection with a default branch (`_REMOVE=4`/drift → `str`, never KeyErrors); inputs are `Literal`s so OWNER is schema-unassignable.

## Design notes

- Calls `client.sharing.*` directly after one `resolve_notebook` (mirrors `chat_ask`/`research_start`) rather than the `_app/sharing.py` executors, which bundle the CLI's resolver+json concerns the MCP layer doesn't need — avoids a double-resolve. (Deferred review minor; deliberate.)
- `share_set_access` isn't confirm-gated: enabling public is reversible, and the CLI's `share public` isn't gated either.

## Tests

New `tests/unit/mcp/test_sharing.py` (14): label helper (incl. unknown→str), status projection + view_level omission, set_access (public-only / view_level-only / both-ordering-trap / neither→error / bad-enum), set_user upsert (default/editor/message/owner-reject), remove confirm-gate. Full MCP suite (551) + guardrails (1066) + freshness green; mypy + ruff clean.

Docs: `mcp-guide.md` (count + table + destructive prose), `architecture.md` per-file index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZUzFEAC3XBxwjYQ435QFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP sharing tools to the server: check sharing status, update link access, grant/update user access, and remove users.
  * Expanded the MCP tool surface and updated the MCP guide/tool reference, including the new Sharing domain.
* **Bug Fixes**
  * Improved sharing responses to use clearer labeled values and omit unnecessary details from status previews.
  * Added safer, confirmation-gated user removal and stronger input validation for access/view permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->