### PR TITLE
feat(mcp): source_wait subset targeting + source_list label filter

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -10,8 +10,8 @@ flow through ``_app.source_add`` (``build_source_add_plan`` + ``execute_source_a
 ``drive`` flows through ``_app.source_mutations.execute_source_add_drive`` (the
 neutral ``source_add`` core has no Drive path). It also has a batch mode
 (``urls=[...]``) that adds many http(s) URLs sequentially and returns an explicit
-per-item result list. ``source_wait`` waits for one source when ``source`` is
-given, else every source in the notebook.
+per-item result list. ``source_wait`` waits for a subset when ``sources`` is
+given, one source when ``source`` is given, else every source in the notebook.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -358,20 +358,26 @@ def register(mcp: Any) -> None:
             if interval <= 0:
                 raise ValidationError(f"interval must be > 0; got {interval}")
 
+            # All input guards fire BEFORE any I/O (fail-fast, like the bounds
+            # checks above): the empty-``sources`` and mutual-exclusion errors must
+            # not be masked by a notebook NOT_FOUND from ``resolve_notebook``.
             coerced = coerce_list(sources)
             if source is not None and coerced is not None:
                 raise ValidationError(
                     "pass either 'source' (one) or 'sources' (a subset), not both"
                 )
+            if coerced is not None and not coerced:
+                raise ValidationError(
+                    "'sources' was empty; omit it to wait on all sources, or pass at least one source ref"
+                )
 
             nb_id = await resolve_notebook(client, notebook)
 
             if coerced is not None:
-                if not coerced:
-                    raise ValidationError(
-                        "'sources' was empty; omit it to wait on all sources, or pass at least one source ref"
-                    )
-                src_ids = await resolve_sources(client, nb_id, coerced)
+                # Dedupe: distinct refs can resolve to the same id (title + its id,
+                # or a literal repeat), which would spawn redundant pollers and emit
+                # duplicate ``ready`` rows. ``dict.fromkeys`` preserves input order.
+                src_ids = list(dict.fromkeys(await resolve_sources(client, nb_id, coerced)))
                 outcomes = await _wait_all_sources(
                     client, nb_id, src_ids, timeout=timeout, interval=interval
                 )

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -26,8 +26,10 @@ from typing import TYPE_CHECKING, Any, Literal
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
 
+from ..._app import labels as labels_core
 from ..._app import source_add as add_core
 from ..._app import source_content as content_core
+from ..._app import source_listing as listing_core
 from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
 from ..._app.serialize import to_jsonable
@@ -40,12 +42,13 @@ from ...exceptions import (
 )
 from ...types import source_status_to_str
 from ...urls import is_youtube_url
+from .._coerce import coerce_list
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors, tool_error_payload
 from .._filelink import UPLOAD_TTL, FileTransferConfig
 from .._paginate import DEFAULT_LIMIT, paginate
-from .._resolve import resolve_notebook, resolve_source
+from .._resolve import resolve_notebook, resolve_source, resolve_sources
 from ._content_sanity import _annotate_thin_warnings
 from ._passthrough import passthrough_child_id
 from ._preview import title_for_id
@@ -123,28 +126,29 @@ def register(mcp: Any) -> None:
         ctx: Context,
         notebook: str,
         status: Literal["ready", "processing", "error", "preparing"] | None = None,
+        label: str | None = None,
         limit: int = DEFAULT_LIMIT,
         offset: int = 0,
     ) -> dict[str, Any]:
         """List a notebook's sources. Accepts a notebook name or ID.
 
-        Each source carries string ``kind`` / ``status_label`` labels (not just the
-        raw type/status codes) so an agent never has to guess the enums.
+        Each source carries string ``kind`` / ``status_label`` labels alongside the
+        raw codes, so an agent never has to guess the enums.
 
-        Pass ``status`` to return only sources whose ``status_label`` matches —
-        filter by the SAME label the listing emits. ``error`` is a failed import
-        (the "ghost row" left by a broken ``source_add``); use
-        ``source_list(status="error")`` to find them without paging the whole list,
-        then clean up with ``source_delete``. Omitting ``status`` returns every
-        source (unchanged behavior).
+        Pass ``status`` to return only sources whose ``status_label`` matches.
+        ``error`` is a failed import (the "ghost row" from a broken ``source_add``);
+        use ``source_list(status="error")`` to find them, then clean up with
+        ``source_delete``. Omitting ``status`` returns every source.
 
-        A ``label`` filter is not offered yet: labels are a notebook-level concept,
-        not a per-source attribute, so there is nothing to filter on here today.
+        Pass ``label`` (name or ID) to restrict to that label's members; composes
+        with ``status`` (resolves by ID, unambiguous prefix, or exact name).
         """
         client = get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
-            sources = await client.sources.list(nb_id)
+            sources = await listing_core.fetch_sources(
+                client, nb_id, label_filter=label, label_resolver=labels_core.resolve_label_id
+            )
             # Filter on the raw Source BEFORE serializing, so _source_view (which
             # runs to_jsonable) is only paid for the sources that survive the
             # filter. Uses the same source_status_to_str label _source_view emits.
@@ -320,34 +324,32 @@ def register(mcp: Any) -> None:
         ctx: Context,
         notebook: str,
         source: str | None = None,
+        sources: list[str] | str | None = None,
         timeout: float = 120.0,
         interval: float = 1.0,
     ) -> dict[str, Any]:
         """Wait for sources to finish processing. Accepts a notebook name or ID.
 
-        Waits for a single source when ``source`` (name or ID) is given, otherwise
-        for every source in the notebook. BOTH modes return the SAME structured
-        aggregate, so an agent never has to branch on the shape:
+        Waits for a subset when ``sources`` (list or comma/JSON string) is given, a
+        single source when ``source`` (name or ID) is given, else every source. All
+        three modes return the SAME structured aggregate, so an agent never has to
+        branch on the shape:
 
             {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
 
-        ``ready`` holds the sources that reached READY (each with ``kind`` /
-        ``status_label`` labels); ``timed_out`` / ``failed`` / ``not_found`` hold
-        ``{"source_id", "error"}`` entries for the sources that did not. ``ok`` is
-        ``true`` iff all three error buckets are empty. The all-sources mode reports
-        **partial progress** — a slow or failed source no longer discards the ones
-        that did become ready.
+        ``ready`` holds sources that reached READY (with ``kind`` / ``status_label``
+        labels); ``timed_out`` / ``failed`` / ``not_found`` hold ``{"source_id",
+        "error"}`` entries. ``ok`` is ``true`` iff all error buckets are empty. Subset
+        and all-sources modes report **partial progress** (a slow or failed source no
+        longer discards the ones that did become ready).
 
-        A READY **web-page** entry may carry a non-blocking ``warning`` when its
-        indexed text is suspiciously thin — a likely dead link / soft-404 / paywalled
-        "ghost source" add-time status can't catch. Advisory only (still READY, still
-        ``ok``; verify with ``source_read`` (detail="full")); short pasted text / transcripts
-        are never flagged.
+        A READY **web-page** entry may carry a non-blocking ``warning`` when its indexed
+        text is suspiciously thin (likely dead link / soft-404 / paywall); advisory only
+        (still READY, still ``ok`` — verify with ``source_read`` (detail="full")).
 
-        A single-source ``source`` ref that does not resolve (e.g. an unknown title)
-        still raises NOT_FOUND before the wait — that is an input error, distinct
-        from a resolved source the backend reports missing/failed/slow (which lands
-        in a bucket).
+        An unresolved ref in ``sources`` / ``source`` raises NOT_FOUND before the wait —
+        an input error, distinct from a resolved source the backend reports missing /
+        failed / slow (which lands in a bucket).
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -355,8 +357,26 @@ def register(mcp: Any) -> None:
                 raise ValidationError(f"timeout must be >= 0; got {timeout}")
             if interval <= 0:
                 raise ValidationError(f"interval must be > 0; got {interval}")
+
+            coerced = coerce_list(sources)
+            if source is not None and coerced is not None:
+                raise ValidationError(
+                    "pass either 'source' (one) or 'sources' (a subset), not both"
+                )
+
             nb_id = await resolve_notebook(client, notebook)
-            if source is not None:
+
+            if coerced is not None:
+                if not coerced:
+                    raise ValidationError(
+                        "'sources' was empty; omit it to wait on all sources, or pass at least one source ref"
+                    )
+                src_ids = await resolve_sources(client, nb_id, coerced)
+                outcomes = await _wait_all_sources(
+                    client, nb_id, src_ids, timeout=timeout, interval=interval
+                )
+                return await _aggregate_wait_outcomes(client, nb_id, outcomes)
+            elif source is not None:
                 src_id = await resolve_source(client, nb_id, source)
                 outcome = await wait_core.execute_source_wait(
                     client,
@@ -368,11 +388,16 @@ def register(mcp: Any) -> None:
                     ),
                 )
                 return await _aggregate_wait_outcomes(client, nb_id, [outcome])
-            sources = await client.sources.list(nb_id)
-            outcomes = await _wait_all_sources(
-                client, nb_id, [s.id for s in sources], timeout=timeout, interval=interval
-            )
-            return await _aggregate_wait_outcomes(client, nb_id, outcomes)
+            else:
+                sources_list = await client.sources.list(nb_id)
+                outcomes = await _wait_all_sources(
+                    client,
+                    nb_id,
+                    [s.id for s in sources_list],
+                    timeout=timeout,
+                    interval=interval,
+                )
+                return await _aggregate_wait_outcomes(client, nb_id, outcomes)
 
     @mcp.tool
     async def source_add(

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,6 +31,7 @@ from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
 )
 from notebooklm.mcp._errors import tool_error_payload  # noqa: E402 - after importorskip guard
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
+from notebooklm.types import Label  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -1710,6 +1712,58 @@ async def test_source_wait_empty_sources_raises(mcp_call, mock_client) -> None:
     assert "was empty" in str(excinfo.value)
 
 
+async def test_source_wait_subset_json_array_string(mcp_call, mock_client) -> None:
+    """Subset mode: accepts a JSON-array string, coerced to a list (end-to-end)."""
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            SRC_ID: FakeSource(id=SRC_ID, title="A"),
+            SRC2_ID: FakeSource(id=SRC2_ID, title="B"),
+        }
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    result = await mcp_call(
+        "source_wait", {"notebook": NB_ID, "sources": f'["{SRC_ID}","{SRC2_ID}"]'}
+    )
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert {row["id"] for row in sc["ready"]} == {SRC_ID, SRC2_ID}
+
+
+async def test_source_wait_subset_dedupes(mcp_call, mock_client) -> None:
+    """Subset mode: a repeated ref collapses to one poll + one ready row."""
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {SRC_ID: FakeSource(id=SRC_ID, title="A")}
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "sources": [SRC_ID, SRC_ID]})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert [row["id"] for row in sc["ready"]] == [SRC_ID]
+    # Deduped BEFORE waiting: the source is polled exactly once, not twice.
+    assert mock_client.sources.wait_until_ready.call_count == 1
+
+
+async def test_source_wait_empty_sources_fails_before_notebook_lookup(
+    mcp_call, mock_client
+) -> None:
+    """Empty-``sources`` is an input error that fires BEFORE any I/O.
+
+    A bad notebook ref must NOT mask the VALIDATION error: the guard runs before
+    ``resolve_notebook``, so ``client.notebooks.list`` is never awaited.
+    """
+    mock_client.notebooks.list = AsyncMock(side_effect=AssertionError("resolve_notebook ran"))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_wait", {"notebook": "no-such-notebook", "sources": []})
+    assert "VALIDATION" in str(excinfo.value)
+    assert "was empty" in str(excinfo.value)
+    mock_client.notebooks.list.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # source_list label filter (#1745)
 # ---------------------------------------------------------------------------
@@ -1717,9 +1771,6 @@ async def test_source_wait_empty_sources_raises(mcp_call, mock_client) -> None:
 
 async def test_source_list_label_filter(mcp_call, mock_client) -> None:
     """Filtering source list by label returns only member sources."""
-    from unittest.mock import MagicMock
-
-    from notebooklm.types import Label
 
     mock_client.labels = MagicMock()
     mock_client.labels.list = AsyncMock(
@@ -1738,9 +1789,6 @@ async def test_source_list_label_filter(mcp_call, mock_client) -> None:
 
 async def test_source_list_label_and_status_filter(mcp_call, mock_client) -> None:
     """Label and status filters compose to further narrow the result."""
-    from unittest.mock import MagicMock
-
-    from notebooklm.types import Label
 
     mock_client.labels = MagicMock()
     mock_client.labels.list = AsyncMock(
@@ -1762,8 +1810,6 @@ async def test_source_list_label_and_status_filter(mcp_call, mock_client) -> Non
 
 async def test_source_list_unknown_label_raises(mcp_call, mock_client) -> None:
     """An unknown label raises NOT_FOUND structured error."""
-    from unittest.mock import MagicMock
-
     mock_client.labels = MagicMock()
     mock_client.labels.list = AsyncMock(return_value=[])
 
@@ -1774,9 +1820,6 @@ async def test_source_list_unknown_label_raises(mcp_call, mock_client) -> None:
 
 async def test_source_list_ambiguous_label_raises(mcp_call, mock_client) -> None:
     """An ambiguous label token raises AMBIGUOUS_* structured error."""
-    from unittest.mock import MagicMock
-
-    from notebooklm.types import Label
 
     mock_client.labels = MagicMock()
     mock_client.labels.list = AsyncMock(

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1620,3 +1620,173 @@ async def test_source_add_batch_youtube_accepted(mcp_call, mock_client) -> None:
     }
     mock_client.sources.add_url.assert_awaited_once_with(NB_ID, yt)
     mock_client.sources.get_fulltext.assert_awaited_once_with(NB_ID, SRC_ID, output_format="text")
+
+
+# ---------------------------------------------------------------------------
+# source_wait subset targeting (#1745)
+# ---------------------------------------------------------------------------
+
+
+async def test_source_wait_subset_ready(mcp_call, mock_client) -> None:
+    """Subset mode: waits only on specified sources; returns aggregate outcomes."""
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            SRC_ID: FakeSource(id=SRC_ID, title="A"),
+            SRC2_ID: FakeSource(id=SRC2_ID, title="B"),
+        }
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    # Subset targeting with a list of IDs.
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "sources": [SRC_ID, SRC2_ID]})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert {row["id"] for row in sc["ready"]} == {SRC_ID, SRC2_ID}
+    assert sc["timed_out"] == sc["failed"] == sc["not_found"] == []
+
+
+async def test_source_wait_subset_comma_string(mcp_call, mock_client) -> None:
+    """Subset mode: accepts comma-separated string, coerced to list."""
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            SRC_ID: FakeSource(id=SRC_ID, title="A"),
+            SRC2_ID: FakeSource(id=SRC2_ID, title="B"),
+        }
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "sources": f"{SRC_ID},{SRC2_ID}"})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is True
+    assert {row["id"] for row in sc["ready"]} == {SRC_ID, SRC2_ID}
+
+
+async def test_source_wait_subset_partial_failures(mcp_call, mock_client) -> None:
+    """Subset mode: wait on multiple sources with some failing/timing out."""
+    mock_client.sources.wait_until_ready = _dispatch_wait_until_ready(
+        {
+            SRC_ID: FakeSource(id=SRC_ID, title="A"),
+            SRC2_ID: SourceTimeoutError(SRC2_ID, 5.0),
+        }
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "sources": [SRC_ID, SRC2_ID]})
+    sc = result.structured_content
+    _assert_aggregate_shape(sc)
+    assert sc["ok"] is False
+    assert [row["id"] for row in sc["ready"]] == [SRC_ID]
+    assert [e["source_id"] for e in sc["timed_out"]] == [SRC2_ID]
+
+
+async def test_source_wait_subset_unresolvable_raises(mcp_call, mock_client) -> None:
+    """An unresolvable ref in subset raises NOT_FOUND before waiting."""
+    mock_client.sources.list = AsyncMock(return_value=[FakeSource(id=SRC_ID, title="Doc")])
+    mock_client.sources.wait_until_ready = AsyncMock()
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_wait", {"notebook": NB_ID, "sources": [SRC_ID, "unresolvable_ref"]})
+    assert "NOT_FOUND" in str(excinfo.value)
+    mock_client.sources.wait_until_ready.assert_not_called()
+
+
+async def test_source_wait_mutual_exclusion(mcp_call, mock_client) -> None:
+    """Providing both source and sources raises a validation error."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID, "sources": [SRC2_ID]})
+    assert "VALIDATION" in str(excinfo.value)
+    assert "not both" in str(excinfo.value)
+
+
+async def test_source_wait_empty_sources_raises(mcp_call, mock_client) -> None:
+    """Providing an empty sources list/string raises a validation error."""
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_wait", {"notebook": NB_ID, "sources": []})
+    assert "VALIDATION" in str(excinfo.value)
+    assert "was empty" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# source_list label filter (#1745)
+# ---------------------------------------------------------------------------
+
+
+async def test_source_list_label_filter(mcp_call, mock_client) -> None:
+    """Filtering source list by label returns only member sources."""
+    from unittest.mock import MagicMock
+
+    from notebooklm.types import Label
+
+    mock_client.labels = MagicMock()
+    mock_client.labels.list = AsyncMock(
+        return_value=[Label(id="lbl_work", name="Work", source_ids=[SRC_ID])]
+    )
+    mock_client.labels.sources = AsyncMock(return_value=[FakeSource(id=SRC_ID, title="WorkDoc")])
+
+    result = await mcp_call("source_list", {"notebook": NB_ID, "label": "Work"})
+    sc = result.structured_content
+    assert sc["notebook_id"] == NB_ID
+    assert len(sc["sources"]) == 1
+    assert sc["sources"][0]["id"] == SRC_ID
+    assert sc["sources"][0]["title"] == "WorkDoc"
+    mock_client.labels.sources.assert_awaited_once_with(NB_ID, "lbl_work")
+
+
+async def test_source_list_label_and_status_filter(mcp_call, mock_client) -> None:
+    """Label and status filters compose to further narrow the result."""
+    from unittest.mock import MagicMock
+
+    from notebooklm.types import Label
+
+    mock_client.labels = MagicMock()
+    mock_client.labels.list = AsyncMock(
+        return_value=[Label(id="lbl_work", name="Work", source_ids=[SRC_ID, SRC2_ID])]
+    )
+    mock_client.labels.sources = AsyncMock(
+        return_value=[
+            FakeSource(id=SRC_ID, title="Ready Doc"),
+            FakeFailedSource(id=SRC2_ID, title="Broken Doc"),
+        ]
+    )
+
+    result = await mcp_call("source_list", {"notebook": NB_ID, "label": "Work", "status": "error"})
+    sc = result.structured_content
+    assert len(sc["sources"]) == 1
+    assert sc["sources"][0]["id"] == SRC2_ID
+    assert sc["sources"][0]["status_label"] == "error"
+
+
+async def test_source_list_unknown_label_raises(mcp_call, mock_client) -> None:
+    """An unknown label raises NOT_FOUND structured error."""
+    from unittest.mock import MagicMock
+
+    mock_client.labels = MagicMock()
+    mock_client.labels.list = AsyncMock(return_value=[])
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_list", {"notebook": NB_ID, "label": "Unknown"})
+    assert "No label found matching" in str(excinfo.value)
+
+
+async def test_source_list_ambiguous_label_raises(mcp_call, mock_client) -> None:
+    """An ambiguous label token raises AMBIGUOUS_* structured error."""
+    from unittest.mock import MagicMock
+
+    from notebooklm.types import Label
+
+    mock_client.labels = MagicMock()
+    mock_client.labels.list = AsyncMock(
+        return_value=[
+            Label(id="lbl_work1", name="Work", source_ids=[]),
+            Label(id="lbl_work2", name="Work", source_ids=[]),
+        ]
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("source_list", {"notebook": NB_ID, "label": "Work"})
+    assert "matches 2 labels" in str(excinfo.value)
+    assert "Use a label id instead" in str(excinfo.value)


### PR DESCRIPTION
## Summary

Two sources-domain gaps surfaced by the 2026-07-02 multi-model MCP gap review (`docs/notes/mcp-gap-review-2026-07-02.md`), both **param-only** — no new tools, ceiling-neutral. This is the cheap slice of the labels domain; the fuller labels surface stays in #1728.

### 1. `source_wait` subset targeting (Med)
`source_wait` waited on one source or *all* sources only, so after `source_add(urls=[…])` an agent had to make N calls or wait on unrelated stale failures. It now accepts `sources: list[str] | str | None` and aggregates exactly that subset:

- Coerces via `coerce_list` (list / comma-string / JSON-array-string).
- Resolves the batch via `resolve_sources` (the plural per-id resolver — single `sources.list` snapshot, raises NOT_FOUND/AMBIGUOUS in input order before waiting).
- Waits + buckets through the existing `_wait_all_sources` / `_aggregate_wait_outcomes`, so subset mode returns the SAME partial-progress aggregate (`{ok, ready, timed_out, failed, not_found}`) as single/all modes.
- Mutually exclusive with `source`; an empty `sources` fails loud (never a silent no-op success — consistent with the `[]`=zero contract, #1652).

### 2. `source_list` label filter (Med — cheap first step of #1728)
No way to ask "which sources are in label X", and the docstring's "labels aren't a per-source attribute" was wrong (membership is real via `client.labels.add_sources`/`remove_sources`). `source_list` now accepts `label: str | None`:

- Resolves the ref via `_app.labels.resolve_label_id` (id / unambiguous-prefix / exact-name).
- Filters to the label's members through the existing transport-neutral `_app.source_listing.fetch_sources` adapter (the same one the CLI uses — full parity, no new adapter).
- Composes with `status`. Docstring corrected.

## Notes
- **No new tools** (both are optional params on existing tools). Docstrings were trimmed to keep the surface under the ADR-0025 MCP schema-char ratchet (`tests/unit/mcp/test_tool_eval.py`): 36200 / 36250.
- Reuses existing helpers throughout — no new `_app` adapter, no new RPC.

## Testing
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- FULL `uv run pytest` — 11205 passed (incl. new subset/label tests, schema-char ratchet, module-size ratchet 980/1000).
- 11 new unit tests in `tests/unit/mcp/test_sources.py` (subset ready/comma/partial-fail/unresolvable/mutual-exclusion/empty; label filter / label+status compose / unknown / ambiguous).

Closes #1745. Refs #1728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added label-based filtering to source listings (optionally combined with existing status filtering).
  * Enhanced source waiting to support targeting a subset of sources via `sources` (in addition to waiting on a single source or all sources).

* **Bug Fixes**
  * Strengthened input validation (mutually exclusive `source`/`sources`, rejects empty subsets) and improved handling for unknown/ambiguous labels.
  * Deduplicates repeated source refs when polling.

* **Tests**
  * Added unit coverage for subset waiting behavior, aggregation outcomes, input formats, validation, and label-filtering cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->