### PR TITLE
fix(mcp): resolve notebook/source/note/artifact refs by unique title prefix (#1786)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -208,13 +208,15 @@ bearer-only deploy → the two file tools return a clear "not configured" error
 These conventions hold across every tool:
 
 - **Name *or* ID.** Every `notebook`/`source`/`note`/`artifact` argument accepts a human title **or**
-  an ID (full, or a unique prefix). Use the matching `*_list` tool to discover them. An ambiguous name
-  or prefix returns a `VALIDATION` error listing the candidates so you can retry with an exact ID.
-  When a name lookup *fails* but is close to a real title — a bare prefix, or a punctuation-only
-  slip such as a hyphen typed for an em-dash (`—`) or a normal space for a non-breaking one — the
-  error's `Did you mean: …` hint names up to three near-miss candidates, each with its **title and
-  id** inline, so you can retry with the full title or id instead of guessing (a label near-miss
-  reached via `source_list(label=…)` gets the same enrichment on its `VALIDATION` error).
+  an ID. Both resolve by prefix: an exact title wins, otherwise a **unique title prefix** matches
+  (so `"Scientific"` finds `"Scientific PDF Parsing — …"`), and likewise a full ID or a unique ID
+  prefix. Use the matching `*_list` tool to discover them. An ambiguous name or prefix returns a
+  `VALIDATION` error listing the candidates so you can retry with an exact title or ID. When a name
+  lookup *fails* but is close to a real title — a punctuation-only slip such as a hyphen typed for an
+  em-dash (`—`) or a normal space for a non-breaking one — the error's `Did you mean: …` hint names
+  up to three near-miss candidates, each with its **title and id** inline, so you can retry with the
+  full title or id instead of guessing (a label near-miss reached via `source_list(label=…)` gets the
+  same enrichment on its `VALIDATION` error).
 - **Destructive tools need confirmation.** `notebook_delete`, `source_delete`,
   `studio_delete`, and `share_remove_user` take `confirm` (default `false`). Called without it, they return a `needs_confirmation` preview
   (with the resolved title) and delete **nothing**; call again with `confirm=true` to execute.

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -4,7 +4,10 @@ MCP tools accept a human-friendly ``notebook`` / ``source`` reference and turn i
 into a canonical backend id. The matching rules build on the neutral
 :func:`notebooklm._app.resolve.resolve_ref` (full/partial-UUID fast-path, exact
 id, unique prefix, ambiguous-prefix -> :class:`AmbiguousIdError`) and ADD
-case-insensitive **exact-title** matching for human references.
+case-insensitive **title** matching for human references: an exact title, or —
+when nothing matches exactly — a unique title *prefix* (#1786), so a name is as
+prefix-resolvable as an id and the surface stays consistent across notebook /
+source / note / artifact refs.
 
 Routing is by token shape:
 
@@ -15,9 +18,13 @@ Routing is by token shape:
   if the id/prefix path finds nothing — so an item whose title is all-hex
   (``"beef"``, ``"1234"``) is still reachable by name. An *ambiguous* hex prefix
   raises :class:`AmbiguousIdError` and never falls through to title.
-* Anything else takes the title path: a case-insensitive exact match over the
-  items' titles — 0 matches raises the public ``*NotFoundError``, >1 raises
-  :class:`AmbiguousIdError` carrying the colliding ids.
+* Anything else takes the title path: a case-insensitive **exact** title match
+  wins first; failing that, a case-insensitive unique title **prefix** match.
+  0 matches raises the public ``*NotFoundError``; an ambiguous exact title or an
+  ambiguous prefix (>1) raises :class:`AmbiguousIdError` carrying the colliding
+  ids. Exact wins over prefix, so a title that is also a prefix of a longer one
+  (``"Report"`` vs ``"Report Q1"``) resolves to itself rather than reporting
+  ambiguity — mirroring the id resolver's exact-over-prefix rule.
 
 Sources are resolved within their notebook's source list. The prefix path's
 no-match (``ValidationError`` from ``resolve_ref``) is re-raised as the
@@ -69,6 +76,23 @@ _HEX_ISH = re.compile(r"^[0-9a-fA-F-]+$")
 _MAX_AMBIGUOUS_CANDIDATES = 5
 
 
+def _ambiguous_title_error(token: str, matches: Sequence[Any], *, kind: str) -> AmbiguousIdError:
+    """Build an :class:`AmbiguousIdError` listing each colliding candidate.
+
+    ``kind`` is the human word for how ``token`` matched — ``"title"`` for an
+    exact-title collision, ``"prefix"`` for a title-prefix collision — so the
+    message tells the caller which axis was ambiguous.
+    """
+    candidate_ids = [str(item.id) for item in matches]
+    lines = [f"Ambiguous {kind} '{token}' matches {len(matches)} items:"]
+    for item in matches[:_MAX_AMBIGUOUS_CANDIDATES]:
+        lines.append(f"  {str(item.id)[:12]}... {item.title or '(untitled)'}")
+    if len(matches) > _MAX_AMBIGUOUS_CANDIDATES:
+        lines.append(f"  ... and {len(matches) - _MAX_AMBIGUOUS_CANDIDATES} more")
+    lines.append("\nUse a more specific title or the id.")
+    return AmbiguousIdError(token, candidate_ids, "\n".join(lines))
+
+
 def _resolve_by_title(
     token: str,
     items: Sequence[Any],
@@ -77,40 +101,59 @@ def _resolve_by_title(
         NotebookNotFoundError | SourceNotFoundError | NoteNotFoundError | ArtifactNotFoundError
     ],
 ) -> str:
-    """Resolve ``token`` by case-insensitive exact title over ``items``.
+    """Resolve ``token`` by title over ``items``: exact match wins, else unique prefix.
 
-    Raises ``not_found(token)`` on 0 matches and :class:`AmbiguousIdError` on >1.
+    Matching order (mirrors the id resolver's "exact wins over prefix"):
+
+    1. Case-insensitive **exact** title: exactly one -> that id; more than one ->
+       :class:`AmbiguousIdError`.
+    2. No exact match -> case-insensitive title **prefix** (#1786): exactly one ->
+       that id; more than one -> :class:`AmbiguousIdError` listing the candidates;
+       none -> ``not_found(token)``.
+
+    Exact precedence means a title that is also a prefix of a longer one
+    (``"Report"`` vs ``"Report Q1"``) resolves to itself rather than being
+    reported ambiguous.
+
+    Items with no title (``item.title`` is ``None`` — e.g. an untitled source)
+    fold to ``""`` and so never match a non-empty ``token`` on either axis.
+
+    ``token`` is assumed already stripped and non-empty (callers run
+    :func:`~notebooklm._app.resolve.validate_id` first), so an empty prefix
+    cannot match every item.
     """
     # casefold (not lower) for correct non-ASCII case-insensitive matching, e.g.
     # German ß folds to "ss" so "STRASSE" matches a title "Straße".
     token_folded = token.casefold()
-    matches = [item for item in items if (item.title or "").casefold() == token_folded]
 
-    if len(matches) == 1:
-        (match,) = matches  # unpack (not matches[0]) — these are typed items, not an RPC row
+    exact = [item for item in items if (item.title or "").casefold() == token_folded]
+    if len(exact) == 1:
+        (match,) = exact  # unpack (not exact[0]) — these are typed items, not an RPC row
         return str(match.id)
+    if len(exact) > 1:
+        raise _ambiguous_title_error(token, exact, kind="title")
 
-    if not matches:
-        # Enrich the miss with near-miss "did you mean" candidates (issue #1787):
-        # a title mistyped with a hyphen for an em-dash, a non-breaking space for
-        # a normal one, or a bare prefix would otherwise force a blind retry loop.
-        error = not_found(token)
-        error.candidates = near_miss_candidates(
-            token,
-            items,
-            id_of=lambda item: str(item.id),
-            title_of=lambda item: item.title,
-        )
-        raise error
+    # No exact title -> fall back to a unique title prefix so a name is as
+    # prefix-resolvable as an id (issue #1786).
+    prefix = [item for item in items if (item.title or "").casefold().startswith(token_folded)]
+    if len(prefix) == 1:
+        (match,) = prefix
+        return str(match.id)
+    if len(prefix) > 1:
+        raise _ambiguous_title_error(token, prefix, kind="prefix")
 
-    candidate_ids = [str(item.id) for item in matches]
-    lines = [f"Ambiguous title '{token}' matches {len(matches)} items:"]
-    for item in matches[:_MAX_AMBIGUOUS_CANDIDATES]:
-        lines.append(f"  {str(item.id)[:12]}... {item.title or '(untitled)'}")
-    if len(matches) > _MAX_AMBIGUOUS_CANDIDATES:
-        lines.append(f"  ... and {len(matches) - _MAX_AMBIGUOUS_CANDIDATES} more")
-    lines.append("\nUse a more specific title or the id.")
-    raise AmbiguousIdError(token, candidate_ids, "\n".join(lines))
+    # Neither an exact title nor a unique/ambiguous prefix matched -> a true miss.
+    # Enrich it with near-miss "did you mean" candidates (issue #1787): a title
+    # mistyped with a hyphen for an em-dash, a non-breaking space for a normal
+    # one, or a not-quite prefix would otherwise force a blind retry loop.
+    error = not_found(token)
+    error.candidates = near_miss_candidates(
+        token,
+        items,
+        id_of=lambda item: str(item.id),
+        title_of=lambda item: item.title,
+    )
+    raise error
 
 
 def _resolve_by_id_or_prefix(
@@ -168,18 +211,20 @@ def _resolve_hex(
         # the title path; surface the candidates.
         raise
     except not_found:
-        # The id/prefix path found nothing. Try an exact-title match before failing
-        # so all-hex titles ("beef", "1234", "DEADBEEF") remain reachable by name.
+        # The id/prefix path found nothing. Try a title match (exact, then unique
+        # prefix) before failing so all-hex titles ("beef", "1234", "DEADBEEF")
+        # remain reachable by name.
         return _resolve_by_title(token, items, not_found=not_found)
 
 
 async def resolve_notebook(client: NotebookLMClient, ref: str) -> str:
-    """Resolve a notebook reference (full/partial id or exact title) to its id.
+    """Resolve a notebook reference (full/partial id, exact title, or unique title prefix) to its id.
 
     Args:
         client: The lifespan-bound client.
-        ref: A full canonical UUID, a hex id prefix, or an exact (case-insensitive)
-            notebook title.
+        ref: A full canonical UUID, a hex id prefix, an exact (case-insensitive)
+            title, or a unique (case-insensitive) title prefix over the
+            notebook list.
 
     Returns:
         The notebook's canonical id.
@@ -205,8 +250,9 @@ async def resolve_source(client: NotebookLMClient, notebook_id: str, ref: str) -
     Args:
         client: The lifespan-bound client.
         notebook_id: The (already-resolved) notebook id the source lives in.
-        ref: A full canonical UUID, a hex id prefix, or an exact (case-insensitive)
-            source title.
+        ref: A full canonical UUID, a hex id prefix, an exact (case-insensitive)
+            title, or a unique (case-insensitive) title prefix over the
+            notebook's source list.
 
     Returns:
         The source's canonical id.
@@ -237,8 +283,8 @@ async def resolve_sources(
     list RPCs. This resolves the whole batch against a single source-list snapshot.
 
     Matching rules are identical to :func:`resolve_source` (full-UUID fast-path,
-    hex id/prefix, exact case-insensitive title) and reuse the same single-ref
-    helpers, so behavior per ref is unchanged. An all-UUID batch still makes no
+    hex id/prefix, exact case-insensitive title, then unique title prefix) and
+    reuse the same single-ref helpers, so behavior per ref is unchanged. An all-UUID batch still makes no
     list call (each ref takes the fast-path, as before). Two differences from the
     old ``gather`` path:
 
@@ -252,7 +298,7 @@ async def resolve_sources(
     Args:
         client: The lifespan-bound client.
         notebook_id: The (already-resolved) notebook id the sources live in.
-        refs: Source references (full/partial id or exact title).
+        refs: Source references (full/partial id, exact title, or unique title prefix).
 
     Returns:
         The resolved canonical ids, in the same order as ``refs``. An empty
@@ -291,8 +337,9 @@ async def resolve_note(client: NotebookLMClient, notebook_id: str, ref: str) -> 
     Args:
         client: The lifespan-bound client.
         notebook_id: The (already-resolved) notebook id the note lives in.
-        ref: A full canonical UUID, a hex id prefix, or an exact (case-insensitive)
-            note title.
+        ref: A full canonical UUID, a hex id prefix, an exact (case-insensitive)
+            title, or a unique (case-insensitive) title prefix over the
+            notebook's note list.
 
     Returns:
         The note's canonical id.
@@ -327,8 +374,9 @@ async def resolve_artifact(client: NotebookLMClient, notebook_id: str, ref: str)
     Args:
         client: The lifespan-bound client.
         notebook_id: The (already-resolved) notebook id the artifact lives in.
-        ref: A full canonical UUID, a hex id prefix, or an exact (case-insensitive)
-            artifact title.
+        ref: A full canonical UUID, a hex id prefix, an exact (case-insensitive)
+            title, or a unique (case-insensitive) title prefix over the
+            notebook's artifact list.
 
     Returns:
         The artifact's canonical id.

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -138,6 +138,10 @@ def _resolve_by_title(
     # No exact title -> fall back to a unique title prefix so a name is as
     # prefix-resolvable as an id (issue #1786). Kept as a second pass (rather than
     # a single fused loop) so exact-wins-over-prefix reads directly off the code.
+    # This pass casefolds but deliberately does NOT dash/space-normalize (unlike
+    # near_miss_candidates below): a punctuation-slip token like "Acme - X" for a
+    # title "Acme — X" must stay a true miss here so it reaches the near-miss
+    # "did you mean" path (#1787) rather than silently resolving to a near match.
     prefix = [item for title_folded, item in folded if title_folded.startswith(token_folded)]
     if len(prefix) == 1:
         (match,) = prefix

--- a/src/notebooklm/mcp/_resolve.py
+++ b/src/notebooklm/mcp/_resolve.py
@@ -123,10 +123,12 @@ def _resolve_by_title(
     cannot match every item.
     """
     # casefold (not lower) for correct non-ASCII case-insensitive matching, e.g.
-    # German ß folds to "ss" so "STRASSE" matches a title "Straße".
+    # German ß folds to "ss" so "STRASSE" matches a title "Straße". Fold each
+    # title once up front so the two passes below don't re-casefold every item.
     token_folded = token.casefold()
+    folded = [((item.title or "").casefold(), item) for item in items]
 
-    exact = [item for item in items if (item.title or "").casefold() == token_folded]
+    exact = [item for title_folded, item in folded if title_folded == token_folded]
     if len(exact) == 1:
         (match,) = exact  # unpack (not exact[0]) — these are typed items, not an RPC row
         return str(match.id)
@@ -134,8 +136,9 @@ def _resolve_by_title(
         raise _ambiguous_title_error(token, exact, kind="title")
 
     # No exact title -> fall back to a unique title prefix so a name is as
-    # prefix-resolvable as an id (issue #1786).
-    prefix = [item for item in items if (item.title or "").casefold().startswith(token_folded)]
+    # prefix-resolvable as an id (issue #1786). Kept as a second pass (rather than
+    # a single fused loop) so exact-wins-over-prefix reads directly off the code.
+    prefix = [item for title_folded, item in folded if title_folded.startswith(token_folded)]
     if len(prefix) == 1:
         (match,) = prefix
         return str(match.id)
@@ -284,8 +287,9 @@ async def resolve_sources(
 
     Matching rules are identical to :func:`resolve_source` (full-UUID fast-path,
     hex id/prefix, exact case-insensitive title, then unique title prefix) and
-    reuse the same single-ref helpers, so behavior per ref is unchanged. An all-UUID batch still makes no
-    list call (each ref takes the fast-path, as before). Two differences from the
+    reuse the same single-ref helpers, so behavior per ref is unchanged. An
+    all-UUID batch still makes no list call (each ref takes the fast-path, as
+    before). Two differences from the
     old ``gather`` path:
 
     * Non-UUID refs share a **single** ``sources.list`` snapshot instead of one

--- a/tests/unit/mcp/test_resolve.py
+++ b/tests/unit/mcp/test_resolve.py
@@ -492,6 +492,7 @@ async def test_note_ambiguous_title_prefix_raises() -> None:
     with pytest.raises(AmbiguousIdError) as caught:
         await resolve_note(client, "nb-1", "Report")
     assert set(caught.value.candidate_ids) == {"ab0001cdef", "cd0002abef"}
+    assert "prefix" in str(caught.value)
 
 
 async def test_note_no_match_raises_note_not_found() -> None:

--- a/tests/unit/mcp/test_resolve.py
+++ b/tests/unit/mcp/test_resolve.py
@@ -23,11 +23,13 @@ from notebooklm._app.resolve import AmbiguousIdError  # noqa: E402 - after impor
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     ArtifactNotFoundError,
     NotebookNotFoundError,
+    NoteNotFoundError,
     SourceNotFoundError,
     ValidationError,
 )
 from notebooklm.mcp._resolve import (  # noqa: E402 - after importorskip guard
     resolve_artifact,
+    resolve_note,
     resolve_notebook,
     resolve_source,
     resolve_sources,
@@ -55,15 +57,23 @@ class _Art:
     title: str | None
 
 
+@dataclass
+class _Note:
+    id: str
+    title: str | None
+
+
 def _client(
     notebooks: list[_NB] | None = None,
     sources: list[_Src] | None = None,
     artifacts: list[_Art] | None = None,
+    notes: list[_Note] | None = None,
 ) -> AsyncMock:
     client = AsyncMock()
     client.notebooks.list = AsyncMock(return_value=notebooks or [])
     client.sources.list = AsyncMock(return_value=sources or [])
     client.artifacts.list = AsyncMock(return_value=artifacts or [])
+    client.notes.list = AsyncMock(return_value=notes or [])
     return client
 
 
@@ -128,12 +138,19 @@ async def test_no_match_prefix_raises_not_found() -> None:
 # near-miss candidates on a failed name lookup (issue #1787)
 # --------------------------------------------------------------------------- #
 async def test_prefix_near_miss_attaches_candidate() -> None:
-    """A bare prefix of a real title surfaces that title as a candidate."""
-    real = "Scientific PDF Parsing — Landscape, Benchmarks & Multimodal Extraction"
+    """A near-prefix that can't cleanly resolve (a punctuation slip) surfaces the title.
+
+    A clean unique title prefix now *resolves* (issue #1786), so it never reaches
+    the near-miss path. This exercises the surviving near-miss prefix case: a token
+    that would be a prefix but for an em-dash/hyphen slip, so it misses and the real
+    title is offered as a candidate.
+    """
+    real = "Scientific — PDF Parsing, Benchmarks & Multimodal Extraction"
     client = _client(notebooks=[_NB("37fe5c1d", real), _NB("cafef00d", "Unrelated")])
     with pytest.raises(NotebookNotFoundError) as caught:
-        await resolve_notebook(client, "Scientific")
-    assert list(caught.value.candidates) == [{"id": "37fe5c1d", "title": real}]
+        # hyphen typed for the em-dash -> not a raw prefix -> true miss -> near-miss
+        await resolve_notebook(client, "Scientific - PDF")
+    assert [c["id"] for c in caught.value.candidates] == ["37fe5c1d"]
 
 
 async def test_em_dash_hyphen_near_miss_attaches_candidate() -> None:
@@ -191,6 +208,79 @@ async def test_hex_token_matching_neither_id_nor_title_raises_not_found() -> Non
 
 
 # --------------------------------------------------------------------------- #
+# resolve_notebook — unique TITLE-prefix resolution (#1786)
+# --------------------------------------------------------------------------- #
+async def test_unique_title_prefix_resolves() -> None:
+    """A unique title PREFIX resolves like an id prefix does (issue #1786 repro)."""
+    client = _client(
+        notebooks=[
+            _NB("deadbeef", "Scientific PDF Parsing — Landscape, Benchmarks & Extraction"),
+            _NB("cafef00d", "Marketing Plan"),
+        ]
+    )
+    assert await resolve_notebook(client, "Scientific") == "deadbeef"
+
+
+async def test_unique_title_prefix_is_case_insensitive() -> None:
+    """The prefix match casefolds, so 'sci' resolves a 'Scientific …' title."""
+    client = _client(notebooks=[_NB("deadbeef", "Scientific Report"), _NB("cafef00d", "Other")])
+    assert await resolve_notebook(client, "sci") == "deadbeef"
+
+
+async def test_ambiguous_title_prefix_raises_with_candidates() -> None:
+    """An ambiguous title prefix raises AmbiguousIdError listing every candidate."""
+    client = _client(notebooks=[_NB("deadbeef", "Report Q1"), _NB("cafef00d", "Report Q2")])
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_notebook(client, "Report")
+    assert set(caught.value.candidate_ids) == {"deadbeef", "cafef00d"}
+    # The message names the axis that was ambiguous so the caller can react.
+    assert "prefix" in str(caught.value)
+
+
+async def test_exact_title_wins_over_prefix() -> None:
+    """A title that is ALSO a prefix of a longer one resolves to itself, not ambiguous."""
+    client = _client(notebooks=[_NB("deadbeef", "Report"), _NB("cafef00d", "Report Q1")])
+    assert await resolve_notebook(client, "Report") == "deadbeef"
+
+
+async def test_partial_that_is_not_a_prefix_raises_not_found() -> None:
+    """A token that is neither exact nor a prefix of any title still raises NOT_FOUND."""
+    client = _client(notebooks=[_NB("deadbeef", "Scientific Report"), _NB("cafef00d", "Other")])
+    with pytest.raises(NotebookNotFoundError):
+        await resolve_notebook(client, "Scientif Report")  # interior gap, not a prefix
+
+
+async def test_exact_title_ambiguity_short_circuits_before_prefix() -> None:
+    """Two exact-title collisions raise as a *title* ambiguity, never reaching the prefix pass.
+
+    With titles "Report" x2 plus a longer "Report Q1", token "Report" has two
+    EXACT matches — that must raise before the prefix pass (which would otherwise
+    see all three). The message names the ``title`` axis, not ``prefix``.
+    """
+    client = _client(
+        notebooks=[
+            _NB("deadbeef", "Report"),
+            _NB("cafef00d", "report"),  # casefold-equal exact match
+            _NB("f00dcafe", "Report Q1"),  # prefix-only; must be excluded from the error
+        ]
+    )
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_notebook(client, "Report")
+    assert set(caught.value.candidate_ids) == {"deadbeef", "cafef00d"}
+    assert "title" in str(caught.value)
+
+
+async def test_hex_token_falls_back_to_title_prefix() -> None:
+    """A hex-ish token that is not an id-prefix falls back to a unique title *prefix*.
+
+    'bee' is hex-ish so it takes the id/prefix path first; no id starts with it,
+    so it falls through to the title path, which now prefix-matches "beef report".
+    """
+    client = _client(notebooks=[_NB("0000aaaa1111", "beef report"), _NB("cafef00d", "Other")])
+    assert await resolve_notebook(client, "bee") == "0000aaaa1111"
+
+
+# --------------------------------------------------------------------------- #
 # resolve_source
 # --------------------------------------------------------------------------- #
 async def test_source_full_uuid_skips_list() -> None:
@@ -215,6 +305,20 @@ async def test_source_ambiguous_title_raises() -> None:
     with pytest.raises(AmbiguousIdError) as caught:
         await resolve_source(client, "nb-1", "Dup")
     assert set(caught.value.candidate_ids) == {"ab0001cdef", "cd0002abef"}
+
+
+async def test_source_unique_title_prefix_resolves() -> None:
+    """Title-prefix resolution is shared, so sources gain it too (#1786 parity)."""
+    client = _client(sources=[_Src("ab0001cdef", "Report.pdf"), _Src("cd0002abef", "Notes.txt")])
+    assert await resolve_source(client, "nb-1", "Report") == "ab0001cdef"
+
+
+async def test_source_none_title_is_skipped_by_prefix() -> None:
+    """A source with no title cannot be prefix-matched (``None`` folds to '')."""
+    client = _client(sources=[_Src("ab0001cdef", None), _Src("cd0002abef", "Report.pdf")])
+    assert await resolve_source(client, "nb-1", "Rep") == "cd0002abef"
+    with pytest.raises(SourceNotFoundError):
+        await resolve_source(client, "nb-1", "Untitled")
 
 
 async def test_source_no_match_raises_source_not_found() -> None:
@@ -268,6 +372,14 @@ async def test_sources_title_refs_list_exactly_once() -> None:
     )
     result = await resolve_sources(client, "nb-1", ["Notes", "Report.pdf"])
     assert result == ["cd0002abef", "ab0001cdef"]
+    client.sources.list.assert_awaited_once_with("nb-1")
+
+
+async def test_sources_unique_title_prefix_resolves_batch() -> None:
+    """Batch resolution shares the same helper, so title prefixes resolve in a batch too."""
+    client = _client(sources=[_Src("ab0001cdef", "Report.pdf"), _Src("cd0002abef", "Notes.txt")])
+    result = await resolve_sources(client, "nb-1", ["Report", "Notes"])
+    assert result == ["ab0001cdef", "cd0002abef"]
     client.sources.list.assert_awaited_once_with("nb-1")
 
 
@@ -332,6 +444,14 @@ async def test_artifact_ambiguous_prefix_raises() -> None:
     assert set(caught.value.candidate_ids) == {"beef0001", "beef0002"}
 
 
+async def test_artifact_unique_title_prefix_resolves() -> None:
+    """Title-prefix resolution is shared, so artifacts gain it too (#1786 parity)."""
+    client = _client(
+        artifacts=[_Art("ab0001cdef", "My Podcast"), _Art("cd0002abef", "Weekly Quiz")]
+    )
+    assert await resolve_artifact(client, "nb-1", "My Pod") == "ab0001cdef"
+
+
 async def test_artifact_no_match_raises_artifact_not_found() -> None:
     client = _client(artifacts=[_Art("ab0001cdef", "Podcast")])
     with pytest.raises(ArtifactNotFoundError):
@@ -351,3 +471,30 @@ async def test_artifact_whitespace_ref_raises_validation_before_listing() -> Non
     with pytest.raises(ValidationError):
         await resolve_artifact(client, "nb-1", "   ")
     client.artifacts.list.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# resolve_note (fourth resolver family — shares the same helper)
+# --------------------------------------------------------------------------- #
+async def test_note_title_match() -> None:
+    client = _client(notes=[_Note("ab0001cdef", "Meeting Notes"), _Note("cd0002abef", "Tasks")])
+    assert await resolve_note(client, "nb-1", "meeting notes") == "ab0001cdef"
+
+
+async def test_note_unique_title_prefix_resolves() -> None:
+    """Title-prefix resolution is shared, so notes gain it too (#1786 parity)."""
+    client = _client(notes=[_Note("ab0001cdef", "Meeting Notes"), _Note("cd0002abef", "Tasks")])
+    assert await resolve_note(client, "nb-1", "Meeting") == "ab0001cdef"
+
+
+async def test_note_ambiguous_title_prefix_raises() -> None:
+    client = _client(notes=[_Note("ab0001cdef", "Report Q1"), _Note("cd0002abef", "Report Q2")])
+    with pytest.raises(AmbiguousIdError) as caught:
+        await resolve_note(client, "nb-1", "Report")
+    assert set(caught.value.candidate_ids) == {"ab0001cdef", "cd0002abef"}
+
+
+async def test_note_no_match_raises_note_not_found() -> None:
+    client = _client(notes=[_Note("ab0001cdef", "Meeting Notes")])
+    with pytest.raises(NoteNotFoundError):
+        await resolve_note(client, "nb-1", "Missing Title")


### PR DESCRIPTION
## Summary

- MCP name resolution accepted only an exact (case-insensitive) title or an id / id-prefix, so a **unique title prefix** like `"Scientific"` failed with `NOT_FOUND` even when exactly one notebook matched — inconsistent with how ids resolve by unique prefix (issue #1786).
- Teach the **shared** `_resolve_by_title` helper (used by all four MCP resolvers — `resolve_notebook` / `resolve_source` / `resolve_note` / `resolve_artifact`) to fall back to a unique title prefix when no exact title matches. Exact wins over prefix (so `"Report"` resolves to itself even when `"Report Q1"` exists); a unique prefix resolves; an ambiguous prefix raises `AmbiguousIdError` listing the candidates — mirroring the id resolver's exact-over-prefix rule.
- `None`-titled items (untitled sources) fold to `""` and never match a non-empty ref, on either axis.

Fixing it in the shared helper (rather than notebook-only) keeps the name-resolution surface **consistent** across all four ref families, which is the whole point of the issue.

## Repro (now fixed)

```
# One notebook titled "Scientific PDF Parsing — …"; no other starts with "Scientific"
source_list(notebook="Scientific")   # was: NOT_FOUND — now resolves to that notebook
```

## Test plan

- [x] `tests/unit/mcp/test_resolve.py` — 52 passed (unique prefix resolves; case-insensitive; ambiguous prefix → `AmbiguousIdError` with candidates; exact wins over prefix; non-prefix miss → `NOT_FOUND`; `None`-title skipped; hex-token → title-prefix fallback; parity across notebook/source/note/artifact + batch `resolve_sources`).
- [x] `uv run pytest` full suite green; `mypy` clean (302 files); `ruff check` + `ruff format --check` clean.

## Polish

Ran `/polish` (code-simplifier → triple review claude+codex+agy → ultrathink). No correctness findings; all three reviewers converged on the same test-coverage gaps, now closed with 8 added tests. Deferred findings: none.

## Note on overlap with #1787

#1787 (near-miss candidates on `NOT_FOUND`) also touches `_resolve_by_title`. This PR is rebased on latest `origin/main`; whichever merges second will reconcile the `not_found(token)` raise site (the two changes compose: prefix resolves the unique case, near-miss candidates aid the true-miss case).

Closes #1786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Name/ID lookup now supports case-insensitive exact title matching and unique title-prefix matching (with exact-title precedence).
  * Hex-like tokens can resolve by title when ID/prefix resolution fails.

* **Bug Fixes**
  * Ambiguous title matches return a validation error listing candidate targets (and indicate ambiguity by title/prefix).
  * “Did you mean” hints are improved to focus on punctuation/space-only differences.

* **Documentation**
  * MCP guide updated to clarify precedence, ambiguity handling, and retry behavior.

* **Tests**
  * Expanded resolver tests across notebooks, sources, artifacts, and notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->