### PR TITLE
docs(mcp): document thin-content / soft-404 warning threshold (closes #1788)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -279,6 +279,49 @@ error, never added as text); `source_type`/`url`/`text`/`title`/`path`/
 `document_id`/`mime_type` are not valid with `urls`, but `allow_internal`
 applies to every entry.
 
+### Content-sanity warnings on ready web pages
+
+A dead link, [soft-404](https://en.wikipedia.org/wiki/HTTP_404#Soft_404), or
+paywalled page frequently ingests as a **READY** source with little-to-no
+extractable text — a "ghost source" that add-time status can't catch because a
+soft-404 serves HTTP 200. `source_wait` — and batch `source_add(urls=[...])` for
+an item that is *already* READY the moment it returns (single-mode `source_add`
+adds asynchronously, so it never runs this check) — attaches a non-blocking,
+advisory `warning` to such a source. The check is **best-effort and never
+rejects**: the source stays READY, `ok` stays `true`, and any fetch failure
+(including a >5s slow `source_read`) degrades to no warning rather than breaking
+the wait.
+
+It fires on a **web-page source only** (`kind == "web_page"`) via two body-only
+signals — the title is never scanned:
+
+| Signal | Threshold | Warning contains |
+|--------|-----------|------------------|
+| **char-thin** | indexed text shorter than **100 characters** | `"little/no text extracted (N chars) …"` |
+| **dead-link boilerplate** | a body shorter than **2000 characters** that (casefolded) contains any of the phrases below | `"ingested as ready (N chars) but the body matches a dead-link / error-page pattern …"` |
+
+The full dead-link phrase set (the complete list, so you can build a fixture that
+trips it): `broken link`, `page not found`, `page isn't available`, `page does
+not exist`, `page no longer available`, `no longer available`, `error 404`, `404
+not found`, `whoops!`.
+
+Both signals are deliberately conservative. The 2000-char body gate is what keeps
+the weaker phrases safe: a healthy page at or above 2000 chars is never
+phrase-scanned (so `broken link` in a real article about broken links, or a shop's
+`no longer available`, does not false-positive), and the phrases are all
+multi-word / anchored — no bare `404` or `not found`. The warning always ends with
+`verify with source_read (detail="full")`.
+
+**To exercise the warning branch** (the reason this is documented): note that a
+`text` source — even an empty one — is *never* flagged; only a `web_page` under
+the thresholds above is. So the reliable trigger is a URL that resolves to a
+near-empty or soft-404 page. To unit-test your own handling of the branch
+without a live URL, mock the source's fetched body under the threshold and assert
+the warning shape — copy the pattern from
+[`tests/unit/mcp/test_sources.py`](../tests/unit/mcp/test_sources.py) (see
+`test_source_wait_thin_web_page_warns`, `test_source_wait_soft_404_body_phrase_warns`,
+and the `_THIN_SOURCE_CHAR_THRESHOLD` boundary test).
+
 ### Generate and download a studio artifact
 
 ```text

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -298,19 +298,21 @@ signals — the title is never scanned:
 | Signal | Threshold | Warning contains |
 |--------|-----------|------------------|
 | **char-thin** | indexed text shorter than **100 characters** | `"little/no text extracted (N chars) …"` |
-| **dead-link boilerplate** | a body shorter than **2000 characters** that (casefolded) contains any of the phrases below | `"ingested as ready (N chars) but the body matches a dead-link / error-page pattern …"` |
+| **dead-link boilerplate** | **indexed text** shorter than **2000 characters** that (casefolded) contains any of the phrases below | `"ingested as ready (N chars) but the body matches a dead-link / error-page pattern …"` |
 
 The full dead-link phrase set (the complete list, so you can build a fixture that
 trips it): `broken link`, `page not found`, `page isn't available`, `page does
 not exist`, `page no longer available`, `no longer available`, `error 404`, `404
 not found`, `whoops!`.
 
-Both signals are deliberately conservative. The 2000-char body gate is what keeps
-the weaker phrases safe: a healthy page at or above 2000 chars is never
-phrase-scanned (so `broken link` in a real article about broken links, or a shop's
-`no longer available`, does not false-positive), and the phrases are all
-multi-word / anchored — no bare `404` or `not found`. The warning always ends with
-`verify with source_read (detail="full")`.
+Both gates measure the source's **indexed text** length (`char_count` from a
+`source_read` with `detail="full"`), not the raw HTTP response — a large HTML
+page that indexes to little text is still caught. The 2000-char gate is what
+keeps the weaker phrases safe: a page whose indexed text is 2000 chars or longer
+is never phrase-scanned (so `broken link` in a real article about broken links,
+or a shop's `no longer available`, does not false-positive), and the phrases are
+all multi-word / anchored — no bare `404` or `not found`. Every warning ends with
+`verify with source_read (detail="full").` (trailing period included).
 
 **To exercise the warning branch** (the reason this is documented): note that a
 `text` source — even an empty one — is *never* flagged; only a `web_page` under

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -30,6 +30,9 @@ from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     SourceTimeoutError,
 )
 from notebooklm.mcp._errors import tool_error_payload  # noqa: E402 - after importorskip guard
+from notebooklm.mcp.tools._content_sanity import (  # noqa: E402 - after importorskip guard
+    _THIN_SOURCE_CHAR_THRESHOLD,
+)
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
 from notebooklm.types import Label  # noqa: E402 - after importorskip guard
 
@@ -884,6 +887,40 @@ async def test_source_wait_ample_web_page_no_warning(mcp_call, mock_client) -> N
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
     sc = result.structured_content
     assert sc["ready"][0].get("warning") is None
+
+
+@pytest.mark.parametrize(
+    ("char_count", "expect_warning"),
+    [
+        (_THIN_SOURCE_CHAR_THRESHOLD - 1, True),  # just under → char-thin warning
+        (_THIN_SOURCE_CHAR_THRESHOLD, False),  # exactly at → not flagged (gate is ``<``)
+    ],
+)
+async def test_source_wait_thin_threshold_boundary(
+    mcp_call, mock_client, char_count: int, expect_warning: bool
+) -> None:
+    """Pin the char-thin boundary to the documented threshold constant, so the number
+    in ``docs/mcp-guide.md`` (and the copyable trigger downstream users build against)
+    can't silently drift from :data:`_THIN_SOURCE_CHAR_THRESHOLD`. The gate is ``<``:
+    ``threshold - 1`` warns, exactly ``threshold`` does not."""
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Boundary")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * char_count, char_count=char_count)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    warning = result.structured_content["ready"][0].get("warning")
+    if expect_warning:
+        assert warning is not None
+        # Pin the char-thin branch specifically (not merely "some warning"): the
+        # message reports the count and points at source_read — the exact shape the
+        # doc tells downstream integrators to assert against.
+        assert f"{char_count} chars" in warning
+        assert "little/no text extracted" in warning
+        assert 'source_read (detail="full")' in warning
+    else:
+        assert warning is None
 
 
 async def test_source_wait_zero_char_web_page_warns(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Summary

Closes #1788. The content-sanity `warning` that `source_wait` (and batch `source_add(urls=[...])`) attaches to a READY web-page source — for a likely dead link / soft-404 / paywall "ghost source" — was described in the tool docstrings but its **triggering threshold was undocumented**, so integrators couldn't construct a fixture to validate their handling of the branch. Across live testing of `v0.8.0a1` the warning never fired and stayed unobservable.

This documents the real heuristic (the numbers come straight from `src/notebooklm/mcp/tools/_content_sanity.py`, not invented) and ships a copyable, constant-pinned test. No product code changes.

## What changed

- **`docs/mcp-guide.md`** — new "Content-sanity warnings on ready web pages" subsection documenting the exact heuristic:
  - web-page-only (`kind == "web_page"`); a `text` source — even an empty one — is **never** flagged (this is precisely why the reporter couldn't reproduce it);
  - **char-thin**: indexed text `< 100` chars (`_THIN_SOURCE_CHAR_THRESHOLD`);
  - **soft-404 boilerplate**: a body `< 2000` chars (`_SOFT_404_BODY_SCAN_LIMIT`) whose casefolded text contains one of the **complete** dead-link phrase list;
  - advisory-only / best-effort / never-rejects semantics (5s fetch, degrades to no warning);
  - how to exercise the branch + a pointer to the copyable unit tests.
- **`tests/unit/mcp/test_sources.py`** — `test_source_wait_thin_threshold_boundary`, a parametrized boundary test pinned to `_THIN_SOURCE_CHAR_THRESHOLD` (so the documented `100` can't silently drift from the `<` gate) that also asserts the char-thin branch's full message shape as the pattern downstream users copy.

## Why docs, not the tool docstrings

Option (2) in the issue suggested the tool docstrings, but the MCP tool-schema char budget (ADR-0025, `test_tool_eval.py`) sits at its ceiling (~41 chars of headroom), and the docstrings already advertise the warning. The threshold detail is integrator-facing, so it lives in `docs/mcp-guide.md` (not schema-counted) — satisfying the issue's "referenced in docs/" while combining options (2) + (3).

## Verification

- `uv run pytest tests/unit/mcp/test_sources.py tests/unit/mcp/test_tool_eval.py tests/_guardrails` — pass (schema budget unaffected; no product code).
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run ruff check . && uv run ruff format --check .` — clean.
- Every documented number, phrase, warning-string fragment, and the `web_page`-only / `text`-never claim cross-checked against `_content_sanity.py` (Claude + Codex review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance describing best-effort “content-sanity warnings” for web-page ingestion where results may be marked READY despite thin or dead-link-like content.
  * Documented that warnings are non-blocking, apply only to web pages, and are triggered by body-based heuristics (very short text or dead-link boilerplate patterns), with a recommendation to verify using a full read.

* **Tests**
  * Added/extended unit coverage to validate the thin-content warning boundary for READY web pages (warning below the threshold, absent at the threshold).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->