### PR TITLE
docs(readme): regroup use-case recipes into 4 themes + accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NotebookLM is a **grounded** engine: Gemini does the heavy reading and answers f
 
 - **📞 Grounded knowledge base / troubleshooting oracle (RAG)** — Load product docs, FAQs, RFCs, and past tickets, then `ask --json` for **source-grounded, cited** answers for support, on-call, or internal Q&A. Or have an agent point it at an entire fast-moving tool's docs — more than the agent can hold in context — as a **troubleshooting oracle** it queries the moment it hits an error. *In the wild: [OpenClaw drove the library to scrape all 524 pages of `docs.openclaw.ai`, dedupe the duplicate translations, and audit it down to 269 clean sources (missing/extra/duplicate = 0)](https://x.com/onenewbite/status/2024819940327379286).*
 - **🔁 Multi-format content repurposing** — One source set, every format: `generate audio` (podcast), `generate video`, `generate slide-deck`, plus a `generate report` blog draft, `generate quiz`, and `generate flashcards` — fan a single notebook out across channels.
-- **📤 Bulk, scriptable exports** — Pull mind maps as JSON, flashcards/quizzes as JSON/Markdown/HTML, data tables as CSV, and reports as Markdown — **in bulk, to local files, straight into Anki, your mind-mapping tool, or a repo** (`download --all` / `artifact export`). The programmatic "get data *out*" half of the library, not just "put sources in."
+- **📤 Bulk, scriptable exports** — Pull mind maps as JSON, flashcards/quizzes as JSON/Markdown/HTML, data tables as CSV, and reports as Markdown — **in bulk, to local files, straight into Anki, your mind-mapping tool, or a repo** (`download <type>` / `download <type> --all`). The programmatic "get data *out*" half of the library, not just "put sources in."
 - **🕸️ Obsidian / knowledge-graph sync** — Run the CLI from your vault root so downloaded artifacts (reports, mind-map JSON, transcripts) land as files in your knowledge graph; community skills built on this library even resolve NotebookLM's citation markers into Obsidian `[[wikilinks]]`. Pair with a podcast overview for an audio digest of your notes. *In the wild: ["Claude Code + NotebookLM + Obsidian = GOD MODE"](https://www.youtube.com/watch?v=kU3qYQ7ACMA).*
 
 **Run it unattended, at scale, or on the go** — scheduled, headless, and remote:
@@ -63,7 +63,7 @@ NotebookLM is a **grounded** engine: Gemini does the heavy reading and answers f
 - **🚨 Incident runbook generator** — On an alert, spin up a notebook of the relevant docs, ask targeted diagnostic questions, and generate a briefing-doc report (`generate report --format briefing-doc --wait`, then `download report`) as an automated runbook.
 - **📚 Curriculum / study-set builder** — Scrape a syllabus or developer roadmap, create one notebook per topic (with deliberate pacing to dodge rate limits), and bulk-generate podcasts, quizzes, and flashcards for each.
 - **📰 Scheduled audio briefings** — Pair `auth refresh --quiet` (cron/launchd/systemd) with `generate audio` to publish a fresh personalized briefing to a podcast feed on a schedule.
-- **📱 NotebookLM from your phone, agent-driven** — Self-host the [remote MCP connector](docs/mcp-guide.md#remote-deployment-docker--a-tunnel) behind a Cloudflare/Tailscale tunnel and add it as a custom connector **on the web** (claude.ai Connectors, or ChatGPT with Developer Mode). Then drive the full toolset — deep research, source ingestion, studio generation, cited Q&A — from the **claude.ai or ChatGPT mobile app**, chained with your other MCP tools, instead of app-hopping.
+- **📱 NotebookLM from your phone, agent-driven** — Self-host the [remote MCP connector](docs/mcp-guide.md#remote-deployment-docker--a-tunnel) behind a Cloudflare/Tailscale tunnel and add it as a custom connector **on the web** (claude.ai Connectors, or ChatGPT with Developer Mode). Then drive the full toolset — deep research, source ingestion, studio generation, cited Q&A — from the **claude.ai mobile app** on the go (ChatGPT's MCP connectors are web-only), chained with your other MCP tools, instead of app-hopping.
 
 These combine ordinary library primitives — see the [CLI Reference](docs/cli-reference.md) and [Python API](docs/python-api.md). The agent-side glue (skills, scheduling, vault layout) lives in your own setup, not this package. Per-notebook source counts depend on your Google account tier — split across notebooks if you hit a cap.
 
@@ -75,7 +75,7 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 |--------|----------|
 | **Python API** | Application integration, async workflows, custom pipelines |
 | **CLI** | Shell scripts, quick tasks, CI/CD automation |
-| **MCP Server** | Exposing NotebookLM tools to Claude Desktop/Code, Cursor, Windsurf, and other MCP clients — locally (stdio) **or** as a self-hosted **remote connector** reachable from **claude.ai and ChatGPT** (Developer Mode) and mobile, over a Cloudflare/Tailscale tunnel |
+| **MCP Server** | Exposing NotebookLM tools to Claude Desktop/Code, Cursor, Windsurf, and other MCP clients — locally (stdio) **or** as a self-hosted **remote connector** reachable from **claude.ai** (incl. mobile) **and ChatGPT** (web, Developer Mode — full MCP write tools need a Business/Enterprise/Edu workspace), over a Cloudflare/Tailscale tunnel |
 | **REST Server** | Local automation over guarded HTTP routes without spawning a CLI process per call |
 | **Agent Integration** | Claude Code, Codex, LLM agents, natural language automation |
 
@@ -97,7 +97,7 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 
 | Type | Options | Download Format |
 |------|---------|-----------------|
-| **Audio Overview** | 4 formats (deep-dive, brief, critique, debate), 3 lengths, 50+ languages | MP3 |
+| **Audio Overview** | 4 formats (deep-dive, brief, critique, debate), 3 lengths, 50+ languages | MP3/MP4 |
 | **Video Overview** | 3 formats (explainer, brief, cinematic), 8 visual styles (+ auto/custom), plus a dedicated `cinematic-video` CLI alias | MP4 |
 | **Slide Deck** | Detailed or presenter format, adjustable length; individual slide revision | PDF, PPTX |
 | **Infographic** | 3 orientations, 3 detail levels | PNG |

--- a/README.md
+++ b/README.md
@@ -37,22 +37,37 @@
 
 ## Use Cases & Recipes
 
-NotebookLM is a **grounded** engine: Gemini does the heavy reading and answers from *your* sources with citations. The winning pattern is to let it do the expensive analysis while your agent (Claude Code, Codex, …) orchestrates and handles the final mile. Recipes people build on top of this library:
+NotebookLM is a **grounded** engine: Gemini does the heavy reading and answers from *your* sources with citations. The winning pattern is to let it do the expensive analysis while your agent (Claude Code, Codex, …) orchestrates and handles the final mile — using NotebookLM as a **zero-token synthesis + memory layer an agent drives in a loop**, and pulling structured artifacts **out** in bulk and in richer, scriptable formats. Recipes people build on top of this library, grouped by what they use NotebookLM *as*:
 
-- **🪙 Zero-token research offload** — Throw 30 documents into a notebook, let Gemini do the heavy analysis, and have your agent spend tokens only on the final polish. The agent just orchestrates (`create` → `source add` → `ask`); the reasoning happens server-side.
-- **🧠 Web research → expert agent** — Run [Deep Research](docs/cli-reference.md#source-add-research) (`source add-research`) to scan the web into a sourced report, then distill that report into a reusable Claude skill — a packaged domain expert without hand-curating sources.
+**Spend fewer tokens** — let NotebookLM do the expensive thinking:
+
+- **🪙 Zero-token research offload** — Throw 30 documents into a notebook, let Gemini do the heavy analysis, and have your agent spend tokens only on the final polish. The agent just orchestrates (`create` → `source add` → `ask`); the reasoning happens server-side. *In the wild: [a four-workflow guide to stop Claude Code burning tokens on NotebookLM](https://x.com/hooeem/status/2042293751805329445).*
+- **🧠 Knowledge distillation → a permanent skill** — Run [Deep Research](docs/cli-reference.md#source-add-research) (`source add-research "your topic" --mode deep`) or load a doc corpus, let NotebookLM's Gemini condense it, and bake the result into a `SKILL.md` your agent loads at startup — **build once, reuse with zero runtime tokens or network calls**, git-versioned and immune to UI drift. A packaged domain expert without hand-curating sources. (Dumping raw docs into a skill flattens the hierarchy; NotebookLM condensing first is what makes it work.)
+- **✅ Self-validating skills** — Have NotebookLM generate the *eval set* — a quiz straight from your sources — to grade an agent skill against ground truth instead of test questions you'd bias yourself. Build the skill, run it against the NotebookLM-authored evals, iterate to a pass. *In the wild: [a skill that scored 4/10 on the first pass and 10/10 after one iteration, graded by a NotebookLM-generated quiz](https://x.com/nurijanian/status/2037136490157986277).*
+
+**Give your agent memory** — persistent, grounded recall:
+
 - **💾 Persistent cross-session memory** — Keep a "Master Brain" notebook; a wrap-up step appends each session's decisions and fixes as notes (`note create` / `ask --save-as-note`), and a line in your `CLAUDE.md` queries it (`ask`) at the start of the next session. Storage and recall live on Google's infrastructure.
-- **🕸️ Obsidian / knowledge-graph sync** — Run the CLI from your vault root so downloaded artifacts (reports, mind-map JSON, transcripts) land as files in your knowledge graph; community skills built on this library even resolve NotebookLM's citation markers into Obsidian `[[wikilinks]]`. Pair with a podcast overview for an audio digest of your notes.
+- **🧩 Grounded memory for coding agents** — Expose a notebook of your internal docs/RFCs/architecture over the [MCP server](docs/mcp-guide.md) (or plain `ask`) so an agent answers from *your* code with citations rather than plausible-sounding guesses — a zero-infra alternative to standing up your own vector DB and embedding pipeline. *In the wild: [turning a notebook into the source-grounded "project brain" a coding agent consults before it writes code](https://medium.com/@pradeep00271/every-software-project-needs-a-project-brain-5cbc33917160).*
+- **🪞 Query your own notes / journal** — Load years of daily notes, meeting logs, or a journal and `ask` for **cited** answers *across your own history* — surfacing long-term patterns a keyword search can't (e.g. a weekly summary synthesized from 282 daily notes, every claim linked back to the entry it came from). *In the wild: [chatting with a year of daily notes as a cited knowledge base](https://artemxtech.substack.com/p/notebooklm-has-a-knowledge-graph).*
+
+**Turn your sources into answers & artifacts** — cited responses, generated media, and exports:
+
+- **📞 Grounded knowledge base / troubleshooting oracle (RAG)** — Load product docs, FAQs, RFCs, and past tickets, then `ask --json` for **source-grounded, cited** answers for support, on-call, or internal Q&A. Or have an agent point it at an entire fast-moving tool's docs — more than the agent can hold in context — as a **troubleshooting oracle** it queries the moment it hits an error. *In the wild: [OpenClaw drove the library to scrape all 524 pages of `docs.openclaw.ai`, dedupe the duplicate translations, and audit it down to 269 clean sources (missing/extra/duplicate = 0)](https://x.com/onenewbite/status/2024819940327379286).*
 - **🔁 Multi-format content repurposing** — One source set, every format: `generate audio` (podcast), `generate video`, `generate slide-deck`, plus a `generate report` blog draft, `generate quiz`, and `generate flashcards` — fan a single notebook out across channels.
-- **📞 Grounded knowledge base (RAG)** — Load product docs, FAQs, RFCs, and past tickets, then `ask --json` for **source-grounded, cited** answers for support, on-call, or internal Q&A.
-- **🧩 Grounded memory for coding agents** — Expose a notebook of your internal docs/RFCs/architecture over the [MCP server](docs/mcp-guide.md) (or plain `ask`) so an agent answers from *your* code with citations rather than plausible-sounding guesses — a zero-infra alternative to standing up your own vector DB and embedding pipeline.
-- **🚨 Incident runbook generator** — On an alert, spin up a notebook of the relevant docs, ask targeted diagnostic questions, and emit a briefing-doc report (`generate report --format briefing-doc`) as an automated runbook.
+- **📤 Bulk, scriptable exports** — Pull mind maps as JSON, flashcards/quizzes as JSON/Markdown/HTML, data tables as CSV, and reports as Markdown — **in bulk, to local files, straight into Anki, your mind-mapping tool, or a repo** (`download --all` / `artifact export`). The programmatic "get data *out*" half of the library, not just "put sources in."
+- **🕸️ Obsidian / knowledge-graph sync** — Run the CLI from your vault root so downloaded artifacts (reports, mind-map JSON, transcripts) land as files in your knowledge graph; community skills built on this library even resolve NotebookLM's citation markers into Obsidian `[[wikilinks]]`. Pair with a podcast overview for an audio digest of your notes. *In the wild: ["Claude Code + NotebookLM + Obsidian = GOD MODE"](https://www.youtube.com/watch?v=kU3qYQ7ACMA).*
+
+**Run it unattended, at scale, or on the go** — scheduled, headless, and remote:
+
+- **🚨 Incident runbook generator** — On an alert, spin up a notebook of the relevant docs, ask targeted diagnostic questions, and generate a briefing-doc report (`generate report --format briefing-doc --wait`, then `download report`) as an automated runbook.
 - **📚 Curriculum / study-set builder** — Scrape a syllabus or developer roadmap, create one notebook per topic (with deliberate pacing to dodge rate limits), and bulk-generate podcasts, quizzes, and flashcards for each.
 - **📰 Scheduled audio briefings** — Pair `auth refresh --quiet` (cron/launchd/systemd) with `generate audio` to publish a fresh personalized briefing to a podcast feed on a schedule.
+- **📱 NotebookLM from your phone, agent-driven** — Self-host the [remote MCP connector](docs/mcp-guide.md#remote-deployment-docker--a-tunnel) behind a Cloudflare/Tailscale tunnel and add it as a custom connector **on the web** (claude.ai Connectors, or ChatGPT with Developer Mode). Then drive the full toolset — deep research, source ingestion, studio generation, cited Q&A — from the **claude.ai or ChatGPT mobile app**, chained with your other MCP tools, instead of app-hopping.
 
-These combine ordinary library primitives — see the [CLI Reference](docs/cli-reference.md) and [Python API](docs/python-api.md). The agent-side glue (skills, scheduling, vault layout) lives in your own setup, not this package.
+These combine ordinary library primitives — see the [CLI Reference](docs/cli-reference.md) and [Python API](docs/python-api.md). The agent-side glue (skills, scheduling, vault layout) lives in your own setup, not this package. Per-notebook source counts depend on your Google account tier — split across notebooks if you hit a cap.
 
-**Seen in the wild:** ["Claude Code + NotebookLM = CHEAT CODE"](https://www.youtube.com/watch?v=usTeU4Uh0iM) · ["…+ Obsidian = GOD MODE"](https://www.youtube.com/watch?v=kU3qYQ7ACMA) · [a browser-free YouTube→notebook→cited-answers pipeline driven entirely from the terminal](https://artemxtech.substack.com/p/notebooklm-has-a-knowledge-graph) · [a four-workflow guide to offloading heavy document analysis onto NotebookLM so Claude Code stops burning tokens (zero-token research, web-research agents, cross-session memory, an Obsidian "second brain")](https://x.com/hooeem/status/2042293751805329445) · [turning a notebook into the source-grounded "project brain" a coding agent consults before it writes code](https://medium.com/@pradeep00271/every-software-project-needs-a-project-brain-5cbc33917160).
+**New here?** Start with a walkthrough: [Claude Code + NotebookLM = CHEAT CODE (video)](https://www.youtube.com/watch?v=usTeU4Uh0iM) · [5 demos + 50 use cases, with prompts](https://aiblewmymind.substack.com/p/notebooklm-claude-code-use-cases).
 
 ## Ways to Use
 
@@ -60,7 +75,7 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 |--------|----------|
 | **Python API** | Application integration, async workflows, custom pipelines |
 | **CLI** | Shell scripts, quick tasks, CI/CD automation |
-| **MCP Server** | Exposing NotebookLM tools to Claude Desktop/Code, Cursor, Windsurf, and other MCP clients — locally (stdio) or as a self-hosted **remote connector** for claude.ai |
+| **MCP Server** | Exposing NotebookLM tools to Claude Desktop/Code, Cursor, Windsurf, and other MCP clients — locally (stdio) **or** as a self-hosted **remote connector** reachable from **claude.ai and ChatGPT** (Developer Mode) and mobile, over a Cloudflare/Tailscale tunnel |
 | **REST Server** | Local automation over guarded HTTP routes without spawning a CLI process per call |
 | **Agent Integration** | Claude Code, Codex, LLM agents, natural language automation |
 
@@ -82,8 +97,8 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 
 | Type | Options | Download Format |
 |------|---------|-----------------|
-| **Audio Overview** | 4 formats (deep-dive, brief, critique, debate), 3 lengths, 50+ languages | MP3/MP4 |
-| **Video Overview** | 3 formats (explainer, brief, cinematic), 9 visual styles, plus a dedicated `cinematic-video` CLI alias | MP4 |
+| **Audio Overview** | 4 formats (deep-dive, brief, critique, debate), 3 lengths, 50+ languages | MP3 |
+| **Video Overview** | 3 formats (explainer, brief, cinematic), 8 visual styles (+ auto/custom), plus a dedicated `cinematic-video` CLI alias | MP4 |
 | **Slide Deck** | Detailed or presenter format, adjustable length; individual slide revision | PDF, PPTX |
 | **Infographic** | 3 orientations, 3 detail levels | PNG |
 | **Quiz** | Configurable quantity and difficulty | JSON, Markdown, HTML |
@@ -94,21 +109,26 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 
 ### Beyond the Web UI
 
-These features are available via API/CLI but not exposed in NotebookLM's web interface:
+Programmatic, batch, and local-file capabilities the API/CLI make easy — several in richer formats, or at a scale, than clicking through the web app:
 
 - **Batch downloads** - Download all artifacts of a type at once
-- **Quiz/Flashcard export** - Get structured JSON, Markdown, or HTML (web UI only shows interactive view)
+- **Quiz/Flashcard export** - Get structured JSON, Markdown, or HTML files
 - **Mind map data extraction** - Export hierarchical JSON for visualization tools
 - **Data table CSV export** - Download structured tables as spreadsheets
-- **Slide deck as PPTX** - Download editable PowerPoint files (web UI only offers PDF)
+- **Slide deck as PPTX or PDF** - Download editable PowerPoint or PDF files
 - **Slide revision** - Modify individual slides with natural-language prompts
 - **Report template customization** - Append extra instructions to built-in format templates
-- **Save chat to notes** - Save Q&A answers or conversation history as notebook notes
+- **Save chat history to notes** - Persist a whole Q&A conversation (not just a single answer) as a notebook note
 - **Source fulltext access** - Retrieve the indexed text content of any source
 - **Programmatic sharing** - Manage permissions without the UI
-- **Multi-account profiles** - Switch between Google accounts without re-authenticating
-- **Browser cookie import** - Reuse cookies from your existing browser session instead of driving Playwright
-- **Headless / unattended auth** - Re-mint web cookies from a durable master token with no per-session browser (`login --master-token`) — for servers, CI, and the remote MCP connector
+
+### Authentication & Access
+
+Flexible auth for local dev, headless servers, and multi-tenant setups:
+
+- **Three ways to get cookies** - Interactive Playwright login (default), import from an already-signed-in browser (`login --browser-cookies chrome`, no Playwright), or a durable **master token**.
+- **Master-token auth** - Mints fresh web cookies **on demand** with no per-session browser (`login --master-token --account you@example.com`), so it self-heals expired sessions unattended — the auth model for servers, CI, and the remote MCP connector (claude.ai / ChatGPT).
+- **Multi-account profiles** - Switch between Google accounts without re-authenticating.
 
 ## Installation
 
@@ -206,7 +226,7 @@ notebooklm agent show claude         # Print bundled Claude Code skill template
 notebooklm language list             # List supported output languages
 notebooklm metadata --json           # Export notebook metadata and sources
 notebooklm share status              # Inspect sharing state
-notebooklm source add-research "AI"  # Start web research and import sources
+notebooklm source add-research "AI" --import-all  # web research + import found sources
 notebooklm skill status              # Check local agent skill installation
 notebooklm profile list              # List all Google account profiles
 notebooklm profile switch work       # Switch active account profile
@@ -243,8 +263,8 @@ async def main():
         # Generate a mind map via the unified client.mind_maps API (issue #1256) —
         # two kinds: the newer MindMapKind.INTERACTIVE studio map (shown; polled to
         # completion by default) or MindMapKind.NOTE_BACKED JSON. Both export via:
-        await client.mind_maps.generate(nb.id, kind=MindMapKind.INTERACTIVE)
-        await client.artifacts.download_mind_map(nb.id, "mindmap.json")
+        mm = await client.mind_maps.generate(nb.id, kind=MindMapKind.INTERACTIVE)
+        await client.artifacts.download_mind_map(nb.id, "mindmap.json", mm.id)
 
 asyncio.run(main())
 ```


### PR DESCRIPTION
## What

Restructures the **Use Cases & Recipes** section of the README and hardens the doc's factual claims. README-only change.

### Structure
- **Grouped the recipes into 4 themes** by what NotebookLM is used *as*: *spend fewer tokens · give your agent memory · turn sources into answers & artifacts · run it unattended* (mirrors the intro's framing).
- **Two new recipes** surfaced from in-the-wild research: **self-validating skills** (NotebookLM generates the eval set to grade an agent skill) and **query-your-own-notes/journal**.
- Reframed the RAG recipe as a **troubleshooting oracle** (with the OpenClaw docs-ingest example), added a **bulk/scriptable export** recipe, and inlined real-world evidence links per recipe.
- Moved auth mechanics out of "Beyond the Web UI" into a new **Authentication & Access** subsection.
- Noted the remote MCP connector reaches **claude.ai + ChatGPT** (added on the web, then driven from mobile).

### Accuracy (verified against source)
Hardened in a **3-round multi-model review (codex + claude + agy)** that cross-checked every claim against `docs/cli-reference.md`, `docs/python-api.md`, and `src/`:
- **Fixed a broken Python example** — an interactive mind map must pass its artifact id to `download_mind_map` (the no-id path only resolves note-backed maps → `ArtifactNotReadyError`).
- `login --master-token --account`; `source add-research --import-all` / `--mode deep`; briefing-doc runbook needs `--wait` + `download report`.
- Audio Overview downloads MP3 (not MP3/MP4); video = 8 styles (+auto/custom).
- Reframed stale "the web UI can't" claims as programmatic/batch/local capabilities (flashcard CSV, PPTX, etc. are no longer web-UI-exclusive).
- Added an account-tier caveat for large per-notebook source counts.

Review converged: Claude and agy both returned no substantive issues; codex's remaining notes were marketing-tone suggestions left to the maintainer.

## Note
The maintainer's `deploy/README.md` + `mcp-guide.md` tunnel-docs work is intentionally **not** in this branch — this PR is README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB8mwAvNpxq228pSLp5QaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the README’s “Use Cases & Recipes” into grouped guidance (token-spend/offload, agent memory, artifact generation/export, unattended/scaled runs).
  * Rewrote “Ways to Use” into a clearer table, including expanded MCP Server details for both local (stdio) and remote/self-hosted connector usage (with mobile considerations).
  * Updated feature highlights for content generation (including revised visual style options and preserved `cinematic-video` alias) and expanded download/export formats.
  * Broadened “Beyond the Web UI” and authentication guidance, including clearer cookie acquisition options and expanded programmatic/batch/local-file capabilities.
  * Updated CLI and Python API examples to match the latest recommended patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->