### PR TITLE
fix(mcp): catch download mkdtemp OSError → clean 500, not raw 500 (#1771)

### DIFF
--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -329,7 +329,21 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         temp_dir: str | None = None
         success = False
         try:
-            temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
+            try:
+                temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-dl-")
+            except OSError:
+                # Temp-dir creation failed (e.g. ENOSPC) — the exact temp-disk
+                # exhaustion this cap defends against. Scoped to mkdtemp ONLY (not the
+                # whole try) so it stays distinct from the post-fetch paths; without it
+                # the OSError escapes as a RAW Starlette 500 (the outer finally still
+                # releases the slot, but the response is bare). Return a clean 500,
+                # mirroring the upload route. No dir was created, so the outer finally's
+                # temp_dir cleanup is a no-op and success stays False → slot released.
+                return PlainTextResponse(
+                    "Download could not be prepared (server storage error).",
+                    status_code=500,
+                    headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
+                )
             temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
             try:
                 args: dict[str, object] = {

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -150,9 +150,13 @@ def test_download_error_releases_slot(monkeypatch, mock_client, config) -> None:
     assert _fileroutes._inflight_downloads == before
 
 
-def test_download_mkdtemp_failure_releases_slot(monkeypatch, mock_client, config) -> None:
-    # ``mkdtemp`` raising (ENOSPC — the very temp-disk exhaustion this cap guards
-    # against) must NOT leak the slot: it runs inside the counter's ``try``/``finally``.
+def test_download_mkdtemp_failure_is_clean_500_releases_slot(
+    monkeypatch, mock_client, config
+) -> None:
+    # ``mkdtemp`` raising (ENOSPC — the temp-disk exhaustion this cap guards against)
+    # must be a CLEAN caught 500 (not a raw Starlette 500) AND must not leak the slot.
+    # Uses the DEFAULT TestClient (``raise_server_exceptions=True``): an uncaught OSError
+    # would be re-raised here, so a returned 500 proves the exception is now caught.
     def boom(*_a, **_k):
         raise OSError("No space left on device")
 
@@ -160,10 +164,11 @@ def test_download_mkdtemp_failure_releases_slot(monkeypatch, mock_client, config
     before = _fileroutes._inflight_downloads
     app = _build(mock_client, config)
     url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
-    with starlette_testclient.TestClient(app, raise_server_exceptions=False) as client:
+    with starlette_testclient.TestClient(app) as client:
         resp = client.get(_path(url))
     assert resp.status_code == 500
-    assert _fileroutes._inflight_downloads == before
+    assert "server storage error" in resp.text  # clean body, not raw "Internal Server Error"
+    assert _fileroutes._inflight_downloads == before  # slot released
 
 
 def test_download_post_fetch_exception_cleans_temp_and_releases_slot(


### PR DESCRIPTION
## Summary
- Symmetry follow-up to #1770. The `/files/dl` download route called `tempfile.mkdtemp(prefix="nblm-mcp-dl-")` inside a `try` whose only handlers were `except ValidationError`/`except NotebookLMError` + a `finally` (slot release) — so an `OSError` there (e.g. ENOSPC) escaped as a **raw Starlette 500**.
- Wrap **only** `mkdtemp` in a nested `except OSError` returning a clean, header-bearing **500** (`Cache-Control: no-store` + `Referrer-Policy: no-referrer`), mirroring the upload route. Scoped to `mkdtemp` so post-fetch OSErrors (`FileResponse` init, path resolution) keep their existing path — **not** swallowed.
- The early `return` still unwinds the outer `finally` (`success=False` → slot released; `temp_dir` stays `None` → cleanup no-op), so slot accounting is unchanged.

Fixes #1771.

## Test plan
- [x] Renamed `test_download_mkdtemp_failure_releases_slot` → `_is_clean_500_releases_slot`; now asserts the caught 500 **body** (`"server storage error"`) + slot release via the **default** `TestClient` (`raise_server_exceptions=True`), so an uncaught `OSError` would be re-raised — proving the exception is now caught.
- [x] Verified the test **fails** against `main` (raw `OSError` propagates) and **passes** with the fix.
- [x] `tests/unit/mcp/` (706 passed), ruff, mypy (confirms `temp_dir` narrowing holds), module-size + mcp-boundary guardrails all green.

## Deferred polish findings (out of scope)
- The upload (#1770) and download mkdtemp guards are now near-duplicates; a shared helper is a possible future DRY refactor, not done here to keep the fix minimal.
- agy raised a hypothetical "a *stricter* mypy config might not narrow `temp_dir`" → add `assert temp_dir is not None`. This repo's mypy passes clean and both other reviewers confirmed the narrowing; the assert would be redundant dead code, so not added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xay22TTv3tDvaLStyha2PL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download failure handling when temporary storage cannot be created, returning a clearer 500 response instead of an unhandled server error.
  * Added safer cleanup so active download tracking is released correctly even when the download cannot start.
  * Included coverage for the storage-failure path to confirm the response remains user-friendly and the service state stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->