### PR TITLE
feat(server): close REST↔MCP capability + hardening gaps (source content, research, studio lifecycle, output parity)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1293,8 +1293,9 @@ src/notebooklm/
         ├── notebooks.py         # /v1/notebooks list/get/create/delete
         ├── sources.py           # /v1/notebooks/{id}/sources list/get/add(url·text·file)/delete + poll-the-resource status
         ├── notes.py             # /v1/notebooks/{id}/notes list/get/create/update(PUT)/delete — thin adapter over client.notes
-        ├── chat.py              # POST /v1/notebooks/{id}/chat — blocking ask (no SSE)
+        ├── chat.py              # POST /v1/notebooks/{id}/chat — blocking ask (no SSE) + POST /chat/configure over _app.chat.execute_configure
         ├── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download (registry-projected poll; server-generated temp download path)
+        ├── research.py          # /v1/notebooks/{id}/research start(202)/status/cancel/import — split-tool shape over client.research + _app.research.poll_and_classify (poll_id = report_id or task_id)
         └── share.py             # /v1/notebooks/{id}/share status/public/users/view-level over _app.sharing
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1038,6 +1038,7 @@ src/notebooklm/
 ├── _sharing_manager.py          # Sharing management logic
 ├── _version_check.py            # Deprecation version guard
 ├── _research_task_parser.py     # Research task result-type parser
+├── _redact.py                   # Transport-neutral secret/home-path/file-link scrubber (redact(msg, max_length)); shared chokepoint under both mcp/_errors.py and server/_errors.py
 ├── _app/                        # Transport-neutral business-logic layer (CLI/MCP/HTTP adapters share it)
 │   ├── __init__.py              # Re-exports the neutral primitives
 │   ├── artifacts.py             # Click-free artifact core: get/rename/delete/export + poll/wait/retry; kind-aware mind-map dispatch (mind_maps.list for rename, notes.list_mind_maps for delete), get_artifact raises ArtifactNotFoundError, typed Rename/Export results + ArtifactStatusView/status_view neutral status DTO (CLI builds every --json envelope from the typed fields)
@@ -1055,6 +1056,7 @@ src/notebooklm/
 │   ├── mcp_install.py           # Click-free `mcp install <client>` core: supported-client catalog (claude-desktop/claude-code/cursor/windsurf) + per-OS resolve_config_path + uvx build_server_block + merge_server_config read-modify-merge into mcpServers (created/updated/unchanged; never clobbers unrelated keys); UnsupportedClientError. CLI owns the atomic write (cli/mcp_cmd.py)
 │   ├── notebooks.py             # Click-free notebook core: create/delete/rename/describe(summary)/metadata fetch+compute (injected resolve_notebook_id; summary/metadata serializers stay in cli/notebook_cmd.py)
 │   ├── notes.py                 # Click-free note core: create/get/save/rename/delete (typed-facade only — notes.create returns a Note) + content-preserving rename (resolve_note_content); found-flag results map to the CLI NOT_FOUND/exit-1 path (injected notebook/note resolvers)
+│   ├── pagination.py            # Transport-neutral bounded-slice paginate(items, limit, offset) -> (page, {total,offset,has_more}) with bound validation; the shared slice under both the MCP *_list tools and the REST list-route envelope (Option B-lite)
 │   ├── profile.py               # Click-free profile core: gather_profile_list -> ProfileEntry rows (injected list_profiles/resolve_profile/get_storage_path/read_account_metadata), is_protected_profile delete-guard decision, set_default/retarget_default config.json mutators (CLI keeps the locked _atomic_write_config + click.confirm + Rich render)
 │   ├── research.py              # Click-free `research` status/wait core: poll_and_classify -> ResearchStatusResult, ResearchWaitPlan/Result + execute_research_wait (resolver/importer/wait-context injected), validate_research_wait_flags (-> ValidationError); returns typed results only (CLI owns the --json envelope)
 │   ├── resolve.py               # Click-free validate_id + resolve_ref (AmbiguousIdError/Resolution)
@@ -1068,7 +1070,8 @@ src/notebooklm/
 │   ├── source_listing.py        # Click-free `source list` fetch core: fetch_sources (label_filter resolution; label_resolver injected)
 │   ├── source_mutations.py      # Click-free source delete/delete-by-title/rename/refresh/add-drive core: resolvers + SourceMutationError + typed results (validate_id/resolve_source_id injected; confirmer injected)
 │   ├── source_research.py       # Click-free `source add-research` start/wait/import workflow + validate_add_research_flags (importer injected; SourceAddResearchPlan/Result)
-│   └── source_wait.py           # Click-free `source wait` readiness-poll core: execute_source_wait + typed SourceWaitOutcome (wait_context injected)
+│   ├── source_wait.py           # Click-free `source wait` readiness-poll core: execute_source_wait + typed SourceWaitOutcome (wait_context injected)
+│   └── views.py                 # Transport-neutral output-projection views: share_status_view (access/permission/view_level enum→label), source_view (kind/status_label added), ask_result_view (raw_response debug blob stripped); shared by the MCP tools + REST routes so both emit the identical enriched shape (Option B)
 ├── _runtime/                    # Client-runtime subpackage (promoted from flat _runtime_*.py, #1328)
 │   ├── __init__.py              # Re-exports the cluster's public names
 │   ├── auth.py                  # AuthRefreshCoordinator (refresh task + auth-snapshot lock)
@@ -1286,6 +1289,7 @@ src/notebooklm/
     ├── _context.py              # AppState (lifespan-bound client + pending registry) + get_client / get_pending FastAPI dependencies
     ├── _auth.py                 # Bearer-token (constant-time, 401) + loopback-Host (DNS-rebinding guard, 403) dependency for /v1
     ├── _errors.py               # ErrorCategory -> HTTP status table + _redact + the classify-once exception handler emitting {error:{category,message}}
+    ├── _pagination.py           # Opt-in, non-breaking list-route envelope: paginate_envelope(items, key=…, limit, offset, **extra) — default (no limit) returns the full list under its existing key unchanged; ?limit= slices via _app.pagination.paginate + adds a meta:{total,has_more,limit,offset} block (Option B-lite)
     ├── _pending.py              # In-process pending-id registry (per-notebook provenance for poll -> 200-pending vs 404)
     └── routes/                  # Per-resource FastAPI routers; handlers call _app.serialize.to_jsonable directly
         ├── __init__.py          # Aggregates the resource routers for the app factory

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1294,13 +1294,14 @@ src/notebooklm/
     └── routes/                  # Per-resource FastAPI routers; handlers call _app.serialize.to_jsonable directly
         ├── __init__.py          # Aggregates the resource routers for the app factory
         ├── _passthrough.py      # Pass-through resolvers handed to the _app cores (REST works in full ids)
-        ├── notebooks.py         # /v1/notebooks list/get/create/delete
-        ├── sources.py           # /v1/notebooks/{id}/sources list/get/add(url·text·file)/delete + poll-the-resource status
+        ├── notebooks.py         # /v1/notebooks list/get/create/rename(PATCH)/delete + GET /{id}/suggested-prompts (client.notebooks.suggest_prompts; surface→mode map pinned to MCP)
+        ├── sources.py           # /v1/notebooks/{id}/sources list/get/add(url·text·file·drive·batch)/rename(PATCH)/wait/delete + poll-the-resource status
         ├── notes.py             # /v1/notebooks/{id}/notes list/get/create/update(PUT)/delete — thin adapter over client.notes
         ├── chat.py              # POST /v1/notebooks/{id}/chat — blocking ask (no SSE) + POST /chat/configure over _app.chat.execute_configure
-        ├── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download (registry-projected poll; server-generated temp download path)
+        ├── artifacts.py         # /v1/notebooks/{id}/artifacts list/generate/poll/download/rename(PATCH)/retry/delete + GET /{id}/prompt (per-kind generate-option validation pinned to core maps; registry-projected poll; server-generated temp download path)
         ├── research.py          # /v1/notebooks/{id}/research start(202)/status/cancel/import — split-tool shape over client.research + _app.research.poll_and_classify (poll_id = report_id or task_id)
-        └── share.py             # /v1/notebooks/{id}/share status/public/users/view-level over _app.sharing
+        ├── share.py             # /v1/notebooks/{id}/share status/public/users/view-level over _app.sharing
+        └── meta.py              # GET /v1/server/info — version + local auth-health probe (run_auth_check) + opt-in account block; scrubs the on-disk storage path (mirrors MCP server_info)
 ```
 
 ## ADR cross-references

--- a/docs/notes/rest-vs-mcp-gap-review-2026-07-02.md
+++ b/docs/notes/rest-vs-mcp-gap-review-2026-07-02.md
@@ -1,0 +1,140 @@
+# REST server vs MCP server — gap review (2026-07-02)
+
+**Inputs (4 lenses):** 2 native Claude (capability-parity matrix · shared-capability contract
+divergence) + Codex CLI (REST security/hardening vs MCP) + agy CLI (unique-to-each inventory). All
+read the current `src/notebooklm/{server,mcp}/` tree. Both adapters are thin wrappers over the same
+`src/notebooklm/_app/` cores, so a "gap" = an `_app/` capability one adapter exposes and the other
+doesn't (or exposes with a materially different contract).
+
+## Headline
+
+The gap is **overwhelmingly one-directional**. The REST server is missing ~11 capability areas the
+MCP server has; the MCP server is missing **~zero** real capabilities REST has. On top of that, REST
+lags MCP on a whole tier of **hardening** (confirm gates, redaction, resource caps, poll semantics).
+
+- **MCP → REST (things REST lacks):** deep research (entire core), source **content** read,
+  `chat_configure`, studio lifecycle (delete/retry/rename/get_prompt), `source_wait`,
+  `suggest_prompts`, notebook/source rename, `server_info`, Drive/YouTube/batch source-add.
+- **REST → MCP (things MCP lacks):** **none of substance.** REST's dedicated `/notes` CRUD looks
+  unique but MCP covers all of it through the cross-type Studio surface (`note_save` upsert +
+  `studio_list` read/enumerate with `kind="note"` + `studio_delete`). This is an interface-shape
+  difference, not a capability gap. *(Corrects one lens that called MCP a "write-only notes client" —
+  `_studio_items.py:95-111` reads `client.notes.list`; `studio_delete` deletes notes.)*
+
+**Bottom line:** REST is **not** a viable substitute for MCP today. It can create notebooks, add
+url/text/file sources, run a blocking chat, and generate + download artifacts — but a REST client
+**cannot read what a source actually says, cannot run deep research, and cannot tune chat.** It is
+also the softer target of the two on security.
+
+---
+
+## A. Capability gaps — MCP has it, REST doesn't
+
+Ranked by user impact. Backing `_app/` core in parens.
+
+| # | Gap (REST-missing) | `_app/` core | Impact | Close cost |
+|---|---|---|---|---|
+| 1 | **Deep research** (start/status/cancel/import) — no research router mounted at all | `research`, `source_research` | **HIGH** | New `/research` router |
+| 2 | **Source content read** — `GET /sources/{id}` returns metadata/status only (`get_or_none`), never the extracted fulltext MCP's `source_read` serves | `source_content` | **HIGH** | New content route |
+| 3 | **`chat_configure`** — REST chat is locked to notebook defaults (no goal/persona/length) | `chat.execute_configure` | **MED-HIGH** | New route |
+| 4 | **Studio delete** — REST generates artifacts but can never remove them | `artifacts.delete_artifact` | **MED** | New route |
+| 5 | **Studio retry** — a failed generation can't be retried in place | `generate_retry` | **MED** | New route |
+| 6 | **`source_wait`** — no readiness primitive; REST callers hand-roll polling | `source_wait` | **MED** | New route |
+| 7 | **Drive/YouTube/batch source-add** — REST has only url/text/file, one at a time | `source_add` | **MED** | Extend routes/models |
+| 8 | **`suggest_prompts`** — no recommended-question affordance | (client namespace) | **LOW-MED** | New route |
+| 9 | **`studio_get_prompt`** — can't retrieve the prompt an artifact was generated with | `artifacts.get_artifact_prompt` | **LOW** | New route |
+| 10 | **notebook/source/artifact rename** — no PATCH/rename verbs | `notebooks`, `source_mutations`, `artifacts` | **LOW** | Trivial passthrough routes |
+| 11 | **`server_info`** — REST has only unauthed `/healthz` liveness, no account/version block | `profile`, `auth_check` | **LOW** | New route |
+
+## B. Capability gaps — REST has it, MCP doesn't
+
+**Effectively none.** REST's `/notes` list/get/put/delete map to MCP's `note_save` + `studio_list`
+(`kind="note"`, single-fetch by ref returns `content`) + `studio_delete`. Same underlying
+`_app.notes` ops, different URL shape. Not a gap.
+
+---
+
+## C. Contract divergence on shared capabilities (both surfaces expose these, but differently)
+
+Consensus items (2+ lenses) first.
+
+1. **Async generation poll semantics are genuinely incompatible — HIGH.** MCP `studio_status` is
+   **stateless**: any `task_id` polls its real status and terminal states (FAILED/REMOVED) come back
+   as fields. REST records the id in a **process-local in-memory `PendingRegistry`**
+   (`server/_pending.py:18-22`) and maps unknown→404, REMOVED→410, FAILED→409. A real, still-running
+   task the process didn't create (or created before a restart) returns **404 on REST but live status
+   on MCP**. (`artifacts.py:298-324`) *(Lens B)*
+
+2. **Destructive + outward ops: MCP confirm-gated, REST fires immediately — HIGH.** *(Codex + Lens B
+   consensus)* MCP two-steps every delete and gates public-widening / user-grant behind `confirm=`.
+   REST: `POST /share/public` makes a notebook public, and `POST /share/users` grants access **and
+   emails the user**, each on a single unconfirmed request. Deletes are bare `DELETE` verbs (defensible
+   HTTP idiom) but the **outward sharing** ops have no guard at all. (`share.py:74,86,115`)
+
+3. **`notify` default is inverted — MED.** *(Codex + Lens B consensus)* `share_set_user` defaults
+   `notify=False` on MCP; REST `POST /share/users` defaults `notify=True` (`share.py:31`) — the same
+   grant emails a third party by default on REST, silently on MCP. (REST's `PATCH /users/{email}`
+   carries no notify flag at all.)
+
+4. **Output leaks MCP intentionally strips — MED.** *(Lens B)* REST `to_jsonable`s raw results:
+   sharing status ships bare integer enums (`access=1`, `permission=3`) instead of MCP's string labels
+   (`share.py:71,83,143`); chat ships the `raw_response` debug blob MCP pops (`chat.py:47`). Source
+   list ships raw integer status/type codes with no `kind`/`status_label`.
+
+5. **Error contract thinner + a redaction hole — MED.** *(Codex + Lens B)* MCP errors carry
+   `retriable` + `hint` and redact home paths / file tokens; REST returns `{category, message}` + HTTP
+   status with **no `retriable`, no `hint`, and no home-path redaction** (`server/_errors.py:94-107`).
+   A file-upload path error can leak `/home/<user>/…` in a REST body.
+
+6. **Identifiers: MCP resolves name-or-id-prefix, REST is id-only — MED.** *(Lens B)* REST resolvers
+   are literal passthroughs (`_passthrough.py:27-31`); a REST caller must hold canonical UUIDs.
+
+7. **Lists: MCP paginated (limit/offset/total/has_more), REST returns the whole collection raw — MED.**
+   *(Lens B)* Large notebooks/accounts dump unbounded raw-code payloads over REST.
+
+8. **Note create/update ergonomics inverted — MED.** *(Lens B)* MCP requires title+content on create,
+   allows partial update; REST allows an empty-body create (`title="New Note"`, `content=""`) but
+   forces a full title+content replacement on `PUT` (`notes.py:35-47,70-79`).
+
+> Verified non-issue: the `source_ids` **None=all vs []=none** footgun is honored correctly on **both**
+> sides (`artifacts.py:269` + `_passthrough.py:52` mirror `studio.py:424` + `173`). No divergence.
+
+---
+
+## D. Security / hardening asymmetry (REST lags MCP)
+
+From Codex, all REST-side, all citing an MCP protection REST doesn't replicate:
+
+| Sev | Finding | Where |
+|---|---|---|
+| HIGH | Public-share + user-grant widen access with no confirm gate (dup of C.2) | `share.py:74,86,115` |
+| HIGH | Share invite **emails by default** (`notify=True`) (dup of C.3) | `share.py:31` |
+| HIGH | Destructive deletes have no confirm/preview | `notebooks.py:62`, `sources.py:235`, `notes.py:82` |
+| MED | Multipart uploads spool to disk before the size cap runs (chunked/no-`Content-Length` bypass) | `app.py:97`, `sources.py:204` |
+| MED | Artifact downloads unbounded + cleanup only via background task — no disconnect-safe slot cap like MCP | `artifacts.py:339,353,382` |
+| MED | `--token` CLI arg writes the bearer token where `ps` can read it; MCP is env-only on purpose | `__main__.py:107,152` |
+| MED | Loopback guard is launcher-only + spoofable `Host` header in-app; running the ASGI app directly on `0.0.0.0` is reachable | `__main__.py:55,157`, `_auth.py:114` |
+| LOW | Error redaction lacks MCP's home-path / file-link patterns (dup of C.5) | `_errors.py:94` |
+| LOW | Artifact generate silently accepts wrong-kind options and drops mind-map `instructions` | `artifacts.py:264,275` |
+| LOW | Upload filename sanitization weaker than MCP's `_safe_upload_name` | `sources.py:57` |
+
+*(Auth token comparison itself: worth confirming `server/_auth.py` uses `compare_digest` — Codex
+didn't flag a timing leak, so assume present; verify if hardening this.)*
+
+---
+
+## Recommended priority if REST is to be taken seriously
+
+**Tier 1 (makes REST usable at all):** source content read (A.2), deep research router (A.1),
+`chat_configure` (A.3). Without the first, a REST client is blind to its own documents.
+
+**Tier 2 (safety parity):** confirm-gate outward sharing + flip `notify` default (C.2/C.3/D),
+port MCP's home-path redaction (C.5/D), add download concurrency cap (D). These are small diffs that
+close the sharpest security asymmetries.
+
+**Tier 3 (completeness):** studio delete/retry (A.4/A.5), `source_wait` (A.6), rename verbs (A.10),
+pagination (C.7), fix the stateful-poll 404 (C.1 — either document it or back the registry with a real
+status probe on cache-miss).
+
+**Cheapest high-value single fix:** flip `notify` default to `False` and confirm-gate `POST
+/share/public` — one-line-ish changes that remove two HIGH outward-facing footguns.

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -127,14 +127,14 @@ CATEGORY_HINTS: dict[ErrorCategory, str | None] = {
     ErrorCategory.NOT_FOUND: (
         "Check the id/name with the matching *_list tool; the resource may have been deleted."
     ),
-    ErrorCategory.AUTH: "Re-authenticate (run `notebooklm login`) and retry.",
+    ErrorCategory.AUTH: "Re-authenticate and retry.",
     ErrorCategory.RATE_LIMITED: "Back off and retry after a short delay.",
     ErrorCategory.VALIDATION: "Fix the invalid argument and retry; this will not succeed unchanged.",
     ErrorCategory.CONFIG: "Check the auth profile / storage configuration.",
     ErrorCategory.NETWORK: "Transient connectivity issue; retry.",
     ErrorCategory.NOTEBOOK_LIMIT: "Notebook quota is exhausted; delete an existing notebook first.",
     ErrorCategory.ARTIFACT_TIMEOUT: (
-        "Generation is still running; poll studio_status with the task_id."
+        "Generation is still running; poll the task status with the task_id."
     ),
     ErrorCategory.TIMEOUT: "The operation did not finish in time; retry or poll for completion.",
     ErrorCategory.SERVER: "Upstream NotebookLM error; retry after a short delay.",
@@ -297,4 +297,4 @@ def classify(exc: BaseException) -> ClassifiedError:
         (``isinstance``), so it is stable and side-effect-free.
     """
     category = _category_for(exc)
-    return ClassifiedError(category=category, retriable=category in _RETRIABLE_CATEGORIES)
+    return ClassifiedError(category=category, retriable=is_retriable(category))

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -117,6 +117,36 @@ class ErrorCategory(Enum):
     UNEXPECTED = "unexpected"
 
 
+#: Short remediation hint for each :class:`ErrorCategory`, or ``None`` when no
+#: useful action exists beyond reading the message. This is the single neutral
+#: source of truth for the hint text shared by the MCP projector (which pairs it
+#: with its own manifest ``code`` in ``mcp/_errors.CATEGORY_TABLE``) and the REST
+#: error body (``server/_errors``), so the two surfaces cannot drift. Covers
+#: EVERY category (pinned by the adapter coverage tests).
+CATEGORY_HINTS: dict[ErrorCategory, str | None] = {
+    ErrorCategory.NOT_FOUND: (
+        "Check the id/name with the matching *_list tool; the resource may have been deleted."
+    ),
+    ErrorCategory.AUTH: "Re-authenticate (run `notebooklm login`) and retry.",
+    ErrorCategory.RATE_LIMITED: "Back off and retry after a short delay.",
+    ErrorCategory.VALIDATION: "Fix the invalid argument and retry; this will not succeed unchanged.",
+    ErrorCategory.CONFIG: "Check the auth profile / storage configuration.",
+    ErrorCategory.NETWORK: "Transient connectivity issue; retry.",
+    ErrorCategory.NOTEBOOK_LIMIT: "Notebook quota is exhausted; delete an existing notebook first.",
+    ErrorCategory.ARTIFACT_TIMEOUT: (
+        "Generation is still running; poll studio_status with the task_id."
+    ),
+    ErrorCategory.TIMEOUT: "The operation did not finish in time; retry or poll for completion.",
+    ErrorCategory.SERVER: "Upstream NotebookLM error; retry after a short delay.",
+    ErrorCategory.RPC: None,
+    ErrorCategory.SOURCE_MUTATION: (
+        "Resolve the source reference (it was missing, ambiguous, or needs confirmation)."
+    ),
+    ErrorCategory.LIBRARY: None,
+    ErrorCategory.UNEXPECTED: None,
+}
+
+
 @dataclass(frozen=True)
 class ClassifiedError:
     """The neutral classification of an exception.
@@ -144,6 +174,18 @@ _RETRIABLE_CATEGORIES = frozenset(
         ErrorCategory.NETWORK,
     }
 )
+
+
+def is_retriable(category: ErrorCategory) -> bool:
+    """Return whether retrying an operation that failed with ``category`` may succeed.
+
+    The single neutral source of the retriability decision (the same
+    :data:`_RETRIABLE_CATEGORIES` set that backs :func:`classify`), so a surface
+    that only knows a *category* (e.g. the REST server projecting a hand-raised
+    ``HTTPException`` status onto a category, where there is no exception to
+    :func:`classify`) can read the same flag without re-deriving it.
+    """
+    return category in _RETRIABLE_CATEGORIES
 
 
 def _normalized_rpc_code(exc: ClientError) -> int | None:

--- a/src/notebooklm/_app/pagination.py
+++ b/src/notebooklm/_app/pagination.py
@@ -1,0 +1,42 @@
+"""Transport-neutral bounded-pagination slice for list adapters.
+
+The ``*_list`` surfaces return a whole collection; on a large account or notebook
+that can be a big payload. :func:`paginate` is the shared, pure slice + bound
+validation that both the MCP ``*_list`` tools and the REST list routes build their
+own envelope on top of (Option B-lite: shared slice helper, each adapter keeps its
+own envelope field names).
+
+The underlying ``batchexecute`` RPCs don't paginate, so this is a client-side
+slice over the already-fetched list — the whole collection is still fetched, only
+the *returned* payload is bounded.
+
+This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
+``fastmcp`` imports (enforced by ``tests/_guardrails/test_app_boundary.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..exceptions import ValidationError
+
+__all__ = ["paginate"]
+
+
+def paginate(items: list[Any], limit: int, offset: int = 0) -> tuple[list[Any], dict[str, Any]]:
+    """Return ``(page, meta)`` — the ``items[offset : offset+limit]`` slice + meta.
+
+    ``meta`` is ``{"total": <full count>, "offset": <offset>, "has_more": <bool>}``.
+    ``limit`` must be >= 1 (a bounded page is the point) and ``offset`` >= 0; page
+    forward by re-calling with ``offset += limit`` until ``has_more`` is false.
+    """
+    if limit < 1:
+        raise ValidationError("limit must be >= 1.")
+    if offset < 0:
+        raise ValidationError("offset must be >= 0.")
+    page = items[offset : offset + limit]
+    return page, {
+        "total": len(items),
+        "offset": offset,
+        "has_more": offset + len(page) < len(items),
+    }

--- a/src/notebooklm/_app/research.py
+++ b/src/notebooklm/_app/research.py
@@ -111,6 +111,63 @@ async def poll_and_classify(
     )
 
 
+async def poll_sources_for_import(
+    client: Any, notebook_id: str, run_id: str
+) -> list[dict[str, Any]]:
+    """Poll a research run and return its importable sources, or raise.
+
+    The single shared importable-state guard for the "import a completed run's
+    found sources" flow — driven by BOTH the MCP ``research_import`` tool and the
+    REST ``POST .../research/{run_id}/import`` route so the ladder cannot drift
+    between the two adapters.
+
+    Polls FOR THE REQUESTED ``run_id`` (via :func:`poll_and_classify`, which
+    forwards it to ``client.research.poll`` as the task discriminator) so the
+    returned sources belong to that run — never the notebook's current (possibly
+    different) research run's sources. Every non-importable state raises the
+    public :class:`~notebooklm.exceptions.ValidationError` (each adapter maps it
+    to its own surface + status), so an unfinished / failed / empty run is never
+    imported as a partial success:
+
+    * ``not_found`` — the pinned run is not among the polled runs (nothing to
+      import; the typed ``NOT_FOUND`` sentinel, not a fallback to the current run);
+    * ``failed`` — the run will not complete;
+    * any non-``completed`` status (e.g. ``in_progress`` / ``no_research``) —
+      only a completed run has a final source set;
+    * ``completed`` with no sources — refuse the silent empty import.
+
+    Returns the completed run's importable sources (the legacy ``list[dict]``
+    shape) on success. The caller then drives ``client.research.import_sources``
+    and shapes its own response.
+
+    The ``run`` noun is surface-neutral (the MCP tool documents it as the
+    ``task_id``); the message names no adapter-specific route or tool so the one
+    string reads cleanly on both surfaces.
+    """
+    status = await poll_and_classify(client, notebook_id, run_id)
+    if status.status == "not_found":
+        raise ValidationError(
+            f"Research run {run_id!r} is not among notebook {notebook_id}'s research "
+            "runs; nothing to import. Check its status first."
+        )
+    # Only a COMPLETED run has a final source set. Importing an
+    # in_progress/no_research/failed snapshot would import a partial/empty set as
+    # a "success" — refuse with an action-appropriate message.
+    if status.status == "failed":
+        raise ValidationError(
+            f"Research run {run_id!r} failed; it will not complete — start a new "
+            "research session rather than polling."
+        )
+    if status.status != "completed":
+        raise ValidationError(
+            f"Research run {run_id!r} is not complete (status {status.status!r}); poll "
+            "its status until 'completed' before importing."
+        )
+    if not status.sources:
+        raise ValidationError(f"Research run {run_id!r} completed with no sources to import.")
+    return status.sources
+
+
 # ===========================================================================
 # research cancel
 # ===========================================================================
@@ -355,5 +412,6 @@ __all__ = [
     "cancel_research",
     "execute_research_wait",
     "poll_and_classify",
+    "poll_sources_for_import",
     "validate_research_wait_flags",
 ]

--- a/src/notebooklm/_app/source_add.py
+++ b/src/notebooklm/_app/source_add.py
@@ -23,6 +23,8 @@ This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
 from __future__ import annotations
 
 import ipaddress
+import os
+import re
 import socket
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -38,6 +40,68 @@ if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
 SourceAddType = Literal["url", "text", "file", "youtube"]
+
+#: Maximum length of a file's basename on the common filesystems (ext4, APFS,
+#: NTFS) — measured in **bytes**, not characters. A multibyte name (emoji, CJK)
+#: can blow past this while looking short by ``len()``, so truncation is
+#: byte-aware.
+_MAX_BASENAME_BYTES = 255
+
+#: Control chars stripped from an upload name: C0 (``\x00-\x1f``), DEL (``\x7f``),
+#: and the C1 range (``\x80-\x9f``). None are legitimate in a filename, and a NUL
+#: would make ``os.open`` raise ``ValueError``.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    """Return ``text`` clipped to at most ``max_bytes`` UTF-8 bytes.
+
+    Never splits a multibyte character — a trailing partial sequence left by the
+    byte clip is dropped (``decode(..., "ignore")``).
+    """
+    if max_bytes <= 0:
+        return ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", "ignore")
+
+
+def safe_upload_name(filename: str | None) -> str:
+    """Return a safe basename for a spooled upload file, preserving the extension.
+
+    Shared by every transport that spools a caller-named upload to a private
+    ``mkdtemp`` dir (the REST ``add_file`` route and the MCP ``/files/ul`` route).
+    NotebookLM 400s on an extensionless upload and the source-id extraction keys
+    off the real basename+extension, so the caller's name must survive — but
+    safely:
+
+    * control chars are stripped — C0 (``\\x00-\\x1f``), DEL (``\\x7f``), and the
+      C1 range (``\\x80-\\x9f``); a NUL would make ``os.open`` raise
+      ``ValueError`` and none are legitimate in a filename;
+    * ``\\`` is normalized so a Windows-style ``C:\\dir\\x.pdf`` yields its real
+      leaf, then :func:`os.path.basename` strips directory components (the
+      path-traversal guard);
+    * the directory-cursor names ``.`` / ``..`` fall back to a safe extensioned
+      default (they would target an existing dir and fail ``O_EXCL``);
+    * an over-long name is truncated on its **stem** (never the extension), by
+      UTF-8 **byte** length so a multibyte name (emoji, CJK) stays under the
+      255-byte filesystem basename limit rather than only under 255 *characters*.
+
+    An empty / cursor / extensionless-default input falls back to ``"upload.bin"``
+    (never extensionless).
+    """
+    cleaned = _CONTROL_CHARS.sub("", filename or "").replace("\\", "/")
+    base = os.path.basename(cleaned)
+    if not base or base in (".", ".."):
+        return "upload.bin"
+    if len(base.encode("utf-8")) <= _MAX_BASENAME_BYTES:
+        return base
+    # Preserve the extension: clip it first (in the pathological all-suffix case),
+    # then give the stem whatever byte budget remains.
+    suffix = _truncate_utf8(Path(base).suffix, _MAX_BASENAME_BYTES)
+    stem_budget = _MAX_BASENAME_BYTES - len(suffix.encode("utf-8"))
+    return _truncate_utf8(Path(base).stem, stem_budget) + suffix
 
 
 class SourceAddValidationError(ValidationError):
@@ -402,6 +466,7 @@ __all__ = [
     "build_source_add_plan",
     "execute_source_add",
     "looks_like_path",
+    "safe_upload_name",
     "validate_upload_path",
     "validate_url",
 ]

--- a/src/notebooklm/_app/source_content.py
+++ b/src/notebooklm/_app/source_content.py
@@ -15,11 +15,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from ..exceptions import ConfigurationError, SourceNotFoundError, ValidationError
+
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
     from ..types import Source, SourceFulltext
 
 FulltextFormat = Literal["text", "markdown"]
+
+#: Default cap on the returned body when ``max_chars`` is omitted — the content is
+#: bounded (not dumped whole) so a large source can't flood a caller's context.
+DEFAULT_CONTENT_CHARS = 10_000
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +136,105 @@ async def execute_source_guide(
 
 
 # ---------------------------------------------------------------------------
+# source read (existence/ready-gated fulltext with windowing)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceReadPlan:
+    """Prepared inputs for :func:`execute_source_read`.
+
+    ``max_chars`` ``None`` applies :data:`DEFAULT_CONTENT_CHARS`; ``offset`` and a
+    non-negative ``max_chars`` window the body (``content[offset:offset+max]``).
+    """
+
+    notebook_id: str
+    source_id: str
+    output_format: FulltextFormat = "text"
+    max_chars: int | None = None
+    offset: int = 0
+
+
+@dataclass(frozen=True)
+class SourceReadResult:
+    """The resolved source plus its (windowed) content.
+
+    ``content`` is ``None`` and ``char_count`` 0 when the source is not READY
+    (still processing / errored) or has no extractable text; ``char_count`` is
+    always the FULL indexed length, and ``truncated`` reports whether the returned
+    slice omits any remainder.
+    """
+
+    source: Source
+    content: str | None
+    char_count: int
+    truncated: bool
+
+
+async def execute_source_read(client: NotebookLMClient, plan: SourceReadPlan) -> SourceReadResult:
+    """Read a source's body with an existence + ready gate and windowing.
+
+    Mirrors the MCP ``source_read`` (detail="full") core so both the MCP tool and
+    the REST content route share one implementation:
+
+    * ``execute_source_get`` is the **existence guard** — a resolved id the backend
+      no longer has raises :class:`SourceNotFoundError` (surfacing NOT_FOUND rather
+      than a misleading empty success).
+    * The body is fetched via ``execute_source_fulltext`` **only when the source is
+      READY**. Gating on status (rather than catching the fulltext fetch's
+      :class:`SourceNotFoundError`) keeps a genuine "source is gone" — e.g. deleted
+      between the two calls — propagating as NOT_FOUND instead of masquerading as
+      "no content".
+    * ``output_format='markdown'`` needs the optional ``markdownify`` extra; an
+      :class:`ImportError` on that path is remapped to a deterministic
+      :class:`ConfigurationError` (the text path re-raises — a genuine bug).
+    """
+    if plan.max_chars is not None and plan.max_chars < 0:
+        raise ValidationError(f"max_chars must be >= 0; got {plan.max_chars}")
+    if plan.offset < 0:
+        raise ValidationError(f"offset must be >= 0; got {plan.offset}")
+
+    get_result = await execute_source_get(
+        client, SourceGetPlan(notebook_id=plan.notebook_id, source_id=plan.source_id)
+    )
+    if get_result.source is None:
+        raise SourceNotFoundError(plan.source_id)
+    source = get_result.source
+
+    content: str | None = None
+    char_count = 0
+    if source.is_ready:
+        try:
+            fulltext_result = await execute_source_fulltext(
+                client,
+                SourceFulltextPlan(
+                    notebook_id=plan.notebook_id,
+                    source_id=plan.source_id,
+                    output_format=plan.output_format,
+                ),
+            )
+        except ImportError as exc:
+            if plan.output_format != "markdown":
+                raise
+            raise ConfigurationError(str(exc)) from exc
+        content = fulltext_result.fulltext.content or None
+        char_count = fulltext_result.fulltext.char_count
+
+    truncated = False
+    if content is not None:
+        effective_max = DEFAULT_CONTENT_CHARS if plan.max_chars is None else plan.max_chars
+        windowed = content[plan.offset : plan.offset + effective_max]
+        truncated = len(windowed) < (len(content) - plan.offset)
+        # Normalize an empty slice (e.g. offset past the end) to None, matching the
+        # fetch-path contract (content is null when there's nothing to show).
+        content = windowed or None
+
+    return SourceReadResult(
+        source=source, content=content, char_count=char_count, truncated=truncated
+    )
+
+
+# ---------------------------------------------------------------------------
 # source stale
 # ---------------------------------------------------------------------------
 
@@ -169,6 +274,7 @@ async def execute_source_stale(
 
 
 __all__ = [
+    "DEFAULT_CONTENT_CHARS",
     "FulltextFormat",
     "SourceFulltextPlan",
     "SourceFulltextResult",
@@ -176,10 +282,13 @@ __all__ = [
     "SourceGetResult",
     "SourceGuidePlan",
     "SourceGuideResult",
+    "SourceReadPlan",
+    "SourceReadResult",
     "SourceStalePlan",
     "SourceStaleResult",
     "execute_source_fulltext",
     "execute_source_get",
     "execute_source_guide",
+    "execute_source_read",
     "execute_source_stale",
 ]

--- a/src/notebooklm/_app/views.py
+++ b/src/notebooklm/_app/views.py
@@ -1,0 +1,115 @@
+"""Transport-neutral output-projection views (enum→label, debug-blob strip).
+
+Where a wire result would otherwise leak raw protocol integers or a debug blob,
+these helpers project the typed domain object into an agent-readable dict. They
+are the single home for projections the MCP tools historically hand-rolled, so
+the CLI/MCP/REST adapters all emit the SAME enriched shape (Option B — lift the
+projection into ``_app`` rather than copy it per adapter):
+
+* :func:`share_status_view` — ``ShareStatus`` with string-labeled access /
+  permission / view_level enums (a raw :func:`to_jsonable` pass would leak
+  ``access=1`` etc.).
+* :func:`source_view` — a ``Source`` with string ``kind`` / ``status_label``
+  labels added alongside the raw ``status`` / ``_type_code`` integers.
+* :func:`ask_result_view` — an ``AskResult`` serialized with the internal
+  ``raw_response`` debugging blob stripped (it just burns agent context; the
+  field stays on the dataclass, it is only omitted from the wire).
+
+This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
+``fastmcp`` imports (enforced by ``tests/_guardrails/test_app_boundary.py``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..types import source_status_to_str
+from .serialize import to_jsonable
+
+if TYPE_CHECKING:
+    from ..types import AskResult, ShareStatus, Source
+
+__all__ = [
+    "ACCESS_LABELS",
+    "PERMISSION_LABELS",
+    "VIEW_LEVEL_LABELS",
+    "ask_result_view",
+    "label",
+    "share_status_view",
+    "source_view",
+]
+
+#: ``int, Enum`` value → wire label for the three share enums. Unknown values
+#: (e.g. ``SharePermission._REMOVE`` or protocol drift) degrade to ``str(value)``
+#: via :func:`label` so the projection never KeyErrors.
+ACCESS_LABELS = {0: "restricted", 1: "anyone_with_link"}
+VIEW_LEVEL_LABELS = {0: "full", 1: "chat"}
+PERMISSION_LABELS = {1: "owner", 2: "editor", 3: "viewer"}
+
+
+def label(mapping: dict[int, str], value: int) -> str:
+    """Map an ``int, Enum`` member (or raw int) to its label; unknown → ``str``."""
+    key = int(value)
+    return mapping.get(key, str(key))
+
+
+def share_status_view(status: ShareStatus, *, include_view_level: bool = False) -> dict[str, Any]:
+    """Project ``ShareStatus`` to a wire dict with string-labeled enums.
+
+    ``view_level`` is included ONLY when ``include_view_level`` is set. The
+    ``GET_SHARE_STATUS`` read does not report it (``ShareStatus.from_api_response``
+    hardcodes ``FULL_NOTEBOOK``), so shipping it from a read would be
+    confidently-wrong data; the only trustworthy source is ``set_view_level``'s
+    own return, so the caller opts in on that path alone.
+    """
+    payload: dict[str, Any] = {
+        "notebook_id": status.notebook_id,
+        "is_public": status.is_public,
+        "access": label(ACCESS_LABELS, status.access),
+        "share_url": status.share_url,
+        "shared_users": [
+            {
+                "email": user.email,
+                "permission": label(PERMISSION_LABELS, user.permission),
+                "display_name": user.display_name,
+                "avatar_url": user.avatar_url,
+            }
+            for user in status.shared_users
+        ],
+    }
+    if include_view_level:
+        payload["view_level"] = label(VIEW_LEVEL_LABELS, status.view_level)
+    return payload
+
+
+def source_view(source: Source) -> dict[str, Any]:
+    """Serialize a ``Source`` with agent-readable string labels added.
+
+    ``to_jsonable`` emits only dataclass fields, so the integer ``status`` and
+    ``_type_code`` arrive as bare numbers and the ``kind`` *property* is dropped —
+    forcing an agent to guess what ``3``/``5``/``2`` mean. Add ``kind`` (e.g.
+    ``"pdf"``/``"web_page"``) and ``status_label`` (e.g. ``"ready"``/``"error"``)
+    string labels alongside the raw codes.
+
+    ``status_label`` comes from :func:`~notebooklm.rpc.types.source_status_to_str`
+    — the repo's single source of truth for status→string — so every adapter's
+    label stays in lock-step. It is one of ``ready``/``processing``/``error``/
+    ``preparing`` (``unknown`` for an unrecognized code).
+    """
+    view = to_jsonable(source)
+    view["kind"] = source.kind.value
+    view["status_label"] = source_status_to_str(source.status)
+    return view
+
+
+def ask_result_view(result: AskResult) -> dict[str, Any]:
+    """Serialize an ``AskResult``, dropping the internal ``raw_response`` blob.
+
+    ``raw_response`` is a debug-only truncated wire dump that just burns agent
+    context; it is omitted from the wire on every adapter (the field stays on the
+    dataclass for local debugging). Callers that want a trimmed ``references``
+    projection apply it on top of this base dict.
+    """
+    payload = to_jsonable(result)
+    payload.pop("raw_response", None)
+    return payload

--- a/src/notebooklm/_redact.py
+++ b/src/notebooklm/_redact.py
@@ -1,0 +1,80 @@
+"""Shared, transport-neutral message redaction for wire-bound error text.
+
+Both adapter error projectors (:mod:`notebooklm.mcp._errors` and
+:mod:`notebooklm.server._errors`) must scrub the same set of leak shapes before
+an exception message reaches a client: the package-wide credential shapes
+(bearer tokens / session cookies / Google credentials, via
+:func:`notebooklm._logging.scrub_secrets`) **plus** two surfaces the raw SDK
+string can carry — the signed ``/files/(dl|ul)/<token>`` side-channel token and
+local home-directory paths (the OS username is PII / host disclosure).
+
+Historically these two extra patterns lived only in the MCP projector, so a
+home-path in a REST error body leaked ``/home/<user>/…``. Lifting them into this
+single neutral chokepoint (per the rev-2 plan's Option B) makes the redaction
+identical on both surfaces. It lives at the package root rather than under
+``_app/`` because it composes :func:`notebooklm._logging.scrub_secrets`, and the
+``_app`` boundary gate (``tests/_guardrails/test_app_boundary.py``) forbids
+``_app`` from importing private siblings — but both adapter layers may import it.
+
+This module imports NO ``click`` / ``rich`` / ``cli`` / ``fastmcp``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ._logging import scrub_secrets
+
+__all__ = ["DEFAULT_MAX_MESSAGE", "redact"]
+
+#: Default maximum wire length for a redacted message before it is truncated.
+DEFAULT_MAX_MESSAGE = 300
+
+#: A home-directory username token: alphanumerics / underscore with INTERNAL
+#: dots/hyphens (``john.doe``, ``web-admin``) but no leading/trailing punctuation,
+#: so a trailing ``.``/``:``/``)`` of surrounding prose is never eaten.
+_HOME_USER = r"\w+(?:[.-]+\w+)*"
+
+#: Redaction patterns applied AFTER the shared ``scrub_secrets`` pass:
+#:
+#: 1. **Signed file-transfer URL tokens.** The ``/files/(dl|ul)/<token>``
+#:    side-channel (ADR-0024) carries an HMAC token ``b64url(body).b64url(mac)``;
+#:    the route prefix is kept as a shape hint and the whole token segment is
+#:    dropped. The dot-inclusive class redacts the entire segment regardless of
+#:    dot count and stops at ``/``, ``?``, whitespace, or end.
+#: 2. **Home-directory paths** (POSIX ``/home|/Users`` and Windows
+#:    ``X:\Users\``). A single-word username is redacted anywhere; a ``First
+#:    Last`` username (one space) only when followed by a path separator, so the
+#:    space cannot swallow following prose across multiple paths. The token
+#:    alternation is anchored on disjoint character classes (no overlapping
+#:    quantifiers), so there is no catastrophic-backtracking risk. Generic
+#:    absolute paths (``/var``/``/tmp``) are intentionally NOT redacted.
+_EXTRA_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(/files/(?:dl|ul)/)[A-Za-z0-9._-]+"), r"\1***"),
+    (re.compile(rf"(/(?:home|Users)/)(?:{_HOME_USER} {_HOME_USER}(?=/)|{_HOME_USER})"), r"\1***"),
+    (
+        re.compile(
+            rf"([A-Za-z]:[\\/]Users[\\/])(?:{_HOME_USER} {_HOME_USER}(?=[\\/])|{_HOME_USER})",
+            re.IGNORECASE,
+        ),
+        r"\1***",
+    ),
+)
+
+
+def redact(message: object, *, max_length: int = DEFAULT_MAX_MESSAGE) -> str:
+    """Scrub secrets + local paths, collapse whitespace, and length-cap ``message``.
+
+    Runs the shared package scrubber (:func:`notebooklm._logging.scrub_secrets`)
+    then the :data:`_EXTRA_PATTERNS` (signed ``/files/*`` tokens + home-directory
+    paths), THEN collapses whitespace and caps the length. Redaction runs
+    **before** the length cap so a secret sitting near the cap can never be
+    partially revealed.
+    """
+    text = scrub_secrets(message)
+    for pattern, replacement in _EXTRA_PATTERNS:
+        text = pattern.sub(replacement, text)
+    text = " ".join(text.split())
+    if len(text) > max_length:
+        text = text[:max_length] + "…"
+    return text

--- a/src/notebooklm/mcp/_errors.py
+++ b/src/notebooklm/mcp/_errors.py
@@ -29,15 +29,14 @@ This module imports NO ``click`` / ``rich`` / ``cli`` — only ``fastmcp``, the
 
 from __future__ import annotations
 
-import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 
 from fastmcp.exceptions import ToolError
 
-from .._app.errors import ErrorCategory, classify
-from .._logging import scrub_secrets
+from .._app.errors import CATEGORY_HINTS, ErrorCategory, classify
+from .._redact import redact
 from ..exceptions import NotebookLMError
 
 __all__ = [
@@ -49,9 +48,6 @@ __all__ = [
     "tool_error_payload",
 ]
 
-#: Maximum wire length for a tool-error message before it is truncated.
-_MAX_MESSAGE = 300
-
 #: Generic message returned for an UNEXPECTED (non-library) exception. A bug's
 #: ``str(exc)`` can carry anything (arbitrary paths, env-derived detail), and
 #: :func:`redact` is a *denylist* of known credential/path shapes — so the raw text
@@ -60,128 +56,38 @@ _MAX_MESSAGE = 300
 #: are still preserved so agents branch correctly).
 _UNEXPECTED_MESSAGE = "An unexpected internal error occurred."
 
-#: MCP-specific redaction patterns applied AFTER the shared ``scrub_secrets`` pass
-#: (which already covers bearer tokens / session cookies / Google credential
-#: shapes). Two surfaces only the MCP transport produces:
-#:
-#: 1. **Signed file-transfer URL tokens.** The ``/files/(dl|ul)/<token>``
-#:    side-channel (ADR-0024) carries an HMAC token ``b64url(body).b64url(mac)``;
-#:    the route prefix is kept as a shape hint and the whole token segment is
-#:    dropped. The dot-inclusive class redacts the entire segment regardless of dot
-#:    count (a malformed ``/files/dl/a.b.c`` leaves no ``.c`` tail), and it stops at
-#:    ``/``, ``?``, whitespace, or end — so a token inside a full
-#:    ``https://host/files/dl/<tok>?x=1`` URL is redacted in place.
-#: 2. **Home-directory paths** (the OS username is PII / host disclosure). The
-#:    username matcher (:data:`_HOME_USER`) is a word token (alphanumerics /
-#:    underscore with INTERNAL dots/hyphens — ``john.doe``, ``web-admin`` — but no
-#:    leading/trailing punctuation, so a trailing ``.``/``:``/``)`` of surrounding
-#:    prose is never eaten). Two cases:
-#:      * a single-word username is redacted ANYWHERE (no trailing separator
-#:        needed — it has no space, so it cannot greedily cross prose), so a bare
-#:        terminal ``/home/alice`` and ``/home/alice: denied`` are both masked
-#:        while the prose survives;
-#:      * a ``First Last`` username (one space) is only redacted when followed by a
-#:        path separator, so the space cannot swallow following prose across
-#:        multiple paths (``/home/a or /home/b/x`` must not become ``/home/***/x``).
-#:    Deliberate fail-safe bounds: a two-word username NOT followed by a separator
-#:    masks only its first word; ``/Users/Shared/…`` over-redacts; both err toward
-#:    not mangling the message. Generic absolute paths (``/var``/``/tmp``) are
-#:    intentionally NOT redacted (would mangle id-shaped ``NOT_FOUND``/RPC text for
-#:    little gain). The token alternation is anchored on disjoint character classes
-#:    (no overlapping quantifiers), so there is no catastrophic-backtracking risk.
-_HOME_USER = r"\w+(?:[.-]+\w+)*"
-_EXTRA_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"(/files/(?:dl|ul)/)[A-Za-z0-9._-]+"), r"\1***"),
-    (re.compile(rf"(/(?:home|Users)/)(?:{_HOME_USER} {_HOME_USER}(?=/)|{_HOME_USER})"), r"\1***"),
-    (
-        re.compile(
-            rf"([A-Za-z]:[\\/]Users[\\/])(?:{_HOME_USER} {_HOME_USER}(?=[\\/])|{_HOME_USER})",
-            re.IGNORECASE,
-        ),
-        r"\1***",
-    ),
-)
+#: The MCP manifest ``code`` for each neutral :class:`ErrorCategory`. The hint
+#: half lives in the shared :data:`notebooklm._app.errors.CATEGORY_HINTS` (reused
+#: by the REST error body too, so the two surfaces cannot drift);
+#: :data:`CATEGORY_TABLE` pairs each code with that shared hint.
+_CATEGORY_CODES: dict[ErrorCategory, str] = {
+    ErrorCategory.NOT_FOUND: "NOT_FOUND",
+    ErrorCategory.AUTH: "AUTH",
+    ErrorCategory.RATE_LIMITED: "RATE_LIMITED",
+    ErrorCategory.VALIDATION: "VALIDATION",
+    ErrorCategory.CONFIG: "CONFIG",
+    ErrorCategory.NETWORK: "NETWORK",
+    ErrorCategory.NOTEBOOK_LIMIT: "NOTEBOOK_LIMIT",
+    ErrorCategory.ARTIFACT_TIMEOUT: "ARTIFACT_TIMEOUT",
+    ErrorCategory.TIMEOUT: "TIMEOUT",
+    ErrorCategory.SERVER: "SERVER",
+    ErrorCategory.RPC: "RPC",
+    ErrorCategory.SOURCE_MUTATION: "SOURCE_MUTATION",
+    ErrorCategory.LIBRARY: "ERROR",
+    ErrorCategory.UNEXPECTED: "UNEXPECTED",
+}
 
 #: The MCP projection of each neutral :class:`ErrorCategory`: ``(code, hint)``.
 #: Covers EVERY ``ErrorCategory`` value (pinned by ``test_errors.py``). ``hint``
-#: is a short remediation string for the actionable categories, or ``None`` when
-#: no useful action exists beyond reading the message.
+#: is a short remediation string for the actionable categories (from the shared
+#: :data:`CATEGORY_HINTS`), or ``None`` when no useful action exists beyond
+#: reading the message.
 CATEGORY_TABLE: dict[ErrorCategory, tuple[str, str | None]] = {
-    ErrorCategory.NOT_FOUND: (
-        "NOT_FOUND",
-        "Check the id/name with the matching *_list tool; the resource may have been deleted.",
-    ),
-    ErrorCategory.AUTH: (
-        "AUTH",
-        "Re-authenticate (run `notebooklm login`) and retry.",
-    ),
-    ErrorCategory.RATE_LIMITED: (
-        "RATE_LIMITED",
-        "Back off and retry after a short delay.",
-    ),
-    ErrorCategory.VALIDATION: (
-        "VALIDATION",
-        "Fix the invalid argument and retry; this will not succeed unchanged.",
-    ),
-    ErrorCategory.CONFIG: (
-        "CONFIG",
-        "Check the auth profile / storage configuration.",
-    ),
-    ErrorCategory.NETWORK: (
-        "NETWORK",
-        "Transient connectivity issue; retry.",
-    ),
-    ErrorCategory.NOTEBOOK_LIMIT: (
-        "NOTEBOOK_LIMIT",
-        "Notebook quota is exhausted; delete an existing notebook first.",
-    ),
-    ErrorCategory.ARTIFACT_TIMEOUT: (
-        "ARTIFACT_TIMEOUT",
-        "Generation is still running; poll studio_status with the task_id.",
-    ),
-    ErrorCategory.TIMEOUT: (
-        "TIMEOUT",
-        "The operation did not finish in time; retry or poll for completion.",
-    ),
-    ErrorCategory.SERVER: (
-        "SERVER",
-        "Upstream NotebookLM error; retry after a short delay.",
-    ),
-    ErrorCategory.RPC: ("RPC", None),
-    ErrorCategory.SOURCE_MUTATION: (
-        "SOURCE_MUTATION",
-        "Resolve the source reference (it was missing, ambiguous, or needs confirmation).",
-    ),
-    ErrorCategory.LIBRARY: ("ERROR", None),
-    ErrorCategory.UNEXPECTED: ("UNEXPECTED", None),
+    category: (code, CATEGORY_HINTS[category]) for category, code in _CATEGORY_CODES.items()
 }
 
 #: Stable set of codes the server can emit (pinned by the manifest test).
 ERROR_CODES: frozenset[str] = frozenset(code for code, _ in CATEGORY_TABLE.values())
-
-
-def redact(message: str) -> str:
-    """Scrub secrets, collapse whitespace, and length-cap a message for the wire.
-
-    SDK exception messages are already designed to be secret-free (raw responses
-    are truncated at construction, per ADR-0019), but a tool-error message can also
-    carry upstream text or local paths. As defense-in-depth this runs the shared
-    package scrubber (:func:`notebooklm._logging.scrub_secrets`, masking bearer
-    tokens / session cookies / Google credential shapes) and the MCP-specific
-    :data:`_EXTRA_PATTERNS` (signed ``/files/*`` URL tokens + local home-directory
-    paths), THEN collapses whitespace and caps the length. Redaction runs **before**
-    the length cap so a secret sitting near the cap can never be partially revealed.
-
-    The single chokepoint is reused by both :func:`tool_error_payload` (MCP
-    JSON-RPC tool errors) and the ``/files/*`` route handlers (:mod:`._fileroutes`).
-    """
-    text = scrub_secrets(message)
-    for pattern, replacement in _EXTRA_PATTERNS:
-        text = pattern.sub(replacement, text)
-    text = " ".join(text.split())
-    if len(text) > _MAX_MESSAGE:
-        text = text[:_MAX_MESSAGE] + "…"
-    return text
 
 
 def tool_error_payload(exc: BaseException) -> dict[str, Any]:

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import html
 import os
-import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -160,36 +159,11 @@ def _upstream_error_response(exc: NotebookLMError, *, note: str = "") -> PlainTe
     )
 
 
-def _safe_upload_name(filename: str | None) -> str:
-    """Return a safe basename for the spooled upload file.
-
-    The browser's ``fetch(body: file)`` does NOT send the filename, so the page
-    passes it as ``?filename=``; NotebookLM 400s on an extensionless name and the
-    source-id extraction keys off the real basename+extension, so we must keep the
-    caller's name. :func:`os.path.basename` strips directory components (the
-    path-traversal guard), and the file lands in a private ``mkdtemp`` dir so an odd
-    basename is isolated. An empty/extensionless-default falls back to
-    ``"upload.bin"`` (never extensionless). Re-implemented locally on purpose — the
-    REST route's twin lives behind the ``server`` extra (``fastapi``), which this
-    ``mcp``-only module must not import.
-    """
-    # Strip control chars (NUL would make ``os.open`` raise ``ValueError``; the rest
-    # are never legitimate in a filename), normalize ``\`` so a Windows-style
-    # ``C:\dir\x.pdf`` from a sandbox PUT yields its real leaf, then take the
-    # basename (the path-traversal guard). Reject the directory-cursor names
-    # ``.``/``..`` (which would target an existing dir and fail ``O_EXCL`` → 500) —
-    # fall back to a safe extensioned default.
-    cleaned = re.sub(r"[\x00-\x1f]", "", filename or "").replace("\\", "/")
-    base = os.path.basename(cleaned)
-    if not base or base in (".", ".."):
-        return "upload.bin"
-    if len(base) > 255:
-        # Truncate the STEM, not the whole name — lopping a pathological 300-char
-        # name to 255 could drop the extension, and NotebookLM 400s on an
-        # extensionless upload. Keep the suffix.
-        suffix = Path(base).suffix[:255]
-        base = Path(base).stem[: 255 - len(suffix)] + suffix
-    return base
+#: Safe-basename sanitizer for a spooled upload. Aliased to the shared neutral
+#: helper (:func:`notebooklm._app.source_add.safe_upload_name`) so the MCP
+#: ``/files/ul`` route and the REST ``add_file`` route sanitize identically
+#: (strip control chars, reject ``.``/``..``, basename the path, stem-truncate).
+_safe_upload_name = add_core.safe_upload_name
 
 
 def _cleanup(path: str) -> None:

--- a/src/notebooklm/mcp/_paginate.py
+++ b/src/notebooklm/mcp/_paginate.py
@@ -5,40 +5,20 @@ that can be a big payload that burns agent context. :func:`paginate` slices to a
 ``limit`` and reports ``total`` / ``has_more`` so the agent sees a bounded page
 and knows whether to ask for more.
 
-The underlying ``batchexecute`` RPCs don't paginate, so this is a client-side
-slice over the already-fetched list — the whole collection is still fetched, only
-the *returned* payload is bounded. (ponytail: client-side slice; push paging into
-the RPC layer only if list sizes ever make the fetch itself the bottleneck.)
+The pure slice + bound-validation now lives in the transport-neutral
+:func:`notebooklm._app.pagination.paginate` (shared with the REST list routes,
+Option B-lite); this module re-exports it and pins the MCP-specific default page
+size. (ponytail: client-side slice; push paging into the RPC layer only if list
+sizes ever make the fetch itself the bottleneck.)
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from .._app.pagination import paginate
 
-from ..exceptions import ValidationError
-
-__all__ = ["paginate", "DEFAULT_LIMIT"]
+__all__ = ["DEFAULT_LIMIT", "paginate"]
 
 #: Default page size for the ``*_list`` tools when the caller omits ``limit``.
 DEFAULT_LIMIT = 50
-
-
-def paginate(items: list[Any], limit: int, offset: int = 0) -> tuple[list[Any], dict[str, Any]]:
-    """Return ``(page, meta)`` — the ``items[offset : offset+limit]`` slice + meta.
-
-    ``meta`` is ``{"total": <full count>, "offset": <offset>, "has_more": <bool>}``.
-    ``limit`` must be >= 1 (a bounded page is the point) and ``offset`` >= 0; page
-    forward by re-calling with ``offset += limit`` until ``has_more`` is false.
-    """
-    if limit < 1:
-        raise ValidationError("limit must be >= 1.")
-    if offset < 0:
-        raise ValidationError("offset must be >= 0.")
-    page = items[offset : offset + limit]
-    return page, {
-        "total": len(items),
-        "offset": offset,
-        "has_more": offset + len(page) < len(items),
-    }

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -30,6 +30,7 @@ from fastmcp import Context
 from ..._app import chat as core
 from ..._app.chat import ChatModeChoice, ResponseLengthChoice
 from ..._app.serialize import to_jsonable
+from ..._app.views import ask_result_view
 from ...exceptions import ValidationError
 from .._coerce import coerce_list
 from .._confirm import READ_ONLY
@@ -227,9 +228,9 @@ def register(mcp: Any) -> None:
                 ask_result, suggestions = None, None
 
             if ask_result is not None:
-                ask_payload = to_jsonable(ask_result)
-                # Drop the debug-only raw wire-protocol blob (it just burns agent context).
-                ask_payload.pop("raw_response", None)
+                # Shared view: serialize + drop the debug-only ``raw_response`` blob
+                # (it just burns agent context) — identical on the REST chat route.
+                ask_payload = ask_result_view(ask_result)
                 if references == "lite":
                     # ``or []`` (not a get-default) so a null ``references`` value is
                     # tolerated, not iterated.

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -271,47 +271,26 @@ def register(mcp: Any) -> None:
                 raise ValidationError("task_id is required to import a research task")
             task_id = task_id.strip()
             nb_id = await resolve_notebook(client, notebook)
-            # Poll FOR THE REQUESTED task so the polled sources belong to it.
-            # ``poll`` returns the typed ``NOT_FOUND`` sentinel (status
-            # ``not_found``) when the pinned task is not among the polled
-            # results — guard against that here so we never fall back to
-            # importing whatever the notebook's current task happens to be.
-            status = await research_core.poll_and_classify(client, nb_id, task_id)
-            if status.status == "not_found":
-                raise ValidationError(
-                    f"Research task {task_id!r} is not among notebook {nb_id}'s "
-                    "research tasks; nothing to import. Check research_status."
-                )
-            # Only a COMPLETED task has a final source set. Importing an
-            # in_progress/no_research/failed snapshot would import a partial/empty
-            # set as a "success" — refuse with an action-appropriate message.
-            if status.status == "failed":
-                raise ValidationError(
-                    f"Research task {task_id!r} failed; it will not complete — "
-                    "start a new research session rather than polling."
-                )
-            if status.status != "completed":
-                raise ValidationError(
-                    f"Research task {task_id!r} is not complete (status "
-                    f"{status.status!r}); poll research_status until 'completed' "
-                    "before importing."
-                )
-            if not status.sources:
-                raise ValidationError(
-                    f"Research task {task_id!r} completed with no sources to import."
-                )
-            # TOCTOU note: ``import_sources`` imports the sources from THIS
-            # ``poll_and_classify`` snapshot rather than re-fetching atomically, so
-            # a concurrent/external change to the task between the poll above and
-            # the import below could theoretically race. Acceptable here: research
-            # tasks are user-driven (no high-frequency concurrent mutation), and
-            # the per-source ``task_id`` guard above prevents cross-task wiring —
-            # we never import a *different* task's sources.
-            imported = await client.research.import_sources(nb_id, task_id, status.sources)
+            # Poll FOR THE REQUESTED task (via the shared importable-state guard,
+            # which forwards ``task_id`` to ``poll`` as the discriminator) so the
+            # polled sources belong to it and every non-importable state
+            # (not_found / failed / non-completed / empty) is refused before we
+            # touch ``import_sources`` — we never fall back to importing whatever
+            # the notebook's current task happens to be. The same helper backs
+            # the REST import route so the ladder cannot drift.
+            sources = await research_core.poll_sources_for_import(client, nb_id, task_id)
+            # TOCTOU note: ``import_sources`` imports the sources from the poll
+            # snapshot above rather than re-fetching atomically, so a
+            # concurrent/external change to the task between the poll and the
+            # import could theoretically race. Acceptable here: research tasks are
+            # user-driven (no high-frequency concurrent mutation), and the pinned
+            # ``task_id`` prevents cross-task wiring — we never import a
+            # *different* task's sources.
+            imported = await client.research.import_sources(nb_id, task_id, sources)
             return {
                 "status": "imported",
                 "notebook_id": nb_id,
                 "task_id": task_id,
                 "imported": to_jsonable(imported),
-                "sources_found": len(status.sources),
+                "sources_found": len(sources),
             }

--- a/src/notebooklm/mcp/tools/sharing.py
+++ b/src/notebooklm/mcp/tools/sharing.py
@@ -30,6 +30,9 @@ from typing import Any, Literal
 
 from fastmcp import Context
 
+from ..._app.views import VIEW_LEVEL_LABELS as _VIEW_LEVEL_LABELS
+from ..._app.views import label as _label
+from ..._app.views import share_status_view as _status_payload
 from ..._types.sharing import ShareStatus
 from ...exceptions import ValidationError
 from ...rpc.types import SharePermission, ShareViewLevel
@@ -38,47 +41,16 @@ from .._context import get_client
 from .._errors import mcp_errors
 from .._resolve import resolve_notebook
 
-#: ``int, Enum`` value → wire label. Unknown values (e.g. ``SharePermission._REMOVE``
-#: or protocol drift) degrade to ``str(value)`` so the projection never KeyErrors.
-_ACCESS_LABELS = {0: "restricted", 1: "anyone_with_link"}
-_VIEW_LEVEL_LABELS = {0: "full", 1: "chat"}
-_PERMISSION_LABELS = {1: "owner", 2: "editor", 3: "viewer"}
+# The enum→label projection (``_label`` / ``_status_payload``) + its label maps
+# now live in the shared, transport-neutral ``_app.views`` so the REST adapter
+# emits the identical labeled shape (Option B). Re-imported here under the
+# historical private names to keep the tool bodies (and the ``_label`` unit test)
+# unchanged. ``_VIEW_LEVEL_LABELS`` is still referenced inline for the
+# ``set_view_level``-authoritative echo below.
 
 #: Wire input → enum. OWNER is intentionally absent (cannot be assigned via share).
 _PERMISSION_INPUT = {"editor": SharePermission.EDITOR, "viewer": SharePermission.VIEWER}
 _VIEW_LEVEL_INPUT = {"full": ShareViewLevel.FULL_NOTEBOOK, "chat": ShareViewLevel.CHAT_ONLY}
-
-
-def _label(mapping: dict[int, str], value: int) -> str:
-    """Map an ``int, Enum`` member (or raw int) to its label; unknown → ``str``."""
-    key = int(value)
-    return mapping.get(key, str(key))
-
-
-def _status_payload(status: ShareStatus, *, include_view_level: bool = False) -> dict[str, Any]:
-    """Project ``ShareStatus`` to a wire dict with string-labeled enums.
-
-    ``view_level`` is included only when ``include_view_level`` is set (i.e. the
-    status came from ``set_view_level``, the only source with a trustworthy value).
-    """
-    payload: dict[str, Any] = {
-        "notebook_id": status.notebook_id,
-        "is_public": status.is_public,
-        "access": _label(_ACCESS_LABELS, status.access),
-        "share_url": status.share_url,
-        "shared_users": [
-            {
-                "email": user.email,
-                "permission": _label(_PERMISSION_LABELS, user.permission),
-                "display_name": user.display_name,
-                "avatar_url": user.avatar_url,
-            }
-            for user in status.shared_users
-        ],
-    }
-    if include_view_level:
-        payload["view_level"] = _label(_VIEW_LEVEL_LABELS, status.view_level)
-    return payload
 
 
 def register(mcp: Any) -> None:

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -33,6 +33,7 @@ from ..._app import source_listing as listing_core
 from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
 from ..._app.serialize import to_jsonable
+from ..._app.views import source_view as _source_view
 from ...exceptions import (
     SourceNotFoundError,
     SourceProcessingError,
@@ -67,25 +68,10 @@ _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 _DEFAULT_DRIVE_MIME = "google-doc"
 
 
-def _source_view(source: Any) -> dict[str, Any]:
-    """Serialize a Source with agent-readable string labels added.
-
-    ``to_jsonable`` emits only dataclass fields, so the integer ``status`` and
-    ``_type_code`` arrive as bare numbers and the ``kind`` *property* is dropped —
-    forcing an agent to guess what ``3``/``5``/``2`` mean. Add ``kind`` (e.g.
-    ``"pdf"``/``"web_page"``) and ``status_label`` (e.g. ``"ready"``/``"error"``)
-    string labels alongside the raw codes.
-
-    ``status_label`` comes from :func:`~notebooklm.rpc.types.source_status_to_str`
-    — the repo's single source of truth for status→string — so the MCP label stays
-    in lock-step with the CLI surface. It is one of ``ready``/``processing``/
-    ``error``/``preparing`` (``unknown`` for an unrecognized code), the same
-    vocabulary the ``source_list`` ``status`` filter accepts.
-    """
-    view = to_jsonable(source)
-    view["kind"] = source.kind.value
-    view["status_label"] = source_status_to_str(source.status)
-    return view
+# ``_source_view`` (Source → dict with string ``kind`` / ``status_label`` labels)
+# now lives in the shared, transport-neutral ``_app.views`` so the REST source
+# list/get routes emit the identical enriched shape (Option B). Imported above
+# under its historical private name so the tool bodies below are unchanged.
 
 
 def _add_result_payload(source: Any, base: dict[str, Any]) -> dict[str, Any]:

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -34,7 +34,6 @@ from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
 from ..._app.serialize import to_jsonable
 from ...exceptions import (
-    ConfigurationError,
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
@@ -66,10 +65,6 @@ _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
 #: The default Drive MIME choice when the caller does not specify one.
 _DEFAULT_DRIVE_MIME = "google-doc"
-
-#: Default cap for ``source_read`` (detail="full") when ``max_chars`` is omitted — the body
-#: is bounded (not dumped whole) so a large source can't flood agent context.
-_DEFAULT_CONTENT_CHARS = 10_000
 
 
 def _source_view(source: Any) -> dict[str, Any]:
@@ -190,23 +185,25 @@ def register(mcp: Any) -> None:
         with mcp_errors():
             # Validate windowing args unconditionally — a bad value must error even
             # in ``summary`` mode (where they are ignored), never silently pass.
+            # (``execute_source_read`` re-validates for the full path; this keeps the
+            # error raised BEFORE any notebook I/O and covers the summary path too.)
             if max_chars is not None and max_chars < 0:
                 raise ValidationError(f"max_chars must be >= 0; got {max_chars}")
             if offset < 0:
                 raise ValidationError(f"offset must be >= 0; got {offset}")
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
-            # Shared existence guard (both modes). A full-UUID ref skips list
-            # resolution (the resolver trusts a full id), so a non-existent id
-            # reaches ``get_or_none`` and yields a ``None`` source — surface that as
-            # NOT_FOUND rather than a misleading empty success.
-            result = await content_core.execute_source_get(
-                client, content_core.SourceGetPlan(notebook_id=nb_id, source_id=src_id)
-            )
-            if result.source is None:
-                raise SourceNotFoundError(src_id)
 
             if detail == "summary":
+                # Existence guard: a full-UUID ref skips list resolution (the
+                # resolver trusts a full id), so a non-existent id reaches
+                # ``get_or_none`` and yields a ``None`` source — surface NOT_FOUND
+                # rather than a misleading empty success.
+                get_result = await content_core.execute_source_get(
+                    client, content_core.SourceGetPlan(notebook_id=nb_id, source_id=src_id)
+                )
+                if get_result.source is None:
+                    raise SourceNotFoundError(src_id)
                 # Guide RPC → the AI digest (a missing guide returns empty summary/
                 # keywords — the existence guard above already ruled out a deleted
                 # source, so this is a real "no guide yet", not a false success).
@@ -220,59 +217,31 @@ def register(mcp: Any) -> None:
                     "keywords": list(guide.keywords),
                 }
 
-            # detail == "full":
-            # Only fetch the body once the source is READY. A not-ready source
-            # (still processing / errored) has no retrievable text yet, so return
-            # its metadata with content=None instead of fetching. Gating on status
-            # (rather than catching the fulltext fetch's SourceNotFoundError) keeps
-            # a genuine "source is gone" — e.g. deleted between these two calls —
-            # propagating as NOT_FOUND instead of masquerading as "no content".
-            content: str | None = None
-            char_count = 0
-            if result.source.is_ready:
-                try:
-                    fulltext = await content_core.execute_source_fulltext(
-                        client,
-                        content_core.SourceFulltextPlan(
-                            notebook_id=nb_id, source_id=src_id, output_format=output_format
-                        ),
-                    )
-                except ImportError as exc:
-                    # ``output_format='markdown'`` needs the optional ``markdownify``
-                    # extra, which the server may not have installed. Surface a
-                    # deterministic CONFIG error (with the install hint) rather than
-                    # the bug-class UNEXPECTED a bare ImportError would project as.
-                    # Restrict the remap to the markdown path: an ImportError on the
-                    # text path (or a future regression) is genuinely unexpected and
-                    # must keep propagating as such, not be mislabeled CONFIG.
-                    if output_format != "markdown":
-                        raise
-                    raise ConfigurationError(str(exc)) from exc
-                content = fulltext.fulltext.content or None
-                char_count = fulltext.fulltext.char_count
-
-            # Window the body. The returned ``content`` is ALWAYS bounded — omitting
-            # ``max_chars`` applies a default cap (not the full body) so a large
-            # source can't silently dump tens of thousands of tokens into context;
-            # pass a larger ``max_chars`` (and/or ``offset``) to read more.
-            # ``char_count`` stays the FULL length; ``truncated`` reports whether the
-            # returned slice omits any remainder.
-            truncated = False
-            if content is not None:
-                effective_max = _DEFAULT_CONTENT_CHARS if max_chars is None else max_chars
-                windowed = content[offset : offset + effective_max]
-                truncated = len(windowed) < (len(content) - offset)
-                # Normalize an empty slice (e.g. offset past the end) to None, matching
-                # the fetch-path contract (content is null when there's nothing to show).
-                content = windowed or None
-
-            payload = to_jsonable(result)
-            payload["source"] = _source_view(result.source)
-            payload["content"] = content
-            payload["char_count"] = char_count
-            payload["truncated"] = truncated
-            payload["output_format"] = output_format
-            return payload
+            # detail == "full": the existence/ready gate + ready-only fulltext fetch
+            # + max_chars/offset windowing live in the shared ``execute_source_read``
+            # core (also driven by the REST content route), so both surfaces stay in
+            # lock-step. A resolved-but-missing source raises NOT_FOUND; a not-ready
+            # source returns content=None; the markdown ImportError→CONFIG remap and
+            # the default cap are handled inside the core.
+            read = await content_core.execute_source_read(
+                client,
+                content_core.SourceReadPlan(
+                    notebook_id=nb_id,
+                    source_id=src_id,
+                    output_format=output_format,
+                    max_chars=max_chars,
+                    offset=offset,
+                ),
+            )
+            return {
+                "notebook_id": nb_id,
+                "source_id": src_id,
+                "source": _source_view(read.source),
+                "content": read.content,
+                "char_count": read.char_count,
+                "truncated": read.truncated,
+                "output_format": output_format,
+            }
 
     @mcp.tool
     async def source_rename(

--- a/src/notebooklm/server/__main__.py
+++ b/src/notebooklm/server/__main__.py
@@ -18,14 +18,17 @@ import ipaddress
 import logging
 import os
 import sys
+from pathlib import Path
 
-from ._auth import SERVER_TOKEN_ENV, get_configured_token
+from ._auth import ALLOW_EXTERNAL_BIND_ENV, SERVER_TOKEN_ENV, get_configured_token
 from .app import create_app
 
 __all__ = ["main"]
 
-#: Env var that opts a deployment into binding to a non-loopback interface.
-ALLOW_EXTERNAL_BIND_ENV = "NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND"
+#: Env var pointing at a file whose contents are the bearer token. Preferred over
+#: the deprecated ``--token`` flag, whose value is visible to other local users
+#: via ``ps``.
+SERVER_TOKEN_FILE_ENV = "NOTEBOOKLM_SERVER_TOKEN_FILE"
 
 #: Hostnames always treated as loopback even though they are not numeric IP
 #: literals. An empty / whitespace host is intentionally NOT here — it must be
@@ -81,9 +84,42 @@ def _check_token_configured() -> None:
     if get_configured_token() is None:
         raise SystemExit(
             f"Refusing to start the REST server without a bearer token. Set "
-            f"{SERVER_TOKEN_ENV} to a secret value (a credential-fronting server "
-            f"must never run tokenless)."
+            f"{SERVER_TOKEN_ENV} (or point {SERVER_TOKEN_FILE_ENV} / --token-file at "
+            f"a file containing it) — a credential-fronting server must never run "
+            f"tokenless."
         )
+
+
+def _reject_argv_token(token: str | None) -> None:
+    """Refuse the deprecated ``--token`` flag (it leaks via ``ps``).
+
+    A bearer token passed on the command line is visible to any other local user
+    via the process table, so it is never accepted. The token must come from
+    ``NOTEBOOKLM_SERVER_TOKEN`` or a token file instead.
+    """
+    if token is not None:
+        raise SystemExit(
+            "The --token flag is deprecated and insecure: a token on the command "
+            "line is visible to other local users via `ps`. Set the "
+            f"{SERVER_TOKEN_ENV} environment variable, or pass --token-file / set "
+            f"{SERVER_TOKEN_FILE_ENV} to a file containing the token."
+        )
+
+
+def _load_token_file(path: str) -> None:
+    """Read the bearer token from ``path`` into the environment the auth reads.
+
+    Only the file PATH ever appears on argv / the process table — the secret
+    itself does not. A missing/unreadable or empty file fails closed with a clear
+    message.
+    """
+    try:
+        token = Path(path).read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise SystemExit(f"Could not read the token file {path!r}: {exc}") from exc
+    if not token:
+        raise SystemExit(f"The token file {path!r} is empty.")
+    os.environ[SERVER_TOKEN_ENV] = token
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -106,10 +142,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--token",
-        default=os.environ.get(SERVER_TOKEN_ENV),
+        default=None,
+        # DEPRECATED and insecure: a token on argv is visible to other local users
+        # via ``ps``. Passing it is refused at startup (see ``main``). Kept only to
+        # emit a clear migration error instead of an "unknown flag" one.
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--token-file",
+        default=os.environ.get(SERVER_TOKEN_FILE_ENV),
         help=(
-            "Bearer token every request must present (default: "
-            f"${SERVER_TOKEN_ENV}). Required — the server refuses to start without it."
+            "Path to a file whose contents are the bearer token (default: "
+            f"${SERVER_TOKEN_FILE_ENV}). Preferred over the environment for "
+            "keeping the secret off the process table. The token must otherwise be "
+            f"supplied via ${SERVER_TOKEN_ENV}."
         ),
     )
     parser.add_argument(
@@ -149,10 +195,12 @@ def main(argv: list[str] | None = None) -> None:
         "change without notice. Pin a version for automation."
     )
 
-    # A --token (or its NOTEBOOKLM_SERVER_TOKEN default) seeds the env the auth
-    # dependency reads, so an explicit flag works even when the env was unset.
-    if args.token:
-        os.environ[SERVER_TOKEN_ENV] = args.token
+    # The deprecated --token flag is refused outright (it leaks via `ps`). A
+    # --token-file (or its env default) seeds the env the auth dependency reads,
+    # keeping the secret off the process table.
+    _reject_argv_token(args.token)
+    if args.token_file:
+        _load_token_file(args.token_file)
 
     _check_token_configured()
     allow_external = os.environ.get(ALLOW_EXTERNAL_BIND_ENV) == "1"
@@ -162,7 +210,19 @@ def main(argv: list[str] | None = None) -> None:
 
     app = create_app()
     uvicorn.run(
-        app, host=args.host, port=_resolve_port(args.port), log_level=args.log_level.lower()
+        app,
+        host=args.host,
+        port=_resolve_port(args.port),
+        log_level=args.log_level.lower(),
+        # In the default (loopback) mode the auth guard trusts ``request.client.host``
+        # as the real socket peer, so uvicorn must NOT rewrite it from a spoofable
+        # ``X-Forwarded-For`` header. Uvicorn enables ``--proxy-headers`` by default
+        # (with ``forwarded_allow_ips="127.0.0.1"``), which would let a request from
+        # a loopback-adjacent proxy override the peer address — pin it OFF so the
+        # loopback check is peer-by-construction. Only when a deployment opts into an
+        # external bind (behind a trusted reverse proxy, where the loopback guard is
+        # already disabled) do we honor forwarded headers.
+        proxy_headers=allow_external,
     )
 
 

--- a/src/notebooklm/server/_auth.py
+++ b/src/notebooklm/server/_auth.py
@@ -29,6 +29,7 @@ import os
 from fastapi import HTTPException, Request
 
 __all__ = [
+    "ALLOW_EXTERNAL_BIND_ENV",
     "SERVER_TOKEN_ENV",
     "get_configured_token",
     "require_auth",
@@ -36,6 +37,13 @@ __all__ = [
 
 #: Env var carrying the bearer token the server validates every request against.
 SERVER_TOKEN_ENV = "NOTEBOOKLM_SERVER_TOKEN"
+
+#: Env var that opts a deployment into serving non-loopback peers (a public bind
+#: behind a trusted proxy). When UNSET (the default), the auth dependency enforces
+#: loopback on the real PEER address — not the spoofable ``Host`` header — so a
+#: ``--host 0.0.0.0`` bind plus a forged ``Host: 127.0.0.1`` cannot reach ``/v1``.
+#: Shared with the launcher's bind guard (:mod:`.__main__`).
+ALLOW_EXTERNAL_BIND_ENV = "NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND"
 
 #: Hostnames always treated as loopback even though they are not numeric IP
 #: literals. An empty host is intentionally absent — it must be rejected.
@@ -94,6 +102,28 @@ def _host_is_loopback(host_header: str) -> bool:
         return False
 
 
+def _peer_is_loopback(request: Request) -> bool:
+    """Return whether the request's PEER address is a loopback interface.
+
+    Reads ``request.client.host`` — the actual transport-level source address,
+    which a remote caller cannot spoof (unlike the ``Host`` header). ``None`` when
+    the ASGI server did not populate a client address (treated as non-loopback,
+    fail closed).
+    """
+    client = request.client
+    if client is None:
+        return False
+    try:
+        return ipaddress.ip_address(client.host).is_loopback
+    except ValueError:
+        return False
+
+
+def _allow_external_bind() -> bool:
+    """Whether the deployment opted into serving non-loopback peers."""
+    return os.environ.get(ALLOW_EXTERNAL_BIND_ENV) == "1"
+
+
 def _extract_bearer(authorization: str | None) -> str | None:
     """Return the token from an ``Authorization: Bearer <token>`` header, or None."""
     if not authorization:
@@ -107,12 +137,22 @@ async def require_auth(request: Request) -> None:
     """FastAPI dependency: enforce the loopback-Host + bearer-token gate.
 
     Raises:
-        HTTPException: ``403`` if the ``Host`` is not a loopback literal
-            (DNS-rebinding guard, checked first); ``401`` if the bearer token is
-            missing/empty/mismatched or no token is configured.
+        HTTPException: ``403`` if the request originates off-loopback — enforced on
+            the unspoofable PEER address (``request.client.host``), with the
+            ``Host``-header literal kept as a supplemental DNS-rebinding guard;
+            both are skipped when ``NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1``.
+            ``401`` if the bearer token is missing/empty/mismatched or no token is
+            configured.
     """
-    if not _host_is_loopback(request.headers.get("host", "")):
-        raise HTTPException(status_code=403, detail="Host not allowed")
+    if not _allow_external_bind():
+        # Enforce loopback on the real PEER address first (unspoofable). A
+        # ``--host 0.0.0.0`` bind plus a forged ``Host: 127.0.0.1`` no longer
+        # reaches here. The Host-header check stays as a supplemental
+        # DNS-rebinding guard for the loopback-bound case.
+        if not _peer_is_loopback(request):
+            raise HTTPException(status_code=403, detail="Peer address is not loopback")
+        if not _host_is_loopback(request.headers.get("host", "")):
+            raise HTTPException(status_code=403, detail="Host not allowed")
 
     configured = get_configured_token()
     presented = _extract_bearer(request.headers.get("authorization"))

--- a/src/notebooklm/server/_auth.py
+++ b/src/notebooklm/server/_auth.py
@@ -65,6 +65,26 @@ def get_configured_token() -> str | None:
     return token or None
 
 
+def _addr_is_loopback(text: str) -> bool:
+    """Whether an IP literal is a loopback address, independent of Python version.
+
+    ``ipaddress`` only resolves an IPv4-mapped IPv6 address (e.g.
+    ``::ffff:127.0.0.1``) to its embedded IPv4 loopback in newer CPython patch
+    releases, so ``IPv6Address.is_loopback`` is unreliable across the interpreter
+    versions/patch levels we run on (it returned ``False`` for the mapped form on
+    some macOS 3.10/3.11 runners). Unwrap ``ipv4_mapped`` ourselves first, then
+    fall back to the native check. Returns ``False`` for anything unparseable.
+    """
+    try:
+        addr = ipaddress.ip_address(text)
+    except ValueError:
+        return False
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        return mapped.is_loopback
+    return addr.is_loopback
+
+
 def _host_is_loopback(host_header: str) -> bool:
     """Return whether the ``Host`` header addresses a loopback literal.
 
@@ -96,10 +116,7 @@ def _host_is_loopback(host_header: str) -> bool:
     # Host hostnames are case-insensitive (RFC 3986/7230).
     if candidate.lower() in _LOOPBACK_HOSTNAMES:
         return True
-    try:
-        return ipaddress.ip_address(candidate).is_loopback
-    except ValueError:
-        return False
+    return _addr_is_loopback(candidate)
 
 
 def _peer_is_loopback(request: Request) -> bool:
@@ -113,10 +130,7 @@ def _peer_is_loopback(request: Request) -> bool:
     client = request.client
     if client is None:
         return False
-    try:
-        return ipaddress.ip_address(client.host).is_loopback
-    except ValueError:
-        return False
+    return _addr_is_loopback(client.host)
 
 
 def _allow_external_bind() -> bool:

--- a/src/notebooklm/server/_errors.py
+++ b/src/notebooklm/server/_errors.py
@@ -36,12 +36,19 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .._app.errors import CATEGORY_HINTS, ErrorCategory, classify, is_retriable
+from .._app.errors import (
+    CATEGORY_HINTS,
+    ClassifiedError,
+    ErrorCategory,
+    classify,
+    is_retriable,
+)
 from .._redact import redact as _shared_redact
 from ..exceptions import NotebookLMError
 
 __all__ = [
     "CATEGORY_STATUS",
+    "error_item",
     "error_response",
     "http_error_response",
     "install_exception_handlers",
@@ -196,22 +203,12 @@ def http_error_response(status: int, detail: object) -> JSONResponse:
     return JSONResponse(status_code=status, content={"error": body})
 
 
-def error_response(exc: BaseException) -> JSONResponse:
-    """Build the typed JSON error response for ``exc``.
-
-    Calls :func:`classify` exactly once and looks up the status from
-    :data:`CATEGORY_STATUS`; the category is never re-derived. The message is the
-    scrubbed ``str(exc)`` for library errors, and a fixed generic string for an
-    unexpected (non-library) bug — whose ``str(exc)`` is never echoed.
-
-    The body also carries the neutral ``retriable`` flag (from :func:`classify`,
-    so an agent client can branch a back-off) and, where the category has one, a
-    ``hint`` — both drawn from the SAME shared tables the MCP surface uses
-    (:func:`classify` + :data:`CATEGORY_HINTS`), never re-derived here.
+def _project_classified(exc: BaseException, classified: ClassifiedError) -> dict[str, object]:
+    """Build the inner ``{category, message, retriable, hint?}`` body from an
+    ALREADY-computed classification — so a caller that also needs the status can
+    classify once and reuse the result rather than re-running :func:`classify`.
     """
-    classified = classify(exc)
     category = classified.category
-    status = CATEGORY_STATUS[category]
     message = _UNEXPECTED_MESSAGE if category is ErrorCategory.UNEXPECTED else _redact(str(exc))
     body: dict[str, object] = {
         "category": category.value,
@@ -221,6 +218,40 @@ def error_response(exc: BaseException) -> JSONResponse:
     hint = CATEGORY_HINTS.get(category)
     if hint is not None:
         body["hint"] = hint
+    return body
+
+
+def error_item(exc: BaseException) -> dict[str, object]:
+    """Project ``exc`` onto the inner ``{category, message, retriable, hint?}`` body.
+
+    The single classify-once projection shared by :func:`error_response` (which
+    wraps it in the ``{"error": ...}`` envelope + HTTP status) and any route that
+    needs a per-item error shape WITHOUT aborting the request — e.g. the batch
+    ``POST .../sources/batch`` route, which reports one such item per failed URL
+    (mirroring the MCP ``source_add`` batch contract) while the batch as a whole
+    still returns 201. The message is the scrubbed ``str(exc)`` for library
+    errors and a fixed generic string for an unexpected (non-library) bug.
+    """
+    return _project_classified(exc, classify(exc))
+
+
+def error_response(exc: BaseException) -> JSONResponse:
+    """Build the typed JSON error response for ``exc``.
+
+    Calls :func:`classify` exactly once — reusing that single result for BOTH the
+    body projection and the :data:`CATEGORY_STATUS` status lookup; the category
+    is never re-derived. The message is the scrubbed ``str(exc)`` for library
+    errors, and a fixed generic string for an unexpected (non-library) bug —
+    whose ``str(exc)`` is never echoed.
+
+    The body also carries the neutral ``retriable`` flag (from :func:`classify`,
+    so an agent client can branch a back-off) and, where the category has one, a
+    ``hint`` — both drawn from the SAME shared tables the MCP surface uses
+    (:func:`classify` + :data:`CATEGORY_HINTS`), never re-derived here.
+    """
+    classified = classify(exc)
+    body = _project_classified(exc, classified)
+    status = CATEGORY_STATUS[classified.category]
     return JSONResponse(status_code=status, content={"error": body})
 
 

--- a/src/notebooklm/server/_errors.py
+++ b/src/notebooklm/server/_errors.py
@@ -2,7 +2,14 @@
 
 The REST server surfaces every failure as an HTTP status plus a typed body::
 
-    {"error": {"category": "<category>", "message": "<scrubbed>"}}
+    {"error": {"category": "<category>", "message": "<scrubbed>",
+               "retriable": <bool>, "hint"?: "<remediation>"}}
+
+The ``retriable`` flag and optional ``hint`` are present on EVERY response whose
+status maps to a neutral :class:`~notebooklm._app.errors.ErrorCategory` — both
+classified library errors and hand-raised ``HTTPException``s (401/404/411/413/
+422/…) — drawn from the shared ``_app.errors`` tables so the two paths cannot
+drift. HTTP-protocol-only statuses (409/410) carry just ``category`` + ``message``.
 
 The **category** decision is delegated to
 :func:`notebooklm._app.errors.classify` (the single neutral source of truth
@@ -29,8 +36,8 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .._app.errors import ErrorCategory, classify
-from .._logging import scrub_secrets
+from .._app.errors import CATEGORY_HINTS, ErrorCategory, classify, is_retriable
+from .._redact import redact as _shared_redact
 from ..exceptions import NotebookLMError
 
 __all__ = [
@@ -44,26 +51,37 @@ __all__ = [
 #: Maximum wire length for an error message before it is truncated.
 _MAX_MESSAGE = 300
 
-#: Category label for an ``HTTPException`` raised explicitly by a route or the
-#: auth dependency, keyed by HTTP status. Keeps the ``{"error": {...}}`` envelope
-#: uniform across *both* classified library errors and hand-raised
-#: ``HTTPException``s (the R9 single-shape contract), instead of letting FastAPI
-#: emit its default ``{"detail": ...}`` for the latter. Statuses not listed fall
-#: back to a coarse class label (see :func:`_http_category`).
-_STATUS_CATEGORY: dict[int, str] = {
-    400: ErrorCategory.VALIDATION.value,
-    401: ErrorCategory.AUTH.value,
-    403: ErrorCategory.AUTH.value,
-    404: ErrorCategory.NOT_FOUND.value,
+#: The neutral :class:`ErrorCategory` an ``HTTPException`` raised explicitly by a
+#: route or the auth dependency (keyed by HTTP status) projects onto. Keeps the
+#: ``{"error": {...}}`` envelope uniform across *both* classified library errors
+#: and hand-raised ``HTTPException``s (the R9 single-shape contract), instead of
+#: letting FastAPI emit its default ``{"detail": ...}`` for the latter. Because
+#: the status resolves to a neutral category, the hand-raised body ALSO carries
+#: the SAME ``retriable`` + ``hint`` enrichment as a classified library error
+#: (drawn from the shared ``_app.errors`` tables — never re-derived here), so the
+#: wire contract is uniform. Statuses not listed here get a coarse label and no
+#: enrichment (see :data:`_STATUS_LABEL` / :func:`_http_category_label`).
+_STATUS_CATEGORY: dict[int, ErrorCategory] = {
+    400: ErrorCategory.VALIDATION,
+    401: ErrorCategory.AUTH,
+    403: ErrorCategory.AUTH,
+    404: ErrorCategory.NOT_FOUND,
+    411: ErrorCategory.VALIDATION,
+    413: ErrorCategory.VALIDATION,
+    422: ErrorCategory.VALIDATION,
+    429: ErrorCategory.RATE_LIMITED,
+    500: ErrorCategory.UNEXPECTED,
+    502: ErrorCategory.SERVER,
+    503: ErrorCategory.SERVER,
+    504: ErrorCategory.TIMEOUT,
+}
+
+#: HTTP-protocol-only statuses with no neutral :class:`ErrorCategory`. They get a
+#: coarse label for the envelope ``category`` and NO ``retriable`` / ``hint``
+#: enrichment (there is no category to draw those from).
+_STATUS_LABEL: dict[int, str] = {
     409: "conflict",
     410: "gone",
-    413: ErrorCategory.VALIDATION.value,
-    422: ErrorCategory.VALIDATION.value,
-    429: ErrorCategory.RATE_LIMITED.value,
-    500: ErrorCategory.UNEXPECTED.value,
-    502: ErrorCategory.SERVER.value,
-    503: ErrorCategory.SERVER.value,
-    504: ErrorCategory.TIMEOUT.value,
 }
 
 #: Generic message returned for an unexpected (non-library) exception — a bug's
@@ -92,19 +110,17 @@ CATEGORY_STATUS: dict[ErrorCategory, int] = {
 
 
 def _redact(message: object) -> str:
-    """Scrub secrets, collapse whitespace, and length-cap a message for the wire.
+    """Scrub secrets + local paths, collapse whitespace, and length-cap for the wire.
 
+    Delegates to the shared, transport-neutral
+    :func:`notebooklm._redact.redact` — the SAME chokepoint the MCP projector
+    uses — so a home-directory path (``/home/<user>/…``) or a signed ``/files/*``
+    URL token in an exception string is masked on BOTH surfaces, not just MCP.
     SDK exception messages are already designed to be secret-free (raw responses
-    are truncated at construction, per ADR-0019), but the server runs every
-    wire-bound message through :func:`notebooklm._logging.scrub_secrets` as
-    defense-in-depth (so a stray ``Authorization``/``Cookie`` fragment in any
-    exception or upstream error string is masked), then collapses whitespace and
-    caps the length so a schema-drift dump cannot bloat or over-disclose the body.
+    are truncated at construction, per ADR-0019); this is defense-in-depth plus
+    the length cap so a schema-drift dump cannot bloat or over-disclose the body.
     """
-    scrubbed = " ".join(scrub_secrets(message).split())
-    if len(scrubbed) > _MAX_MESSAGE:
-        scrubbed = scrubbed[:_MAX_MESSAGE] + "…"
-    return scrubbed
+    return _shared_redact(message, max_length=_MAX_MESSAGE)
 
 
 def safe_detail(message: object) -> str:
@@ -117,13 +133,17 @@ def safe_detail(message: object) -> str:
     return _redact(message)
 
 
-def _http_category(status: int) -> str:
+def _http_category_label(status: int) -> str:
     """Map an HTTP status to its envelope ``category`` label.
 
-    Uses the explicit :data:`_STATUS_CATEGORY` table, falling back to a coarse
-    class label so an unanticipated status still yields a non-empty category.
+    Prefers the neutral :data:`_STATUS_CATEGORY` category (its ``.value``), then
+    the coarse :data:`_STATUS_LABEL`, falling back to a class label so an
+    unanticipated status still yields a non-empty category.
     """
-    label = _STATUS_CATEGORY.get(status)
+    category = _STATUS_CATEGORY.get(status)
+    if category is not None:
+        return category.value
+    label = _STATUS_LABEL.get(status)
     if label is not None:
         return label
     if 400 <= status < 500:
@@ -151,15 +171,29 @@ def http_error_response(status: int, detail: object) -> JSONResponse:
     """Build the typed envelope for a hand-raised ``HTTPException``.
 
     Renders ``HTTPException``s (the auth dependency's 401/403, an artifact poll's
-    404/409/410, an oversized-upload 413) through the same
-    ``{"error": {"category": ..., "message": ...}}`` shape as classified library
-    errors, so the wire contract is uniform. The ``detail`` is scrubbed +
-    length-capped via :func:`_redact`.
+    404/409/410, an oversized-upload 413, a chunked-multipart 411, a
+    request-body 422, a content-route 404) through the same
+    ``{"error": {"category": ..., "message": ..., "retriable": ..., "hint"?: ...}}``
+    shape as classified library errors, so the wire contract is uniform across
+    EVERY REST error response. When the status maps to a neutral
+    :class:`ErrorCategory` (:data:`_STATUS_CATEGORY`), the body carries the SAME
+    ``retriable`` flag and (where present) ``hint`` as a classified error — both
+    read from the shared ``_app.errors`` tables (:func:`is_retriable` +
+    :data:`CATEGORY_HINTS`), never re-derived here. Statuses with only a coarse
+    label (:data:`_STATUS_LABEL`, e.g. 409/410) omit both. The ``detail`` is
+    scrubbed + length-capped via :func:`_redact`.
     """
-    return JSONResponse(
-        status_code=status,
-        content={"error": {"category": _http_category(status), "message": _redact(detail)}},
-    )
+    body: dict[str, object] = {
+        "category": _http_category_label(status),
+        "message": _redact(detail),
+    }
+    category = _STATUS_CATEGORY.get(status)
+    if category is not None:
+        body["retriable"] = is_retriable(category)
+        hint = CATEGORY_HINTS.get(category)
+        if hint is not None:
+            body["hint"] = hint
+    return JSONResponse(status_code=status, content={"error": body})
 
 
 def error_response(exc: BaseException) -> JSONResponse:
@@ -169,14 +203,25 @@ def error_response(exc: BaseException) -> JSONResponse:
     :data:`CATEGORY_STATUS`; the category is never re-derived. The message is the
     scrubbed ``str(exc)`` for library errors, and a fixed generic string for an
     unexpected (non-library) bug — whose ``str(exc)`` is never echoed.
+
+    The body also carries the neutral ``retriable`` flag (from :func:`classify`,
+    so an agent client can branch a back-off) and, where the category has one, a
+    ``hint`` — both drawn from the SAME shared tables the MCP surface uses
+    (:func:`classify` + :data:`CATEGORY_HINTS`), never re-derived here.
     """
-    category = classify(exc).category
+    classified = classify(exc)
+    category = classified.category
     status = CATEGORY_STATUS[category]
     message = _UNEXPECTED_MESSAGE if category is ErrorCategory.UNEXPECTED else _redact(str(exc))
-    return JSONResponse(
-        status_code=status,
-        content={"error": {"category": category.value, "message": message}},
-    )
+    body: dict[str, object] = {
+        "category": category.value,
+        "message": message,
+        "retriable": classified.retriable,
+    }
+    hint = CATEGORY_HINTS.get(category)
+    if hint is not None:
+        body["hint"] = hint
+    return JSONResponse(status_code=status, content={"error": body})
 
 
 def install_exception_handlers(app: FastAPI) -> None:

--- a/src/notebooklm/server/_pagination.py
+++ b/src/notebooklm/server/_pagination.py
@@ -1,0 +1,68 @@
+"""Opt-in, non-breaking pagination envelope for the REST list routes.
+
+The list routes (`GET` notebooks / sources / notes / artifacts) default to the
+FULL collection under their existing top-level key — the DEFAULT shape is
+unchanged (no ``limit`` supplied ⇒ full, unbounded list, exactly as before). When
+the caller supplies ``?limit=``, the already-projected collection is sliced via
+the shared, transport-neutral :func:`notebooklm._app.pagination.paginate` (the
+SAME slice + bound validation the MCP ``*_list`` tools use — Option B-lite: shared
+slice, adapter-owned envelope) and a ``meta`` block
+(``{total, has_more, limit, offset}``) is added alongside the existing list key.
+
+Bounds are validated by FastAPI ``Query`` constraints at the route boundary
+(``limit >= 1``, ``offset >= 0`` ⇒ 422 on a bad value), so a bad request never
+reaches the slice; the shared helper's own validation remains the guard for the
+MCP path.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._app.pagination import paginate
+from ..exceptions import ValidationError
+
+__all__ = ["MAX_LIMIT", "paginate_envelope"]
+
+#: Upper bound on the list-route ``?limit=`` query param. The whole collection is
+#: still fetched from the RPC layer; this only caps the *returned* page so a huge
+#: ``limit`` cannot defeat the bounded-response contract. Enforced by the routes'
+#: ``Query(ge=1, le=MAX_LIMIT)`` (a larger value ⇒ 422 before the slice).
+MAX_LIMIT = 1000
+
+
+def paginate_envelope(
+    items: list[Any], *, key: str, limit: int | None, offset: int, **extra: Any
+) -> dict[str, Any]:
+    """Wrap an already-projected ``items`` list in the list-route response envelope.
+
+    ``extra`` carries any sibling top-level fields (e.g. ``notebook_id=...``) and is
+    emitted first so the key ordering matches the pre-pagination shape. When
+    ``limit`` is ``None`` (the default) the full list is returned under ``key`` with
+    NO ``meta`` block — byte-for-byte the historical shape. When ``limit`` is set,
+    ``items`` is sliced and a ``meta`` block (``{total, has_more, limit, offset}``)
+    is added alongside ``key``.
+
+    A non-zero ``offset`` without a ``limit`` is a contract error (the paging
+    window is ambiguous — ``offset`` only means something relative to a page size),
+    rejected with a :class:`~notebooklm.exceptions.ValidationError` (⇒ 400) rather
+    than silently ignored. ``offset=0`` with no ``limit`` is the unchanged
+    full-list default.
+    """
+    if limit is None:
+        if offset != 0:
+            raise ValidationError("offset requires limit; supply ?limit= to page with ?offset=.")
+        return {**extra, key: items}
+    page, meta = paginate(items, limit, offset)
+    return {
+        **extra,
+        key: page,
+        "meta": {
+            "total": meta["total"],
+            "has_more": meta["has_more"],
+            "limit": limit,
+            "offset": offset,
+        },
+    }

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -35,7 +35,7 @@ from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
 from ._pending import PendingRegistry
-from .routes import artifacts, chat, notebooks, notes, share, sources
+from .routes import artifacts, chat, notebooks, notes, research, share, sources
 from .routes.sources import MAX_UPLOAD_BYTES
 
 __all__ = ["SERVER_NAME", "create_app"]
@@ -140,6 +140,7 @@ def create_app(*, client_factory: ClientFactory | None = None) -> FastAPI:
     v1.include_router(notes.router)
     v1.include_router(chat.router)
     v1.include_router(artifacts.router)
+    v1.include_router(research.router)
     v1.include_router(share.router)
     app.include_router(v1)
 

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -102,19 +102,26 @@ def create_app(*, client_factory: ClientFactory | None = None) -> FastAPI:
         # route reads/parses the body — Starlette's multipart parser spools file
         # parts to disk unbounded, so a post-parse check is too late (the body is
         # already on disk). This Content-Length pre-check is the actual disk-
-        # exhaustion mitigation. Residual: a chunked request (no Content-Length)
-        # bypasses it, and Starlette still spools the full part before the upload
-        # handler's per-chunk check can reject it — so that per-chunk check caps
-        # only the copy into our own temp file, not Starlette's spool. Acceptable
-        # for a single-user loopback-only server; revisit if ever exposed wider.
-        # Nothing legitimate exceeds the upload cap, so applying it to every
-        # request is safe.
+        # exhaustion mitigation. Nothing legitimate exceeds the upload cap, so
+        # applying it to every request is safe.
+        content_type = request.headers.get("content-type", "")
+        is_multipart = content_type.lstrip().lower().startswith("multipart/form-data")
         content_length = request.headers.get("content-length")
-        if content_length is not None:
+        if content_length is None:
+            # A chunked (no-Content-Length) multipart upload would otherwise let
+            # Starlette spool the full part to disk before any per-chunk cap runs.
+            # Require an up-front declared length for multipart so the size can be
+            # bounded before a byte is spooled; other verbs (GET/JSON) are
+            # unaffected. Route through the shared projector for a uniform envelope.
+            if is_multipart:
+                return http_error_response(411, "Content-Length is required for multipart uploads")
+        else:
             try:
                 declared = int(content_length)
             except ValueError:
                 declared = -1
+            if declared < 0 and is_multipart:
+                return http_error_response(411, "A valid Content-Length is required for uploads")
             if declared > MAX_UPLOAD_BYTES:
                 # Route through the shared projector so the envelope shape +
                 # lowercase category match every other error response.

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -35,7 +35,7 @@ from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
 from ._pending import PendingRegistry
-from .routes import artifacts, chat, notebooks, notes, research, share, sources
+from .routes import artifacts, chat, meta, notebooks, notes, research, share, sources
 from .routes.sources import MAX_UPLOAD_BYTES
 
 __all__ = ["SERVER_NAME", "create_app"]
@@ -142,6 +142,7 @@ def create_app(*, client_factory: ClientFactory | None = None) -> FastAPI:
     v1.include_router(artifacts.router)
     v1.include_router(research.router)
     v1.include_router(share.router)
+    v1.include_router(meta.router)
     app.include_router(v1)
 
     return app

--- a/src/notebooklm/server/routes/__init__.py
+++ b/src/notebooklm/server/routes/__init__.py
@@ -8,6 +8,15 @@ NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from . import artifacts, chat, notebooks, notes, share, sources
+from . import artifacts, chat, meta, notebooks, notes, research, share, sources
 
-__all__ = ["artifacts", "chat", "notebooks", "notes", "share", "sources"]
+__all__ = [
+    "artifacts",
+    "chat",
+    "meta",
+    "notebooks",
+    "notes",
+    "research",
+    "share",
+    "sources",
+]

--- a/src/notebooklm/server/routes/_passthrough.py
+++ b/src/notebooklm/server/routes/_passthrough.py
@@ -20,6 +20,7 @@ __all__ = [
     "passthrough_artifact_id",
     "passthrough_download_notebook",
     "passthrough_notebook_id",
+    "passthrough_source_id",
     "passthrough_source_ids",
 ]
 
@@ -29,6 +30,19 @@ async def passthrough_notebook_id(
 ) -> str:
     """Return ``notebook_id`` unchanged (the REST adapter works in full ids)."""
     return notebook_id
+
+
+async def passthrough_source_id(
+    _client: NotebookLMClient, _notebook_id: str, source_id: str, *, json_output: bool = False
+) -> str:
+    """Return a single ``source_id`` unchanged (REST works in full ids).
+
+    Shaped for the ``_app.source_mutations`` executors' injected
+    ``resolve_source_id`` callable (which the CLI fills with its
+    ``rich``-coupled partial-id resolver); the REST adapter already holds a full
+    id, so resolution is a pass-through.
+    """
+    return source_id
 
 
 async def passthrough_source_ids(

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -410,15 +410,18 @@ async def generate(
             raise ValidationError(f"Invalid {key} {value!r}; expected one of {list(choices)}")
         overrides[key] = value
 
+    # Treat empty / whitespace-only instructions as absent so the default request
+    # shape stays byte-identical (no blank prompt slot reaches the server).
+    instructions = body.instructions if (body.instructions and body.instructions.strip()) else None
     raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[body.type])
     raw_args.update(
         {
             "notebook_id": notebook_id,
-            "description": body.instructions or "",
+            "description": instructions or "",
             # ``mind-map`` reads ``raw_args["instructions"]`` (every other kind reads
             # ``description``); forward BOTH so mind-map instructions actually reach
             # the client — the extra key is ignored by the other builders.
-            "instructions": body.instructions or None,
+            "instructions": instructions,
             "source_ids": tuple(body.source_ids or ()),
             "language": body.language,
             "wait": False,
@@ -503,15 +506,22 @@ async def rename(
 
 
 @router.post("/{artifact_id}/retry")
-async def retry(notebook_id: str, artifact_id: str, client: ClientDep) -> dict[str, Any]:
+async def retry(
+    notebook_id: str, artifact_id: str, client: ClientDep, pending: PendingDep
+) -> dict[str, Any]:
     """Retry a failed artifact in place (the UI "Retry" action).
 
     Non-blocking: on acceptance returns the kicked-off ``task_id`` (equal to the
     artifact id) and the new ``status``; poll ``GET .../artifacts/{task_id}``
     until complete. A synchronous refusal (rate limit / quota / not-retryable)
     surfaces as the classified error.
+
+    The ``task_id`` is recorded in the pending registry (as ``generate`` does) so a
+    poll that briefly races ahead of the artifact listing resolves to ``200``
+    pending instead of a spurious ``404``.
     """
     status = await artifact_core.retry_artifact(client, notebook_id, artifact_id)
+    pending.record(notebook_id, status.task_id)
     return {
         "notebook_id": notebook_id,
         "artifact_id": artifact_id,

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from starlette.types import Receive, Scope, Send
@@ -51,6 +51,7 @@ from ...exceptions import ValidationError
 from ...types import ArtifactType, GenerationState
 from .._context import get_client, get_pending
 from .._errors import safe_detail
+from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
 from ._passthrough import (
     passthrough_artifact_id,
@@ -243,10 +244,21 @@ class ArtifactDownload(BaseModel):
 
 
 @router.get("")
-async def list_artifacts(notebook_id: str, client: ClientDep) -> dict[str, Any]:
-    """List a notebook's studio artifacts."""
+async def list_artifacts(
+    notebook_id: str,
+    client: ClientDep,
+    limit: Annotated[int | None, Query(ge=1, le=MAX_LIMIT)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """List a notebook's studio artifacts.
+
+    Defaults to the full collection under ``artifacts`` (unchanged). Supply
+    ``?limit=`` to slice and add a ``meta`` block; ``?offset=`` pages forward.
+    """
     artifacts = await client.artifacts.list(notebook_id)
-    return {"notebook_id": notebook_id, "artifacts": to_jsonable(artifacts)}
+    return paginate_envelope(
+        to_jsonable(artifacts), key="artifacts", limit=limit, offset=offset, notebook_id=notebook_id
+    )
 
 
 @router.post("", status_code=202)
@@ -299,7 +311,14 @@ async def generate(
 async def poll(
     notebook_id: str, task_id: str, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
-    """Poll a generation task, projecting state through the pending registry."""
+    """Poll a generation task, projecting state through the pending registry.
+
+    An id the in-process registry has never seen (e.g. a task from a prior server
+    process, or one whose post-generate NOT_FOUND lag has elapsed and been dropped)
+    is a deliberate 404: this is a personal-automation surface with no persistent
+    job store (reviewer consensus — see ``_pending.py``), so an unknown id is
+    "not found" rather than silently 200. Re-poll a live task with its ``task_id``.
+    """
     status = await artifact_core.poll_artifact(client, notebook_id, task_id)
     view = artifact_core.status_view(status)
     state = status.status

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -36,7 +36,7 @@ import tempfile
 from pathlib import Path
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from starlette.types import Receive, Scope, Send
@@ -45,6 +45,7 @@ from ..._app import artifacts as artifact_core
 from ..._app import download as download_core
 from ..._app import generate as generate_core
 from ..._app.language import is_supported_language
+from ..._app.resolve import FULL_ID_PATTERN
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from ...exceptions import ValidationError
@@ -63,6 +64,22 @@ from ._passthrough import (
 __all__ = ["DOWNLOAD_SPECS", "GENERATE_TYPES", "router"]
 
 router = APIRouter(prefix="/notebooks/{notebook_id}/artifacts", tags=["artifacts"])
+
+
+def _canonical_artifact_id(artifact_id: str) -> str:
+    """Lowercase a full-UUID artifact id before the kind-aware core call.
+
+    The rename/delete cores detect a note-backed mind map with a CASE-SENSITIVE
+    scan of ``mind_maps.list`` / ``mind_maps.list_note_backed`` (whose ids are
+    canonically lowercase), so an UPPERCASE full UUID would miss the mind-map
+    route and be mislabeled — a note-backed map would report ``renamed`` /
+    ``deleted`` without actually being cleared. Backend ids are canonically
+    lowercase, so lowering a full UUID is safe for the plain artifact path too;
+    a non-UUID (partial) ref is left untouched (its own resolver owns casing).
+    Mirrors the MCP ``studio_rename`` / ``studio_delete`` full-UUID carve-out.
+    """
+    return artifact_id.lower() if FULL_ID_PATTERN.fullmatch(artifact_id) else artifact_id
+
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
 PendingDep = Annotated[PendingRegistry, Depends(get_pending)]
@@ -99,15 +116,78 @@ _KIND_DEFAULTS: dict[str, dict[str, Any]] = {
     "report": {"report_format": "briefing-doc"},
 }
 
-#: Accepted values for the caller-facing per-kind options, validated up front so
-#: a bad choice is a clean 400 rather than a raw ``KeyError`` from a generate-core
-#: display-name lookup that runs before its own choice validation.
-_OPTION_CHOICES: dict[str, tuple[str, ...]] = {
-    "report_format": ("briefing-doc", "study-guide", "blog-post", "custom"),
-    "audio_format": ("deep-dive", "brief", "critique", "debate"),
-    "audio_length": ("short", "default", "long"),
-    "quantity": ("fewer", "standard", "more"),
-    "difficulty": ("easy", "medium", "hard"),
+#: Per-kind agent-settable options → their accepted choices (``None`` = free text,
+#: only ``style_prompt``). Mirrors the MCP ``studio_generate`` ``_KIND_OPTIONS``
+#: table so the REST generate route enforces the SAME three things:
+#:
+#: * **Choice validation** up front — a bad value is a clean 400, not a raw
+#:   ``KeyError`` from a generate-core display-name lookup that runs before its own
+#:   choice validation.
+#: * **The ``style`` collision** — ``video`` and ``infographic`` both take a
+#:   ``style`` kwarg with DIFFERENT value sets; keying by ``type`` keeps them apart.
+#: * **Wrong-kind rejection** — an option irrelevant to the chosen type (e.g.
+#:   ``orientation`` on ``quiz``) is rejected rather than silently ignored by the
+#:   neutral core (``build_generation_plan`` "picks the relevant subset").
+#:
+#: The literal tuples are DUPLICATED from the neutral core's private ``_*_MAP``
+#: maps (the server layer must not import the core privates — same rule the MCP
+#: table follows); ``tests/server/test_artifacts.py`` pins them equal to the core
+#: maps so they cannot silently drift. ``map_kind`` has no core map (the core reads
+#: it raw), so it is validated here ONLY.
+_KIND_OPTIONS: dict[str, dict[str, tuple[str, ...] | None]] = {
+    "audio": {
+        "audio_format": ("deep-dive", "brief", "critique", "debate"),
+        "audio_length": ("short", "default", "long"),
+    },
+    "video": {
+        "video_format": ("explainer", "brief", "cinematic"),
+        "style": (
+            "auto",
+            "custom",
+            "classic",
+            "whiteboard",
+            "kawaii",
+            "anime",
+            "watercolor",
+            "retro-print",
+            "heritage",
+            "paper-craft",
+        ),
+        "style_prompt": None,
+    },
+    "cinematic-video": {},
+    "slide-deck": {
+        "deck_format": ("detailed", "presenter"),
+        "deck_length": ("default", "short"),
+    },
+    "quiz": {
+        "quantity": ("fewer", "standard", "more"),
+        "difficulty": ("easy", "medium", "hard"),
+    },
+    "flashcards": {
+        "quantity": ("fewer", "standard", "more"),
+        "difficulty": ("easy", "medium", "hard"),
+    },
+    "infographic": {
+        "orientation": ("landscape", "portrait", "square"),
+        "detail": ("concise", "standard", "detailed"),
+        "style": (
+            "auto",
+            "sketch-note",
+            "professional",
+            "bento-grid",
+            "editorial",
+            "instructional",
+            "bricks",
+            "clay",
+            "anime",
+            "kawaii",
+            "scientific",
+        ),
+    },
+    "data-table": {},
+    "mind-map": {"map_kind": ("interactive", "note-backed")},
+    "report": {"report_format": ("briefing-doc", "study-guide", "blog-post", "custom")},
 }
 
 
@@ -223,7 +303,14 @@ DOWNLOAD_SPECS: dict[str, download_core.DownloadTypeSpec] = _download_specs()
 
 
 class ArtifactGenerate(BaseModel):
-    """Request body for starting a studio-artifact generation."""
+    """Request body for starting a studio-artifact generation.
+
+    Carries the full per-kind option surface (mirroring the MCP
+    ``studio_generate`` tool). Each option is valid ONLY for the kind(s) that
+    accept it — passing one to a different ``type`` (e.g. ``orientation`` to
+    ``quiz``) is a 400, not a silent no-op. ``style`` is shared by ``video`` and
+    ``infographic`` with each kind's own value set.
+    """
 
     type: str
     source_ids: list[str] | None = None
@@ -234,6 +321,20 @@ class ArtifactGenerate(BaseModel):
     audio_length: str | None = None
     quantity: str | None = None
     difficulty: str | None = None
+    video_format: str | None = None
+    style: str | None = None
+    style_prompt: str | None = None
+    deck_format: str | None = None
+    deck_length: str | None = None
+    orientation: str | None = None
+    detail: str | None = None
+    map_kind: str | None = None
+
+
+class ArtifactRename(BaseModel):
+    """Request body for renaming a studio artifact (title only)."""
+
+    title: str
 
 
 class ArtifactDownload(BaseModel):
@@ -273,29 +374,58 @@ async def generate(
     if body.language is not None and not is_supported_language(body.language):
         raise ValidationError(f"Unsupported language {body.language!r}")
 
-    raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[body.type])
-    raw_args.update(
-        {
-            "notebook_id": notebook_id,
-            "description": body.instructions or "",
-            "source_ids": tuple(body.source_ids or ()),
-            "language": body.language,
-            "wait": False,
-            "json_output": True,
-        }
-    )
+    # Validate caller-supplied per-kind overrides against the choice set for THIS
+    # ``type`` (mirroring the MCP ``studio_generate`` loop): an option not accepted
+    # by this kind is rejected — the neutral core would otherwise silently ignore
+    # it — and a bad value is a clean 400. ``style_prompt`` (choices ``None``) is
+    # free text; the core enforces the ``style=custom`` ⇔ ``style_prompt`` rule.
+    allowed = _KIND_OPTIONS[body.type]
+    overrides: dict[str, Any] = {}
     for key, value in (
         ("report_format", body.report_format),
         ("audio_format", body.audio_format),
         ("audio_length", body.audio_length),
         ("quantity", body.quantity),
         ("difficulty", body.difficulty),
+        ("video_format", body.video_format),
+        ("style", body.style),
+        ("style_prompt", body.style_prompt),
+        ("deck_format", body.deck_format),
+        ("deck_length", body.deck_length),
+        ("orientation", body.orientation),
+        ("detail", body.detail),
+        ("map_kind", body.map_kind),
     ):
-        if value is not None:
-            choices = _OPTION_CHOICES[key]
-            if value not in choices:
-                raise ValidationError(f"Invalid {key} {value!r}; expected one of {list(choices)}")
-            raw_args[key] = value
+        if value is None:
+            continue
+        if key not in allowed:
+            accepts = (
+                f"this kind accepts {sorted(allowed)}"
+                if allowed
+                else "this kind accepts no per-kind options"
+            )
+            raise ValidationError(f"option {key!r} is not valid for type {body.type!r}; {accepts}")
+        choices = allowed[key]
+        if choices is not None and value not in choices:
+            raise ValidationError(f"Invalid {key} {value!r}; expected one of {list(choices)}")
+        overrides[key] = value
+
+    raw_args: dict[str, Any] = dict(_KIND_DEFAULTS[body.type])
+    raw_args.update(
+        {
+            "notebook_id": notebook_id,
+            "description": body.instructions or "",
+            # ``mind-map`` reads ``raw_args["instructions"]`` (every other kind reads
+            # ``description``); forward BOTH so mind-map instructions actually reach
+            # the client — the extra key is ignored by the other builders.
+            "instructions": body.instructions or None,
+            "source_ids": tuple(body.source_ids or ()),
+            "language": body.language,
+            "wait": False,
+            "json_output": True,
+        }
+    )
+    raw_args.update(overrides)
 
     plan = generate_core.build_generation_plan(body.type, raw_args)
     result = await generate_core.execute_generation(
@@ -341,6 +471,68 @@ async def poll(
     # COMPLETED — and, defensively, any unmodeled state — surfaces the projected
     # view rather than a 500.
     return projected
+
+
+@router.get("/{artifact_id}/prompt")
+async def get_prompt(notebook_id: str, artifact_id: str, client: ClientDep) -> dict[str, Any]:
+    """Fetch the free-text prompt an artifact was generated from.
+
+    Returns ``{notebook_id, artifact_id, prompt}``. A ``null`` ``prompt`` (the
+    artifact records none — e.g. a note-backed mind map) is a valid 200 result,
+    NOT a 404; an unknown artifact id raises ``ArtifactNotFoundError`` → 404.
+    """
+    prompt = await artifact_core.get_artifact_prompt(client, notebook_id, artifact_id)
+    return {"notebook_id": notebook_id, "artifact_id": artifact_id, "prompt": prompt}
+
+
+@router.patch("/{artifact_id}")
+async def rename(
+    notebook_id: str, artifact_id: str, body: ArtifactRename, client: ClientDep
+) -> dict[str, Any]:
+    """Rename an artifact (title only), dispatching mind maps kind-aware."""
+    result = await artifact_core.rename_artifact(
+        client, notebook_id, _canonical_artifact_id(artifact_id), body.title
+    )
+    return {
+        "status": "renamed",
+        "notebook_id": notebook_id,
+        "artifact_id": result.artifact_id,
+        "new_title": result.new_title,
+        "is_mind_map": result.is_mind_map,
+    }
+
+
+@router.post("/{artifact_id}/retry")
+async def retry(notebook_id: str, artifact_id: str, client: ClientDep) -> dict[str, Any]:
+    """Retry a failed artifact in place (the UI "Retry" action).
+
+    Non-blocking: on acceptance returns the kicked-off ``task_id`` (equal to the
+    artifact id) and the new ``status``; poll ``GET .../artifacts/{task_id}``
+    until complete. A synchronous refusal (rate limit / quota / not-retryable)
+    surfaces as the classified error.
+    """
+    status = await artifact_core.retry_artifact(client, notebook_id, artifact_id)
+    return {
+        "notebook_id": notebook_id,
+        "artifact_id": artifact_id,
+        "task_id": status.task_id,
+        # ``GenerationStatus.status`` is raw-string-permissive (documented in
+        # ``_types/artifacts.py``: an instance built with a plain ``str`` keeps
+        # working), so ``.value`` is NOT guaranteed — emit it enum-or-str-safely.
+        "status": to_jsonable(status.status),
+    }
+
+
+@router.delete("/{artifact_id}", status_code=204)
+async def delete(notebook_id: str, artifact_id: str, client: ClientDep) -> Response:
+    """Delete an artifact (irreversible).
+
+    The bare DELETE verb is the destructive gate (consistent with the notebook /
+    source / note DELETE routes — no confirm param). A note-backed mind map is
+    cleared via the note system inside the shared core. Returns 204.
+    """
+    await artifact_core.delete_artifact(client, notebook_id, _canonical_artifact_id(artifact_id))
+    return Response(status_code=204)
 
 
 class _CleanupFileResponse(FileResponse):

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -39,7 +39,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
-from starlette.background import BackgroundTask
+from starlette.types import Receive, Scope, Send
 
 from ..._app import artifacts as artifact_core
 from ..._app import download as download_core
@@ -324,6 +324,28 @@ async def poll(
     return projected
 
 
+class _CleanupFileResponse(FileResponse):
+    """A ``FileResponse`` that removes its private temp dir once the body has
+    finished streaming — or the client disconnected / the stream aborted.
+
+    Cleaning in a ``finally`` around the ASGI ``__call__`` (not via a
+    ``BackgroundTask``, which Starlette drops when the client disconnects
+    mid-stream) guarantees the spooled artifact's temp dir is always removed, so a
+    disconnect can never leak it. Error / early-return paths never construct this
+    response — the route's own ``finally`` cleans those.
+    """
+
+    def __init__(self, *args: Any, temp_dir: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._temp_dir = temp_dir
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            _cleanup(self._temp_dir)
+
+
 @router.post("/download")
 async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) -> FileResponse:
     """Download a completed artifact, streaming from a server-generated temp path."""
@@ -337,8 +359,13 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
     # (download.py); an isolated empty dir avoids that, and we assert the served
     # path stays inside it so a surprising resolved path can never be streamed.
     temp_dir = tempfile.mkdtemp(prefix="nblm-download-")
-    temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+    # On SUCCESS, ownership of the temp dir passes to the returned
+    # ``_CleanupFileResponse`` (cleans after streaming, disconnect-safe); every
+    # other exit — validation, a not-ready 409, an unexpected raise — cleans in the
+    # ``finally`` below.
+    success = False
     try:
+        temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
         args: dict[str, Any] = {
             "notebook_id": notebook_id,
             "output_path": temp_path,
@@ -357,33 +384,31 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
             notebook_resolver=passthrough_download_notebook,
             artifact_resolver=passthrough_artifact_id,
         )
-    except BaseException:
-        _cleanup(temp_dir)
-        raise
 
-    # No completed artifact of this kind exists yet (not ready), or a pre-download
-    # error — surface as 409, not 500, and clean up the unused temp dir.
-    if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
-        _cleanup(temp_dir)
-        detail = (
-            safe_detail(result.error)
-            if result.error
-            else (f"No completed {body.type} artifact is available yet")
+        # No completed artifact of this kind exists yet (not ready), or a
+        # pre-download error — surface as 409, not 500.
+        if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
+            detail = (
+                safe_detail(result.error)
+                if result.error
+                else (f"No completed {body.type} artifact is available yet")
+            )
+            raise HTTPException(status_code=409, detail=detail)
+
+        # Stream the actual written file. The core may resolve a conflict to a
+        # different name, but it must stay inside our private dir — anything else is
+        # a bug, not a file we serve.
+        served = result.output_path or temp_path
+        if Path(temp_dir).resolve() not in Path(served).resolve().parents:
+            raise ValidationError("Download produced an unexpected output path")
+        response = _CleanupFileResponse(
+            served, filename=os.path.basename(served), temp_dir=temp_dir
         )
-        raise HTTPException(status_code=409, detail=detail)
-
-    # Stream the actual written file. The core may resolve a conflict to a
-    # different name, but it must stay inside our private dir — anything else is a
-    # bug, not a file we serve.
-    served = result.output_path or temp_path
-    if Path(temp_dir).resolve() not in Path(served).resolve().parents:
-        _cleanup(temp_dir)
-        raise ValidationError("Download produced an unexpected output path")
-    return FileResponse(
-        served,
-        filename=os.path.basename(served),
-        background=BackgroundTask(_cleanup, temp_dir),
-    )
+        success = True
+        return response
+    finally:
+        if not success:
+            _cleanup(temp_dir)
 
 
 def _cleanup(path: str) -> None:

--- a/src/notebooklm/server/routes/chat.py
+++ b/src/notebooklm/server/routes/chat.py
@@ -19,6 +19,8 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from ..._app import chat as chat_core
+from ..._app.chat import ChatModeChoice, ResponseLengthChoice
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
@@ -37,6 +39,24 @@ class ChatAsk(BaseModel):
     conversation_id: str | None = None
 
 
+class ChatConfigure(BaseModel):
+    """Request body for configuring a notebook's chat behavior.
+
+    Two mutually-exclusive styles (mirrors the MCP ``chat_configure`` tool):
+
+    * ``chat_mode`` applies a predefined preset (``default`` / ``learning-guide``
+      / ``concise`` / ``detailed``) and replaces the whole chat-settings block,
+      so it cannot be combined with ``goal`` / ``response_length``.
+    * ``goal`` (free-text custom persona, selects the CUSTOM chat goal) and/or
+      ``response_length`` (``default`` / ``longer`` / ``shorter``) set a custom
+      configuration.
+    """
+
+    chat_mode: ChatModeChoice | None = None
+    goal: str | None = None
+    response_length: ResponseLengthChoice | None = None
+
+
 @router.post("")
 async def ask(notebook_id: str, body: ChatAsk, client: ClientDep) -> dict[str, Any]:
     """Ask the notebook's sources a question and return the full answer.
@@ -46,3 +66,28 @@ async def ask(notebook_id: str, body: ChatAsk, client: ClientDep) -> dict[str, A
     """
     result = await client.chat.ask(notebook_id, body.question, conversation_id=body.conversation_id)
     return to_jsonable(result)
+
+
+@router.post("/configure")
+async def configure(notebook_id: str, body: ChatConfigure, client: ClientDep) -> dict[str, Any]:
+    """Configure a notebook's chat behavior (preset OR custom).
+
+    Pass ``chat_mode`` for a predefined preset, or ``goal`` / ``response_length``
+    for a custom configuration; the two styles cannot be combined (rejected with
+    400, not silently dropped).
+
+    NOTE: in the custom (``goal`` / ``response_length``) branch this writes the
+    full chat-settings block, so an omitted field resets to its default (e.g.
+    setting only ``response_length`` clears a previously-set custom ``goal``).
+    Pass every field you want to keep. (A ``chat_mode`` preset has no sub-fields.)
+    """
+    # The preset-vs-custom mutual-exclusion + enum validation live in the shared
+    # ``execute_configure`` core, so the CLI, MCP, and this route enforce one rule.
+    result = await chat_core.execute_configure(
+        client,
+        notebook_id,
+        chat_mode=body.chat_mode,
+        persona=body.goal,
+        response_length=body.response_length,
+    )
+    return {"status": "configured", **to_jsonable(result)}

--- a/src/notebooklm/server/routes/chat.py
+++ b/src/notebooklm/server/routes/chat.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 from ..._app import chat as chat_core
 from ..._app.chat import ChatModeChoice, ResponseLengthChoice
 from ..._app.serialize import to_jsonable
+from ..._app.views import ask_result_view
 from ...client import NotebookLMClient
 from .._context import get_client
 
@@ -65,7 +66,9 @@ async def ask(notebook_id: str, body: ChatAsk, client: ClientDep) -> dict[str, A
     continue the notebook's most-recent conversation (or start a new one).
     """
     result = await client.chat.ask(notebook_id, body.question, conversation_id=body.conversation_id)
-    return to_jsonable(result)
+    # Shared view: drop the internal ``raw_response`` debug blob (identical on the
+    # MCP chat_ask surface); the field stays on the dataclass, just not on the wire.
+    return ask_result_view(result)
 
 
 @router.post("/configure")

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -1,0 +1,132 @@
+"""Server-info route — ``GET /v1/server/info``.
+
+Mirrors the MCP ``server_info`` tool (``mcp/tools/meta.py``): reports the package
+version and a local auth-health probe (storage-exists / JSON-valid /
+cookies-present / SID) so an agent can tell, before any notebook call, whether the
+server is authenticated. The probe reuses the transport-neutral
+:func:`notebooklm._app.auth_check.run_auth_check` core driven against the on-disk
+``storage_state.json`` the runtime would actually load (no network — ``test_fetch``
+is off).
+
+``?include_account=true`` additionally fetches the signed-in identity + quota
+limits + output language, which need a *live* session (so the block is off by
+default and degrades to ``{available: False, reason}`` on a stale session rather
+than failing the whole call).
+
+The absolute on-disk storage path is deliberately **not** returned — it leaks the
+server-host OS username / filesystem layout to the caller while telling it nothing
+actionable (the MCP surface scrubs it identically). This is a single-tenant
+server, so the info reflects the one lifespan-bound client.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+
+from ... import __version__
+from ..._app.auth_check import AuthCheckPlan, run_auth_check
+from ..._redact import redact
+from ...client import NotebookLMClient
+from ...exceptions import NotebookLMError
+from ...paths import get_active_profile, get_storage_path
+from .._context import get_client
+
+__all__ = ["router"]
+
+#: Named here rather than imported from ``server.app`` to avoid a circular import
+#: (``app`` imports this router). Kept equal to ``server.app.SERVER_NAME`` by
+#: ``tests/server/test_main.py``.
+SERVER_NAME = "notebooklm-server"
+
+router = APIRouter(prefix="/server", tags=["server"])
+
+ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
+
+
+def _no_env_auth_json() -> str:
+    """Inline-auth reader for the neutral core.
+
+    The server authenticates from on-disk storage (``from_storage``), never from
+    inline ``NOTEBOOKLM_AUTH_JSON``, so the plan sets ``has_env_auth=False`` and
+    this accessor is never invoked. It satisfies the core's required keyword only.
+    """
+    return ""  # pragma: no cover - unreachable while has_env_auth is False
+
+
+async def _account_block(client: NotebookLMClient, *, authenticated: bool) -> dict[str, Any]:
+    """Best-effort account identity + quota limits for pacing (mirrors MCP).
+
+    ``email`` / ``authuser`` come from the client; the limits/language fields need
+    a live session and degrade to ``{available: False, reason}`` (scrubbed) rather
+    than sinking the whole response when the session is stale.
+    """
+    identity: dict[str, Any] = {
+        "email": await client.get_account_email(live_fallback=authenticated),
+        "authuser": client.get_account_authuser(),
+    }
+    if not authenticated:
+        return {**identity, "available": False, "reason": "not authenticated"}
+    try:
+        limits, output_language = await asyncio.gather(
+            client.settings.get_account_limits(),
+            client.settings.get_output_language(),
+        )
+    except NotebookLMError as exc:  # degrade, don't sink the whole response
+        return {**identity, "available": False, "reason": redact(str(exc))}
+    return {
+        **identity,
+        "available": True,
+        "notebook_limit": limits.notebook_limit,
+        "source_limit": limits.source_limit,
+        "output_language": output_language,
+    }
+
+
+@router.get("/info")
+async def server_info(
+    client: ClientDep,
+    include_account: Annotated[bool, Query()] = False,
+) -> dict[str, Any]:
+    """Report the server version and local authentication health.
+
+    Returns ``version`` and an ``auth`` block (``authenticated`` /
+    ``storage_exists`` / ``json_valid`` / ``cookies_present`` / ``sid_cookie`` /
+    ``profile``). Set ``?include_account=true`` to also fetch an ``account`` block
+    (signed-in identity + quota limits + output language); it needs a live session,
+    so it degrades to ``{available: False, reason}`` rather than failing the call.
+
+    The absolute on-disk storage path is deliberately not returned (it leaks the
+    host filesystem layout while telling the agent nothing actionable).
+    """
+    profile = get_active_profile()
+    storage_path = get_storage_path(profile)
+    plan = AuthCheckPlan(
+        storage_path=storage_path,
+        profile=profile,
+        has_env_auth=False,
+        has_home_env=False,
+        auth_source_label=f"file ({storage_path})",
+        test_fetch=False,
+        json_output=True,
+    )
+    result = await run_auth_check(plan, read_env_auth_json=_no_env_auth_json)
+    info: dict[str, Any] = {
+        "server": SERVER_NAME,
+        "version": __version__,
+        "auth": {
+            "authenticated": result.all_passed,
+            "storage_exists": bool(result.checks.get("storage_exists")),
+            "json_valid": bool(result.checks.get("json_valid")),
+            "cookies_present": bool(result.checks.get("cookies_present")),
+            "sid_cookie": bool(result.checks.get("sid_cookie")),
+            "profile": profile,
+        },
+    }
+    if include_account:
+        info["account"] = await _account_block(client, authenticated=result.all_passed)
+    return info

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel
 
 from ..._app import notebooks as core
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
+from .._pagination import MAX_LIMIT, paginate_envelope
 
 __all__ = ["router"]
 
@@ -39,10 +40,18 @@ class NotebookCreate(BaseModel):
 
 
 @router.get("")
-async def list_notebooks(client: ClientDep) -> dict[str, Any]:
-    """List all notebooks."""
+async def list_notebooks(
+    client: ClientDep,
+    limit: Annotated[int | None, Query(ge=1, le=MAX_LIMIT)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """List all notebooks.
+
+    Defaults to the full collection under ``notebooks`` (unchanged). Supply
+    ``?limit=`` to slice and add a ``meta`` block; ``?offset=`` pages forward.
+    """
     notebooks = await client.notebooks.list()
-    return {"notebooks": to_jsonable(notebooks)}
+    return paginate_envelope(to_jsonable(notebooks), key="notebooks", limit=limit, offset=offset)
 
 
 @router.get("/{notebook_id}")

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -15,7 +15,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel
@@ -25,6 +25,7 @@ from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
 from .._pagination import MAX_LIMIT, paginate_envelope
+from ._passthrough import passthrough_notebook_id
 
 __all__ = ["router"]
 
@@ -32,9 +33,44 @@ router = APIRouter(prefix="/notebooks", tags=["notebooks"])
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
 
+#: ``suggested-prompts`` ``surface`` → the ``otmP3b`` (GeneratePromptSuggestions)
+#: ``mode`` int selecting the product surface/format the prompts are written for.
+#: DUPLICATED from the MCP ``suggest_prompts`` tool's ``_SUGGEST_SURFACE`` (the
+#: server layer must not import ``mcp/``); ``tests/server/test_notebooks.py`` pins
+#: the two equal so they cannot drift. Map established by the #1726 live probe.
+SuggestSurface = Literal[
+    "ask",
+    "audio-deep-dive",
+    "audio-brief",
+    "audio-critique",
+    "audio-debate",
+    "video-explainer",
+    "video-short",
+    "quiz",
+    "flashcards",
+]
+
+_SUGGEST_SURFACE: dict[str, int] = {
+    "ask": 4,
+    "audio-deep-dive": 1,
+    "audio-brief": 2,
+    "audio-critique": 5,
+    "audio-debate": 6,
+    "video-explainer": 3,
+    "video-short": 10,
+    "quiz": 8,
+    "flashcards": 9,
+}
+
 
 class NotebookCreate(BaseModel):
     """Request body for creating a notebook."""
+
+    title: str
+
+
+class NotebookRename(BaseModel):
+    """Request body for renaming a notebook."""
 
     title: str
 
@@ -66,6 +102,45 @@ async def create_notebook(body: NotebookCreate, client: ClientDep) -> dict[str, 
     """Create a notebook with the given title."""
     result = await core.execute_notebook_create(client, body.title)
     return to_jsonable(result.notebook)
+
+
+@router.patch("/{notebook_id}")
+async def rename_notebook(
+    notebook_id: str, body: NotebookRename, client: ClientDep
+) -> dict[str, Any]:
+    """Rename a notebook."""
+    result = await core.execute_notebook_rename(
+        client, notebook_id, body.title, resolve_notebook_id=passthrough_notebook_id
+    )
+    return {"status": "renamed", **to_jsonable(result)}
+
+
+@router.get("/{notebook_id}/suggested-prompts")
+async def suggested_prompts(
+    notebook_id: str,
+    client: ClientDep,
+    surface: Annotated[SuggestSurface, Query()] = "ask",
+    source_ids: Annotated[list[str] | None, Query()] = None,
+    query: Annotated[str | None, Query()] = None,
+) -> dict[str, Any]:
+    """Get AI-suggested, ready-to-send prompts for a studio surface.
+
+    ``surface`` (default ``ask``) selects what the prompts are written for — chat
+    questions (``ask``), or steering an audio / video / quiz / flashcards
+    generation. ``source_ids`` (repeatable query param) scopes to specific
+    sources; omit for all. ``query`` optionally steers the suggestions. Mirrors
+    the MCP ``suggest_prompts`` tool.
+    """
+    rows = await client.notebooks.suggest_prompts(
+        notebook_id,
+        source_ids=list(source_ids) if source_ids else None,
+        mode=_SUGGEST_SURFACE[surface],
+        query=query,
+    )
+    return {
+        "notebook_id": notebook_id,
+        "suggestions": [{"title": s.title, "prompt": s.prompt} for s in rows],
+    }
 
 
 @router.delete("/{notebook_id}", status_code=204)

--- a/src/notebooklm/server/routes/notes.py
+++ b/src/notebooklm/server/routes/notes.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel
 
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
+from .._pagination import MAX_LIMIT, paginate_envelope
 
 __all__ = ["router"]
 
@@ -47,10 +48,21 @@ class NoteUpdate(BaseModel):
 
 
 @router.get("")
-async def list_notes(notebook_id: str, client: ClientDep) -> dict[str, Any]:
-    """List a notebook's text notes (excludes mind maps and deleted notes)."""
+async def list_notes(
+    notebook_id: str,
+    client: ClientDep,
+    limit: Annotated[int | None, Query(ge=1, le=MAX_LIMIT)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """List a notebook's text notes (excludes mind maps and deleted notes).
+
+    Defaults to the full collection under ``notes`` (unchanged). Supply
+    ``?limit=`` to slice and add a ``meta`` block; ``?offset=`` pages forward.
+    """
     notes = await client.notes.list(notebook_id)
-    return {"notebook_id": notebook_id, "notes": to_jsonable(notes)}
+    return paginate_envelope(
+        to_jsonable(notes), key="notes", limit=limit, offset=offset, notebook_id=notebook_id
+    )
 
 
 @router.get("/{note_id}")

--- a/src/notebooklm/server/routes/research.py
+++ b/src/notebooklm/server/routes/research.py
@@ -1,0 +1,154 @@
+"""Deep-research routes — ``/v1/notebooks/{id}/research`` start / status / cancel / import.
+
+Thin adapters over the research surface, following the MCP ``research_*`` tools'
+**split-tool** shape (``mcp/tools/research.py``) rather than the CLI-shaped
+``_app.source_research`` bundle (a start→wait→import workflow with an injected
+importer that does not decompose into four independent HTTP routes):
+
+* ``POST   .../research``               → ``client.research.start`` (202).
+* ``GET    .../research/{run_id}``      → ``_app.research.poll_and_classify``.
+* ``DELETE .../research/{run_id}``      → ``_app.research.cancel_research``.
+* ``POST   .../research/{run_id}/import`` → guard the poll, then
+  ``client.research.import_sources``.
+
+**The ``run_id`` land mine.** ``client.research.start`` returns BOTH a
+``task_id`` and (for **deep** mode) a ``report_id``; poll / cancel / import must
+key off the ``report_id`` for a deep run (deep's ``task_id`` is a sessionId that
+``poll`` reports as ``not_found`` and ``cancel`` silently no-ops). So the 202
+start response surfaces an unambiguous ``poll_id`` — the ``report_id`` for a
+**deep** run and the ``task_id`` for a **fast** run (gated on ``mode``
+explicitly, NOT a ``report_id or task_id`` fallback that could emit a deep
+``task_id`` that polls as ``not_found``; a deep start missing its ``report_id``
+fails loud instead). The ``{run_id}`` path segment on the status / cancel /
+import routes IS that ``poll_id`` — forwarded verbatim as the poll/cancel/import
+discriminator. A caller that pins ``poll_id`` is correct for both modes.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..._app import research as research_core
+from ..._app.serialize import to_jsonable
+from ...client import NotebookLMClient
+from ...exceptions import DecodingError, ValidationError
+from .._context import get_client
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/notebooks/{notebook_id}/research", tags=["research"])
+
+ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
+
+
+class ResearchStartBody(BaseModel):
+    """Request body for starting a research session."""
+
+    query: str
+    source: Literal["web", "drive"] = "web"
+    mode: Literal["fast", "deep"] = "fast"
+
+
+@router.post("", status_code=202)
+async def start_research(
+    notebook_id: str, body: ResearchStartBody, client: ClientDep
+) -> dict[str, Any]:
+    """Start a research session (non-blocking, returns 202).
+
+    ``mode`` is ``fast`` (default) or ``deep``; ``source`` is ``web`` (default)
+    or ``drive``. Deep research is web-only (the ``drive`` + ``deep`` combination
+    is rejected with 400).
+
+    The response carries ``poll_id`` — the unambiguous id to hand to the status /
+    cancel / import routes as ``{run_id}``. For a deep run this is the
+    ``report_id`` (NOT the ``task_id``, which is a sessionId the poll cannot see);
+    for a fast run it is the ``task_id``.
+    """
+    # ``deep`` is web-only — the independent Literals cannot express this
+    # cross-field rule, so reject it here (mirrors the MCP ``research_start``
+    # tool). ``client.research.start`` also validates this, but catching it up
+    # front keeps the message action-appropriate.
+    if body.source == "drive" and body.mode == "deep":
+        raise ValidationError("mode 'deep' is web-only; use source 'web' for deep research")
+    result = await client.research.start(notebook_id, body.query, body.source, body.mode)
+    # Poll/cancel/import discriminator contract, gated on mode EXPLICITLY (not a
+    # ``report_id or task_id`` fallback): a DEEP run keys off ``report_id`` — its
+    # ``task_id`` is a sessionId that ``poll`` reports as ``not_found`` and
+    # ``cancel`` silently no-ops — while a FAST run keys off ``task_id``. A deep
+    # start that returns no ``report_id`` cannot form a pollable id, so fail loud
+    # rather than emit a ``task_id`` that will immediately poll as ``not_found``.
+    if body.mode == "deep":
+        if not result.report_id:
+            raise DecodingError(
+                "Deep research start returned no report_id; cannot form a pollable run "
+                "id (the deep task_id is a sessionId the poll/cancel cannot use)."
+            )
+        poll_id = result.report_id
+    else:
+        poll_id = result.task_id
+    return {"notebook_id": notebook_id, "poll_id": poll_id, **to_jsonable(result)}
+
+
+@router.get("/{run_id}")
+async def research_status(notebook_id: str, run_id: str, client: ClientDep) -> dict[str, Any]:
+    """Poll a research run's status.
+
+    ``run_id`` is the ``poll_id`` from the start response. Returns ``status``
+    (``no_research`` | ``in_progress`` | ``completed`` | ``failed`` |
+    ``not_found``), the found ``sources``, and any ``report`` once complete. Poll
+    until ``completed``, then ``POST .../{run_id}/import``.
+    """
+    result = await research_core.poll_and_classify(client, notebook_id, run_id)
+    return {
+        "notebook_id": notebook_id,
+        "run_id": run_id,
+        "task_id": result.task_id,
+        "kind": result.kind,
+        "status": result.status,
+        "query": result.query,
+        "sources": to_jsonable(result.sources),
+        "summary": result.summary,
+        "report": result.report,
+    }
+
+
+@router.delete("/{run_id}")
+async def cancel_research(notebook_id: str, run_id: str, client: ClientDep) -> dict[str, Any]:
+    """Cancel an in-flight research run (fire-and-forget).
+
+    The server returns nothing to confirm the cancel and does not validate
+    ``run_id``, so this always reports ``cancelled: true`` without asserting the
+    run existed. Poll ``GET .../{run_id}`` afterward to confirm — a cancelled
+    in-progress run surfaces as ``failed``.
+    """
+    await research_core.cancel_research(client, notebook_id, run_id)
+    return {"status": "cancelled", "notebook_id": notebook_id, "run_id": run_id, "cancelled": True}
+
+
+@router.post("/{run_id}/import", status_code=201)
+async def import_research(notebook_id: str, run_id: str, client: ClientDep) -> dict[str, Any]:
+    """Import a completed research run's found sources into the notebook.
+
+    ``run_id`` is the ``poll_id`` from the start response. The run is polled FOR
+    THAT id so only its sources are imported. A run that is not found / failed /
+    still in progress, or that completed with no sources, is rejected (400) — an
+    unfinished or empty run is never imported as a partial success (mirrors the
+    MCP ``research_import`` guard).
+    """
+    # Poll FOR THE REQUESTED run and guard every non-importable state before
+    # touching ``import_sources``. The same shared helper backs the MCP
+    # ``research_import`` tool so the importable-state ladder cannot drift.
+    sources = await research_core.poll_sources_for_import(client, notebook_id, run_id)
+    imported = await client.research.import_sources(notebook_id, run_id, sources)
+    return {
+        "status": "imported",
+        "notebook_id": notebook_id,
+        "run_id": run_id,
+        "imported": to_jsonable(imported),
+        "sources_found": len(sources),
+    }

--- a/src/notebooklm/server/routes/research.py
+++ b/src/notebooklm/server/routes/research.py
@@ -37,13 +37,15 @@ from ..._app import research as research_core
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from ...exceptions import DecodingError, ValidationError
-from .._context import get_client
+from .._context import get_client, get_pending
+from .._pending import PendingRegistry
 
 __all__ = ["router"]
 
 router = APIRouter(prefix="/notebooks/{notebook_id}/research", tags=["research"])
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
+PendingDep = Annotated[PendingRegistry, Depends(get_pending)]
 
 
 class ResearchStartBody(BaseModel):
@@ -90,8 +92,18 @@ async def start_research(
             )
         poll_id = result.report_id
     else:
+        # Fast mode keys off ``task_id``; guard its emptiness the same way deep
+        # guards ``report_id`` so a fast start that returns no ``task_id`` fails
+        # loud instead of emitting an empty, unpollable ``poll_id``.
+        if not result.task_id:
+            raise DecodingError(
+                "Fast research start returned no task_id; cannot form a pollable run id."
+            )
         poll_id = result.task_id
-    return {"notebook_id": notebook_id, "poll_id": poll_id, **to_jsonable(result)}
+    # The explicit discriminators (``notebook_id`` / ``poll_id``) go AFTER the
+    # spread so a ``to_jsonable(result)`` field (e.g. ``task_id`` / ``report_id``)
+    # can never clobber the computed ``poll_id``.
+    return {**to_jsonable(result), "notebook_id": notebook_id, "poll_id": poll_id}
 
 
 @router.get("/{run_id}")
@@ -131,7 +143,9 @@ async def cancel_research(notebook_id: str, run_id: str, client: ClientDep) -> d
 
 
 @router.post("/{run_id}/import", status_code=201)
-async def import_research(notebook_id: str, run_id: str, client: ClientDep) -> dict[str, Any]:
+async def import_research(
+    notebook_id: str, run_id: str, client: ClientDep, pending: PendingDep
+) -> dict[str, Any]:
     """Import a completed research run's found sources into the notebook.
 
     ``run_id`` is the ``poll_id`` from the start response. The run is polled FOR
@@ -139,12 +153,26 @@ async def import_research(notebook_id: str, run_id: str, client: ClientDep) -> d
     still in progress, or that completed with no sources, is rejected (400) — an
     unfinished or empty run is never imported as a partial success (mirrors the
     MCP ``research_import`` guard).
+
+    Each imported source id is recorded in the pending registry (same provenance
+    contract as the ``POST .../sources`` create routes), so a ``GET
+    .../sources/{id}`` poll for a just-imported id resolves to a ``200`` pending
+    rather than a spurious ``404`` during the not-yet-listable window.
     """
     # Poll FOR THE REQUESTED run and guard every non-importable state before
     # touching ``import_sources``. The same shared helper backs the MCP
     # ``research_import`` tool so the importable-state ladder cannot drift.
     sources = await research_core.poll_sources_for_import(client, notebook_id, run_id)
+    # Match the MCP ``research_import`` tool exactly — it imports via the plain
+    # ``import_sources`` (NOT ``import_sources_with_verification``), so the REST
+    # route does the same to keep the two surfaces in lock-step.
     imported = await client.research.import_sources(notebook_id, run_id, sources)
+    # Record each new source id in the pending registry so the source poll route
+    # can answer 200-pending (not 404) for the not-yet-listable window.
+    for item in imported:
+        source_id = item.get("id")
+        if source_id:
+            pending.record(notebook_id, source_id)
     return {
         "status": "imported",
         "notebook_id": notebook_id,

--- a/src/notebooklm/server/routes/share.py
+++ b/src/notebooklm/server/routes/share.py
@@ -33,7 +33,10 @@ class ShareUserAdd(BaseModel):
 
     email: str
     permission: Literal["viewer", "editor"] = "viewer"
-    notify: bool = True
+    # Default OFF: a localhost automation server must not silently email a third
+    # party. The caller opts in explicitly with ``notify=true``. (The widening
+    # confirm gate is deferred to land jointly with the MCP #1742 shared idiom.)
+    notify: bool = False
     welcome_message: str = ""
 
 

--- a/src/notebooklm/server/routes/share.py
+++ b/src/notebooklm/server/routes/share.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel
 
 from ..._app import sharing as core
-from ..._app.serialize import to_jsonable
+from ..._app.views import share_status_view
 from ...client import NotebookLMClient
 from ...types import SharePermission
 from ...types import ShareViewLevel as ShareViewLevelEnum
@@ -71,7 +71,10 @@ async def get_share_status(notebook_id: str, client: ClientDep) -> dict[str, Any
         notebook_id,
         resolve_notebook_id=passthrough_notebook_id,
     )
-    return to_jsonable(status)
+    # Shared view: label the access/permission enums (identical to the MCP surface).
+    # ``view_level`` is omitted — the read RPC does not report it (would always
+    # read "full"); set it via POST /view-level, which echoes the value it set.
+    return share_status_view(status)
 
 
 @router.post("/public")
@@ -83,7 +86,7 @@ async def set_public(notebook_id: str, body: SharePublic, client: ClientDep) -> 
         body.enable,
         resolve_notebook_id=passthrough_notebook_id,
     )
-    return to_jsonable(status)
+    return share_status_view(status)
 
 
 @router.post("/users", status_code=201)
@@ -143,4 +146,6 @@ async def set_view_level(
         _VIEW_LEVELS[body.level],
         resolve_notebook_id=passthrough_notebook_id,
     )
-    return to_jsonable(status)
+    # ``set_view_level``'s return is the only authoritative source for view_level
+    # (the read RPC hardcodes FULL), so it is surfaced here (labeled) but nowhere else.
+    return share_status_view(status, include_view_level=True)

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -37,11 +37,12 @@ from ..._app import source_add as add_core
 from ..._app import source_content as content_core
 from ..._app import source_mutations as mut_core
 from ..._app import source_wait as wait_core
+from ..._app.errors import classify
 from ..._app.views import source_view
 from ...client import NotebookLMClient
 from ...exceptions import ValidationError
 from .._context import get_client, get_pending
-from .._errors import error_item
+from .._errors import CATEGORY_STATUS, error_item, safe_detail
 from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
 from ._passthrough import passthrough_source_id
@@ -387,6 +388,25 @@ async def add_drive(
     return source_view(result.source)
 
 
+def _batch_item_is_fatal(exc: BaseException) -> bool:
+    """Decide whether a per-item add failure must abort the whole batch.
+
+    Per-item isolation is correct ONLY for per-URL, user-input failures (a bad
+    URL / SSRF-blocked host / not-found → 4xx-input): those are properly reported
+    as a per-entry ``error`` while the rest of the batch proceeds. A service /
+    infrastructure failure (expired auth, rate limiting, an upstream 5xx /
+    transport error) is NOT specific to the one URL — folding it into a per-item
+    result would return a ``200``/``201`` batch envelope for what is really a
+    top-level ``401`` / ``429`` / ``5xx``. So classify the exception and treat it
+    as fatal (re-raise, letting the top-level handler map it) when its projected
+    HTTP status is ``401`` / ``429`` or a server error (``>= 500``); everything
+    else (``400`` bad URL, ``404`` not-found, ``409`` conflict, ``422``) stays
+    isolated. ``CancelledError`` is a ``BaseException`` and is never passed here.
+    """
+    status = CATEGORY_STATUS[classify(exc).category]
+    return status in (401, 429) or status >= 500
+
+
 @router.post("/batch", status_code=201)
 async def add_batch(
     notebook_id: str,
@@ -436,6 +456,15 @@ async def add_batch(
                 client, add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan)
             )
         except Exception as exc:  # noqa: BLE001 - per-item isolation; CancelledError still propagates
+            # Re-raise service/infra failures (auth / rate-limit / server /
+            # transport) so the top-level handler maps them to the correct
+            # 401 / 429 / 5xx instead of masking them as a 200/201 batch
+            # envelope; keep per-item isolation only for per-URL input failures.
+            if _batch_item_is_fatal(exc):
+                raise
+            # ``error_item`` routes ``str(exc)`` through the shared ``_redact``
+            # chokepoint (same scrubber as ``safe_detail``), so the per-item text
+            # carries no raw exception/stack detail (CodeQL information-exposure).
             results.append({"input": entry, "status": "error", "error": error_item(exc)})
         else:
             pending.record(notebook_id, result.source.id)
@@ -610,5 +639,10 @@ def _aggregate_wait_outcomes(
 
 
 def _wait_bucket_entry(error: Any) -> dict[str, str]:
-    """Project a handled wait failure onto its ``{source_id, error}`` bucket entry."""
-    return {"source_id": error.source_id, "error": str(error)}
+    """Project a handled wait failure onto its ``{source_id, error}`` bucket entry.
+
+    The message is scrubbed + length-capped via :func:`safe_detail` (the same
+    ``_redact`` chokepoint the rest of the server error projection uses) so the
+    bucket entry cannot leak a credential or a multi-kilobyte dump.
+    """
+    return {"source_id": error.source_id, "error": safe_detail(str(error))}

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -33,9 +33,10 @@ from pydantic import BaseModel
 
 from ..._app import source_add as add_core
 from ..._app import source_content as content_core
-from ..._app.serialize import to_jsonable
+from ..._app.views import source_view
 from ...client import NotebookLMClient
 from .._context import get_client, get_pending
+from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
 
 __all__ = ["MAX_UPLOAD_BYTES", "router"]
@@ -109,14 +110,31 @@ async def _add_source(
         client, add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan)
     )
     pending.record(notebook_id, result.source.id)
-    return to_jsonable(result.source)
+    # Project with the shared enriched view (string ``kind`` / ``status_label``
+    # alongside the raw codes) so the create path matches ``GET`` — a raw
+    # ``to_jsonable`` here would leak bare ``status`` / ``_type_code`` integers.
+    return source_view(result.source)
 
 
 @router.get("")
-async def list_sources(notebook_id: str, client: ClientDep) -> dict[str, Any]:
-    """List a notebook's sources."""
+async def list_sources(
+    notebook_id: str,
+    client: ClientDep,
+    limit: Annotated[int | None, Query(ge=1, le=MAX_LIMIT)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """List a notebook's sources.
+
+    Each source carries string ``kind`` / ``status_label`` labels alongside the
+    raw type/status codes (shared with the MCP ``source_list`` surface). Defaults
+    to the full collection under ``sources`` (unchanged); supply ``?limit=`` to
+    slice and add a ``meta`` block, ``?offset=`` to page forward.
+    """
     sources = await client.sources.list(notebook_id)
-    return {"notebook_id": notebook_id, "sources": to_jsonable(sources)}
+    data = [source_view(s) for s in sources]
+    return paginate_envelope(
+        data, key="sources", limit=limit, offset=offset, notebook_id=notebook_id
+    )
 
 
 @router.get("/{source_id}")
@@ -136,7 +154,9 @@ async def get_source(
         raise HTTPException(status_code=404, detail="Source not found")
     if source.is_ready:
         pending.drop(notebook_id, source_id)
-    return to_jsonable(source)
+    # Enriched view: string ``kind`` / ``status_label`` alongside the raw codes
+    # (shared with the MCP source surface).
+    return source_view(source)
 
 
 @router.post("/url", status_code=201)

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -26,12 +26,13 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from pydantic import BaseModel
 
 from ..._app import source_add as add_core
+from ..._app import source_content as content_core
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client, get_pending
@@ -54,18 +55,12 @@ MAX_UPLOAD_BYTES = 200 * 1024 * 1024
 _UPLOAD_CHUNK = 1024 * 1024
 
 
-def _safe_upload_name(filename: str | None) -> str:
-    """Return a safe basename for the spooled upload file.
-
-    The resumable-upload init derives the upload filename from the temp path and
-    the source-id extraction keys off it, so the file must keep the caller's
-    *real* name (with its extension — the API 400s on an extensionless one).
-    :func:`os.path.basename` strips any directory components (the path-traversal
-    guard); the file is then created inside a private ``mkdtemp`` directory, so
-    even an odd basename is isolated. Falls back to ``"upload"`` for an empty
-    name and bounds the length.
-    """
-    return (os.path.basename(filename or "") or "upload")[:255]
+#: Safe-basename sanitizer for a spooled upload. Aliased to the shared neutral
+#: helper (:func:`notebooklm._app.source_add.safe_upload_name`) so the REST
+#: ``add_file`` route and the MCP ``/files/ul`` route sanitize identically —
+#: control chars stripped, ``.``/``..`` and slashes rejected, extension preserved
+#: on stem-truncation (the old ``basename(...)[:255]`` could drop the extension).
+_safe_upload_name = add_core.safe_upload_name
 
 
 class SourceAddUrl(BaseModel):
@@ -185,6 +180,11 @@ async def add_file(
 ) -> dict[str, Any]:
     """Add a file source by spooling the multipart upload to a temp file.
 
+    The multipart request MUST send a ``Content-Length`` header: a chunked
+    (no-Content-Length) multipart upload is rejected with ``411`` by design, so
+    the size can be bounded before any part is spooled to disk (see the app
+    middleware in ``app.py``).
+
     The upload is spooled into a private ``0o700`` ``mkdtemp`` directory, named
     after the caller's basename (see :func:`_safe_upload_name`). The real name
     matters: the resumable-upload init derives the upload filename from the path,
@@ -230,6 +230,71 @@ async def add_file(
         )
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@router.get("/{source_id}/content")
+async def get_source_content(
+    notebook_id: str,
+    source_id: str,
+    client: ClientDep,
+    detail: Annotated[Literal["full", "summary"], Query()] = "full",
+    output_format: Annotated[Literal["text", "markdown"], Query()] = "text",
+    max_chars: Annotated[int | None, Query(ge=0)] = None,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """Read a source's content (distinct from the status-poll ``GET /{source_id}``).
+
+    ``detail=full`` (default) returns the extracted body, bounded by ``max_chars``
+    (default 10,000) and windowed by ``offset``, with the FULL ``char_count`` and a
+    ``truncated`` flag. ``content`` is ``null`` (``char_count`` 0) when the source
+    is not READY yet or has no extractable text. A resolved id the backend no
+    longer has is a 404 (existence-gated), never a false empty success. Unlike the
+    status-poll ``GET /{source_id}`` route, this requires a *listable* source: a
+    known-but-not-yet-listable (pending) id is a 404 here, not a pending indicator.
+
+    ``output_format`` (``text`` default / ``markdown``) selects the extracted-body
+    format for ``detail=full`` (ignored for ``summary``); ``markdown`` needs the
+    server's ``markdownify`` extra and otherwise fails with a deterministic
+    ``config`` error. Mirrors the MCP ``source_read`` tool's ``output_format``.
+
+    ``detail=summary`` returns the AI source-guide digest ``{summary, keywords}``
+    for cheap low-token triage.
+    """
+    if detail == "summary":
+        # Existence guard so a missing source is a 404, not an empty guide.
+        guard = await content_core.execute_source_get(
+            client, content_core.SourceGetPlan(notebook_id=notebook_id, source_id=source_id)
+        )
+        if guard.source is None:
+            raise HTTPException(status_code=404, detail="Source not found")
+        guide = await content_core.execute_source_guide(
+            client, content_core.SourceGuidePlan(notebook_id=notebook_id, source_id=source_id)
+        )
+        return {
+            "notebook_id": notebook_id,
+            "source_id": guide.source_id,
+            "summary": guide.summary,
+            "keywords": list(guide.keywords),
+        }
+
+    read = await content_core.execute_source_read(
+        client,
+        content_core.SourceReadPlan(
+            notebook_id=notebook_id,
+            source_id=source_id,
+            output_format=output_format,
+            max_chars=max_chars,
+            offset=offset,
+        ),
+    )
+    return {
+        "notebook_id": notebook_id,
+        "source_id": source_id,
+        "content": read.content,
+        "char_count": read.char_count,
+        "truncated": read.truncated,
+        "output_format": output_format,
+    }
 
 
 @router.delete("/{source_id}", status_code=204)

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -23,6 +23,8 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import asyncio
+import math
 import os
 import shutil
 import tempfile
@@ -33,13 +35,18 @@ from pydantic import BaseModel
 
 from ..._app import source_add as add_core
 from ..._app import source_content as content_core
+from ..._app import source_mutations as mut_core
+from ..._app import source_wait as wait_core
 from ..._app.views import source_view
 from ...client import NotebookLMClient
+from ...exceptions import ValidationError
 from .._context import get_client, get_pending
+from .._errors import error_item
 from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
+from ._passthrough import passthrough_source_id
 
-__all__ = ["MAX_UPLOAD_BYTES", "router"]
+__all__ = ["MAX_UPLOAD_BYTES", "MAX_WAIT_TIMEOUT", "router"]
 
 router = APIRouter(prefix="/notebooks/{notebook_id}/sources", tags=["sources"])
 
@@ -54,6 +61,12 @@ MAX_UPLOAD_BYTES = 200 * 1024 * 1024
 
 #: Chunk size when streaming an upload to the temp file.
 _UPLOAD_CHUNK = 1024 * 1024
+
+#: Upper bound on a ``source_wait`` timeout (seconds). Bounds how long a single
+#: request can hold a worker; a caller wanting to wait longer re-polls. Also the
+#: backstop that turns a ``timeout=inf`` (valid JSON) into a clean 400 rather
+#: than a request that never returns.
+MAX_WAIT_TIMEOUT = 3600.0
 
 
 #: Safe-basename sanitizer for a spooled upload. Aliased to the shared neutral
@@ -76,6 +89,39 @@ class SourceAddText(BaseModel):
 
     text: str
     title: str | None = None
+
+
+class SourceAddDrive(BaseModel):
+    """Request body for adding a Google Drive document source."""
+
+    document_id: str
+    title: str | None = None
+    mime_type: mut_core.DriveMimeChoice = "google-doc"
+
+
+class SourceAddBatch(BaseModel):
+    """Request body for adding many http(s) URL sources in one call."""
+
+    urls: list[str]
+    allow_internal: bool = False
+
+
+class SourceRename(BaseModel):
+    """Request body for renaming a source (title only)."""
+
+    title: str
+
+
+class SourceWaitBody(BaseModel):
+    """Request body for waiting on source readiness.
+
+    Omitting ``source_ids`` waits for EVERY source in the notebook (mirroring the
+    MCP ``source_wait`` all-sources mode).
+    """
+
+    source_ids: list[str] | None = None
+    timeout: float = 120.0
+    interval: float = 1.0
 
 
 async def _add_source(
@@ -317,6 +363,168 @@ async def get_source_content(
     }
 
 
+@router.post("/drive", status_code=201)
+async def add_drive(
+    notebook_id: str, body: SourceAddDrive, client: ClientDep, pending: PendingDep
+) -> dict[str, Any]:
+    """Add a Google Drive document as a source.
+
+    ``mime_type`` is one of ``google-doc`` (default) / ``google-slides`` /
+    ``google-sheets`` / ``pdf`` (validated by the neutral core, which 400s on an
+    unknown value). Flows through ``_app.source_mutations.execute_source_add_drive``
+    (the neutral ``source_add`` core has no Drive path).
+    """
+    result = await mut_core.execute_source_add_drive(
+        client,
+        mut_core.SourceAddDrivePlan(
+            notebook_id=notebook_id,
+            file_id=body.document_id,
+            title=body.title or "",
+            mime_type=body.mime_type,
+        ),
+    )
+    pending.record(notebook_id, result.source.id)
+    return source_view(result.source)
+
+
+@router.post("/batch", status_code=201)
+async def add_batch(
+    notebook_id: str,
+    body: SourceAddBatch,
+    client: ClientDep,
+    pending: PendingDep,
+    response: Response,
+) -> dict[str, Any]:
+    """Add many http(s) URL sources in one call (mirrors MCP ``source_add`` batch).
+
+    The shared notebook / auth context is validated ONCE up front (a bad
+    ``notebook_id`` or stale auth surfaces as the normal top-level 404 / 401),
+    so a whole-batch failure is never masked as ``201`` with every item errored.
+    Only per-entry URL / add failures inside the loop are isolated — recorded as
+    an ``error`` item and skipped, never aborting the batch — so partial failure
+    stays visible. Each entry is added SEQUENTIALLY (concurrent bulk writes
+    invite backend rate-limiting) with ``source_type="url"`` so the http/https
+    SSRF guard runs per item. Results are positional (``results[i]`` ↔
+    ``urls[i]``).
+
+    The top-level ``status`` is ``"added"`` once at least one source was added,
+    else ``"error"`` (every item failed) — so the envelope can't claim success
+    while every ``results[].status`` says error (MCP ``_add_url_batch`` parity).
+    An all-failed batch returns ``200`` (nothing was created) rather than ``201``.
+    """
+    if not body.urls:
+        raise ValidationError("urls must contain at least one URL")
+    # Validate the SHARED context once, before the per-item loop: a missing
+    # notebook or stale auth would otherwise fail every entry identically and be
+    # swallowed into a 201-all-errored body. Letting it raise here routes it
+    # through the normal classify → 404 / 401 contract.
+    await client.notebooks.get(notebook_id)
+    results: list[dict[str, Any]] = []
+    for entry in body.urls:
+        try:
+            plan = add_core.build_source_add_plan(
+                content=entry,
+                source_type="url",
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=add_core.validate_upload_path,
+                looks_path_shaped=add_core.looks_like_path,
+                allow_internal=body.allow_internal,
+            )
+            result = await add_core.execute_source_add(
+                client, add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan)
+            )
+        except Exception as exc:  # noqa: BLE001 - per-item isolation; CancelledError still propagates
+            results.append({"input": entry, "status": "error", "error": error_item(exc)})
+        else:
+            pending.record(notebook_id, result.source.id)
+            view = source_view(result.source)
+            results.append(
+                {
+                    "input": entry,
+                    "status": "added",
+                    "source_id": result.source.id,
+                    "title": result.source.title,
+                    "status_label": view["status_label"],
+                }
+            )
+    added = sum(1 for item in results if item["status"] == "added")
+    # Nothing created → 200 (not 201). ``status`` mirrors the MCP batch envelope:
+    # "added" when ≥1 succeeded, "error" when every item failed.
+    if not added:
+        response.status_code = 200
+    return {
+        "status": "added" if added else "error",
+        "notebook_id": notebook_id,
+        "added": added,
+        "failed": len(results) - added,
+        "results": results,
+    }
+
+
+@router.post("/wait")
+async def wait_sources(notebook_id: str, body: SourceWaitBody, client: ClientDep) -> dict[str, Any]:
+    """Wait for source(s) to finish processing (mirrors MCP ``source_wait``).
+
+    Waits for the given ``source_ids``, or — when omitted — for EVERY source in
+    the notebook. Both modes return the SAME aggregate::
+
+        {"notebook_id", "ok", "ready", "timed_out", "failed", "not_found"}
+
+    ``ready`` holds the sources that reached READY (each with ``kind`` /
+    ``status_label`` labels); the error buckets hold ``{"source_id", "error"}``
+    entries. ``ok`` is true iff all three error buckets are empty — the
+    all-sources mode reports partial progress rather than discarding the sources
+    that did become ready.
+    """
+    # Reject non-finite bounds first: JSON allows ``inf`` / ``NaN`` (Python's
+    # json module parses ``Infinity`` / ``NaN``), and ``timeout=inf`` would wait
+    # forever while ``NaN`` breaks every comparison. ``math.isfinite`` is False
+    # for both.
+    if not math.isfinite(body.timeout):
+        raise ValidationError(f"timeout must be a finite number; got {body.timeout}")
+    if not math.isfinite(body.interval):
+        raise ValidationError(f"interval must be a finite number; got {body.interval}")
+    if body.timeout < 0:
+        raise ValidationError(f"timeout must be >= 0; got {body.timeout}")
+    if body.timeout > MAX_WAIT_TIMEOUT:
+        raise ValidationError(f"timeout must be <= {MAX_WAIT_TIMEOUT}; got {body.timeout}")
+    if body.interval <= 0:
+        raise ValidationError(f"interval must be > 0; got {body.interval}")
+    if body.source_ids is not None:
+        # An EXPLICIT empty list is rejected: it would otherwise return an
+        # immediate ``ok:true`` with nothing waited on — a false "ready" for a
+        # caller that serialized "all sources" as ``[]``. Omit ``source_ids``
+        # (None) to wait for every source.
+        if not body.source_ids:
+            raise ValidationError(
+                "source_ids must not be empty; omit it entirely to wait for all sources"
+            )
+        ids = list(body.source_ids)
+    else:
+        ids = [s.id for s in await client.sources.list(notebook_id)]
+    outcomes = await _wait_all_sources(
+        client, notebook_id, ids, timeout=body.timeout, interval=body.interval
+    )
+    return _aggregate_wait_outcomes(notebook_id, outcomes)
+
+
+@router.patch("/{source_id}")
+async def rename_source(
+    notebook_id: str, source_id: str, body: SourceRename, client: ClientDep
+) -> dict[str, Any]:
+    """Rename a source (title only). Returns the enriched source view."""
+    result = await mut_core.execute_source_rename(
+        client,
+        mut_core.SourceRenamePlan(
+            notebook_id=notebook_id, source_id=source_id, new_title=body.title, json_output=True
+        ),
+        resolve_source_id=passthrough_source_id,
+    )
+    return source_view(result.source)
+
+
 @router.delete("/{source_id}", status_code=204)
 async def delete_source(
     notebook_id: str, source_id: str, client: ClientDep, pending: PendingDep
@@ -325,3 +533,82 @@ async def delete_source(
     await client.sources.delete(notebook_id, source_id)
     pending.drop(notebook_id, source_id)
     return Response(status_code=204)
+
+
+async def _wait_all_sources(
+    client: NotebookLMClient,
+    notebook_id: str,
+    source_ids: list[str],
+    *,
+    timeout: float,
+    interval: float,
+) -> list[wait_core.SourceWaitOutcome]:
+    """Wait for every source concurrently, one typed outcome per source.
+
+    Each per-source wait runs through ``execute_source_wait`` (which maps the
+    three handled ``SourceWait*`` failures to a typed outcome instead of raising),
+    so a slow or failed source never discards its siblings' progress. An
+    UNEXPECTED escape (auth/transport ``RPCError``, a bug) cancels + drains the
+    still-running sibling pollers before re-raising (it then flows through the
+    server's classify-once handler) rather than leaking coroutines.
+    """
+    tasks = [
+        asyncio.create_task(
+            wait_core.execute_source_wait(
+                client,
+                wait_core.SourceWaitPlan(
+                    notebook_id=notebook_id, source_id=sid, timeout=timeout, interval=interval
+                ),
+            )
+        )
+        for sid in source_ids
+    ]
+    try:
+        return list(await asyncio.gather(*tasks))
+    except BaseException:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+
+def _aggregate_wait_outcomes(
+    notebook_id: str, outcomes: list[wait_core.SourceWaitOutcome]
+) -> dict[str, Any]:
+    """Project per-source wait outcomes onto the unified aggregate wire shape.
+
+    Ready sources (enriched via :func:`source_view`) are returned alongside the
+    ones that timed out / failed / went missing. ``ok`` is true iff nothing landed
+    in an error bucket. (The MCP surface additionally annotates thin web-page
+    content here; REST deliberately omits that costly extra fetch — Phase 1's
+    scope decision — so this is warning-free.)
+    """
+    ready: list[dict[str, Any]] = []
+    timed_out: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    not_found: list[dict[str, str]] = []
+    for outcome in outcomes:
+        if isinstance(outcome, wait_core.SourceWaitReady):
+            ready.append(source_view(outcome.source))
+        elif isinstance(outcome, wait_core.SourceWaitTimeout):
+            timed_out.append(_wait_bucket_entry(outcome.error))
+        elif isinstance(outcome, wait_core.SourceWaitProcessingError):
+            failed.append(_wait_bucket_entry(outcome.error))
+        elif isinstance(outcome, wait_core.SourceWaitNotFound):
+            not_found.append(_wait_bucket_entry(outcome.error))
+        else:  # exhaustive over the closed SourceWaitOutcome union
+            raise AssertionError(f"unhandled SourceWaitOutcome: {outcome!r}")
+    return {
+        "notebook_id": notebook_id,
+        "ok": not (timed_out or failed or not_found),
+        "ready": ready,
+        "timed_out": timed_out,
+        "failed": failed,
+        "not_found": not_found,
+    }
+
+
+def _wait_bucket_entry(error: Any) -> dict[str, str]:
+    """Project a handled wait failure onto its ``{source_id, error}`` bucket entry."""
+    return {"source_id": error.source_id, "error": str(error)}

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -63,16 +63,23 @@ def app(fake_client: FakeClient) -> Any:
 
 @pytest.fixture
 def raw_client(app: Any) -> Iterator[TestClient]:
-    """A TestClient WITHOUT auth headers (for auth-rejection tests)."""
+    """A TestClient WITHOUT auth headers (for auth-rejection tests).
+
+    ``client=("127.0.0.1", …)`` gives requests a loopback PEER address so the
+    unspoofable peer-loopback guard passes — leaving the Host-header /
+    bearer-token gates as the thing under test.
+    """
     # raise_server_exceptions=False so a projected 500 envelope (the UNEXPECTED
     # bug path) is returned rather than re-raised into the test.
-    with TestClient(app, raise_server_exceptions=False) as client:
+    with TestClient(app, client=("127.0.0.1", 5555), raise_server_exceptions=False) as client:
         yield client
 
 
 @pytest.fixture
 def authed_client(app: Any) -> Iterator[TestClient]:
-    """A TestClient with a valid bearer token + loopback Host on every request."""
+    """A TestClient with a valid bearer token + loopback Host + loopback peer."""
     headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
-    with TestClient(app, headers=headers, raise_server_exceptions=False) as client:
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
         yield client

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -196,6 +196,7 @@ class FakeChat:
             conversation_id=conversation_id or "conv-1",
             turn_number=1,
             is_follow_up=conversation_id is not None,
+            raw_response='[["wrb.fr", ... internal wire blob ...]]',
         )
 
     async def set_mode(self, notebook_id: str, mode: Any) -> None:

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -20,7 +20,13 @@ from notebooklm._types.artifacts import Artifact, GenerationState, GenerationSta
 from notebooklm._types.chat import AskResult
 from notebooklm._types.notebooks import Notebook
 from notebooklm._types.notes import Note
-from notebooklm._types.research import SourceGuide
+from notebooklm._types.research import (
+    ResearchSource,
+    ResearchStart,
+    ResearchStatus,
+    ResearchTask,
+    SourceGuide,
+)
 from notebooklm._types.sharing import SharedUser, ShareStatus
 from notebooklm._types.sources import Source, SourceFulltext
 from notebooklm.exceptions import NotebookNotFoundError, NoteNotFoundError
@@ -192,6 +198,24 @@ class FakeChat:
             is_follow_up=conversation_id is not None,
         )
 
+    async def set_mode(self, notebook_id: str, mode: Any) -> None:
+        self._s.last_configure = {"notebook_id": notebook_id, "mode": mode}
+
+    async def configure(
+        self,
+        notebook_id: str,
+        *,
+        goal: Any = None,
+        response_length: Any = None,
+        custom_prompt: str | None = None,
+    ) -> None:
+        self._s.last_configure = {
+            "notebook_id": notebook_id,
+            "goal": goal,
+            "response_length": response_length,
+            "custom_prompt": custom_prompt,
+        }
+
 
 class FakeArtifacts:
     def __init__(self, state: FakeClient) -> None:
@@ -285,6 +309,72 @@ class FakeSharing:
         return self._s.share_status(notebook_id)
 
 
+class FakeResearch:
+    """Scriptable in-memory research surface (start / poll / cancel / import).
+
+    ``start`` records an ``in_progress`` task keyed by the route's ``poll_id``
+    (``report_id`` for deep, ``task_id`` for fast); a test drives it to
+    ``completed`` via :meth:`FakeClient.set_research_completed`. ``poll`` returns
+    the stored task or a typed ``not_found`` sentinel for an unknown id.
+    """
+
+    def __init__(self, state: FakeClient) -> None:
+        self._s = state
+
+    async def start(
+        self, notebook_id: str, query: str, source: str = "web", mode: str = "fast"
+    ) -> ResearchStart:
+        n = self._s.next_research
+        self._s.next_research += 1
+        task_id = f"rtask-{n}"
+        # ``deep_missing_report_id`` simulates the backend returning a deep start
+        # WITHOUT a report_id — the route must fail loud rather than emit the
+        # sessionId task_id as a pollable id.
+        report_id = (
+            f"rreport-{n}" if mode == "deep" and not self._s.deep_missing_report_id else None
+        )
+        poll_id = report_id or task_id
+        self._s.last_research_start = {
+            "notebook_id": notebook_id,
+            "query": query,
+            "source": source,
+            "mode": mode,
+        }
+        # Record the started run as in-progress under its poll id.
+        self._s.research_tasks[(notebook_id, poll_id)] = ResearchTask(
+            task_id=poll_id, status=ResearchStatus.IN_PROGRESS, query=query
+        )
+        return ResearchStart(
+            task_id=task_id,
+            report_id=report_id,
+            notebook_id=notebook_id,
+            query=query,
+            mode=mode,
+        )
+
+    async def poll(self, notebook_id: str, task_id: str | None = None) -> ResearchTask:
+        if task_id is None:
+            return ResearchTask.empty()
+        task = self._s.research_tasks.get((notebook_id, task_id))
+        if task is None:
+            return ResearchTask.not_found(task_id)
+        return task
+
+    async def cancel(self, notebook_id: str, run_id: str) -> None:
+        # Fire-and-forget: record the call, never raise on an unknown id.
+        self._s.cancelled_research.append((notebook_id, run_id))
+
+    async def import_sources(
+        self, notebook_id: str, task_id: str, sources: Any
+    ) -> list[dict[str, str]]:
+        rows = list(sources)
+        self._s.imported_research.append((notebook_id, task_id, rows))
+        return [
+            {"id": f"src-imported-{i}", "title": str(row.get("title", ""))}
+            for i, row in enumerate(rows)
+        ]
+
+
 class FakeClient:
     """Scriptable in-memory client mirroring the namespaces the routes use."""
 
@@ -299,6 +389,9 @@ class FakeClient:
         self.shared_users: dict[str, dict[str, SharedUser]] = {}
         self.fulltext_store: dict[tuple[str, str], str] = {}
         self.guide_store: dict[tuple[str, str], SourceGuide] = {}
+        self.research_tasks: dict[tuple[str, str], ResearchTask] = {}
+        self.cancelled_research: list[tuple[str, str]] = []
+        self.imported_research: list[tuple[str, str, list[Any]]] = []
 
         self.new_source_status: SourceStatus = SourceStatus.PROCESSING
         self.hide_new_sources: bool = False
@@ -306,10 +399,14 @@ class FakeClient:
         self.download_return_path: str | None = None
         self.chat_error: Exception | None = None
         self.last_share_notify: bool | None = None
+        self.last_configure: dict[str, Any] | None = None
+        self.last_research_start: dict[str, Any] | None = None
+        self.deep_missing_report_id: bool = False
 
         self.next_task = 1
         self.next_source = 1
         self.next_note = 1
+        self.next_research = 1
         self.uploaded_paths: list[str] = []
         self.last_ask: dict[str, Any] | None = None
 
@@ -319,6 +416,36 @@ class FakeClient:
         self.chat = FakeChat(self)
         self.artifacts = FakeArtifacts(self)
         self.sharing = FakeSharing(self)
+        self.research = FakeResearch(self)
+
+    def set_research_completed(
+        self,
+        notebook_id: str,
+        poll_id: str,
+        *,
+        query: str = "q",
+        sources: list[dict[str, str]] | None = None,
+        report: str = "report body",
+    ) -> None:
+        """Drive a started research run to ``completed`` with the given sources."""
+        src_models = tuple(
+            ResearchSource(url=s.get("url", ""), title=s.get("title", "")) for s in (sources or [])
+        )
+        self.research_tasks[(notebook_id, poll_id)] = ResearchTask(
+            task_id=poll_id,
+            status=ResearchStatus.COMPLETED,
+            query=query,
+            sources=src_models,
+            report=report,
+        )
+
+    def set_research_failed(self, notebook_id: str, poll_id: str, *, query: str = "q") -> None:
+        """Drive a started research run to the terminal ``failed`` state."""
+        self.research_tasks[(notebook_id, poll_id)] = ResearchTask(
+            task_id=poll_id,
+            status=ResearchStatus.FAILED,
+            query=query,
+        )
 
     def share_status(self, notebook_id: str) -> ShareStatus:
         is_public = self.public_shares.get(notebook_id, False)

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -18,7 +18,8 @@ from typing import Any
 
 from notebooklm._types.artifacts import Artifact, GenerationState, GenerationStatus
 from notebooklm._types.chat import AskResult
-from notebooklm._types.notebooks import Notebook
+from notebooklm._types.common import AccountLimits
+from notebooklm._types.notebooks import Notebook, PromptSuggestion
 from notebooklm._types.notes import Note
 from notebooklm._types.research import (
     ResearchSource,
@@ -29,7 +30,14 @@ from notebooklm._types.research import (
 )
 from notebooklm._types.sharing import SharedUser, ShareStatus
 from notebooklm._types.sources import Source, SourceFulltext
-from notebooklm.exceptions import NotebookNotFoundError, NoteNotFoundError
+from notebooklm.exceptions import (
+    ArtifactNotFoundError,
+    NotebookNotFoundError,
+    NoteNotFoundError,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceTimeoutError,
+)
 from notebooklm.rpc.types import ShareAccess, SharePermission, ShareViewLevel, SourceStatus
 
 #: download-spec kind -> internal artifact type-code.
@@ -77,6 +85,27 @@ class FakeNotebooks:
         # Idempotent-on-missing (the public delete contract).
         self._s.notebooks_store.pop(notebook_id, None)
 
+    async def rename(self, notebook_id: str, new_title: str) -> None:
+        existing = self._s.notebooks_store.get(notebook_id)
+        if existing is not None:
+            self._s.notebooks_store[notebook_id] = Notebook(id=notebook_id, title=new_title)
+
+    async def suggest_prompts(
+        self,
+        notebook_id: str,
+        *,
+        source_ids: list[str] | None = None,
+        mode: int = 4,
+        query: str | None = None,
+    ) -> list[PromptSuggestion]:
+        self._s.last_suggest = {
+            "notebook_id": notebook_id,
+            "source_ids": source_ids,
+            "mode": mode,
+            "query": query,
+        }
+        return list(self._s.suggest_rows)
+
 
 class FakeSources:
     def __init__(self, state: FakeClient) -> None:
@@ -115,6 +144,34 @@ class FakeSources:
     ) -> Source:
         self._s.uploaded_paths.append(path)
         return self._add(notebook_id, title=title or "file")
+
+    async def add_drive(self, notebook_id: str, file_id: str, title: str, mime_type: str) -> Source:
+        self._s.added_drive.append((notebook_id, file_id, title, mime_type))
+        return self._add(notebook_id, title=title or file_id)
+
+    async def rename(self, notebook_id: str, source_id: str, new_title: str) -> Source | None:
+        src = self._s.sources_store.get(notebook_id, {}).get(source_id)
+        if src is None:
+            raise SourceNotFoundError(source_id)
+        renamed = Source(id=source_id, title=new_title, url=src.url, status=src.status)
+        self._s.sources_store[notebook_id][source_id] = renamed
+        return renamed
+
+    async def wait_until_ready(
+        self, notebook_id: str, source_id: str, *, timeout: float, initial_interval: float
+    ) -> Source:
+        # Scriptable per-source outcome; default "ready".
+        outcome = self._s.wait_outcomes.get(source_id, "ready")
+        if outcome == "timeout":
+            raise SourceTimeoutError(source_id, timeout)
+        if outcome == "processing":
+            raise SourceProcessingError(source_id)
+        if outcome == "not_found":
+            raise SourceNotFoundError(source_id)
+        src = self._s.sources_store.get(notebook_id, {}).get(source_id)
+        title = src.title if src is not None else "src"
+        url = src.url if src is not None else None
+        return Source(id=source_id, title=title, url=url, status=SourceStatus.READY)
 
     async def delete(self, notebook_id: str, source_id: str) -> None:
         self._s.sources_store.get(notebook_id, {}).pop(source_id, None)
@@ -233,7 +290,57 @@ class FakeArtifacts:
             error="boom" if state == GenerationState.FAILED else None,
         )
 
+    async def rename(
+        self, notebook_id: str, artifact_id: str, new_title: str, *, return_object: bool = True
+    ) -> None:
+        bucket = self._s.artifacts_store.get(notebook_id, {})
+        art = bucket.get(artifact_id)
+        if art is not None:
+            bucket[artifact_id] = Artifact(
+                id=art.id,
+                title=new_title,
+                _artifact_type=art._artifact_type,
+                status=art.status,
+                created_at=art.created_at,
+            )
+        self._s.renamed_artifacts.append((notebook_id, artifact_id, new_title))
+
+    async def delete(self, notebook_id: str, artifact_id: str) -> None:
+        # Idempotent-on-missing (the public delete contract).
+        self._s.artifacts_store.get(notebook_id, {}).pop(artifact_id, None)
+        self._s.deleted_artifacts.append((notebook_id, artifact_id))
+
+    async def retry_failed(self, notebook_id: str, artifact_id: str) -> GenerationStatus:
+        if self._s.retry_error is not None:
+            raise self._s.retry_error
+        # Retry kicks off a task whose id equals the artifact id.
+        self._s.poll_states[(notebook_id, artifact_id)] = GenerationState.PENDING
+        # ``retry_status`` lets a test force the raw ``status`` value — including a
+        # PLAIN STR (the GenerationStatus contract is raw-string-permissive), which
+        # exercises the route's enum-or-str-safe status projection. Default: the
+        # ``GenerationState`` enum member (the normal path).
+        status = (
+            self._s.retry_status if self._s.retry_status is not None else GenerationState.PENDING
+        )
+        return GenerationStatus(task_id=artifact_id, status=status)
+
+    async def get_prompt(self, notebook_id: str, artifact_id: str) -> str | None:
+        if (notebook_id, artifact_id) in self._s.prompts_store:
+            return self._s.prompts_store[(notebook_id, artifact_id)]
+        if artifact_id in self._s.artifacts_store.get(notebook_id, {}):
+            return None  # known artifact, no prompt set → valid null (not 404)
+        raise ArtifactNotFoundError(artifact_id)
+
+    async def generate_mind_map(self, notebook_id: str, **kwargs: Any) -> Any:
+        # The generate core resolves ``getattr(client.artifacts, "generate_mind_map")``
+        # unconditionally, even when the INTERACTIVE path routes through
+        # ``client.mind_maps.generate`` instead (so it is never CALLED there). It IS
+        # called for the note-backed ``map_kind`` path; record + return a map.
+        self._s.last_mind_map_generate = {"notebook_id": notebook_id, **kwargs}
+        return {"root": "note-backed"}
+
     async def generate_audio(self, notebook_id: str, **kwargs: Any) -> GenerationStatus:
+        self._s.last_generate_kwargs = {"notebook_id": notebook_id, **kwargs}
         task_id = f"task-{self._s.next_task}"
         self._s.next_task += 1
         self._s.poll_states[(notebook_id, task_id)] = GenerationState.PENDING
@@ -376,6 +483,78 @@ class FakeResearch:
         ]
 
 
+class FakeMindMaps:
+    """Mind-map membership probes for the artifact rename/delete cores.
+
+    ``rename_artifact`` consults :meth:`list` (and, for a match, calls
+    :meth:`rename` with the map's ``kind``); ``delete_artifact`` consults
+    :meth:`list_note_backed`. Both lists default to empty (a plain artifact routes
+    the non-mind-map path); a test seeds :attr:`FakeClient.mind_maps_store` (for
+    the rename probe) / :attr:`FakeClient.note_backed_mind_maps` (for the delete
+    probe).
+    """
+
+    def __init__(self, state: FakeClient) -> None:
+        self._s = state
+
+    async def list(self, notebook_id: str) -> list[Any]:
+        return list(self._s.mind_maps_store.get(notebook_id, []))
+
+    async def list_note_backed(self, notebook_id: str) -> list[Any]:
+        return list(self._s.note_backed_mind_maps.get(notebook_id, []))
+
+    async def rename(
+        self,
+        notebook_id: str,
+        mind_map_id: str,
+        new_title: str,
+        *,
+        kind: Any = None,
+        return_object: bool = True,
+    ) -> None:
+        self._s.renamed_mind_maps.append((notebook_id, mind_map_id, new_title, kind))
+
+    async def generate(
+        self,
+        notebook_id: str,
+        source_ids: Any = None,
+        *,
+        kind: Any,
+        language: str | None = "en",
+        instructions: str | None = None,
+        wait: bool = True,
+    ) -> Any:
+        # Record the forwarded kwargs so a test can assert instructions reach here.
+        self._s.last_mind_map_generate = {
+            "notebook_id": notebook_id,
+            "source_ids": source_ids,
+            "kind": kind,
+            "language": language,
+            "instructions": instructions,
+        }
+        from notebooklm._types.mind_maps import MindMap, MindMapKind
+
+        return MindMap(
+            id="mm-1",
+            notebook_id=notebook_id,
+            title="Mind map",
+            kind=kind if isinstance(kind, MindMapKind) else MindMapKind.INTERACTIVE,
+        )
+
+
+class FakeSettings:
+    """Account limits + output language for ``server_info(include_account=True)``."""
+
+    def __init__(self, state: FakeClient) -> None:
+        self._s = state
+
+    async def get_account_limits(self) -> AccountLimits:
+        return self._s.account_limits
+
+    async def get_output_language(self) -> str | None:
+        return self._s.output_language
+
+
 class FakeClient:
     """Scriptable in-memory client mirroring the namespaces the routes use."""
 
@@ -393,6 +572,29 @@ class FakeClient:
         self.research_tasks: dict[tuple[str, str], ResearchTask] = {}
         self.cancelled_research: list[tuple[str, str]] = []
         self.imported_research: list[tuple[str, str, list[Any]]] = []
+        self.prompts_store: dict[tuple[str, str], str | None] = {}
+        self.note_backed_mind_maps: dict[str, list[Any]] = {}
+        self.mind_maps_store: dict[str, list[Any]] = {}
+        self.renamed_mind_maps: list[tuple[str, str, str, Any]] = []
+        self.last_mind_map_generate: dict[str, Any] | None = None
+        self.wait_outcomes: dict[str, str] = {}
+        self.suggest_rows: list[PromptSuggestion] = [
+            PromptSuggestion(title="Q1", prompt="Ask about X"),
+            PromptSuggestion(title="Q2", prompt="Ask about Y"),
+        ]
+        self.renamed_artifacts: list[tuple[str, str, str]] = []
+        self.deleted_artifacts: list[tuple[str, str]] = []
+        self.added_drive: list[tuple[str, str, str, str]] = []
+        self.retry_error: Exception | None = None
+        self.retry_status: Any = None
+        self.last_suggest: dict[str, Any] | None = None
+        self.last_generate_kwargs: dict[str, Any] | None = None
+
+        # server_info(include_account=True) surface.
+        self.account_email: str | None = "user@example.com"
+        self.account_authuser: int = 0
+        self.account_limits = AccountLimits(notebook_limit=100, source_limit=50)
+        self.output_language: str | None = "en"
 
         self.new_source_status: SourceStatus = SourceStatus.PROCESSING
         self.hide_new_sources: bool = False
@@ -418,6 +620,14 @@ class FakeClient:
         self.artifacts = FakeArtifacts(self)
         self.sharing = FakeSharing(self)
         self.research = FakeResearch(self)
+        self.mind_maps = FakeMindMaps(self)
+        self.settings = FakeSettings(self)
+
+    async def get_account_email(self, *, live_fallback: bool = True) -> str | None:
+        return self.account_email
+
+    def get_account_authuser(self) -> int:
+        return self.account_authuser
 
     def set_research_completed(
         self,

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -20,8 +20,9 @@ from notebooklm._types.artifacts import Artifact, GenerationState, GenerationSta
 from notebooklm._types.chat import AskResult
 from notebooklm._types.notebooks import Notebook
 from notebooklm._types.notes import Note
+from notebooklm._types.research import SourceGuide
 from notebooklm._types.sharing import SharedUser, ShareStatus
-from notebooklm._types.sources import Source
+from notebooklm._types.sources import Source, SourceFulltext
 from notebooklm.exceptions import NotebookNotFoundError, NoteNotFoundError
 from notebooklm.rpc.types import ShareAccess, SharePermission, ShareViewLevel, SourceStatus
 
@@ -80,6 +81,17 @@ class FakeSources:
 
     async def get_or_none(self, notebook_id: str, source_id: str) -> Source | None:
         return self._s.sources_store.get(notebook_id, {}).get(source_id)
+
+    async def get_fulltext(
+        self, notebook_id: str, source_id: str, *, output_format: str = "text"
+    ) -> SourceFulltext:
+        content = self._s.fulltext_store.get((notebook_id, source_id), "")
+        return SourceFulltext(
+            source_id=source_id, title="", content=content, char_count=len(content)
+        )
+
+    async def get_guide(self, notebook_id: str, source_id: str) -> SourceGuide:
+        return self._s.guide_store.get((notebook_id, source_id), SourceGuide())
 
     async def add_url(self, notebook_id: str, url: str) -> Source:
         return self._add(notebook_id, title=url, url=url)
@@ -285,6 +297,8 @@ class FakeClient:
         self.public_shares: dict[str, bool] = {}
         self.share_view_levels: dict[str, ShareViewLevel] = {}
         self.shared_users: dict[str, dict[str, SharedUser]] = {}
+        self.fulltext_store: dict[tuple[str, str], str] = {}
+        self.guide_store: dict[tuple[str, str], SourceGuide] = {}
 
         self.new_source_status: SourceStatus = SourceStatus.PROCESSING
         self.hide_new_sources: bool = False

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 
+import pytest
 from fastapi.testclient import TestClient
 
 from notebooklm._app.generate import GenerationExecutionResult
@@ -289,10 +290,11 @@ async def test_cleanup_file_response_cleans_on_disconnect(tmp_path: object) -> N
         raise _Boom  # abort mid-stream, as a disconnect would
 
     scope = {"type": "http", "method": "GET", "headers": []}
-    try:
+    # Catch the SPECIFIC simulated-abort exception so an unrelated failure in the
+    # cleanup path is not silently swallowed — the test only passes for the abort
+    # it staged.
+    with pytest.raises(_Boom):
         await resp(scope, _receive, _send)
-    except BaseException:
-        pass
     assert not os.path.exists(temp_dir)
 
 

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -329,6 +329,20 @@ def test_retry_artifact_returns_task_id_and_status(
     assert authed_client.get("/v1/notebooks/nb-1/artifacts/a1").json()["status"] == "pending"
 
 
+def test_retry_records_task_in_pending_registry(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # retry records its task_id (like generate), so a poll that briefly races ahead
+    # of the artifact listing resolves to 200 pending instead of a spurious 404.
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/ghost/retry")
+    assert resp.status_code == 200
+    # Transient window: the retried task polls NOT_FOUND before it appears in listings.
+    fake_client.poll_states[("nb-1", "ghost")] = GenerationState.NOT_FOUND
+    poll = authed_client.get("/v1/notebooks/nb-1/artifacts/ghost")
+    assert poll.status_code == 200  # recorded on retry → 200 (would be 404 unrecorded)
+    assert poll.json()["status"] == "not_found"
+
+
 def test_retry_refusal_propagates_as_error(
     authed_client: TestClient, fake_client: FakeClient
 ) -> None:
@@ -528,6 +542,20 @@ def test_generate_forwards_instructions(authed_client: TestClient, fake_client: 
     assert resp.status_code == 202
     assert fake_client.last_generate_kwargs is not None
     assert fake_client.last_generate_kwargs.get("instructions") == "focus on chapter 3"
+
+
+def test_generate_blank_instructions_treated_as_absent(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # Whitespace-only instructions must not reach the client as a blank prompt slot
+    # (keeps the default request shape byte-identical).
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts",
+        json={"type": "audio", "instructions": "   "},
+    )
+    assert resp.status_code == 202
+    assert fake_client.last_generate_kwargs is not None
+    assert fake_client.last_generate_kwargs.get("instructions") is None
 
 
 def test_generate_mind_map_forwards_instructions(

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -105,6 +105,26 @@ def test_list_artifacts(authed_client: TestClient, fake_client: FakeClient) -> N
     resp = authed_client.get("/v1/notebooks/nb-1/artifacts")
     assert resp.status_code == 200
     assert resp.json()["artifacts"][0]["title"] == "Pod"
+    # Default (no limit) stays unbounded, no meta block.
+    assert "meta" not in resp.json()
+
+
+def test_list_artifacts_pagination_slices_and_adds_meta(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.artifacts_store["nb-1"] = {
+        f"a{i}": make_artifact(f"a{i}", "audio", title=f"Pod{i}") for i in range(5)
+    }
+    body = authed_client.get(
+        "/v1/notebooks/nb-1/artifacts", params={"limit": 2, "offset": 1}
+    ).json()
+    assert body["notebook_id"] == "nb-1"
+    assert len(body["artifacts"]) == 2
+    assert body["meta"] == {"total": 5, "has_more": True, "limit": 2, "offset": 1}
+
+
+def test_list_artifacts_bad_limit_is_422(authed_client: TestClient) -> None:
+    assert authed_client.get("/v1/notebooks/nb-1/artifacts", params={"limit": 0}).status_code == 422
 
 
 # --- generate: input validation (400s) --------------------------------------

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 
 from fastapi.testclient import TestClient
 
@@ -221,6 +222,58 @@ def test_generation_payload_outcome_without_task_id_is_not_recorded() -> None:
     payload = artifacts_route._generation_payload("nb-1", result, pending)
     assert payload["task_id"] == ""
     assert not pending.knows("nb-1", "")
+
+
+def test_download_temp_dir_cleaned_on_normal_completion(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    import pytest
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    made: list[str] = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _tracking_mkdtemp(*args: object, **kwargs: object) -> str:
+        d = real_mkdtemp(*args, **kwargs)
+        made.append(d)
+        return d
+
+    monkeypatch.setattr(artifacts_route.tempfile, "mkdtemp", _tracking_mkdtemp)
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})
+    assert resp.status_code == 200
+    assert resp.content == fake_client.download_bytes
+    # After the TestClient fully consumed the streamed body, the temp dir the
+    # download spooled into is gone (the _CleanupFileResponse finally ran).
+    assert made and not os.path.exists(made[0])
+
+
+async def test_cleanup_file_response_cleans_on_disconnect(tmp_path: object) -> None:
+    # Simulate a client disconnect mid-stream: super().__call__ raises, and the
+    # subclass's finally must still remove the temp dir (a BackgroundTask would be
+    # dropped on disconnect and leak it).
+    temp_dir = tempfile.mkdtemp(prefix="nblm-disconnect-", dir=str(tmp_path))
+    served = os.path.join(temp_dir, "artifact.mp3")
+    with open(served, "wb") as fh:
+        fh.write(b"bytes")
+
+    resp = artifacts_route._CleanupFileResponse(served, temp_dir=temp_dir)
+
+    class _Boom(Exception):
+        pass
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.disconnect"}
+
+    async def _send(message: dict[str, object]) -> None:
+        raise _Boom  # abort mid-stream, as a disconnect would
+
+    scope = {"type": "http", "method": "GET", "headers": []}
+    try:
+        await resp(scope, _receive, _send)
+    except BaseException:
+        pass
+    assert not os.path.exists(temp_dir)
 
 
 def test_download_spec_exhaustiveness() -> None:

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -296,6 +296,316 @@ async def test_cleanup_file_response_cleans_on_disconnect(tmp_path: object) -> N
     assert not os.path.exists(temp_dir)
 
 
+# --- Phase 4: studio lifecycle (delete / retry) ------------------------------
+
+
+def test_delete_artifact_is_204(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    resp = authed_client.delete("/v1/notebooks/nb-1/artifacts/a1")
+    assert resp.status_code == 204
+    assert ("nb-1", "a1") in fake_client.deleted_artifacts
+    assert "a1" not in fake_client.artifacts_store["nb-1"]
+
+
+def test_delete_absent_artifact_is_204_idempotent(authed_client: TestClient) -> None:
+    # Idempotent-on-missing, like the notebook/source/note DELETE routes.
+    assert authed_client.delete("/v1/notebooks/nb-1/artifacts/ghost").status_code == 204
+
+
+def test_retry_artifact_returns_task_id_and_status(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/a1/retry")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Retry kicks off a task whose id equals the artifact id (mirrors MCP).
+    assert body["artifact_id"] == "a1"
+    assert body["task_id"] == "a1"
+    assert body["status"] == "pending"
+    # The kicked-off task is now pollable.
+    assert authed_client.get("/v1/notebooks/nb-1/artifacts/a1").json()["status"] == "pending"
+
+
+def test_retry_refusal_propagates_as_error(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    from notebooklm.exceptions import RateLimitError
+
+    fake_client.retry_error = RateLimitError("slow down")
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/a1/retry")
+    assert resp.status_code == 429
+    assert resp.json()["error"]["retriable"] is True
+
+
+def test_retry_plain_str_status_does_not_crash(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # GenerationStatus.status is raw-string-permissive: a plain-str status must
+    # NOT crash the route (``.value`` would raise AttributeError). The route
+    # projects it enum-or-str-safely.
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    fake_client.retry_status = "pending"  # a plain str, not a GenerationState enum
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/a1/retry")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+
+# --- Phase 4: artifact rename (PATCH) ----------------------------------------
+
+
+def test_rename_artifact(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio", title="Old")}
+    resp = authed_client.patch("/v1/notebooks/nb-1/artifacts/a1", json={"title": "New"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "renamed"
+    assert body["new_title"] == "New"
+    assert body["is_mind_map"] is False
+    assert fake_client.artifacts_store["nb-1"]["a1"].title == "New"
+
+
+def test_rename_artifact_missing_title_is_422(authed_client: TestClient) -> None:
+    assert authed_client.patch("/v1/notebooks/nb-1/artifacts/a1", json={}).status_code == 422
+
+
+# --- Phase 4: kind-aware mind-map rename/delete + full-UUID case ---------------
+
+# A canonical (lowercase) full UUID and its uppercase spelling. The backend id is
+# canonically lowercase; a caller may send the uppercase form.
+_MM_ID = "abcd1234-5678-4abc-def0-1234567890ab"
+_MM_ID_UPPER = _MM_ID.upper()
+
+
+def _seed_note_backed_mind_map(fake_client: FakeClient, mm_id: str) -> None:
+    """Seed a note-backed mind map (the ``delete_artifact`` probe list) plus a
+    backing note with the same id, so a note-path delete is observable."""
+    from types import SimpleNamespace
+
+    from notebooklm._types.notes import Note
+
+    fake_client.note_backed_mind_maps["nb-1"] = [SimpleNamespace(id=mm_id)]
+    fake_client.notes_store["nb-1"] = {
+        mm_id: Note(id=mm_id, notebook_id="nb-1", title="Map", content="")
+    }
+
+
+def _seed_interactive_mind_map(fake_client: FakeClient, mm_id: str) -> None:
+    """Seed an interactive mind map into the ``rename_artifact`` probe list."""
+    from notebooklm._types.mind_maps import MindMap, MindMapKind
+
+    fake_client.mind_maps_store["nb-1"] = [
+        MindMap(id=mm_id, notebook_id="nb-1", title="Map", kind=MindMapKind.INTERACTIVE)
+    ]
+
+
+def test_rename_mind_map_is_mind_map_branch(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A resolved mind map routes through the kind-aware mind_maps.rename, not the
+    # plain artifacts.rename, and is flagged is_mind_map=True.
+    from notebooklm._types.mind_maps import MindMapKind
+
+    _seed_interactive_mind_map(fake_client, "mm-1")
+    resp = authed_client.patch("/v1/notebooks/nb-1/artifacts/mm-1", json={"title": "New"})
+    assert resp.status_code == 200
+    assert resp.json()["is_mind_map"] is True
+    nb, mm_id, title, kind = fake_client.renamed_mind_maps[0]
+    assert (nb, mm_id, title) == ("nb-1", "mm-1", "New")
+    assert kind == MindMapKind.INTERACTIVE
+    # The plain artifact rename path was NOT taken.
+    assert fake_client.renamed_artifacts == []
+
+
+def test_rename_uppercase_full_uuid_mind_map_routes_mind_map_path(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # An UPPERCASE full UUID for a note-backed/interactive mind map must be
+    # normalized to canonical lowercase before the case-sensitive core probe, so
+    # it still routes to the mind-map path (not a false plain-artifact success).
+    _seed_interactive_mind_map(fake_client, _MM_ID)
+    # URL built in a local, then passed to the HTTP PATCH helper — keeping an
+    # f-string out of the client call so the ADR-0007 monkeypatch guardrail does
+    # not false-positive an ``authed_client`` HTTP PATCH as a computed mock target.
+    url = f"/v1/notebooks/nb-1/artifacts/{_MM_ID_UPPER}"
+    resp = authed_client.patch(url, json={"title": "New"})
+    assert resp.status_code == 200
+    assert resp.json()["is_mind_map"] is True
+    # Renamed via the mind-map path with the canonical lowercase id.
+    assert fake_client.renamed_mind_maps
+    assert fake_client.renamed_mind_maps[0][1] == _MM_ID
+    assert fake_client.renamed_artifacts == []
+
+
+def test_delete_note_backed_mind_map_routes_notes_delete(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A note-backed mind map is CLEARED via notes.delete, never artifacts.delete.
+    _seed_note_backed_mind_map(fake_client, "mm-note")
+    resp = authed_client.delete("/v1/notebooks/nb-1/artifacts/mm-note")
+    assert resp.status_code == 204
+    # notes.delete removed the backing note; the artifact delete path was skipped.
+    assert "mm-note" not in fake_client.notes_store["nb-1"]
+    assert fake_client.deleted_artifacts == []
+
+
+def test_delete_uppercase_full_uuid_note_backed_mind_map_routes_notes_delete(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # The full-UUID case-normalization fix: an uppercase UUID for a note-backed
+    # mind map still routes to the note path instead of a false artifact-delete
+    # "success" that leaves the map intact.
+    _seed_note_backed_mind_map(fake_client, _MM_ID)
+    resp = authed_client.delete(f"/v1/notebooks/nb-1/artifacts/{_MM_ID_UPPER}")
+    assert resp.status_code == 204
+    assert _MM_ID not in fake_client.notes_store["nb-1"]
+    assert fake_client.deleted_artifacts == []
+
+
+# --- Phase 4: artifact prompt read -------------------------------------------
+
+
+def test_get_prompt_returns_stored_prompt(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "report")}
+    fake_client.prompts_store[("nb-1", "a1")] = "Summarize the sources"
+    resp = authed_client.get("/v1/notebooks/nb-1/artifacts/a1/prompt")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "notebook_id": "nb-1",
+        "artifact_id": "a1",
+        "prompt": "Summarize the sources",
+    }
+
+
+def test_get_prompt_null_is_200_not_404(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # A known artifact that records no prompt → prompt=null at 200, not a 404.
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "mind-map")}
+    resp = authed_client.get("/v1/notebooks/nb-1/artifacts/a1/prompt")
+    assert resp.status_code == 200
+    assert resp.json()["prompt"] is None
+
+
+def test_get_prompt_unknown_artifact_is_404(authed_client: TestClient) -> None:
+    assert authed_client.get("/v1/notebooks/nb-1/artifacts/ghost/prompt").status_code == 404
+
+
+# --- Phase 4: generate option hygiene ----------------------------------------
+
+
+def test_generate_wrong_kind_option_is_400(authed_client: TestClient) -> None:
+    # ``orientation`` belongs to infographic, not audio → rejected (not silent no-op).
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "audio", "orientation": "landscape"}
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_optionless_kind_rejects_any_option(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "data-table", "difficulty": "easy"}
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_bad_new_option_value_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts", json={"type": "video", "style": "not-a-style"}
+    )
+    assert resp.status_code == 400
+
+
+def test_generate_forwards_instructions(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # Both ``description`` and ``instructions`` are set in raw_args; for audio the
+    # generate core forwards the instruction text to the client generator.
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts",
+        json={"type": "audio", "instructions": "focus on chapter 3"},
+    )
+    assert resp.status_code == 202
+    assert fake_client.last_generate_kwargs is not None
+    assert fake_client.last_generate_kwargs.get("instructions") == "focus on chapter 3"
+
+
+def test_generate_mind_map_forwards_instructions(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # mind-map reads raw_args["instructions"] (not ``description``): the default
+    # interactive kind routes through client.mind_maps.generate, and the
+    # instruction text must reach it.
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts",
+        json={"type": "mind-map", "instructions": "group by theme"},
+    )
+    assert resp.status_code == 202
+    assert fake_client.last_mind_map_generate is not None
+    assert fake_client.last_mind_map_generate["instructions"] == "group by theme"
+
+
+def test_kind_options_match_core_maps() -> None:
+    """The REST per-kind option table is pinned to the neutral core's choice maps.
+
+    Duplicated (the server layer must not import the core privates) but pinned so
+    a core-map change surfaces here — the same guardrail the MCP ``_KIND_OPTIONS``
+    table carries.
+    """
+    import notebooklm._app.generate_plans as gp
+    from notebooklm.server.routes.artifacts import _KIND_OPTIONS
+
+    assert _KIND_OPTIONS["audio"]["audio_format"] == tuple(gp._AUDIO_FORMAT_MAP)
+    assert _KIND_OPTIONS["audio"]["audio_length"] == tuple(gp._AUDIO_LENGTH_MAP)
+    assert _KIND_OPTIONS["video"]["video_format"] == tuple(gp._VIDEO_FORMAT_MAP)
+    assert _KIND_OPTIONS["video"]["style"] == tuple(gp._VIDEO_STYLE_MAP)
+    assert _KIND_OPTIONS["slide-deck"]["deck_format"] == tuple(gp._SLIDE_FORMAT_MAP)
+    assert _KIND_OPTIONS["slide-deck"]["deck_length"] == tuple(gp._SLIDE_LENGTH_MAP)
+    assert _KIND_OPTIONS["quiz"]["quantity"] == tuple(gp._QUIZ_QUANTITY_MAP)
+    assert _KIND_OPTIONS["quiz"]["difficulty"] == tuple(gp._QUIZ_DIFFICULTY_MAP)
+    assert _KIND_OPTIONS["flashcards"]["quantity"] == tuple(gp._QUIZ_QUANTITY_MAP)
+    assert _KIND_OPTIONS["flashcards"]["difficulty"] == tuple(gp._QUIZ_DIFFICULTY_MAP)
+    assert _KIND_OPTIONS["infographic"]["orientation"] == tuple(gp._INFOGRAPHIC_ORIENTATION_MAP)
+    assert _KIND_OPTIONS["infographic"]["detail"] == tuple(gp._INFOGRAPHIC_DETAIL_MAP)
+    assert _KIND_OPTIONS["infographic"]["style"] == tuple(gp._INFOGRAPHIC_STYLE_MAP)
+    assert _KIND_OPTIONS["report"]["report_format"] == tuple(gp._REPORT_FORMAT_MAP)
+
+
+def test_kind_options_exact_mcp_parity() -> None:
+    """The REST and MCP ``_KIND_OPTIONS`` tables must be byte-for-byte identical.
+
+    Both are duplicated from the neutral core (the CLI/MCP/server boundary forbids
+    importing the core privates); pinning them EQUAL to each other guarantees the
+    two agent surfaces validate the SAME per-kind options with the SAME choices.
+    """
+    import pytest
+
+    pytest.importorskip("fastmcp")  # MCP tools need the ``mcp`` extra
+    from notebooklm.mcp.tools.studio import _KIND_OPTIONS as mcp_options
+    from notebooklm.server.routes.artifacts import _KIND_OPTIONS as rest_options
+
+    assert rest_options == mcp_options
+
+
+def test_kind_options_cover_every_generate_type() -> None:
+    """Every ``GENERATE_TYPES`` kind has a ``_KIND_OPTIONS`` entry, and the
+    per-kind-only keys (``map_kind``, ``style_prompt``) + optionless kinds are
+    exactly as expected — so a new generate kind can't silently ship without its
+    option contract."""
+    from notebooklm.server.routes.artifacts import _KIND_OPTIONS
+
+    # Exhaustive over the generate surface (no missing / extra kinds).
+    assert set(_KIND_OPTIONS) == set(GENERATE_TYPES)
+    # ``map_kind`` is validated at the boundary ONLY (no core map) — it must exist
+    # on mind-map and nowhere else.
+    assert "map_kind" in _KIND_OPTIONS["mind-map"]
+    assert all("map_kind" not in opts for k, opts in _KIND_OPTIONS.items() if k != "mind-map")
+    # ``style_prompt`` (free text, choices None) belongs to video only.
+    assert _KIND_OPTIONS["video"]["style_prompt"] is None
+    assert all("style_prompt" not in opts for k, opts in _KIND_OPTIONS.items() if k != "video")
+    # Optionless kinds carry an explicit empty map (so a stray option is rejected).
+    assert _KIND_OPTIONS["cinematic-video"] == {}
+    assert _KIND_OPTIONS["data-table"] == {}
+
+
 def test_download_spec_exhaustiveness() -> None:
     """Every studio download kind the client supports has a server spec.
 

--- a/tests/server/test_chat.py
+++ b/tests/server/test_chat.py
@@ -18,6 +18,13 @@ def test_ask_returns_full_answer(authed_client: TestClient) -> None:
     assert "references" in body
 
 
+def test_ask_strips_raw_response_debug_blob(authed_client: TestClient) -> None:
+    """The internal ``raw_response`` debug blob is never serialized (shared view)."""
+    resp = authed_client.post("/v1/notebooks/nb-1/chat", json={"question": "What is X?"})
+    assert resp.status_code == 200
+    assert "raw_response" not in resp.json()
+
+
 def test_conversation_id_is_forwarded(authed_client: TestClient, fake_client: FakeClient) -> None:
     resp = authed_client.post(
         "/v1/notebooks/nb-1/chat",

--- a/tests/server/test_chat.py
+++ b/tests/server/test_chat.py
@@ -40,3 +40,55 @@ def test_unauthorized_is_401(raw_client: TestClient) -> None:
         "/v1/notebooks/nb-1/chat", json={"question": "hi"}, headers={"Host": "127.0.0.1"}
     )
     assert resp.status_code == 401
+
+
+# --- POST /v1/notebooks/{id}/chat/configure ---------------------------------
+
+
+def test_configure_preset_writes_mode(authed_client: TestClient, fake_client: FakeClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/chat/configure", json={"chat_mode": "learning-guide"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "configured"
+    assert body["mode"] == "learning-guide"
+    # A preset short-circuits to set_mode (not the custom configure path).
+    assert fake_client.last_configure is not None
+    assert fake_client.last_configure["notebook_id"] == "nb-1"
+    assert "mode" in fake_client.last_configure
+
+
+def test_configure_custom_writes_goal_and_length(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/chat/configure",
+        json={"goal": "Explain like I'm five", "response_length": "shorter"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "configured"
+    assert body["mode"] is None
+    # A non-empty goal selects the CUSTOM chat goal.
+    assert body["goal_name"] == "custom"
+    assert body["persona"] == "Explain like I'm five"
+    assert body["response_length"] == "shorter"
+    assert fake_client.last_configure is not None
+    assert fake_client.last_configure["custom_prompt"] == "Explain like I'm five"
+
+
+def test_configure_preset_and_custom_conflict_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/chat/configure",
+        json={"chat_mode": "concise", "response_length": "longer"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"
+
+
+def test_configure_unknown_mode_is_422(authed_client: TestClient) -> None:
+    # ``chat_mode`` is a Literal, so an out-of-enum value is rejected at the
+    # request-schema boundary (422), not reaching the core.
+    resp = authed_client.post("/v1/notebooks/nb-1/chat/configure", json={"chat_mode": "bogus"})
+    assert resp.status_code == 422

--- a/tests/server/test_errors.py
+++ b/tests/server/test_errors.py
@@ -34,7 +34,9 @@ def _client_raising(error: BaseException) -> TestClient:
 
     app = create_app(client_factory=factory)
     headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
-    client = TestClient(app, headers=headers, raise_server_exceptions=False)
+    client = TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    )
     client.__enter__()
     return client
 
@@ -86,6 +88,62 @@ def test_status_7_is_not_routed_to_404() -> None:
     assert resp.json()["error"]["category"] == "rpc"
 
 
+def _error_body(exc_obj: BaseException) -> dict[str, object]:
+    import json
+
+    return json.loads(error_response(exc_obj).body.decode())["error"]
+
+
+def test_error_body_carries_retriable_flag() -> None:
+    # A retriable category (rate-limit) and a non-retriable one (validation) both
+    # surface the neutral ``retriable`` flag so an agent client can branch a backoff.
+    retriable = error_response(exc.RateLimitError("slow down"))
+    assert retriable.status_code == 429
+    assert _error_body(exc.RateLimitError("slow down"))["retriable"] is True
+    assert _error_body(exc.ValidationError("bad"))["retriable"] is False
+
+
+def test_error_body_carries_hint_where_present() -> None:
+    assert "hint" in _error_body(exc.RateLimitError("slow down"))
+    # A category with no hint (RPC) omits the field entirely.
+    assert "hint" not in _error_body(exc.RPCError("decode failed"))
+
+
+def test_http_error_response_enriches_mapped_status() -> None:
+    """A status that maps to a neutral ErrorCategory (411 → validation) carries
+    retriable + hint, drawn from the shared _app tables."""
+    import json
+
+    from notebooklm.server._errors import http_error_response
+
+    body = json.loads(http_error_response(411, "Content-Length required").body.decode())["error"]
+    assert body["category"] == "validation"
+    assert body["retriable"] is False
+    assert "hint" in body
+
+
+def test_http_error_response_protocol_only_status_omits_enrichment() -> None:
+    """An HTTP-protocol-only status (409 conflict) has no neutral category, so it
+    carries just category + message — no retriable / hint."""
+    import json
+
+    from notebooklm.server._errors import http_error_response
+
+    body = json.loads(http_error_response(409, "already exists").body.decode())["error"]
+    assert body["category"] == "conflict"
+    assert "retriable" not in body
+    assert "hint" not in body
+
+
+def test_home_directory_path_is_redacted_in_body() -> None:
+    # A file/upload error carrying a local home path must not leak the OS username
+    # (PII / host disclosure) on the REST surface — the shared redactor masks it.
+    resp = error_response(exc.ValidationError("open /home/secretuser/private/x.pdf failed"))
+    body = resp.body.decode()
+    assert "secretuser" not in body
+    assert "/home/***" in body
+
+
 def test_long_message_is_truncated() -> None:
     long = "x " * 400
     resp = error_response(exc.RPCError(long))
@@ -93,6 +151,49 @@ def test_long_message_is_truncated() -> None:
     assert "…" in body
     # The redacted message is capped well under the raw length.
     assert len(_redact(long)) <= 301
+
+
+def test_route_404_carries_retriable_and_hint(authed_client: object) -> None:
+    """A hand-raised HTTPException (in-route 404) carries the SAME retriable + hint
+    enrichment as a classified library error, not just {category, message}."""
+    from fastapi.testclient import TestClient
+
+    assert isinstance(authed_client, TestClient)
+    resp = authed_client.get("/v1/notebooks/nb-1/sources/nope/content")
+    assert resp.status_code == 404
+    err = resp.json()["error"]
+    assert err["category"] == "not_found"
+    assert err["retriable"] is False
+    assert "hint" in err and isinstance(err["hint"], str)
+
+
+def test_route_422_carries_retriable_and_hint(authed_client: object) -> None:
+    """A request-body 422 (RequestValidationError → hand-raised path) is enriched."""
+    from fastapi.testclient import TestClient
+
+    assert isinstance(authed_client, TestClient)
+    resp = authed_client.post("/v1/notebooks/nb-1/chat", json={})
+    assert resp.status_code == 422
+    err = resp.json()["error"]
+    assert err["category"] == "validation"
+    assert err["retriable"] is False
+    assert "hint" in err
+
+
+def test_auth_401_carries_retriable_and_hint(app: object) -> None:
+    """The auth dependency's 401 (a hand-raised HTTPException) is enriched too."""
+    from fastapi.testclient import TestClient
+
+    headers = {"Authorization": "Bearer wrong-token", "Host": "127.0.0.1"}
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
+        resp = client.get("/v1/notebooks")
+    assert resp.status_code == 401
+    err = resp.json()["error"]
+    assert err["category"] == "auth"
+    assert err["retriable"] is False
+    assert "hint" in err
 
 
 def test_request_validation_message_has_no_source_paths(authed_client: object) -> None:

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -22,6 +22,8 @@ from notebooklm.server._auth import _host_is_loopback  # noqa: E402
 from notebooklm.server._errors import _redact  # noqa: E402
 from notebooklm.server._pending import _MAX_ENTRIES, PendingRegistry  # noqa: E402
 
+from .conftest import TEST_TOKEN  # noqa: E402
+
 
 class TestHostLoopbackGuard:
     @pytest.mark.parametrize(
@@ -98,8 +100,10 @@ class TestUploadPreBufferLimit:
         monkeypatch.setattr(fake_client.sources, "add_file", spy)
         monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 8)
 
-        headers = {"Authorization": "Bearer test-token", "Host": "127.0.0.1"}
-        with TestClient(app, headers=headers, raise_server_exceptions=False) as c:
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
             resp = c.post(
                 "/v1/notebooks/nb-1/sources/file",
                 files={"file": ("big.txt", b"x" * 4096, "text/plain")},
@@ -107,6 +111,72 @@ class TestUploadPreBufferLimit:
         assert resp.status_code == 413
         assert called["add_file"] is False
         assert resp.json()["error"]["category"] == "validation"
+
+
+class TestChunkedMultipartRejected:
+    def test_multipart_without_content_length_is_411(self, app: Any) -> None:
+        from fastapi.testclient import TestClient
+
+        # A generator body makes httpx use chunked transfer-encoding (no
+        # Content-Length), the exact bypass a running-cap-after-spool leaves open.
+        def _chunks() -> Any:
+            yield b"--b\r\nContent-Disposition: form-data; name=file; filename=x\r\n\r\n"
+            yield b"data\r\n--b--\r\n"
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "multipart/form-data; boundary=b",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post("/v1/notebooks/nb-1/sources/file", content=_chunks())
+        assert resp.status_code == 411
+        assert resp.json()["error"]["category"] == "validation"
+
+
+class TestPeerLoopbackGuard:
+    def test_non_loopback_peer_rejected_even_with_spoofed_host(self, app: Any) -> None:
+        from fastapi.testclient import TestClient
+
+        # Off-loopback PEER address + a forged loopback Host header: the
+        # unspoofable peer-address check rejects it (the Host spoof does not help).
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=("8.8.8.8", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.get("/v1/notebooks")
+        assert resp.status_code == 403
+        assert resp.json()["error"]["category"] == "auth"
+
+    @pytest.mark.parametrize("peer_host", ["::1", "::ffff:127.0.0.1"])
+    def test_ipv6_loopback_peer_allowed(self, app: Any, peer_host: str) -> None:
+        from fastapi.testclient import TestClient
+
+        # An IPv6 loopback peer (``::1``) and the IPv4-mapped loopback
+        # (``::ffff:127.0.0.1``) both satisfy the unspoofable peer-loopback guard.
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=(peer_host, 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.get("/v1/notebooks")
+        assert resp.status_code == 200
+
+    def test_external_bind_optin_allows_non_loopback_peer(
+        self, app: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        from notebooklm.server._auth import ALLOW_EXTERNAL_BIND_ENV
+
+        monkeypatch.setenv(ALLOW_EXTERNAL_BIND_ENV, "1")
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "example.com"}
+        with TestClient(
+            app, headers=headers, client=("8.8.8.8", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.get("/v1/notebooks")
+        assert resp.status_code == 200
 
 
 class TestNoContentResponses:
@@ -154,14 +224,25 @@ class TestUploadPathSafety:
         assert os.path.isabs(path) and ".." not in path
 
     def test_safe_upload_name(self) -> None:
+        # Now the shared neutral helper (_app.source_add.safe_upload_name): control
+        # chars stripped, . / .. rejected, extension preserved on truncation.
         from notebooklm.server.routes.sources import _safe_upload_name
 
         assert _safe_upload_name("report.pdf") == "report.pdf"
         assert _safe_upload_name("../../etc/passwd") == "passwd"  # traversal stripped
         assert _safe_upload_name("a/b/c.txt") == "c.txt"
-        assert _safe_upload_name("") == "upload"  # empty fallback
-        assert _safe_upload_name(None) == "upload"
-        assert len(_safe_upload_name("x" * 500)) <= 255  # length-bounded
+        assert _safe_upload_name("a\x00b.pdf") == "ab.pdf"  # control chars stripped
+        assert _safe_upload_name("a\x7fb.pdf") == "ab.pdf"  # DEL stripped
+        assert _safe_upload_name("a\x85b.pdf") == "ab.pdf"  # C1 control stripped
+        assert _safe_upload_name("..") == "upload.bin"  # directory cursor rejected
+        assert _safe_upload_name("") == "upload.bin"  # empty fallback
+        assert _safe_upload_name(None) == "upload.bin"
+        # Length-bounded AND extension-preserving (stem truncated, ".pdf" kept).
+        long = _safe_upload_name("x" * 500 + ".pdf")
+        assert len(long) <= 255 and long.endswith(".pdf")
+        # Multibyte names are bounded by BYTE length (255), not char count.
+        emoji = _safe_upload_name("😀" * 300 + ".pdf")
+        assert len(emoji.encode("utf-8")) <= 255 and emoji.endswith(".pdf")
 
 
 class TestGenerateSourceDefaulting:
@@ -199,9 +280,11 @@ class TestErrorEnvelopeShape:
     def test_missing_token_401_uses_envelope(self, app: Any) -> None:
         from fastapi.testclient import TestClient
 
-        # Loopback Host clears the rebinding guard; the wrong token trips the 401.
+        # Loopback peer + Host clear the rebinding guard; the wrong token trips 401.
         headers = {"Authorization": "Bearer wrong-token", "Host": "127.0.0.1"}
-        with TestClient(app, headers=headers, raise_server_exceptions=False) as c:
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
             resp = c.get("/v1/notebooks")
         assert resp.status_code == 401
         body = resp.json()

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -150,6 +150,26 @@ class TestPeerLoopbackGuard:
         assert resp.status_code == 403
         assert resp.json()["error"]["category"] == "auth"
 
+    @pytest.mark.parametrize(
+        ("addr", "expected"),
+        [
+            ("127.0.0.1", True),
+            ("::1", True),
+            # IPv4-mapped IPv6 loopback: ``ipaddress.is_loopback`` only resolves the
+            # mapped IPv4 in newer CPython patch levels, so this must be pinned
+            # version-independently (it regressed on some macOS 3.10/3.11 runners).
+            ("::ffff:127.0.0.1", True),
+            ("8.8.8.8", False),
+            ("::ffff:8.8.8.8", False),  # mapped *external* — must NOT read as loopback
+            ("0.0.0.0", False),
+            ("not-an-ip", False),
+        ],
+    )
+    def test_addr_is_loopback_version_independent(self, addr: str, expected: bool) -> None:
+        from notebooklm.server._auth import _addr_is_loopback
+
+        assert _addr_is_loopback(addr) is expected
+
     @pytest.mark.parametrize("peer_host", ["::1", "::ffff:127.0.0.1"])
     def test_ipv6_loopback_peer_allowed(self, app: Any, peer_host: str) -> None:
         from fastapi.testclient import TestClient

--- a/tests/server/test_integration_real_client.py
+++ b/tests/server/test_integration_real_client.py
@@ -85,7 +85,9 @@ def real_authed_client() -> Iterator[TestClient]:
 
     app = create_app(client_factory=factory)
     headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
-    with TestClient(app, headers=headers, raise_server_exceptions=False) as c:
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as c:
         yield c
 
 

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -74,10 +74,12 @@ def test_build_parser_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in ("NOTEBOOKLM_SERVER_HOST", "NOTEBOOKLM_SERVER_PORT", "NOTEBOOKLM_LOG_LEVEL"):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(launcher.SERVER_TOKEN_FILE_ENV, raising=False)
     args = launcher._build_parser().parse_args([])
     assert args.host == "127.0.0.1"
     assert args.port == "8000"  # kept as a string; converted later by _resolve_port
-    assert args.token is None
+    assert args.token is None  # deprecated flag defaults to None (never env-seeded)
+    assert args.token_file is None
     assert args.log_level == "INFO"
 
 
@@ -85,11 +87,14 @@ def test_build_parser_reads_env_defaults(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("NOTEBOOKLM_SERVER_HOST", "::1")
     monkeypatch.setenv("NOTEBOOKLM_SERVER_PORT", "9001")
     monkeypatch.setenv("NOTEBOOKLM_LOG_LEVEL", "DEBUG")
-    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
+    # The bearer token no longer feeds --token (deprecated); --token-file reads its
+    # own env default instead.
+    monkeypatch.setenv(launcher.SERVER_TOKEN_FILE_ENV, "/etc/nblm/token")
     args = launcher._build_parser().parse_args([])
     assert args.host == "::1"
     assert args.port == "9001"
-    assert args.token == "env-secret"
+    assert args.token is None
+    assert args.token_file == "/etc/nblm/token"
     assert args.log_level == "DEBUG"
 
 
@@ -145,21 +150,48 @@ def _stub_uvicorn_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
 
 def test_main_runs_server_with_resolved_args(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _stub_uvicorn_run(monkeypatch)
-    launcher.main(
-        ["--host", "127.0.0.1", "--port", "8123", "--token", "secret", "--log-level", "WARNING"]
-    )
+    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
+    launcher.main(["--host", "127.0.0.1", "--port", "8123", "--log-level", "WARNING"])
     assert captured["app"] == "APP"
     assert captured["host"] == "127.0.0.1"
     assert captured["port"] == 8123  # _resolve_port converts the string to an int
     assert captured["log_level"] == "warning"  # uvicorn wants a lowercase level
+    # Default (loopback) mode: proxy headers OFF so request.client.host is the real
+    # socket peer (the loopback guard's basis), not a spoofable X-Forwarded-For.
+    assert captured["proxy_headers"] is False
 
 
-def test_main_seeds_token_env_from_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_rejects_deprecated_token_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
+    # --token leaks via `ps`; it is refused outright even when a valid env token
+    # would otherwise let the server start.
+    with pytest.raises(SystemExit):
+        launcher.main(["--host", "127.0.0.1", "--token", "argv-secret"])
+
+
+def test_main_loads_token_from_file(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    from pathlib import Path
+
     _stub_uvicorn_run(monkeypatch)
     monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
-    launcher.main(["--host", "127.0.0.1", "--token", "flag-token"])
-    # The --token flag seeds the env the auth dependency later reads.
-    assert os.environ[SERVER_TOKEN_ENV] == "flag-token"
+    token_path = Path(str(tmp_path)) / "token.txt"
+    token_path.write_text("file-token\n", encoding="utf-8")
+    launcher.main(["--host", "127.0.0.1", "--token-file", str(token_path)])
+    # The file's contents (stripped) seed the env the auth dependency reads; only
+    # the PATH ever appeared on argv.
+    assert os.environ[SERVER_TOKEN_ENV] == "file-token"
+
+
+def test_main_empty_token_file_refuses(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    from pathlib import Path
+
+    _stub_uvicorn_run(monkeypatch)
+    monkeypatch.delenv(SERVER_TOKEN_ENV, raising=False)
+    token_path = Path(str(tmp_path)) / "empty.txt"
+    token_path.write_text("   \n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        launcher.main(["--host", "127.0.0.1", "--token-file", str(token_path)])
 
 
 def test_main_refuses_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -171,13 +203,17 @@ def test_main_refuses_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_main_refuses_non_loopback_host(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_uvicorn_run(monkeypatch)
+    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
     monkeypatch.delenv(launcher.ALLOW_EXTERNAL_BIND_ENV, raising=False)
     with pytest.raises(SystemExit):
-        launcher.main(["--host", "0.0.0.0", "--token", "secret"])
+        launcher.main(["--host", "0.0.0.0"])
 
 
 def test_main_allows_external_bind_with_optin(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _stub_uvicorn_run(monkeypatch)
+    monkeypatch.setenv(SERVER_TOKEN_ENV, "env-secret")
     monkeypatch.setenv(launcher.ALLOW_EXTERNAL_BIND_ENV, "1")
-    launcher.main(["--host", "0.0.0.0", "--token", "secret"])
+    launcher.main(["--host", "0.0.0.0"])
     assert captured["host"] == "0.0.0.0"
+    # External-bind opt-in (behind a trusted proxy): forwarded headers are honored.
+    assert captured["proxy_headers"] is True

--- a/tests/server/test_main.py
+++ b/tests/server/test_main.py
@@ -217,3 +217,13 @@ def test_main_allows_external_bind_with_optin(monkeypatch: pytest.MonkeyPatch) -
     assert captured["host"] == "0.0.0.0"
     # External-bind opt-in (behind a trusted proxy): forwarded headers are honored.
     assert captured["proxy_headers"] is True
+
+
+def test_meta_server_name_matches_app_server_name() -> None:
+    # meta.SERVER_NAME is named locally (not imported) to avoid a circular import
+    # with server.app; pin the two equal so they can never drift (the comment in
+    # meta.py points here — enforce, don't document).
+    from notebooklm.server.app import SERVER_NAME as app_name
+    from notebooklm.server.routes.meta import SERVER_NAME as meta_name
+
+    assert meta_name == app_name

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -1,0 +1,80 @@
+"""Phase 4: GET /v1/server/info — version + auth health (mirrors MCP server_info)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from notebooklm.server.routes import meta as meta_route
+
+from .fakes import FakeClient
+
+
+class _FakeAuthResult:
+    def __init__(self, *, all_passed: bool) -> None:
+        self.all_passed = all_passed
+        self.checks = {
+            "storage_exists": True,
+            "json_valid": True,
+            "cookies_present": True,
+            "sid_cookie": all_passed,
+        }
+
+
+def _patch_auth(monkeypatch: pytest.MonkeyPatch, *, all_passed: bool) -> None:
+    async def _fake_run(plan: Any, *, read_env_auth_json: Any) -> _FakeAuthResult:
+        return _FakeAuthResult(all_passed=all_passed)
+
+    monkeypatch.setattr(meta_route, "run_auth_check", _fake_run)
+
+
+def test_server_info_reports_version_and_auth(
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_auth(monkeypatch, all_passed=True)
+    resp = authed_client.get("/v1/server/info")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["server"] == "notebooklm-server"
+    assert isinstance(body["version"], str) and body["version"]
+    assert body["auth"]["authenticated"] is True
+    assert body["auth"]["sid_cookie"] is True
+    # Default call does not include the account block.
+    assert "account" not in body
+
+
+def test_server_info_does_not_leak_storage_path(
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_auth(monkeypatch, all_passed=True)
+    body = authed_client.get("/v1/server/info").json()
+    # No absolute on-disk storage path anywhere in the response (MCP scrubs it too).
+    assert "storage_path" not in body["auth"]
+    assert "/" not in str(body["auth"].get("profile", ""))
+
+
+def test_server_info_include_account(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_auth(monkeypatch, all_passed=True)
+    resp = authed_client.get("/v1/server/info", params={"include_account": True})
+    assert resp.status_code == 200
+    account = resp.json()["account"]
+    assert account["email"] == "user@example.com"
+    assert account["available"] is True
+    assert account["notebook_limit"] == 100
+    assert account["source_limit"] == 50
+    assert account["output_language"] == "en"
+
+
+def test_server_info_include_account_unauthenticated_degrades(
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_auth(monkeypatch, all_passed=False)
+    account = authed_client.get("/v1/server/info", params={"include_account": True}).json()[
+        "account"
+    ]
+    assert account["available"] is False
+    assert account["reason"] == "not authenticated"

--- a/tests/server/test_notebooks.py
+++ b/tests/server/test_notebooks.py
@@ -79,3 +79,62 @@ def test_unauthorized_on_each_verb(raw_client: TestClient) -> None:
     assert raw_client.get("/v1/notebooks", headers=h).status_code == 401
     assert raw_client.post("/v1/notebooks", json={"title": "x"}, headers=h).status_code == 401
     assert raw_client.delete("/v1/notebooks/nb-1", headers=h).status_code == 401
+
+
+# --- Phase 4: notebook rename (PATCH) ----------------------------------------
+
+
+def test_rename_notebook(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.notebooks_store["nb-1"] = Notebook(id="nb-1", title="Old")
+    resp = authed_client.patch("/v1/notebooks/nb-1", json={"title": "New"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "renamed"
+    assert body["new_title"] == "New"
+    assert fake_client.notebooks_store["nb-1"].title == "New"
+
+
+def test_rename_notebook_missing_title_is_422(authed_client: TestClient) -> None:
+    assert authed_client.patch("/v1/notebooks/nb-1", json={}).status_code == 422
+
+
+# --- Phase 4: suggested-prompts ----------------------------------------------
+
+
+def test_suggested_prompts_default_surface(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.get("/v1/notebooks/nb-1/suggested-prompts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["notebook_id"] == "nb-1"
+    assert [s["title"] for s in body["suggestions"]] == ["Q1", "Q2"]
+    # Default surface ``ask`` → mode 4.
+    assert fake_client.last_suggest["mode"] == 4
+    assert fake_client.last_suggest["source_ids"] is None
+
+
+def test_suggested_prompts_surface_and_source_ids(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.get(
+        "/v1/notebooks/nb-1/suggested-prompts",
+        params={"surface": "quiz", "source_ids": ["s1", "s2"], "query": "steer"},
+    )
+    assert resp.status_code == 200
+    assert fake_client.last_suggest["mode"] == 8  # quiz
+    assert fake_client.last_suggest["source_ids"] == ["s1", "s2"]
+    assert fake_client.last_suggest["query"] == "steer"
+
+
+def test_suggested_prompts_bad_surface_is_422(authed_client: TestClient) -> None:
+    resp = authed_client.get("/v1/notebooks/nb-1/suggested-prompts", params={"surface": "bogus"})
+    assert resp.status_code == 422
+
+
+def test_suggest_surface_map_matches_mcp() -> None:
+    """The REST surface→mode map is pinned equal to the MCP tool's copy."""
+    from notebooklm.mcp.tools.chat import _SUGGEST_SURFACE as mcp_map
+    from notebooklm.server.routes.notebooks import _SUGGEST_SURFACE as rest_map
+
+    assert rest_map == dict(mcp_map)

--- a/tests/server/test_notebooks.py
+++ b/tests/server/test_notebooks.py
@@ -17,6 +17,32 @@ def test_list_returns_notebooks(authed_client: TestClient, fake_client: FakeClie
     assert titles == ["First"]
 
 
+def test_list_default_is_unbounded_no_meta(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """The default call (no ``limit``) returns the full list, shape unchanged."""
+    for i in range(3):
+        fake_client.notebooks_store[f"nb-{i}"] = Notebook(id=f"nb-{i}", title=f"N{i}")
+    body = authed_client.get("/v1/notebooks").json()
+    assert len(body["notebooks"]) == 3
+    assert "meta" not in body
+
+
+def test_list_pagination_slices_and_adds_meta(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    for i in range(5):
+        fake_client.notebooks_store[f"nb-{i}"] = Notebook(id=f"nb-{i}", title=f"N{i}")
+    body = authed_client.get("/v1/notebooks", params={"limit": 2, "offset": 1}).json()
+    assert len(body["notebooks"]) == 2
+    assert body["meta"] == {"total": 5, "has_more": True, "limit": 2, "offset": 1}
+
+
+def test_list_bad_bounds_is_422(authed_client: TestClient) -> None:
+    assert authed_client.get("/v1/notebooks", params={"limit": 0}).status_code == 422
+    assert authed_client.get("/v1/notebooks", params={"offset": -1}).status_code == 422
+
+
 def test_create_returns_201_with_new_notebook(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks", json={"title": "Fresh"})
     assert resp.status_code == 201

--- a/tests/server/test_notes.py
+++ b/tests/server/test_notes.py
@@ -22,6 +22,25 @@ def test_list_returns_notes(authed_client: TestClient, fake_client: FakeClient) 
     assert [n["title"] for n in body["notes"]] == ["First"]
 
 
+def test_list_pagination_slices_and_adds_meta(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    for i in range(5):
+        _seed(fake_client, Note(id=f"n-{i}", notebook_id="nb-1", title=f"N{i}", content="x"))
+    default = authed_client.get("/v1/notebooks/nb-1/notes").json()
+    assert len(default["notes"]) == 5
+    assert "meta" not in default
+
+    body = authed_client.get("/v1/notebooks/nb-1/notes", params={"limit": 2, "offset": 1}).json()
+    assert body["notebook_id"] == "nb-1"
+    assert len(body["notes"]) == 2
+    assert body["meta"] == {"total": 5, "has_more": True, "limit": 2, "offset": 1}
+
+
+def test_list_bad_bounds_is_422(authed_client: TestClient) -> None:
+    assert authed_client.get("/v1/notebooks/nb-1/notes", params={"limit": 0}).status_code == 422
+
+
 def test_create_returns_201_with_new_note(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks/nb-1/notes", json={"title": "T", "content": "C"})
     assert resp.status_code == 201

--- a/tests/server/test_research.py
+++ b/tests/server/test_research.py
@@ -1,0 +1,171 @@
+"""Deep-research routes — /v1/notebooks/{id}/research start / status / cancel / import."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from .fakes import FakeClient
+
+
+def test_start_status_import_happy_path(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # Start (202): fast mode has only a task_id, so poll_id == task_id.
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "topic"})
+    assert resp.status_code == 202
+    body = resp.json()
+    poll_id = body["poll_id"]
+    assert body["report_id"] is None
+    assert poll_id == body["task_id"]
+    assert fake_client.last_research_start == {
+        "notebook_id": "nb-1",
+        "query": "topic",
+        "source": "web",
+        "mode": "fast",
+    }
+
+    # Status: in progress right after start.
+    resp = authed_client.get(f"/v1/notebooks/nb-1/research/{poll_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "in_progress"
+
+    # Drive the run to completion with one found source.
+    fake_client.set_research_completed(
+        "nb-1", poll_id, sources=[{"url": "https://a.example", "title": "A"}]
+    )
+    resp = authed_client.get(f"/v1/notebooks/nb-1/research/{poll_id}")
+    body = resp.json()
+    assert body["status"] == "completed"
+    assert body["run_id"] == poll_id
+    assert len(body["sources"]) == 1
+
+    # Import the completed run's sources.
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "imported"
+    assert body["sources_found"] == 1
+    assert len(body["imported"]) == 1
+    # The import is keyed on the poll id, not the notebook's current task.
+    assert fake_client.imported_research[0][0] == "nb-1"
+    assert fake_client.imported_research[0][1] == poll_id
+
+
+def test_deep_start_poll_id_is_report_id(authed_client: TestClient) -> None:
+    # Deep mode returns BOTH a task_id and a report_id; poll_id must be the
+    # report_id (deep's task_id is a sessionId the poll/cancel cannot use).
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t", "mode": "deep"})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["report_id"] is not None
+    assert body["poll_id"] == body["report_id"]
+    assert body["poll_id"] != body["task_id"]
+
+
+def test_deep_start_status_import_happy_path(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # Deep mode keys the whole workflow off report_id: prove start→status→import
+    # survives end-to-end when poll_id is the report_id (not the sessionId task_id).
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t", "mode": "deep"})
+    assert resp.status_code == 202
+    body = resp.json()
+    poll_id = body["poll_id"]
+    assert poll_id == body["report_id"]
+    assert poll_id != body["task_id"]
+
+    # Status polls the report_id and sees the in-progress run.
+    resp = authed_client.get(f"/v1/notebooks/nb-1/research/{poll_id}")
+    assert resp.json()["status"] == "in_progress"
+
+    fake_client.set_research_completed(
+        "nb-1", poll_id, sources=[{"url": "https://a.example", "title": "A"}]
+    )
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 201
+    assert resp.json()["sources_found"] == 1
+    # The import keyed on the report_id (the deep task_id would poll as not_found).
+    assert fake_client.imported_research[0][1] == poll_id
+
+
+def test_deep_start_missing_report_id_raises(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A deep start that returns no report_id cannot form a pollable id — the
+    # route must fail loud (server/decode error) rather than emit the sessionId
+    # task_id that would immediately poll as not_found.
+    fake_client.deep_missing_report_id = True
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t", "mode": "deep"})
+    assert resp.status_code >= 500
+    assert "poll_id" not in resp.json()
+
+
+def test_import_failed_run_rejected(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # A FAILED run is a distinct non-importable branch — refuse (400) and never
+    # touch import_sources.
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    poll_id = resp.json()["poll_id"]
+    fake_client.set_research_failed("nb-1", poll_id)
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"
+    assert "failed" in resp.json()["error"]["message"].lower()
+    assert fake_client.imported_research == []
+
+
+def test_deep_drive_combination_rejected(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/research", json={"query": "t", "source": "drive", "mode": "deep"}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"
+
+
+def test_cancel_is_fire_and_forget(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # Cancel does not validate the id — an unknown run still reports cancelled.
+    resp = authed_client.delete("/v1/notebooks/nb-1/research/run-9")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["cancelled"] is True
+    assert body["run_id"] == "run-9"
+    assert ("nb-1", "run-9") in fake_client.cancelled_research
+
+
+def test_import_before_complete_rejected(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    poll_id = resp.json()["poll_id"]
+    # Still in progress — import must refuse and never touch import_sources.
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"
+    assert fake_client.imported_research == []
+
+
+def test_import_unknown_run_rejected(authed_client: TestClient, fake_client: FakeClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/research/does-not-exist/import")
+    assert resp.status_code == 400
+    assert fake_client.imported_research == []
+
+
+def test_import_empty_completed_rejected(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    poll_id = resp.json()["poll_id"]
+    fake_client.set_research_completed("nb-1", poll_id, sources=[])
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 400
+    assert fake_client.imported_research == []
+
+
+def test_status_unknown_run_is_not_found(authed_client: TestClient) -> None:
+    resp = authed_client.get("/v1/notebooks/nb-1/research/ghost")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "not_found"
+
+
+def test_unauthorized_is_401(raw_client: TestClient) -> None:
+    resp = raw_client.post(
+        "/v1/notebooks/nb-1/research", json={"query": "t"}, headers={"Host": "127.0.0.1"}
+    )
+    assert resp.status_code == 401

--- a/tests/server/test_research.py
+++ b/tests/server/test_research.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
+
+from notebooklm._types.research import ResearchStart
 
 from .fakes import FakeClient
 
@@ -162,6 +165,81 @@ def test_status_unknown_run_is_not_found(authed_client: TestClient) -> None:
     resp = authed_client.get("/v1/notebooks/nb-1/research/ghost")
     assert resp.status_code == 200
     assert resp.json()["status"] == "not_found"
+
+
+def test_start_explicit_discriminators_win_over_spread(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``to_jsonable(result)`` carries ``notebook_id`` (and ``task_id`` /
+    # ``report_id``), so the explicit ``notebook_id`` / ``poll_id`` must be spread
+    # LAST or a stale/embedded value could clobber the computed discriminator.
+    # Return a start whose embedded ``notebook_id`` DIFFERS from the path arg.
+    async def _start(
+        notebook_id: str, query: str, source: str = "web", mode: str = "fast"
+    ) -> ResearchStart:
+        return ResearchStart(
+            task_id="rtask-x",
+            report_id=None,
+            notebook_id="EMBEDDED-WRONG",
+            query=query,
+            mode=mode,
+        )
+
+    monkeypatch.setattr(fake_client.research, "start", _start)
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    assert resp.status_code == 202
+    body = resp.json()
+    # The explicit path notebook_id wins over the spread's embedded one.
+    assert body["notebook_id"] == "nb-1"
+    # poll_id is the computed fast task_id, present alongside the spread.
+    assert body["poll_id"] == "rtask-x"
+    assert body["task_id"] == "rtask-x"
+
+
+def test_fast_start_missing_task_id_raises(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A fast start that returns no task_id cannot form a pollable poll_id — the
+    # route must fail loud (parallel to the deep no-report_id guard) rather than
+    # emit an empty, unpollable poll_id.
+    async def _start(
+        notebook_id: str, query: str, source: str = "web", mode: str = "fast"
+    ) -> ResearchStart:
+        return ResearchStart(
+            task_id="", report_id=None, notebook_id=notebook_id, query=query, mode=mode
+        )
+
+    monkeypatch.setattr(fake_client.research, "start", _start)
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    assert resp.status_code >= 500
+    assert "poll_id" not in resp.json()
+
+
+def test_import_records_imported_ids_in_pending(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # After an import, each imported source id is recorded in the pending registry
+    # so a source poll for it resolves to 200 pending (not a spurious 404) during
+    # the not-yet-listable window (same provenance contract as the create routes).
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "t"})
+    poll_id = resp.json()["poll_id"]
+    fake_client.set_research_completed(
+        "nb-1", poll_id, sources=[{"url": "https://a.example", "title": "A"}]
+    )
+    resp = authed_client.post(f"/v1/notebooks/nb-1/research/{poll_id}/import")
+    assert resp.status_code == 201
+    imported = resp.json()["imported"]
+    assert len(imported) == 1
+    imported_id = imported[0]["id"]
+
+    # The imported id (not in the source store yet) is now pending-known → 200.
+    resp = authed_client.get(f"/v1/notebooks/nb-1/sources/{imported_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    # An id that was never imported is still an unknown 404 (guards over-recording).
+    resp = authed_client.get("/v1/notebooks/nb-1/sources/never-imported")
+    assert resp.status_code == 404
 
 
 def test_unauthorized_is_401(raw_client: TestClient) -> None:

--- a/tests/server/test_share.py
+++ b/tests/server/test_share.py
@@ -79,6 +79,28 @@ def test_add_update_and_remove_user(authed_client: TestClient, fake_client: Fake
     assert "reader@example.com" not in fake_client.shared_users["nb-1"]
 
 
+def test_add_user_notify_defaults_off(authed_client: TestClient, fake_client: FakeClient) -> None:
+    """Omitting ``notify`` must NOT email the third party (default flipped to False)."""
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/share/users",
+        json={"email": "reader@example.com", "permission": "viewer"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["notify"] is False
+    assert fake_client.last_share_notify is False
+
+
+def test_add_user_notify_opt_in(authed_client: TestClient, fake_client: FakeClient) -> None:
+    """An explicit ``notify=true`` still emails."""
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/share/users",
+        json={"email": "reader@example.com", "permission": "viewer", "notify": True},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["notify"] is True
+    assert fake_client.last_share_notify is True
+
+
 def test_set_view_level(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks/nb-1/share/view-level", json={"level": "chat"})
 

--- a/tests/server/test_share.py
+++ b/tests/server/test_share.py
@@ -27,8 +27,13 @@ def test_share_status_returns_current_state(
     body = resp.json()
     assert body["notebook_id"] == "nb-1"
     assert body["is_public"] is True
+    # Shared view: access/permission are string labels; view_level is omitted on
+    # the read path (the read RPC does not report it).
+    assert body["access"] == "anyone_with_link"
     assert body["share_url"].endswith("/nb-1")
     assert body["shared_users"][0]["email"] == "reader@example.com"
+    assert body["shared_users"][0]["permission"] == "viewer"
+    assert "view_level" not in body
 
 
 def test_set_public_toggles_link(authed_client: TestClient) -> None:
@@ -36,12 +41,14 @@ def test_set_public_toggles_link(authed_client: TestClient) -> None:
 
     assert resp.status_code == 200
     assert resp.json()["is_public"] is True
-    assert resp.json()["access"] == 1
+    # Shared view labels the access enum (not a bare int).
+    assert resp.json()["access"] == "anyone_with_link"
 
     resp = authed_client.post("/v1/notebooks/nb-1/share/public", json={"enable": False})
 
     assert resp.status_code == 200
     assert resp.json()["is_public"] is False
+    assert resp.json()["access"] == "restricted"
     assert resp.json()["share_url"] is None
 
 
@@ -105,7 +112,8 @@ def test_set_view_level(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks/nb-1/share/view-level", json={"level": "chat"})
 
     assert resp.status_code == 200
-    assert resp.json()["view_level"] == 1
+    # set_view_level's return is authoritative, so view_level is surfaced (labeled).
+    assert resp.json()["view_level"] == "chat"
 
 
 def test_share_rejects_bad_permission(authed_client: TestClient) -> None:

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -89,6 +89,165 @@ def test_poll_unknown_source_is_404(authed_client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+def _seed_ready_source(fake_client: FakeClient, *, content: str) -> str:
+    src_id = "src-ready"
+    fake_client.sources_store["nb-1"] = {
+        src_id: Source(id=src_id, title="Doc", status=SourceStatus.READY)
+    }
+    fake_client.fulltext_store[("nb-1", src_id)] = content
+    return src_id
+
+
+def test_content_ready_source_returns_body(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    src_id = _seed_ready_source(fake_client, content="hello world")
+    resp = authed_client.get(f"/v1/notebooks/nb-1/sources/{src_id}/content")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == "hello world"
+    assert body["char_count"] == 11
+    assert body["truncated"] is False
+
+
+def test_content_windowing_max_chars_offset_truncated(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    src_id = _seed_ready_source(fake_client, content="abcdefghij")
+    resp = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"offset": 2, "max_chars": 3}
+    )
+    body = resp.json()
+    assert body["content"] == "cde"
+    assert body["char_count"] == 10  # full length, not the window
+    assert body["truncated"] is True
+    # A window covering the remainder is not truncated.
+    resp2 = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"offset": 7, "max_chars": 100}
+    )
+    assert resp2.json()["content"] == "hij"
+    assert resp2.json()["truncated"] is False
+
+
+def test_content_negative_max_chars_is_422(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    src_id = _seed_ready_source(fake_client, content="abc")
+    resp = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"max_chars": -1}
+    )
+    assert resp.status_code == 422
+
+
+def test_content_ready_but_empty_fulltext_is_null(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A READY source whose extracted text is empty → content None (not ""), char 0.
+    src_id = _seed_ready_source(fake_client, content="")
+    resp = authed_client.get(f"/v1/notebooks/nb-1/sources/{src_id}/content")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] is None
+    assert body["char_count"] == 0
+    assert body["truncated"] is False
+
+
+def test_content_offset_past_end_is_null_not_truncated(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # An offset beyond the body yields an empty slice → normalized to None, and
+    # nothing was omitted past the window, so truncated is False.
+    src_id = _seed_ready_source(fake_client, content="abc")
+    resp = authed_client.get(f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"offset": 10})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] is None
+    assert body["char_count"] == 3  # full length preserved
+    assert body["truncated"] is False
+
+
+def test_content_output_format_markdown(authed_client: TestClient, fake_client: FakeClient) -> None:
+    # output_format is propagated to the shared read core and echoed in the body
+    # (parity with the MCP source_read tool).
+    src_id = _seed_ready_source(fake_client, content="# Heading")
+    resp = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"output_format": "markdown"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["output_format"] == "markdown"
+    assert body["content"] == "# Heading"
+    # The default is text.
+    default = authed_client.get(f"/v1/notebooks/nb-1/sources/{src_id}/content").json()
+    assert default["output_format"] == "text"
+
+
+def test_content_bad_output_format_is_422(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    src_id = _seed_ready_source(fake_client, content="abc")
+    resp = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"output_format": "html"}
+    )
+    assert resp.status_code == 422
+
+
+def test_content_known_pending_source_is_404(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # The content route requires a LISTABLE source: a known-but-not-yet-listable
+    # (pending) id — unlike the status-poll GET /{source_id} route — is a 404 here.
+    created = authed_client.post(
+        "/v1/notebooks/nb-1/sources/url", json={"url": "https://example.com"}
+    ).json()
+    source_id = created["id"]
+    fake_client.sources_store["nb-1"].pop(source_id)
+    resp = authed_client.get(f"/v1/notebooks/nb-1/sources/{source_id}/content")
+    assert resp.status_code == 404
+
+
+def test_content_not_ready_source_content_is_null(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.sources_store["nb-1"] = {
+        "src-p": Source(id="src-p", title="Doc", status=SourceStatus.PROCESSING)
+    }
+    resp = authed_client.get("/v1/notebooks/nb-1/sources/src-p/content")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] is None
+    assert body["char_count"] == 0
+    assert body["truncated"] is False
+
+
+def test_content_missing_source_is_404(authed_client: TestClient) -> None:
+    resp = authed_client.get("/v1/notebooks/nb-1/sources/nope/content")
+    assert resp.status_code == 404
+
+
+def test_content_summary_variant(authed_client: TestClient, fake_client: FakeClient) -> None:
+    from notebooklm._types.research import SourceGuide
+
+    src_id = _seed_ready_source(fake_client, content="body")
+    fake_client.guide_store[("nb-1", src_id)] = SourceGuide(
+        summary="A digest", keywords=("k1", "k2")
+    )
+    resp = authed_client.get(
+        f"/v1/notebooks/nb-1/sources/{src_id}/content", params={"detail": "summary"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["summary"] == "A digest"
+    assert body["keywords"] == ["k1", "k2"]
+
+
+def test_content_summary_missing_source_is_404(authed_client: TestClient) -> None:
+    resp = authed_client.get(
+        "/v1/notebooks/nb-1/sources/nope/content", params={"detail": "summary"}
+    )
+    assert resp.status_code == 404
+
+
 def test_list_and_delete(authed_client: TestClient, fake_client: FakeClient) -> None:
     fake_client.sources_store["nb-1"] = {
         "src-7": Source(id="src-7", title="S", status=SourceStatus.READY)

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -512,6 +512,84 @@ def test_add_batch_stale_auth_is_top_level_401(
     assert resp.json()["error"]["category"] == "auth"
 
 
+def test_add_batch_mid_item_auth_is_top_level_401(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    # An AUTH failure raised DURING an item's add (not the shared preflight) must
+    # propagate as a top-level 401 — NOT be folded into a per-item error and
+    # returned as a 200/201 batch envelope.
+    import pytest
+
+    from notebooklm.exceptions import AuthError
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    _seed_notebook(fake_client)
+
+    async def _boom(notebook_id: str, url: str) -> object:
+        raise AuthError("session expired mid-batch")
+
+    monkeypatch.setattr(fake_client.sources, "add_url", _boom)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={"urls": ["https://a.example.com", "https://b.example.com"]},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["category"] == "auth"
+    # It aborted — no batch envelope with per-item results.
+    assert "results" not in resp.json()
+
+
+def test_add_batch_mid_item_rate_limit_is_top_level_429(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    # A RATE_LIMIT failure mid-batch is fatal too (429), not a per-item error.
+    import pytest
+
+    from notebooklm.exceptions import RateLimitError
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    _seed_notebook(fake_client)
+
+    async def _boom(notebook_id: str, url: str) -> object:
+        raise RateLimitError("slow down")
+
+    monkeypatch.setattr(fake_client.sources, "add_url", _boom)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch", json={"urls": ["https://a.example.com"]}
+    )
+    assert resp.status_code == 429
+    assert resp.json()["error"]["category"] == "rate_limited"
+    assert "results" not in resp.json()
+
+
+def test_add_batch_per_item_error_is_redacted(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    # A per-item (isolated, 4xx-input) failure whose message carries a home path
+    # must be scrubbed in the batch envelope — no raw /home/<user>/ leak.
+    import pytest
+
+    from notebooklm.exceptions import ValidationError
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    _seed_notebook(fake_client)
+
+    async def _boom(notebook_id: str, url: str) -> object:
+        raise ValidationError("bad source spooled to /home/alice/secret.txt")
+
+    monkeypatch.setattr(fake_client.sources, "add_url", _boom)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch", json={"urls": ["https://a.example.com"]}
+    )
+    # A VALIDATION failure stays isolated: nothing created → 200 status=error.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    message = body["results"][0]["error"]["message"]
+    assert "/home/alice" not in message
+    assert "/home/***" in message
+
+
 def test_add_batch_empty_is_400(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks/nb-1/sources/batch", json={"urls": []})
     assert resp.status_code == 400
@@ -610,3 +688,20 @@ def test_wait_explicit_empty_source_ids_is_400(authed_client: TestClient) -> Non
     resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"source_ids": []})
     assert resp.status_code == 400
     assert resp.json()["error"]["category"] == "validation"
+
+
+def test_wait_bucket_entry_redacts_error_text() -> None:
+    # A handled wait failure's error text is scrubbed via safe_detail before it
+    # reaches the {source_id, error} bucket — no raw /home/<user>/ leak (F7).
+    from notebooklm.server.routes.sources import _wait_bucket_entry
+
+    class _Err:
+        source_id = "src-1"
+
+        def __str__(self) -> str:
+            return "processing failed, spooled to /home/alice/tmp/x"
+
+    entry = _wait_bucket_entry(_Err())
+    assert entry["source_id"] == "src-1"
+    assert "/home/alice" not in entry["error"]
+    assert "/home/***" in entry["error"]

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -6,11 +6,17 @@ import io
 
 from fastapi.testclient import TestClient
 
+from notebooklm._types.notebooks import Notebook
 from notebooklm._types.sources import Source
 from notebooklm.rpc.types import SourceStatus
 from notebooklm.server._pagination import MAX_LIMIT
 
 from .fakes import FakeClient
+
+
+def _seed_notebook(fake_client: FakeClient, nid: str = "nb-1") -> None:
+    """Seed the notebook so the batch route's shared-context preflight passes."""
+    fake_client.notebooks_store[nid] = Notebook(id=nid, title="NB")
 
 
 def test_add_url_returns_non_ready_source(authed_client: TestClient) -> None:
@@ -346,3 +352,261 @@ def test_add_url_returns_enriched_view(authed_client: TestClient) -> None:
     assert "kind" in body
     assert "status_label" in body
     assert body["status_label"] == "processing"
+
+
+# --- Phase 4: source rename (PATCH) ------------------------------------------
+
+
+def _seed_source(
+    fake_client: FakeClient, nid: str, sid: str, *, status: SourceStatus = SourceStatus.PROCESSING
+) -> None:
+    fake_client.sources_store.setdefault(nid, {})[sid] = Source(
+        id=sid, title="Old", url=None, status=status
+    )
+
+
+def test_rename_source(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed_source(fake_client, "nb-1", "src-1")
+    resp = authed_client.patch("/v1/notebooks/nb-1/sources/src-1", json={"title": "Renamed"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Renamed"
+    # Enriched view shape (matches GET).
+    assert "kind" in body and "status_label" in body
+    assert fake_client.sources_store["nb-1"]["src-1"].title == "Renamed"
+
+
+def test_rename_missing_source_is_404(authed_client: TestClient) -> None:
+    resp = authed_client.patch("/v1/notebooks/nb-1/sources/ghost", json={"title": "X"})
+    assert resp.status_code == 404
+
+
+# --- Phase 4: Drive source add -----------------------------------------------
+
+
+def test_add_drive_source(authed_client: TestClient, fake_client: FakeClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/drive",
+        json={"document_id": "doc-abc", "title": "Spec", "mime_type": "google-doc"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["title"] == "Spec"
+    assert "status_label" in body
+    # The core maps the ``google-doc`` choice to the real Drive MIME before add.
+    nid, doc, title, mime = fake_client.added_drive[0]
+    assert (nid, doc, title) == ("nb-1", "doc-abc", "Spec")
+    assert mime == "application/vnd.google-apps.document"
+
+
+def test_add_drive_default_mime(authed_client: TestClient, fake_client: FakeClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/drive", json={"document_id": "doc-1"})
+    assert resp.status_code == 201
+    # Default choice ``google-doc`` → Google Docs MIME.
+    assert fake_client.added_drive[0][3] == "application/vnd.google-apps.document"
+
+
+def test_add_drive_bad_mime_is_422(authed_client: TestClient) -> None:
+    # mime_type is a Literal → rejected at the schema boundary.
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/drive",
+        json={"document_id": "doc-1", "mime_type": "bogus"},
+    )
+    assert resp.status_code == 422
+
+
+# --- Phase 4: batch URL add --------------------------------------------------
+
+
+def test_add_batch_all_valid(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed_notebook(fake_client)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={"urls": ["https://a.example.com", "https://b.example.com"]},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    # Top-level status mirrors the MCP batch envelope (parity).
+    assert body["status"] == "added"
+    assert body["added"] == 2
+    assert body["failed"] == 0
+    # Results are positional and carry status_label.
+    assert body["results"][0]["input"] == "https://a.example.com"
+    assert body["results"][0]["status"] == "added"
+    assert "status_label" in body["results"][0]
+
+
+def test_add_batch_partial_failure_isolated(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A private/SSRF URL fails its own item without aborting the batch.
+    _seed_notebook(fake_client)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={"urls": ["https://ok.example.com", "http://127.0.0.1:9/secret"]},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "added"  # ≥1 added
+    assert body["added"] == 1
+    assert body["failed"] == 1
+    assert body["results"][1]["status"] == "error"
+    err = body["results"][1]["error"]
+    assert err["category"] == "validation"
+    assert "retriable" in err
+
+
+def test_add_batch_all_failed_is_200_status_error(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # Every item fails a per-item VALIDATION check → nothing created: 200 (not
+    # 201) with a top-level status="error" (MCP _add_url_batch parity), so the
+    # envelope never claims success while every result says error.
+    _seed_notebook(fake_client)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={"urls": ["http://127.0.0.1:9/a", "http://169.254.169.254/b"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert body["added"] == 0
+    assert body["failed"] == 2
+
+
+def test_add_batch_bad_notebook_is_top_level_404(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    # A shared-context failure (unknown notebook) is validated ONCE up front and
+    # surfaces as a top-level 404 — NOT a 201 with every item silently errored.
+    # (nb-1 is intentionally NOT seeded.)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={"urls": ["https://a.example.com", "https://b.example.com"]},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["category"] == "not_found"
+    # No item was attempted (the batch aborted before the loop).
+    assert not fake_client.sources_store.get("nb-1")
+
+
+def test_add_batch_stale_auth_is_top_level_401(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    # Stale auth on the shared preflight surfaces as a top-level 401, not a
+    # 201-all-errored body.
+    import pytest
+
+    from notebooklm.exceptions import AuthError
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+
+    async def _boom(notebook_id: str) -> object:
+        raise AuthError("session expired")
+
+    monkeypatch.setattr(fake_client.notebooks, "get", _boom)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch", json={"urls": ["https://a.example.com"]}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["category"] == "auth"
+
+
+def test_add_batch_empty_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/batch", json={"urls": []})
+    assert resp.status_code == 400
+
+
+# --- Phase 4: source_wait ----------------------------------------------------
+
+
+def test_wait_specific_source_ready(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed_source(fake_client, "nb-1", "src-1")
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait", json={"source_ids": ["src-1"], "timeout": 1.0}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert len(body["ready"]) == 1
+    assert body["ready"][0]["status_label"] == "ready"
+    assert body["timed_out"] == [] and body["failed"] == [] and body["not_found"] == []
+
+
+def test_wait_all_sources_partial(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed_source(fake_client, "nb-1", "src-ok")
+    _seed_source(fake_client, "nb-1", "src-slow")
+    _seed_source(fake_client, "nb-1", "src-bad")
+    fake_client.wait_outcomes["src-slow"] = "timeout"
+    fake_client.wait_outcomes["src-bad"] = "processing"
+    # No source_ids → wait for every source in the notebook.
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"timeout": 0.5})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    ready_ids = {r["id"] for r in body["ready"]}
+    assert ready_ids == {"src-ok"}
+    assert body["timed_out"][0]["source_id"] == "src-slow"
+    assert body["failed"][0]["source_id"] == "src-bad"
+
+
+def test_wait_not_found_bucket(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.wait_outcomes["src-x"] = "not_found"
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"source_ids": ["src-x"]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["not_found"][0]["source_id"] == "src-x"
+
+
+def test_wait_bad_timeout_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait", json={"source_ids": ["s"], "timeout": -1}
+    )
+    assert resp.status_code == 400
+
+
+def test_wait_bad_interval_is_400(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait", json={"source_ids": ["s"], "interval": 0}
+    )
+    assert resp.status_code == 400
+
+
+def test_wait_non_finite_timeout_is_rejected(authed_client: TestClient) -> None:
+    # JSON allows Infinity / NaN; timeout=inf would wait forever, NaN breaks
+    # comparisons. Both must be rejected before any waiting starts.
+    for bad in ("Infinity", "NaN"):
+        resp = authed_client.post(
+            "/v1/notebooks/nb-1/sources/wait",
+            content=f'{{"source_ids": ["s"], "timeout": {bad}}}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code in (400, 422), (bad, resp.status_code)
+
+
+def test_wait_non_finite_interval_is_rejected(authed_client: TestClient) -> None:
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait",
+        content='{"source_ids": ["s"], "interval": Infinity}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code in (400, 422)
+
+
+def test_wait_timeout_over_max_is_400(authed_client: TestClient) -> None:
+    from notebooklm.server.routes.sources import MAX_WAIT_TIMEOUT
+
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait",
+        json={"source_ids": ["s"], "timeout": MAX_WAIT_TIMEOUT + 1},
+    )
+    assert resp.status_code == 400
+
+
+def test_wait_explicit_empty_source_ids_is_400(authed_client: TestClient) -> None:
+    # An explicit empty list would return immediate ok:true (false-ready if a
+    # caller serialized "all" as []). Reject it; omitting source_ids waits all.
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"source_ids": []})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from notebooklm._types.sources import Source
 from notebooklm.rpc.types import SourceStatus
+from notebooklm.server._pagination import MAX_LIMIT
 
 from .fakes import FakeClient
 
@@ -254,9 +255,94 @@ def test_list_and_delete(authed_client: TestClient, fake_client: FakeClient) -> 
     }
     listed = authed_client.get("/v1/notebooks/nb-1/sources")
     assert listed.status_code == 200
-    assert listed.json()["sources"][0]["id"] == "src-7"
+    row = listed.json()["sources"][0]
+    assert row["id"] == "src-7"
+    # Shared view: string kind + status_label alongside the raw status int.
+    assert row["status_label"] == "ready"
+    assert "kind" in row
+    # Default (no limit) stays unbounded, no meta block.
+    assert "meta" not in listed.json()
 
     deleted = authed_client.delete("/v1/notebooks/nb-1/sources/src-7")
     assert deleted.status_code == 204
     # Idempotent re-delete.
     assert authed_client.delete("/v1/notebooks/nb-1/sources/src-7").status_code == 204
+
+
+def test_get_source_carries_kind_and_status_label(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.sources_store["nb-1"] = {
+        "src-9": Source(id="src-9", title="Doc", status=SourceStatus.READY)
+    }
+    resp = authed_client.get("/v1/notebooks/nb-1/sources/src-9")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == "src-9"
+    assert body["status_label"] == "ready"
+    assert "kind" in body
+
+
+def test_source_list_pagination_slices_and_adds_meta(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.sources_store["nb-1"] = {
+        f"src-{i}": Source(id=f"src-{i}", title=f"S{i}", status=SourceStatus.READY)
+        for i in range(5)
+    }
+    resp = authed_client.get("/v1/notebooks/nb-1/sources", params={"limit": 2, "offset": 1})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["notebook_id"] == "nb-1"
+    assert len(body["sources"]) == 2
+    assert body["meta"] == {"total": 5, "has_more": True, "limit": 2, "offset": 1}
+
+
+def test_source_list_bad_limit_is_422(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.sources_store["nb-1"] = {
+        "src-1": Source(id="src-1", title="S", status=SourceStatus.READY)
+    }
+    assert authed_client.get("/v1/notebooks/nb-1/sources", params={"limit": 0}).status_code == 422
+    assert authed_client.get("/v1/notebooks/nb-1/sources", params={"offset": -1}).status_code == 422
+
+
+def test_source_list_limit_over_max_is_422(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.sources_store["nb-1"] = {
+        "src-1": Source(id="src-1", title="S", status=SourceStatus.READY)
+    }
+    over = authed_client.get("/v1/notebooks/nb-1/sources", params={"limit": MAX_LIMIT + 1})
+    assert over.status_code == 422
+    at_cap = authed_client.get("/v1/notebooks/nb-1/sources", params={"limit": MAX_LIMIT})
+    assert at_cap.status_code == 200
+
+
+def test_source_list_offset_without_limit_is_rejected(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.sources_store["nb-1"] = {
+        f"src-{i}": Source(id=f"src-{i}", title=f"S{i}", status=SourceStatus.READY)
+        for i in range(3)
+    }
+    # offset>0 with no limit is an ambiguous window → 400, not silently ignored.
+    rejected = authed_client.get("/v1/notebooks/nb-1/sources", params={"offset": 2})
+    assert rejected.status_code == 400
+    assert rejected.json()["error"]["category"] == "validation"
+    # offset=0 with no limit is the unchanged full-list default (no meta).
+    full = authed_client.get("/v1/notebooks/nb-1/sources", params={"offset": 0})
+    assert full.status_code == 200
+    body = full.json()
+    assert len(body["sources"]) == 3
+    assert "meta" not in body
+
+
+def test_add_url_returns_enriched_view(authed_client: TestClient) -> None:
+    # The create path projects the shared enriched view (string kind /
+    # status_label), matching GET rather than leaking bare integer codes.
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/url", json={"url": "https://example.com"})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "kind" in body
+    assert "status_label" in body
+    assert body["status_label"] == "processing"

--- a/tests/unit/app/test_app_errors.py
+++ b/tests/unit/app/test_app_errors.py
@@ -8,7 +8,13 @@ import pytest
 
 from notebooklm import exceptions as exc
 from notebooklm._app.download import DownloadPlanValidationError
-from notebooklm._app.errors import ClassifiedError, ErrorCategory, classify
+from notebooklm._app.errors import (
+    CATEGORY_HINTS,
+    ClassifiedError,
+    ErrorCategory,
+    classify,
+    is_retriable,
+)
 from notebooklm._app.source_add import SourceAddValidationError
 from notebooklm._app.source_mutations import SourceMutationError
 
@@ -253,3 +259,42 @@ def test_retriable_only_for_transient_categories() -> None:
         result = classify(sample)
         assert result.category is category
         assert result.retriable is (category in transient)
+
+
+def test_classify_retriable_delegates_to_is_retriable() -> None:
+    """``classify`` reads retriability from ``is_retriable`` (single source of truth).
+
+    Rather than re-inlining ``category in _RETRIABLE_CATEGORIES``, ``classify``
+    must agree with :func:`is_retriable` for both transient and deterministic
+    exceptions — so the two never drift.
+    """
+    samples = [
+        exc.RateLimitError("x"),
+        exc.ServerError("x"),
+        exc.NetworkError("x"),
+        exc.AuthError("x"),
+        exc.ValidationError("x"),
+        ValueError("x"),
+    ]
+    for sample in samples:
+        result = classify(sample)
+        assert result.retriable is is_retriable(result.category)
+
+
+def test_category_hints_are_surface_neutral() -> None:
+    """The shared REST+MCP hints must not name a specific tool or CLI command.
+
+    ``CATEGORY_HINTS`` is consumed by BOTH the MCP projector and the REST error
+    body, so a hint that names ``studio_status`` or ``notebooklm login`` would be
+    wrong on the other surface. Guards the F2 neutralization.
+    """
+    banned = ("studio_status", "notebooklm ", "`")
+    for category, hint in CATEGORY_HINTS.items():
+        if hint is None:
+            continue
+        for token in banned:
+            assert token not in hint, (
+                f"{category} hint leaks surface-specific token {token!r}: {hint}"
+            )
+    assert CATEGORY_HINTS[ErrorCategory.AUTH] == "Re-authenticate and retry."
+    assert "task status" in CATEGORY_HINTS[ErrorCategory.ARTIFACT_TIMEOUT]

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -287,7 +287,7 @@ def test_redact_exact_output_for_multi_path_prose() -> None:
 def test_redact_home_pattern_capture_group_is_only_the_prefix() -> None:
     """The ``\\1`` capture is just the ``/home/`` prefix — the username is the part
     dropped, not coincidentally preserved (gemini #1695 testing guidance)."""
-    from notebooklm.mcp._errors import _EXTRA_PATTERNS
+    from notebooklm._redact import _EXTRA_PATTERNS
 
     home_pattern = _EXTRA_PATTERNS[1][0]
     m = home_pattern.search("Could not find /home/alice")

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -505,6 +505,9 @@ def test_upload_post_missing_filename_defaults_to_extensioned_name(mock_client, 
     [
         ("a\x00b.pdf", "ab.pdf"),  # NUL stripped (would make os.open raise)
         ("a\x01\x1fb.pdf", "ab.pdf"),  # other control chars stripped too
+        ("a\x7fb.pdf", "ab.pdf"),  # DEL stripped
+        ("a\x85b.pdf", "ab.pdf"),  # C1 control (NEL) stripped
+        ("a\x80\x9fb.pdf", "ab.pdf"),  # C1 range stripped
         ("..", "upload.bin"),  # directory cursor → safe default
         (".", "upload.bin"),
         ("", "upload.bin"),
@@ -517,6 +520,16 @@ def test_safe_upload_name_hardening(raw, expected) -> None:
     # Security: odd filenames must normalize to a harmless leaf, never reach
     # os.open as a NUL/cursor name (which would 500).
     assert _fileroutes._safe_upload_name(raw) == expected
+
+
+def test_safe_upload_name_truncates_by_bytes_preserving_extension() -> None:
+    # A multibyte name (emoji = 4 UTF-8 bytes each) must be clipped to the 255-BYTE
+    # filesystem basename limit, not merely 255 characters, and keep its extension.
+    name = _fileroutes._safe_upload_name("😀" * 300 + ".pdf")
+    assert len(name.encode("utf-8")) <= 255
+    assert name.endswith(".pdf")
+    # No partial multibyte char survives the byte clip.
+    assert name.encode("utf-8").decode("utf-8") == name
 
 
 def test_upload_dotdot_filename_defaults_cleanly_not_500(mock_client, config) -> None:


### PR DESCRIPTION
## What & why

The experimental REST server (`src/notebooklm/server/`) lagged the mature MCP server despite both being thin adapters over the same `_app/` core. A 4-lens gap review (2 Claude + Codex + agy — committed at `docs/notes/rest-vs-mcp-gap-review-2026-07-02.md`) found the gap was **almost entirely one-directional**: REST lacked ~11 capabilities MCP had (and was the softer target on safety), while MCP lacked ~zero that REST had. This PR closes those gaps and lifts the shared projections into `_app/` so **both** adapters share one implementation (Option B), rather than REST duplicating MCP's helpers.

Planned + reviewed with oracle+momus across claude/codex/agy (2 rounds to convergence); each phase went through a claude+codex+agy triple-review polish gate before commit.

## What shipped

**Shared `_app` lifts** (MCP refactored onto them — output byte-identical, pinned by tests):
- `notebooklm/_redact.py` — home-path / signed-token redaction (both adapters)
- `_app/views.py` — share enum→label, `source_view` (`kind`/`status_label`), `ask_result_view` (strips `raw_response`)
- `_app/pagination.py` — pure slice + bound validation
- `_app.source_content.execute_source_read`, `_app.source_add.safe_upload_name`, `_app.research.poll_sources_for_import`, `_app.errors.CATEGORY_HINTS` + `is_retriable`

**REST — new capability (17 endpoints):** source-content read; deep-research router (start/status/cancel/import); `chat/configure`; studio `DELETE`/`retry`; PATCH renames (notebook/source/artifact); `sources/wait`; `suggested-prompts`; `/server/info`; artifact prompt; `sources/drive` + `sources/batch`; per-kind generate-option validation + mind-map `instructions` forwarding; opt-in **non-breaking** pagination.

**REST — hardening (parity with MCP):** uniform `{category, message, retriable, hint}` errors + home-path redaction; `--token` argv refusal (`--token-file`/env only); loopback enforced on the unspoofable peer address (`request.client.host`, `proxy_headers` off); multipart `Content-Length` 411 gate; disconnect-safe download cleanup; `notify` default flipped to `false`.

> Sharing **widening-confirm** is intentionally deferred — it landed MCP-side in #1748; a follow-up can share that gate via `_app` so REST and MCP use one idiom. Fail-loud `chat_configure` (#1744) and the research reliability work (#1741) are already inherited through the shared cores.

## Verification
- Full suite: **11,515 passed** (2 failures are `--extra browser`/playwright env-only, proven passing against the same code with playwright present).
- ruff + mypy clean; module-size, server-boundary, and architecture-freshness guardrails green.
- Rebased onto current `main` (past the #1741/#1744/#1748 MCP work) — no conflicts, semantics re-verified.

## Review notes
Each phase's triple review caught and fixed real bugs before commit: uppercase-full-UUID mind-map mis-route on PATCH/DELETE, batch swallowing shared auth/notebook failures, non-finite `wait` timeout, a `GenerationState` enum/str `.value` crash, and a half-applied error contract on hand-raised HTTP errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional pagination (`limit`/`offset` with `meta`) to notebook, source, note, and artifact list endpoints.
  * Expanded REST functionality: notebook rename & suggested prompts, source content read & wait, batch URL add & Drive source add, chat configuration, research workflows, and richer artifact management (prompt/rename/retry/delete/download).
  * Added `GET /server/info` (with optional account details).

* **Bug Fixes**
  * Standardized REST error responses with consistent categories, `retriable`, and optional `hint`, with tightened message redaction.
  * Hardened auth and uploads (token-file support, loopback checks, stricter multipart `Content-Length` handling); share notifications now default to off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->