### PR TITLE
fix(server_info): report the resolved profile, not the raw active one (#1790)

### DIFF
--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -27,7 +27,7 @@ from fastmcp import Context
 from ..._app.auth_check import AuthCheckPlan, run_auth_check
 from ..._version_info import version_string
 from ...exceptions import NotebookLMError
-from ...paths import get_active_profile, get_storage_path
+from ...paths import get_storage_path, resolve_profile
 from .._confirm import READ_ONLY
 from .._context import get_client
 from .._errors import mcp_errors, redact
@@ -120,13 +120,21 @@ def register(mcp: Any) -> None:
         fields degrade to ``{available: False, reason: ...}`` (identity still
         included) rather than failing the whole call.
 
+        ``profile`` names the resolved storage profile the probe ran against
+        (e.g. ``"default"``); the booleans are the actual health signals.
+
         The absolute on-disk storage path is deliberately **not** returned: it
         leaks the server-host OS username / filesystem layout to any (possibly
-        remote) caller, while telling the agent nothing it can act on. The
-        ``profile`` name + booleans are sufficient to diagnose auth health.
+        remote) caller, while telling the agent nothing it can act on.
         """
         with mcp_errors():
-            profile = get_active_profile()
+            # Report the *resolved* profile (never ``None``) rather than the raw
+            # module-level active profile: the MCP server never sets an active
+            # profile, so ``get_active_profile()`` was always ``None`` here even
+            # though ``get_storage_path`` resolves and checks a concrete profile
+            # (#1790). ``resolve_profile()`` names the profile the auth probe
+            # actually ran against — the same value the CLI ``status`` reports.
+            profile = resolve_profile()
             storage_path = get_storage_path(profile)
             plan = AuthCheckPlan(
                 storage_path=storage_path,

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -33,7 +33,7 @@ from ..._redact import redact
 from ..._version_info import version_string
 from ...client import NotebookLMClient
 from ...exceptions import NotebookLMError
-from ...paths import get_active_profile, get_storage_path
+from ...paths import get_storage_path, resolve_profile
 from .._context import get_client
 
 __all__ = ["router"]
@@ -103,7 +103,12 @@ async def server_info(
     The absolute on-disk storage path is deliberately not returned (it leaks the
     host filesystem layout while telling the agent nothing actionable).
     """
-    profile = get_active_profile()
+    # Report the *resolved* profile (never ``None``) rather than the raw
+    # module-level active profile: the server never sets an active profile, so
+    # ``get_active_profile()`` was always ``None`` here even though
+    # ``get_storage_path`` resolves and checks a concrete profile (#1790).
+    # ``resolve_profile()`` names the profile the auth probe actually ran against.
+    profile = resolve_profile()
     storage_path = get_storage_path(profile)
     plan = AuthCheckPlan(
         storage_path=storage_path,

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -55,6 +55,24 @@ def test_server_info_does_not_leak_storage_path(
     assert "/" not in str(body["auth"].get("profile", ""))
 
 
+def test_server_info_profile_is_resolved_not_null(
+    authed_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``auth.profile`` reports the resolved profile, never ``None`` (#1790).
+
+    The server never sets a module-level active profile, so the field used to come
+    back ``null`` even on a healthy session. It must name the profile the auth probe
+    ran against (``"default"`` when no named profile is configured).
+    """
+    from notebooklm import paths
+
+    _patch_auth(monkeypatch, all_passed=True)
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.setattr(paths, "_active_profile", None)
+    body = authed_client.get("/v1/server/info").json()
+    assert body["auth"]["profile"] == "default"
+
+
 def test_server_info_include_account(
     authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -116,6 +116,38 @@ async def test_server_info_does_not_leak_absolute_storage_path(
     assert "authenticated" in auth
 
 
+async def test_server_info_profile_is_resolved_not_null(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """``auth.profile`` reports the resolved profile, never ``None`` (#1790).
+
+    The MCP server never sets a module-level active profile, so the field used to
+    come back ``null`` even on a healthy session — undercutting the docstring that
+    points diagnostics at it. It must instead name the profile the auth probe ran
+    against (``"default"`` when no named profile is configured).
+    """
+    from notebooklm import paths
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.setattr(paths, "_active_profile", None)
+    result = await mcp_call("server_info")
+    assert result.structured_content["auth"]["profile"] == "default"
+
+
+async def test_server_info_profile_reflects_named_profile(
+    mcp_call, mock_client, tmp_path, monkeypatch
+) -> None:
+    """A named profile (via ``NOTEBOOKLM_PROFILE``) is surfaced in ``auth.profile``."""
+    from notebooklm import paths
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.setenv("NOTEBOOKLM_PROFILE", "work")
+    monkeypatch.setattr(paths, "_active_profile", None)
+    result = await mcp_call("server_info")
+    assert result.structured_content["auth"]["profile"] == "work"
+
+
 async def test_server_info_default_omits_account(
     mcp_call, mock_client, tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #1790.

`server_info` — the MCP `server_info` tool and the REST `GET /v1/server/info`
route — reported `auth.profile` as `null` even on a fully authenticated, healthy
session. The docstring pointed diagnostics at that field, so the guidance was
inert.

Root cause: both call sites read `paths.get_active_profile()`, which returns the
raw module-level `_active_profile`. That global is only ever set by the CLI's
`--profile` flag / `use` command; the long-running MCP/REST server never sets it,
so it was always `None`. Meanwhile the auth-health probe's storage path was
already resolved via `resolve_profile()` (inside `get_storage_path`), so the
*reported* profile was inconsistent with the profile the probe actually ran
against.

## Fix

- Swap both call sites (`mcp/tools/meta.py`, `server/routes/meta.py`) from
  `get_active_profile()` to `resolve_profile()`. `resolve_profile()` never
  returns `None` (falls back to `"default"`), follows the full precedence chain,
  and is the same value the CLI `status` command reports — so `auth.profile` now
  names the profile the probe measured.
- Tighten the MCP docstring so it no longer over-claims `profile` as a
  "sufficient" health signal: the booleans are the real signals, `profile` is a
  label for *which* profile was probed.

## Tests

- `tests/unit/mcp/test_meta.py`: `auth.profile` is the resolved profile
  (`"default"` with no named profile) and reflects a `NOTEBOOKLM_PROFILE`-named
  profile. Both fail against the old `get_active_profile()` code (verified).
- `tests/server/test_meta.py`: parallel assertion for the REST route.
- Test isolation uses object-target `monkeypatch.setattr(paths, "_active_profile", None)`
  (ADR-0007 forbids string-target monkeypatch) plus the autouse
  `NOTEBOOKLM_HOME` tmp-dir fixture and `NOTEBOOKLM_PROFILE` control.

## Verification

- `mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check . && ruff format --check .` — clean (whole tree)
- `pytest tests/unit/mcp tests/server` — 1002 passed
- ADR-0025 schema-char budget + ADR-0007 monkeypatch guardrails — pass

## Deferred (out of scope)

A pre-existing, separate correctness gap surfaced during review: a server started
with an explicit `--profile X` flag (no matching `NOTEBOOKLM_PROFILE` env / config
`default_profile`) binds the client to `X` but `resolve_profile()` still returns
`"default"`, so the probe checks the wrong storage. This predates #1790 and is
tracked in #1791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The server info response now reports the actual resolved profile used by the auth health check, preventing a null profile value in healthy sessions.
  * The reported auth profile now matches the CLI status output more consistently.

* **Tests**
  * Added coverage to verify server info returns a resolved, non-null profile in both default and named profile scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->