### PR TITLE
fix(mcp): resolve OAuth state_path from the active profile, not raw env (#1765)

### DIFF
--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -243,7 +243,8 @@ def main(argv: list[str] | None = None) -> None:
         # optional self-hosted OAuth (claude.ai) are both env-driven; get_oauth_config()
         # raises on partial/weak/non-https config (fail closed).
         token = get_configured_token()
-        oauth_config = get_oauth_config()
+        # Bind OAuth state persistence to the SAME profile the server drives (#1765).
+        oauth_config = get_oauth_config(profile=args.profile)
         _check_http_auth_required(host, token, oauth_config)
         oauth = build_oauth_provider(oauth_config) if oauth_config else None
         # Optional remote file transfer: built only here (http path), validated, and

--- a/src/notebooklm/mcp/_oauth.py
+++ b/src/notebooklm/mcp/_oauth.py
@@ -477,14 +477,17 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
             "r2a": dict(self._refresh_to_access_map),
         }
         try:
+            # Persistence is on by default now (#1765) and this dir may be created here
+            # before any `login`, so create it 0700 (like get_profile_dir) — a full-account
+            # secret must not be group/other-listable. `mode=` secures it AT creation, with
+            # no create→chmod TOCTOU window. We deliberately do NOT chmod an existing dir:
+            # on a shared/bind-mounted NOTEBOOKLM_HOME the server may not own it, and a
+            # failed chmod inside this try would abort the write and drop state on restart.
             parent = self._state_path.parent
-            parent.mkdir(parents=True, exist_ok=True)
-            # Persistence is on by default now (#1765), so this dir may be created here
-            # before any `login`. oauth_state.json is a full-account secret, so hold the
-            # profile dir to the same 0700 invariant get_profile_dir enforces — a bare
-            # umask mkdir could leave it group/other-listable.
             if os.name == "posix":
-                parent.chmod(0o700)
+                parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            else:
+                parent.mkdir(parents=True, exist_ok=True)
             atomic_write_json(self._state_path, data)  # POSIX-atomic, 0600, filelock
         except OSError as exc:  # disk error must not crash an active server
             logger.warning("Could not persist OAuth state to %s: %s", self._state_path, exc)

--- a/src/notebooklm/mcp/_oauth.py
+++ b/src/notebooklm/mcp/_oauth.py
@@ -77,6 +77,7 @@ from starlette.responses import HTMLResponse, RedirectResponse, Response
 from starlette.routing import Route
 
 from notebooklm._atomic_io import atomic_write_json
+from notebooklm.paths import get_profile_dir
 
 from ._urlcheck import _validate_bare_https_origin
 
@@ -141,15 +142,27 @@ class OAuthConfig:
     trust_proxy: bool = field(default=False)
 
 
-def get_oauth_config() -> OAuthConfig | None:
+def get_oauth_config(profile: str | None = None) -> OAuthConfig | None:
     """Resolve the OAuth config from env, or ``None`` when OAuth is off.
 
     OFF when neither var is set. When EITHER is set the user intends OAuth, so BOTH
     are required (fail closed), the password must clear a strength bar, and the base
     URL must be https (the MCP SDK rejects non-HTTPS non-localhost issuers anyway).
 
+    ``state_path`` (where issued tokens + registered clients persist, 0600) is
+    resolved through the SAME canonical profile resolver the client runtime uses
+    (:func:`notebooklm.paths.get_profile_dir`), so it always tracks the profile the
+    server actually drives — the ``--profile`` flag, ``NOTEBOOKLM_PROFILE``, the
+    ``notebooklm use``-set active profile, or the ``~/.notebooklm`` home default
+    (#1765). Pass ``profile`` to bind an explicit one; ``None`` resolves the active
+    profile.
+
+    Args:
+        profile: Explicit auth profile to persist OAuth state under. ``None``
+            resolves the active profile via the standard precedence.
+
     Raises:
-        SystemExit: partial/invalid config (clear message).
+        SystemExit: partial/invalid config, or a malformed ``profile`` name.
     """
     password = os.environ.get(OAUTH_PASSWORD_ENV) or ""
     base_url = (os.environ.get(OAUTH_BASE_URL_ENV) or "").strip()
@@ -174,11 +187,15 @@ def get_oauth_config() -> OAuthConfig | None:
     # fine.) The same check guards the file-transfer base URL — shared helper.
     _validate_bare_https_origin(base_url, OAUTH_BASE_URL_ENV)
 
-    state_path: Path | None = None
-    home = os.environ.get("NOTEBOOKLM_HOME")
-    profile = os.environ.get("NOTEBOOKLM_PROFILE")
-    if home and profile:
-        state_path = Path(home) / "profiles" / profile / "oauth_state.json"
+    # Persist OAuth state under the SAME profile dir the client runtime drives —
+    # not a separate raw-env derivation that silently diverged (#1765). Honors the
+    # --profile flag / NOTEBOOKLM_PROFILE / active profile / ~/.notebooklm default.
+    try:
+        state_path: Path = get_profile_dir(profile) / "oauth_state.json"
+    except ValueError as exc:
+        # Malformed profile name (e.g. path traversal). Fail clean on the http
+        # startup path instead of leaking a traceback.
+        raise SystemExit(str(exc)) from exc
 
     # Opt-in trusted-proxy: only reached once OAuth is fully configured, so it never
     # fires on the OAuth-off path. Default off keeps the throttle keyed on the socket peer.
@@ -460,7 +477,14 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
             "r2a": dict(self._refresh_to_access_map),
         }
         try:
-            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            parent = self._state_path.parent
+            parent.mkdir(parents=True, exist_ok=True)
+            # Persistence is on by default now (#1765), so this dir may be created here
+            # before any `login`. oauth_state.json is a full-account secret, so hold the
+            # profile dir to the same 0700 invariant get_profile_dir enforces — a bare
+            # umask mkdir could leave it group/other-listable.
+            if os.name == "posix":
+                parent.chmod(0o700)
             atomic_write_json(self._state_path, data)  # POSIX-atomic, 0600, filelock
         except OSError as exc:  # disk error must not crash an active server
             logger.warning("Could not persist OAuth state to %s: %s", self._state_path, exc)
@@ -509,15 +533,9 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
 def build_oauth_provider(config: OAuthConfig) -> AuthProvider:
     """Build the self-hosted OAuth provider from validated config.
 
-    Runs once at HTTP-server startup. Warns (once) when OAuth is enabled but state is not
-    persisted — issued tokens + registered clients then live in memory only and a restart
-    silently forces every client to re-register and the owner to re-login."""
-    if config.state_path is None:
-        logger.warning(
-            "OAuth is enabled but state is not persisted (set NOTEBOOKLM_HOME and "
-            "NOTEBOOKLM_PROFILE); issued tokens and registered clients are in-memory only "
-            "and a restart forces re-login."
-        )
+    Runs once at HTTP-server startup. ``config.state_path`` is resolved by
+    :func:`get_oauth_config` under the active profile dir, so issued tokens +
+    registered clients persist (0600) across restarts by default (#1765)."""
     return SelfHostedOAuthProvider(
         password=config.password,
         base_url=config.base_url,

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -109,6 +109,33 @@ def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch)
     assert captured["auth"] is None
 
 
+def test_http_threads_profile_into_oauth_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1765 regression guard: the ``--profile`` flag must reach ``get_oauth_config`` so
+    OAuth state persists under the profile the server actually drives. Without this, the
+    entrypoint could silently regress to ``get_oauth_config()`` and the direct unit test
+    would still pass."""
+    seen: dict[str, object] = {}
+
+    def spy_get_oauth_config(profile: str | None = None):
+        seen["profile"] = profile
+        return None  # OAuth off → loopback needs no auth, so main() proceeds
+
+    monkeypatch.setattr(entry, "get_oauth_config", spy_get_oauth_config)
+    monkeypatch.setattr(
+        entry,
+        "create_server",
+        lambda *, profile=None, client_factory=None, auth=None, file_transfer=None: MagicMock(),
+    )
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", raising=False)
+
+    entry.main(
+        ["--transport", "http", "--host", "127.0.0.1", "--port", "8124", "--profile", "work"]
+    )
+
+    assert seen["profile"] == "work"
+
+
 def test_http_default_port_is_9420(monkeypatch: pytest.MonkeyPatch) -> None:
     """The default HTTP port is 9420 (no --port / NOTEBOOKLM_MCP_PORT)."""
     fake_server = MagicMock()

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -125,6 +125,30 @@ def test_config_ok_with_state_path(_clear_env: None, monkeypatch: pytest.MonkeyP
     assert cfg.state_path.parts[-3:] == ("profiles", "server", "oauth_state.json")
 
 
+def test_config_state_path_honors_profile_without_env(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1765: state_path resolves through the canonical profile resolver. An explicit
+    profile (the --profile flag) is honored even when NOTEBOOKLM_PROFILE is unset (the
+    old code read env only and ignored it), and with NOTEBOOKLM_HOME also unset it still
+    resolves to a real path under the default home instead of silently going None."""
+    monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
+    monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
+    cfg = get_oauth_config(profile="work")  # no HOME/PROFILE env set
+    assert cfg is not None and cfg.state_path is not None
+    assert cfg.state_path.parts[-3:] == ("profiles", "work", "oauth_state.json")
+
+
+def test_config_rejects_malformed_profile(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path-traversal profile name fails clean (SystemExit), not a raw traceback."""
+    monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
+    monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
+    with pytest.raises(SystemExit):
+        get_oauth_config(profile="../escape")
+
+
 # --------------------------------------------------------------------------- routes / DCR
 def test_provider_routes_include_login_and_register() -> None:
     p = _provider()
@@ -406,24 +430,13 @@ def test_throttle_separates_buckets_by_cf_header_when_trusted() -> None:
             assert r.status_code == 401  # never 429 — each IP has only one failure
 
 
-# --------------------------------------------------------------------------- #1761 startup warning
-def test_build_oauth_provider_warns_when_state_not_persisted(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """OAuth on but state_path None → one startup WARNING naming the persistence env vars."""
-    cfg = OAuthConfig(password=_PW, base_url="https://h.example.com", state_path=None)
-    with caplog.at_level(logging.WARNING, logger="notebooklm.mcp._oauth"):
-        provider = build_oauth_provider(cfg)
-    assert isinstance(provider, SelfHostedOAuthProvider)
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert "NOTEBOOKLM_HOME" in warnings[0].message and "NOTEBOOKLM_PROFILE" in warnings[0].message
-
-
-def test_build_oauth_provider_no_warn_when_state_persisted(
+# --------------------------------------------------------------------------- build_oauth_provider
+def test_build_oauth_provider_wires_state_without_warning(
     tmp_path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """With a state_path set, the non-persistence warning must NOT fire."""
+    """#1765: state_path now always resolves (get_oauth_config binds it to the active
+    profile dir), so build_oauth_provider just wires it through — the old "state not
+    persisted" startup warning was removed and must not fire."""
     cfg = OAuthConfig(
         password=_PW, base_url="https://h.example.com", state_path=tmp_path / "oauth_state.json"
     )


### PR DESCRIPTION
## Summary
`get_oauth_config()` derived the self-hosted-OAuth `state_path` from raw `NOTEBOOKLM_HOME` + `NOTEBOOKLM_PROFILE`, requiring **both** set — otherwise `state_path=None` and OAuth state (issued tokens + registered clients) was never persisted. This silently diverged from the profile the server actually drives:
- the `--profile` flag was ignored (env-only),
- a `notebooklm use`-set active profile (config `default_profile`) was ignored,
- with `NOTEBOOKLM_HOME` unset (the common case), state was **never persisted** — every restart forced re-login.

Fix: resolve `state_path` through the canonical `get_profile_dir(profile)` — the same resolver `from_storage()` uses — and thread `args.profile` in from the entrypoint. OAuth state now tracks the active profile across all four resolution paths.

## Notes
- **Default-persistence flip (intended):** `state_path` now always resolves, so `oauth_state.json` (a full-account secret) persists by default. The docker-compose deploy (sets both env vars) resolves to the **same** path — no data-loss regression. `_save_state` now holds the profile dir to the `0700` invariant `get_profile_dir` enforces, since persistence can now create the dir before any `login`.
- The dead "state not persisted" startup warning (it named `NOTEBOOKLM_HOME`/`NOTEBOOKLM_PROFILE`) is removed — `state_path` never resolves to `None` now.
- A malformed `--profile` (path traversal) fails clean (`SystemExit`) instead of a traceback on the http-startup path.

## Scope
Only #1765 (mcp-only). **#1768** is superseded by #1767 (`_reject_argv_token` + `--token-file`). **#1769** (REST `--profile` + shared bind-guard dedup) is deferred until #1767 merges — it rewrites the same `server/__main__.py` regions.

## Test plan
- [x] `test_config_state_path_honors_profile_without_env` — explicit `--profile` honored with `NOTEBOOKLM_PROFILE`/`NOTEBOOKLM_HOME` unset, non-None path (old code returned None here)
- [x] `test_config_rejects_malformed_profile` — path-traversal profile → `SystemExit`
- [x] `test_http_threads_profile_into_oauth_config` — regression guard: `--profile` reaches `get_oauth_config` via `main()`
- [x] existing `test_config_ok_with_state_path` (env path) still green; warning tests reconciled
- [x] mypy + ruff clean; full mcp unit suite (707) + doc-freshness guardrails green

## Deferred polish findings
- Unit test for `get_oauth_config(profile=None)` → config `default_profile` fall-through (covered transitively by `resolve_profile` tests in `test_paths.py`).
- Write/reload round-trip assertion for the HOME-unset case (this PR changes path *resolution* only; persistence round-trip is covered by existing provider tests).

Closes #1765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth sign-in state now persists under the selected server profile, ensuring correct behavior when using `--profile`.
  * Invalid or malformed profile names now fail cleanly during startup.
  * Strengthened permissions for the directory that stores sensitive OAuth state.

* **Tests**
  * Added regression coverage to verify the HTTP entrypoint passes the selected profile into OAuth config.
  * Added unit tests for canonical profile-based state path resolution and updated OAuth persistence expectations.

* **Documentation**
  * Updated OAuth provider guidance to reflect that token/client state persistence is enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->