### PR TITLE
feat(mcp): expose global output_language in server_info account block

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -297,7 +297,7 @@ a single in-flight task.
 | **Artifacts** | `artifact_list(notebook)` · `artifact_generate(notebook, artifact_type, …)` · `artifact_status(notebook, task_id)` · `artifact_download(notebook, artifact_type, path, output_format?, artifact_id?)` · `artifact_rename(notebook, artifact, new_title)` · `artifact_delete(notebook, artifact, confirm)` |
 | **Research** | `research_start(notebook, query, source, mode)` · `research_status(notebook, task_id?)` · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` |
 | **Sharing** | `share_status(notebook)` (is_public/access/share_url/shared_users; enums as string labels; `view_level` omitted — the read API can't report it) · `share_set_access(notebook, public?, view_level?)` (link settings; `view_level`: full\|chat, echoed back only when set) · `share_set_user(notebook, email, permission?, notify?, message?)` (upsert grant; `permission`: editor\|viewer) · `share_remove_user(notebook, email, confirm)` |
-| **Server** | `server_info(include_account?)` — version + local auth health; `include_account=true` adds an `account` block (tier, plan name, notebook/source limits) for quota pacing (best-effort, needs a live session) |
+| **Server** | `server_info(include_account?)` — version + local auth health; `include_account=true` adds an `account` block (tier, plan name, notebook/source limits, global `output_language`) for quota pacing + language context (best-effort, needs a live session) |
 
 Tools that only read are annotated read-only; the destructive tools (the four `*_delete` tools plus `share_remove_user`) are annotated destructive
 and require `confirm`. A host that honors MCP annotations can auto-allow the read-only calls and

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -12,9 +12,10 @@ active profile are resolved via the neutral :mod:`notebooklm.paths` helpers, so
 this module imports NO ``click`` / ``rich`` / ``cli``.
 
 It also accepts an opt-in ``include_account`` flag that adds the account tier +
-notebook/source limits (for an agent to pace against quota). That block requires
-a *live* session, so it is off by default — the default call stays a fast,
-network-free auth-health probe that works even when unauthenticated.
+notebook/source limits + the global output language (for an agent to pace against
+quota and know which language artifacts generate in). That block requires a *live*
+session, so it is off by default — the default call stays a fast, network-free
+auth-health probe that works even when unauthenticated.
 """
 
 from __future__ import annotations
@@ -60,11 +61,15 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
         return {"available": False, "reason": "not authenticated"}
     client = get_client(ctx)
     try:
-        # Two independent reads → run concurrently (repo convention for
-        # independent RPCs). A NotebookLMError from either is still caught below.
-        limits, tier = await asyncio.gather(
+        # Three concurrent reads (repo convention: each public getter is
+        # self-contained). ``get_account_limits`` + ``get_output_language`` both hit
+        # GET_USER_SETTINGS, so this fires it twice — a client-layer single-fetch
+        # dedupe is tracked in #1724 (kept simple here; the adapter uses the public
+        # getters, not RPC internals). A NotebookLMError from any is caught below.
+        limits, tier, output_language = await asyncio.gather(
             client.settings.get_account_limits(),
             client.settings.get_account_tier(),
+            client.settings.get_output_language(),
         )
     except NotebookLMError as exc:  # degrade, don't sink the whole response
         # Route through the shared scrubber (same chokepoint as every other MCP
@@ -78,6 +83,9 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
         "plan_name": tier.plan_name,
         "notebook_limit": limits.notebook_limit,
         "source_limit": limits.source_limit,
+        # Global account output language (e.g. "en" / "ja" / "zh_Hans"); ``None``
+        # when unset. Read-only here — a setter is tracked separately (#1723).
+        "output_language": output_language,
     }
 
 
@@ -95,12 +103,14 @@ def register(mcp: Any) -> None:
         the server host.
 
         Set ``include_account=True`` to also fetch an ``account`` block for quota
-        pacing: ``{available, tier, plan_name, notebook_limit, source_limit}``.
-        This needs a *live* session (two RPCs), so it is off by default — the
-        default call is a fast, network-free probe. When the session is missing or
-        stale the block degrades to ``{available: False, reason: ...}`` rather than
-        failing the whole call; ``tier`` may be ``None`` even when ``available`` is
-        true (it is a best-effort signal).
+        pacing: ``{available, tier, plan_name, notebook_limit, source_limit,
+        output_language}`` (``output_language`` is the global account setting, e.g.
+        ``"en"``/``"ja"``, or ``None`` when unset). This needs a *live* session
+        (a few reads), so it is off by default — the default call is a fast,
+        network-free probe. When the session is missing or stale the block
+        degrades to ``{available: False, reason: ...}`` rather than failing the
+        whole call; ``tier`` may be ``None`` even when ``available`` is true (it
+        is a best-effort signal).
 
         The absolute on-disk storage path is deliberately **not** returned: it
         leaks the server-host OS username / filesystem layout to any (possibly

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -84,7 +84,7 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
         "notebook_limit": limits.notebook_limit,
         "source_limit": limits.source_limit,
         # Global account output language (e.g. "en" / "ja" / "zh_Hans"); ``None``
-        # when unset. Read-only here — a setter is tracked separately (#1723).
+        # when unset or unparseable. Read-only here — a setter is tracked in #1723.
         "output_language": output_language,
     }
 
@@ -105,7 +105,7 @@ def register(mcp: Any) -> None:
         Set ``include_account=True`` to also fetch an ``account`` block for quota
         pacing: ``{available, tier, plan_name, notebook_limit, source_limit,
         output_language}`` (``output_language`` is the global account setting, e.g.
-        ``"en"``/``"ja"``, or ``None`` when unset). This needs a *live* session
+        ``"en"``/``"ja"``, or ``None`` when unset or unparseable). This needs a *live* session
         (a few reads), so it is off by default — the default call is a fast,
         network-free probe. When the session is missing or stale the block
         degrades to ``{available: False, reason: ...}`` rather than failing the

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -120,16 +120,18 @@ async def test_server_info_default_omits_account(
     _write_authed_storage()
     mock_client.settings.get_account_limits = AsyncMock()
     mock_client.settings.get_account_tier = AsyncMock()
+    mock_client.settings.get_output_language = AsyncMock()
     result = await mcp_call("server_info")
     assert "account" not in result.structured_content
     mock_client.settings.get_account_limits.assert_not_called()
     mock_client.settings.get_account_tier.assert_not_called()
+    mock_client.settings.get_output_language.assert_not_called()
 
 
 async def test_server_info_include_account_authenticated(
     mcp_call, mock_client, tmp_path, monkeypatch
 ) -> None:
-    """include_account=True + live session → account block with tier + limits."""
+    """include_account=True + live session → account block with tier + limits + language."""
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     _write_authed_storage()
     mock_client.settings.get_account_limits = AsyncMock(
@@ -138,6 +140,7 @@ async def test_server_info_include_account_authenticated(
     mock_client.settings.get_account_tier = AsyncMock(
         return_value=AccountTier(tier="NOTEBOOKLM_TIER_PRO", plan_name="Pro")
     )
+    mock_client.settings.get_output_language = AsyncMock(return_value="ja")
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"] == {
         "available": True,
@@ -145,6 +148,7 @@ async def test_server_info_include_account_authenticated(
         "plan_name": "Pro",
         "notebook_limit": 100,
         "source_limit": 50,
+        "output_language": "ja",
     }
 
 
@@ -155,6 +159,7 @@ async def test_server_info_include_account_unauthenticated(
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "empty"))
     mock_client.settings.get_account_limits = AsyncMock()
     mock_client.settings.get_account_tier = AsyncMock()
+    mock_client.settings.get_output_language = AsyncMock()
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"] == {
         "available": False,
@@ -162,6 +167,7 @@ async def test_server_info_include_account_unauthenticated(
     }
     mock_client.settings.get_account_limits.assert_not_called()
     mock_client.settings.get_account_tier.assert_not_called()
+    mock_client.settings.get_output_language.assert_not_called()
 
 
 async def test_server_info_include_account_degrades_on_rpc_error(
@@ -173,6 +179,7 @@ async def test_server_info_include_account_degrades_on_rpc_error(
     _write_authed_storage()
     mock_client.settings.get_account_limits = AsyncMock(side_effect=RPCError("session expired"))
     mock_client.settings.get_account_tier = AsyncMock()
+    mock_client.settings.get_output_language = AsyncMock()
     result = await mcp_call("server_info", {"include_account": True})
     account = result.structured_content["account"]
     assert account["available"] is False
@@ -191,6 +198,7 @@ async def test_server_info_include_account_degrades_when_tier_rpc_raises(
     _write_authed_storage()
     mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
     mock_client.settings.get_account_tier = AsyncMock(side_effect=RPCError("tier lookup failed"))
+    mock_client.settings.get_output_language = AsyncMock()
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"]["available"] is False
     assert "tier lookup failed" in result.structured_content["account"]["reason"]
@@ -205,6 +213,7 @@ async def test_server_info_include_account_tier_none_is_available(
     _write_authed_storage()
     mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
     mock_client.settings.get_account_tier = AsyncMock(return_value=AccountTier())
+    mock_client.settings.get_output_language = AsyncMock(return_value=None)
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"] == {
         "available": True,
@@ -212,6 +221,7 @@ async def test_server_info_include_account_tier_none_is_available(
         "plan_name": None,
         "notebook_limit": None,
         "source_limit": None,
+        "output_language": None,
     }
 
 
@@ -225,6 +235,7 @@ async def test_server_info_include_account_degraded_reason_is_scrubbed(
     leaky = RPCError("auth failed loading /home/secretuser/.notebooklm/storage_state.json")
     mock_client.settings.get_account_limits = AsyncMock(side_effect=leaky)
     mock_client.settings.get_account_tier = AsyncMock()
+    mock_client.settings.get_output_language = AsyncMock()
     result = await mcp_call("server_info", {"include_account": True})
     reason = result.structured_content["account"]["reason"]
     assert result.structured_content["account"]["available"] is False

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -204,6 +204,23 @@ async def test_server_info_include_account_degrades_when_tier_rpc_raises(
     assert "tier lookup failed" in result.structured_content["account"]["reason"]
 
 
+async def test_server_info_include_account_degrades_when_language_rpc_raises(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """The output-language RPC failing (the third concurrent read) also degrades
+    gracefully — all three reads share one degrade handler."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+    mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
+    mock_client.settings.get_account_tier = AsyncMock(return_value=AccountTier())
+    mock_client.settings.get_output_language = AsyncMock(
+        side_effect=RPCError("language lookup failed")
+    )
+    result = await mcp_call("server_info", {"include_account": True})
+    assert result.structured_content["account"]["available"] is False
+    assert "language lookup failed" in result.structured_content["account"]["reason"]
+
+
 async def test_server_info_include_account_tier_none_is_available(
     mcp_call, mock_client, tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Part of #1684 (Settings/language tier). Ships the **getter** half of output-language; the **setter** is deferred (#1723).

## What

Folds the global account **output language** into the existing `server_info(include_account=true)` `account` block — **ceiling-neutral** (no new tool). The block now returns `{available, tier, plan_name, notebook_limit, source_limit, output_language}`, where `output_language` is the account-wide setting (`"en"`/`"ja"`/…, or `null` when unset). One extra concurrent read in the existing `asyncio.gather`.

## Why this shape (not a `configure` tool)

Language is a **global account setting**, not notebook-scoped — so it doesn't belong in `chat_configure` (notebook-scoped). The account-read surface already lives in `server_info`'s account block (tier/limits), so the language *getter* sits there naturally. The *setter* is a global, high-blast-radius mutation an agent rarely needs → deferred to #1723 (would cost a ceiling bump; a focused `settings_set_language` tool, not a `configure` wrapper).

## Notes

- Degrade path unchanged: a `NotebookLMError` from any of the three reads → `{available: false, reason: <scrubbed>}`. `output_language: null` (unset) is cleanly distinct from the degraded case.
- **Follow-up #1724** (review-flagged by codex + claude): `get_account_limits` + `get_output_language` both hit `GET_USER_SETTINGS`, so this fires it twice — a client-layer single-fetch dedupe, out of scope here (the adapter correctly uses the public getters).

## Tests

`test_meta.py` — all 7 `include_account` cases updated (authenticated returns `output_language`, unset→`null`, degrade paths, not-called on the default path). Full MCP suite (557) + manifest + freshness green; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZUzFEAC3XBxwjYQ435QFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced `server_info(include_account=True)` so the optional account details now also include `output_language`, alongside existing tier, plan, and limit information.
  * Improved graceful handling for missing/expired sessions and partial backend failures, including unauthenticated and degraded responses (with safe, scrubbed error messaging).
* **Documentation**
  * Updated the MCP tool reference for `server_info(include_account?)` to describe the new `output_language` field and the live-session best-effort behavior.
* **Tests**
  * Expanded unit coverage to validate `output_language` inclusion and degraded/edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->