### PR TITLE
perf(settings): dedupe GET_USER_SETTINGS via get_user_settings() (#1724)

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1767,6 +1767,7 @@ await client.notes.delete_mind_map(nb_id, mind_map_id)
 |--------|------------|---------|-------------|
 | `get_output_language()` | none | `Optional[str]` | Get current output language setting |
 | `get_account_limits()` | none | `AccountLimits` | Get account-level limits such as max notebooks and sources per notebook |
+| `get_user_settings()` | none | `UserSettings` | Get account limits **and** output language in a single request (both share one server call) |
 | `set_output_language(language)` | `str` | `Optional[str]` | Set output language for artifact generation |
 
 **Example:**
@@ -1778,6 +1779,10 @@ print(f"Current language: {lang}")  # e.g., "en", "ja", "zh_Hans"
 # Get server-reported account limits
 limits = await client.settings.get_account_limits()
 print(f"Notebook limit: {limits.notebook_limit}")
+
+# Need both limits and language? One request instead of two:
+settings = await client.settings.get_user_settings()
+print(settings.limits.notebook_limit, settings.output_language)
 
 # Set language for artifact generation
 result = await client.settings.set_output_language("ja")  # Japanese
@@ -2251,6 +2256,20 @@ class AccountLimits:
     notebook_limit: int | None = None  # Max notebooks the account can hold
     source_limit: int | None = None    # Max sources per notebook
     raw_limits: tuple[Any, ...] = ()   # Untouched RPC payload for forensic use
+```
+
+### UserSettings
+
+Returned by `client.settings.get_user_settings()`. A single account-settings
+request carries both the account limits and the output language, so this is the
+one-call path when you need both (`get_account_limits()` and
+`get_output_language()` each make their own request).
+
+```python
+@dataclass(frozen=True)
+class UserSettings:
+    limits: AccountLimits = AccountLimits()  # Account-level quota limits
+    output_language: str | None = None       # Global output language, or None
 ```
 
 ### SourceFulltext

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -172,6 +172,7 @@ from .types import (
     SuggestedTopic,
     # Warnings
     UnknownTypeWarning,
+    UserSettings,
     VideoFormat,
     VideoStyle,
 )
@@ -192,6 +193,7 @@ __all__ = [
     "reset_request_id",
     # Types
     "AccountLimits",
+    "UserSettings",
     "ConnectionLimits",
     "ClientMetricsSnapshot",
     "RpcTelemetryEvent",

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from ._runtime.contracts import RpcCaller
 from .rpc import RPCMethod, safe_index
-from .types import AccountLimits
+from .types import AccountLimits, UserSettings
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +203,50 @@ class SettingsAPI:
         self._log_language_result(current_language, "Output language is now")
         return current_language
 
+    async def _fetch_user_settings(self) -> Any:
+        """Fetch the raw GET_USER_SETTINGS response (one POST)."""
+        logger.debug("Fetching user settings")
+        return await self._rpc.rpc_call(
+            RPCMethod.GET_USER_SETTINGS,
+            build_get_user_settings_params(),
+            source_path="/",
+        )
+
+    def _extract_limits(self, result: Any) -> AccountLimits:
+        limits = extract_account_limits(result)
+        if limits.notebook_limit is not None:
+            logger.debug("Notebook limit from user settings: %s", limits.notebook_limit)
+        else:
+            logger.debug("Could not parse account limits from response")
+        return limits
+
+    def _extract_output_language(self, result: Any) -> str | None:
+        language = _extract_language(
+            result,
+            self._GET_SETTINGS_PREFIX,
+            self._GET_SETTINGS_TAIL,
+            method_id=RPCMethod.GET_USER_SETTINGS.value,
+            source="_settings.get_output_language",
+        )
+        self._log_language_result(language, "Current output language")
+        return language
+
+    async def get_user_settings(self) -> UserSettings:
+        """Fetch user settings once, returning both limits and output language.
+
+        A single ``GET_USER_SETTINGS`` response carries both payloads, so callers
+        that need both (e.g. MCP ``server_info``) should use this instead of
+        firing ``get_account_limits`` and ``get_output_language`` separately.
+
+        Returns:
+            UserSettings with parsed account limits and output language.
+        """
+        result = await self._fetch_user_settings()
+        return UserSettings(
+            limits=self._extract_limits(result),
+            output_language=self._extract_output_language(result),
+        )
+
     async def get_output_language(self) -> str | None:
         """Get the current output language setting.
 
@@ -212,23 +256,7 @@ class SettingsAPI:
             The current language code (e.g., "en", "ja", "zh_Hans"),
             or None if not set or couldn't be parsed.
         """
-        logger.debug("Fetching user settings to get output language")
-
-        result = await self._rpc.rpc_call(
-            RPCMethod.GET_USER_SETTINGS,
-            build_get_user_settings_params(),
-            source_path="/",
-        )
-
-        current_language = _extract_language(
-            result,
-            self._GET_SETTINGS_PREFIX,
-            self._GET_SETTINGS_TAIL,
-            method_id=RPCMethod.GET_USER_SETTINGS.value,
-            source="_settings.get_output_language",
-        )
-        self._log_language_result(current_language, "Current output language")
-        return current_language
+        return self._extract_output_language(await self._fetch_user_settings())
 
     async def get_account_limits(self) -> AccountLimits:
         """Get account-level limits advertised by NotebookLM user settings.
@@ -236,20 +264,7 @@ class SettingsAPI:
         Returns:
             AccountLimits with parsed notebook/source limits when present.
         """
-        logger.debug("Fetching user settings to get account limits")
-
-        result = await self._rpc.rpc_call(
-            RPCMethod.GET_USER_SETTINGS,
-            build_get_user_settings_params(),
-            source_path="/",
-        )
-
-        limits = extract_account_limits(result)
-        if limits.notebook_limit is not None:
-            logger.debug("Notebook limit from user settings: %s", limits.notebook_limit)
-        else:
-            logger.debug("Could not parse account limits from response")
-        return limits
+        return self._extract_limits(await self._fetch_user_settings())
 
     def _log_language_result(self, language: str | None, success_prefix: str) -> None:
         """Log the result of a language operation."""

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -226,7 +226,9 @@ class SettingsAPI:
             self._GET_SETTINGS_PREFIX,
             self._GET_SETTINGS_TAIL,
             method_id=RPCMethod.GET_USER_SETTINGS.value,
-            source="_settings.get_output_language",
+            # Describes the extraction site, not any one public caller — this
+            # helper backs both get_output_language() and get_user_settings().
+            source="_settings._extract_output_language",
         )
         self._log_language_result(language, "Current output language")
         return language

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -127,6 +127,20 @@ class AccountLimits:
 
 
 @dataclass(frozen=True)
+class UserSettings:
+    """A single GET_USER_SETTINGS response, parsed into its two payloads.
+
+    Both ``get_account_limits`` and ``get_output_language`` read the same
+    ``GET_USER_SETTINGS`` response; ``get_user_settings`` returns both from one
+    fetch so callers that need both (e.g. MCP ``server_info``) avoid a duplicate
+    POST.
+    """
+
+    limits: AccountLimits = field(default_factory=AccountLimits)
+    output_language: str | None = None
+
+
+@dataclass(frozen=True)
 class CitedSourceSelection:
     """Result of applying cited-only filtering to research sources."""
 

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -20,7 +20,6 @@ auth-health probe that works even when unauthenticated.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from fastmcp import Context
@@ -75,15 +74,10 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
     if not authenticated:
         return {**identity, "available": False, "reason": "not authenticated"}
     try:
-        # Two concurrent reads (repo convention: each public getter is
-        # self-contained). ``get_account_limits`` + ``get_output_language`` both hit
-        # GET_USER_SETTINGS, so this fires it twice — a client-layer single-fetch
-        # dedupe is tracked in #1724 (kept simple here; the adapter uses the public
-        # getters, not RPC internals). A NotebookLMError from any is caught below.
-        limits, output_language = await asyncio.gather(
-            client.settings.get_account_limits(),
-            client.settings.get_output_language(),
-        )
+        # Both account limits and output language ride one GET_USER_SETTINGS
+        # response (#1724): a single fetch instead of two identical POSTs.
+        settings = await client.settings.get_user_settings()
+        limits, output_language = settings.limits, settings.output_language
     except NotebookLMError as exc:  # degrade, don't sink the whole response
         # Route through the shared scrubber (same chokepoint as every other MCP
         # error): a NotebookLMError on the auth/config path can carry the on-disk

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -32,6 +32,7 @@ from ._types.common import (
     ConnectionLimits,
     RpcTelemetryEvent,
     UnknownTypeWarning,
+    UserSettings,
 )
 from ._types.labels import Label
 from ._types.mind_maps import MindMap, MindMapKind
@@ -229,6 +230,7 @@ for _public_common_type in (
     ConnectionLimits,
     RpcTelemetryEvent,
     UnknownTypeWarning,
+    UserSettings,
 ):
     _public_common_type.__module__ = __name__
 del _public_common_type

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -139,6 +139,8 @@ _CITED_SOURCE_SELECTION_TYPE_HINT_GLOBALS = (ResearchSourceInput,)
 
 __all__ = [
     # Dataclasses
+    "AccountLimits",
+    "UserSettings",
     "CitedSourceSelection",
     "ConnectionLimits",
     "ClientMetricsSnapshot",

--- a/tests/fixtures/baselines/types_all.json
+++ b/tests/fixtures/baselines/types_all.json
@@ -1,4 +1,6 @@
 [
+  "AccountLimits",
+  "UserSettings",
   "CitedSourceSelection",
   "ConnectionLimits",
   "ClientMetricsSnapshot",

--- a/tests/fixtures/baselines/ungated_surface.json
+++ b/tests/fixtures/baselines/ungated_surface.json
@@ -8,6 +8,7 @@
     "set_request_id",
     "reset_request_id",
     "AccountLimits",
+    "UserSettings",
     "ConnectionLimits",
     "ClientMetricsSnapshot",
     "RpcTelemetryEvent",

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -19,7 +19,10 @@ pytest.importorskip("fastmcp")
 
 from notebooklm import __version__  # noqa: E402 - after importorskip guard
 from notebooklm.exceptions import RPCError  # noqa: E402 - after importorskip guard
-from notebooklm.types import AccountLimits  # noqa: E402 - after importorskip guard
+from notebooklm.types import (  # noqa: E402 - after importorskip guard
+    AccountLimits,
+    UserSettings,
+)
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -119,12 +122,10 @@ async def test_server_info_default_omits_account(
     """Default call (include_account unset) has NO ``account`` key and hits no RPC."""
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     _write_authed_storage()
-    mock_client.settings.get_account_limits = AsyncMock()
-    mock_client.settings.get_output_language = AsyncMock()
+    mock_client.settings.get_user_settings = AsyncMock()
     result = await mcp_call("server_info")
     assert "account" not in result.structured_content
-    mock_client.settings.get_account_limits.assert_not_called()
-    mock_client.settings.get_output_language.assert_not_called()
+    mock_client.settings.get_user_settings.assert_not_called()
 
 
 async def test_server_info_include_account_authenticated(
@@ -135,10 +136,12 @@ async def test_server_info_include_account_authenticated(
     _write_authed_storage()
     mock_client.get_account_email = AsyncMock(return_value="alice@example.com")
     mock_client.get_account_authuser = MagicMock(return_value=1)
-    mock_client.settings.get_account_limits = AsyncMock(
-        return_value=AccountLimits(notebook_limit=100, source_limit=50)
+    mock_client.settings.get_user_settings = AsyncMock(
+        return_value=UserSettings(
+            limits=AccountLimits(notebook_limit=100, source_limit=50),
+            output_language="ja",
+        )
     )
-    mock_client.settings.get_output_language = AsyncMock(return_value="ja")
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"] == {
         "email": "alice@example.com",
@@ -150,6 +153,8 @@ async def test_server_info_include_account_authenticated(
     }
     # The live probe is enabled only when the local auth check passed.
     mock_client.get_account_email.assert_awaited_once_with(live_fallback=True)
+    # One fetch backs both limits + language (the #1724 dedupe contract).
+    mock_client.settings.get_user_settings.assert_awaited_once_with()
 
 
 async def test_server_info_include_account_unauthenticated(
@@ -157,8 +162,7 @@ async def test_server_info_include_account_unauthenticated(
 ) -> None:
     """include_account=True but no storage → degraded, and no RPC is attempted."""
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "empty"))
-    mock_client.settings.get_account_limits = AsyncMock()
-    mock_client.settings.get_output_language = AsyncMock()
+    mock_client.settings.get_user_settings = AsyncMock()
     result = await mcp_call("server_info", {"include_account": True})
     assert result.structured_content["account"] == {
         "email": None,
@@ -168,8 +172,7 @@ async def test_server_info_include_account_unauthenticated(
     }
     # Identity is still surfaced, but the live probe is suppressed offline.
     mock_client.get_account_email.assert_awaited_once_with(live_fallback=False)
-    mock_client.settings.get_account_limits.assert_not_called()
-    mock_client.settings.get_output_language.assert_not_called()
+    mock_client.settings.get_user_settings.assert_not_called()
 
 
 async def test_server_info_include_account_degrades_on_rpc_error(
@@ -181,8 +184,7 @@ async def test_server_info_include_account_degrades_on_rpc_error(
     _write_authed_storage()
     mock_client.get_account_email = AsyncMock(return_value="alice@example.com")
     mock_client.get_account_authuser = MagicMock(return_value=1)
-    mock_client.settings.get_account_limits = AsyncMock(side_effect=RPCError("session expired"))
-    mock_client.settings.get_output_language = AsyncMock()
+    mock_client.settings.get_user_settings = AsyncMock(side_effect=RPCError("session expired"))
     result = await mcp_call("server_info", {"include_account": True})
     account = result.structured_content["account"]
     assert account["available"] is False
@@ -195,30 +197,15 @@ async def test_server_info_include_account_degrades_on_rpc_error(
     assert result.structured_content["auth"]["authenticated"] is True
 
 
-async def test_server_info_include_account_degrades_when_language_rpc_raises(
-    mcp_call, mock_client, tmp_path, monkeypatch
-) -> None:
-    """The output-language RPC failing (the other concurrent read) also degrades
-    gracefully — both reads share one degrade handler."""
-    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
-    _write_authed_storage()
-    mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
-    mock_client.settings.get_output_language = AsyncMock(
-        side_effect=RPCError("language lookup failed")
-    )
-    result = await mcp_call("server_info", {"include_account": True})
-    assert result.structured_content["account"]["available"] is False
-    assert "language lookup failed" in result.structured_content["account"]["reason"]
-
-
 async def test_server_info_include_account_success_with_null_fields(
     mcp_call, mock_client, tmp_path, monkeypatch
 ) -> None:
     """Bare limits + no language is available:True (locks the success-with-null contract)."""
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     _write_authed_storage()
-    mock_client.settings.get_account_limits = AsyncMock(return_value=AccountLimits())
-    mock_client.settings.get_output_language = AsyncMock(return_value=None)
+    mock_client.settings.get_user_settings = AsyncMock(
+        return_value=UserSettings(limits=AccountLimits(), output_language=None)
+    )
     result = await mcp_call("server_info", {"include_account": True})
     # Default mock identity (email None, authuser 0) is tolerated on the success path.
     assert result.structured_content["account"] == {
@@ -239,8 +226,7 @@ async def test_server_info_include_account_degraded_reason_is_scrubbed(
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     _write_authed_storage()
     leaky = RPCError("auth failed loading /home/secretuser/.notebooklm/storage_state.json")
-    mock_client.settings.get_account_limits = AsyncMock(side_effect=leaky)
-    mock_client.settings.get_output_language = AsyncMock()
+    mock_client.settings.get_user_settings = AsyncMock(side_effect=leaky)
     result = await mcp_call("server_info", {"include_account": True})
     reason = result.structured_content["account"]["reason"]
     assert result.structured_content["account"]["available"] is False

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -12,7 +12,7 @@ from notebooklm._settings import (
 )
 from notebooklm.exceptions import UnknownRPCMethodError
 from notebooklm.rpc import RPCMethod
-from notebooklm.types import AccountLimits
+from notebooklm.types import AccountLimits, UserSettings
 
 
 def test_build_get_user_settings_params_returns_fresh_params():
@@ -79,6 +79,43 @@ async def test_get_account_limits_calls_user_settings_rpc():
         [None, [1, None, None, None, None, None, None, None, None, None, [1]]],
         source_path="/",
     )
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_fetches_once_returns_both():
+    from tests._fixtures.fake_core import make_fake_core
+
+    # Realistic full GET response: limits at [0][1], language flags at [0][2].
+    response = [[None, [6, 200, 100, 500000, 1], [True, None, None, True, ["fr"]]]]
+    core = make_fake_core(rpc_call=AsyncMock(return_value=response))
+    api = SettingsAPI(core.rpc_executor)
+
+    settings = await api.get_user_settings()
+
+    assert settings == UserSettings(
+        limits=AccountLimits(
+            notebook_limit=200, source_limit=100, raw_limits=(6, 200, 100, 500000, 1)
+        ),
+        output_language="fr",
+    )
+    core.rpc_executor.rpc_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_user_settings_preserves_getter_contracts():
+    """The combined method keeps each getter's semantics: limits stay tolerant of a
+    malformed response, while language envelope drift still raises."""
+    from tests._fixtures.fake_core import make_fake_core
+
+    # Junk inner: no [0][1] limits shape, no [0][2] flags block.
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[["junk"]]))
+    api = SettingsAPI(core.rpc_executor)
+
+    with pytest.raises(UnknownRPCMethodError):
+        await api.get_user_settings()
+
+    # Same response through the tolerant getter never raises.
+    assert await api.get_account_limits() == AccountLimits()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1724.

`client.settings.get_account_limits()` and `get_output_language()` both call `GET_USER_SETTINGS`, and a **single** response carries both the account limits and the output-language code. Callers that need both (e.g. MCP `server_info(include_account=true)`) therefore fired **two identical POSTs** where one would do.

This adds a public **`get_user_settings() -> UserSettings`** that fetches once and returns both. MCP `server_info` now uses it, replacing the `asyncio.gather` over the two getters.

## Design note (the subtle bit)

The two existing getters keep their **exact** prior extraction semantics — I share only the *fetch*, not the *extraction*:

- `get_account_limits()` stays **tolerant** (parses `[0][1]`, never raises).
- `get_output_language()` keeps **strict** `safe_index` envelope-drift detection (raises `UnknownRPCMethodError` on drift).
- `get_user_settings()` composes both; on envelope drift it raises, which MCP's `except NotebookLMError` degrade path still catches (`UnknownRPCMethodError` ⊂ `NotebookLMError`).

Routing `get_account_limits` through the strict language path would have regressed it from non-raising to raising — deliberately avoided.

## Public API

`UserSettings` is a frozen dataclass exported at both `notebooklm.types` and top-level `notebooklm`, mirroring its sibling `AccountLimits` (public-surface baseline + docs updated).

## Tests

- New: `get_user_settings` single-fetch (`assert_awaited_once`) + a direct contract test (tolerant limits / strict language drift).
- MCP: `get_user_settings.assert_awaited_once_with()` pins the one-fetch contract; the now-impossible independent-language-read degrade test was removed.
- Full unit + guardrail suite green (10364 passed); mypy + ruff clean; public-API compat audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `get_user_settings()` API to fetch account limits and the global output language in a single request.
  * Added a new `UserSettings` type to return both values together.
* **Bug Fixes**
  * Reduced duplicate settings requests when enriching account information.
  * Improved account enrichment behavior so settings failures degrade gracefully while preserving available identity details.
* **Documentation**
  * Updated the Python API reference and examples to document `get_user_settings()` and the `UserSettings` return shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->