### PR TITLE
fix(mcp): rename research id params to poll_task_id, alias old names (#1789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP research tools now accept the poll id under one name, `poll_task_id`.**
+  `research_status`, `research_import`, and `research_cancel` previously took the
+  value that `research_start` / `research_status` surface as `poll_task_id` under
+  mismatched parameter names (`task_id` on status/import, `run_id` on cancel),
+  forcing docstring warnings about which id goes where and inviting copy-paste
+  mistakes. All three now accept it as `poll_task_id`, so the value pastes
+  verbatim from one tool's output into the next. The old `task_id` / `run_id`
+  names still work as **deprecated aliases** (removed in v0.9.0): passing one
+  emits a `DeprecationWarning` and adds a `deprecation` note to the result;
+  passing both names with different values is a validation error.
+  ([#1789](https://github.com/teng-lin/notebooklm-py/issues/1789))
+
 ### Fixed
 
 - **The `.mcpb` desktop bundle now ships for pre-releases and launches the

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -21,6 +21,7 @@ the broader stability policy (semver promise, supported Python versions, the
 | Deprecated | Replacement | Since | Removal | Notes |
 |------------|-------------|-------|---------|-------|
 | Awaiting `NotebookLMClient.from_storage(...)` | `async with NotebookLMClient.from_storage(...) as client:` | v0.5.0 | v1.0 | The `__await__` form still works. Warning emitted via `src/notebooklm/_deprecation.py::warn_deprecated`; suppress with `NOTEBOOKLM_QUIET_DEPRECATIONS=1` ([#1369](https://github.com/teng-lin/notebooklm-py/issues/1369)) |
+| MCP `research_status(task_id=…)` / `research_import(task_id=…)` / `research_cancel(run_id=…)` | The same value under `poll_task_id=…` on all three | v0.8.0 | v0.9.0 | The three tools each accept the id that `research_start` / `research_status` surface as `poll_task_id` — renamed so the value copies verbatim between tools. The old `task_id` / `run_id` param names still work as aliases but emit a `DeprecationWarning` (via `warn_deprecated`) and add a `deprecation` note to the tool result; passing both names with different values is a validation error. ([#1789](https://github.com/teng-lin/notebooklm-py/issues/1789)) |
 
 > The v0.8.0 error-contract runways (`get()`-returns-`None`, the
 > `wait_for_completion(interval=...)` alias, the dict-subscript bridge,

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -307,18 +307,25 @@ validation error, not a silent no-op.
 
 ```text
 task = research_start(notebook="Quantum Computing", query="post-quantum cryptography", source="web", mode="deep")
-research_status(notebook="Quantum Computing", task_id=task["poll_task_id"])
-research_import(notebook="Quantum Computing", task_id=task["poll_task_id"])
+research_status(notebook="Quantum Computing", poll_task_id=task["poll_task_id"])
+research_import(notebook="Quantum Computing", poll_task_id=task["poll_task_id"])
 ```
 
 `source` is `web` or `drive`; `mode` is `fast` or `deep`. Pass the
-`poll_task_id` returned by `research_start` when polling, importing, or
-cancelling so the request is pinned to the intended research task — it is the
-one id that drives polling (for a **deep** run it is the `report_id`; the raw
+`poll_task_id` returned by `research_start` — under the **same** parameter name,
+`poll_task_id` — when polling, importing, or cancelling, so the value copies
+verbatim from one tool's output into the next and the request is pinned to the
+intended research task (for a **deep** run it is the `report_id`; the raw
 `task_id` is an unpollable sessionId). Omitting the pin on `research_status` is
 allowed only when the notebook has a single in-flight task. `research_status`
 omits the large report by default — pass `include_report=true` to fetch it once
 `completed`.
+
+> **Deprecated (removed in v0.9.0):** `research_status`/`research_import` also
+> accept the old `task_id` name and `research_cancel` the old `run_id` name as
+> aliases for `poll_task_id`. Passing an alias still works but emits a
+> `DeprecationWarning` and adds a `deprecation` note to the result — switch to
+> `poll_task_id`. See [docs/deprecations.md](deprecations.md).
 
 ## Tool reference
 
@@ -329,7 +336,7 @@ omits the large report by default — pass `include_report=true` to fetch it onc
 | **Chat** | `chat_ask(notebook, question?, conversation_id?, references?, source_ids?, history?, suggest_followups?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all; `history`>0 also returns up to N prior `{question, answer}` pairs — omit `question` to recall only; `suggest_followups=true` also returns `suggested_prompts` (3 questions to ask — works question-less too)) · `chat_configure(notebook, chat_mode?, goal?, response_length?)` (`chat_mode`: default\|learning-guide\|concise\|detailed — a preset, mutually exclusive with `goal`/`response_length`; a **partial** custom call sets just `goal` or just `response_length` and **merges** with the current settings — the omitted field is preserved, not reset; only a bare call, no preset and neither field, is rejected) · `suggest_prompts(notebook, surface?, source_ids?, query?)` (READ_ONLY; `surface`: ask\|audio-deep-dive\|audio-brief\|audio-critique\|audio-debate\|video-explainer\|video-short\|quiz\|flashcards — returns `{title, prompt}` suggestions to steer that studio surface; `ask` (default) = chat questions) |
 | **Notes** | `note_save(notebook, note?, title?, content?)` (upsert: omit `note` to **create** — `title` AND `content` required; pass a `note` ref to **update** — `title` and/or `content`, title-only = rename). Reading and deleting notes fold into the Studio row below. |
 | **Studio** | `studio_list(notebook, item?, kind?, detail?, limit?, offset?)` (the unified Studio panel — **notes AND artifacts** merged into one `items` list; each item has `id`/`title`/`type` where `type` is `note` or a hyphenated artifact kind; artifacts add `status_label`/`url`; `detail=summary` (default) gives each note a bounded `content_preview` + full-body `char_count` to keep a discovery listing low-token, `detail=full` returns the whole note `content`; `kind` filters to one `type`; `item` fetches one note-or-artifact by ref as a 1-element list, always with the note's full `content`) · `studio_generate(notebook, artifact_type, …)` · `studio_status(notebook, task_id)` · `studio_get_prompt(notebook, artifact)` (the free-text prompt an artifact was generated from; `null` if none) · `studio_download(notebook, artifact? \| artifact_type?, path?, output_format?, artifact_id?)` (target by `artifact` name-or-id ref **or** by `artifact_type` [+ `artifact_id` for a specific one, else latest]) · `studio_rename(notebook, item, new_title)` (cross-type: renames a note OR an artifact resolved from the merged list) · `studio_retry(notebook, artifact)` (re-run a failed artifact in place; task_id == artifact_id) · `studio_delete(notebook, item, confirm)` (cross-type: deletes a note OR an artifact resolved from the merged list) |
-| **Research** | `research_start(notebook, query, source, mode)` (returns `poll_task_id` — the one id status/import/cancel drive off) · `research_status(notebook, task_id?, include_report?, report_max_chars?, source_limit?, source_offset?)` (report + per-source `report_markdown` omitted unless `include_report`) · `research_import(notebook, task_id)` · `research_cancel(notebook, run_id)` (sends the cancel unless the run is already terminal → `cancel_requested`) |
+| **Research** | `research_start(notebook, query, source, mode)` (returns `poll_task_id` — the one id status/import/cancel drive off) · `research_status(notebook, poll_task_id?, include_report?, report_max_chars?, source_limit?, source_offset?)` (report + per-source `report_markdown` omitted unless `include_report`) · `research_import(notebook, poll_task_id)` · `research_cancel(notebook, poll_task_id)` (sends the cancel unless the run is already terminal → `cancel_requested`). The old `task_id` / `run_id` param names are deprecated aliases for `poll_task_id`, removed in v0.9.0 |
 | **Sharing** | `share_status(notebook)` (is_public/access/share_url/shared_users; enums as string labels; `view_level` omitted — the read API can't report it) · `share_set_access(notebook, public?, view_level?, confirm)` (link settings; `view_level`: full\|chat, echoed back only when set; `confirm` gates public widening restricted→public) · `share_set_user(notebook, email, permission?, notify?, message?, confirm)` (upsert grant; `permission`: editor\|viewer; `notify` defaults `false`; `confirm` gates every grant) · `share_remove_user(notebook, email, confirm)` |
 | **Server** | `server_info(include_account?)` — version + local auth health; `include_account=true` adds an `account` block: signed-in identity (`email`, `authuser`) plus notebook/source limits and global `output_language` for quota pacing + language context (best-effort; identity is network-free from the profile, the quota fields need a live session). `email` is real account PII, returned only under this opt-in flag |
 

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -65,12 +65,15 @@ def _resolve_poll_task_id(
     """Fold a deprecated id alias into the canonical ``poll_task_id`` (issue #1789).
 
     Returns ``(resolved, deprecation_note)``. ``resolved`` is ``poll_task_id``
-    when supplied, else the ``alias`` value. When only the alias was used it emits
-    a gated ``DeprecationWarning`` (via :func:`warn_deprecated`) and returns a
-    caller-visible ``deprecation_note`` (else ``None``) so the MCP client — which
-    never sees the Python warning — is nudged toward the new name. Passing both
-    with different (stripped) values is rejected as ``ValidationError``; passing
-    both with the same value is allowed (the canonical wins, no warning).
+    when supplied, else the ``alias`` value. When only the alias was used with a
+    substantive value it emits a gated ``DeprecationWarning`` (via
+    :func:`warn_deprecated`) and returns a caller-visible ``deprecation_note``
+    (else ``None``) so the MCP client — which never sees the Python warning — is
+    nudged toward the new name. Passing both with different (stripped) values is
+    rejected as ``ValidationError``; passing both with the same value is allowed
+    (the canonical wins, no warning). A blank/whitespace-only alias is handed back
+    unwarned so the caller's own empty-id guard rejects it — no deprecation signal
+    is spent on a value that is about to be refused.
     """
     if poll_task_id is not None and alias is not None:
         if poll_task_id.strip() != alias.strip():
@@ -79,17 +82,23 @@ def _resolve_poll_task_id(
                 f"{tool}, not both with different values"
             )
         return poll_task_id, None
-    if alias is not None:
+    if alias is not None and alias.strip():
+        # ``stacklevel=4``: warn_deprecated (1) → _resolve_poll_task_id (2) → the
+        # tool coroutine (3) → the caller (4), so the warning points past this
+        # helper at the tool boundary rather than at the helper's own line.
         warn_deprecated(
             f"{tool}({old_name}=...) is deprecated; pass poll_task_id instead (the same value).",
             removal=_POLL_ID_ALIAS_REMOVAL,
+            stacklevel=4,
         )
         note = (
             f"'{old_name}' is deprecated; pass 'poll_task_id' instead (the same "
             f"value). '{old_name}' will be removed in v{_POLL_ID_ALIAS_REMOVAL}."
         )
         return alias, note
-    return poll_task_id, None
+    # No canonical value, and the alias (if any) is blank → return whatever was
+    # given (``poll_task_id`` is ``None`` here) so the tool's empty-id guard runs.
+    return (poll_task_id if poll_task_id is not None else alias), None
 
 
 def register(mcp: Any) -> None:

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -18,9 +18,13 @@ Thin adapters over the research surface:
   cancelled, and ``cancel_requested`` + ``run_status_before`` report honestly.
 
 One id value threads the whole flow — the ``poll_task_id`` surfaced by
-``research_start`` (deep's ``report_id`` / fast's ``task_id``). Pass it to
-``research_status`` / ``research_import`` (as ``task_id``) and ``research_cancel``
-(as ``run_id``); the per-tool param names differ but the value is the same.
+``research_start`` (deep's ``report_id`` / fast's ``task_id``). Every downstream
+tool now accepts it under the SAME name, ``poll_task_id`` (issue #1789), so the
+value copied from one tool's output pastes verbatim into the next. The original
+per-tool names — ``research_status``/``research_import``'s ``task_id`` and
+``research_cancel``'s ``run_id`` — remain accepted as deprecated aliases for one
+release (they emit a ``DeprecationWarning`` and a ``deprecation`` note in the
+result); see ``docs/deprecations.md``.
 
 Although the design sketch lists ``research_start(query, …)`` without a notebook
 argument, ``client.research.start`` is notebook-scoped (it needs a
@@ -39,11 +43,53 @@ from fastmcp import Context
 
 from ..._app import research as research_core
 from ..._app.serialize import to_jsonable
+from ..._deprecation import warn_deprecated
 from ...exceptions import ValidationError
 from .._confirm import READ_ONLY
 from .._context import get_client
 from .._errors import mcp_errors
 from .._resolve import resolve_notebook
+
+# One release of overlap: the ``task_id`` / ``run_id`` aliases are accepted
+# through the v0.8.0 line and removed in v0.9.0 (issue #1789). Named once so the
+# warning text and the ``docs/deprecations.md`` row stay in lock-step.
+_POLL_ID_ALIAS_REMOVAL = "0.9.0"
+
+
+def _resolve_poll_task_id(
+    tool: str,
+    old_name: str,
+    poll_task_id: str | None,
+    alias: str | None,
+) -> tuple[str | None, str | None]:
+    """Fold a deprecated id alias into the canonical ``poll_task_id`` (issue #1789).
+
+    Returns ``(resolved, deprecation_note)``. ``resolved`` is ``poll_task_id``
+    when supplied, else the ``alias`` value. When only the alias was used it emits
+    a gated ``DeprecationWarning`` (via :func:`warn_deprecated`) and returns a
+    caller-visible ``deprecation_note`` (else ``None``) so the MCP client — which
+    never sees the Python warning — is nudged toward the new name. Passing both
+    with different (stripped) values is rejected as ``ValidationError``; passing
+    both with the same value is allowed (the canonical wins, no warning).
+    """
+    if poll_task_id is not None and alias is not None:
+        if poll_task_id.strip() != alias.strip():
+            raise ValidationError(
+                f"pass either poll_task_id or the deprecated {old_name} to "
+                f"{tool}, not both with different values"
+            )
+        return poll_task_id, None
+    if alias is not None:
+        warn_deprecated(
+            f"{tool}({old_name}=...) is deprecated; pass poll_task_id instead (the same value).",
+            removal=_POLL_ID_ALIAS_REMOVAL,
+        )
+        note = (
+            f"'{old_name}' is deprecated; pass 'poll_task_id' instead (the same "
+            f"value). '{old_name}' will be removed in v{_POLL_ID_ALIAS_REMOVAL}."
+        )
+        return alias, note
+    return poll_task_id, None
 
 
 def register(mcp: Any) -> None:
@@ -103,6 +149,7 @@ def register(mcp: Any) -> None:
     async def research_status(
         ctx: Context,
         notebook: str,
+        poll_task_id: str | None = None,
         task_id: str | None = None,
         include_report: bool = False,
         report_max_chars: int = 20000,
@@ -115,41 +162,44 @@ def register(mcp: Any) -> None:
         the polled ``poll_task_id``, the found ``sources``, and report metadata.
         Poll until ``completed``, then pass ``poll_task_id`` to ``research_import``.
 
-        The large deep ``report`` and each source's ``report_markdown`` are
-        omitted by default; set ``include_report=True`` (optionally
-        ``report_max_chars``) to include them, truncated to that length.
-        ``report_char_count`` is the full size; ``report_truncated`` is true
-        whenever the returned ``report`` omits text (truncated OR omitted).
-        ``source_limit`` / ``source_offset`` page ``sources``;
-        ``sources_total`` / ``sources_returned`` describe the window.
+        The deep ``report`` and each source's ``report_markdown`` are omitted by
+        default; set ``include_report=True`` (optionally ``report_max_chars``) to
+        include them, truncated to that length. ``report_char_count`` is the full
+        size; ``report_truncated`` is true whenever the returned ``report`` omits
+        text. ``source_limit`` / ``source_offset`` page ``sources``.
 
-        ``task_id`` (optional) pins one task when several are in flight — pass a
-        ``poll_task_id``. Omit it for a single task; omitting it with two or more
-        running errors as ambiguous. An unmatched pin reports ``not_found``.
+        ``poll_task_id`` (optional) pins one task when several are in flight. Omit
+        it for a single task; omitting it with two or more running errors as
+        ambiguous. An unmatched pin reports ``not_found``. ``task_id`` is a
+        deprecated alias (removed in v0.9.0).
         """
         client = get_client(ctx)
         with mcp_errors():
+            # Fold the deprecated ``task_id`` pin into ``poll_task_id`` (#1789).
+            poll_task_id, deprecation = _resolve_poll_task_id(
+                "research_status", "task_id", poll_task_id, task_id
+            )
             # Validate windowing bounds BEFORE the poll so a bad request never
             # spends a read-only RPC. Reject an explicit empty/whitespace pin too:
-            # ``poll`` treats a falsy ``task_id`` as an UNFILTERED poll, so ``""``
-            # must not silently degrade into "any task" (``None`` stays the
-            # legitimate unfiltered path).
+            # ``poll`` treats a falsy id as an UNFILTERED poll, so ``""`` must not
+            # silently degrade into "any task" (``None`` stays the legitimate
+            # unfiltered path).
             if report_max_chars < 1:
                 raise ValidationError("report_max_chars must be >= 1")
             if source_limit is not None and source_limit < 0:
                 raise ValidationError("source_limit must be >= 0")
             if source_offset < 0:
                 raise ValidationError("source_offset must be >= 0")
-            if task_id is not None and not task_id.strip():
+            if poll_task_id is not None and not poll_task_id.strip():
                 raise ValidationError(
-                    "task_id must be a non-empty id (omit it to poll a single task)"
+                    "poll_task_id must be a non-empty id (omit it to poll a single task)"
                 )
             # Normalize a padded pin so surrounding whitespace never reaches the
             # backend as a spurious mismatch.
-            task_id = task_id.strip() if task_id is not None else None
+            poll_task_id = poll_task_id.strip() if poll_task_id is not None else None
 
             nb_id = await resolve_notebook(client, notebook)
-            result = await research_core.poll_and_classify(client, nb_id, task_id)
+            result = await research_core.poll_and_classify(client, nb_id, poll_task_id)
 
             # Report content lives in TWO places — the top-level ``report`` AND
             # each source's ``report_markdown`` — so BOTH are gated by
@@ -174,7 +224,7 @@ def register(mcp: Any) -> None:
             # can trust the flag without special-casing the omitted path.
             report_truncated = len(report or "") < report_char_count
 
-            return {
+            payload: dict[str, Any] = {
                 "notebook_id": nb_id,
                 "task_id": result.task_id,
                 "poll_task_id": result.task_id,
@@ -190,46 +240,61 @@ def register(mcp: Any) -> None:
                 "report_char_count": report_char_count,
                 "report_truncated": report_truncated,
             }
+            if deprecation is not None:
+                payload["deprecation"] = deprecation
+            return payload
 
     @mcp.tool
-    async def research_cancel(ctx: Context, notebook: str, run_id: str) -> dict[str, Any]:
+    async def research_cancel(
+        ctx: Context,
+        notebook: str,
+        poll_task_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
         """Cancel an in-flight research run in a notebook.
 
-        Accepts a notebook name or ID and the ``run_id`` to cancel — pass a
-        ``poll_task_id`` from ``research_start`` / ``research_status``.
+        Accepts a notebook name or ID and the ``poll_task_id`` to cancel — the
+        value from ``research_start`` / ``research_status``. ``run_id`` is a
+        deprecated alias (removed in v0.9.0).
 
-        Preflights the named notebook and sends the cancel unless the run is
-        already TERMINAL (``completed`` / ``failed``), which returns
+        Preflights the notebook and sends the cancel unless the run is already
+        TERMINAL (``completed`` / ``failed``), which returns
         ``cancel_requested: false`` with the observed ``status`` and no RPC.
         Otherwise it cancels and returns ``cancel_requested: true`` with
-        ``run_status_before`` (the preflight status). A run polled right after
-        ``research_start`` can transiently read ``not_found`` / ``no_research``
-        (replication lag), so those are cancelled too rather than silently
-        suppressed — the RPC is a harmless no-op for a genuinely unknown id. The
-        cancel is fire-and-forget; poll ``research_status`` afterward to confirm
-        (a cancelled in-progress run surfaces as ``failed``).
+        ``run_status_before`` (the preflight status). A just-started run can
+        transiently read ``not_found`` / ``no_research`` (replication lag), so
+        those are cancelled too. The cancel is fire-and-forget; poll
+        ``research_status`` afterward to confirm.
         """
         client = get_client(ctx)
         with mcp_errors():
-            # Reject an empty/whitespace run_id BEFORE preflight: ``poll`` treats
-            # a falsy task_id as an UNFILTERED poll, so ``run_id=""`` would match
+            # Fold the deprecated ``run_id`` alias into ``poll_task_id`` (#1789).
+            poll_task_id, deprecation = _resolve_poll_task_id(
+                "research_cancel", "run_id", poll_task_id, run_id
+            )
+            # Reject an empty/whitespace/absent id BEFORE preflight: ``poll``
+            # treats a falsy id as an UNFILTERED poll, so an empty id would match
             # some other in-flight task and cancel the wrong run.
-            if not run_id or not run_id.strip():
-                raise ValidationError("run_id is required to cancel a research run")
-            run_id = run_id.strip()
+            if not poll_task_id or not poll_task_id.strip():
+                raise ValidationError("poll_task_id is required to cancel a research run")
+            poll_task_id = poll_task_id.strip()
             nb_id = await resolve_notebook(client, notebook)
-            # Preflight (``run_id`` as the discriminator → typed NOT_FOUND
+            # Preflight (``poll_task_id`` as the discriminator → typed NOT_FOUND
             # sentinel, never raises). Only an already-TERMINAL run
             # (``completed`` / ``failed``) is left alone — those states are stable,
             # so cancelling is a meaningless no-op we can honestly skip.
-            status = await research_core.poll_and_classify(client, nb_id, run_id)
+            status = await research_core.poll_and_classify(client, nb_id, poll_task_id)
             if status.status in ("completed", "failed"):
-                return {
+                result: dict[str, Any] = {
                     "status": status.status,
                     "notebook_id": nb_id,
-                    "run_id": run_id,
+                    "poll_task_id": poll_task_id,
+                    "run_id": poll_task_id,
                     "cancel_requested": False,
                 }
+                if deprecation is not None:
+                    result["deprecation"] = deprecation
+                return result
             # Otherwise send the fire-and-forget cancel. For ``in_progress`` this
             # is the obvious path; for ``not_found`` / ``no_research`` we STILL send
             # it, because a poll immediately after ``research_start`` can transiently
@@ -239,58 +304,75 @@ def register(mcp: Any) -> None:
             # a genuinely unknown id. ``run_status_before`` surfaces what the
             # preflight actually observed so a caller can tell a confirmed-running
             # cancel from an unconfirmed (lag-or-unknown) one.
-            await client.research.cancel(nb_id, run_id)
-            return {
+            await client.research.cancel(nb_id, poll_task_id)
+            result = {
                 "status": "cancel_requested",
                 "notebook_id": nb_id,
-                "run_id": run_id,
+                "poll_task_id": poll_task_id,
+                "run_id": poll_task_id,
                 "cancel_requested": True,
                 "run_status_before": status.status,
             }
+            if deprecation is not None:
+                result["deprecation"] = deprecation
+            return result
 
     @mcp.tool
-    async def research_import(ctx: Context, notebook: str, task_id: str) -> dict[str, Any]:
+    async def research_import(
+        ctx: Context,
+        notebook: str,
+        poll_task_id: str | None = None,
+        task_id: str | None = None,
+    ) -> dict[str, Any]:
         """Import a completed research task's sources into the notebook.
 
-        Accepts a notebook name or ID and the ``task_id`` to import — pass the
-        ``poll_task_id`` from ``research_start`` / ``research_status``.
+        Accepts a notebook name or ID and the ``poll_task_id`` to import — the
+        value from ``research_start`` / ``research_status``. ``task_id`` is a
+        deprecated alias (removed in v0.9.0).
 
-        The supplied ``task_id`` is the task discriminator: the notebook is
-        polled FOR THAT TASK so only its found sources are imported — never the
-        notebook's current (possibly different) research task's sources. If the
-        requested task is not among the notebook's polled tasks, the import
-        fails cleanly (``not_found``) rather than silently importing the wrong
-        task's sources. Returns the imported sources (verify with ``source_list``).
+        The supplied id is the task discriminator: the notebook is polled FOR
+        THAT TASK so only its sources are imported, never a different task's. If
+        the task is not among the notebook's polled tasks, the import fails
+        cleanly (``not_found``). Returns the imported sources (verify with
+        ``source_list``).
         """
         client = get_client(ctx)
         with mcp_errors():
-            # Reject an empty/whitespace task_id: ``poll`` treats a falsy id as an
-            # UNFILTERED poll, which would let an empty pin import whatever task
+            # Fold the deprecated ``task_id`` alias into ``poll_task_id`` (#1789).
+            poll_task_id, deprecation = _resolve_poll_task_id(
+                "research_import", "task_id", poll_task_id, task_id
+            )
+            # Reject an empty/whitespace/absent id: ``poll`` treats a falsy id as
+            # an UNFILTERED poll, which would let an empty pin import whatever task
             # the notebook happens to have in flight (cross-wire).
-            if not task_id or not task_id.strip():
-                raise ValidationError("task_id is required to import a research task")
-            task_id = task_id.strip()
+            if not poll_task_id or not poll_task_id.strip():
+                raise ValidationError("poll_task_id is required to import a research task")
+            poll_task_id = poll_task_id.strip()
             nb_id = await resolve_notebook(client, notebook)
             # Poll FOR THE REQUESTED task (via the shared importable-state guard,
-            # which forwards ``task_id`` to ``poll`` as the discriminator) so the
-            # polled sources belong to it and every non-importable state
+            # which forwards ``poll_task_id`` to ``poll`` as the discriminator) so
+            # the polled sources belong to it and every non-importable state
             # (not_found / failed / non-completed / empty) is refused before we
             # touch ``import_sources`` — we never fall back to importing whatever
             # the notebook's current task happens to be. The same helper backs
             # the REST import route so the ladder cannot drift.
-            sources = await research_core.poll_sources_for_import(client, nb_id, task_id)
+            sources = await research_core.poll_sources_for_import(client, nb_id, poll_task_id)
             # TOCTOU note: ``import_sources`` imports the sources from the poll
             # snapshot above rather than re-fetching atomically, so a
             # concurrent/external change to the task between the poll and the
             # import could theoretically race. Acceptable here: research tasks are
             # user-driven (no high-frequency concurrent mutation), and the pinned
-            # ``task_id`` prevents cross-task wiring — we never import a
-            # *different* task's sources.
-            imported = await client.research.import_sources(nb_id, task_id, sources)
-            return {
+            # id prevents cross-task wiring — we never import a *different* task's
+            # sources.
+            imported = await client.research.import_sources(nb_id, poll_task_id, sources)
+            result: dict[str, Any] = {
                 "status": "imported",
                 "notebook_id": nb_id,
-                "task_id": task_id,
+                "poll_task_id": poll_task_id,
+                "task_id": poll_task_id,
                 "imported": to_jsonable(imported),
                 "sources_found": len(sources),
             }
+            if deprecation is not None:
+                result["deprecation"] = deprecation
+            return result

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -528,7 +528,7 @@ class TestMcpResearch:
         # coverage matrix report a false positive).
         run_id = started.get("poll_task_id") or status.get("poll_task_id")
         assert run_id, f"research_start/status yielded no run id to cancel: {started} / {status}"
-        cancelled = await _call(client, "research_cancel", {"notebook": nb, "run_id": run_id})
+        cancelled = await _call(client, "research_cancel", {"notebook": nb, "poll_task_id": run_id})
         # A freshly-started fast run is normally still in_progress at this
         # immediate poll, so the preflight fires the cancel (cancel_requested
         # True). Tolerate the race where it already reached a terminal state

--- a/tests/integration/mcp_vcr/test_research.py
+++ b/tests/integration/mcp_vcr/test_research.py
@@ -143,7 +143,7 @@ async def test_mcp_research_status_in_progress_over_vcr() -> None:
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
             "research_status",
-            {"notebook": RESEARCH_NOTEBOOK_ID, "task_id": PINNED_TASK_ID},
+            {"notebook": RESEARCH_NOTEBOOK_ID, "poll_task_id": PINNED_TASK_ID},
         )
 
     structured = result.structured_content
@@ -204,7 +204,7 @@ async def test_mcp_research_import_incomplete_task_refused_over_vcr() -> None:
         with pytest.raises(ToolError) as excinfo:
             await mcp_client.call_tool(
                 "research_import",
-                {"notebook": RESEARCH_NOTEBOOK_ID, "task_id": PINNED_TASK_ID},
+                {"notebook": RESEARCH_NOTEBOOK_ID, "poll_task_id": PINNED_TASK_ID},
             )
     assert "VALIDATION" in str(excinfo.value)
 
@@ -223,13 +223,14 @@ async def test_mcp_research_import_populated_sources_over_vcr() -> None:
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
             "research_import",
-            {"notebook": POPULATED_RESEARCH_NOTEBOOK_ID, "task_id": POPULATED_TASK_ID},
+            {"notebook": POPULATED_RESEARCH_NOTEBOOK_ID, "poll_task_id": POPULATED_TASK_ID},
         )
 
     structured = result.structured_content
     assert isinstance(structured, dict)
     assert structured["notebook_id"] == POPULATED_RESEARCH_NOTEBOOK_ID
     assert structured["task_id"] == POPULATED_TASK_ID
+    assert structured["poll_task_id"] == POPULATED_TASK_ID
     assert structured["sources_found"] == 10
     imported = structured["imported"]
     # The LBwxtb import returned real, decoded sources (the leg the empty cassette

--- a/tests/unit/mcp/test_research.py
+++ b/tests/unit/mcp/test_research.py
@@ -8,6 +8,7 @@ the start→status poll shape, the import workflow, and error projection.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -199,13 +200,15 @@ async def test_research_status_surfaces_task_id(mcp_call, mock_client) -> None:
     assert result.structured_content["task_id"] == TASK_ID
 
 
-async def test_research_status_pins_task_id_when_given(mcp_call, mock_client) -> None:
-    """A supplied ``task_id`` is threaded through ``poll`` as the discriminator."""
+async def test_research_status_pins_poll_task_id_when_given(mcp_call, mock_client) -> None:
+    """A supplied ``poll_task_id`` is threaded through ``poll`` as the discriminator."""
     mock_client.research.poll = AsyncMock(
         return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED, task_id=TASK_ID)
     )
-    result = await mcp_call("research_status", {"notebook": NB_ID, "task_id": TASK_ID})
+    result = await mcp_call("research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert result.structured_content["task_id"] == TASK_ID
+    # No deprecated alias was used → no deprecation note.
+    assert "deprecation" not in result.structured_content
     mock_client.research.poll.assert_awaited_once_with(NB_ID, TASK_ID)
 
 
@@ -341,8 +344,8 @@ async def test_research_status_source_limit_zero(mcp_call, mock_client) -> None:
         {"report_max_chars": 0},
         {"source_limit": -1},
         {"source_offset": -1},
-        {"task_id": "  "},
-        {"task_id": ""},
+        {"poll_task_id": "  "},
+        {"poll_task_id": ""},
     ],
 )
 async def test_research_status_rejects_bad_bounds(bad_args, mcp_call, mock_client) -> None:
@@ -370,12 +373,15 @@ async def test_research_import(mcp_call, mock_client) -> None:
         )
     )
     mock_client.research.import_sources = AsyncMock(return_value=[{"id": "src-1", "title": "A"}])
-    result = await mcp_call("research_import", {"notebook": NB_ID, "task_id": TASK_ID})
+    result = await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert result.structured_content["notebook_id"] == NB_ID
     assert result.structured_content["imported"] == [{"id": "src-1", "title": "A"}]
-    # The requested task_id is threaded through ``poll`` as the discriminator so
-    # the freshly-polled sources belong to that task (not the notebook's current
-    # task).
+    # The response echoes the id under both the canonical and legacy keys.
+    assert result.structured_content["poll_task_id"] == TASK_ID
+    assert result.structured_content["task_id"] == TASK_ID
+    assert "deprecation" not in result.structured_content
+    # The requested id is threaded through ``poll`` as the discriminator so the
+    # freshly-polled sources belong to that task (not the notebook's current task).
     mock_client.research.poll.assert_awaited_once_with(NB_ID, TASK_ID)
     mock_client.research.import_sources.assert_awaited_once()
     called = mock_client.research.import_sources.await_args.args
@@ -383,15 +389,19 @@ async def test_research_import(mcp_call, mock_client) -> None:
     assert called[1] == TASK_ID
 
 
-async def test_research_import_empty_task_id_rejected(mcp_call, mock_client) -> None:
-    """An empty/whitespace task_id is rejected before any poll or import (the
+async def test_research_import_empty_poll_task_id_rejected(mcp_call, mock_client) -> None:
+    """An empty/whitespace poll_task_id is rejected before any poll or import (the
     falsy-id unfiltered-poll cross-wire trap)."""
     mock_client.research.poll = AsyncMock(return_value=FakeResearchTask())
     mock_client.research.import_sources = AsyncMock(return_value=[])
     for bad in ("", "   "):
         with pytest.raises(ToolError) as excinfo:
-            await mcp_call("research_import", {"notebook": NB_ID, "task_id": bad})
+            await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": bad})
         assert "VALIDATION" in str(excinfo.value)
+    # Omitting the id entirely is likewise rejected (neither canonical nor alias).
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("research_import", {"notebook": NB_ID})
+    assert "VALIDATION" in str(excinfo.value)
     mock_client.research.poll.assert_not_called()
     mock_client.research.import_sources.assert_not_called()
 
@@ -411,7 +421,7 @@ async def test_research_import_non_current_task_fails_cleanly(mcp_call, mock_cli
     )
     mock_client.research.import_sources = AsyncMock(return_value=[])
     with pytest.raises(ToolError) as excinfo:
-        await mcp_call("research_import", {"notebook": NB_ID, "task_id": other_task})
+        await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": other_task})
     # A clean validation/not-found projection — never a silent cross-wire import.
     msg = str(excinfo.value)
     assert "VALIDATION" in msg or "NOT_FOUND" in msg
@@ -429,10 +439,11 @@ async def test_research_cancel(mcp_call, mock_client) -> None:
         return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
     )
     mock_client.research.cancel = AsyncMock(return_value=None)
-    result = await mcp_call("research_cancel", {"notebook": NB_ID, "run_id": TASK_ID})
+    result = await mcp_call("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert result.structured_content == {
         "status": "cancel_requested",
         "notebook_id": NB_ID,
+        "poll_task_id": TASK_ID,
         "run_id": TASK_ID,
         "cancel_requested": True,
         "run_status_before": "in_progress",
@@ -449,7 +460,7 @@ async def test_research_cancel_resolves_notebook_by_name(mcp_call, mock_client) 
         return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
     )
     mock_client.research.cancel = AsyncMock(return_value=None)
-    result = await mcp_call("research_cancel", {"notebook": "My Notebook", "run_id": TASK_ID})
+    result = await mcp_call("research_cancel", {"notebook": "My Notebook", "poll_task_id": TASK_ID})
     assert result.structured_content["cancel_requested"] is True
     mock_client.research.cancel.assert_awaited_once_with(NB_ID, TASK_ID)
 
@@ -463,7 +474,7 @@ async def test_research_cancel_absent_run_still_cancelled(status, mcp_call, mock
         return_value=FakeResearchTask(status=status, task_id="just-started")
     )
     mock_client.research.cancel = AsyncMock(return_value=None)
-    result = await mcp_call("research_cancel", {"notebook": NB_ID, "run_id": "just-started"})
+    result = await mcp_call("research_cancel", {"notebook": NB_ID, "poll_task_id": "just-started"})
     sc = result.structured_content
     assert sc["cancel_requested"] is True
     assert sc["status"] == "cancel_requested"
@@ -480,21 +491,25 @@ async def test_research_cancel_terminal_run_not_cancelled(status, mcp_call, mock
         return_value=FakeResearchTask(status=status, task_id=TASK_ID)
     )
     mock_client.research.cancel = AsyncMock(return_value=None)
-    result = await mcp_call("research_cancel", {"notebook": NB_ID, "run_id": TASK_ID})
+    result = await mcp_call("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     sc = result.structured_content
     assert sc["cancel_requested"] is False
     assert sc["status"] == status.value
     mock_client.research.cancel.assert_not_called()
 
 
-async def test_research_cancel_empty_run_id_rejected(mcp_call, mock_client) -> None:
-    """An empty/whitespace run_id is rejected before any poll or cancel."""
+async def test_research_cancel_empty_poll_task_id_rejected(mcp_call, mock_client) -> None:
+    """An empty/whitespace/absent poll_task_id is rejected before any poll or cancel."""
     mock_client.research.poll = AsyncMock(return_value=FakeResearchTask())
     mock_client.research.cancel = AsyncMock(return_value=None)
     for bad in ("", "   "):
         with pytest.raises(ToolError) as excinfo:
-            await mcp_call("research_cancel", {"notebook": NB_ID, "run_id": bad})
+            await mcp_call("research_cancel", {"notebook": NB_ID, "poll_task_id": bad})
         assert "VALIDATION" in str(excinfo.value)
+    # Omitting the id entirely (neither canonical nor alias) is likewise rejected.
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("research_cancel", {"notebook": NB_ID})
+    assert "VALIDATION" in str(excinfo.value)
     mock_client.research.poll.assert_not_called()
     mock_client.research.cancel.assert_not_called()
 
@@ -550,7 +565,7 @@ async def test_research_import_in_progress_refused(mcp_call, mock_client) -> Non
     )
     mock_client.research.import_sources = AsyncMock(return_value=[])
     with pytest.raises(ToolError) as excinfo:
-        await mcp_call("research_import", {"notebook": NB_ID, "task_id": TASK_ID})
+        await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert "VALIDATION" in str(excinfo.value)
     mock_client.research.import_sources.assert_not_called()
 
@@ -564,7 +579,7 @@ async def test_research_import_completed_but_empty_refused(mcp_call, mock_client
     )
     mock_client.research.import_sources = AsyncMock(return_value=[])
     with pytest.raises(ToolError) as excinfo:
-        await mcp_call("research_import", {"notebook": NB_ID, "task_id": TASK_ID})
+        await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert "VALIDATION" in str(excinfo.value)
     mock_client.research.import_sources.assert_not_called()
 
@@ -581,6 +596,137 @@ async def test_research_import_non_completed_status_refused(status, mcp_call, mo
     )
     mock_client.research.import_sources = AsyncMock(return_value=[])
     with pytest.raises(ToolError) as excinfo:
-        await mcp_call("research_import", {"notebook": NB_ID, "task_id": TASK_ID})
+        await mcp_call("research_import", {"notebook": NB_ID, "poll_task_id": TASK_ID})
     assert "VALIDATION" in str(excinfo.value)
     mock_client.research.import_sources.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# deprecated id-param aliases (issue #1789): task_id / run_id → poll_task_id
+#
+# Each downstream tool renamed its id param to ``poll_task_id`` and keeps the old
+# name as an accepted alias for one release. The alias must (a) resolve to the
+# same behavior as ``poll_task_id``, (b) emit a ``DeprecationWarning``, and (c)
+# surface a caller-visible ``deprecation`` note in the result. The Python-level
+# ``DeprecationWarning`` is asserted directly on the resolution helper (FastMCP's
+# tool-execution boundary swallows warnings, so ``pytest.warns`` around a tool
+# call is unreliable); the agent-visible ``deprecation`` note is asserted through
+# the full tool call.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_poll_task_id_alias_warns_and_notes() -> None:
+    """The helper emits a ``DeprecationWarning`` and a note when only the alias is used."""
+    from notebooklm.mcp.tools.research import _resolve_poll_task_id
+
+    with pytest.warns(DeprecationWarning, match="research_import.*task_id.*poll_task_id"):
+        resolved, note = _resolve_poll_task_id("research_import", "task_id", None, "abc")
+    assert resolved == "abc"
+    assert note is not None and "task_id" in note and "poll_task_id" in note
+
+
+def test_resolve_poll_task_id_canonical_no_warning() -> None:
+    """The canonical name (with no alias) warns not, notes not."""
+    from notebooklm.mcp.tools.research import _resolve_poll_task_id
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        resolved, note = _resolve_poll_task_id("research_status", "task_id", "abc", None)
+    assert resolved == "abc"
+    assert note is None
+
+
+def test_resolve_poll_task_id_same_value_prefers_canonical_no_warning() -> None:
+    """Both names, same value → canonical wins silently (no warning, no note)."""
+    from notebooklm.mcp.tools.research import _resolve_poll_task_id
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        resolved, note = _resolve_poll_task_id("research_cancel", "run_id", "abc", " abc ")
+    assert resolved == "abc"
+    assert note is None
+
+
+def test_resolve_poll_task_id_conflict_raises() -> None:
+    """Both names, different values → ValidationError."""
+    from notebooklm.exceptions import ValidationError
+    from notebooklm.mcp.tools.research import _resolve_poll_task_id
+
+    with pytest.raises(ValidationError):
+        _resolve_poll_task_id("research_status", "task_id", "a", "b")
+
+
+async def test_research_status_task_id_alias_matches_poll_task_id(mcp_call, mock_client) -> None:
+    """The deprecated ``task_id`` pin resolves exactly like ``poll_task_id``."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED, task_id=TASK_ID)
+    )
+    result = await mcp_call("research_status", {"notebook": NB_ID, "task_id": TASK_ID})
+    sc = result.structured_content
+    assert sc["poll_task_id"] == TASK_ID
+    # The alias is threaded through ``poll`` identically to the canonical name.
+    mock_client.research.poll.assert_awaited_once_with(NB_ID, TASK_ID)
+    # A caller-visible note names the old param and its replacement.
+    assert "task_id" in sc["deprecation"] and "poll_task_id" in sc["deprecation"]
+
+
+async def test_research_import_task_id_alias_matches_poll_task_id(mcp_call, mock_client) -> None:
+    """The deprecated ``task_id`` import arg resolves exactly like ``poll_task_id``."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(
+            status=FakeResearchStatus.COMPLETED,
+            sources=[FakeSource(url="http://a", title="A")],
+            task_id=TASK_ID,
+        )
+    )
+    mock_client.research.import_sources = AsyncMock(return_value=[{"id": "src-1", "title": "A"}])
+    result = await mcp_call("research_import", {"notebook": NB_ID, "task_id": TASK_ID})
+    sc = result.structured_content
+    assert sc["imported"] == [{"id": "src-1", "title": "A"}]
+    assert sc["poll_task_id"] == TASK_ID
+    mock_client.research.poll.assert_awaited_once_with(NB_ID, TASK_ID)
+    assert mock_client.research.import_sources.await_args.args[1] == TASK_ID
+    assert "task_id" in sc["deprecation"]
+
+
+async def test_research_cancel_run_id_alias_matches_poll_task_id(mcp_call, mock_client) -> None:
+    """The deprecated ``run_id`` cancel arg resolves exactly like ``poll_task_id``."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+    )
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    result = await mcp_call("research_cancel", {"notebook": NB_ID, "run_id": TASK_ID})
+    sc = result.structured_content
+    assert sc["cancel_requested"] is True
+    assert sc["poll_task_id"] == TASK_ID
+    # The legacy ``run_id`` response key is retained for one release.
+    assert sc["run_id"] == TASK_ID
+    mock_client.research.cancel.assert_awaited_once_with(NB_ID, TASK_ID)
+    assert "run_id" in sc["deprecation"]
+
+
+async def test_research_alias_and_canonical_same_value_no_note(mcp_call, mock_client) -> None:
+    """Passing both names with the SAME value is accepted (canonical wins, no note)."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED, task_id=TASK_ID)
+    )
+    result = await mcp_call(
+        "research_status",
+        {"notebook": NB_ID, "poll_task_id": TASK_ID, "task_id": TASK_ID},
+    )
+    assert "deprecation" not in result.structured_content
+    mock_client.research.poll.assert_awaited_once_with(NB_ID, TASK_ID)
+
+
+async def test_research_alias_and_canonical_conflict_rejected(mcp_call, mock_client) -> None:
+    """Passing both names with DIFFERENT values is rejected up front (no poll)."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED)
+    )
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "research_status",
+            {"notebook": NB_ID, "poll_task_id": "a", "task_id": "b"},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.research.poll.assert_not_called()

--- a/tests/unit/mcp/test_research.py
+++ b/tests/unit/mcp/test_research.py
@@ -647,6 +647,32 @@ def test_resolve_poll_task_id_same_value_prefers_canonical_no_warning() -> None:
     assert note is None
 
 
+def test_resolve_poll_task_id_blank_alias_no_warning() -> None:
+    """A whitespace-only alias is handed back unwarned (the tool's empty-id guard
+    rejects it) — no deprecation signal spent on a value about to be refused."""
+    from notebooklm.mcp.tools.research import _resolve_poll_task_id
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        resolved, note = _resolve_poll_task_id("research_import", "task_id", None, "   ")
+    assert resolved == "   "
+    assert note is None
+
+
+async def test_research_import_blank_alias_rejected_without_warning(mcp_call, mock_client) -> None:
+    """A whitespace-only ``task_id`` alias is rejected as VALIDATION and emits no
+    DeprecationWarning through the tool (the empty-id guard fires, not the alias)."""
+    mock_client.research.poll = AsyncMock(return_value=FakeResearchTask())
+    mock_client.research.import_sources = AsyncMock(return_value=[])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(ToolError) as excinfo:
+            await mcp_call("research_import", {"notebook": NB_ID, "task_id": "   "})
+    assert "VALIDATION" in str(excinfo.value)
+    mock_client.research.poll.assert_not_called()
+    mock_client.research.import_sources.assert_not_called()
+
+
 def test_resolve_poll_task_id_conflict_raises() -> None:
     """Both names, different values → ValidationError."""
     from notebooklm.exceptions import ValidationError

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -30,13 +30,15 @@ pytest.importorskip("fastmcp")
 #: Ratchet ceilings — calibrated to the current surface (Tier-1 read-merge took it
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
-SCHEMA_CHAR_BUDGET = 37_020  # total serialized inputSchema + description chars (current 36_979)
+SCHEMA_CHAR_BUDGET = 37_020  # total serialized inputSchema + description chars (current 36_934)
 # ^ Raised from 36_250 for #1741: research_status gained include_report /
 # report_max_chars / source_limit / source_offset windowing params, and the four
 # research tools' docstrings speak one `poll_task_id` id (tightened to stay lean).
-# Measured full-surface cost is 36_780 on this rebase (incl. #1747/#1749/#1755/#1748
-# sharing confirm gates + the review-driven report_truncated/traceability wording);
-# the ceiling is a deliberately minimal buffer (ADR-0025) — trim before adding more.
+# #1789 renamed research_status/import's `task_id` and research_cancel's `run_id`
+# params to `poll_task_id` (keeping the old names as deprecated aliases → one extra
+# param each), absorbed by trimming the now-redundant id-routing prose from those
+# docstrings; measured full-surface cost is 36_934. The ceiling is a deliberately
+# minimal buffer (ADR-0025) — trim before adding more.
 MAX_PARAMS_PER_TOOL = 22  # studio_generate is the current high-water mark
 
 


### PR DESCRIPTION
## Summary

Closes #1789.

The research MCP tools passed the single id that `research_start` surfaces as
`poll_task_id` under mismatched parameter names — `task_id` on
`research_status` / `research_import`, `run_id` on `research_cancel` — which
forced long docstring warnings about which id goes where and invited copy-paste
mistakes (pasting a fast run's `task_id` where a deep run needs its `report_id`,
etc.).

All three tools now accept the id under the **same** name, `poll_task_id`, so the
value copies verbatim from one tool's output into the next.

## What changed

- **`research_status`** — pin param `task_id` → `poll_task_id`.
- **`research_import`** — `task_id` → `poll_task_id`.
- **`research_cancel`** — `run_id` → `poll_task_id`.
- The old `task_id` / `run_id` names remain **accepted aliases for one release**
  (removed in **v0.9.0**). Passing an alias resolves identically, emits a gated
  `DeprecationWarning`, and adds a caller-visible `deprecation` note to the tool
  result (FastMCP swallows the Python warning at the tool boundary, so the
  agent-visible note is the real signal). Passing both names with *different*
  values is a validation error; same value → canonical wins silently.
- Responses surface both the canonical `poll_task_id` and the legacy key
  (`run_id` / `task_id`) for one release, matching `research_status`'s existing
  dual-key response.
- A small `_resolve_poll_task_id(...)` helper centralizes the alias fold /
  warning / note / conflict check.

## Budget & docs

- The now-redundant id-routing docstring prose is trimmed so the extra alias
  param stays within the ADR-0025 schema-char budget (measured **36934 ≤ 37020**).
- `docs/mcp-guide.md`, `docs/deprecations.md`, and `CHANGELOG.md` updated.

## Tests

- Helper-level `pytest.warns(DeprecationWarning)` (deterministic; the tool
  boundary swallows warnings) + conflict / same-value / canonical cases.
- Through-the-tool alias tests asserting the alias resolves to identical
  behavior and surfaces the `deprecation` note, for all three tools.
- Migrated existing unit / mcp_vcr / e2e tests to the canonical `poll_task_id`.

## Verification

- `uv run mypy src/notebooklm --ignore-missing-imports` — clean (302 files)
- `uv run ruff check . && uv run ruff format --check .` — clean
- `uv run pytest` — **11689 passed, 77 skipped, 1 xfailed**
- `scripts/check_deprecation_targets.py` + `scripts/audit_public_api_compat.py` — clean (no new API breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP research tools now consistently use a single `poll_task_id` field across status, import, and cancel workflows.

* **Bug Fixes**
  * Legacy `task_id` / `run_id` aliases remain supported but now emit deprecation warnings and include deprecation notes in responses when used.
  * Clear validation errors occur when canonical and alias identifiers are provided with different values; empty/whitespace identifiers are rejected.
  * Cancel behavior and returned identifiers are now consistent with the canonical `poll_task_id`.

* **Documentation**
  * Updated the MCP guide and changelog to reflect `poll_task_id` and the deprecations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->