### PR TITLE
feat(mcp): single-use (jti) upload tokens for the file-transfer side-channel

### DIFF
--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -150,26 +150,29 @@ user-tamperable); the **filename** (which the token cannot know — it is minted
 before the user picks a file) arrives as the sanitized `?filename=` query param
 from the browser/sandbox and seeds the temp file's basename+extension.
 
-### Stateless, token-encoded — no registry, no sweeper
+### Stateless, token-encoded — no registry, one scoped inline sweeper (`ul`)
 
 The signed token **encodes the operation parameters**, so the handlers hold no
 server-side state:
 
-- download token payload: `{op:"dl", nb, atype, fmt?, aid?, exp}`
-- upload token payload:   `{op:"ul", nb, title?, mime?, exp}`
+- download token payload: `{op:"dl", nb, atype, fmt?, aid?, exp, jti}`
+- upload token payload:   `{op:"ul", nb, title?, mime?, exp, jti}`
 
 Carrying `title`/`mime` in the upload token preserves the current
 `source_add type=file` parameters across the browser round-trip — and because
 they are signed, the uploader cannot tamper with them.
 
 Token = `base64url(json(payload)) + "." + base64url(HMAC-SHA256(key, body))`
-(stdlib `hmac`/`hashlib`/`base64`/`json` — no new dependency; `itsdangerous` is
-not installed). Verify enforces a max token length **before** any decode/HMAC
-work, re-pads base64url, recomputes the MAC in constant time
+(stdlib `hmac`/`hashlib`/`base64`/`json`/`secrets` — no new dependency;
+`itsdangerous` is not installed). Verify enforces a max token length **before** any
+decode/HMAC work, re-pads base64url, recomputes the MAC in constant time
 (`hmac.compare_digest`), and checks `exp`.
 
-This drops the ref-registry + TTL-sweeper that a stateful design would need.
-The token is the state.
+There is **no ref-registry and no *background* sweeper**. The one piece of state
+is the `ul` single-use tracker added by #1746 (see *Residual risk* below): an
+ephemeral, bounded, **inline-swept** in-process set of consumed `jti`s that dies
+with the process just like the signing key. `dl` remains fully stateless
+(multi-use within its TTL). For downloads the token is still the state.
 
 ### Auth model (verified against fastmcp 3.2.0)
 
@@ -250,24 +253,28 @@ upgrade that changes either fails loudly. Handlers take `(request)` only and rea
 - Reuses the proven cores: `_app.download` + `download_core.execute_download`, the
   `source_add` file core + `validate_upload_path`, the 200 MiB cap, the temp-spool
   + `BackgroundTask` cleanup patterns from `server/routes/*`.
-- No new dependency; no persistent state; no background sweeper.
+- No new dependency; no persistent state; no background sweeper (the #1746 `ul`
+  single-use tracker is an ephemeral, inline-swept in-process set — no background task).
 - stdio behavior unchanged.
 
 **Negative / risks**
 - Depends on FastMCP not force-gating custom routes (pinned by a regression test).
 - A leaked upload URL within its 15-min TTL lets someone add a source **to the
   single tenant's own notebook**; a leaked download URL within 30 min streams one
-  artifact. Single-tenant blast radius, short TTL — accepted; replay-burn is
-  deliberately skipped (add a one-shot nonce store if this ever goes multi-tenant).
-  Note the tension: shortening `UPLOAD_TTL` to bound a leak also shrinks the
-  retry window — a 200 MiB upload over a poor link can take ~13 min, near the
-  15-min TTL, so a failed-then-retried upload can outlive the token. Don't shorten
-  `ul` without weighing that.
-  A leaked upload token is also replayable *concurrently* (N parallel POSTs each
-  spool up to 200 MiB before the running cap / source-add), so transient `/tmp`
-  pressure is N×200 MiB — still token-gated, single-tenant, behind the tunnel, and
-  self-cleaning (`finally: _cleanup`). Accepted; add a global in-flight-upload
-  semaphore / aggregate temp-byte budget only if this is ever multi-tenant.
+  artifact. Single-tenant blast radius, short TTL. **Update (#1746):** `ul` replay-burn
+  is **no longer skipped** — upload tokens are now single-use (one *successful* add per
+  token), because a leaked `ul` link is a content-agnostic write/injection primitive
+  (see *Residual risk* below). `dl` replay-burn **is** still deliberately skipped
+  (multi-use within its 30-min TTL — Range/resume needs it). Note the tension:
+  shortening `UPLOAD_TTL` to bound a leak also shrinks the retry window — a 200 MiB
+  upload over a poor link can take ~13 min, near the 15-min TTL — so `ul` single-use
+  is recorded **on success only**, leaving a failed-then-retried upload able to reuse
+  the same link. Don't shorten `ul` without weighing that.
+  A leaked upload token's *concurrent* replay is now also bounded by the atomic jti
+  claim (`try_begin`): a second concurrent POST of the same token is rejected before it
+  spools, so the pre-#1746 N×200 MiB concurrent-spool window collapses to the narrow
+  race of two POSTs that both pass the claim before either commits — itself capped by
+  `_MAX_CONCURRENT_UPLOADS` and self-cleaning (`finally: _cleanup`).
 - Two new internet-facing routes on the tunnel — covered by: a streamed byte cap
   (real defense) plus a `Content-Length` early-reject (413); `title`/`mime` carried
   in the signed token (not user-tamperable) and the `?filename` basename-sanitized;
@@ -288,73 +295,81 @@ upgrade that changes either fails loudly. Handlers take `(request)` only and rea
   (separate ASGI app, FastAPI `Depends`); the side-channel belongs on the MCP app.
   Shared *logic* is reused; the FastAPI plumbing is not.
 
-### Residual risk: signed-token replay within TTL (accepted)
+### Residual risk: signed-token replay within TTL (`ul` now single-use — #1746; `dl` accepted)
 
-The signed `ul`/`dl` tokens are **multi-use within their TTL** — there is no
-nonce, no `jti` claim, and no single-use tracking. `FileLinkSigner.verify`
-(`_filelink.py`) checks the length cap, the HMAC, `exp`, and the `op` claim, but a
-token that passes those checks passes them **every time** until it expires. So:
+`FileLinkSigner.verify` (`_filelink.py`) checks the length cap, the HMAC, `exp`, and
+the `op` claim; a token that passes those checks passes them **every time** until it
+expires. Leakage is plausible, not theoretical: the token rides in the URL **path**,
+so it is captured by claude.ai, browser history, tunnel access logs
+(Cloudflare/Tailscale), and any `Referer`. The `no-referrer` / `no-store` headers
+narrow, but do not eliminate, that surface. The two ops differ in blast radius:
 
-- A leaked **`ul`** token can add a source **repeatedly** — once per request —
-  until it expires (`UPLOAD_TTL` = 15 min), each time against the single tenant's
-  own notebook carried in the signed payload.
+- A leaked **`ul`** token is a **content-agnostic write primitive**: its payload is
+  only `{nb, title?, mime?}` and the uploaded bytes are the raw request body, so
+  whoever holds the link can POST **arbitrary content** (≤200 MiB) as a *source* into
+  the owner's notebook — a content / prompt-injection vector, not merely a same-file
+  replay.
 - A leaked **`dl`** token can **re-exfiltrate** the current latest artifact of that
   type until it expires (`DOWNLOAD_TTL` = 30 min). The token pins
   `{nb, atype, fmt?, aid?}`, not a byte snapshot, so a replay serves whatever the
   download core resolves at replay time.
 
-Leakage is plausible, not theoretical: the token rides in the URL **path**, so it
-is captured by claude.ai, browser history, tunnel access logs
-(Cloudflare/Tailscale), and any `Referer`. The `no-referrer` / `no-store` headers
-narrow, but do not eliminate, that surface.
+**Decision (updated by #1746): `ul` is single-use; `dl` stays multi-use.**
 
-**Bounding factors already in place** (why the residual is small):
+`ul` — **single-use enforced.** Every token now carries a random `jti` (128-bit
+`secrets`, injected by `sign()` and covered by the MAC). The `/files/ul` POST route
+atomically **claims** the jti (`ConsumedJtiStore.try_begin`) before spooling and
+**commits** (burns) it only after a *successful* `source_add`; a failed / aborted /
+429'd upload **rolls back** the claim from the route's `finally` so the link can be
+retried. Consequences:
 
-- **Short TTLs** — 15 min (`ul`) / 30 min (`dl`) — cap the replay window.
-- **Ephemeral per-process signing key** — `secrets.token_bytes(32)` minted at
-  server start, so a restart invalidates every outstanding token unconditionally.
-- **Single-tenant scope** — the blast radius is the operator's own account and
-  their own notebooks; there is no cross-tenant escalation.
-- **HMAC integrity** — a token cannot be forged or its parameters tampered with;
-  replay requires capturing a *legitimately issued* token.
-- **Download concurrency cap** — `_MAX_CONCURRENT_DOWNLOADS = 4` (added in the same
-  change, #1681, mirroring the existing upload cap) bounds concurrent in-flight
-  downloads, so a replayed token cannot fan out unbounded fresh Google fetches or
-  accumulate unbounded spooled artifacts on temp disk. The slot is held for the
-  whole lifetime the artifact occupies temp disk — released from a `finally` at the
-  end of the response's stream (via a `FileResponse` subclass), so slow/held
-  streams still count against the cap **and** a mid-stream disconnect or aborted
-  `Range` can never leak a slot and wedge the route.
+- A sequential replay (the realistic leaked-from-logs case) is rejected with a flat
+  403 before any spool, once the token's one successful use has happened.
+- The atomic claim also rejects a *concurrent* duplicate POST before it spools,
+  collapsing the pre-#1746 N×200 MiB concurrent-spool window to the narrow race of two
+  POSTs that both pass the claim before either commits (bounded by
+  `_MAX_CONCURRENT_UPLOADS`).
+- Recording **on success only** preserves the large-file retry window this ADR
+  protects (a 200 MiB upload over a poor link can take ~13 min): a failed upload does
+  not burn the link.
 
-**Decision — accept the replay-within-TTL residual; do NOT add `jti` tracking and
-do NOT shorten the TTLs now.**
+`dl` — **replay-within-TTL accepted (multi-use).** The `jti` is present but **not**
+enforced for downloads, because `GET /files/dl/{token}` is streamed directly and a
+`Range`/resumable client legitimately re-issues the GET (a reconnect with `Range:`)
+to resume a dropped stream — single-use would 403 the resume and break large-artifact
+downloads. `dl` is also lower severity (re-reads the *same* artifact; not a write
+primitive) and is already bounded by:
 
-Reasons for **not** adding a single-use `jti` claim + seen-set:
+- **Short TTL** — 30 min caps the replay window.
+- **Ephemeral per-process signing key** — `secrets.token_bytes(32)` minted at server
+  start invalidates every outstanding token on restart.
+- **Single-tenant scope** — blast radius is the operator's own account; no cross-tenant
+  escalation.
+- **HMAC integrity** — a token cannot be forged or tampered with; replay needs a
+  *legitimately issued* token.
+- **Download concurrency cap** — `_MAX_CONCURRENT_DOWNLOADS = 4` (#1681) bounds
+  concurrent in-flight downloads and holds each slot for the artifact's whole temp-disk
+  lifetime, released from a `finally` at end-of-stream (a `FileResponse` subclass), so
+  a replay cannot fan out unbounded fetches and a disconnect/aborted `Range` cannot
+  leak a slot.
 
-1. A seen-set **reintroduces the exact in-process server-side state** that the
-   stateless, token-is-the-state design (see *Stateless, token-encoded — no
-   registry, no sweeper*) deliberately eliminated — the registry and sweeper come
-   straight back.
-2. It **does not survive a restart**: an in-memory seen-set is empty after a
-   restart, so it is not a durable guarantee — and the ephemeral key already
-   invalidates *all* tokens on restart, so the only window a seen-set could guard
-   is one the key rotation already closes.
-3. It is **redundant with the short TTL + single-tenant scope**: the window is
-   already minutes-long and the blast radius is the operator's own account.
+**Why the `ul` reversal is consistent with the stateless design.** The two original
+objections to a `jti` seen-set are answered, not ignored: the store is **ephemeral,
+bounded (8192), and inline-swept** — it dies with the process exactly like the signing
+key, and its non-durability across a restart is moot because the key rotation already
+invalidates every token on restart. There is still **no ref-registry and no background
+sweeper**; `dl` remains fully stateless.
 
-Reasons for **not** shortening the TTLs now: they are already short, and further
-shrinking trades legitimate slow-upload / slow-download UX for marginal risk
-reduction. A 200 MiB upload over a poor link can take ~13 min — already close to
-the 15-min `ul` TTL — so a failed-then-retried upload can outlive an even shorter
-token.
-
-**What would change this decision.** Any of the following flips the tradeoff and
-warrants adding a `jti` claim + a bounded in-memory seen-set and/or shortening the
-TTLs:
-
-- the server becomes **multi-tenant** (cross-account blast radius appears);
-- the TTLs are **lengthened** for any reason (a larger replay window);
-- a **replay incident is reported** in practice.
+**What triggered the reversal, and what would change it further.** The original ADR
+enumerated three conditions that would flip the tradeoff — multi-tenant, TTLs
+lengthened, or a reported replay incident. #1746 is **none of those**; it is an added
+**fourth** trigger: the 2026-07-02 multi-model MCP gap review **re-weighted the `ul`
+severity** — reframing a leaked upload token as a *write / content-injection
+primitive* rather than a same-file re-read — which raised it above the "re-exfiltrate
+low-sensitivity metadata" framing the original decision weighed. The three original
+conditions still stand as reasons to revisit **`dl`** single-use and/or shorten the
+TTLs; none has fired for `dl`, and `dl`'s Range/resume constraint is the standing
+reason it stays multi-use.
 
 ### Why the REST server is out of scope
 

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -11,13 +11,23 @@ Token wire format::
     base64url(json(payload)) + "." + base64url(HMAC-SHA256(key, body))
 
 where ``body`` is the base64url(json(payload)) string the MAC is computed over.
-Stdlib ``hmac``/``hashlib``/``base64``/``json`` only — no new dependency
+Stdlib ``hmac``/``hashlib``/``base64``/``json``/``secrets`` only — no new dependency
 (``itsdangerous`` is not installed). :meth:`FileLinkSigner.verify` enforces a max
 token length **before** any decode/HMAC work, re-pads base64url, recomputes the
 MAC in constant time (:func:`hmac.compare_digest`), checks ``exp``, and matches
 the operation. The signing key is an ephemeral ``secrets.token_bytes(32)`` minted
 at server start (a restart invalidating outstanding links is acceptable and
 removes a secret to manage).
+
+Every minted token also carries a random ``jti`` (like ``exp``, injected by
+:meth:`FileLinkSigner.sign` and covered by the MAC). ``jti`` powers a **scoped
+single-use** guarantee for the ``ul`` (upload) op: the ``/files/ul`` POST route
+claims + burns the jti via :class:`ConsumedJtiStore` so a leaked upload link
+cannot be replayed as a content-injection write primitive (ADR-0024, #1746). The
+store is an ephemeral, bounded, inline-swept in-process set that dies with the
+process just like the signing key — there is no *background* sweeper. Downloads
+(``dl``) stay multi-use so ``Range``/resumable clients keep working; their jti is
+present but not enforced.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -29,6 +39,7 @@ import binascii
 import hashlib
 import hmac
 import json
+import secrets
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -95,11 +106,16 @@ class FileLinkSigner:
     def sign(self, payload: dict[str, Any], ttl: int) -> str:
         """Return a signed token for ``payload`` valid for ``ttl`` seconds.
 
-        ``exp`` is injected here (callers never set it). The MAC covers the
-        encoded body, so neither the parameters nor the expiry are tamperable.
+        ``exp`` and a random ``jti`` are injected here (callers never set either).
+        The MAC covers the encoded body, so neither the parameters, the expiry, nor
+        the jti are tamperable. The ``jti`` (128-bit CSPRNG, ``secrets``) uniquely
+        names the token so the ``ul`` route can enforce single-use
+        (:class:`ConsumedJtiStore`); it is injected for every op uniformly, but only
+        ``ul`` enforces it (``dl`` stays multi-use for Range/resume).
         """
         body = dict(payload)
         body["exp"] = int(time.time()) + ttl
+        body["jti"] = secrets.token_urlsafe(16)
         encoded = _b64url(json.dumps(body, separators=(",", ":"), sort_keys=True).encode("utf-8"))
         mac = hmac.new(self.key, encoded.encode("ascii"), hashlib.sha256).digest()
         return f"{encoded}.{_b64url(mac)}"
@@ -149,18 +165,96 @@ class FileLinkSigner:
         return payload
 
 
+#: Cap on the consumed-jti record. The server mints one jti per file-tool call and
+#: every entry is inline-swept once its token's ``exp`` passes (≤ ``UPLOAD_TTL``), so
+#: the live set is tiny in practice; an attacker cannot mint jtis (no key). This bound
+#: is pure defense-in-depth against a runaway — 8192 is generous headroom.
+_MAX_SEEN_JTIS = 8192
+
+
+@dataclass
+class ConsumedJtiStore:
+    """Bounded, TTL-swept record of consumed single-use upload token ids (``jti``),
+    plus the set of ids currently mid-upload.
+
+    Single process / single tenant: every method is fully synchronous and contains NO
+    ``await``, so it runs atomically w.r.t. other coroutines on the one server event
+    loop (no coroutine interleaves mid-method) — the same rule the ``_fileroutes``
+    in-flight counters rely on, so no lock is needed. The store dies with the process,
+    like the ephemeral signing key.
+
+    Lifecycle per upload: :meth:`try_begin` (atomic claim) → :meth:`commit` (success,
+    permanent) OR :meth:`rollback` (failure / abort / 429, freeing the jti for retry).
+    ``try_begin`` being the single atomic check-and-mark closes the concurrent-replay
+    race; ``commit`` / ``rollback`` are driven from the route's ``finally`` so a client
+    disconnect (``CancelledError`` — which ``finally`` still runs on) can never wedge a
+    jti in the active set.
+    """
+
+    #: jti -> exp (unix seconds); a permanently-burned single-use upload token.
+    _seen: dict[str, int] = field(default_factory=dict)
+    #: jtis currently mid-upload (claimed, not yet committed/rolled back). Bounded by
+    #: the concurrent request count and always released in the route's ``finally``, so
+    #: it needs no sweep or size cap.
+    _active: set[str] = field(default_factory=set)
+
+    def _sweep(self, now: int) -> None:
+        for jti in [j for j, exp in self._seen.items() if exp <= now]:
+            del self._seen[jti]
+
+    def try_begin(self, jti: str) -> bool:
+        """Atomically claim ``jti`` for a single upload.
+
+        Return ``False`` if the jti was already consumed (:attr:`_seen`) or is already
+        mid-upload (:attr:`_active`) — a sequential replay or a concurrent duplicate;
+        otherwise mark it active and return ``True``. No ``await`` runs between the
+        check and the mark, so on the single server event loop the claim is atomic.
+        """
+        if jti in self._active or jti in self._seen:
+            return False
+        self._active.add(jti)
+        return True
+
+    def commit(self, jti: str, exp: int) -> None:
+        """Burn ``jti`` permanently (its upload succeeded).
+
+        Sweeps expired entries and enforces the size bound here — the only mutating hot
+        path — so :meth:`try_begin` stays O(1).
+        """
+        self._active.discard(jti)
+        self._sweep(int(time.time()))
+        if len(self._seen) >= _MAX_SEEN_JTIS:
+            # Practically unreachable (single-tenant; one jti per file-tool call; all
+            # <= TTL and swept). Evict the soonest-to-expire entry — the least loss of
+            # protection, since it is closest to natural expiry anyway. ``_seen`` is
+            # non-empty here (the cap is >= 1), so ``min`` is safe.
+            del self._seen[min(self._seen, key=self._seen.__getitem__)]
+        self._seen[jti] = exp
+
+    def rollback(self, jti: str) -> None:
+        """Release a claimed-but-unfinished ``jti`` (upload failed / aborted / 429) so
+        the same link can be retried — honors ADR-0024's large-file retry window."""
+        self._active.discard(jti)
+
+
 @dataclass(frozen=True)
 class FileTransferConfig:
     """Resolved file-transfer config: the signer + the validated public base URL.
 
     Carried on :class:`~notebooklm.mcp._context.AppState`. The two file tools mint
     URLs through :meth:`upload_url` / :meth:`download_url`; the ``/files/*`` routes
-    verify the tokens with the same :attr:`signer`. ``base_url`` is a bare https
-    origin (validated by ``_validate_bare_https_origin``).
+    verify the tokens with the same :attr:`signer` and enforce ``ul`` single-use via
+    :attr:`jti_store`. ``base_url`` is a bare https origin (validated by
+    ``_validate_bare_https_origin``).
     """
 
     signer: FileLinkSigner
     base_url: str
+    #: In-process single-use tracker for ``ul`` tokens. ``compare=False`` keeps this
+    #: frozen dataclass hashable/comparable by (signer, base_url) only — the store is a
+    #: mutable, dict-bearing (unhashable) object, so including it in ``__eq__``/
+    #: ``__hash__`` would make every config unhashable and equality depend on live state.
+    jti_store: ConsumedJtiStore = field(default_factory=ConsumedJtiStore, compare=False)
 
     def upload_url(self, payload: dict[str, Any]) -> str:
         """Sign ``payload`` with the upload TTL and build the ``/files/ul`` URL.

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -199,8 +199,12 @@ class ConsumedJtiStore:
     _active: set[str] = field(default_factory=set)
 
     def _sweep(self, now: int) -> None:
-        for jti in [j for j, exp in self._seen.items() if exp <= now]:
-            del self._seen[jti]
+        # ``exp < now`` (strict), matching ``verify``'s ``time.time() > exp`` rejection:
+        # a jti is dropped only once its token is already expired *and* rejectable, never
+        # while ``verify`` would still accept the token — so the sweep opens no re-claim
+        # window at the exact expiry second. ``now`` is the caller's ``int(time.time())``.
+        for expired_jti in [j for j, exp in self._seen.items() if exp < now]:
+            del self._seen[expired_jti]
 
     def try_begin(self, jti: str) -> bool:
         """Atomically claim ``jti`` for a single upload.
@@ -223,11 +227,14 @@ class ConsumedJtiStore:
         """
         self._active.discard(jti)
         self._sweep(int(time.time()))
-        if len(self._seen) >= _MAX_SEEN_JTIS:
-            # Practically unreachable (single-tenant; one jti per file-tool call; all
-            # <= TTL and swept). Evict the soonest-to-expire entry — the least loss of
-            # protection, since it is closest to natural expiry anyway. ``_seen`` is
-            # non-empty here (the cap is >= 1), so ``min`` is safe.
+        if jti not in self._seen and len(self._seen) >= _MAX_SEEN_JTIS:
+            # Only evict when this commit actually GROWS the set (jti is new). Re-committing
+            # an already-recorded jti just refreshes its exp in place, so it must not evict
+            # a different valid entry and shrink the protection window. Practically
+            # unreachable (single-tenant; one jti per file-tool call; all TTL-swept). Evict
+            # the soonest-to-expire entry — the least loss of protection, since it is
+            # closest to natural expiry anyway. ``_seen`` is non-empty here, so ``min`` is
+            # safe.
             del self._seen[min(self._seen, key=self._seen.__getitem__)]
         self._seen[jti] = exp
 

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -60,6 +60,12 @@ if TYPE_CHECKING:
 #: ``Content-Length``, and authoritatively via the running byte cap below.
 MAX_UPLOAD_BYTES = 200 * 1024 * 1024
 
+#: One opaque 403 message shared by every ``/files/ul`` POST rejection — a bad
+#: signature/expiry, a missing/malformed ``jti``, or an already-consumed / mid-flight
+#: single-use token. Keeping them identical means the response never reveals WHICH
+#: check failed, so a probing client gets no oracle.
+_UPLOAD_LINK_REJECTED = "This upload link is invalid or has expired."
+
 #: Cap concurrent in-flight uploads. The per-request byte cap bounds ONE upload to
 #: 200 MiB, but a leaked/replayable ``ul`` token (valid for its full TTL) could
 #: otherwise drive N parallel streams = N×200 MiB of transient temp disk →
@@ -424,7 +430,15 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         try:
             payload = config.signer.verify(token, op="ul")
         except FileLinkError:
-            return PlainTextResponse("This upload link is invalid or has expired.", status_code=403)
+            return PlainTextResponse(_UPLOAD_LINK_REJECTED, status_code=403)
+        # Single-use (jti) guard — ``ul`` only (ADR-0024, #1746). A leaked upload token
+        # is a content-agnostic WRITE primitive (anyone can POST arbitrary bytes as a
+        # source), so unlike ``dl`` (which stays multi-use for Range/resume) an upload
+        # token authorizes exactly one *successful* add. ``sign`` always injects a str
+        # ``jti``, so a missing/non-str one means a malformed/hand-built token → 403.
+        jti = payload.get("jti")
+        if not isinstance(jti, str) or not jti:
+            return PlainTextResponse(_UPLOAD_LINK_REJECTED, status_code=403)
         # Early 413 on a declared over-cap body (the running cap below is the real
         # defense — a chunked / under-stated Content-Length slips past this).
         declared = request.headers.get("content-length")
@@ -439,93 +453,125 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         except RuntimeError:
             return PlainTextResponse("Server is not ready.", status_code=500)
 
-        # Bound aggregate temp-disk: reject (fast, no disk touched) when too many
-        # uploads are already streaming. The counter is mutated only between awaits
-        # in this single-process async server, so no lock is needed.
-        global _inflight_uploads
-        if _inflight_uploads >= _MAX_CONCURRENT_UPLOADS:
-            return PlainTextResponse(
-                "Too many concurrent uploads in progress; retry shortly.", status_code=429
-            )
-        _inflight_uploads += 1
+        # Atomically claim the single-use jti BEFORE any concurrency slot / spool: a
+        # sequential replay (jti already consumed) or a concurrent duplicate (jti
+        # already mid-upload) is rejected here with a flat 403. Placed after the cheap
+        # validations above (which never mark the token active, so nothing to release)
+        # and before the slot. ``try_begin`` runs no ``await``, so the check-and-mark
+        # is atomic on the one event loop.
+        if not config.jti_store.try_begin(jti):
+            return PlainTextResponse(_UPLOAD_LINK_REJECTED, status_code=403)
+        committed = False
         try:
-            # Filename: the raw fetch body omits it, so it arrives sanitized via
-            # ?filename=. Content-type: the signed token's mime WINS; the request
-            # Content-Type header is the fallback. Strip any ``; charset=…`` params
-            # off the header so only the bare MIME type reaches the backend.
-            filename = _safe_upload_name(request.query_params.get("filename"))
-            raw_mime = payload.get("mime") or request.headers.get("content-type")
-            mime = raw_mime.split(";")[0].strip() if raw_mime else None
-
-            temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
-            temp_path = os.path.join(temp_dir, filename)
+            # Bound aggregate temp-disk: reject (fast, no disk touched) when too many
+            # uploads are already streaming. The counter is mutated only between awaits
+            # in this single-process async server, so no lock is needed.
+            global _inflight_uploads
+            if _inflight_uploads >= _MAX_CONCURRENT_UPLOADS:
+                return PlainTextResponse(
+                    "Too many concurrent uploads in progress; retry shortly.", status_code=429
+                )
+            _inflight_uploads += 1
             try:
-                fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-                total = 0
-                with os.fdopen(fd, "wb") as out:
-                    async for chunk in request.stream():
-                        if not chunk:
-                            continue
-                        total += len(chunk)
-                        if total > MAX_UPLOAD_BYTES:
-                            return PlainTextResponse(
-                                "Upload exceeds the size limit.", status_code=413
-                            )
-                        out.write(chunk)
-                plan = add_core.build_source_add_plan(
-                    content=os.path.realpath(temp_path),
-                    source_type="file",
-                    title=payload.get("title"),
-                    mime_type=str(mime) if mime is not None else None,
-                    follow_symlinks=False,
-                    validate_path=add_core.validate_upload_path,
-                    looks_path_shaped=add_core.looks_like_path,
-                )
-                result = await add_core.execute_source_add(
-                    client,
-                    add_core.SourceAddExecutionPlan(notebook_id=str(payload.get("nb")), plan=plan),
-                )
-                source_id = str(result.source.id)
-                # The documented sandbox-`curl`/PUT path (an agent uploading a file
-                # it holds) gets clean JSON when it asks for it; a human browser gets
-                # the HTML page.
-                if "application/json" in request.headers.get("accept", ""):
-                    return JSONResponse(
-                        {"status": "added", "source_id": source_id},
+                # Filename: the raw fetch body omits it, so it arrives sanitized via
+                # ?filename=. Content-type: the signed token's mime WINS; the request
+                # Content-Type header is the fallback. Strip any ``; charset=…`` params
+                # off the header so only the bare MIME type reaches the backend.
+                filename = _safe_upload_name(request.query_params.get("filename"))
+                raw_mime = payload.get("mime") or request.headers.get("content-type")
+                mime = raw_mime.split(";")[0].strip() if raw_mime else None
+
+                temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
+                temp_path = os.path.join(temp_dir, filename)
+                try:
+                    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                    total = 0
+                    with os.fdopen(fd, "wb") as out:
+                        async for chunk in request.stream():
+                            if not chunk:
+                                continue
+                            total += len(chunk)
+                            if total > MAX_UPLOAD_BYTES:
+                                return PlainTextResponse(
+                                    "Upload exceeds the size limit.", status_code=413
+                                )
+                            out.write(chunk)
+                    plan = add_core.build_source_add_plan(
+                        content=os.path.realpath(temp_path),
+                        source_type="file",
+                        title=payload.get("title"),
+                        mime_type=str(mime) if mime is not None else None,
+                        follow_symlinks=False,
+                        validate_path=add_core.validate_upload_path,
+                        looks_path_shaped=add_core.looks_like_path,
+                    )
+                    result = await add_core.execute_source_add(
+                        client,
+                        add_core.SourceAddExecutionPlan(
+                            notebook_id=str(payload.get("nb")), plan=plan
+                        ),
+                    )
+                    source_id = str(result.source.id)
+                    # Burn the single-use jti now the add SUCCEEDED — before the
+                    # JSON-vs-HTML branch so BOTH return paths consume it. Recording only
+                    # on success means a failed/aborted upload (handled by the outer
+                    # ``finally`` rollback) leaves the link usable for retry, honoring
+                    # ADR-0024's large-file retry window. ``exp`` was validated as an int
+                    # by ``verify``.
+                    config.jti_store.commit(jti, payload["exp"])
+                    committed = True
+                    # The documented sandbox-`curl`/PUT path (an agent uploading a file
+                    # it holds) gets clean JSON when it asks for it; a human browser gets
+                    # the HTML page.
+                    if "application/json" in request.headers.get("accept", ""):
+                        return JSONResponse(
+                            {"status": "added", "source_id": source_id},
+                            headers={
+                                "Cache-Control": "no-store",
+                                "Referrer-Policy": "no-referrer",
+                            },
+                        )
+                    return HTMLResponse(
+                        "<!doctype html><html><body style='font-family:system-ui'>"
+                        f"<h2>Source added</h2><p>id = <code>{html.escape(source_id)}</code></p>"
+                        "<p>You can close this tab and return to your assistant.</p>"
+                        "</body></html>",
+                        headers=_HTML_SECURITY_HEADERS,
+                    )
+                except ValidationError as exc:
+                    # ValidationError ⊂ NotebookLMError, so this MUST precede the
+                    # NotebookLMError handler. ``validate_upload_path`` rejections can
+                    # embed the local file path, so the detail is redacted.
+                    return PlainTextResponse(
+                        f"Upload rejected: {redact(str(exc))}",
+                        status_code=400,
                         headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
                     )
-                return HTMLResponse(
-                    "<!doctype html><html><body style='font-family:system-ui'>"
-                    f"<h2>Source added</h2><p>id = <code>{html.escape(source_id)}</code></p>"
-                    "<p>You can close this tab and return to your assistant.</p>"
-                    "</body></html>",
-                    headers=_HTML_SECURITY_HEADERS,
-                )
-            except ValidationError as exc:
-                # ValidationError ⊂ NotebookLMError, so this MUST precede the
-                # NotebookLMError handler. ``validate_upload_path`` rejections can
-                # embed the local file path, so the detail is redacted.
-                return PlainTextResponse(
-                    f"Upload rejected: {redact(str(exc))}",
-                    status_code=400,
-                    headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
-                )
-            except NotebookLMError as exc:
-                # An upstream auth/server/rate-limit error from execute_source_add
-                # (add_file → RPC) would otherwise escape as a raw 500. The bytes
-                # already finished uploading by here, so tell the user a retry
-                # re-sends the whole file (vs a mid-stream failure that did not).
-                return _upstream_error_response(
-                    exc,
-                    note="Your file uploaded, but adding it as a source failed (a retry re-uploads it).",
-                )
-            except OSError:
-                # A bad filename / fs error (e.g. a name that survives sanitization
-                # but the fs rejects) is a clean 400, not a bare 500.
-                return PlainTextResponse("Upload could not be processed.", status_code=400)
+                except NotebookLMError as exc:
+                    # An upstream auth/server/rate-limit error from execute_source_add
+                    # (add_file → RPC) would otherwise escape as a raw 500. The bytes
+                    # already finished uploading by here, so tell the user a retry
+                    # re-sends the whole file (vs a mid-stream failure that did not).
+                    return _upstream_error_response(
+                        exc,
+                        note="Your file uploaded, but adding it as a source failed "
+                        "(a retry re-uploads it).",
+                    )
+                except OSError:
+                    # A bad filename / fs error (e.g. a name that survives sanitization
+                    # but the fs rejects) is a clean 400, not a bare 500.
+                    return PlainTextResponse("Upload could not be processed.", status_code=400)
+                finally:
+                    # Always remove the temp dir — on success (bytes already uploaded), a
+                    # rejection, an fs error, or a mid-stream client disconnect.
+                    _cleanup(temp_dir)
             finally:
-                # Always remove the temp dir — on success (bytes already uploaded), a
-                # rejection, an fs error, or a mid-stream client disconnect.
-                _cleanup(temp_dir)
+                _inflight_uploads -= 1
         finally:
-            _inflight_uploads -= 1
+            # Release a claimed-but-not-committed jti so the link can be retried: this
+            # covers the 429, the validation / upstream / OSError returns, and a
+            # mid-stream disconnect (``CancelledError`` ⊂ ``BaseException``, which
+            # ``finally`` still runs on — an ``except Exception`` would miss it and wedge
+            # the jti in the active set). A committed upload keeps the jti burned.
+            if not committed:
+                config.jti_store.rollback(jti)

--- a/tests/unit/mcp/test_filelink.py
+++ b/tests/unit/mcp/test_filelink.py
@@ -241,6 +241,20 @@ def test_store_bound_evicts_soonest_to_expire(monkeypatch) -> None:
     assert {"b", "c", "d"} <= set(store._seen)
 
 
+def test_store_recommit_same_jti_does_not_evict_at_cap(monkeypatch) -> None:
+    # Re-committing an already-recorded jti refreshes its exp in place; it must NOT evict
+    # a different valid entry (order-independence at the size cap). The route can't drive
+    # a double-commit — try_begin gates it — but commit stays self-consistent regardless.
+    monkeypatch.setattr(filelink, "_MAX_SEEN_JTIS", 2)
+    store = ConsumedJtiStore()
+    base = int(time.time()) + 10_000  # far future → sweep never fires
+    store.commit("a", base + 1)
+    store.commit("b", base + 5)  # store is now full (2/2)
+    store.commit("a", base + 9)  # re-commit "a" — must refresh, not evict "b"
+    assert set(store._seen) == {"a", "b"}
+    assert store._seen["a"] == base + 9  # exp refreshed in place
+
+
 def test_config_jti_store_excluded_from_equality_and_default_constructed() -> None:
     # `compare=False` keeps the frozen config comparable by (signer, base_url) only —
     # the store is a mutable, dict-bearing object that must not drive __eq__/__hash__.

--- a/tests/unit/mcp/test_filelink.py
+++ b/tests/unit/mcp/test_filelink.py
@@ -20,6 +20,7 @@ import notebooklm.mcp._filelink as filelink
 from notebooklm.mcp._filelink import (
     DOWNLOAD_TTL,
     UPLOAD_TTL,
+    ConsumedJtiStore,
     FileLinkError,
     FileLinkSigner,
     FileTransferConfig,
@@ -158,3 +159,94 @@ def test_config_builds_ttl_scoped_urls() -> None:
     down_exp = signer.verify(down.rsplit("/", 1)[1], op="dl")["exp"]
     assert UPLOAD_TTL == 15 * 60 and DOWNLOAD_TTL == 30 * 60
     assert down_exp - up_exp >= DOWNLOAD_TTL - UPLOAD_TTL - 2
+
+
+# --------------------------------------------------------------------------- #
+# jti minting (single-use support — #1746)
+# --------------------------------------------------------------------------- #
+def test_sign_injects_unique_jti_per_mint() -> None:
+    # Every token carries a random jti (CSPRNG), so two mints of the SAME payload get
+    # DIFFERENT jtis — the property the ul single-use tracker keys off.
+    signer = _signer()
+    p1 = signer.verify(signer.sign({"op": "ul", "nb": "n1"}, ttl=60), op="ul")
+    p2 = signer.verify(signer.sign({"op": "ul", "nb": "n1"}, ttl=60), op="ul")
+    assert isinstance(p1["jti"], str) and p1["jti"]
+    assert isinstance(p2["jti"], str) and p2["jti"]
+    assert p1["jti"] != p2["jti"]
+
+
+def test_jti_is_covered_by_the_mac() -> None:
+    # The jti is injected into the signed body, so tampering with it (keeping the old
+    # MAC) is rejected — same guarantee as any other payload field.
+    signer = _signer()
+    token = signer.sign({"op": "ul", "nb": "n1"}, ttl=60)
+    body_b64, mac_b64 = token.split(".")
+    payload = json.loads(_b64url_decode(body_b64))
+    payload["jti"] = "attacker-chosen-jti"
+    forged_body = (
+        base64.urlsafe_b64encode(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        )
+        .rstrip(b"=")
+        .decode()
+    )
+    with pytest.raises(FileLinkError):
+        signer.verify(f"{forged_body}.{mac_b64}", op="ul")
+
+
+# --------------------------------------------------------------------------- #
+# ConsumedJtiStore lifecycle
+# --------------------------------------------------------------------------- #
+def test_store_try_begin_then_commit_makes_jti_single_use() -> None:
+    store = ConsumedJtiStore()
+    exp = int(time.time()) + 60
+    assert store.try_begin("j1") is True  # first claim wins
+    assert store.try_begin("j1") is False  # concurrent duplicate rejected (still active)
+    store.commit("j1", exp)
+    assert store.try_begin("j1") is False  # consumed → permanently rejected
+
+
+def test_store_rollback_frees_jti_for_retry() -> None:
+    # A claimed-but-not-committed jti (failed/aborted upload) is released, so the same
+    # link can be retried — the record-on-success behavior ADR-0024 relies on.
+    store = ConsumedJtiStore()
+    assert store.try_begin("j1") is True
+    store.rollback("j1")
+    assert store.try_begin("j1") is True  # reusable after rollback
+
+
+def test_store_sweeps_expired_seen_entries_on_commit() -> None:
+    # Expired jtis are inline-swept (memory reclamation) when a later commit runs; a
+    # live one is retained. A swept jti being re-claimable is harmless — verify()
+    # rejects the expired token itself on the exp check.
+    store = ConsumedJtiStore()
+    now = int(time.time())
+    store.commit("old", now - 10)  # already expired
+    store.commit("fresh", now + 60)  # live
+    assert "old" not in store._seen
+    assert "fresh" in store._seen
+    assert store.try_begin("old") is True  # swept → re-claimable (harmless)
+
+
+def test_store_bound_evicts_soonest_to_expire(monkeypatch) -> None:
+    monkeypatch.setattr(filelink, "_MAX_SEEN_JTIS", 3)
+    store = ConsumedJtiStore()
+    base = int(time.time()) + 10_000  # all far-future so the sweep never fires
+    store.commit("a", base + 1)
+    store.commit("b", base + 5)
+    store.commit("c", base + 9)
+    store.commit("d", base + 7)  # over cap → evict the soonest-to-expire ("a")
+    assert len(store._seen) <= 3
+    assert "a" not in store._seen  # soonest-to-expire evicted
+    assert {"b", "c", "d"} <= set(store._seen)
+
+
+def test_config_jti_store_excluded_from_equality_and_default_constructed() -> None:
+    # `compare=False` keeps the frozen config comparable by (signer, base_url) only —
+    # the store is a mutable, dict-bearing object that must not drive __eq__/__hash__.
+    signer = _signer()
+    a = FileTransferConfig(signer=signer, base_url="https://h.example")
+    b = FileTransferConfig(signer=signer, base_url="https://h.example")
+    assert isinstance(a.jti_store, ConsumedJtiStore)  # default-constructed
+    a.jti_store.try_begin("j1")  # mutate one store
+    assert a == b  # equality ignores the (now diverged) stores

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -10,9 +10,14 @@ running byte cap, ``?filename`` handling, temp cleanup, and the lifespan-unset 5
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import hashlib
+import hmac
+import json
 import os
 import tempfile
+import time
 from collections.abc import AsyncIterator, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
@@ -604,6 +609,134 @@ def test_upload_post_cleans_temp_on_success(monkeypatch, mock_client, config) ->
         resp = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
     assert resp.status_code == 200
     assert cleaned and not Path(cleaned[0]).exists()
+
+
+# --------------------------------------------------------------------------- #
+# Upload single-use (jti) enforcement — #1746
+# --------------------------------------------------------------------------- #
+def test_upload_single_use_replay_rejected(mock_client, config) -> None:
+    # Security (#1746): a leaked ul token is a content-agnostic write primitive. After
+    # ONE successful add it is burned — a second POST with the same token 403s, and only
+    # the first request actually added a source.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        first = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+        second = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert first.status_code == 200
+    assert second.status_code == 403  # jti consumed → replay rejected
+    add_file.assert_awaited_once()  # only the first request added a source
+
+
+def test_upload_page_get_does_not_consume_jti(mock_client, config) -> None:
+    # Loading the upload PAGE (GET) only calls verify(), it must NOT claim the jti — else
+    # the user's subsequent POST would 403 before they ever upload.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        page = client.get(_path(url))
+        posted = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert page.status_code == 200  # page rendered
+    assert posted.status_code == 200  # POST still works — GET never burned the token
+
+
+def test_upload_failed_add_frees_jti_for_retry(monkeypatch, mock_client, config) -> None:
+    # record-on-success: a failed add rolls the jti back (via the route's finally), so the
+    # SAME link is retryable — honors ADR-0024's large-file retry window.
+    from notebooklm.exceptions import ServerError
+
+    calls = {"n": 0}
+
+    async def fake(client, exec_plan):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ServerError("upstream 503")
+        return MagicMock(source=MagicMock(id="src-ok"))
+
+    monkeypatch.setattr(_fileroutes.add_core, "execute_source_add", fake)
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        first = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+        second = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert first.status_code == 502  # add failed → jti rolled back
+    assert second.status_code == 200  # retry with the same link succeeds
+    assert "src-ok" in second.text
+
+
+def test_upload_429_does_not_burn_jti(monkeypatch, mock_client, config) -> None:
+    # A 429 (concurrency cap) is not a use of the token: the claim is rolled back in the
+    # outer finally, so the same link works once a slot frees up.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        monkeypatch.setattr(_fileroutes, "_inflight_uploads", _fileroutes._MAX_CONCURRENT_UPLOADS)
+        capped = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+        monkeypatch.setattr(_fileroutes, "_inflight_uploads", 0)
+        retried = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert capped.status_code == 429
+    assert retried.status_code == 200  # the 429 rolled the claim back → link still usable
+
+
+def test_upload_midstream_413_does_not_burn_jti(monkeypatch, mock_client, config) -> None:
+    # The over-cap early-return INSIDE the streaming loop is a distinct rollback path
+    # from the pre-slot 429 and the post-stream error paths: it must also release the
+    # claim (via the outer finally) so a corrected retry on the same link works.
+    monkeypatch.setattr(_fileroutes, "MAX_UPLOAD_BYTES", 5)
+    mock_client.sources.add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+
+    def big_body() -> Iterator[bytes]:
+        yield b"abcd"
+        yield b"efgh"  # streams past the 5-byte cap → mid-stream 413
+
+    with starlette_testclient.TestClient(app) as client:
+        capped = client.post(_path(url) + "?filename=a.pdf", content=big_body())
+        retried = client.post(_path(url) + "?filename=a.pdf", content=b"ok")
+    assert capped.status_code == 413
+    assert retried.status_code == 200  # mid-stream 413 rolled the claim back
+
+
+def test_download_multi_use_range_resume_preserved(monkeypatch, mock_client, config) -> None:
+    # RANGE/RESUME GUARDRAIL: dl tokens stay multi-use so a resumed download (a second
+    # GET, e.g. a Range reconnect) is not 403'd. Do NOT regress this — any future dl
+    # single-use must first solve resume.
+    monkeypatch.setattr(
+        _fileroutes.download_core, "execute_download", _fake_download_writing(b"AUDIO")
+    )
+    app = _build(mock_client, config)
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(app) as client:
+        first = client.get(_path(url))
+        second = client.get(_path(url))  # a Range/resume re-GET must still stream
+    assert first.status_code == 200 and second.status_code == 200
+    assert first.content == b"AUDIO" and second.content == b"AUDIO"
+
+
+def test_upload_missing_jti_token_403(mock_client, config) -> None:
+    # A validly-signed ul token whose payload carries NO jti (older / hand-built) is
+    # rejected by the defensive guard. Built directly with the fixture key (b"k"*32),
+    # mirroring test_filelink's tamper construction, so the MAC is valid but jti absent.
+    key = b"k" * 32
+    body = {"exp": int(time.time()) + 60, "nb": NB, "op": "ul"}  # no jti
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(body, separators=(",", ":"), sort_keys=True).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    mac = hmac.new(key, encoded.encode("ascii"), hashlib.sha256).digest()
+    token = f"{encoded}.{base64.urlsafe_b64encode(mac).rstrip(b'=').decode()}"
+    app = _build(mock_client, config)
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(f"/files/ul/{token}?filename=a.pdf", content=b"DATA")
+    assert resp.status_code == 403
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
Closes #1746 (Refs #1656, ADR-0024). Interim security hardening ahead of the SEP-2631 migration.

The signed `/files/*` tokens (ADR-0024) enforced MAC/exp/op but had **no single-use tracking** — a token was replayable for its whole TTL. The **upload (`ul`) token is a content-agnostic WRITE primitive** (`{nb, title?, mime?}` + raw request body), so a leaked `ul` URL (it rides in the URL path → proxy/tunnel logs, browser history) let anyone POST arbitrary content as a *source* into the owner's notebook for 15 min — a content/prompt-injection vector, not just a same-file replay.

- **`sign()`** injects a random 128-bit `jti` (`secrets.token_urlsafe`) into every token, covered by the MAC. `verify()`'s crypto order (length-cap → MAC → JSON → exp → op) is **unchanged**.
- **`ConsumedJtiStore`** on the frozen `FileTransferConfig` (`compare=False`): `try_begin` (atomic claim) → `commit` (burn on a *successful* add; inline-swept, bounded to 8192, soonest-to-expire eviction) → `rollback` (release on failure). Fully **synchronous** (no `await`) → atomic + lock-free on the single event loop (same rule as the existing in-flight counters). Ephemeral, dies with the process like the signing key — **no registry, no background sweeper**.
- **`/files/ul` POST/PUT route:** claim the jti before the concurrency slot; `commit` only after a successful `source_add`, before the JSON-vs-HTML branch; an outer `finally` rolls back a claimed-but-uncommitted jti (429, validation/upstream/OS error, mid-stream disconnect — `finally` runs on `CancelledError`). Record-on-success preserves ADR-0024's large-file retry window; the atomic claim also rejects a concurrent duplicate before it spools. All upload rejections share one opaque 403 message (no failure oracle).
- **Downloads (`dl`) stay MULTI-use** by design: `GET /files/dl` is streamed and a Range/resumable client re-issues the GET to resume, so single-use would break large-artifact downloads. Lower severity (re-reads the same artifact) and already bounded by the concurrency cap + TTL. Its `jti` is present but unenforced.

Reverses ADR-0024's "accept the replay-within-TTL residual" decision **for `ul` only**, documenting the content-injection reframing as the trigger (an added fourth condition beyond the original three) and the retained `dl`-multi-use rationale.

## Design provenance
Plan converged via `momus` + `agy` (both independently favored the in-progress-set / atomic-claim design over plain record-on-success — it closes the concurrent-replay race AND preserves retry). Polished via code-simplifier + claude code-review (no ship-blockers) + ultrathink.

## Test plan
- [x] `tests/unit/mcp/test_filelink.py` — jti mint uniqueness + MAC coverage; `ConsumedJtiStore` lifecycle (claim/commit/rollback), TTL sweep, bound+eviction, `compare=False` equality.
- [x] `tests/unit/mcp/test_fileroutes.py` — upload replay → 403; GET page doesn't consume; failed add / 429 / mid-stream 413 all roll back → retry works; `dl` multi-use (Range/resume) preserved; missing-jti token → 403.
- [x] `ruff check .` + `ruff format --check .` (whole tree), `mypy src/notebooklm` clean, full `tests/unit/mcp` + `tests/_guardrails` green (1691 passed).

## Deferred polish findings
- Intentional: `ConsumedJtiStore`/`_MAX_SEEN_JTIS` not in `_filelink.__all__` (private module; tests import directly, mirroring `_b64url_decode`).
- Store unit tests read `_seen` directly — appropriate for internals coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload links now work as single-use tokens, helping prevent repeated uploads from the same link.
  * Download links continue to support repeated use within their valid time window.

* **Bug Fixes**
  * Improved handling of failed or interrupted uploads so valid links can be retried when an upload does not complete.
  * Strengthened rejection of invalid or replayed upload links for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->