### PR TITLE
fix(mcp): catch upload mkdtemp OSError → clean 500, not raw 500 (#1754)

### DIFF
--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -481,7 +481,23 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 raw_mime = payload.get("mime") or request.headers.get("content-type")
                 mime = raw_mime.split(";")[0].strip() if raw_mime else None
 
-                temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
+                try:
+                    temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
+                except OSError:
+                    # Temp-dir creation failed (e.g. ENOSPC) — the exact temp-disk
+                    # exhaustion the concurrency cap guards against. mkdtemp sits OUTSIDE
+                    # the spool ``try`` below (whose ``except OSError`` maps a bad
+                    # *filename* to a 400), so without this its OSError would escape as a
+                    # raw Starlette 500. A failed dir-create is a SERVER storage problem,
+                    # not bad input, so 500 (mirrors the download route's status) — kept
+                    # distinct from the 400 os.open path. Accounting stays safe: the outer
+                    # finallys release the slot + roll back the jti; no dir was made, so
+                    # nothing to clean.
+                    return PlainTextResponse(
+                        "Upload could not be stored (server storage error).",
+                        status_code=500,
+                        headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+                    )
                 temp_path = os.path.join(temp_dir, filename)
                 try:
                     fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -704,6 +704,38 @@ def test_upload_midstream_413_does_not_burn_jti(monkeypatch, mock_client, config
     assert retried.status_code == 200  # mid-stream 413 rolled the claim back
 
 
+def test_upload_mkdtemp_failure_is_clean_500_releases_slot_and_frees_jti(
+    monkeypatch, mock_client, config
+) -> None:
+    # ``mkdtemp`` raising (ENOSPC — the temp-disk exhaustion the cap guards against)
+    # sits OUTSIDE the spool ``try`` whose ``except OSError`` maps a bad filename to a
+    # 400, so without its own catch it escaped as a RAW Starlette 500. This uses the
+    # DEFAULT TestClient (``raise_server_exceptions=True``): an uncaught OSError would
+    # be re-raised here (failing the test), so a returned 500 proves it is now caught.
+    # It must also release the slot and — being a non-use of the token — roll the jti
+    # back so the same link is retryable.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    real_mkdtemp = _fileroutes.tempfile.mkdtemp
+
+    def boom(*_a, **_k):
+        raise OSError("No space left on device")
+
+    before = _fileroutes._inflight_uploads
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        monkeypatch.setattr(_fileroutes.tempfile, "mkdtemp", boom)
+        failed = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+        monkeypatch.setattr(_fileroutes.tempfile, "mkdtemp", real_mkdtemp)
+        retried = client.post(_path(url) + "?filename=a.pdf", content=b"DATA")
+    assert failed.status_code == 500  # clean caught 500, not a raised uncaught exception
+    assert "server storage error" in failed.text  # our message, not raw "Internal Server Error"
+    assert _fileroutes._inflight_uploads == before  # slot released
+    assert retried.status_code == 200  # jti rolled back → same link retryable
+    add_file.assert_awaited_once()  # failed attempt short-circuited before the add; only retry added
+
+
 def test_download_multi_use_range_resume_preserved(monkeypatch, mock_client, config) -> None:
     # RANGE/RESUME GUARDRAIL: dl tokens stay multi-use so a resumed download (a second
     # GET, e.g. a Range reconnect) is not 403'd. Do NOT regress this — any future dl


### PR DESCRIPTION
## Summary
- The `/files/ul` upload POST/PUT route called `tempfile.mkdtemp()` **outside** the inner spool `try` (whose `except OSError` maps a bad *filename* to a 400), so an `OSError` there (e.g. ENOSPC) escaped as a **raw Starlette 500**.
- Wrap `mkdtemp` in its own `except OSError` returning a clean, header-bearing **500** — a failed dir-create is a server storage problem, not bad input, so it stays distinct from the 400 `os.open` path. `500` (not `507`) because `OSError ⊋ ENOSPC` and it matches the download route's status for the same failure.
- Accounting was already safe — the outer `finally`s release the concurrency slot and roll back the single-use `jti`; the early `return` unwinds through both.

Fixes #1754.

## Test plan
- [x] New `test_upload_mkdtemp_failure_is_clean_500_releases_slot_and_frees_jti` — asserts the caught 500 + body, slot release (`_inflight_uploads` restored), and jti rollback (same link retried → 200). Uses the **default** `TestClient` (`raise_server_exceptions=True`), so an uncaught `OSError` would be re-raised — proving the exception is now genuinely caught.
- [x] Verified the test **fails** against unfixed `main` (raw `OSError` propagates) and **passes** with the fix.
- [x] `tests/unit/mcp/` (706 passed), ruff, mypy, module-size + mcp-boundary guardrails all green.

## Deferred polish findings (out of scope for this minimal fix)
- The **download** route (`/files/dl`) has the same latent `mkdtemp`→raw-500 (its outer `finally` only releases the slot). Symmetry fix is a reasonable follow-up; not changed here to keep the fix minimal and #1754-scoped.
- The sibling `os.open`→400 path omits the `no-store`/`no-referrer` headers the new 500 response carries — a pre-existing inconsistency, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xay22TTv3tDvaLStyha2PL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload failures caused by temporary storage creation issues now return a clear server error instead of being mistaken for a client-side processing problem.
  * Upload retries are handled more reliably when a temporary storage error occurs, with upload slots and one-time tokens properly reset.
* **Tests**
  * Added coverage for failed upload storage creation and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->