### PR TITLE
fix(mcp): harden OAuth transport throttle keying + startup signal (#1761)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -19,6 +19,11 @@ NOTEBOOKLM_MCP_TOKEN=
 # together (partial → refuses to start).
 # NOTEBOOKLM_MCP_OAUTH_PASSWORD=
 # NOTEBOOKLM_MCP_OAUTH_BASE_URL=https://your-host.example.com
+# Cloudflare ONLY: trust the tunnel's CF-Connecting-IP header so the login throttle keys
+# per-IP instead of globally. Leave unset unless a trusted proxy sets that header (an
+# exposed-directly origin could forge it to dodge the throttle). Tailscale Funnel does not
+# set it, so this is a no-op there.
+# NOTEBOOKLM_MCP_TRUST_PROXY=1
 
 # --- Tunnel: pick ONE (see README §"Connect from claude.ai" / the tunnel options) ---
 # A) Cloudflare (`make dev` / TUNNEL=cloudflare) — needs a domain in your Cloudflare

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       # (registered clients + tokens) persists under the mounted profile volume.
       NOTEBOOKLM_MCP_OAUTH_PASSWORD: ${NOTEBOOKLM_MCP_OAUTH_PASSWORD:-}
       NOTEBOOKLM_MCP_OAUTH_BASE_URL: ${NOTEBOOKLM_MCP_OAUTH_BASE_URL:-}
+      # Optional (Cloudflare profile only): trust the tunnel's CF-Connecting-IP header as
+      # the per-IP login-throttle key. Default off → throttle keys on the socket peer (the
+      # tunnel egress), i.e. one global bucket. Tailscale Funnel does not set this header.
+      NOTEBOOKLM_MCP_TRUST_PROXY: ${NOTEBOOKLM_MCP_TRUST_PROXY:-}
       # Point the app at the mounted profile, independent of the (arbitrary) uid's
       # home. The host dir is always mounted as the profile literally named
       # "server"; NOTEBOOKLM_HOME/profiles/server is where the app reads+writes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,7 @@ automatically.
 | `NOTEBOOKLM_MCP_HOST` | MCP HTTP transport bind host; non-loopback refused unless `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` | `127.0.0.1` |
 | `NOTEBOOKLM_MCP_PORT` | MCP HTTP transport bind port | `8000` |
 | `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND` | Allow MCP HTTP transport to bind a non-loopback host. Use only behind a trusted proxy. | `0` |
+| `NOTEBOOKLM_MCP_TRUST_PROXY` | Trust the proxy-set `CF-Connecting-IP` header as the self-hosted-OAuth login-throttle key. Only enable behind a trusted proxy (e.g. the Cloudflare tunnel); default off keys on the socket peer. | `0` |
 | `NOTEBOOKLM_SERVER_TOKEN` | Bearer token required by every REST `/v1` request. The REST server refuses to start without it. | - |
 | `NOTEBOOKLM_SERVER_HOST` | REST server bind host; non-loopback refused unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1` | `127.0.0.1` |
 | `NOTEBOOKLM_SERVER_PORT` | REST server bind port | `8000` |
@@ -218,6 +219,7 @@ be audited from one location.
 | `NOTEBOOKLM_MCP_HOST` | HTTP bind host for `notebooklm-mcp --transport http`. Non-loopback refused unless `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1`. | `--host` flag → env var → `127.0.0.1` | `mcp.__main__._build_parser` / `_check_http_bind_allowed` |
 | `NOTEBOOKLM_MCP_PORT` | HTTP bind port for `notebooklm-mcp --transport http`. | `--port` flag → env var → `8000` | `mcp.__main__._build_parser` / `_resolve_port` |
 | `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND` | Allow MCP HTTP transport to bind a non-loopback host. Use only behind a trusted proxy. | Literal `1` enables; all other values disabled. | `mcp.__main__._check_http_bind_allowed` |
+| `NOTEBOOKLM_MCP_TRUST_PROXY` | Trust the proxy-set `CF-Connecting-IP` header as the self-hosted-OAuth login-throttle key. Enable only behind a trusted proxy (e.g. the Cloudflare tunnel); default off keys the throttle on the socket peer. | Literal `1` enables; all other values disabled. | `mcp._oauth.get_oauth_config` / `_client_ip` |
 | `NOTEBOOKLM_SERVER_TOKEN` | Bearer token required by every REST `/v1` request. The server refuses to start when unset/empty. | `--token` flag → env var → startup failure | `server.__main__._check_token_configured` / `server._auth.require_auth` |
 | `NOTEBOOKLM_SERVER_HOST` | REST server bind host. Non-loopback refused unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1`. | `--host` flag → env var → `127.0.0.1` | `server.__main__._build_parser` / `_check_bind_allowed` |
 | `NOTEBOOKLM_SERVER_PORT` | REST server bind port. | `--port` flag → env var → `8000` | `server.__main__._build_parser` / `_resolve_port` |

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -130,6 +130,11 @@ cp deploy/.env.example deploy/.env                              # edit per the s
 3. `.env`: `NOTEBOOKLM_MCP_OAUTH_BASE_URL=https://notebooklm.yourdomain.com` (bare origin).
 4. Run: `cd deploy && make dev` (Cloudflare is the default profile).
 
+> Optional: set `NOTEBOOKLM_MCP_TRUST_PROXY=1` to key the per-IP login throttle on the
+> tunnel's `CF-Connecting-IP` header. Default off keys on the socket peer (the tunnel
+> egress) — one global throttle bucket. Only enable it behind a trusted proxy that sets the
+> header; an exposed-directly origin could forge it to dodge the throttle.
+
 ### Tunnel B — Tailscale Funnel (no domain — free, stable `*.ts.net` HTTPS)
 Best when you don't own a domain: Tailscale Funnel gives a stable public HTTPS hostname on
 Tailscale's domain, free on the personal plan, no DNS to manage. **One-time tailnet setup in

--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -254,7 +254,19 @@ def main(argv: list[str] | None = None) -> None:
             auth=build_auth(token, oauth),
             file_transfer=file_transfer,
         )
-        server.run(transport="http", host=host, port=_resolve_port(args.port))
+        # proxy_headers=False: Uvicorn defaults to rewriting the peer address from
+        # X-Forwarded-For when the immediate client is a trusted host, which would let a
+        # request forge its own source IP and defeat the OAuth login throttle's per-IP
+        # keying (which reads request.client.host). We do the trusted-proxy decision
+        # ourselves via NOTEBOOKLM_MCP_TRUST_PROXY (CF-Connecting-IP only), so keep the ASGI
+        # peer the true socket peer. Nothing here derives security from the forwarded scheme
+        # (OAuth endpoints + signed links use the explicitly-configured base URL).
+        server.run(
+            transport="http",
+            host=host,
+            port=_resolve_port(args.port),
+            uvicorn_config={"proxy_headers": False},
+        )
     else:
         # show_banner=False keeps FastMCP's startup banner out of the host's logs
         # (and off stdout — stdio requires uncontaminated JSON-RPC).

--- a/src/notebooklm/mcp/_oauth.py
+++ b/src/notebooklm/mcp/_oauth.py
@@ -85,6 +85,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "OAUTH_BASE_URL_ENV",
     "OAUTH_PASSWORD_ENV",
+    "TRUST_PROXY_ENV",
     "OAuthConfig",
     "SelfHostedOAuthProvider",
     "build_oauth_provider",
@@ -95,6 +96,11 @@ __all__ = [
 #: enable OAuth; unset → bearer-only (Phase A unchanged).
 OAUTH_PASSWORD_ENV = "NOTEBOOKLM_MCP_OAUTH_PASSWORD"
 OAUTH_BASE_URL_ENV = "NOTEBOOKLM_MCP_OAUTH_BASE_URL"
+#: Opt-in: trust the proxy-set ``CF-Connecting-IP`` header as the login-throttle key
+#: (``"1"`` to enable). Default off → key on the socket peer. Only set this when a trusted
+#: proxy (e.g. the Cloudflare tunnel) authoritatively sets the header; if the origin is
+#: exposed directly, a client could forge ``CF-Connecting-IP`` to dodge the per-IP throttle.
+TRUST_PROXY_ENV = "NOTEBOOKLM_MCP_TRUST_PROXY"
 
 #: The password is the gate, so insist it's strong (the primary brute-force defense).
 MIN_PASSWORD_LEN = 16
@@ -130,6 +136,9 @@ class OAuthConfig:
     password: str = field(repr=False)
     base_url: str = field(repr=True)
     state_path: Path | None = field(default=None)  # persist target; None → no persistence
+    # Trust the proxy-set CF-Connecting-IP header for throttle keying (default off — the
+    # socket peer is used unless an operator asserts a trusted proxy sets the header).
+    trust_proxy: bool = field(default=False)
 
 
 def get_oauth_config() -> OAuthConfig | None:
@@ -171,19 +180,31 @@ def get_oauth_config() -> OAuthConfig | None:
     if home and profile:
         state_path = Path(home) / "profiles" / profile / "oauth_state.json"
 
-    return OAuthConfig(password=password, base_url=base_url, state_path=state_path)
+    # Opt-in trusted-proxy: only reached once OAuth is fully configured, so it never
+    # fires on the OAuth-off path. Default off keeps the throttle keyed on the socket peer.
+    trust_proxy = os.environ.get(TRUST_PROXY_ENV) == "1"
+
+    return OAuthConfig(
+        password=password, base_url=base_url, state_path=state_path, trust_proxy=trust_proxy
+    )
 
 
-def _client_ip(request: Request) -> str:
-    """Best-effort client IP for per-IP throttling. Behind the Cloudflare tunnel the
-    real client is in ``CF-Connecting-IP`` (Cloudflare sets it authoritatively, and the
-    tunnel admits no direct origin traffic, so it can't be spoofed in the intended
-    deploy). Falls back to the socket peer. CAVEAT: if the origin is exposed directly
-    (no tunnel/proxy), a client could spoof ``CF-Connecting-IP`` to dodge the throttle —
-    but the throttle is only secondary; the strong-password check is the real wall."""
-    cf = request.headers.get("cf-connecting-ip")
-    if cf:
-        return cf.strip()
+def _client_ip(request: Request, *, trust_proxy: bool) -> str:
+    """Best-effort client IP for per-IP login throttling.
+
+    The proxy-set ``CF-Connecting-IP`` header is trusted ONLY when ``trust_proxy`` is set
+    (``NOTEBOOKLM_MCP_TRUST_PROXY=1``) — i.e. the operator asserts a trusted proxy (the
+    Cloudflare tunnel) authoritatively sets it. Default off: an exposed-directly origin
+    would otherwise let a client forge ``CF-Connecting-IP`` to dodge the per-IP throttle,
+    so we key on the socket peer instead. With the flag off behind a tunnel the peer is the
+    tunnel egress, degrading the throttle to a single global bucket — strictly MORE
+    restrictive, never a spoof bypass. Secondary defense either way; the strong-password
+    check is the real wall. A present-but-empty header falls back to the peer so it can't
+    poison the bucket with a ``""`` key."""
+    if trust_proxy:
+        cf = (request.headers.get("cf-connecting-ip") or "").strip()
+        if cf:
+            return cf
     return request.client.host if request.client else "unknown"
 
 
@@ -191,7 +212,13 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
     """``InMemoryOAuthProvider`` + a password-gated ``/authorize``, with DoS bounds and
     file-backed persistence of clients + tokens."""
 
-    def __init__(self, password: str, base_url: str, state_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        password: str,
+        base_url: str,
+        state_path: Path | None = None,
+        trust_proxy: bool = False,
+    ) -> None:
         super().__init__(
             base_url=base_url,
             # DCR is OFF by default — without this NO /register route is mounted and
@@ -212,6 +239,7 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
         # run them OFF the event loop so a burst can't stall request servicing.
         self._kdf_limiter = anyio.CapacityLimiter(4)
         self._state_path = state_path
+        self._trust_proxy = trust_proxy
         # sid -> _Pending(client, validated params, expiry_ts, attempts). Pre-auth + bounded.
         self._pending: dict[str, _Pending] = {}
         # per-IP failed-login timestamps (throttle).
@@ -285,7 +313,7 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
             redirect = str(entry.params.redirect_uri) if entry else None
             return self._render_form(sid, redirect_uri=redirect)
 
-        ip = _client_ip(request)
+        ip = _client_ip(request, trust_proxy=self._trust_proxy)
         retry_after = self._throttled(ip)
         if retry_after is not None:
             return Response(
@@ -479,7 +507,20 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
 
 
 def build_oauth_provider(config: OAuthConfig) -> AuthProvider:
-    """Build the self-hosted OAuth provider from validated config."""
+    """Build the self-hosted OAuth provider from validated config.
+
+    Runs once at HTTP-server startup. Warns (once) when OAuth is enabled but state is not
+    persisted — issued tokens + registered clients then live in memory only and a restart
+    silently forces every client to re-register and the owner to re-login."""
+    if config.state_path is None:
+        logger.warning(
+            "OAuth is enabled but state is not persisted (set NOTEBOOKLM_HOME and "
+            "NOTEBOOKLM_PROFILE); issued tokens and registered clients are in-memory only "
+            "and a restart forces re-login."
+        )
     return SelfHostedOAuthProvider(
-        password=config.password, base_url=config.base_url, state_path=config.state_path
+        password=config.password,
+        base_url=config.base_url,
+        state_path=config.state_path,
+        trust_proxy=config.trust_proxy,
     )

--- a/src/notebooklm/mcp/_urlcheck.py
+++ b/src/notebooklm/mcp/_urlcheck.py
@@ -37,6 +37,17 @@ def _validate_bare_https_origin(url: str, env_name: str) -> None:
     Raises:
         SystemExit: ``url`` is not a bare https origin (clear, env-named message).
     """
+    # NOTE (security tripwire): this validator guards the *shape* of the origin
+    # (scheme/host/no-path), NOT its reachability. A special-use / private / loopback /
+    # link-local / metadata host is INTENTIONALLY accepted — the base URL is operator-
+    # supplied config that is only advertised in OAuth discovery metadata + signed links,
+    # never fetched by the server, so it is not an SSRF sink today, and rejecting private
+    # hosts would break split-horizon / self-hosted-DNS tunnels. IF a future refactor ever
+    # makes the server *fetch* this URL, it inherits an SSRF hole: at that call site resolve
+    # the hostname and reject if ANY resolved address is not a public unicast target — i.e.
+    # `not ip.is_global or ip.is_multicast` (this subsumes private/loopback/link-local/
+    # reserved AND catches CGNAT/unspecified/multicast that a partial predicate list misses).
+    # Inspecting an IP literal alone is insufficient (DNS rebinding — resolve, then filter).
     parsed = urlsplit(url)
     if (
         parsed.scheme.lower() != "https"

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -32,7 +32,11 @@ def _clear_oauth_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """``main()`` reads the self-hosted-OAuth env on every HTTP run; clear it by
     default so an ambient dev/CI environment can't perturb the bearer-focused tests
     (the OAuth tests set the vars explicitly after this autouse cleanup)."""
-    for var in ("NOTEBOOKLM_MCP_OAUTH_PASSWORD", "NOTEBOOKLM_MCP_OAUTH_BASE_URL"):
+    for var in (
+        "NOTEBOOKLM_MCP_OAUTH_PASSWORD",
+        "NOTEBOOKLM_MCP_OAUTH_BASE_URL",
+        "NOTEBOOKLM_MCP_TRUST_PROXY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -98,7 +98,9 @@ def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch)
 
     entry.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8123"])
 
-    fake_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=8123)
+    fake_server.run.assert_called_once_with(
+        transport="http", host="127.0.0.1", port=8123, uvicorn_config={"proxy_headers": False}
+    )
     # Loopback + no token → unauthenticated (today's local-dev behavior preserved).
     assert captured["auth"] is None
 
@@ -117,7 +119,27 @@ def test_http_default_port_is_9420(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry.main(["--transport", "http"])
 
-    fake_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=9420)
+    fake_server.run.assert_called_once_with(
+        transport="http", host="127.0.0.1", port=9420, uvicorn_config={"proxy_headers": False}
+    )
+
+
+def test_http_run_disables_uvicorn_proxy_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The HTTP run path must pass uvicorn_config proxy_headers=False so Uvicorn does NOT
+    rewrite the ASGI peer from X-Forwarded-For — otherwise a request could forge its source
+    IP and defeat the OAuth login throttle's per-IP keying (which reads request.client.host)."""
+    fake_server = MagicMock()
+    monkeypatch.setattr(
+        entry,
+        "create_server",
+        lambda *, profile=None, client_factory=None, auth=None, file_transfer=None: fake_server,
+    )
+    monkeypatch.delenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+
+    entry.main(["--transport", "http"])
+
+    assert fake_server.run.call_args.kwargs["uvicorn_config"] == {"proxy_headers": False}
 
 
 def test_bogus_transport_env_default_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -203,7 +225,9 @@ def test_http_non_loopback_with_token_attaches_auth(monkeypatch: pytest.MonkeyPa
 
     entry.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8000"])
 
-    fake_server.run.assert_called_once_with(transport="http", host="0.0.0.0", port=8000)
+    fake_server.run.assert_called_once_with(
+        transport="http", host="0.0.0.0", port=8000, uvicorn_config={"proxy_headers": False}
+    )
     assert isinstance(captured["auth"], McpBearerAuthProvider)
 
 

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -9,6 +9,7 @@ register→authorize→login→token→verify flow.
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -18,6 +19,7 @@ from fastmcp.server.auth import MultiAuth  # noqa: E402
 from mcp.server.auth.provider import AuthorizationParams  # noqa: E402
 from mcp.shared.auth import OAuthClientInformationFull  # noqa: E402
 from starlette.applications import Starlette  # noqa: E402
+from starlette.datastructures import Headers  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 from notebooklm.mcp._auth import McpBearerAuthProvider, build_auth  # noqa: E402
@@ -27,8 +29,11 @@ from notebooklm.mcp._oauth import (  # noqa: E402
     OAUTH_BASE_URL_ENV,
     OAUTH_PASSWORD_ENV,
     THROTTLE_MAX_FAILURES,
+    TRUST_PROXY_ENV,
     OAuthConfig,
     SelfHostedOAuthProvider,
+    _client_ip,
+    build_oauth_provider,
     get_oauth_config,
 )
 
@@ -37,8 +42,23 @@ _PW = "a-strong-random-password-1234567890"
 
 @pytest.fixture
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for k in (OAUTH_PASSWORD_ENV, OAUTH_BASE_URL_ENV, "NOTEBOOKLM_HOME", "NOTEBOOKLM_PROFILE"):
+    for k in (
+        OAUTH_PASSWORD_ENV,
+        OAUTH_BASE_URL_ENV,
+        TRUST_PROXY_ENV,
+        "NOTEBOOKLM_HOME",
+        "NOTEBOOKLM_PROFILE",
+    ):
         monkeypatch.delenv(k, raising=False)
+
+
+class _FakeRequest:
+    """Minimal Request stand-in for `_client_ip`: case-insensitive `.headers` (Starlette
+    `Headers`) plus a `.client` with `.host` (or `None` to exercise the no-peer branch)."""
+
+    def __init__(self, *, cf: str | None, peer: str | None) -> None:
+        self.headers = Headers({"cf-connecting-ip": cf} if cf is not None else {})
+        self.client = None if peer is None else type("C", (), {"host": peer})()
 
 
 def _provider(tmp_path=None) -> SelfHostedOAuthProvider:
@@ -288,3 +308,125 @@ def test_fail_times_drops_empty_entries() -> None:
     p._fail_times["1.2.3.4"] = [0.0]  # an ancient failure (epoch), outside the window
     assert p._throttled("1.2.3.4") is None
     assert "1.2.3.4" not in p._fail_times
+
+
+# --------------------------------------------------------------------------- #1761 trusted-proxy
+def test_client_ip_ignores_cf_header_when_untrusted() -> None:
+    """Default (flag off): CF-Connecting-IP is NOT trusted — key on the socket peer, so a
+    forged header can't dodge the throttle when the origin is exposed directly."""
+    req = _FakeRequest(cf="9.9.9.9", peer="10.0.0.1")
+    assert _client_ip(req, trust_proxy=False) == "10.0.0.1"
+
+
+def test_client_ip_honors_cf_header_when_trusted() -> None:
+    """Flag on (trusted proxy sets the header): key on CF-Connecting-IP."""
+    req = _FakeRequest(cf="9.9.9.9", peer="10.0.0.1")
+    assert _client_ip(req, trust_proxy=True) == "9.9.9.9"
+
+
+def test_client_ip_empty_cf_header_falls_back_to_peer() -> None:
+    """Even when trusted, a present-but-blank CF-Connecting-IP must NOT become a '' key —
+    fall back to the socket peer."""
+    assert _client_ip(_FakeRequest(cf="   ", peer="10.0.0.1"), trust_proxy=True) == "10.0.0.1"
+
+
+def test_client_ip_no_peer_returns_unknown() -> None:
+    """No socket peer and no trusted header → the 'unknown' fallback (bounded key)."""
+    assert _client_ip(_FakeRequest(cf="9.9.9.9", peer=None), trust_proxy=False) == "unknown"
+
+
+def test_config_resolves_trust_proxy_flag(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_oauth_config reads NOTEBOOKLM_MCP_TRUST_PROXY (=='1' → True; unset → False)."""
+    monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
+    monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
+    off = get_oauth_config()
+    assert off is not None and off.trust_proxy is False
+    monkeypatch.setenv(TRUST_PROXY_ENV, "1")
+    on = get_oauth_config()
+    assert on is not None and on.trust_proxy is True
+
+
+def test_provider_stores_trust_proxy() -> None:
+    p = SelfHostedOAuthProvider(password=_PW, base_url="https://h.example.com", trust_proxy=True)
+    assert p._trust_proxy is True
+
+
+def test_throttle_keys_on_peer_not_spoofed_cf_header() -> None:
+    """End-to-end through /login: with the flag OFF, THROTTLE_MAX_FAILURES wrong POSTs — each
+    with a FRESH sid and a DIFFERENT spoofed CF-Connecting-IP — still trip the throttle,
+    proving the varying header is NOT the key (all failures bucket under the one peer).
+
+    A fresh sid per POST is required: one sid burns after MAX_LOGIN_ATTEMPTS (< the throttle
+    threshold) and a burned sid returns the expired form WITHOUT recording a failure."""
+    assert MAX_LOGIN_ATTEMPTS < THROTTLE_MAX_FAILURES  # guards the fresh-sid necessity
+    p = _provider()  # trust_proxy defaults False
+    client = _client()
+    asyncio.run(p.register_client(client))
+    with TestClient(Starlette(routes=p.get_routes())) as c:
+        for i in range(THROTTLE_MAX_FAILURES):
+            sid = asyncio.run(p.authorize(client, _params())).split("sid=")[1]
+            r = c.post(
+                "/login",
+                data={"sid": sid, "password": "nope"},
+                headers={"cf-connecting-ip": f"203.0.113.{i}"},  # varies every request
+                follow_redirects=False,
+            )
+            assert r.status_code == 401
+        # next attempt (a fresh sid, another distinct spoofed IP) is throttled → the header
+        # was never the key; the socket peer bucketed all failures together.
+        sid = asyncio.run(p.authorize(client, _params())).split("sid=")[1]
+        r = c.post(
+            "/login",
+            data={"sid": sid, "password": "nope"},
+            headers={"cf-connecting-ip": "203.0.113.250"},
+            follow_redirects=False,
+        )
+    assert r.status_code == 429
+
+
+def test_throttle_separates_buckets_by_cf_header_when_trusted() -> None:
+    """Inverse of the above: with trust_proxy=True, distinct CF-Connecting-IP values bucket
+    SEPARATELY, so wrong POSTs from many spoofed IPs do NOT trip the throttle — proving the
+    trusted path keys on the header. (Each distinct IP accrues a single failure < threshold.)"""
+    p = SelfHostedOAuthProvider(password=_PW, base_url="https://host.example.com", trust_proxy=True)
+    client = _client()
+    asyncio.run(p.register_client(client))
+    with TestClient(Starlette(routes=p.get_routes())) as c:
+        for i in range(THROTTLE_MAX_FAILURES + 1):
+            sid = asyncio.run(p.authorize(client, _params())).split("sid=")[1]
+            r = c.post(
+                "/login",
+                data={"sid": sid, "password": "nope"},
+                headers={"cf-connecting-ip": f"198.51.100.{i}"},  # a fresh IP each time
+                follow_redirects=False,
+            )
+            assert r.status_code == 401  # never 429 — each IP has only one failure
+
+
+# --------------------------------------------------------------------------- #1761 startup warning
+def test_build_oauth_provider_warns_when_state_not_persisted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """OAuth on but state_path None → one startup WARNING naming the persistence env vars."""
+    cfg = OAuthConfig(password=_PW, base_url="https://h.example.com", state_path=None)
+    with caplog.at_level(logging.WARNING, logger="notebooklm.mcp._oauth"):
+        provider = build_oauth_provider(cfg)
+    assert isinstance(provider, SelfHostedOAuthProvider)
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "NOTEBOOKLM_HOME" in warnings[0].message and "NOTEBOOKLM_PROFILE" in warnings[0].message
+
+
+def test_build_oauth_provider_no_warn_when_state_persisted(
+    tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """With a state_path set, the non-persistence warning must NOT fire."""
+    cfg = OAuthConfig(
+        password=_PW, base_url="https://h.example.com", state_path=tmp_path / "oauth_state.json"
+    )
+    with caplog.at_level(logging.WARNING, logger="notebooklm.mcp._oauth"):
+        provider = build_oauth_provider(cfg)
+    assert isinstance(provider, SelfHostedOAuthProvider)
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -330,8 +330,9 @@ def test_client_ip_empty_cf_header_falls_back_to_peer() -> None:
     assert _client_ip(_FakeRequest(cf="   ", peer="10.0.0.1"), trust_proxy=True) == "10.0.0.1"
 
 
-def test_client_ip_no_peer_returns_unknown() -> None:
-    """No socket peer and no trusted header → the 'unknown' fallback (bounded key)."""
+def test_client_ip_no_peer_untrusted_cf_returns_unknown() -> None:
+    """No socket peer, and the CF header present but UNTRUSTED (flag off, so ignored) →
+    the bounded 'unknown' fallback rather than the attacker-controlled header value."""
     assert _client_ip(_FakeRequest(cf="9.9.9.9", peer=None), trust_proxy=False) == "unknown"
 
 


### PR DESCRIPTION
## Summary
Defense-in-depth for the self-hosted OAuth MCP transport (issue #1761). All three items are Low-severity — walled off by the 16-char scrypt password, which remains the real wall — but they close footguns and complete a guarantee the throttle implicitly claims. No schema change → no MCP tool-count / char-budget impact.

- **`_client_ip` trusted-proxy gate** — `CF-Connecting-IP` is trusted as the login-throttle key **only** behind a new opt-in `NOTEBOOKLM_MCP_TRUST_PROXY=1` flag. Default **off** keys on the socket peer, so a directly-exposed origin can't forge the header to dodge the per-IP throttle. A blank header falls back to the peer (no `""` key).
- **Uvicorn `proxy_headers=False`** (found in review) — the HTTP run path now disables Uvicorn's default `X-Forwarded-For` rewrite of `request.client.host`. Otherwise a lower layer could spoof the very "socket peer" the new keying relies on. Nothing here derives security from the forwarded scheme (OAuth endpoints + signed links use the explicitly-configured base URL).
- **Non-persisted-state startup warning** — `build_oauth_provider` logs one `warning` when OAuth is enabled but `NOTEBOOKLM_HOME`/`NOTEBOOKLM_PROFILE` are unset (tokens/clients in-memory only; a restart silently forces re-login).
- **`_urlcheck` SSRF tripwire (comment-only)** — the base URL is never fetched server-side today, so private/metadata hosts are intentionally accepted; the comment documents the resolve-and-filter (`not ip.is_global or ip.is_multicast`, DNS-rebind-aware) guard a future *fetching* refactor must add.

## Behavior-change note (for existing Cloudflare-tunnel operators)
Today `CF-Connecting-IP` is trusted unconditionally, so per-IP throttling currently works in the CF deploy. After this change those deploys degrade to a **global** throttle (strictly more restrictive, availability-only, bounded by the 60s window) until they set `NOTEBOOKLM_MCP_TRUST_PROXY=1`. Documented in mcp-guide.md.

## Trusted-proxy default = OFF
Plan reviewed by momus + codex + agy: default OFF is the fail-safe choice — default ON would re-introduce the exact spoof this fix targets whenever the tunnel assumption doesn't hold.

## Test plan
- [x] `tests/unit/mcp/test_selfhosted_oauth.py`: `_client_ip` both directions + blank-header + no-peer; config resolves `trust_proxy`; provider stores it; throttle keys on peer when off (varying spoofed headers still trip 429) **and** separates by header when on (varying IPs never trip); startup warning fires once / not when persisted.
- [x] `tests/unit/mcp/test_entrypoint.py`: HTTP run passes `uvicorn_config={"proxy_headers": False}`.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean; ruff clean; full `tests/_guardrails` + `tests/unit/mcp` = 1771 passed.

## Deferred polish findings
None.

Closes #1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JbvuTDoUwkxYvyEcUTzuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `NOTEBOOKLM_MCP_TRUST_PROXY` for Cloudflare Tunnel deployments, enabling per-IP login throttling based on `CF-Connecting-IP`.
  * Added a startup warning when authentication is enabled without persistent OAuth state.

* **Bug Fixes**
  * Prevented unintended proxy header rewriting so spoofed IP information isn’t trusted unless explicitly enabled.

* **Documentation**
  * Updated configuration and MCP guides with setup details, defaults, precedence, and security notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->