### PR TITLE
feat(resolve): near-miss candidates on failed name lookups (closes #1787)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -210,6 +210,10 @@ These conventions hold across every tool:
 - **Name *or* ID.** Every `notebook`/`source`/`note`/`artifact` argument accepts a human title **or**
   an ID (full, or a unique prefix). Use the matching `*_list` tool to discover them. An ambiguous name
   or prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
+  When a name lookup *fails* but is close to a real title — a bare prefix, or a punctuation-only
+  slip such as a hyphen typed for an em-dash (`—`) or a normal space for a non-breaking one — the
+  `NOT_FOUND` error carries up to three near-miss `candidates` (`{id, title}`) plus a
+  `Did you mean: …` hint, so you can retry with the full title or id instead of guessing.
 - **Destructive tools need confirmation.** `notebook_delete`, `source_delete`,
   `studio_delete`, and `share_remove_user` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
   (with the resolved title) and delete **nothing**; call again with `confirm=true` to execute.
@@ -238,7 +242,9 @@ These conventions hold across every tool:
   `AUTH`, `RATE_LIMITED`, `NOT_FOUND`, `VALIDATION`, `TIMEOUT`, `NETWORK`, `SERVER`, `RPC`,
   `CONFIG`, `NOTEBOOK_LIMIT`, `ARTIFACT_TIMEOUT`, `SOURCE_MUTATION`, `ERROR`, or `UNEXPECTED`. The
   `retriable` flag tells an agent whether a retry could succeed (e.g. `RATE_LIMITED`, `TIMEOUT`,
-  `NETWORK`). Many errors also carry an actionable `hint` (e.g. `AUTH → run notebooklm login`).
+  `NETWORK`). Many errors also carry an actionable `hint` (e.g. `AUTH → run notebooklm login`); a
+  `NOT_FOUND` from a near-miss name lookup additionally carries a `candidates` list (see
+  **Name *or* ID** above).
 
 ## Workflows
 

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -212,8 +212,9 @@ These conventions hold across every tool:
   or prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
   When a name lookup *fails* but is close to a real title — a bare prefix, or a punctuation-only
   slip such as a hyphen typed for an em-dash (`—`) or a normal space for a non-breaking one — the
-  `NOT_FOUND` error carries up to three near-miss `candidates` (`{id, title}`) plus a
-  `Did you mean: …` hint, so you can retry with the full title or id instead of guessing.
+  error's `Did you mean: …` hint names up to three near-miss candidates, each with its **title and
+  id** inline, so you can retry with the full title or id instead of guessing (a label near-miss
+  reached via `source_list(label=…)` gets the same enrichment on its `VALIDATION` error).
 - **Destructive tools need confirmation.** `notebook_delete`, `source_delete`,
   `studio_delete`, and `share_remove_user` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
   (with the resolved title) and delete **nothing**; call again with `confirm=true` to execute.
@@ -243,7 +244,7 @@ These conventions hold across every tool:
   `CONFIG`, `NOTEBOOK_LIMIT`, `ARTIFACT_TIMEOUT`, `SOURCE_MUTATION`, `ERROR`, or `UNEXPECTED`. The
   `retriable` flag tells an agent whether a retry could succeed (e.g. `RATE_LIMITED`, `TIMEOUT`,
   `NETWORK`). Many errors also carry an actionable `hint` (e.g. `AUTH → run notebooklm login`); a
-  `NOT_FOUND` from a near-miss name lookup additionally carries a `candidates` list (see
+  near-miss name lookup puts its `Did you mean: …` candidates (title + id) in that hint (see
   **Name *or* ID** above).
 
 ## Workflows

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -49,6 +49,7 @@ This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 
@@ -145,6 +146,20 @@ CATEGORY_HINTS: dict[ErrorCategory, str | None] = {
     ErrorCategory.LIBRARY: None,
     ErrorCategory.UNEXPECTED: None,
 }
+
+
+def did_you_mean_hint(candidates: Sequence[Mapping[str, str]]) -> str:
+    """Build the NOT_FOUND "did you mean" hint from near-miss candidates.
+
+    Shared by every surface (MCP ``tool_error_payload``, the REST error body,
+    the CLI ``NOT_FOUND`` envelope) so the phrasing cannot drift. Lists each
+    candidate's title inline — the MCP wire flattens the structured error to a
+    string, so an agent that only reads the flat ``hint:`` still sees the
+    suggestions. Replaces the generic :data:`CATEGORY_HINTS` NOT_FOUND hint only
+    when a lookup actually produced near matches.
+    """
+    titles = ", ".join(repr(candidate["title"]) for candidate in candidates)
+    return f"Did you mean: {titles}? Pass the full title or id."
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -153,13 +153,15 @@ def did_you_mean_hint(candidates: Sequence[Mapping[str, str]]) -> str:
 
     Shared by every surface (MCP ``tool_error_payload``, the REST error body,
     the CLI ``NOT_FOUND`` envelope) so the phrasing cannot drift. Lists each
-    candidate's title inline — the MCP wire flattens the structured error to a
-    string, so an agent that only reads the flat ``hint:`` still sees the
-    suggestions. Replaces the generic :data:`CATEGORY_HINTS` NOT_FOUND hint only
-    when a lookup actually produced near matches.
+    candidate's title **and id** inline — the MCP wire flattens the structured
+    error to a string via ``to_tool_error`` (which serializes only
+    code/message/retriable/hint and drops the structured ``candidates`` list), so
+    the id must live in the hint text for a flat-string client to retry by id
+    without another list call. Replaces the generic :data:`CATEGORY_HINTS`
+    NOT_FOUND hint only when a lookup actually produced near matches.
     """
-    titles = ", ".join(repr(candidate["title"]) for candidate in candidates)
-    return f"Did you mean: {titles}? Pass the full title or id."
+    parts = ", ".join(f"{c['title']!r} (id: {c['id']})" for c in candidates)
+    return f"Did you mean: {parts}? Pass the full title or id."
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/_app/labels.py
+++ b/src/notebooklm/_app/labels.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from ..exceptions import ValidationError
 from ..types import Label
-from .resolve import validate_id
+from .resolve import near_miss_candidates, validate_id
 
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
@@ -173,10 +173,22 @@ async def resolve_label_id(
             {"name": token, "candidates": _candidate_payload(name_matches)},
         )
 
+    # Near-miss "did you mean" candidates (issue #1787): a name mistyped with a
+    # hyphen for an em-dash or a bare prefix surfaces the real label(s) so the
+    # command layer can render them instead of a bare NOT_FOUND.
+    extra: dict[str, Any] = {"id": token, "notebook_id": notebook_id}
+    candidates = near_miss_candidates(
+        token,
+        labels,
+        id_of=lambda label: label.id,
+        title_of=lambda label: label.name,
+    )
+    if candidates:
+        extra["candidates"] = candidates
     raise LabelResolutionError(
         f"No label found matching '{token}'. Run 'notebooklm label list' to see available labels.",
         "NOT_FOUND",
-        {"id": token, "notebook_id": notebook_id},
+        extra,
     )
 
 

--- a/src/notebooklm/_app/labels.py
+++ b/src/notebooklm/_app/labels.py
@@ -66,6 +66,15 @@ class LabelResolutionError(ValidationError):
     preserved.
     """
 
+    #: Near-miss ``{"id", "title"}`` candidates for a failed name lookup
+    #: (issue #1787). Mirrors :attr:`NotFoundError.candidates` so the MCP / REST
+    #: surfaces — which read ``getattr(exc, "candidates", ())`` and never reach
+    #: into ``.extra`` — enrich a label near-miss too, even though this error
+    #: classifies as ``VALIDATION`` rather than ``NOT_FOUND``. Empty unless the
+    #: resolver sets it; the ``.extra["candidates"]`` copy still feeds the CLI
+    #: ``--json`` envelope (which surfaces ``.extra``).
+    candidates: Sequence[dict[str, str]] = ()
+
     def __init__(
         self,
         message: str,
@@ -174,8 +183,11 @@ async def resolve_label_id(
         )
 
     # Near-miss "did you mean" candidates (issue #1787): a name mistyped with a
-    # hyphen for an em-dash or a bare prefix surfaces the real label(s) so the
-    # command layer can render them instead of a bare NOT_FOUND.
+    # hyphen for an em-dash or a bare prefix surfaces the real label(s). Stored on
+    # ``.extra`` (for the CLI ``--json`` envelope) AND on ``.candidates`` (for the
+    # MCP / REST surfaces, reached by ``source_list(label=…)``, which read the
+    # attribute — not ``.extra`` — and never see a VALIDATION error's near-misses
+    # otherwise).
     extra: dict[str, Any] = {"id": token, "notebook_id": notebook_id}
     candidates = near_miss_candidates(
         token,
@@ -185,11 +197,13 @@ async def resolve_label_id(
     )
     if candidates:
         extra["candidates"] = candidates
-    raise LabelResolutionError(
+    error = LabelResolutionError(
         f"No label found matching '{token}'. Run 'notebooklm label list' to see available labels.",
         "NOT_FOUND",
         extra,
     )
+    error.candidates = candidates
+    raise error
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/_app/resolve.py
+++ b/src/notebooklm/_app/resolve.py
@@ -14,8 +14,10 @@ imports (enforced by ``tests/_guardrails/test_app_boundary.py``).
 
 from __future__ import annotations
 
+import difflib
 import re
-from collections.abc import Callable, Sequence
+import unicodedata
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -174,3 +176,102 @@ def resolve_ref(
         lines.append(f"  ... and {len(matches) - _MAX_AMBIGUOUS_CANDIDATES} more")
     lines.append("\nSpecify more characters to narrow down.")
     raise AmbiguousIdError(token, candidate_ids, "\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Near-miss suggestions for a failed *name* lookup (issue #1787)
+# ---------------------------------------------------------------------------
+
+#: Dash variants agents commonly type in place of one another (or of a plain
+#: hyphen) when referencing an em-dash-heavy title: hyphen/non-breaking-hyphen,
+#: figure/en/em dash, horizontal bar, and the minus sign. All fold to a plain
+#: ``-`` before comparison so ``"… - Intel"`` still matches ``"… — Intel"``.
+_DASH_TRANSLATION = str.maketrans(dict.fromkeys("‐‑‒–—―−", "-"))
+
+#: Minimum :func:`difflib.get_close_matches` similarity ratio for a fuzzy
+#: near-miss suggestion. The library default; low enough to catch a couple of
+#: transposed/changed characters, high enough to avoid noise.
+_FUZZY_CUTOFF = 0.6
+
+#: Default maximum near-miss candidates surfaced on a failed name lookup.
+_MAX_NEAR_MISS_CANDIDATES = 3
+
+
+def _normalize_for_match(text: str) -> str:
+    """Fold a title/token for punctuation- and case-insensitive comparison.
+
+    NFKC folds compatibility forms (e.g. a non-breaking space to a plain space),
+    every dash variant collapses to a plain hyphen, runs of whitespace collapse
+    to a single space, and the result is casefolded. This is what lets a hyphen
+    typed for an em-dash — or a normal space typed for a non-breaking one — still
+    match the real title.
+    """
+    folded = unicodedata.normalize("NFKC", text).translate(_DASH_TRANSLATION)
+    return " ".join(folded.split()).casefold()
+
+
+def near_miss_candidates(
+    token: str,
+    items: Iterable[Any],
+    *,
+    id_of: Callable[[Any], str],
+    title_of: Callable[[Any], str | None],
+    limit: int = _MAX_NEAR_MISS_CANDIDATES,
+) -> list[dict[str, str]]:
+    """Return up to ``limit`` near-miss ``{"id", "title"}`` suggestions for ``token``.
+
+    Enriches a failed *name* lookup (``NOT_FOUND``) with "did you mean" hints.
+    Two cheap, stdlib-only passes over the already-fetched ``items`` (no extra
+    RPC): a **prefix** pass (titles whose normalized form starts with the
+    normalized token — catches ``"Scientific"`` -> ``"Scientific PDF Parsing —
+    …"``), then a **fuzzy** pass via :func:`difflib.get_close_matches` over the
+    normalized titles (catches punctuation-only differences such as em-dash vs
+    hyphen, whose normalized forms are near-identical).
+
+    Both passes compare *normalized* text (see :func:`_normalize_for_match`), so
+    an em-dash/hyphen or non-breaking-space mismatch still surfaces the real
+    title. Results de-duplicate by id, cap at ``limit``, and carry each item's
+    ORIGINAL id and title. An empty/whitespace ``token``, or no near match,
+    returns ``[]``.
+    """
+    norm_token = _normalize_for_match(token)
+    if not norm_token:
+        return []
+
+    # (normalized_title, original_id, original_title) for every titled item.
+    entries: list[tuple[str, str, str]] = []
+    for item in items:
+        title = title_of(item)
+        if not title:
+            continue
+        entries.append((_normalize_for_match(title), str(id_of(item)), str(title)))
+
+    results: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    def _add(item_id: str, title: str) -> None:
+        if item_id not in seen:
+            seen.add(item_id)
+            results.append({"id": item_id, "title": title})
+
+    # Pass 1 — prefix matches, in list order.
+    for norm_title, item_id, title in entries:
+        if len(results) >= limit:
+            return results
+        if norm_title.startswith(norm_token):
+            _add(item_id, title)
+
+    # Pass 2 — fuzzy matches over the normalized titles for whatever slots remain.
+    if len(results) < limit and entries:
+        norm_titles = [norm_title for norm_title, _, _ in entries]
+        for match in difflib.get_close_matches(
+            norm_token, norm_titles, n=limit, cutoff=_FUZZY_CUTOFF
+        ):
+            for norm_title, item_id, title in entries:
+                if norm_title == match:
+                    _add(item_id, title)
+                    break
+            if len(results) >= limit:
+                break
+
+    return results

--- a/src/notebooklm/_app/resolve.py
+++ b/src/notebooklm/_app/resolve.py
@@ -265,7 +265,10 @@ def near_miss_candidates(
     # ``norm_titles`` is de-duplicated (order-preserving) so a repeated title does
     # not waste a ``get_close_matches`` slot; every item sharing a matched
     # normalized title is then a candidate (no inner ``break``), so two items whose
-    # titles differ only in punctuation both surface while slots remain.
+    # titles differ only in punctuation both surface while slots remain. ``n=limit``
+    # (not ``limit - len(results)``) is fine: ``limit`` is a cap, not a target, and
+    # ``_add`` drops any fuzzy hit already surfaced by the prefix pass — so the
+    # final count can be below ``limit`` even with more distinct matches available.
     if len(results) < limit and entries:
         norm_titles = list(dict.fromkeys(norm_title for norm_title, _, _ in entries))
         for match in difflib.get_close_matches(

--- a/src/notebooklm/_app/resolve.py
+++ b/src/notebooklm/_app/resolve.py
@@ -262,15 +262,20 @@ def near_miss_candidates(
             _add(item_id, title)
 
     # Pass 2 — fuzzy matches over the normalized titles for whatever slots remain.
+    # ``norm_titles`` is de-duplicated (order-preserving) so a repeated title does
+    # not waste a ``get_close_matches`` slot; every item sharing a matched
+    # normalized title is then a candidate (no inner ``break``), so two items whose
+    # titles differ only in punctuation both surface while slots remain.
     if len(results) < limit and entries:
-        norm_titles = [norm_title for norm_title, _, _ in entries]
+        norm_titles = list(dict.fromkeys(norm_title for norm_title, _, _ in entries))
         for match in difflib.get_close_matches(
             norm_token, norm_titles, n=limit, cutoff=_FUZZY_CUTOFF
         ):
             for norm_title, item_id, title in entries:
                 if norm_title == match:
                     _add(item_id, title)
-                    break
+                    if len(results) >= limit:
+                        break
             if len(results) >= limit:
                 break
 

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -94,10 +94,6 @@ def _not_found_extra(error: NotFoundError) -> dict[str, Any]:
             extra[attr] = value
             extra["id"] = value
             break
-    # Near-miss "did you mean" candidates from a failed name lookup (issue #1787).
-    candidates = list(getattr(error, "candidates", ()) or ())
-    if candidates:
-        extra["candidates"] = candidates
     return extra
 
 
@@ -314,9 +310,11 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
         nf_extra = _not_found_extra(e)
         if verbose and isinstance(e, RPCError) and e.method_id:
             nf_extra["method_id"] = e.method_id
-        # Surface near-miss "did you mean" candidates (issue #1787) as a text-mode
-        # hint; the JSON envelope already carries them via ``nf_extra``.
+        # Near-miss "did you mean" candidates (issue #1787), read once and used for
+        # both the JSON envelope and the text-mode hint.
         nf_candidates = list(getattr(e, "candidates", ()) or ())
+        if nf_candidates:
+            nf_extra["candidates"] = nf_candidates
         _output_error(
             f"Error: {e}",
             "NOT_FOUND",

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -12,6 +12,7 @@ from typing import Any, NoReturn
 
 import click
 
+from .._app.errors import did_you_mean_hint
 from ..exceptions import (
     ArtifactTimeoutError,
     AuthError,
@@ -93,6 +94,10 @@ def _not_found_extra(error: NotFoundError) -> dict[str, Any]:
             extra[attr] = value
             extra["id"] = value
             break
+    # Near-miss "did you mean" candidates from a failed name lookup (issue #1787).
+    candidates = list(getattr(error, "candidates", ()) or ())
+    if candidates:
+        extra["candidates"] = candidates
     return extra
 
 
@@ -309,12 +314,16 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
         nf_extra = _not_found_extra(e)
         if verbose and isinstance(e, RPCError) and e.method_id:
             nf_extra["method_id"] = e.method_id
+        # Surface near-miss "did you mean" candidates (issue #1787) as a text-mode
+        # hint; the JSON envelope already carries them via ``nf_extra``.
+        nf_candidates = list(getattr(e, "candidates", ()) or ())
         _output_error(
             f"Error: {e}",
             "NOT_FOUND",
             json_output,
             1,
             extra=nf_extra or None,
+            hint=did_you_mean_hint(nf_candidates) if nf_candidates else None,
         )
     except NotebookLMError as e:
         extra_info: dict[str, Any] | None = None

--- a/src/notebooklm/cli/label_cmd.py
+++ b/src/notebooklm/cli/label_cmd.py
@@ -25,6 +25,7 @@ from typing import Any, NoReturn
 
 import click
 
+from .._app.errors import did_you_mean_hint
 from .._app.labels import (
     execute_label_add_sources,
     execute_label_create,
@@ -52,12 +53,17 @@ from .services.label_listing import (
 
 def _handle_label_resolution_error(exc: LabelResolutionError, *, json_output: bool) -> NoReturn:
     """Render a typed label-resolution error through the CLI error contract."""
+    # Near-miss candidates (issue #1787) reach the JSON envelope via ``.extra``;
+    # in text mode render them as a "Did you mean" hint so the CLI label path
+    # matches the *NotFoundError handler.
+    candidates = list(exc.candidates)
     output_error(
         exc.message,
         code=exc.code,
         json_output=json_output,
         exit_code=1,
         extra=dict(exc.extra) if exc.extra else None,
+        hint=did_you_mean_hint(candidates) if candidates else None,
     )
     raise AssertionError("unreachable")  # pragma: no cover
 

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -184,17 +184,17 @@ class NotFoundError(NotebookLMError):
     :class:`SourceNotFoundError` is still a :class:`SourceError`, and
     :class:`NotebookNotFoundError` is still an :class:`RPCError` and a
     :class:`NotebookError`. This umbrella is additive and does not
-    change existing catch semantics.
-
-    .. note::
-
-        As of v0.6.0, every concrete ``*NotFoundError`` subclass also mixes in
-        :class:`RPCError`, so ``except RPCError`` catches each of them
-        uniformly. See the v0.6.0 BREAKING-CHANGE entry in CHANGELOG.md
-        for migration guidance (the broad ``except RPCError`` clause now
-        intercepts a missing source / artifact that previously fell
-        through to the specific ``*NotFoundError`` handler).
+    change existing catch semantics. Since v0.6.0 every concrete
+    ``*NotFoundError`` also mixes in :class:`RPCError`, so ``except RPCError``
+    now intercepts a missing source / artifact that previously fell through to
+    the specific ``*NotFoundError`` handler (see the v0.6.0 CHANGELOG entry).
     """
+
+    #: Near-miss ``{"id", "title"}`` candidates for a failed *name* lookup
+    #: (issue #1787); empty unless a name resolver sets it. The immutable empty
+    #: default is never mutated in place — resolvers assign a fresh list. See
+    #: :func:`notebooklm._app.errors.did_you_mean_hint`.
+    candidates: Sequence[dict[str, str]] = ()
 
 
 class WaitTimeoutError(NotebookLMError, TimeoutError):

--- a/src/notebooklm/mcp/_errors.py
+++ b/src/notebooklm/mcp/_errors.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from fastmcp.exceptions import ToolError
 
-from .._app.errors import CATEGORY_HINTS, ErrorCategory, classify
+from .._app.errors import CATEGORY_HINTS, ErrorCategory, classify, did_you_mean_hint
 from .._redact import redact
 from ..exceptions import NotebookLMError
 
@@ -110,6 +110,14 @@ def tool_error_payload(exc: BaseException) -> dict[str, Any]:
         "message": message,
         "retriable": classified.retriable,
     }
+    # A failed *name* lookup may carry near-miss candidates (issue #1787). Surface
+    # them structurally AND replace the generic NOT_FOUND hint with a "Did you
+    # mean …" one that names the titles inline — the FastMCP wire flattens this
+    # payload to a string, so the inline titles are what a flat-string client sees.
+    candidates = list(getattr(exc, "candidates", ()) or ())
+    if candidates:
+        payload["candidates"] = candidates
+        hint = did_you_mean_hint(candidates)
     if hint is not None:
         payload["hint"] = hint
     return payload

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any
 from .._app.resolve import (
     FULL_ID_PATTERN,
     AmbiguousIdError,
+    near_miss_candidates,
     resolve_ref,
     validate_id,
 )
@@ -90,7 +91,17 @@ def _resolve_by_title(
         return str(match.id)
 
     if not matches:
-        raise not_found(token)
+        # Enrich the miss with near-miss "did you mean" candidates (issue #1787):
+        # a title mistyped with a hyphen for an em-dash, a non-breaking space for
+        # a normal one, or a bare prefix would otherwise force a blind retry loop.
+        error = not_found(token)
+        error.candidates = near_miss_candidates(
+            token,
+            items,
+            id_of=lambda item: str(item.id),
+            title_of=lambda item: item.title,
+        )
+        raise error
 
     candidate_ids = [str(item.id) for item in matches]
     lines = [f"Ambiguous title '{token}' matches {len(matches)} items:"]

--- a/src/notebooklm/server/_errors.py
+++ b/src/notebooklm/server/_errors.py
@@ -41,6 +41,7 @@ from .._app.errors import (
     ClassifiedError,
     ErrorCategory,
     classify,
+    did_you_mean_hint,
     is_retriable,
 )
 from .._redact import redact as _shared_redact
@@ -216,6 +217,12 @@ def _project_classified(exc: BaseException, classified: ClassifiedError) -> dict
         "retriable": classified.retriable,
     }
     hint = CATEGORY_HINTS.get(category)
+    # A failed *name* lookup may carry near-miss candidates (issue #1787); surface
+    # them and swap the generic NOT_FOUND hint for a "Did you mean …" one.
+    candidates = list(getattr(exc, "candidates", ()) or ())
+    if candidates:
+        body["candidates"] = candidates
+        hint = did_you_mean_hint(candidates)
     if hint is not None:
         body["hint"] = hint
     return body

--- a/tests/server/test_errors.py
+++ b/tests/server/test_errors.py
@@ -109,6 +109,20 @@ def test_error_body_carries_hint_where_present() -> None:
     assert "hint" not in _error_body(exc.RPCError("decode failed"))
 
 
+def test_not_found_body_carries_near_miss_candidates() -> None:
+    """A failed name lookup surfaces near-miss candidates + a 'Did you mean' hint (#1787)."""
+    err = exc.NotebookNotFoundError("Scientific")
+    err.candidates = [{"id": "37fe5c1d", "title": "Scientific PDF Parsing"}]
+    body = _error_body(err)
+    assert body["candidates"] == [{"id": "37fe5c1d", "title": "Scientific PDF Parsing"}]
+    assert body["hint"].startswith("Did you mean:")
+
+
+def test_not_found_body_without_candidates_omits_the_field() -> None:
+    body = _error_body(exc.NotebookNotFoundError("Scientific"))
+    assert "candidates" not in body
+
+
 def test_http_error_response_enriches_mapped_status() -> None:
     """A status that maps to a neutral ErrorCategory (411 → validation) carries
     retriable + hint, drawn from the shared _app tables."""

--- a/tests/unit/app/test_app_errors.py
+++ b/tests/unit/app/test_app_errors.py
@@ -13,6 +13,7 @@ from notebooklm._app.errors import (
     ClassifiedError,
     ErrorCategory,
     classify,
+    did_you_mean_hint,
     is_retriable,
 )
 from notebooklm._app.source_add import SourceAddValidationError
@@ -298,3 +299,21 @@ def test_category_hints_are_surface_neutral() -> None:
             )
     assert CATEGORY_HINTS[ErrorCategory.AUTH] == "Re-authenticate and retry."
     assert "task status" in CATEGORY_HINTS[ErrorCategory.ARTIFACT_TIMEOUT]
+
+
+# --- did_you_mean_hint (issue #1787) ---------------------------------------
+
+
+def test_did_you_mean_hint_includes_id_and_title() -> None:
+    """The hint carries id AND title so a flat-string MCP client can retry by id."""
+    hint = did_you_mean_hint([{"id": "abc123", "title": "Scientific PDF Parsing"}])
+    assert hint.startswith("Did you mean:")
+    assert "abc123" in hint
+    assert "Scientific PDF Parsing" in hint
+    assert hint.endswith("Pass the full title or id.")
+
+
+def test_did_you_mean_hint_lists_multiple_candidates() -> None:
+    hint = did_you_mean_hint([{"id": "id1", "title": "Alpha"}, {"id": "id2", "title": "Beta"}])
+    assert "id1" in hint and "id2" in hint
+    assert "Alpha" in hint and "Beta" in hint

--- a/tests/unit/app/test_app_resolve.py
+++ b/tests/unit/app/test_app_resolve.py
@@ -9,6 +9,7 @@ import pytest
 from notebooklm._app.resolve import (
     AmbiguousIdError,
     Resolution,
+    near_miss_candidates,
     resolve_ref,
     validate_id,
 )
@@ -158,3 +159,58 @@ def test_resolve_ref_strips_token_before_matching() -> None:
     result = resolve_ref("  abc  ", items, id_of=_id_of, title_of=_title_of)
 
     assert result.id == "abc123"
+
+
+# --- near_miss_candidates (issue #1787) ------------------------------------
+
+
+def test_near_miss_prefix_surfaces_full_title() -> None:
+    real = "Scientific PDF Parsing — Landscape, Benchmarks & Multimodal Extraction"
+    items = [Item(id="37fe5c1d", title=real), Item(id="cafef00d", title="Unrelated")]
+    assert near_miss_candidates("Scientific", items, id_of=_id_of, title_of=_title_of) == [
+        {"id": "37fe5c1d", "title": real}
+    ]
+
+
+def test_near_miss_em_dash_matches_hyphen() -> None:
+    items = [Item(id="deadbeef", title="Acme — Competitive Intel")]
+    # A plain hyphen typed for the em-dash still surfaces the real title.
+    assert near_miss_candidates(
+        "Acme - Competitive Intel", items, id_of=_id_of, title_of=_title_of
+    ) == [{"id": "deadbeef", "title": "Acme — Competitive Intel"}]
+
+
+def test_near_miss_non_breaking_space_matches_normal_space() -> None:
+    items = [Item(id="deadbeef", title="Acme Corp Notes")]
+    assert near_miss_candidates("Acme Corp Notes", items, id_of=_id_of, title_of=_title_of) == [
+        {"id": "deadbeef", "title": "Acme Corp Notes"}
+    ]
+
+
+def test_near_miss_fuzzy_matches_typo() -> None:
+    items = [Item(id="deadbeef", title="Competitive Landscape")]
+    got = near_miss_candidates("Competitve Landscape", items, id_of=_id_of, title_of=_title_of)
+    assert [c["id"] for c in got] == ["deadbeef"]
+
+
+def test_near_miss_no_close_match_returns_empty() -> None:
+    items = [Item(id="deadbeef", title="Alpha"), Item(id="cafef00d", title="Beta")]
+    assert near_miss_candidates("Zzzzqwx", items, id_of=_id_of, title_of=_title_of) == []
+
+
+def test_near_miss_empty_token_returns_empty() -> None:
+    items = [Item(id="deadbeef", title="Alpha")]
+    assert near_miss_candidates("   ", items, id_of=_id_of, title_of=_title_of) == []
+
+
+def test_near_miss_skips_untitled_items() -> None:
+    items = [Item(id="deadbeef", title=None), Item(id="cafef00d", title="Alpha Notes")]
+    got = near_miss_candidates("Alpha", items, id_of=_id_of, title_of=_title_of)
+    assert [c["id"] for c in got] == ["cafef00d"]
+
+
+def test_near_miss_caps_at_limit_and_dedupes() -> None:
+    items = [Item(id=f"id{n}", title=f"Report {n}") for n in range(10)]
+    got = near_miss_candidates("Report", items, id_of=_id_of, title_of=_title_of, limit=3)
+    assert len(got) == 3
+    assert len({c["id"] for c in got}) == 3

--- a/tests/unit/app/test_app_resolve.py
+++ b/tests/unit/app/test_app_resolve.py
@@ -214,3 +214,21 @@ def test_near_miss_caps_at_limit_and_dedupes() -> None:
     got = near_miss_candidates("Report", items, id_of=_id_of, title_of=_title_of, limit=3)
     assert len(got) == 3
     assert len({c["id"] for c in got}) == 3
+
+
+def test_near_miss_fuzzy_surfaces_all_items_sharing_a_normalized_title() -> None:
+    """Distinct items whose titles normalize identically must each surface (#1794 review).
+
+    A shared normalized title must not let the first item shadow the rest while
+    limit slots remain — and the result must not depend on input order.
+    """
+    # "Report — Q3" and "Report - Q3" both normalize to "report - q3"; the token
+    # has a typo so this resolves via the fuzzy pass, not the prefix pass.
+    items = [Item(id="em", title="Reportt — Q3"), Item(id="hy", title="Reportt - Q3")]
+    got = near_miss_candidates("Report Q3", items, id_of=_id_of, title_of=_title_of)
+    assert {c["id"] for c in got} == {"em", "hy"}
+
+    reversed_got = near_miss_candidates(
+        "Report Q3", list(reversed(items)), id_of=_id_of, title_of=_title_of
+    )
+    assert {c["id"] for c in reversed_got} == {"em", "hy"}

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -298,6 +298,30 @@ class TestHandleErrorsNotFound:
         output = capsys.readouterr().err
         assert "Source not found: src_456" in output
 
+    def test_not_found_candidates_in_json_and_text_hint(self, capsys):
+        """Near-miss candidates (issue #1787) surface in JSON and as a text hint."""
+        err = NotebookNotFoundError("Scientific")
+        err.candidates = [{"id": "37fe5c1d", "title": "Scientific PDF Parsing"}]
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise err
+        data = json.loads(capsys.readouterr().out)
+        assert data["code"] == "NOT_FOUND"
+        assert data["candidates"] == [{"id": "37fe5c1d", "title": "Scientific PDF Parsing"}]
+
+        err2 = NotebookNotFoundError("Scientific")
+        err2.candidates = [{"id": "37fe5c1d", "title": "Scientific PDF Parsing"}]
+        with pytest.raises(SystemExit), handle_errors(json_output=False):
+            raise err2
+        text = capsys.readouterr().err
+        assert "Did you mean:" in text
+        assert "Scientific PDF Parsing" in text
+
+    def test_not_found_without_candidates_omits_candidates_key(self, capsys):
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise NotebookNotFoundError("Scientific")
+        data = json.loads(capsys.readouterr().out)
+        assert "candidates" not in data
+
     def test_not_found_verbose_includes_method_id(self, capsys):
         """With ``verbose``, the RPC ``method_id`` is surfaced in the envelope."""
         with pytest.raises(SystemExit), handle_errors(json_output=True, verbose=True):

--- a/tests/unit/cli/test_label_cmd.py
+++ b/tests/unit/cli/test_label_cmd.py
@@ -120,6 +120,47 @@ def test_label_sources_resolves_by_name(runner, mock_auth, mock_fetch_tokens) ->
     client.labels.sources.assert_awaited_once_with("nb_123", "lblaaa111")
 
 
+def test_label_sources_near_miss_text_mode_shows_did_you_mean(
+    runner, mock_auth, mock_fetch_tokens
+) -> None:
+    """A label name mistyped with a hyphen for an em-dash gets a text-mode hint (#1787)."""
+    labels = [Label(id="lblaaa111", name="Q3 — Papers", source_ids=["s1"])]
+    client = _client_with_labels(labels=labels)
+
+    result = _run(
+        runner,
+        mock_auth,
+        mock_fetch_tokens,
+        ["label", "sources", "Q3 - Papers", "-n", "nb_123"],
+        client,
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Did you mean:" in result.output
+    assert "Q3 — Papers" in result.output
+    assert "lblaaa111" in result.output
+
+
+def test_label_sources_near_miss_json_mode_carries_candidates(
+    runner, mock_auth, mock_fetch_tokens
+) -> None:
+    labels = [Label(id="lblaaa111", name="Q3 — Papers", source_ids=["s1"])]
+    client = _client_with_labels(labels=labels)
+
+    result = _run(
+        runner,
+        mock_auth,
+        mock_fetch_tokens,
+        ["label", "sources", "Q3 - Papers", "-n", "nb_123", "--json"],
+        client,
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.stdout)
+    assert payload["code"] == "NOT_FOUND"
+    assert payload["candidates"] == [{"id": "lblaaa111", "title": "Q3 — Papers"}]
+
+
 # ---------------------------------------------------------------------------
 # label create
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_label_listing.py
+++ b/tests/unit/cli/test_label_listing.py
@@ -142,7 +142,12 @@ async def test_resolve_near_miss_attaches_candidates() -> None:
         await resolve_label_id(client, "nb_1", "Q3 - Papers")
     assert exc.value.code == "NOT_FOUND"
     assert exc.value.extra is not None
-    assert exc.value.extra["candidates"] == [{"id": "lblaaa111", "title": "Q3 — Papers"}]
+    expected = [{"id": "lblaaa111", "title": "Q3 — Papers"}]
+    assert exc.value.extra["candidates"] == expected
+    # Also exposed on ``.candidates`` so the MCP / REST surfaces (which read the
+    # attribute, not ``.extra``) enrich a label near-miss reached via
+    # ``source_list(label=…)`` even though the error classifies as VALIDATION.
+    assert list(exc.value.candidates) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_label_listing.py
+++ b/tests/unit/cli/test_label_listing.py
@@ -134,6 +134,29 @@ async def test_resolve_no_match_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_near_miss_attaches_candidates() -> None:
+    """A name mistyped with a hyphen for an em-dash surfaces the real label (#1787)."""
+    labels = [Label(id="lblaaa111", name="Q3 — Papers"), Label(id="lblbbb222", name="Other")]
+    client = _make_client(labels=labels)
+    with pytest.raises(LabelResolutionError) as exc:
+        await resolve_label_id(client, "nb_1", "Q3 - Papers")
+    assert exc.value.code == "NOT_FOUND"
+    assert exc.value.extra is not None
+    assert exc.value.extra["candidates"] == [{"id": "lblaaa111", "title": "Q3 — Papers"}]
+
+
+@pytest.mark.asyncio
+async def test_resolve_no_near_match_omits_candidates() -> None:
+    labels = [Label(id="lblaaa111", name="Papers")]
+    client = _make_client(labels=labels)
+    with pytest.raises(LabelResolutionError) as exc:
+        await resolve_label_id(client, "nb_1", "Zzzzqwx")
+    assert exc.value.code == "NOT_FOUND"
+    assert exc.value.extra is not None
+    assert "candidates" not in exc.value.extra
+
+
+@pytest.mark.asyncio
 async def test_resolve_uuid_shaped_name_after_id_pass_misses() -> None:
     """A UUID-shaped *name* is found by the name pass once the id pass misses.
 

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -146,6 +146,31 @@ def test_to_tool_error_returns_tool_error_with_payload() -> None:
     assert "RATE_LIMITED" in str(err)
 
 
+def test_not_found_candidates_surface_in_payload_and_did_you_mean_hint() -> None:
+    """Near-miss candidates (issue #1787) appear structurally and swap the hint."""
+    err = exc.NotebookNotFoundError("Scientific")
+    err.candidates = [{"id": "37fe5c1d", "title": "Scientific PDF Parsing — Landscape"}]
+    payload = tool_error_payload(err)
+
+    assert payload["code"] == "NOT_FOUND"
+    assert payload["candidates"] == [
+        {"id": "37fe5c1d", "title": "Scientific PDF Parsing — Landscape"}
+    ]
+    # The generic NOT_FOUND hint is replaced by a "Did you mean …" hint that
+    # names the title inline (so a flat-string MCP client still sees it).
+    assert payload["hint"].startswith("Did you mean:")
+    assert "Scientific PDF Parsing — Landscape" in payload["hint"]
+    # And that hint reaches the flattened ToolError wire string.
+    assert "Did you mean:" in str(to_tool_error(err))
+
+
+def test_not_found_without_candidates_keeps_generic_hint() -> None:
+    """A miss with no near match carries no candidates and the generic hint."""
+    payload = tool_error_payload(exc.NotebookNotFoundError("Nonexistent"))
+    assert "candidates" not in payload
+    assert payload["hint"] == CATEGORY_TABLE[ErrorCategory.NOT_FOUND][1]
+
+
 def test_mcp_errors_translates_notebooklm_error() -> None:
     with pytest.raises(ToolError) as caught, mcp_errors():  # noqa: PT012
         raise exc.NotFoundError("missing")

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -171,6 +171,21 @@ def test_not_found_without_candidates_keeps_generic_hint() -> None:
     assert payload["hint"] == CATEGORY_TABLE[ErrorCategory.NOT_FOUND][1]
 
 
+def test_validation_error_with_candidates_is_enriched() -> None:
+    """A label near-miss (VALIDATION-coded, candidates on the attr) still enriches.
+
+    ``source_list(label=…)`` resolves labels by name and raises the VALIDATION-
+    coded ``LabelResolutionError``; its ``.candidates`` must reach the wire with a
+    "Did you mean" hint even though the code is not NOT_FOUND.
+    """
+    err = exc.ValidationError("No label found matching 'Q3 - Papers'")
+    err.candidates = [{"id": "lbl1", "title": "Q3 — Papers"}]  # type: ignore[attr-defined]
+    payload = tool_error_payload(err)
+    assert payload["code"] == "VALIDATION"
+    assert payload["candidates"] == [{"id": "lbl1", "title": "Q3 — Papers"}]
+    assert payload["hint"].startswith("Did you mean:")
+
+
 def test_mcp_errors_translates_notebooklm_error() -> None:
     with pytest.raises(ToolError) as caught, mcp_errors():  # noqa: PT012
         raise exc.NotFoundError("missing")

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -157,11 +157,24 @@ def test_not_found_candidates_surface_in_payload_and_did_you_mean_hint() -> None
         {"id": "37fe5c1d", "title": "Scientific PDF Parsing — Landscape"}
     ]
     # The generic NOT_FOUND hint is replaced by a "Did you mean …" hint that
-    # names the title inline (so a flat-string MCP client still sees it).
+    # names the title AND id inline (so a flat-string MCP client still sees both).
     assert payload["hint"].startswith("Did you mean:")
     assert "Scientific PDF Parsing — Landscape" in payload["hint"]
-    # And that hint reaches the flattened ToolError wire string.
-    assert "Did you mean:" in str(to_tool_error(err))
+    assert "37fe5c1d" in payload["hint"]
+
+
+def test_candidate_id_reaches_the_flattened_toolerror_wire() -> None:
+    """to_tool_error drops the structured list, so the id must ride the hint string.
+
+    Regression for the codex P2: an MCP client only sees the flat ToolError
+    message, and must be able to retry by id without another list call.
+    """
+    err = exc.SourceNotFoundError("Quarterly - Revenue")
+    err.candidates = [{"id": "src-abc123-def456", "title": "Quarterly — Revenue Deck"}]
+    wire = str(to_tool_error(err))
+    assert "Did you mean:" in wire
+    assert "src-abc123-def456" in wire
+    assert "Quarterly — Revenue Deck" in wire
 
 
 def test_not_found_without_candidates_keeps_generic_hint() -> None:

--- a/tests/unit/mcp/test_resolve.py
+++ b/tests/unit/mcp/test_resolve.py
@@ -124,6 +124,40 @@ async def test_no_match_prefix_raises_not_found() -> None:
         await resolve_notebook(client, "ffff")
 
 
+# --------------------------------------------------------------------------- #
+# near-miss candidates on a failed name lookup (issue #1787)
+# --------------------------------------------------------------------------- #
+async def test_prefix_near_miss_attaches_candidate() -> None:
+    """A bare prefix of a real title surfaces that title as a candidate."""
+    real = "Scientific PDF Parsing — Landscape, Benchmarks & Multimodal Extraction"
+    client = _client(notebooks=[_NB("37fe5c1d", real), _NB("cafef00d", "Unrelated")])
+    with pytest.raises(NotebookNotFoundError) as caught:
+        await resolve_notebook(client, "Scientific")
+    assert list(caught.value.candidates) == [{"id": "37fe5c1d", "title": real}]
+
+
+async def test_em_dash_hyphen_near_miss_attaches_candidate() -> None:
+    """A hyphen typed for an em-dash still surfaces the real title."""
+    client = _client(notebooks=[_NB("deadbeef", "Acme — Competitive Intel")])
+    with pytest.raises(NotebookNotFoundError) as caught:
+        await resolve_notebook(client, "Acme - Competitive Intel")
+    assert [c["id"] for c in caught.value.candidates] == ["deadbeef"]
+
+
+async def test_exact_miss_with_no_near_match_has_empty_candidates() -> None:
+    client = _client(notebooks=[_NB("deadbeef", "Alpha"), _NB("cafef00d", "Beta")])
+    with pytest.raises(NotebookNotFoundError) as caught:
+        await resolve_notebook(client, "Zzzzqwx")
+    assert list(caught.value.candidates) == []
+
+
+async def test_source_near_miss_attaches_candidate() -> None:
+    client = _client(sources=[_Src("src0001", "Quarterly — Revenue Deck")])
+    with pytest.raises(SourceNotFoundError) as caught:
+        await resolve_source(client, "nb", "Quarterly - Revenue Deck")
+    assert [c["id"] for c in caught.value.candidates] == ["src0001"]
+
+
 @pytest.mark.parametrize("title", ["beef", "ABBA", "1234", "DEADBEEF"])
 async def test_hex_only_title_falls_back_to_title(title: str) -> None:
     """A notebook whose TITLE is all-hex resolves by name (id/prefix path misses)."""


### PR DESCRIPTION
## Summary

Closes #1787. A failed name resolution used to return only the generic
`NOT_FOUND` hint ("Check the id/name with the matching `*_list` tool"), so an
agent that mistyped a title — a bare prefix, or a punctuation-only slip like a
hyphen for an em-dash (`—`) or a normal space for a non-breaking one — got no
signal that a near-match existed and fell into a blind retry loop. These slips
are common because NotebookLM titles are em-dash-heavy.

Now the name resolvers attach up to **3 near-miss `candidates`** (`{id, title}`)
to the `NOT_FOUND` error, and every surface renders them with a
`Did you mean: …` hint that names the titles inline.

```
source_list(notebook="Scientific")
# NOT_FOUND: Notebook not found: Scientific (retriable=false)
#   candidates: [{"id": "37fe5c1d-…", "title": "Scientific PDF Parsing — Landscape, …"}]
#   hint: Did you mean: 'Scientific PDF Parsing — Landscape, …'? Pass the full title or id.
```

## Design

- **`_app/resolve.near_miss_candidates()`** — stdlib only. NFKC + dash/whitespace
  normalization (so `-`≈`—` and ` `≈`&nbsp;`), a prefix pass, then a
  `difflib.get_close_matches` fuzzy pass. Deduped by id, capped at 3. No new
  RPC — matches over the already-fetched list.
- **`_app/errors.did_you_mean_hint()`** — one shared hint builder so the phrasing
  cannot drift across MCP / REST / CLI.
- **`NotFoundError.candidates`** — immutable empty default on the umbrella;
  resolvers *assign* a fresh list. Net-zero lines in `exceptions.py`, so the
  ADR-0008 module-size ratchet stays pinned at 1546 (no ceiling bump).
- Wired into **`mcp/_resolve`** (one point covers notebook/source/note/artifact)
  and **`_app.labels`** (label `NOT_FOUND`). Surfaced by **`mcp/_errors`**,
  **`server/_errors`**, and **`cli/error_handler`** (JSON `candidates` + text hint).

## Applies to the five resolver types

notebook · source · note (item) · artifact — via `mcp/_resolve._resolve_by_title`;
and label — via `_app.labels.resolve_label_id`.

## Tests

New coverage on every surface: the helper itself (prefix, em-dash/hyphen, NBSP,
fuzzy typo, empty/no-match → `[]`, dedupe/cap), the MCP resolvers, the MCP
payload + flattened `ToolError`, the REST body, the CLI JSON envelope + text
hint, and the label resolver. An exact miss with no near match carries **empty**
candidates and keeps the generic hint. Full suite green (11700 passed), mypy
clean, ruff clean.

## Overlap note

Overlaps #1786 (unique-prefix notebook resolution) in the resolver area. If
#1786 lands first I'll rebase these resolver changes at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Did you mean…” near-miss suggestions for failed name/title lookups and surfaced up to three candidate matches (id + title) in error details.
* **Bug Fixes**
  * Improved suggestion matching for punctuation, spacing, and common typo variants.
  * Marked `NETWORK` as retriable for structured errors.
* **Documentation**
  * Updated the MCP guide wording for near-miss `NOT_FOUND` hints and candidates.
* **Tests**
  * Expanded unit tests covering candidates/hints across app, CLI, server, and MCP flows (including labels).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->