### PR TITLE
docs(release): support alpha/beta/rc pre-releases + stable-only API-compat baseline

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -103,6 +103,9 @@ Proceed with release preparation?
   When in doubt, it's PATCH.
   ```
 
+  For a **pre-release**, target the final version plus a pre-release serial
+  (e.g. `0.8.0a1`) — see [Pre-releases](#pre-releases-alpha--beta--rc).
+
   See [Version Numbering](#version-numbering) for full details.
 
 - [ ] Update version in `pyproject.toml`:
@@ -117,8 +120,9 @@ Proceed with release preparation?
   uv run python scripts/audit_public_api_compat.py
   ```
 - [ ] Read every reported break. The audit compares this checkout with the
-  latest reachable release tag (override with `--baseline-ref vX.Y.Z` only when
-  auditing against a specific previous release).
+  latest reachable **stable** release tag (pre-releases are skipped; override
+  with `--baseline-ref vX.Y.Z` only when auditing against a specific previous
+  release).
 - [ ] If the audit reports an unapproved break, prefer a compatibility shim or
   restored alias. Do **not** proceed to packaging while unapproved breaks remain.
 - [ ] If a break is intentional and allowed by the stability policy, update all
@@ -148,8 +152,9 @@ documented client namespace methods under `NotebookLMClient.notebooks`,
 default values; changing a default is a public behavior change.
 
 The allowlist is **release-scoped**: each entry records a break pending the
-*next* tag, not a permanent exemption. Once `vX.Y.Z` ships, its entries are in
-the baseline and must be pruned — see
+*next* stable release, not a permanent exemption. A pre-release tag does not
+advance the baseline (see the Pre-releases section). Once a stable `vX.Y.Z`
+ships, its entries are in the baseline and must be pruned — see
 [Prune the API-Compat Allowlist](#prune-the-api-compat-allowlist). The Code
 Quality job runs the audit with `--check-stale`, so a stale entry (one matching
 no break against the baseline) is a CI failure, not silent cruft.
@@ -159,6 +164,13 @@ no break against the baseline) is a CI failure, not silent cruft.
 - [ ] Get commits since last release:
   ```bash
   git log $(git describe --tags --abbrev=0)..HEAD --oneline
+  ```
+  During a **pre-release cycle**, base the range on the last *stable* tag so the
+  aggregate changelog captures the whole cycle (a plain `git describe` would
+  start at the alpha):
+  ```bash
+  git log $(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' \
+    --exclude '*a[0-9]*' --exclude '*b[0-9]*' --exclude '*rc[0-9]*')..HEAD --oneline
   ```
 - [ ] Generate changelog entries in Keep a Changelog format:
   - **Added** - New features
@@ -297,7 +309,7 @@ python scripts/mcp_live_smoke.py \
 - [ ] Wait for upload to complete
 - [ ] Verify package appears: https://test.pypi.org/project/notebooklm-py/
 
-> **Note:** TestPyPI does not allow re-uploading the same version. If you need to fix issues after publishing, bump the patch version and start over.
+> **Note:** TestPyPI does not allow re-uploading the same version. If you need to fix issues after publishing, bump the patch version and start over. For a pre-release, bump the **pre-release serial** (`a1 → a2`), not the patch.
 
 ### Verify TestPyPI Package
 
@@ -306,7 +318,8 @@ python scripts/mcp_live_smoke.py \
 - [ ] Wait for all tests to pass (unit, integration, E2E)
 - [ ] If verification fails:
   1. Fix issues in the release worktree
-  2. Bump patch version in `pyproject.toml`
+  2. Bump patch version in `pyproject.toml` (for a pre-release, bump the
+     pre-release serial, e.g. `0.8.0a1 → 0.8.0a2`)
   3. Update `CHANGELOG.md` with fix
   4. Commit, push, and re-run **Publish to TestPyPI**
 
@@ -375,15 +388,19 @@ The `Publish to PyPI` step in `publish.yml` also opts into **PEP 740 attestation
 
 ### Prune the API-Compat Allowlist
 
-Pushing the tag advances the audit baseline — `audit_public_api_compat.py`
-resolves it from `git describe --tags --abbrev=0`, so the breaks you just
-shipped are now part of the `vX.Y.Z` baseline and are **no longer breaks against
-it**. The baseline advances automatically; the allowlist is the manual half that
-must reset, or it accumulates dead entries that describe nothing.
+Pushing a **stable** tag advances the audit baseline — `audit_public_api_compat.py`
+resolves the latest reachable stable release tag (pre-releases are skipped), so
+the breaks you just shipped are now part of the `vX.Y.Z` baseline and are **no
+longer breaks against it**. (A pre-release tag such as `v0.8.0a1` does **not**
+advance the baseline, so the allowlist survives the whole pre-release cycle and
+prunes once, here, at the final `vX.Y.Z`.) The baseline advances automatically;
+the allowlist is the manual half that must reset, or it accumulates dead entries
+that describe nothing.
 
 The lifecycle to keep in mind:
 
-- **baseline** = the last *released* version (automatic — it's the latest tag).
+- **baseline** = the last *stable released* version (automatic — the latest
+  stable release tag; pre-releases are skipped).
 - **allowlist** = the intentional breaks pending the *next* release. It should
   reset to (near) empty at each release boundary.
 
@@ -473,7 +490,56 @@ git push origin :refs/tags/vX.Y.Z
 
 - Check if version already exists on TestPyPI
 - TestPyPI doesn't allow re-uploading same version
-- Bump to next patch version if needed
+- Bump to next patch version if needed (for a pre-release, bump the pre-release serial, e.g. `0.8.0a1 → 0.8.0a2`)
+
+---
+
+## Pre-releases (alpha / beta / rc)
+
+Pre-releases let you stage a release for early adopters without affecting normal
+users. PEP 440 pre-release versions flow through the existing build, tag, publish,
+and verify machinery unchanged, and `pip install notebooklm-py` will not serve
+them to normal users. Follow the normal checklist above, with these differences:
+
+1. **Version format is canonical PEP 440, byte-identical everywhere.** Use
+   `X.Y.ZaN` / `X.Y.ZbN` / `X.Y.ZrcN` (e.g. `0.8.0a1`), tag `vX.Y.ZaN`. Do **not**
+   use non-canonical forms like `0.8.0-alpha.1`, `0.8.0.rc1`, or `0.8.0RC1`:
+   `publish.yml` tag-validation and `verify-package.yml` do raw string compares,
+   and Verify Package compares against the *normalized* `importlib.metadata.version()`
+   — a non-canonical spelling passes tag-match but fails Verify Package with a
+   spurious "version mismatch".
+2. **Serial progression** within one cycle: advance the serial
+   `a1 → a2 → … → b1 → … → rc1 → … → X.Y.0` (final). Do **not** bump the patch
+   between pre-releases.
+3. **A pre-release *is* the final version's real surface.** A `X.Y.ZaN` tag must
+   already contain every breaking flip for that version with deprecation shims
+   removed. The `tests/_guardrails/test_v080_release_gate.py` version parser
+   truncates the pre-release suffix, so the v0.8.0 breaking-flip release-gate
+   fires at `0.8.0a1`. A "soft" alpha that still carries shims is not supported.
+4. **Re-lock after the bump.** After editing `pyproject.toml`'s version, run
+   `uv sync` so `uv.lock`'s workspace-package version matches, else CI `--frozen`
+   installs fail as out-of-date.
+5. **Normal users are unaffected.** `pip install notebooklm-py` skips pre-releases;
+   only `pip install --pre` or an exact `==0.8.0a1` pin selects one.
+6. **Changelog.** Keep pre-release changes accumulating under `## [Unreleased]`
+   (or a single in-progress `## [0.8.0]` heading). Do **not** cut a dated
+   `[X.Y.ZaN]` section per pre-release.
+7. **Baseline / allowlist: no special handling.** `audit_public_api_compat.py`
+   keeps the baseline on the last *stable* tag through the whole pre-release cycle
+   (pre-release tags are skipped), so the allowlist behaves exactly as for a normal
+   release — one prune after the final `X.Y.0` tag.
+8. **Gates still apply; none are optional.** The public-API audit,
+   pre-commit/mypy/pytest, CI on PR, TestPyPI, and Verify Package all run
+   unchanged. Verify Package reads the version from the checked-out ref, so
+   dispatch it on the pre-release branch. Because Verify Package runs E2E, there is
+   no "skip E2E for a pre-release" shortcut.
+9. **GitHub release must be flagged as a pre-release, and the notes must extract
+   the aggregate heading** (not a per-pre-release one, which would yield empty
+   notes):
+   ```bash
+   gh release create v0.8.0a1 --prerelease --title "v0.8.0a1" \
+     --notes "$(sed -n '/## \[0.8.0\]/,/## \[/p' CHANGELOG.md | sed '$d')"
+   ```
 
 ---
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,7 +37,7 @@ Release Plan for vX.Y.Z:
 11. Merge PR to main
 12. ⏸️ CONFIRM: Create and push tag vX.Y.Z?
 13. Wait for PyPI publish
-14. Create GitHub release
+14. Create GitHub release (add `--prerelease` for a pre-release — see [Pre-releases](#pre-releases-alpha--beta--rc))
 15. Clean up worktree
 
 Proceed with release preparation?
@@ -215,9 +215,11 @@ no break against the baseline) is a CI failure, not silent cruft.
   ```bash
   git diff
   ```
-- [ ] Commit:
+- [ ] Commit (stage `uv.lock` too — the version bump changes its workspace-package
+  entry, and for a pre-release the `uv sync` re-lock in the Pre-releases section
+  requires it; staging it is a no-op on releases where it did not change):
   ```bash
-  git add pyproject.toml CHANGELOG.md docs/
+  git add pyproject.toml CHANGELOG.md uv.lock docs/
   git commit -m "chore: release vX.Y.Z"
   ```
 - [ ] Show commit to user:

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -2,8 +2,8 @@
 
 This is a release gate, not a replacement for unit tests. It compares the
 runtime public surface in this checkout against a baseline git ref (by default
-the latest reachable tag) and reports unapproved removals, call-signature
-changes, or return-annotation changes.
+the latest reachable stable release tag; pre-releases are skipped) and reports
+unapproved removals, call-signature changes, or return-annotation changes.
 
 Usage:
     uv run python scripts/audit_public_api_compat.py
@@ -98,12 +98,34 @@ def _run_git(args: list[str], cwd: Path, *, capture: bool = True) -> subprocess.
 
 
 def latest_release_tag(repo_root: Path) -> str:
-    """Return the latest reachable version tag."""
-    result = _run_git(["describe", "--tags", "--abbrev=0"], repo_root)
+    """Return the latest reachable stable release tag.
+
+    Restricts ``git describe`` to release-shaped tags (``--match``) and drops
+    pre-release suffixes (``--exclude`` of aN/bN/rcN), so a pushed ``v0.8.0a1``
+    does not become the compat baseline. Keeping the baseline on the last stable
+    release means the audit checks the real ``vPREV -> vNEXT`` upgrade path for
+    the whole pre-release cycle, and the allowlist prunes once at the final tag.
+    """
+    result = _run_git(
+        [
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match",
+            "v[0-9]*.[0-9]*.[0-9]*",  # release-shaped tags only (skips recovery/*, docs-*, …)
+            "--exclude",
+            "*a[0-9]*",  # drop aN pre-releases
+            "--exclude",
+            "*b[0-9]*",  # drop bN pre-releases
+            "--exclude",
+            "*rc[0-9]*",  # drop rcN pre-releases
+        ],
+        repo_root,
+    )
     if result.returncode != 0:
         stderr = result.stderr.decode("utf-8", errors="replace")
         raise RuntimeError(
-            "could not resolve latest tag: "
+            "could not resolve latest stable release tag: "
             f"{stderr.strip()}. Fetch tags/history or pass --baseline-ref explicitly."
         )
     return result.stdout.decode("utf-8").strip()
@@ -853,7 +875,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--baseline-ref",
         default=None,
-        help="Git ref to compare against. Defaults to `git describe --tags --abbrev=0`.",
+        help=(
+            "Git ref to compare against. Defaults to the latest reachable stable "
+            "release tag (pre-release aN/bN/rcN and non-release tags are skipped)."
+        ),
     )
     parser.add_argument(
         "--allowlist",

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -739,3 +739,49 @@ def test_check_stale_does_not_print_ok_when_stale_blocks(script, tmp_path, monke
     assert "OK:" not in captured.err
     assert "stale" in captured.err.lower()
     assert "notebooklm.AlreadyBaked" in captured.err
+
+
+def test_latest_release_tag_skips_prereleases_and_nonrelease(script, tmp_path):
+    """The default baseline stays on the last STABLE release tag.
+
+    Pre-release (aN/bN/rcN) and non-release tags must not become the baseline,
+    else pushing an alpha would silently rebaseline the compat gate.
+    """
+    import subprocess
+
+    def git(*args):
+        subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    git("init")
+    git("config", "user.email", "t@t.t")
+    git("config", "user.name", "t")
+    git("config", "commit.gpgsign", "false")
+    git("config", "tag.gpgsign", "false")
+
+    (tmp_path / "f").write_text("1")
+    git("add", "f")
+    git("commit", "-m", "c1")
+    git("tag", "v0.7.3")
+
+    (tmp_path / "f").write_text("2")
+    git("commit", "-am", "c2")
+    git("tag", "docs-2026")  # stray non-release tag
+
+    (tmp_path / "f").write_text("3")
+    git("commit", "-am", "c3")
+    git("tag", "v0.8.0a1")  # pre-release
+
+    # Mid-cycle: baseline must skip BOTH the alpha and the stray tag.
+    assert script.latest_release_tag(tmp_path) == "v0.7.3"
+
+    (tmp_path / "f").write_text("4")
+    git("commit", "-am", "c4")
+    git("tag", "v0.8.0")  # final stable
+
+    assert script.latest_release_tag(tmp_path) == "v0.8.0"


### PR DESCRIPTION
## What & why

Enables publishing PEP 440 pre-releases (`0.8.0a1` / `0.8.0b1` / `0.8.0rc1`) to stage a breaking release for early adopters. Three-model review (Claude/Codex/agy via momus, 4 rounds to convergence) confirmed this is **~90% documentation + one script change** — PEP 440 pre-releases already flow through build, tag-validation, Trusted Publishing, and verify-package unchanged, and `pip install notebooklm-py` won't serve them to normal users.

## The one real code change

`git describe --tags --abbrev=0` (the default API-compat baseline in `audit_public_api_compat.py`) is **ancestry-based** — once `v0.8.0a1` is pushed it becomes the baseline for the CI `--check-stale` gate on *every* PR, fragmenting the audit and forcing an allowlist prune per alpha. Fix: restrict the default baseline to release-shaped tags and exclude pre-releases:

```
git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' \
  --exclude '*a[0-9]*' --exclude '*b[0-9]*' --exclude '*rc[0-9]*'
```

The baseline stays on the last **stable** release for the whole cycle; CI inherits it (same `latest_release_tag`), and the allowlist prunes once at the final `X.Y.0` tag — the existing lifecycle, unchanged. The `--match` also fixes a pre-existing wart (a stray `recovery/*` tag could become the baseline). New git-based resolver test proves it skips both a pre-release and a stray non-release tag.

## Docs

New **Pre-releases (alpha / beta / rc)** section in `docs/releasing.md`: canonical PEP 440 spelling (byte-identical tag/pyproject/`__version__`, since the workflows do dumb string compares), serial progression, `--prerelease` release with aggregate-heading notes, `uv sync` re-lock, gates unchanged. Plus a terminology sweep qualifying every "latest tag" baseline reference as the latest *stable* release tag.

## Decision A (no `src/` changes)

A pre-release **is** the fully-flipped version: `tests/_guardrails/test_v080_release_gate.py`'s version parser truncates the pre-release suffix, so the v0.8.0 breaking-flip gate already fires at `0.8.0a1`. Documented, not changed.

## Explicitly not doing (all confirmed unnecessary)
`--pre` in verify-package (exact `==` pin already selects pre-releases), custom parsing in `publish.yml`, workflow/branch-glob changes, SemVer tag sorting.

## Verification
- `tests/unit/test_public_api_compat_audit.py` — 39 passed (incl. new resolver test)
- `tests/_guardrails/` — 1087 passed, 1 xfailed (Decision A gate intact)
- audit runs, resolves stable `v0.7.0`; ruff + mypy clean; doc-drift guardrails clean
- No `src/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified stable vs pre-release release workflows, including versioning format, changelog commit range selection, and GitHub release prerelease handling.
  * Updated API-compatibility baseline and allowlist lifecycle behavior for pre-releases.
  * Refined TestPyPI guidance for re-uploads and pre-release serial progression, plus updated verification failure instructions.
* **Bug Fixes**
  * Improved API compatibility audit default baseline to target the latest stable release tag (skipping pre-release and non-release tags).
* **Tests**
  * Added unit test coverage ensuring the latest stable tag is selected correctly in mixed-tag repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->