### PR TITLE
test: fix auth-load heartbeat CI flake at the source (cheaper tick)

### DIFF
--- a/tests/unit/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/unit/concurrency/test_auth_load_blocks_loop.py
@@ -16,7 +16,7 @@ This test monkeypatches ``notebooklm._auth.storage.save_cookies_to_storage`` to
 ``time.sleep(0.5)``. While ``AuthTokens.from_storage`` is mid-save, a
 concurrently scheduled async task increments a counter every 50 ms.
 Pre-fix the counter is ~0–1 (loop frozen by the sync sleep); post-fix
-it is >= 5 (the sleep runs on a thread, loop keeps ticking).
+it ticks ~10 times (the sleep runs on a thread, loop keeps spinning).
 
 These are unit-style regression tests under ``tests/unit/concurrency/`` so the
 blocking-I/O contract is exercised without the integration harness.
@@ -42,16 +42,21 @@ from notebooklm.auth import AuthTokens
 _SLEEP_SECONDS = 0.5
 
 # Heartbeat cadence for the sibling task that proves the loop is alive.
-# 50 ms gives ~10 ticks in the 0.5 s window; we assert >= 5 to allow for
-# scheduler jitter, CI noise, and the unavoidable initial round-trip
-# before the save site is reached.
+# 50 ms gives ~10 ticks in the 0.5 s window. The tick is a bare ``asyncio.sleep``
+# (see ``_heartbeat``) so per-tick overhead stays tiny even under coverage
+# instrumentation — an earlier ``wait_for(Event.wait())`` tick built a future +
+# timer and raised/caught a ``TimeoutError`` every iteration, and coverage.py
+# tracing that machinery inflated the period enough to drop the count to 4 on a
+# contended macOS CI runner (flaking a >=5 bound).
 _HEARTBEAT_INTERVAL = 0.05
 
-# Lower bound on observed heartbeats during the save window. Pre-fix
-# the synchronous sleep blocks the loop for ~0.5 s, so the counter
-# stays at 0 or 1 (one tick may sneak in before the save is entered).
-# Post-fix the loop is free; 5 is comfortably below the ~10 expected.
-_MIN_HEARTBEATS = 5
+# Lower bound on observed heartbeats during the save window. This test is a
+# FROZEN-vs-ALIVE discriminator, not a throughput benchmark: pre-fix the
+# synchronous sleep blocks the loop for ~0.5 s so the counter stays at 0 or 1
+# (one tick may sneak in before the save is entered); post-fix the loop is free
+# and ticks ~10 times. 3 sits cleanly above the frozen ceiling (1) with wide
+# margin below the healthy count — the number is a floor, not a target.
+_MIN_HEARTBEATS = 3
 
 
 @pytest.mark.asyncio
@@ -63,7 +68,7 @@ async def test_from_storage_save_does_not_block_event_loop(
     """``AuthTokens.from_storage`` must not freeze the loop on save.
 
     Wraps a ``time.sleep(0.5)`` over the storage save and asserts a
-    concurrently scheduled heartbeat ticks at least 5 times during the
+    concurrently scheduled heartbeat keeps ticking during the
     save window — proof that the save runs off the loop (i.e. via
     ``asyncio.to_thread``).
     """
@@ -108,10 +113,12 @@ async def test_from_storage_save_does_not_block_event_loop(
         """Increment a counter every _HEARTBEAT_INTERVAL until stopped."""
         nonlocal heartbeats
         while not stop.is_set():
-            try:
-                await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL)
-            except asyncio.TimeoutError:
-                heartbeats += 1
+            # Bare sleep, not wait_for(Event) — a cheap tick keeps the count
+            # stable under coverage (see _HEARTBEAT_INTERVAL). Shutdown latency is
+            # one interval (the awaiting `finally` absorbs it); a frozen loop still
+            # can't fire this sleep during the save, so it stays the 0-1 baseline.
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            heartbeats += 1
 
     heartbeat_task = asyncio.create_task(_heartbeat())
     try:
@@ -180,10 +187,12 @@ async def test_fetch_tokens_with_domains_save_does_not_block_event_loop(
     async def _heartbeat() -> None:
         nonlocal heartbeats
         while not stop.is_set():
-            try:
-                await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL)
-            except asyncio.TimeoutError:
-                heartbeats += 1
+            # Bare sleep, not wait_for(Event) — a cheap tick keeps the count
+            # stable under coverage (see _HEARTBEAT_INTERVAL). Shutdown latency is
+            # one interval (the awaiting `finally` absorbs it); a frozen loop still
+            # can't fire this sleep during the save, so it stays the 0-1 baseline.
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            heartbeats += 1
 
     heartbeat_task = asyncio.create_task(_heartbeat())
     try:


### PR DESCRIPTION
## Problem

`tests/unit/concurrency/test_auth_load_blocks_loop.py` failed on **macOS Python 3.13** in the post-merge run for #1735 ([job](https://github.com/teng-lin/notebooklm-py/actions/runs/28589016822/job/84767740674)): `only 4 heartbeats fired in 0.5s (expected >= 5)`.

## Diagnosis — flake, not a regression

The two tests prove `AuthTokens.from_storage` / `fetch_tokens_with_domains` run their blocking storage save on a **worker thread** by counting heartbeats from a sibling task during the save: **frozen** loop ⇒ 0–1 ticks, **alive** ⇒ ~10. Evidence it's a flake: 15/16 jobs in the same run passed on identical code; #1735 touches no auth/storage/concurrency files; first failure of this test in the last 15 main runs.

**Root cause (mechanistic):** each tick did `await asyncio.wait_for(stop.wait(), timeout=…)` — which builds a future, arms a timer, and raises+catches a `TimeoutError` *every iteration*. `coverage.py` (CI runs `--cov`) traces all that machinery, so the effective tick period inflated on a contended arm64 runner until the count sagged into the `>= 5` bound. It was **not** the loop actually blocking (it ticked 4×, proving it was alive) and **not** GIL contention (`time.sleep` releases the GIL).

## Fix — at the source, not just the threshold

- **Cheaper tick:** replace the `wait_for(Event.wait())` tick with a bare `asyncio.sleep(interval)` (also *simpler* — drops the try/except). Per-tick overhead stays tiny under coverage, so the healthy count returns to ~10 with wide margin. This removes the actual flake source rather than nudging the bar down inside the noisy regime.
- **Threshold 5 → 3:** kept as a defensive floor cleanly above the 0–1 frozen ceiling — the number is now a floor, not a throughput target.

Frozen-vs-alive detection is unchanged: a genuinely blocked loop still can't fire the sleep during the save, so it stays at the 0–1 baseline and the test still catches the real regression.

The flaked job on main has also been re-run to clear its status.

## Test

`pytest tests/unit/concurrency/` → 26 passed · ruff check + format clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated concurrency regression coverage to be less timing-sensitive and more reliable across environments.
  * Strengthened the check that the app remains responsive during a delayed save operation.
  * Adjusted heartbeat timing expectations to better reflect normal scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->