### PR TITLE
fix(deploy): derive image tag from release version

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -6,10 +6,11 @@
 # writes this; `make up`/`make dev` read it (a `TUNNEL=... make up` override wins).
 TUNNEL=cloudflare
 
-# Which published image `make up`/`make prod` pull. Defaults below match the
-# image published by the release CI; override only for a fork or a pinned tag.
+# Which published image `make up`/`make prod` pull. By default, make uses this
+# checkout's pyproject version. Set this only for raw docker compose, a fork, or
+# a pinned tag.
 # NOTEBOOKLM_MCP_IMAGE=tenglin/notebooklm-mcp
-# NOTEBOOKLM_MCP_VERSION=0.8.0
+# NOTEBOOKLM_MCP_VERSION=<version>
 
 # Bearer token clients must present to use the MCP endpoint. Generate a strong
 # random value, e.g.:  python -c "import secrets; print(secrets.token_urlsafe(32))"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -8,7 +8,7 @@
 #   * DEV / from-source (DEFAULT): installs THIS checkout, so `docker compose up`
 #     deploys exactly the code in this repo. Leave NOTEBOOKLM_SPEC empty.
 #   * PRODUCTION / from PyPI: build with a release spec, e.g.
-#       docker compose build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==0.8.0"
+#       docker compose build --build-arg NOTEBOOKLM_SPEC="notebooklm-py[mcp,headless]==<version>"
 #     (or set it under build.args in docker-compose.yml).
 FROM python:3.12-slim
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -15,17 +15,26 @@ COMPOSE ?= docker compose
 _TUNNEL_DOTENV := $(shell [ -f .env ] && sed -n 's/^TUNNEL=//p' .env | tr -d '\r' | head -1)
 TUNNEL ?= $(if $(_TUNNEL_DOTENV),$(_TUNNEL_DOTENV),cloudflare)
 
-# Pin a published image tag with `make prod VERSION=x.y.z`. Export it to compose
-# ONLY when given on the command line; otherwise leave it unset so compose reads
-# NOTEBOOKLM_MCP_VERSION from .env (default 0.8.0). Same reasoning as the
-# NOTEBOOKLM_PROFILE_DIR note below: a make-exported default would OUTRANK the .env
-# value (shell env > .env) and silently ignore a .env pin.
+# Pin a published image tag with `make prod VERSION=x.y.z`. Otherwise, keep the
+# override order: shell/CLI env, deploy/.env, this checkout's pyproject version,
+# then Make's missing-version guard.
+_PROJECT_VERSION := $(shell [ -f ../pyproject.toml ] && \
+	sed -n '/^\[project\]/,/^\[/ s/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' ../pyproject.toml | tr -d '\r' | head -1)
+_VERSION_DOTENV := $(shell [ -f .env ] && sed -n 's/^NOTEBOOKLM_MCP_VERSION=//p' .env | tr -d '\r' | head -1)
 ifeq ($(origin VERSION),command line)
-VERSION_ENV := NOTEBOOKLM_MCP_VERSION=$(VERSION)
+ifneq ($(strip $(VERSION)),)
+COMPOSE_ENV := NOTEBOOKLM_MCP_VERSION=$(VERSION)
+endif
+else ifneq ($(origin NOTEBOOKLM_MCP_VERSION),undefined)
+COMPOSE_ENV :=
+else ifneq ($(_VERSION_DOTENV),)
+COMPOSE_ENV :=
+else ifneq ($(_PROJECT_VERSION),)
+COMPOSE_ENV := NOTEBOOKLM_MCP_VERSION=$(_PROJECT_VERSION)
 endif
 
 # Profile-aware compose invocation — selects exactly one tunnel sidecar.
-DC = $(COMPOSE) --profile $(TUNNEL)
+DC = $(COMPOSE_ENV) $(COMPOSE) --profile $(TUNNEL)
 # Same, but layer the build override so the image is built from THIS checkout.
 DC_BUILD = $(DC) -f docker-compose.yml -f docker-compose.build.yml
 
@@ -39,11 +48,20 @@ export NOTEBOOKLM_GID ?= $(shell id -g)
 # defaults to ~/.notebooklm/profiles/default on its own; a shell/CLI override such as
 # `NOTEBOOKLM_PROFILE_DIR=… make dev` is still auto-exported by make to the recipe.
 
-.PHONY: help setup dev prod up restart logs down config _require-tunnel-token
+.PHONY: help setup dev prod up restart logs down config _require-image-version _require-tunnel-token
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
 		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-9s\033[0m %s\n", $$1, $$2}'
+
+# Friendly pre-check for source-less deploys: without pyproject.toml, the user
+# must say which published image tag to pull.
+_require-image-version:
+	@if [ -z "$(COMPOSE_ENV)" ] && [ -z "$$NOTEBOOKLM_MCP_VERSION" ] \
+		&& ! grep -qsE '^NOTEBOOKLM_MCP_VERSION=.+' .env; then \
+		echo "✗ NOTEBOOKLM_MCP_VERSION is unknown — run from a source checkout, pass VERSION=x.y.z, or set it in deploy/.env"; \
+		exit 1; \
+	fi
 
 # Friendly pre-check for the chosen tunnel's token (shell env OR deploy/.env). Compose
 # can't do a profile-scoped required-var (it interpolates the whole file before profile
@@ -62,14 +80,14 @@ setup: ## Interactive first run: pick a tunnel + generate secrets → writes .en
 
 up: prod ## Pull the published image and start (the easy path)
 
-prod: _require-tunnel-token ## Pull a published version and start (VERSION=x.y.z, or pin NOTEBOOKLM_MCP_VERSION in .env)
-	$(VERSION_ENV) $(DC) pull
-	$(VERSION_ENV) $(DC) up -d
+prod: _require-image-version _require-tunnel-token ## Pull a published version and start (VERSION=x.y.z, or pin NOTEBOOKLM_MCP_VERSION in .env)
+	$(DC) pull
+	$(DC) up -d
 
-dev: _require-tunnel-token ## Build THIS checkout and start (contributors; TUNNEL=cloudflare|tailscale)
+dev: _require-image-version _require-tunnel-token ## Build THIS checkout and start (contributors; TUNNEL=cloudflare|tailscale)
 	$(DC_BUILD) up -d --build
 
-restart: ## Rebuild THIS checkout + recreate after a source/config change
+restart: _require-image-version _require-tunnel-token ## Rebuild THIS checkout + recreate after a source/config change
 	$(DC_BUILD) up -d --build
 
 logs: ## Tail the server logs

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -135,7 +135,7 @@ pull-vs-build modes — one command each:
 ```bash
 cd deploy
 make up                        # PULL the published image + start (the easy path)
-make prod VERSION=0.8.0        # ...pin a specific published version
+make prod VERSION=<version>    # ...pin a specific published version
 make dev                       # BUILD this checkout + start (contributors)
 make dev TUNNEL=tailscale      # ...forcing the Tailscale Funnel sidecar for this run
 make logs                      # tail the server log (expect: bound 0.0.0.0:9420)
@@ -143,9 +143,16 @@ make restart                   # rebuild this checkout + recreate after a source
 make down                      # stop and remove
 ```
 
-Equivalent raw compose (`--profile` selects the tunnel):
-- **Pull + run (any tunnel):** `docker compose --profile cloudflare pull && \
-  docker compose --profile cloudflare up -d` (swap `tailscale` for the other tunnel).
+`make up` uses this checkout's `pyproject.toml` version. If you copied only
+`deploy/`, pass `VERSION=<version>` or set `NOTEBOOKLM_MCP_VERSION` in `.env`.
+If that version has not been published to Docker Hub yet, pass a published
+`VERSION=<version>` or use `make dev` to build this checkout.
+
+Equivalent raw compose (`--profile` selects the tunnel; set `NOTEBOOKLM_MCP_VERSION`
+first, or put it in `.env`):
+- **Pull + run (any tunnel):** `export NOTEBOOKLM_MCP_VERSION=<version>` then
+  `docker compose --profile cloudflare pull && docker compose --profile cloudflare up -d`
+  (swap `tailscale` for the other tunnel).
 - **Build from source:** add the build override —
   `docker compose -f docker-compose.yml -f docker-compose.build.yml --profile cloudflare up -d --build`.
 - **A different image / tag:** set `NOTEBOOKLM_MCP_IMAGE` / `NOTEBOOKLM_MCP_VERSION` in `.env`.

--- a/deploy/docker-compose.build.yml
+++ b/deploy/docker-compose.build.yml
@@ -11,4 +11,4 @@ services:
       dockerfile: deploy/Dockerfile
       # To build from a published PyPI release instead of this checkout:
       # args:
-      #   NOTEBOOKLM_SPEC: "notebooklm-py[mcp,headless]==0.8.0"
+      #   NOTEBOOKLM_SPEC: "notebooklm-py[mcp,headless]==<version>"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 # Remote notebooklm-mcp behind a tunnel. Pick ONE tunnel via a Compose profile:
 #
-#   cp .env.example .env   # set NOTEBOOKLM_MCP_TOKEN and/or the OAuth vars
+#   cp .env.example .env   # set NOTEBOOKLM_MCP_TOKEN, NOTEBOOKLM_MCP_VERSION, and/or OAuth
 #   docker compose --profile cloudflare up -d   # Cloudflare Tunnel (needs a domain)
 #   docker compose --profile tailscale  up -d   # Tailscale Funnel (no domain; *.ts.net)
 #   # (the Makefile wraps this: `make dev` / `make dev TUNNEL=tailscale`)
@@ -10,12 +10,13 @@
 # tunnel, which terminates TLS at its edge (no CA cert for you to manage). See README.md.
 services:
   notebooklm-mcp:
-    # Pull the published image by default — `make up` / `make prod` and a plain
-    # `docker compose up` need NO source checkout. Override the namespace/tag via
-    # NOTEBOOKLM_MCP_IMAGE / NOTEBOOKLM_MCP_VERSION in .env. Contributors building
-    # from THIS checkout run `make dev`, which layers docker-compose.build.yml to
-    # add a `build:` section back (see that file).
-    image: ${NOTEBOOKLM_MCP_IMAGE:-tenglin/notebooklm-mcp}:${NOTEBOOKLM_MCP_VERSION:-0.8.0}
+    # Pull the published image by default. `make up` / `make prod` require or
+    # inject a version; raw docker compose pull must set NOTEBOOKLM_MCP_VERSION.
+    # Override the namespace/tag via
+    # NOTEBOOKLM_MCP_IMAGE / NOTEBOOKLM_MCP_VERSION in .env. Contributors
+    # building from THIS checkout run `make dev`, which layers
+    # docker-compose.build.yml to add a `build:` section back (see that file).
+    image: ${NOTEBOOKLM_MCP_IMAGE:-tenglin/notebooklm-mcp}:${NOTEBOOKLM_MCP_VERSION:-set-version}
     restart: unless-stopped
     # Run as YOUR uid:gid so the mounted profile's files (owned by you on the
     # host) are readable AND writable with NO chown — and your own `notebooklm`


### PR DESCRIPTION
## Summary
- derive the default deploy image tag from `pyproject.toml` when running from a source checkout
- keep explicit `VERSION=` and `NOTEBOOKLM_MCP_VERSION` overrides, with a clear guard for copied `deploy/` directories
- remove stale hardcoded `0.8.0` deploy examples and document raw Compose/version behavior

## Test plan
- `make -n prod`
- `make -n prod VERSION=1.2.3`
- `make _require-image-version _PROJECT_VERSION= VERSION=` (expected failure)
- `make _require-image-version _PROJECT_VERSION= VERSION=1.2.3`
- `NOTEBOOKLM_MCP_VERSION=1.2.3 docker compose --profile cloudflare config --images`
- `docker compose -f docker-compose.yml -f docker-compose.build.yml --profile cloudflare config --images`
- `NOTEBOOKLM_MCP_VERSION=0.8.0a1 docker compose --profile cloudflare pull notebooklm-mcp`
- `git diff --check`

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pinning a specific published image version during deployment.
  * Improved deployment commands to derive a default version automatically when available.

* **Bug Fixes**
  * Replaced hard-coded example version values with placeholders in deployment guidance.
  * Added clearer checks so deployments fail early if required version or tunnel settings are missing.

* **Documentation**
  * Updated setup and run instructions to explain when to set version-related environment variables and how to use raw Docker Compose commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->