### PR TITLE
fix(mcp): cancel sibling coroutine on gather escape (#1760)

### DIFF
--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -204,7 +204,21 @@ def register(mcp: Any) -> None:
                 else None
             )
             if ask_coro is not None and suggest_coro is not None:
-                ask_result, suggestions = await asyncio.gather(ask_coro, suggest_coro)
+                # Independent RPCs → run concurrently, but drive explicit tasks so a
+                # failure in one cancels + drains the still-running sibling instead of
+                # leaking it (mirrors ``_sources._wait_all_sources``).
+                tasks = (
+                    asyncio.create_task(ask_coro),
+                    asyncio.create_task(suggest_coro),
+                )
+                try:
+                    ask_result, suggestions = await asyncio.gather(*tasks)
+                except BaseException:
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
             elif ask_coro is not None:
                 ask_result, suggestions = await ask_coro, None
             elif suggest_coro is not None:

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -87,16 +87,29 @@ def register(mcp: Any) -> None:
             nb_id = await resolve_notebook(client, notebook)
             if include_metadata:
                 # Two independent reads (description + metadata) → run concurrently
-                # (repo convention for independent RPCs). A NotebookLMError from
-                # either still propagates through ``mcp_errors``.
-                result, meta_result = await asyncio.gather(
+                # (repo convention for independent RPCs). Drive explicit tasks so that
+                # if either raises, the still-running sibling read is cancelled +
+                # drained rather than leaked (mirrors ``_sources._wait_all_sources``).
+                # A NotebookLMError from either still propagates through ``mcp_errors``.
+                describe_task = asyncio.create_task(
                     core.execute_notebook_describe(
                         client, nb_id, resolve_notebook_id=passthrough_notebook_id
-                    ),
+                    )
+                )
+                meta_task = asyncio.create_task(
                     core.execute_notebook_metadata(
                         client, nb_id, resolve_notebook_id=passthrough_notebook_id
-                    ),
+                    )
                 )
+                tasks = (describe_task, meta_task)
+                try:
+                    result, meta_result = await asyncio.gather(*tasks)
+                except BaseException:
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
                 output = to_jsonable(result)
                 output["metadata"] = to_jsonable(meta_result.metadata)
                 return output

--- a/tests/unit/mcp/test_chat.py
+++ b/tests/unit/mcp/test_chat.py
@@ -8,6 +8,7 @@ name-vs-id resolution, the configure goal/length dispatch, and error projection.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -18,7 +19,10 @@ pytest.importorskip("fastmcp")
 
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
-from notebooklm.exceptions import ChatError  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    ChatError,
+    RPCError,
+)
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -337,6 +341,36 @@ async def test_chat_ask_all_three_absent_still_rejected(mcp_call, mock_client) -
     with pytest.raises(ToolError):
         await mcp_call("chat_ask", {"notebook": NB_ID, "suggest_followups": False})
     mock_client.notebooks.suggest_prompts.assert_not_called()
+
+
+async def test_chat_ask_cancels_sibling_on_error(mcp_call, mock_client) -> None:
+    """When ask + suggest run concurrently (question + suggest_followups) and one
+    raises, the still-running sibling is cancelled + drained (no leaked coroutine)
+    and the error propagates as ToolError (#1760)."""
+    sibling_cancelled = asyncio.Event()
+
+    async def _slow_ask(*_a: Any, **_k: Any) -> Any:
+        try:
+            await asyncio.sleep(30)  # the slow sibling — should be cancelled
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        # never reached (cancelled first); return a real fake, not Ellipsis
+        return FakeAskResult(answer="unused", conversation_id=CONV_ID)  # pragma: no cover
+
+    async def _raise_suggest(*_a: Any, **_k: Any) -> Any:
+        await asyncio.sleep(0)  # let the slow sibling start first
+        raise RPCError("unexpected boom")
+
+    mock_client.chat.ask = _slow_ask
+    mock_client.notebooks.suggest_prompts = _raise_suggest
+
+    with pytest.raises(ToolError):
+        await mcp_call(
+            "chat_ask",
+            {"notebook": NB_ID, "question": "what?", "suggest_followups": True},
+        )
+    assert sibling_cancelled.is_set(), "slow sibling read was not cancelled/drained"
 
 
 @dataclass

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -8,6 +8,7 @@ reaching the tool, the confirm preview-then-delete flow, and error projection.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -19,7 +20,10 @@ pytest.importorskip("fastmcp")
 
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
-from notebooklm.exceptions import NotebookNotFoundError  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    NotebookNotFoundError,
+    RPCError,
+)
 from notebooklm.types import (  # noqa: E402 - after importorskip guard
     Notebook,
     NotebookMetadata,
@@ -207,6 +211,32 @@ async def test_notebook_describe_include_metadata_adds_block(mcp_call, mock_clie
     }
     mock_client.notebooks.get_description.assert_awaited_once_with(NB_ID)
     mock_client.notebooks.get_metadata.assert_awaited_once_with(NB_ID)
+
+
+async def test_notebook_describe_cancels_sibling_on_error(mcp_call, mock_client) -> None:
+    """include_metadata=True runs description + metadata concurrently; if one read
+    raises, the still-running sibling read is cancelled + drained (no leaked
+    coroutine) and the error propagates as ToolError (#1760)."""
+    sibling_cancelled = asyncio.Event()
+
+    async def _slow_describe(_nb: str) -> Any:
+        try:
+            await asyncio.sleep(30)  # the slow sibling — should be cancelled
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        return FakeDescription(summary="unused")  # pragma: no cover - never reached
+
+    async def _raise_metadata(_nb: str) -> Any:
+        await asyncio.sleep(0)  # let the slow sibling start first
+        raise RPCError("unexpected boom")
+
+    mock_client.notebooks.get_description = _slow_describe
+    mock_client.notebooks.get_metadata = _raise_metadata
+
+    with pytest.raises(ToolError):
+        await mcp_call("notebook_describe", {"notebook": NB_ID, "include_metadata": True})
+    assert sibling_cancelled.is_set(), "slow sibling read was not cancelled/drained"
 
 
 async def test_notebook_rename(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary
- `notebook_describe` (describe + metadata) and `chat_ask` (ask + suggest) launched two coroutines via `asyncio.gather` without cancelling the still-running sibling when the first raised — the other in-flight read was briefly leaked instead of cancelled.
- Both sites now drive explicit `asyncio.create_task(...)` and, on any escape, cancel the not-done siblings then drain them with `return_exceptions=True` before re-raising. This mirrors the existing inline drain idiom in `_sources._wait_all_sources` and `_content_sanity._annotate_thin_warnings`.
- Read-only RPCs, so there is no data-loss risk; this is cancellation-discipline consistency (gap review 2026-07-02, item #14).

## Design note
A shared helper was intentionally **not** extracted: scope is the two named sites, and the codebase already inlines this exact block at two other sites with cross-referencing comments — inlining keeps consistency and avoids a new module + doc-index churn. Consolidating all four sites into one helper is a reasonable future follow-up, out of scope here.

## Test plan
- [x] New `test_notebook_describe_cancels_sibling_on_error` and `test_chat_ask_cancels_sibling_on_error` assert the slow sibling is cancelled + drained (via an `asyncio.Event` set in its `except CancelledError`) and the error still surfaces as `ToolError`. Mutation-verified: both fail on a bare `gather`, pass with the fix.
- [x] `tests/unit/mcp` (692 passed) · `tests/_guardrails` (1070 passed) · mypy clean · ruff clean.

## Deferred polish findings
- Triple review (claude + codex + agy) found 0 critical / 0 important. One non-blocking note: `await asyncio.gather(*tasks)` degrades the unpacked targets to `Any` — inherent to the idiom and kept for consistency with the two reference sites.

Closes #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JbvuTDoUwkxYvyEcUTzuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple notebook and chat actions run at the same time, ensuring a failure in one request no longer leaves related requests hanging.
  * Partial results are now handled more cleanly when fetching notebook details with metadata, reducing the chance of inconsistent responses.

* **Tests**
  * Added coverage for concurrent error handling and cancellation behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->