### PR TITLE
feat(mcp): Literal typing for studio_list.kind + language docstring hint

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -517,6 +517,15 @@ def register(mcp: Any) -> None:
             # resolve_notebook, so these malformed calls never pay a notebook
             # round-trip. (Content *presence* + the YouTube-host guard still run
             # later, during dispatch — that ordering is unchanged by #1696.)
+            #
+            # ``mime_type`` deliberately stays a free-text ``str`` (NOT a ``Literal``):
+            # it is DUAL-USE — for ``source_type="file"`` it carries an arbitrary,
+            # open-ended MIME type (in the signed upload URL), and only for
+            # ``source_type="drive"`` is it restricted to ``_DRIVE_MIME_CHOICES``.
+            # A ``Literal`` would wrongly reject valid ``file`` MIME types; splitting a
+            # dedicated ``drive_mime_type`` param would grow the ``source_add`` surface
+            # for a niche 4-value option. So the drive choice set is enforced here at
+            # runtime (and listed in the docstring) instead (issue #1759).
             if (
                 mime_type is not None
                 and source_type == "drive"

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -53,7 +53,6 @@ from ._studio_download import (
     _resolve_artifact_id,
 )
 from ._studio_items import (
-    STUDIO_KINDS,
     resolve_studio_item,
     studio_items,
     summarize_studio_item,
@@ -186,7 +185,25 @@ def register(mcp: Any) -> None:
         ctx: Context,
         notebook: str,
         item: str | None = None,
-        kind: str | None = None,
+        # ``kind`` is a ``Literal`` so FastMCP/Pydantic emits a JSON-schema ``enum``
+        # (agents discover the valid filter values from the schema, not by trial) and
+        # rejects an out-of-enum value at the boundary. The members DUPLICATE
+        # ``_studio_items.STUDIO_KINDS`` (a runtime frozenset, so it can't be spelled
+        # as a ``Literal`` directly); ``test_studio_list_kind_enum_matches_studio_kinds``
+        # pins the schema enum equal to ``STUDIO_KINDS`` so the two can't drift.
+        kind: Literal[
+            "audio",
+            "data-table",
+            "flashcards",
+            "infographic",
+            "mind-map",
+            "note",
+            "quiz",
+            "report",
+            "slide-deck",
+            "video",
+        ]
+        | None = None,
         detail: Literal["summary", "full"] = "summary",
         limit: int = DEFAULT_LIMIT,
         offset: int = 0,
@@ -218,10 +235,9 @@ def register(mcp: Any) -> None:
                 raise ValidationError("limit must be >= 1.")
             if offset < 0:
                 raise ValidationError("offset must be >= 0.")
-            if kind is not None and kind not in STUDIO_KINDS:
-                raise ValidationError(
-                    f"unknown kind {kind!r}; valid: {', '.join(sorted(STUDIO_KINDS))}."
-                )
+            # ``kind`` is a ``Literal`` — FastMCP/Pydantic rejects an unknown value at
+            # the schema boundary, so no runtime membership check is needed (same as
+            # ``studio_generate``'s ``artifact_type``).
             nb_id = await resolve_notebook(client, notebook)
             if item is not None:
                 # Single fetch by ref over the merged list; the resolved item's full
@@ -352,7 +368,8 @@ def register(mcp: Any) -> None:
         comma-separated string (the comma form cannot carry a source title that
         itself contains a comma — use a JSON array or a real list for those).
         ``instructions`` is free-text guidance for kinds that accept it
-        (including ``mind-map``).
+        (including ``mind-map``). ``language`` (optional) is a language code,
+        e.g. ``en``/``ja``/``zh_Hans``.
         """
         client = get_client(ctx)
         with mcp_errors():

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1223,6 +1223,21 @@ async def test_source_add_drive_bad_mime_is_validation_error(mcp_call, mock_clie
     mock_client.sources.add_drive.assert_not_called()
 
 
+async def test_source_add_mime_type_has_no_schema_enum(mcp_list_tools) -> None:
+    """``mime_type`` deliberately stays a free-text ``str`` — NOT a ``Literal`` — so its
+    schema carries NO ``enum`` (issue #1759, decision b). It is dual-use: ``source_type=
+    "file"`` accepts arbitrary MIME, only ``drive`` is restricted (enforced at runtime).
+    A future well-meaning narrowing to ``Literal`` (which would reject valid ``file`` MIME)
+    fails here."""
+    tools = {t.name: t for t in await mcp_list_tools()}
+    mime_schema = tools["source_add"].inputSchema["properties"]["mime_type"]
+    # No flat ``enum`` and no ``enum`` inside any ``anyOf``/``oneOf`` branch (the shape a
+    # ``Literal | None`` would take).
+    assert "enum" not in mime_schema
+    branches = (mime_schema.get("anyOf") or []) + (mime_schema.get("oneOf") or [])
+    assert all("enum" not in branch for branch in branches)
+
+
 @pytest.mark.parametrize(
     ("source_type", "good", "foreign"),
     [

--- a/tests/unit/mcp/test_studio.py
+++ b/tests/unit/mcp/test_studio.py
@@ -226,14 +226,34 @@ async def test_studio_list_kind_filter(mcp_call, mock_client) -> None:
 
 @pytest.mark.parametrize("bad", ["mind_map", "slide_deck", "note-backed", "bogus", "unknown"])
 async def test_studio_list_rejects_unknown_kind(mcp_call, mock_client, bad) -> None:
-    """An unknown/underscored ``kind`` is a clean VALIDATION error, not a silently
-    empty page (or a false NOT_FOUND on the by-ref path). ``unknown`` is a display-only
-    pass-through value, not a filterable kind, so it's rejected too."""
-    mock_client.notes.list = AsyncMock(return_value=[])
-    mock_client.artifacts.list = AsyncMock(return_value=[])
+    """An unknown/underscored ``kind`` rejects at the ``Literal`` schema boundary
+    (pydantic ``literal_error``), NOT via the old runtime ``"unknown kind"`` VALIDATION
+    path — mirroring ``studio_generate``'s out-of-enum option rejection. ``unknown`` is a
+    display-only pass-through value, not a filterable kind, so it's rejected too; the
+    underscored forms (``mind_map`` / ``slide_deck``) are not the hyphenated members."""
     with pytest.raises(ToolError) as exc:
         await mcp_call("studio_list", {"notebook": NB_ID, "kind": bad})
-    assert "unknown kind" in str(exc.value)
+    msg = str(exc.value)
+    assert "literal_error" in msg
+    assert "VALIDATION" not in msg
+
+
+async def test_studio_list_kind_enum_matches_studio_kinds(mcp_list_tools) -> None:
+    """The ``kind`` param's schema ``enum`` is pinned equal to ``STUDIO_KINDS`` so the
+    hand-spelled signature ``Literal`` can't drift from the runtime source of truth
+    (``STUDIO_KINDS`` is a frozenset, so it can't BE the ``Literal`` directly).
+
+    Also asserts ``"cinematic-video"`` is absent: it is a ``studio_generate.artifact_type``
+    member but NOT an ``ArtifactType`` / studio kind, so a future ``ArtifactType`` addition
+    can't silently widen this filter via a stale Literal."""
+    from notebooklm.mcp.tools._studio_items import STUDIO_KINDS
+
+    tools = await mcp_list_tools()
+    schema = next(t for t in tools if t.name == "studio_list").inputSchema
+    enum = _schema_enum(schema["properties"]["kind"])
+    assert enum == STUDIO_KINDS
+    assert enum is not None and len(enum) == 10
+    assert "cinematic-video" not in enum
 
 
 async def test_studio_list_summary_truncates_long_note(mcp_call, mock_client) -> None:

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -30,7 +30,7 @@ pytest.importorskip("fastmcp")
 #: Ratchet ceilings — calibrated to the current surface (Tier-1 read-merge took it
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
-SCHEMA_CHAR_BUDGET = 36_820  # total serialized inputSchema + description chars (current 36_780)
+SCHEMA_CHAR_BUDGET = 37_020  # total serialized inputSchema + description chars (current 36_979)
 # ^ Raised from 36_250 for #1741: research_status gained include_report /
 # report_max_chars / source_limit / source_offset windowing params, and the four
 # research tools' docstrings speak one `poll_task_id` id (tightened to stay lean).


### PR DESCRIPTION
Closes #1759 — MCP gap-review item #13 (Low, schema discoverability). Params with a finite value set were bare `str`, so FastMCP emitted no JSON-schema `enum` and agents discovered valid values by trial-and-error.

## Changes
- **`studio_list.kind`: `str` → `Literal[...]`** of the 10 `STUDIO_KINDS` values. FastMCP/Pydantic now rejects an unknown value at the schema boundary, so the runtime `"unknown kind"` membership check (and the now-unused `STUDIO_KINDS` import) are removed — same precedent as `studio_generate.artifact_type`. A guardrail test (`test_studio_list_kind_enum_matches_studio_kinds`) pins the schema enum equal to `STUDIO_KINDS` (a runtime frozenset that can't BE the `Literal`) so the hand-spelled members can't drift; it also asserts `cinematic-video` is absent (a `studio_generate.artifact_type` member but not a studio kind).
- **`studio_generate.language`: stays free-text `str`** (dozens of codes) — just a one-line `e.g. en/ja/zh_Hans` docstring hint.
- **`source_add.mime_type`: stays free-text `str` (decision b, not a `Literal`).** The issue asked us to weigh the over-engineering caution: `mime_type` is **dual-use** — for `source_type="file"` it carries an arbitrary, open-ended MIME type (in the signed upload URL), and only for `source_type="drive"` is it restricted to the 4 `_DRIVE_MIME_CHOICES`. A `Literal` would wrongly reject valid `file` MIME; splitting a dedicated `drive_mime_type` param would grow the `source_add` surface (ADR-0025) for a niche 4-value option. The drive set is already runtime-validated and docstring-listed. The rationale is now recorded in-code, and a new test (`test_source_add_mime_type_has_no_schema_enum`) guards against a future well-meaning narrowing.

## Behavioral change
A bad `studio_list` `kind` now surfaces a Pydantic `literal_error` at the schema boundary instead of the old runtime `VALIDATION` "unknown kind" error. `studio_list` is only ever invoked through FastMCP (an `@mcp.tool`), so no direct-call path loses validation.

## Budget (ADR-0025)
No new tools; ceiling-neutral. The `kind` enum + language hint grow the schema-char surface by **+201** (measured). Rebased on #1756 (which set the budget to 36_820); the true combined surface is **36_979**, so `SCHEMA_CHAR_BUDGET` is reconciled to **37_020** (buffer ~41, mirroring #1756's convention) after trimming the language hint.

## Verification
- `mypy src/notebooklm --ignore-missing-imports` — clean.
- `ruff check .` + `ruff format --check` — clean.
- FULL `uv run pytest` — 11283 passed, 79 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JbvuTDoUwkxYvyEcUTzuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool input validation so invalid studio kinds are rejected earlier and more consistently.
  * Kept file MIME type input flexible while clarifying expected handling for different source types.

* **New Features**
  * Studio selection now uses a clearer, more precise set of allowed options in the tool schema.

* **Tests**
  * Added coverage to verify schema restrictions and validation behavior stay aligned with expected tool inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->