### PR TITLE
feat(version): embed build commit in version string (closes #1758)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ downloads/
 
 # Local working notes (process scratch — not shipped)
 docs/scratch/
+
+# Baked into the wheel by hatch_build.py; never committed.
+src/notebooklm/_commit.py

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -964,6 +964,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_url_utils.py`, `urls.py` | URL parsing/validation internals and the public URL helper facade |
 | `_sharing_manager.py` | Direct sharing management logic |
 | `_version_check.py` | Dynamic client-side version deprecation guard |
+| `_version_info.py` | Human-facing `version_string()` — package version + short git commit (embedded by `hatch_build.py` at build time, or live `git` from a checkout) |
 | `_chat/notes.py` | Chat-adjacent note saving workflow adapter |
 | `_chat/wire.py` | Streamed-chat wire request construction + response parsing for the chat client |
 | `_chat/transport.py` | Chat-specific error mapping over the shared transport pipeline |
@@ -1037,6 +1038,7 @@ src/notebooklm/
 ├── _url_utils.py                # URL validation helpers
 ├── _sharing_manager.py          # Sharing management logic
 ├── _version_check.py            # Deprecation version guard
+├── _version_info.py             # version_string(): version + short git commit
 ├── _research_task_parser.py     # Research task result-type parser
 ├── _redact.py                   # Transport-neutral secret/home-path/file-link scrubber (redact(msg, max_length)); shared chokepoint under both mcp/_errors.py and server/_errors.py
 ├── _app/                        # Transport-neutral business-logic layer (CLI/MCP/HTTP adapters share it)

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,64 @@
+"""Hatchling build hook: bake the git commit into the build as ``_commit.py``.
+
+Runs for both the sdist and the wheel so the commit survives the standard
+release path (``python -m build`` builds the wheel *from* the sdist, which has
+no ``.git``):
+
+- **sdist** (built from a checkout) embeds ``src/notebooklm/_commit.py`` into
+  the tarball, so a wheel later built from that sdist still carries the commit.
+- **wheel** (built directly from a checkout) embeds ``notebooklm/_commit.py``.
+  When built from a carried-forward sdist the hook finds no ``.git`` and skips —
+  the file the sdist carried is packaged normally.
+
+``notebooklm._version_info`` reads it back at runtime so ``--version`` /
+``server_info`` report the commit even with no ``.git`` around.
+
+Only trusts git when ``.git`` sits at the build root — mirrors the runtime
+guard so an sdist unpacked *inside another repo* can't bake in the enclosing
+repo's HEAD. Every step is best-effort: any failure → no file → bare version.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CommitBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        root = Path(self.root)
+        # Only trust git if THIS root is the repo — not an enclosing one.
+        if not (root / ".git").exists():
+            return
+        commit = _git_commit(str(root))
+        if not commit:
+            return
+        gen = root / "build" / "_commit.py"
+        try:
+            gen.parent.mkdir(parents=True, exist_ok=True)
+            gen.write_text(f'COMMIT = "{commit}"\n', encoding="utf-8")
+        except OSError:
+            return  # best-effort: read-only checkout etc. → bare version
+        # sdist keeps the src layout; wheel flattens src/notebooklm -> notebooklm.
+        dest = (
+            "src/notebooklm/_commit.py" if self.target_name == "sdist" else "notebooklm/_commit.py"
+        )
+        build_data["force_include"][str(gen)] = dest
+
+
+def _git_commit(root: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, "rev-parse", "--short=8", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -47,7 +47,7 @@ class CommitBuildHook(BuildHookInterface):
         dest = (
             "src/notebooklm/_commit.py" if self.target_name == "sdist" else "notebooklm/_commit.py"
         )
-        build_data["force_include"][str(gen)] = dest
+        build_data.setdefault("force_include", {})[str(gen)] = dest
 
 
 def _git_commit(root: str) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,9 +130,20 @@ replacement = '](https://github.com/teng-lin/notebooklm-py/blob/v$HFPR_VERSION/A
 pattern = '\]\(CONTRIBUTING\.md\)'
 replacement = '](https://github.com/teng-lin/notebooklm-py/blob/v$HFPR_VERSION/CONTRIBUTING.md)'
 
+# Bakes the build commit into _commit.py (see hatch_build.py). Registered on both
+# targets so the commit survives `python -m build` (wheel is built from the sdist).
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/notebooklm"]
 force-include = {"SKILL.md" = "notebooklm/data/SKILL.md", "AGENTS.md" = "notebooklm/data/CODEX.md"}
+# Re-include the gitignored _commit.py when the wheel is built from a
+# carried-forward sdist (the hook only runs from a checkout with .git).
+artifacts = ["src/notebooklm/_commit.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/notebooklm/_version_info.py
+++ b/src/notebooklm/_version_info.py
@@ -22,9 +22,9 @@ from pathlib import Path
 from . import __version__
 
 # src/notebooklm/_version_info.py -> parents[2] == repo root (holds .git).
-# None if the install lives too shallow to have a parents[2] (pathological).
-_parents = Path(__file__).resolve().parents
-_REPO_ROOT = _parents[2] if len(_parents) > 2 else None
+# Slice (not [2]) yields () when the install lives too shallow to have a
+# parents[2] — avoids an IndexError at import time on a pathological layout.
+_REPO_ROOT = next(iter(Path(__file__).resolve().parents[2:3]), None)
 
 
 def _embedded_commit() -> str | None:

--- a/src/notebooklm/_version_info.py
+++ b/src/notebooklm/_version_info.py
@@ -21,8 +21,10 @@ from pathlib import Path
 
 from . import __version__
 
-# src/notebooklm/_version_info.py -> parents[2] == repo root (holds .git)
-_REPO_ROOT = Path(__file__).resolve().parents[2]
+# src/notebooklm/_version_info.py -> parents[2] == repo root (holds .git).
+# None if the install lives too shallow to have a parents[2] (pathological).
+_parents = Path(__file__).resolve().parents
+_REPO_ROOT = _parents[2] if len(_parents) > 2 else None
 
 
 def _embedded_commit() -> str | None:
@@ -36,7 +38,7 @@ def _embedded_commit() -> str | None:
 
 def _live_commit() -> str | None:
     """First 8 chars of HEAD from a git checkout, or ``None``."""
-    if not (_REPO_ROOT / ".git").exists():
+    if _REPO_ROOT is None or not (_REPO_ROOT / ".git").exists():
         return None
     try:
         out = subprocess.run(

--- a/src/notebooklm/_version_info.py
+++ b/src/notebooklm/_version_info.py
@@ -1,0 +1,64 @@
+"""Human-facing version string, annotated with the short git commit.
+
+The commit resolves in two ways, in order:
+
+1. ``_commit.py`` — baked in at build time by ``hatch_build.py`` when the build
+   ran from a git checkout, so an installed package knows its commit with no
+   ``.git`` nearby (released wheels and ``pip install git+…@main`` both go
+   through that path; ``pip install .`` does too when the build backend can see
+   ``.git``).
+2. A live ``git rev-parse`` — for running straight from a source checkout
+   (editable / ``PYTHONPATH``) where the build hook never ran.
+
+Neither present (build couldn't see git) → bare version, no hash.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+from . import __version__
+
+# src/notebooklm/_version_info.py -> parents[2] == repo root (holds .git)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _embedded_commit() -> str | None:
+    """The commit baked in by the build hook, or ``None`` when absent."""
+    try:
+        from ._commit import COMMIT
+    except ImportError:
+        return None
+    return COMMIT or None
+
+
+def _live_commit() -> str | None:
+    """First 8 chars of HEAD from a git checkout, or ``None``."""
+    if not (_REPO_ROOT / ".git").exists():
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "--short=8", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None
+
+
+@lru_cache(maxsize=1)
+def version_string() -> str:
+    """``"0.8.0 (5d748a26)"`` when the commit is known, else ``"0.8.0"``."""
+    rev = _embedded_commit() or _live_commit()
+    return f"{__version__} ({rev})" if rev else __version__
+
+
+if __name__ == "__main__":  # ponytail: smallest runnable check for the branch
+    v = version_string()
+    assert v.startswith(__version__), v
+    print(v)

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -24,8 +24,8 @@ from typing import Any
 
 from fastmcp import Context
 
-from ... import __version__
 from ..._app.auth_check import AuthCheckPlan, run_auth_check
+from ..._version_info import version_string
 from ...exceptions import NotebookLMError
 from ...paths import get_active_profile, get_storage_path
 from .._confirm import READ_ONLY
@@ -140,7 +140,7 @@ def register(mcp: Any) -> None:
             result = await run_auth_check(plan, read_env_auth_json=_no_env_auth_json)
             info: dict[str, Any] = {
                 "server": SERVER_NAME,
-                "version": __version__,
+                "version": version_string(),
                 "auth": {
                     "authenticated": result.all_passed,
                     "storage_exists": bool(result.checks.get("storage_exists")),

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -91,7 +91,7 @@ _configure_windows_runtime()
 
 import click
 
-from . import __version__
+from ._version_info import version_string
 
 # Import command groups from cli package
 from .cli import (
@@ -131,7 +131,7 @@ __all__ = ["cli", "main"]
 
 
 @click.group(cls=SectionedGroup)
-@click.version_option(version=__version__, prog_name="NotebookLM CLI")
+@click.version_option(version=version_string(), prog_name="NotebookLM CLI")
 @click.option(
     "--storage",
     type=click.Path(exists=False),

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -28,9 +28,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
 
-from ... import __version__
 from ..._app.auth_check import AuthCheckPlan, run_auth_check
 from ..._redact import redact
+from ..._version_info import version_string
 from ...client import NotebookLMClient
 from ...exceptions import NotebookLMError
 from ...paths import get_active_profile, get_storage_path
@@ -117,7 +117,7 @@ async def server_info(
     result = await run_auth_check(plan, read_env_auth_json=_no_env_auth_json)
     info: dict[str, Any] = {
         "server": SERVER_NAME,
-        "version": __version__,
+        "version": version_string(),
         "auth": {
             "authenticated": result.all_passed,
             "storage_exists": bool(result.checks.get("storage_exists")),

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -17,7 +17,7 @@ import pytest
 # Skip cleanly when the `mcp` extra (fastmcp) is absent; see conftest.py.
 pytest.importorskip("fastmcp")
 
-from notebooklm import __version__  # noqa: E402 - after importorskip guard
+from notebooklm._version_info import version_string  # noqa: E402 - after importorskip guard
 from notebooklm.exceptions import RPCError  # noqa: E402 - after importorskip guard
 from notebooklm.types import (  # noqa: E402 - after importorskip guard
     AccountLimits,
@@ -54,7 +54,7 @@ def _write_authed_storage() -> None:
 async def test_server_info_reports_version(mcp_call, mock_client, tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     result = await mcp_call("server_info")
-    assert result.structured_content["version"] == __version__
+    assert result.structured_content["version"] == version_string()
     assert result.structured_content["server"] == "notebooklm"
 
 
@@ -193,7 +193,7 @@ async def test_server_info_include_account_degrades_on_rpc_error(
     assert account["email"] == "alice@example.com"
     assert account["authuser"] == 1
     # The diagnostic stays useful: version + auth block survive the degradation.
-    assert result.structured_content["version"] == __version__
+    assert result.structured_content["version"] == version_string()
     assert result.structured_content["auth"]["authenticated"] is True
 
 

--- a/tests/unit/test_version_info.py
+++ b/tests/unit/test_version_info.py
@@ -1,0 +1,46 @@
+"""Unit tests for ``version_string()`` — the version + short-commit helper.
+
+The two commit sources (build-embedded ``_commit.py`` vs. live ``git``) are
+stubbed so the three resolution outcomes are covered deterministically,
+independent of whether the test runs from a checkout or an installed wheel.
+``version_string`` is ``lru_cache``d, so each test clears the cache first.
+"""
+
+from __future__ import annotations
+
+from notebooklm import _version_info as vi
+
+
+def _reset() -> None:
+    vi.version_string.cache_clear()
+
+
+def test_embedded_commit_wins_and_skips_git(monkeypatch) -> None:
+    """The baked-in commit is used; live git is never consulted."""
+    _reset()
+    monkeypatch.setattr(vi, "_embedded_commit", lambda: "abc12345")
+    monkeypatch.setattr(vi, "_live_commit", lambda: pytest_fail_if_called())
+    assert vi.version_string() == f"{vi.__version__} (abc12345)"
+    _reset()
+
+
+def test_falls_back_to_live_git(monkeypatch) -> None:
+    """No embedded commit → the live-git commit is used."""
+    _reset()
+    monkeypatch.setattr(vi, "_embedded_commit", lambda: None)
+    monkeypatch.setattr(vi, "_live_commit", lambda: "def67890")
+    assert vi.version_string() == f"{vi.__version__} (def67890)"
+    _reset()
+
+
+def test_bare_version_when_no_commit(monkeypatch) -> None:
+    """Neither source knows the commit → bare version, no parens."""
+    _reset()
+    monkeypatch.setattr(vi, "_embedded_commit", lambda: None)
+    monkeypatch.setattr(vi, "_live_commit", lambda: None)
+    assert vi.version_string() == vi.__version__
+    _reset()
+
+
+def pytest_fail_if_called():  # pragma: no cover - only runs if the guard fails
+    raise AssertionError("_live_commit must not be called when a commit is embedded")

--- a/tests/unit/test_version_info.py
+++ b/tests/unit/test_version_info.py
@@ -19,7 +19,7 @@ def test_embedded_commit_wins_and_skips_git(monkeypatch) -> None:
     """The baked-in commit is used; live git is never consulted."""
     _reset()
     monkeypatch.setattr(vi, "_embedded_commit", lambda: "abc12345")
-    monkeypatch.setattr(vi, "_live_commit", lambda: pytest_fail_if_called())
+    monkeypatch.setattr(vi, "_live_commit", lambda: _must_not_be_called())
     assert vi.version_string() == f"{vi.__version__} (abc12345)"
     _reset()
 
@@ -42,5 +42,5 @@ def test_bare_version_when_no_commit(monkeypatch) -> None:
     _reset()
 
 
-def pytest_fail_if_called():  # pragma: no cover - only runs if the guard fails
+def _must_not_be_called():  # pragma: no cover - only runs if the guard fails
     raise AssertionError("_live_commit must not be called when a commit is embedded")


### PR DESCRIPTION
Closes #1758.

## Problem

`main` sits at `0.8.0` unreleased. When someone running `main` files a bug report, the version alone doesn't pin the commit — and a runtime-only `git` lookup fails for `pip install git+…@main` (pip builds a wheel in an isolated dir with no `.git`).

## What this does

`notebooklm --version` and MCP `server_info` now report the version **plus the short git commit** — e.g. `0.8.0 (3cfdb2f1)`.

Runtime resolution (`_version_info.version_string()`), in order:
1. `_commit.py` — baked in at build time by the `hatch_build.py` hook when the build ran from a checkout (so an installed package knows its commit with no `.git` nearby).
2. A live `git rev-parse` when running straight from a checkout.
3. Bare version when the build couldn't see git.

## Why the build hook runs for BOTH sdist and wheel

The release path is `python -m build`, which builds the wheel **from the sdist** (no `.git`). A wheel-only hook would ship bare `0.8.0` on every official release. So:
- the **sdist** (built from the checkout) embeds `src/notebooklm/_commit.py`;
- the **wheel** re-includes it via `artifacts` (overriding the gitignore) when built from that sdist.

The hook only trusts git when `.git` sits at the build root (mirrors the runtime guard), so an sdist unpacked inside another repo can't bake in the enclosing repo's HEAD. Every step is best-effort — no git / read-only tree → bare version, never a build failure.

`_commit.py` is written to a gitignored `build/` file and force-included, so the source tree stays clean and the module-freshness gate never sees it. The hardcoded `version = "0.8.0"` stays authoritative; the hash rides alongside (PyPI rejects `+local` identifiers). The skill-install version stamp is deliberately left as pure semver — a per-commit hash would break its install-idempotency compare.

## Verification

- Built via `python -m build` (the real CI publish path) → installed the resulting wheel in a clean venv with **no `.git`** → `notebooklm --version` reported `0.8.0 (<commit>)`.
- Unit test covers all three resolution branches (`tests/unit/test_version_info.py`).
- Full guardrails + `tests/unit/mcp` + `tests/unit/cli` + mypy + whole-tree ruff pass.

## Known ceiling

An sdist built **offline** (no `.git`, e.g. `pip download --no-binary`) yields a bare version — the hook needs git at build time. CI release builds and `git+…` installs both have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZUzFEAC3XBxwjYQ435QFQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version information now optionally includes a short git commit hash when available, improving build traceability across the CLI and server metadata endpoints.
* **Bug Fixes**
  * More consistent version reporting with safe embedded/live fallback behavior when commit details can’t be embedded or found.
* **Tests**
  * Added deterministic unit tests covering embedded, live, and no-commit scenarios.
* **Documentation**
  * Updated the architecture file map to document the new version info module.
* **Build & Packaging**
  * Added a custom build hook to embed the current commit into release artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->