### PR TITLE
test(mcp): VCR coverage for sharing tools + all studio mutating ops (#1732, #1733)

### DIFF
--- a/tests/cassettes/mcp_studio_delete_artifact.yaml
+++ b/tests/cassettes/mcp_studio_delete_artifact.yaml
@@ -1,0 +1,491 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        176
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",null,2]],[1782991061,365482000]]",null,null,null,"generic"],["di",172],["af.httprm",172,"151646137016956450",8]]
+
+        23
+
+        [["e",4,null,null,214]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '214'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:41 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22gArtLc%22%2C%22%5B%5B2%5D%2C%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%2C%5C%22NOT%20artifact.status%20%3D%20%5C%5C%5C%22ARTIFACT_STATUS_SUGGESTED%5C%5C%5C%22%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '275'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=gArtLc&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        670
+
+        [["wrb.fr","gArtLc","[[[\"6384b603-5734-433c-b2d8-62b490ad4a54\",\"Renamed
+        by VCR\",2,[[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]]],1,null,null,[null,[\"SCRUBBED_NAME\",\"Key
+        insights and important quotes\",null,[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]],\"en\",\"Create
+        a comprehensive briefing document that includes an Executive Summary, detailed
+        analysis of key themes, important quotes with context, and actionable insights.\",null,true],[]],null,null,[1782991059,999283000],null,null,null,null,[1782991057,809637000],null,null,null,1,null,\"MTc4Mjk5MTA1OS05OTkyODMwMDA\\u003d\"]]]",null,null,null,"generic"],["di",200],["af.httprm",200,"3614590802682791347",9]]
+
+        23
+
+        [["e",4,null,null,707]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '707'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:41 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        177
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",null,2]],[1782991061,624059000]]",null,null,null,"generic"],["di",184],["af.httprm",183,"7035018416567098282",8]]
+
+        23
+
+        [["e",4,null,null,215]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '215'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:41 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        177
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",null,2]],[1782991061,834959000]]",null,null,null,"generic"],["di",174],["af.httprm",173,"4330262743636169531",8]]
+
+        23
+
+        [["e",4,null,null,215]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '215'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:41 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22V5N4be%22%2C%22%5B%5B2%5D%2C%5C%226384b603-5734-433c-b2d8-62b490ad4a54%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '181'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=V5N4be&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        104
+
+        [["wrb.fr","V5N4be","[]",null,null,null,"generic"],["di",573],["af.httprm",572,"7469183249720127182",8]]
+
+        23
+
+        [["e",4,null,null,142]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '142'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:41 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:42 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/mcp_studio_delete_note.yaml
+++ b/tests/cassettes/mcp_studio_delete_note.yaml
@@ -1,0 +1,398 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22gArtLc%22%2C%22%5B%5B2%5D%2C%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%2C%5C%22NOT%20artifact.status%20%3D%20%5C%5C%5C%22ARTIFACT_STATUS_SUGGESTED%5C%5C%5C%22%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '275'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=gArtLc&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        671
+
+        [["wrb.fr","gArtLc","[[[\"6384b603-5734-433c-b2d8-62b490ad4a54\",\"Renamed
+        by VCR\",2,[[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]]],1,null,null,[null,[\"SCRUBBED_NAME\",\"Key
+        insights and important quotes\",null,[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]],\"en\",\"Create
+        a comprehensive briefing document that includes an Executive Summary, detailed
+        analysis of key themes, important quotes with context, and actionable insights.\",null,true],[]],null,null,[1782991059,999283000],null,null,null,null,[1782991057,809637000],null,null,null,1,null,\"MTc4Mjk5MTA1OS05OTkyODMwMDA\\u003d\"]]]",null,null,null,"generic"],["di",222],["af.httprm",221,"-2828893969200720815",9]]
+
+        23
+
+        [["e",4,null,null,708]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '708'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:40 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        329
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",\"Delete
+        me.\",[1,\"400237754469\",[1782991056,907165000],null,null,[1782991056,907165000]],null,\"Scratch
+        note\"]]],[1782991060,632603000]]",null,null,null,"generic"],["di",310],["af.httprm",310,"-4137608589540449776",10]]
+
+        23
+
+        [["e",4,null,null,367]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '367'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:40 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        327
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",\"Delete
+        me.\",[1,\"400237754469\",[1782991056,907165000],null,null,[1782991056,907165000]],null,\"Scratch
+        note\"]]],[1782991060,788151000]]",null,null,null,"generic"],["di",184],["af.httprm",183,"3100143088910894069",9]]
+
+        23
+
+        [["e",4,null,null,365]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '365'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:40 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22AH0mwd%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%2Cnull%2C%5B%5C%22a1384eaf-25fa-43eb-ac76-8154f45c0a05%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '235'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=AH0mwd&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        104
+
+        [["wrb.fr","AH0mwd","[]",null,null,null,"generic"],["di",307],["af.httprm",307,"-954685064988728516",9]]
+
+        23
+
+        [["e",4,null,null,142]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '142'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:40 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:41 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/mcp_studio_rename.yaml
+++ b/tests/cassettes/mcp_studio_rename.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        326
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",\"Delete
+        me.\",[1,\"400237754469\",[1782991056,907165000],null,null,[1782991056,907165000]],null,\"Scratch
+        note\"]]],[1782991059,72294000]]",null,null,null,"generic"],["di",178],["af.httprm",177,"-689454741852731378",9]]
+
+        23
+
+        [["e",4,null,null,364]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '364'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:39 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22gArtLc%22%2C%22%5B%5B2%5D%2C%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%2C%5C%22NOT%20artifact.status%20%3D%20%5C%5C%5C%22ARTIFACT_STATUS_SUGGESTED%5C%5C%5C%22%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '275'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=gArtLc&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        683
+
+        [["wrb.fr","gArtLc","[[[\"6384b603-5734-433c-b2d8-62b490ad4a54\",\"zzz-mcp-studio-vcr-scratch\",2,[[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]]],1,null,null,[null,[\"SCRUBBED_NAME\",\"Key
+        insights and important quotes\",null,[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]],\"en\",\"Create
+        a comprehensive briefing document that includes an Executive Summary, detailed
+        analysis of key themes, important quotes with context, and actionable insights.\",null,true],[]],null,null,[1782991057,809637000],null,null,null,null,[1782991057,809637000],null,null,null,1,null,\"MTc4Mjk5MTA1Ny04MDk2MzcwMDA\\u003d\"]]]",null,null,null,"generic"],["di",212],["af.httprm",212,"5900663207426255902",10]]
+
+        23
+
+        [["e",4,null,null,720]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '720'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:39 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cFji9%22%2C%22%5B%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cFji9&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        329
+
+        [["wrb.fr","cFji9","[[[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",[\"a1384eaf-25fa-43eb-ac76-8154f45c0a05\",\"Delete
+        me.\",[1,\"400237754469\",[1782991056,907165000],null,null,[1782991056,907165000]],null,\"Scratch
+        note\"]]],[1782991059,572589000]]",null,null,null,"generic"],["di",195],["af.httprm",194,"-9147616737653865606",10]]
+
+        23
+
+        [["e",4,null,null,367]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '367'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:39 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:39 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22rc3d8d%22%2C%22%5B%5B%5C%226384b603-5734-433c-b2d8-62b490ad4a54%5C%22%2C%5C%22Renamed%20by%20VCR%5C%22%5D%2C%5B%5B%5C%22title%5C%22%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '242'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=rc3d8d&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        666
+
+        [["wrb.fr","rc3d8d","[\"6384b603-5734-433c-b2d8-62b490ad4a54\",\"Renamed by
+        VCR\",2,[[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]]],1,null,null,[null,[\"SCRUBBED_NAME\",\"Key
+        insights and important quotes\",null,[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]],\"en\",\"Create
+        a comprehensive briefing document that includes an Executive Summary, detailed
+        analysis of key themes, important quotes with context, and actionable insights.\",null,true],[]],null,null,[1782991059,999283000],null,null,null,null,[1782991057,809637000],null,null,null,1,null,\"MTc4Mjk5MTA1OS05OTkyODMwMDA\\u003d\"]",null,null,null,"generic"],["di",402],["af.httprm",402,"-499918718599451233",9]]
+
+        23
+
+        [["e",4,null,null,703]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '703'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:39 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22gArtLc%22%2C%22%5B%5B2%5D%2C%5C%229b8fb5be-3897-4360-8d19-fc7eae295747%5C%22%2C%5C%22NOT%20artifact.status%20%3D%20%5C%5C%5C%22ARTIFACT_STATUS_SUGGESTED%5C%5C%5C%22%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1782991052782&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '275'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED; _ga_W0LDH41ZCB=SCRUBBED
+      host:
+      - notebooklm.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=gArtLc&source-path=%2Fnotebook%2F9b8fb5be-3897-4360-8d19-fc7eae295747&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        670
+
+        [["wrb.fr","gArtLc","[[[\"6384b603-5734-433c-b2d8-62b490ad4a54\",\"Renamed
+        by VCR\",2,[[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]]],1,null,null,[null,[\"SCRUBBED_NAME\",\"Key
+        insights and important quotes\",null,[[\"5a7bbe0d-c129-4304-9e4b-7cd0cc375270\"]],\"en\",\"Create
+        a comprehensive briefing document that includes an Executive Summary, detailed
+        analysis of key themes, important quotes with context, and actionable insights.\",null,true],[]],null,null,[1782991059,999283000],null,null,null,null,[1782991057,809637000],null,null,null,1,null,\"MTc4Mjk5MTA1OS05OTkyODMwMDA\\u003d\"]]]",null,null,null,"generic"],["di",212],["af.httprm",211,"448139063617632423",10]]
+
+        23
+
+        [["e",4,null,null,707]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '707'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Thu, 02 Jul 2026 11:17:40 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Fri, 02-Jul-2027 11:17:40 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/mcp_vcr/test_sharing.py
+++ b/tests/integration/mcp_vcr/test_sharing.py
@@ -39,9 +39,9 @@ from .conftest import build_mcp_client
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 
-# Recorded notebook id shared by the cli_share_* / sharing_* cassettes (decoded
-# from each cassette's request body). Decorative for matching — pins the full-UUID
-# resolver fast path so no LIST_NOTEBOOKS RPC is issued.
+# The single recorded notebook id shared by all four cli_share_* / sharing_*
+# cassettes. Decorative for matching — pins the full-UUID resolver fast path so no
+# LIST_NOTEBOOKS RPC is issued.
 SHARE_NOTEBOOK_ID = "62e5c8db-3dd2-407c-8d19-32ae4ae799db"
 
 
@@ -68,6 +68,9 @@ async def test_mcp_share_status_over_vcr() -> None:
     assert isinstance(structured["shared_users"], list)
     for user in structured["shared_users"]:
         assert user["permission"] in {"owner", "editor", "viewer"}
+    # share_url is always projected by _status_payload (may be None) — pin its
+    # presence so a dropped key regresses loudly.
+    assert "share_url" in structured
     # view_level is intentionally NOT surfaced by the read path.
     assert "view_level" not in structured
 
@@ -89,6 +92,8 @@ async def test_mcp_share_set_user_over_vcr() -> None:
                 "notebook": SHARE_NOTEBOOK_ID,
                 "email": "collaborator@example.com",
                 "permission": "editor",
+                # notify is shape-irrelevant (the freq matcher collapses the bool),
+                # so False here replays fine against the notify=True recording.
                 "notify": False,
             },
         )

--- a/tests/integration/mcp_vcr/test_sharing.py
+++ b/tests/integration/mcp_vcr/test_sharing.py
@@ -1,0 +1,153 @@
+"""MCP sharing-tool VCR tests (reuse-only).
+
+Full-stack coverage (MCP tool -> ``sharing.py`` adapter -> real
+``NotebookLMClient`` -> VCR-replayed RPC) for the four sharing tools, reusing the
+SAME cassettes the CLI ``share`` VCR suite recorded. ``NOTEBOOKLM_VCR_RECORD`` is
+deliberately NOT set — no cassette is ever re-recorded here.
+
+Closes the gap flagged in #1732: the sharing tools issue **mutating** access-grant
+RPCs (``QDyure``) yet were exercised by unit tests with a mocked ``client`` only,
+which cannot validate the real ``batchexecute`` request/response shapes — exactly
+the position-sensitive-nested-params class of bug (CLAUDE.md pitfall #2) a mocked
+test passes and a VCR test catches.
+
+Every tool is invoked with the FULL canonical notebook UUID recorded in each
+cassette so :func:`resolve_notebook` takes its full-UUID fast path and never adds
+a ``LIST_NOTEBOOKS`` RPC the cassette lacks. The batchexecute body matcher is
+shape-only, so the id/email/permission VALUES are decorative — the RPC *sequence*
+and body *shape* are what replay.
+
+Sequence map (each mutating op ends with a ``get_status`` re-read, ``JFMDGd``):
+
+* ``share_status``     -> ``get_status``      -> ``JFMDGd``
+* ``share_set_user``   -> ``add_user``        -> ``QDyure`` + ``JFMDGd``
+* ``share_set_access`` -> ``set_public``      -> ``QDyure`` + ``JFMDGd``
+* ``share_remove_user``-> ``remove_user``     -> ``QDyure`` + ``JFMDGd``
+
+(The two RPC ids are distinct, so the ``freq`` matcher pairs them regardless of
+cassette order or of extra unused interactions in a multi-op cassette.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.conftest import skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from .conftest import build_mcp_client
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# Recorded notebook id shared by the cli_share_* / sharing_* cassettes (decoded
+# from each cassette's request body). Decorative for matching — pins the full-UUID
+# resolver fast path so no LIST_NOTEBOOKS RPC is issued.
+SHARE_NOTEBOOK_ID = "62e5c8db-3dd2-407c-8d19-32ae4ae799db"
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("cli_share_status.yaml")
+async def test_mcp_share_status_over_vcr() -> None:
+    """``share_status`` reads sharing state through the real client over VCR.
+
+    End-to-end: tool -> ``resolve_notebook`` (full UUID, no list) ->
+    ``client.sharing.get_status`` -> ``GET_SHARE_STATUS`` (``JFMDGd``). Pins the
+    string-labeled wire shape (``access`` / ``permission`` are labels, never the
+    raw ``int, Enum`` values), and the ``view_level`` OMISSION (the read API
+    cannot report it).
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool("share_status", {"notebook": SHARE_NOTEBOOK_ID})
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["notebook_id"] == SHARE_NOTEBOOK_ID
+    assert isinstance(structured["is_public"], bool)
+    # Access is a string label, never a raw int (the enums are ``int, Enum``).
+    assert structured["access"] in {"restricted", "anyone_with_link"}
+    assert isinstance(structured["shared_users"], list)
+    for user in structured["shared_users"]:
+        assert user["permission"] in {"owner", "editor", "viewer"}
+    # view_level is intentionally NOT surfaced by the read path.
+    assert "view_level" not in structured
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("cli_share_add.yaml")
+async def test_mcp_share_set_user_over_vcr() -> None:
+    """``share_set_user`` grants access through the real client over VCR.
+
+    End-to-end: tool -> ``client.sharing.add_user`` -> the mutating grant RPC
+    (``QDyure``) THEN a ``get_status`` re-read (``JFMDGd``). This is the
+    position-sensitive access-grant path #1732 flags — a mocked test cannot
+    validate the ``QDyure`` body shape; VCR does.
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "share_set_user",
+            {
+                "notebook": SHARE_NOTEBOOK_ID,
+                "email": "collaborator@example.com",
+                "permission": "editor",
+                "notify": False,
+            },
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "updated"
+    assert structured["notebook_id"] == SHARE_NOTEBOOK_ID
+    assert isinstance(structured["shared_users"], list)
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("sharing_set_public.yaml")
+async def test_mcp_share_set_access_public_over_vcr() -> None:
+    """``share_set_access(public=True)`` flips link access through VCR.
+
+    End-to-end: tool -> ``client.sharing.set_public`` -> the mutating
+    link-visibility RPC (``QDyure``) THEN a ``get_status`` re-read (``JFMDGd``).
+    Reuses ``sharing_set_public.yaml`` (recorded from ``set_public``), whose
+    ``QDyure`` body shape matches the link-visibility path (distinct from the
+    per-user grant body). ``view_level`` stays omitted (this call did not set it).
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "share_set_access",
+            {"notebook": SHARE_NOTEBOOK_ID, "public": True},
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "updated"
+    assert structured["notebook_id"] == SHARE_NOTEBOOK_ID
+    assert isinstance(structured["is_public"], bool)
+    # Not set on this call -> not echoed.
+    assert "view_level" not in structured
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("cli_share_remove.yaml")
+async def test_mcp_share_remove_user_over_vcr() -> None:
+    """``share_remove_user(confirm=True)`` revokes access through VCR.
+
+    End-to-end: tool -> ``client.sharing.remove_user`` -> the mutating revoke RPC
+    (``QDyure``) THEN a ``get_status`` re-read (``JFMDGd``). Pins the flat
+    ``{"status": "removed", "notebook_id", "email"}`` wire shape. ``confirm=True``
+    is required — the default confirm-gated preview does not touch the wire.
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "share_remove_user",
+            {
+                "notebook": SHARE_NOTEBOOK_ID,
+                "email": "collaborator@example.com",
+                "confirm": True,
+            },
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "removed"
+    assert structured["notebook_id"] == SHARE_NOTEBOOK_ID
+    assert structured["email"] == "collaborator@example.com"

--- a/tests/integration/mcp_vcr/test_studio_mutations.py
+++ b/tests/integration/mcp_vcr/test_studio_mutations.py
@@ -1,0 +1,101 @@
+"""MCP Studio mutating-tool VCR tests (reuse-only).
+
+Full-stack coverage (MCP tool -> ``artifacts.py`` Studio adapter -> real
+``NotebookLMClient`` -> VCR-replayed RPC) for the Studio ops that were unit-only
+before #1733 and whose exact RPC sequence a recorded cassette already holds:
+``studio_retry`` and ``studio_get_prompt``. Reuses the SAME cassettes the CLI
+``artifact`` VCR suite recorded — ``NOTEBOOKLM_VCR_RECORD`` is deliberately NOT set.
+
+Every tool is invoked with FULL canonical UUIDs (the cassette's recorded
+notebook/artifact ids) so :func:`resolve_notebook` / :func:`resolve_artifact`
+take their full-UUID fast path and never add a ``LIST_NOTEBOOKS`` /
+``LIST_ARTIFACTS`` preflight the cassette lacks. The batchexecute body matcher is
+shape-only, so the id VALUES are decorative — the RPC *sequence* and body *shape*
+are what replay.
+
+NOT covered here — both need a live-auth recording session to capture a RPC
+sequence no existing cassette holds (see #1733):
+
+* ``studio_delete``'s cross-type routing — its merged notes+artifacts preflight
+  issues ``GET_NOTES_AND_MIND_MAPS`` (``cFji9``) **twice** + ``LIST_ARTIFACTS``
+  (``gArtLc``) before the delete RPC.
+* ``studio_rename`` — its kind-aware ``mind_maps.list`` probe likewise issues
+  ``cFji9`` **twice** + ``gArtLc`` (``list_note_backed`` + the interactive-map
+  ``artifacts.list``) before ``RENAME_ARTIFACT`` (``rc3d8d``); the CLI
+  ``artifacts_rename.yaml`` predates that probe and carries a single ``cFji9``.
+
+Both are otherwise unit-covered (``tests/unit/mcp/test_artifacts.py``) and their
+underlying mutation RPCs (``V5N4be`` / ``AH0mwd`` / ``rc3d8d``) are already
+VCR-exercised by the CLI suite, so neither introduces an un-tested wire shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.conftest import skip_no_cassettes
+from tests.vcr_config import notebooklm_vcr
+
+from .conftest import build_mcp_client
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# artifacts_retry_failed.yaml — the recorded ``Rytqqe`` body carries this artifact
+# id; the notebook id is decorative (lives in the URL, which the matcher ignores).
+RETRY_NOTEBOOK_ID = "f66923f0-1df4-4ffe-9822-3ed63c558b1c"
+RETRY_ARTIFACT_ID = "11111111-2222-3333-4444-555555555555"
+
+# artifacts_list.yaml — a completed REPORT artifact whose ``gArtLc`` row carries a
+# stored generation prompt (decoded from the recorded response).
+PROMPT_NOTEBOOK_ID = "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e"
+PROMPT_ARTIFACT_ID = "fdd20d4a-f422-42b3-896c-60997035f4ca"
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("artifacts_retry_failed.yaml")
+async def test_mcp_studio_retry_over_vcr() -> None:
+    """``studio_retry`` re-kicks a failed artifact through the real client over VCR.
+
+    End-to-end: tool -> ``resolve_artifact`` (full UUID, no list) ->
+    ``client.artifacts.retry_failed`` -> ``RETRY_ARTIFACT`` (``Rytqqe``). Pins the
+    non-blocking wire shape (``task_id`` + ``status``) — the mutating retry RPC a
+    mocked test cannot validate.
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "studio_retry",
+            {"notebook": RETRY_NOTEBOOK_ID, "artifact": RETRY_ARTIFACT_ID},
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["notebook_id"] == RETRY_NOTEBOOK_ID
+    assert structured["artifact_id"] == RETRY_ARTIFACT_ID
+    assert structured["task_id"], "retry must return a resume task_id"
+    assert isinstance(structured["status"], str)
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("artifacts_list.yaml")
+async def test_mcp_studio_get_prompt_over_vcr() -> None:
+    """``studio_get_prompt`` reads an artifact's generation prompt over VCR.
+
+    End-to-end: tool -> ``resolve_artifact`` (full UUID, no list) ->
+    ``get_artifact_prompt`` -> studio listing (``gArtLc`` + the mind-map facade
+    ``cFji9``) -> the row's stored prompt. Pins the ``{"notebook_id",
+    "artifact_id", "prompt"}`` wire shape with a real, non-null prompt (the pinned
+    id is a completed report whose row carries one).
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "studio_get_prompt",
+            {"notebook": PROMPT_NOTEBOOK_ID, "artifact": PROMPT_ARTIFACT_ID},
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["notebook_id"] == PROMPT_NOTEBOOK_ID
+    assert structured["artifact_id"] == PROMPT_ARTIFACT_ID
+    # This artifact records a prompt — a real string, not the valid-but-empty None.
+    assert isinstance(structured["prompt"], str)
+    assert structured["prompt"]

--- a/tests/integration/mcp_vcr/test_studio_mutations.py
+++ b/tests/integration/mcp_vcr/test_studio_mutations.py
@@ -1,32 +1,26 @@
-"""MCP Studio mutating-tool VCR tests (reuse-only).
+"""MCP Studio mutating-tool VCR tests.
 
 Full-stack coverage (MCP tool -> ``artifacts.py`` Studio adapter -> real
-``NotebookLMClient`` -> VCR-replayed RPC) for the Studio ops that were unit-only
-before #1733 and whose exact RPC sequence a recorded cassette already holds:
-``studio_retry`` and ``studio_get_prompt``. Reuses the SAME cassettes the CLI
-``artifact`` VCR suite recorded — ``NOTEBOOKLM_VCR_RECORD`` is deliberately NOT set.
+``NotebookLMClient`` -> VCR-replayed RPC) for every Studio mutating/read op that
+was unit-only before #1733: ``studio_retry``, ``studio_get_prompt``,
+``studio_rename``, and ``studio_delete`` (both cross-type routes). Replay only —
+``NOTEBOOKLM_VCR_RECORD`` is deliberately NOT set here.
 
-Every tool is invoked with FULL canonical UUIDs (the cassette's recorded
-notebook/artifact ids) so :func:`resolve_notebook` / :func:`resolve_artifact`
-take their full-UUID fast path and never add a ``LIST_NOTEBOOKS`` /
-``LIST_ARTIFACTS`` preflight the cassette lacks. The batchexecute body matcher is
-shape-only, so the id VALUES are decorative — the RPC *sequence* and body *shape*
-are what replay.
+Two cassette provenances:
 
-NOT covered here — both need a live-auth recording session to capture a RPC
-sequence no existing cassette holds (see #1733):
+* ``studio_retry`` / ``studio_get_prompt`` REUSE cassettes the CLI ``artifact``
+  VCR suite already recorded (``artifacts_retry_failed.yaml`` / ``artifacts_list.yaml``).
+* ``studio_rename`` / ``studio_delete`` needed a bespoke recording — their
+  merged-list / kind-probe preflight issues ``GET_NOTES_AND_MIND_MAPS`` (``cFji9``)
+  **twice or thrice** + ``LIST_ARTIFACTS`` (``gArtLc``) before the mutation RPC, a
+  sequence no CLI cassette holds. The ``mcp_studio_*.yaml`` cassettes were recorded
+  against a throwaway scratch notebook by ``tests/scripts/record_mcp_studio_cassettes.py``.
 
-* ``studio_delete``'s cross-type routing — its merged notes+artifacts preflight
-  issues ``GET_NOTES_AND_MIND_MAPS`` (``cFji9``) **twice** + ``LIST_ARTIFACTS``
-  (``gArtLc``) before the delete RPC.
-* ``studio_rename`` — its kind-aware ``mind_maps.list`` probe likewise issues
-  ``cFji9`` **twice** + ``gArtLc`` (``list_note_backed`` + the interactive-map
-  ``artifacts.list``) before ``RENAME_ARTIFACT`` (``rc3d8d``); the CLI
-  ``artifacts_rename.yaml`` predates that probe and carries a single ``cFji9``.
-
-Both are otherwise unit-covered (``tests/unit/mcp/test_artifacts.py``) and their
-underlying mutation RPCs (``V5N4be`` / ``AH0mwd`` / ``rc3d8d``) are already
-VCR-exercised by the CLI suite, so neither introduces an un-tested wire shape.
+Every tool is invoked with the FULL canonical UUIDs recorded in each cassette so
+:func:`resolve_notebook` / :func:`resolve_artifact` take their full-UUID fast path.
+For ``studio_delete`` / ``studio_rename`` the id VALUES are load-bearing (not
+decorative): the tool resolves the ``item`` over the merged list response, so the
+ref must match an id actually recorded there.
 """
 
 from __future__ import annotations
@@ -49,6 +43,13 @@ RETRY_ARTIFACT_ID = "11111111-2222-3333-4444-555555555555"
 # stored generation prompt (decoded from the recorded response).
 PROMPT_NOTEBOOK_ID = "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e"
 PROMPT_ARTIFACT_ID = "fdd20d4a-f422-42b3-896c-60997035f4ca"
+
+# mcp_studio_*.yaml — recorded (scratch-notebook) ids. The notebook holds ONE note
+# and ONE report; studio_delete/rename resolve these ids over the merged list, so
+# the values must match the ids the recorded LIST responses carry.
+STUDIO_NOTEBOOK_ID = "9b8fb5be-3897-4360-8d19-fc7eae295747"
+STUDIO_REPORT_ID = "6384b603-5734-433c-b2d8-62b490ad4a54"
+STUDIO_NOTE_ID = "a1384eaf-25fa-43eb-ac76-8154f45c0a05"
 
 
 @pytest.mark.asyncio
@@ -99,3 +100,88 @@ async def test_mcp_studio_get_prompt_over_vcr() -> None:
     # This artifact records a prompt — a real string, not the valid-but-empty None.
     assert isinstance(structured["prompt"], str)
     assert structured["prompt"]
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("mcp_studio_rename.yaml")
+async def test_mcp_studio_rename_over_vcr() -> None:
+    """``studio_rename`` retitles a regular artifact through the real client over VCR.
+
+    End-to-end: tool -> ``resolve_artifact`` (full UUID, no list) ->
+    ``rename_artifact`` -> a kind-aware ``mind_maps.list`` probe
+    (``list_note_backed`` ``cFji9`` + ``artifacts.list`` ``gArtLc`` + facade
+    ``cFji9``; the id is NOT a mind map) -> ``client.artifacts.rename`` ->
+    ``RENAME_ARTIFACT`` (``rc3d8d``). Pins the ``{"status": "renamed", ...,
+    "is_mind_map": False}`` wire shape — the mutating rename RPC a mocked test
+    cannot validate.
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "studio_rename",
+            {
+                "notebook": STUDIO_NOTEBOOK_ID,
+                "artifact": STUDIO_REPORT_ID,
+                "new_title": "Renamed by VCR",
+            },
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "renamed"
+    assert structured["notebook_id"] == STUDIO_NOTEBOOK_ID
+    assert structured["artifact_id"] == STUDIO_REPORT_ID
+    assert structured["new_title"] == "Renamed by VCR"
+    assert structured["is_mind_map"] is False
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("mcp_studio_delete_note.yaml")
+async def test_mcp_studio_delete_note_over_vcr() -> None:
+    """``studio_delete`` of a NOTE routes to the note system (cross-type routing).
+
+    The headline #1733 proof: end-to-end, the merged notes+artifacts preflight
+    (``GET_NOTES_AND_MIND_MAPS`` ``cFji9`` ×2 + ``LIST_ARTIFACTS`` ``gArtLc``)
+    resolves ``item`` as a ``note`` and routes it to ``execute_note_delete`` ->
+    ``DELETE_NOTE`` (``AH0mwd``) — NOT the artifact delete path. ``confirm=True`` is
+    required; the default preview does not touch the wire.
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "studio_delete",
+            {"notebook": STUDIO_NOTEBOOK_ID, "item": STUDIO_NOTE_ID, "confirm": True},
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "deleted"
+    assert structured["notebook_id"] == STUDIO_NOTEBOOK_ID
+    assert structured["item_id"] == STUDIO_NOTE_ID
+    # Resolved as a note -> note-delete route (proves the cross-type discriminator).
+    assert structured["type"] == "note"
+    assert structured["was_note_backed"] is False
+
+
+@pytest.mark.asyncio
+@notebooklm_vcr.use_cassette("mcp_studio_delete_artifact.yaml")
+async def test_mcp_studio_delete_artifact_over_vcr() -> None:
+    """``studio_delete`` of a regular artifact routes to the artifact delete RPC.
+
+    The other cross-type branch: the merged preflight (``cFji9`` ×2 + ``gArtLc``)
+    resolves ``item`` as a ``report``, then ``delete_artifact``'s note-backed probe
+    (``list_note_backed`` ``cFji9``) finds no match and routes to
+    ``client.artifacts.delete`` -> ``DELETE_ARTIFACT`` (``V5N4be``).
+    """
+    async with build_mcp_client() as mcp_client:
+        result = await mcp_client.call_tool(
+            "studio_delete",
+            {"notebook": STUDIO_NOTEBOOK_ID, "item": STUDIO_REPORT_ID, "confirm": True},
+        )
+
+    structured = result.structured_content
+    assert isinstance(structured, dict)
+    assert structured["status"] == "deleted"
+    assert structured["notebook_id"] == STUDIO_NOTEBOOK_ID
+    assert structured["item_id"] == STUDIO_REPORT_ID
+    assert structured["type"] == "report"
+    # A regular artifact, not a note-backed mind map -> artifacts.delete path.
+    assert structured["was_note_backed"] is False

--- a/tests/scripts/record_mcp_studio_cassettes.py
+++ b/tests/scripts/record_mcp_studio_cassettes.py
@@ -1,0 +1,157 @@
+"""Maintainer helper: record the MCP Studio mutating-op cassettes against live API.
+
+``studio_delete`` (cross-type note∩artifact routing) and ``studio_rename`` each
+issue ``GET_NOTES_AND_MIND_MAPS`` (``cFji9``) TWICE + ``LIST_ARTIFACTS`` (``gArtLc``)
+as a merged-list / kind-probe preflight BEFORE their mutation RPC — a sequence no
+CLI cassette holds. This script drives the **MCP server** (real ``NotebookLMClient``,
+auth from your ``~/.notebooklm`` profile) under VCR record mode so the recorded
+``f.req`` shapes are exactly what the Studio tools emit.
+
+It is SELF-CONTAINED and DESTRUCTIVE-SAFE: it creates a throwaway scratch notebook
+(one text source, one text note, one generated report), records the three cassettes
+against THAT notebook, then deletes the scratch notebook in a ``finally``. It never
+touches any pre-existing notebook.
+
+Records (into ``tests/cassettes``):
+  * ``mcp_studio_rename.yaml``        — studio_rename(report) → cFji9×2 + gArtLc + rc3d8d
+  * ``mcp_studio_delete_note.yaml``   — studio_delete(note)   → cFji9×2 + gArtLc + AH0mwd
+  * ``mcp_studio_delete_artifact.yaml`` — studio_delete(report) → cFji9×3 + gArtLc + V5N4be
+
+Usage (maintainer, one Google account; consumes a little generation quota)::
+
+    uv run python tests/scripts/record_mcp_studio_cassettes.py
+
+After recording, verify the cassettes are clean:
+
+    uv run python tests/scripts/check_cassettes_clean.py --strict --recursive
+
+CI never runs this script. Replay uses scrubbed cassettes + mock auth.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Make the repo root importable so ``tests.vcr_config`` resolves under a plain
+# ``python`` run (pytest sets pythonpath=["."]; a direct run does not).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+# Record mode + keepalive-poke disable MUST be set before importing the VCR config
+# (its record_mode is computed at import time) and before any client opens (so the
+# RotateCookies poke never records a stray interaction into a cassette).
+os.environ["NOTEBOOKLM_VCR_RECORD"] = "1"
+os.environ["NOTEBOOKLM_DISABLE_KEEPALIVE_POKE"] = "1"
+
+from fastmcp import Client  # noqa: E402
+from tests.vcr_config import notebooklm_vcr  # noqa: E402
+
+from notebooklm.mcp.server import create_server  # noqa: E402
+
+SCRATCH_TITLE = "zzz-mcp-studio-vcr-scratch"
+SOURCE_TEXT = (
+    "The mitochondrion is the powerhouse of the cell. It generates most of the "
+    "cell's supply of adenosine triphosphate (ATP), used as a source of chemical "
+    "energy. This is scratch content for a throwaway VCR recording notebook."
+)
+
+
+def _sc(result: object) -> dict:
+    """Pull the structured_content dict off a FastMCP call_tool result."""
+    sc = getattr(result, "structured_content", None)
+    assert isinstance(sc, dict), f"expected structured_content dict, got {result!r}"
+    return sc
+
+
+async def main() -> None:
+    server = create_server()
+    async with Client(server) as mcp:
+        nb_id: str | None = None
+        try:
+            # --- SETUP (outside any cassette → live, NOT recorded) ---------------
+            nb_id = _sc(await mcp.call_tool("notebook_create", {"title": SCRATCH_TITLE}))[
+                "notebook_id"
+            ]
+            print(f"scratch notebook: {nb_id}")
+
+            await mcp.call_tool(
+                "source_add",
+                {
+                    "notebook": nb_id,
+                    "source_type": "text",
+                    "text": SOURCE_TEXT,
+                    "title": "Scratch source",
+                },
+            )
+            await mcp.call_tool("source_wait", {"notebook": nb_id, "timeout": 180})
+
+            note_id = _sc(
+                await mcp.call_tool(
+                    "note_save",
+                    {"notebook": nb_id, "title": "Scratch note", "content": "Delete me."},
+                )
+            )["note_id"]
+            print(f"scratch note: {note_id}")
+
+            gen = _sc(
+                await mcp.call_tool(
+                    "studio_generate", {"notebook": nb_id, "artifact_type": "report"}
+                )
+            )
+            print(f"generating report: task_id={gen.get('task_id')}")
+
+            # The artifact only needs to APPEAR in the studio listing to be
+            # rename/delete-able (a pending row is fine). The generation task_id is
+            # not guaranteed to equal the listed artifact id, so grab the report
+            # row's own id from studio_list (the fresh notebook has exactly one).
+            art_id: str | None = None
+            for _ in range(40):
+                items = _sc(await mcp.call_tool("studio_list", {"notebook": nb_id}))["items"]
+                reports = [it for it in items if it.get("type") == "report"]
+                if reports:
+                    art_id = str(reports[0]["id"])
+                    break
+                await asyncio.sleep(3)
+            if art_id is None:
+                raise SystemExit("generated report never appeared in studio_list")
+            print(f"report artifact: {art_id}")
+
+            # --- RECORD (each op in its own cassette) ---------------------------
+            with notebooklm_vcr.use_cassette("mcp_studio_rename.yaml"):
+                r = _sc(
+                    await mcp.call_tool(
+                        "studio_rename",
+                        {"notebook": nb_id, "artifact": art_id, "new_title": "Renamed by VCR"},
+                    )
+                )
+                print("rename ->", r)
+
+            with notebooklm_vcr.use_cassette("mcp_studio_delete_note.yaml"):
+                r = _sc(
+                    await mcp.call_tool(
+                        "studio_delete", {"notebook": nb_id, "item": note_id, "confirm": True}
+                    )
+                )
+                print("delete note ->", r)
+
+            with notebooklm_vcr.use_cassette("mcp_studio_delete_artifact.yaml"):
+                r = _sc(
+                    await mcp.call_tool(
+                        "studio_delete", {"notebook": nb_id, "item": art_id, "confirm": True}
+                    )
+                )
+                print("delete artifact ->", r)
+
+            print("\nRECORDED IDS (for the replay tests):")
+            print(f"  RENAME/DELETE_ARTIFACT nb={nb_id} art={art_id}")
+            print(f"  DELETE_NOTE            nb={nb_id} note={note_id}")
+        finally:
+            if nb_id is not None:
+                await mcp.call_tool("notebook_delete", {"notebook": nb_id, "confirm": True})
+                print(f"cleaned up scratch notebook {nb_id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

`mcp_vcr` integration tests that drive the **real** `NotebookLMClient` over VCR, validating the actual `batchexecute` request/response shapes for domains that were exercised only by mocked-client unit tests — exactly the position-sensitive-nested-params class of bug (CLAUDE.md pitfall #2) a mock passes and a VCR test catches. Replay-only; `NOTEBOOKLM_VCR_RECORD` is never set at test time.

## #1732 — sharing (closed)

`tests/integration/mcp_vcr/test_sharing.py` — all four sharing tools, reusing committed CLI cassettes:

| tool | RPC | cassette |
|------|-----|----------|
| `share_status` | `JFMDGd` | `cli_share_status.yaml` |
| `share_set_user` | `QDyure` + `JFMDGd` | `cli_share_add.yaml` |
| `share_set_access(public=True)` | `QDyure` + `JFMDGd` | `sharing_set_public.yaml` |
| `share_remove_user(confirm=True)` | `QDyure` + `JFMDGd` | `cli_share_remove.yaml` |

## #1733 — studio mutating ops (closed)

`tests/integration/mcp_vcr/test_studio_mutations.py` — every op that was unit-only:

- **Reuse** (existing cassettes): `studio_retry` (`Rytqqe`), `studio_get_prompt` (`gArtLc` + facade).
- **Live-recorded** (bespoke cassettes — their merged-list / kind-probe preflight issues `cFji9` 2–3× + `gArtLc` before the mutation RPC, a sequence no CLI cassette holds):
  - `studio_delete` of a **note** → `cFji9`×2 + `gArtLc` + **`AH0mwd`** (DELETE_NOTE)
  - `studio_delete` of a **report** → `cFji9`×3 + `gArtLc` + **`V5N4be`** (DELETE_ARTIFACT)
  - `studio_rename` → `cFji9`×2 + `gArtLc`×2 + **`rc3d8d`**

The note→DELETE_NOTE vs report→DELETE_ARTIFACT split proves the **cross-type routing discriminator** end-to-end over the wire. Recorded by `tests/scripts/record_mcp_studio_cassettes.py` (self-contained, destructive-safe — creates and deletes its own scratch notebook; CI never runs it).

## Scrubbing / safety

Sensitive-data scrubbing verified: `check_cassettes_clean.py --strict --recursive` → **0 leaks** (128 cassettes). The three new cassettes were recorded against a **throwaway scratch notebook** that the script deletes on exit; no pre-existing notebook was touched. No source changes.

## Test

- `pytest tests/integration/mcp_vcr/` → 40 passed
- `pytest tests/_guardrails/` → 1071 passed (incl. per-cassette clean check)
- `mypy src/notebooklm` · `ruff check`/`format` → clean

Closes #1732
Closes #1733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6TEiVAR3ywy7FEYrgy9Az
