### PR TITLE
fix: backport critical 0.7.x wire/security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of #1530). Logs and exception previews now scrub session cookies, secure
   host-cookie names, `LSOLH` / `__Host-GAPS`-style cookies, and Google API key
   token shapes consistently before diagnostics can include them.
+- **`notebooks.get()` / `sources.list()` now use the nested `GET_NOTEBOOK`
+  read payload shape** (backport of #1582). This matches the nested write-path
+  backport from 0.7.2, so migrated Google cohorts no longer break read calls
+  while create/add-url calls keep working.
 
 ## [0.7.3] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or link-local target and write the response body to disk. Redirect requests
   are now checked before they are sent, and percent-encoded hosts are rejected
   instead of decoded into a trusted-looking hostname.
+- **Runtime secret redaction now comes from one canonical registry** (backport
+  of #1530). Logs and exception previews now scrub session cookies, secure
+  host-cookie names, `LSOLH` / `__Host-GAPS`-style cookies, and Google API key
+  token shapes consistently before diagnostics can include them.
 
 ## [0.7.3] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Artifact downloads now re-validate every redirect hop against the trusted
+  host allowlist** (backport of #1532). `download_url` and batch media
+  downloads already checked the initial URL, but `follow_redirects=True` could
+  still follow a trusted Google URL to an off-allowlist, non-HTTPS, localhost,
+  or link-local target and write the response body to disk. Redirect requests
+  are now checked before they are sent, and percent-encoded hosts are rejected
+  instead of decoded into a trusted-looking hostname.
+
 ## [0.7.3] - 2026-06-29
 
 Maintenance patch on the 0.7.x line. Backports fixes from `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ RPC Layer (rpc/)
 | `_runtime/config.py` | `DEFAULT_*` knobs and module-level constants. `CORE_LOGGER_NAME = "notebooklm._core"` is intentionally preserved as a compatibility logging contract even though the `_core` module was deleted; renaming it silently breaks downstream `caplog`/logger filters. |
 | `_env.py`, `config.py` | Runtime environment defaults and the public config re-export surface |
 | `_logging.py`, `log.py` | Redaction/correlation logging internals and the public logging helper surface |
+| `_secrets.py` | Canonical runtime secret-redaction registry shared by logging and exception scrubbing |
 | `_callbacks.py` | Sync-or-async callback invocation helper used by telemetry/retry hooks |
 | `_lookup.py` | `unwrap_or_raise(obj, exc)` — the shared single-row-lookup helper backing the public `get`/`get_or_none` pair across all five namespaces (ADR-0019 Enforcement tier-2; the `get()`-raises wiring lands with the v0.8.0 flip, issue #1247). |
 | `_loop_bound.py` | `LoopBoundPrimitive` — template-method base for the loop-affinity `set_bound_loop` protocol. Owns the `_bound_loop` field + a `set_bound_loop` that always stores the binding and fires the `_on_loop_rebind(old, new)` hook only on a real loop change (hook before store). Trivial owners (`TransportDrainTracker`/`ReqidCounter`/`AuthRefreshCoordinator`) use the default no-op hook; clear-on-rebind owners (`ClientComposed`/`SourceUploadPipeline`/`ChatAPI`) override it to discard their cached loop-bound primitive/locks. Owns only the binding + rebind hook — the cross-loop *assert* stays in `_loop_affinity`, and each owner keeps its own `reset_after_open`. |
@@ -144,6 +145,7 @@ RPC Layer (rpc/)
 | `_mind_map.py` | Specific adapter service representing mind-maps, backed by standard notes |
 | `_mind_maps_api.py` | `client.mind_maps` API — unified surface over both mind-map backends (note-backed JSON + interactive studio-artifact), dispatching each op to the correct RPC family (#1256) |
 | `_artifact/downloads.py` | Asynchronous download coordinator for finished artifacts |
+| `_artifact/_redirect_guard.py` | Per-redirect-hop host/scheme revalidation for artifact media downloads |
 | `_artifact/formatters.py` | Markdown, HTML, and plain text formatters for artifacts |
 | `_artifact/payloads.py` | Stable CREATE_ARTIFACT / GENERATE_MIND_MAP request payload builders |
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
@@ -202,6 +204,7 @@ src/notebooklm/
 ├── _idempotency.py              # Mutating-RPC idempotency registry + wrappers
 ├── _kernel.py                   # Concrete Kernel transport core
 ├── _logging.py                  # Redaction + correlation logging internals
+├── _secrets.py                  # Canonical runtime secret-redaction registry
 ├── _lookup.py                   # unwrap_or_raise — shared single-row-lookup helper for get/get_or_none
 ├── _loop_affinity.py            # Event-loop affinity guard helper (assert_bound_loop free function)
 ├── _loop_bound.py               # LoopBoundPrimitive mixin — template-method set_bound_loop + _on_loop_rebind hook for the loop-bound collaborators
@@ -256,6 +259,7 @@ src/notebooklm/
 │   └── upload_payloads.py       # Source upload request payload builders
 ├── _artifact/                   # Artifact-feature subpackage (promoted from flat _artifact_*.py, #1328)
 │   ├── __init__.py              # Re-exports the cluster's public service classes/builders
+│   ├── _redirect_guard.py       # Per-redirect-hop host/scheme revalidation for downloads
 │   ├── downloads.py             # Artifact download coordinator
 │   ├── formatters.py            # Artifact formatting helpers
 │   ├── payloads.py              # Stable artifact request payload builders

--- a/src/notebooklm/_artifact/_redirect_guard.py
+++ b/src/notebooklm/_artifact/_redirect_guard.py
@@ -1,0 +1,70 @@
+"""Per-redirect-hop allowlist + HTTPS revalidation for artifact downloads.
+
+Both artifact-download clients (the single ``download_url`` stream and the
+``download_urls_batch`` loop in :mod:`notebooklm._artifact.downloads`) use
+``follow_redirects=True``. The initial host + scheme allowlist gate validates
+only the URL the caller passed, so a *trusted* Google URL whose ``Location``
+points off-allowlist — a non-HTTPS hop, or a private/link-local host such as
+``169.254.169.254`` — would otherwise be followed and its body written to the
+caller's ``output_path``. That is an SSRF-style fetch that defeats the
+explicit allowlist (issue #1521).
+
+This module supplies an httpx ``request`` event hook that re-checks every
+hop's host + scheme *before the request is sent*, so an untrusted host never
+receives a connection. The host-trust predicate is injected (rather than
+imported) to keep this module free of a circular dependency on
+``downloads.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from ..exceptions import ArtifactDownloadError
+
+if TYPE_CHECKING:
+    import httpx
+
+# Host-trust predicate signature: ``(hostname | None) -> bool``.
+_HostPredicate = Callable[[str | None], bool]
+
+
+def _assert_trusted_download_request(
+    request: httpx.Request, is_trusted_host: _HostPredicate
+) -> None:
+    """Reject an off-allowlist / non-HTTPS request hop.
+
+    Runs for every hop (the initial request and each redirect target).
+    Legitimate trusted→trusted redirects (Google signed-URL CDNs already on
+    the allowlist) pass through untouched.
+
+    Raises:
+        ArtifactDownloadError: on the first hop whose scheme is not HTTPS or
+            whose host is not on the trusted allowlist.
+    """
+    host = request.url.host or None
+    if request.url.scheme != "https":
+        raise ArtifactDownloadError(
+            "media",
+            details=f"Untrusted redirect to non-HTTPS hop: {host or '<unknown>'}",
+        )
+    if not is_trusted_host(host):
+        raise ArtifactDownloadError(
+            "media",
+            details=f"Untrusted download domain: {host or '<unknown>'}",
+        )
+
+
+def redirect_revalidation_hooks(is_trusted_host: _HostPredicate) -> dict[str, list[Any]]:
+    """Build httpx ``event_hooks`` re-validating every redirect hop (#1521).
+
+    ``is_trusted_host`` is the download module's host-allowlist predicate; it
+    is injected so this guard module has no import dependency on
+    ``downloads.py`` (which imports *this* module).
+    """
+
+    async def _on_request(request: httpx.Request) -> None:
+        _assert_trusted_download_request(request, is_trusted_host)
+
+    return {"request": [_on_request]}

--- a/src/notebooklm/_artifact/_redirect_guard.py
+++ b/src/notebooklm/_artifact/_redirect_guard.py
@@ -47,7 +47,7 @@ def _assert_trusted_download_request(
     if request.url.scheme != "https":
         raise ArtifactDownloadError(
             "media",
-            details=f"Untrusted redirect to non-HTTPS hop: {host or '<unknown>'}",
+            details=f"Untrusted non-HTTPS download hop: {host or '<unknown>'}",
         )
     if not is_trusted_host(host):
         raise ArtifactDownloadError(

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -13,7 +13,7 @@ import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import ParseResult, unquote, urlparse
+from urllib.parse import ParseResult, urlparse
 
 import httpx
 
@@ -30,6 +30,7 @@ from ..types import (
     ArtifactParseError,
     ArtifactType,
 )
+from ._redirect_guard import redirect_revalidation_hooks
 from .formatters import _extract_app_data, _format_interactive_content, _parse_data_table
 
 if TYPE_CHECKING:
@@ -143,8 +144,13 @@ def _load_httpx_cookies(storage_path: Any) -> Any:
 def _is_trusted_download_host(hostname: str | None) -> bool:
     if hostname is None:
         return False
-    hostname = unquote(hostname).lower()
-    if "\\" in hostname or "/" in hostname:
+    # Match the EXACT host httpx connects to. httpx does NOT percent-decode
+    # ``request.url.host``, so the guard must not either: decoding made
+    # ``evil%2egoogleapis.com`` (%2e -> '.') read as trusted while the
+    # connection went to the raw non-Google host (#1521). A real Google host
+    # never contains ``%``, so reject any (defense-in-depth w/ the slash guards).
+    hostname = hostname.lower()
+    if "%" in hostname or "\\" in hostname or "/" in hostname:
         return False
     return any(
         hostname == domain.lstrip(".") or hostname.endswith(domain)
@@ -714,6 +720,7 @@ class ArtifactDownloadService:
             cookies=cookies,
             follow_redirects=True,
             timeout=60.0,
+            event_hooks=redirect_revalidation_hooks(_is_trusted_download_host),  # #1521
         ) as client:
             for url, output_path in urls_and_paths:
                 display_host = ""
@@ -815,6 +822,7 @@ class ArtifactDownloadService:
                     cookies=cookies,
                     follow_redirects=True,
                     timeout=timeout,
+                    event_hooks=redirect_revalidation_hooks(_is_trusted_download_host),  # #1521
                 ) as client:
                     async with client.stream("GET", url) as response:
                         response.raise_for_status()

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -22,6 +22,14 @@ from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import Any
 
+from ._secrets import (
+    AUTH_TOKEN_SHAPE_PATTERNS,
+    COOKIE_VALUE_REPLACEMENT,
+    COOKIE_VALUE_SUFFIX,
+    SECURE_HOST_UMBRELLA_PATTERNS,
+    build_cookie_alternation,
+)
+
 __all__ = [
     "RedactingFilter",
     "RedactingFormatter",
@@ -122,12 +130,69 @@ _CSRF_MARKER_UNQUOTED = re.compile(
 _CSRF_BARE_TOKEN = re.compile(r"(AF1_QpN-)[A-Za-z0-9_-]+")
 
 
+# Bare session-cookie name alternation, DERIVED from the canonical runtime
+# registry (``_secrets.RUNTIME_SESSION_COOKIES``) rather than hand-enumerated
+# here. The registry is kept a superset of the cassette sanitizer's must-scrub
+# bare session cookies by a parity guardrail test, so a cookie added there (the
+# ``NID`` / ``LSOLH`` additions that motivated #1517) flows into this redaction
+# alternation without a second edit. Cookie names are canonical mixed-case, so
+# this pattern stays case-SENSITIVE.
+#
+# Two deliberate, fail-SAFE imprecisions documented here so they aren't "fixed"
+# into leaks:
+#   - A lowercase cookie name (``sid=…``) is NOT matched. This is acceptable:
+#     Google emits canonical mixed/upper-case cookie names, and the carrier-
+#     agnostic shape catch-alls below still scrub a credential-shaped value
+#     under any casing.
+#   - There is no left-boundary anchor, so ``BSID=…`` over-redacts to
+#     ``BSID=***``. This is acceptable because the logging path errs toward MORE
+#     redaction (fail-safe); the cassette scrubber, which must not corrupt
+#     fixtures, keeps its own negative-lookbehind anchor separately.
+#
+# The value is matched by the shared quote-aware ``_secrets.COOKIE_VALUE_SUFFIX``
+# so an RFC 6265 double-quoted value (``SID="opaque"``) is redacted too (gemini
+# review of #1530). Group 1 is the cookie name; the suffix adds groups 2/3/4
+# (opening quote / value / closing quote), redacted via ``COOKIE_VALUE_REPLACEMENT``.
+_COOKIE_NAME_ALTERNATION = build_cookie_alternation()
+_SESSION_COOKIE = re.compile(rf"({_COOKIE_NAME_ALTERNATION}){COOKIE_VALUE_SUFFIX}")
+
+# ``__Secure-*`` / ``__Host-*`` prefix umbrellas, compiled from the same
+# registry. These redact ANY secure/host cookie value by prefix alone, so a
+# future cookie name not yet enumerated anywhere (``__Secure-NEWSESSION=…``)
+# fails closed by construction (codex review of #1517). Group 1 preserves the
+# full cookie name as a shape hint.
+_SECURE_HOST_UMBRELLAS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p) for p in SECURE_HOST_UMBRELLA_PATTERNS
+)
+
+# Carrier-AGNOSTIC Google credential shapes (``g.a000-`` / ``sidts-`` /
+# ``ya29.`` tokens + the ``AIza…`` API key), compiled from the same registry.
+# Defense in depth: even when a secret rides under an UNKNOWN carrier name (a
+# cookie or field not on the alternation above), the raw credential shape is
+# redacted wherever it appears, so disclosure fails closed. The distinctive
+# prefix is preserved as a shape hint; the secret tail is dropped.
+_AUTH_TOKEN_SHAPES: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p) for p in AUTH_TOKEN_SHAPE_PATTERNS
+)
+
+
 # Patterns are immutable. Adding a new pattern requires a unit test.
 # Order matters: longer / more-specific cookie names first within the cookie
 # group so `SID` doesn't shadow `SAPISID`. Patterns are applied in sequence.
+# Query / form-param value class + replacement. Like the cookie suffix, the
+# value may be wrapped in optional double quotes (a logged JSON/dict fragment can
+# carry ``at="…"`` / ``f.sid="…"``); the optional ``("?)`` quotes (groups 2 / 3)
+# bracket the value so a quoted value is redacted too, not just an unquoted URL
+# query param. The value class excludes ``&`` (query-pair delimiter) in addition
+# to whitespace / quotes / angle brackets. Group 1 is the ``name=`` prefix; the
+# replacement keeps the name + ``=`` + the surrounding quotes (if any) and
+# collapses the value to ``***`` (gemini review of #1530).
+_QUERY_VALUE_SUFFIX = r"(\"?)[^&\s\"'<>]+(\"?)"
+_QUERY_VALUE_REPLACEMENT = r"\1\2***\3"
+
 _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     # CSRF / form-body auth tokens (Google batchexecute)
-    (re.compile(r"(\bat=)[^&\s\"'<>]+"), r"\1***"),
+    (re.compile(r"(\bat=)" + _QUERY_VALUE_SUFFIX), _QUERY_VALUE_REPLACEMENT),
     # WIZ_global_data CSRF / session-id markers (see the pattern docs above).
     # The quoted / HTML-escaped variants run before the unquoted one so the
     # quote-aware value classes win on JSON-shaped input.
@@ -136,44 +201,44 @@ _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (_CSRF_MARKER_UNQUOTED, r"\1\2***"),
     # ``csrf=<value>`` form parameter (the CSRF token shows up canonically as
     # ``at=<csrf>``, but a ``csrf=`` alias must not leak the value either).
-    (re.compile(r"(\bcsrf=)[^&\s\"'<>]+", re.IGNORECASE), r"\1***"),
+    (re.compile(r"(\bcsrf=)" + _QUERY_VALUE_SUFFIX, re.IGNORECASE), _QUERY_VALUE_REPLACEMENT),
     # Bare Google CSRF tokens (see the pattern docs above).
     (_CSRF_BARE_TOKEN, r"\1***"),
     # session-id query param
-    (re.compile(r"(\bf\.sid=)[^&\s\"'<>]+"), r"\1***"),
+    (re.compile(r"(\bf\.sid=)" + _QUERY_VALUE_SUFFIX), _QUERY_VALUE_REPLACEMENT),
     # resumable-upload session query param
-    (re.compile(r"(\bupload_id=)[^&\s\"'<>]+", re.IGNORECASE), r"\1***"),
+    (re.compile(r"(\bupload_id=)" + _QUERY_VALUE_SUFFIX, re.IGNORECASE), _QUERY_VALUE_REPLACEMENT),
     # OAuth-shaped credentials (refresh / access / authorization code)
     (
         re.compile(
-            r"(\b(?:refresh_token|access_token|id_token|code)=)[^&\s\"'<>]+",
+            r"(\b(?:refresh_token|access_token|id_token|code)=)" + _QUERY_VALUE_SUFFIX,
             re.IGNORECASE,
         ),
-        r"\1***",
+        _QUERY_VALUE_REPLACEMENT,
     ),
-    # Google session cookies — preserve name, redact value. Longer/more-
-    # specific names appear first as a defensive convention. Python's ``re``
-    # engine backtracks (so ordering is NOT load-bearing for correctness —
-    # the engine retries the next alternative when the trailing ``=`` fails
-    # to match), but longer-first minimizes backtracking on the hot path and
-    # mirrors the canonical Google cookie-family layout. The ``PAPISID``
-    # variants must be enumerated explicitly (NOT covered by the bare
-    # ``APISID`` alternative) so the captured ``\1`` group reflects the full
-    # cookie name in the redacted output, not just the matching suffix.
+    # Google session cookies — preserve name, redact value. The bare cookie-name
+    # alternation is DERIVED from ``_secrets.RUNTIME_SESSION_COOKIES`` (longest-
+    # first) rather than enumerated inline, so the cassette-registry parity
+    # guardrail keeps it covering ``NID`` / ``LSOLH`` and the rest. ``\1`` is the
+    # full cookie name; the shared quote-aware replacement preserves any
+    # RFC 6265 double-quotes around the redacted value.
+    (_SESSION_COOKIE, COOKIE_VALUE_REPLACEMENT),
+    # ``__Secure-*`` / ``__Host-*`` umbrellas — redact ANY secure/host cookie
+    # value by prefix alone, so a future name (``__Secure-NEWSESSION``) fails
+    # closed without enumeration. ``\1`` is the full cookie name; the value
+    # (quoted or not) collapses to ``***`` via the shared replacement.
+    *((umbrella, COOKIE_VALUE_REPLACEMENT) for umbrella in _SECURE_HOST_UMBRELLAS),
+    # Carrier-agnostic Google credential shapes (``g.a000-`` / ``sidts-`` /
+    # ``ya29.`` tokens + the ``AIza…`` API key) as defense in depth. These run
+    # AFTER the name-anchored patterns so a recognized pair is already redacted,
+    # but a secret riding under an unknown carrier name still fails closed here.
+    *((shape, "***") for shape in _AUTH_TOKEN_SHAPES),
+    # Authorization: Bearer <token> (case-insensitive header name). Optional
+    # surrounding quotes so a logged ``Bearer "token"`` (JSON/prose shape) is
+    # redacted too, not just the bare-header form (gemini review of #1530).
     (
-        re.compile(
-            r"(__Secure-1PAPISID|__Secure-3PAPISID"
-            r"|__Secure-1PSIDTS|__Secure-3PSIDTS"
-            r"|__Secure-1PSIDCC|__Secure-3PSIDCC"
-            r"|__Secure-1PSID|__Secure-3PSID"
-            r"|SAPISID|APISID|SIDCC|HSID|SSID|LSID|SID)=([^;\s,\"'<>]+)"
-        ),
-        r"\1=***",
-    ),
-    # Authorization: Bearer <token> (case-insensitive header name)
-    (
-        re.compile(r"(Authorization:\s*Bearer\s+)[^\s\"'<>]+", re.IGNORECASE),
-        r"\1***",
+        re.compile(r"(Authorization:\s*Bearer\s+)" + _QUERY_VALUE_SUFFIX, re.IGNORECASE),
+        _QUERY_VALUE_REPLACEMENT,
     ),
     # Cookie: <whole jar> (request header) and Set-Cookie: (response header)
     (re.compile(r"(Cookie:\s*)[^\r\n]+", re.IGNORECASE), r"\1***"),
@@ -249,13 +314,35 @@ _THIRD_PARTY_LOGGERS: tuple[str, ...] = ("httpx", "urllib3")
 #     then misses.
 #   - "sapisid" is redundant given "sid", but kept as documentation that we
 #     deliberately cover that cookie family.
+#   - "nid", "lsolh" cover the ``NID`` / ``LSOLH`` cookie names that "sid" does
+#     NOT subsume (issue #1517). The bare cookie-name alternation is derived from
+#     ``_secrets.RUNTIME_SESSION_COOKIES``; any name there whose lowercase form
+#     is not already a substring of another token must appear here or the fast
+#     path would skip a real cookie. The parity guardrail keeps the registry
+#     honest; this gate must keep up with it.
+#   - "__secure-" / "__host-" cover the prefix umbrellas
+#     (``_secrets.SECURE_HOST_UMBRELLA_PATTERNS``) so ANY secure/host cookie —
+#     including a future name carrying an opaque (non-token-shaped) value —
+#     triggers the regex sweep (codex review of #1517).
+#   - "g.a000-", "sidts-", "ya29.", "aiza" cover the carrier-agnostic credential
+#     shapes (``_secrets.AUTH_TOKEN_SHAPE_PATTERNS``) so a secret under an
+#     UNKNOWN carrier name still triggers the regex sweep. "sidts-" is subsumed
+#     by "sid" but kept as documentation of the token-shape coverage.
 SECRET_FAST_PATH_TOKENS: tuple[str, ...] = (
     "sid",
     "sapisid",
+    "nid",
+    "lsolh",
+    "__secure-",
+    "__host-",
     "csrf",
     "snlm0e",
     "fdrfje",
     "af1_qpn-",
+    "g.a000-",
+    "sidts-",
+    "ya29.",
+    "aiza",
     "f.sid",
     "continue=",
     "authuser=",

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -169,8 +169,9 @@ _SECURE_HOST_UMBRELLAS: tuple[re.Pattern[str], ...] = tuple(
 # ``ya29.`` tokens + the ``AIza…`` API key), compiled from the same registry.
 # Defense in depth: even when a secret rides under an UNKNOWN carrier name (a
 # cookie or field not on the alternation above), the raw credential shape is
-# redacted wherever it appears, so disclosure fails closed. The distinctive
-# prefix is preserved as a shape hint; the secret tail is dropped.
+# redacted wherever it appears, so disclosure fails closed. These whole tokens
+# are replaced with ``***``; unlike name-anchored cookies, there is no carrier
+# name worth preserving as a shape hint.
 _AUTH_TOKEN_SHAPES: tuple[re.Pattern[str], ...] = tuple(
     re.compile(p) for p in AUTH_TOKEN_SHAPE_PATTERNS
 )

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -42,6 +42,20 @@ def build_create_notebook_params(title: str) -> list[Any]:
     return [title, None, None, build_template_block()]
 
 
+def build_get_notebook_params(notebook_id: str) -> list[Any]:
+    """Return the canonical GET_NOTEBOOK (``rLM1Ne``) RPC payload.
+
+    The Gemini-3.5 rollout migrated the read path's trailing template block from
+    the flat ``[2]`` to the same nested :func:`build_template_block` wrapper the
+    write path adopted in #1548 (issue #1549). Live-verified forward-compatible:
+    the nested shape returns a byte-identical decoded notebook (notebook id /
+    title and every ``SourceRow``) as the flat ``[2]`` on an un-migrated account,
+    so it is safe across cohorts. The trailing ``None, 0`` is unchanged — only
+    the template block at position 2 is migrated (the narrow scope #1549 tracks).
+    """
+    return [notebook_id, None, build_template_block(), None, 0]
+
+
 def _extract_summary(outer: Any) -> str:
     """Extract the summary string from a SUMMARIZE ``result[0]`` payload.
 
@@ -501,7 +515,7 @@ class NotebooksAPI:
                 ``title``) for unknown IDs rather than a proper RPC error, so
                 this method post-validates the parsed response.
         """
-        params = [notebook_id, None, [2], None, 0]
+        params = build_get_notebook_params(notebook_id)
         result = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,
@@ -684,7 +698,7 @@ class NotebooksAPI:
         Returns:
             Raw API response data.
         """
-        params = [notebook_id, None, [2], None, 0]
+        params = build_get_notebook_params(notebook_id)
         return await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,

--- a/src/notebooklm/_secrets.py
+++ b/src/notebooklm/_secrets.py
@@ -1,0 +1,161 @@
+"""Canonical runtime registry of credential-shaped names and token shapes.
+
+This is the single source of truth that the logging redaction patterns
+(:mod:`notebooklm._logging`) and the exception scrubbing (
+:mod:`notebooklm.exceptions`, via ``scrub_secrets``) DERIVE from. Before this
+module the redaction cookie alternation was enumerated inline in
+``_logging.py`` and drifted from the project's own cassette-sanitization
+registry (``tests/cassette_patterns.py``): session cookies the cassette
+registry classifies as must-scrub (``NID`` / ``LSOLH`` / ``__Host-GAPS``) were
+absent from the runtime alternation, so a bare ``NID=g.a000-...`` token logged
+at DEBUG (refresh-cmd stdout/stderr) round-tripped verbatim through
+``scrub_secrets`` (issue #1517).
+
+Runtime code cannot import from ``tests/`` (the test tree is not shipped), so
+this module re-states the canonical names here. A PARITY GUARDRAIL test
+(``tests/_guardrails/test_runtime_secret_registry_parity.py``) asserts that
+this registry stays in lockstep with the cassette registry on every axis:
+:data:`RUNTIME_SESSION_COOKIES` is a SUPERSET of the cassette registry's
+must-scrub bare session cookies; the ``__Secure-*`` / ``__Host-*`` umbrellas
+cover every cassette ``SECURE_COOKIES`` / ``HOST_COOKIES`` name *by
+construction*; and :data:`AUTH_TOKEN_SHAPE_PATTERNS` is regex-string-equal to
+the cassette registry's token-shape + Google-API-key set. So any new must-scrub
+shape added to the cassette registry forces this runtime registry to keep up.
+
+Three complementary layers:
+
+1. **Name-anchored cookie alternation** (:data:`RUNTIME_SESSION_COOKIES`).
+   ``Name=Value`` cookie pairs whose name is on this list have their value
+   redacted, preserving the name as a shape hint. This mirrors the cassette
+   registry's bare ``SESSION_COOKIES``.
+
+2. **Prefix umbrellas** (:data:`SECURE_HOST_UMBRELLA_PATTERNS`). Any
+   ``__Secure-…=`` / ``__Host-…=`` cookie pair is redacted by its prefix alone,
+   so a *future* secure/host cookie name (one not yet enumerated anywhere) fails
+   closed by construction — closing the gap a name-list-only guard would leave
+   (codex review of #1517: ``__Secure-NEWSESSION=opaqueBase64`` must not leak).
+
+3. **Carrier-agnostic shape catch-alls** (:data:`AUTH_TOKEN_SHAPE_PATTERNS`).
+   Defense in depth: the raw ``g.a000-`` / ``sidts-`` / ``ya29.`` credential
+   prefixes AND the Google API-key shape (``AIza…``) are redacted wherever they
+   appear — even under an UNKNOWN carrier name — so disclosure fails closed
+   regardless of which cookie/field carries the value. Ported from the cassette
+   registry's ``_AUTH_TOKEN_PATTERNS`` + ``_GOOGLE_API_KEY_PATTERN``.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "AUTH_TOKEN_SHAPE_PATTERNS",
+    "COOKIE_VALUE_REPLACEMENT",
+    "COOKIE_VALUE_SUFFIX",
+    "RUNTIME_SESSION_COOKIES",
+    "SECURE_HOST_UMBRELLA_PATTERNS",
+    "build_cookie_alternation",
+]
+
+
+# Shared quote-aware ``=<value>`` suffix for the name-anchored cookie patterns
+# (the bare-name alternation in ``_logging.py`` AND the ``__Secure-*`` /
+# ``__Host-*`` umbrellas below). RFC 6265 permits a cookie value to be wrapped in
+# double quotes (``cookie-value = *cookie-octet / DQUOTE *cookie-octet DQUOTE``),
+# so a refresh-cmd log line may carry ``SID="opaque"`` / ``__Secure-X="opaque"``.
+# An optional opening ``"`` (group +1) and closing ``"`` (group +3) bracket the
+# value (group +2); the value class still EXCLUDES ``"`` so it stops before the
+# closing quote rather than swallowing it. Without the optional quotes the whole
+# pattern failed to match a quoted value and it LEAKED — gemini review of #1530.
+#
+# Both consumers place exactly ONE capture group (the cookie name) before this
+# suffix, so the suffix groups are always 2/3/4 and the shared
+# :data:`COOKIE_VALUE_REPLACEMENT` (``\1=\2***\4``) preserves the name, the
+# ``=``, and the surrounding quotes (if any) while collapsing the value to
+# ``***``. Keep that one-preceding-group invariant when reusing the suffix.
+COOKIE_VALUE_SUFFIX = r"=(\"?)([^;\s,\"'<>]+)(\"?)"
+COOKIE_VALUE_REPLACEMENT = r"\1=\2***\4"
+
+
+# Bare Google session cookie names whose VALUES must be redacted from any log
+# line or exception surface. This is the runtime analog of the cassette
+# registry's ``SESSION_COOKIES``. ``__Secure-*`` / ``__Host-*`` cookies are NOT
+# enumerated here — they are caught by the prefix umbrellas below (fail-closed
+# for future names), exactly as the cassette scrubber handles them. Longer /
+# more-specific names appear first so the cookie alternation built from this
+# list does not let a shorter name shadow a longer one (e.g. ``SAPISID`` before
+# ``APISID``). The parity guardrail keeps this a superset of the cassette
+# registry's must-scrub bare session cookies.
+RUNTIME_SESSION_COOKIES: tuple[str, ...] = (
+    "SAPISID",
+    "APISID",
+    "SIDCC",
+    "LSOLH",
+    "HSID",
+    "SSID",
+    "OSID",
+    "LSID",
+    "NID",
+    "SID",
+)
+
+
+# ``__Secure-*`` / ``__Host-*`` cookie-pair umbrellas. The prefix is distinctive
+# enough that no legitimate non-protected cookie shares it, so the value is
+# redacted by prefix alone — a future secure/host cookie name (not yet
+# enumerated anywhere) fails closed by construction.
+#
+# The cookie-NAME class is "any run up to the ``=``", mirroring the cassette
+# registry's ``(__Secure-[^=]+)=…`` / ``(__Host-[^=]+)=…`` umbrellas. A narrower
+# class such as ``[A-Za-z0-9_-]+`` would LEAK any RFC 6265 ``token``-charset name
+# containing ``. ! # $ % & ' * + ^ ` | ~`` (e.g. ``__Secure-NEW.SESSION=…``,
+# ``__Host-GAPS.v2=…``) — codex review of #1517. The only exclusions are the
+# cookie-pair DELIMITERS the surrounding log text uses — ``=`` (name/value
+# split) plus whitespace / ``;`` / ``,`` (pair + prose boundaries) — so the name
+# captures the WHOLE RFC token (including ``'`` / `` ` `` / ``~``) yet a bare
+# ``__Secure-[^=]+`` on a free-form log line cannot swallow surrounding prose the
+# way the cassette form (which runs on an already-parsed single cookie scalar)
+# safely can. Over-broad here errs toward MORE redaction, which is the fail-safe
+# direction. Group 1 is the full cookie name (preserved as a shape hint); the
+# value (quoted or not) is matched by the shared :data:`COOKIE_VALUE_SUFFIX`.
+SECURE_HOST_UMBRELLA_PATTERNS: tuple[str, ...] = (
+    r"(__Secure-[^=\s;,]+)" + COOKIE_VALUE_SUFFIX,
+    r"(__Host-[^=\s;,]+)" + COOKIE_VALUE_SUFFIX,
+)
+
+
+# Carrier-agnostic Google credential shapes, applied as defense-in-depth so a
+# secret leaks NOTHING even when it rides inside a cookie / field whose name is
+# not on :data:`RUNTIME_SESSION_COOKIES`. Ported verbatim from the cassette
+# registry's ``_AUTH_TOKEN_PATTERNS`` + ``_GOOGLE_API_KEY_PATTERN`` (the parity
+# guardrail asserts regex-string equality so the two cannot drift):
+#
+#   * ``g.a000-`` — the raw SID token embedded in SID/LSID/LSOLH cookie values
+#     and OAuth flows. The prefix is distinctive enough to need no length floor;
+#     the REQUIRED trailing ``-`` keeps the bare account-prefix ``g.a000`` from
+#     matching.
+#   * ``sidts-`` / ``ya29.`` — less distinctive prefixes, so each carries a
+#     length floor (``{10,}`` / ``{20,}``) to avoid firing on an incidental
+#     short literal (a bare ``ya29`` mention in prose).
+#   * ``AIza…`` — the canonical Google API-key shape (``AIza`` + 35-or-more
+#     key chars). The NotebookLM web page embeds one in ``WIZ_global_data``
+#     (``JrWMbf`` / ``B8SWKb`` / ``VqImj`` fields); routed through
+#     ``data_at_failure`` / ``payload_preview`` it would otherwise leak. ``{35,}``
+#     (not ``{35}``) is greedy so a longer-than-canonical key is consumed whole,
+#     never leaving a re-matchable tail fragment (cassette-registry rationale).
+AUTH_TOKEN_SHAPE_PATTERNS: tuple[str, ...] = (
+    r"g\.a000-[A-Za-z0-9_\-]+",
+    r"sidts-[A-Za-z0-9_\-]{10,}",
+    r"ya29\.[A-Za-z0-9_\-]{20,}",
+    r"AIza[0-9A-Za-z_\-]{35,}",
+)
+
+
+def build_cookie_alternation(names: tuple[str, ...] = RUNTIME_SESSION_COOKIES) -> str:
+    """Return a regex alternation of escaped cookie names, longest-first.
+
+    Sorting by descending length is a defensive convention: Python's ``re``
+    engine backtracks, so ordering is not load-bearing for correctness, but
+    longest-first minimizes backtracking and guarantees the captured name group
+    reflects the full cookie name rather than a matching suffix.
+    """
+    return "|".join(re.escape(name) for name in sorted(names, key=len, reverse=True))

--- a/src/notebooklm/_source/listing.py
+++ b/src/notebooklm/_source/listing.py
@@ -11,6 +11,7 @@ from .._row_adapters.sources import SourceRow
 from .._runtime.contracts import RpcCaller
 from ..rpc import RPCError, RPCMethod
 from ..types import Source
+from .upload_payloads import build_template_block
 
 # Keep source-list warnings on the historical logger so existing log filters
 # continue to see the same channel after the service extraction.
@@ -35,7 +36,12 @@ class SourceLister:
         ``NOTEBOOKLM_STRICT_DECODE=0`` opt-out into warn-and-return-``[]``
         was retired in v0.7.0; strict decoding is now the only mode.
         """
-        params = [notebook_id, None, [2], None, 0]
+        # GET_NOTEBOOK read-path tail migrated to the nested template block
+        # (#1549; live-verified forward-compatible). Mirrors
+        # ``_notebooks.build_get_notebook_params`` — inlined here because
+        # importing ``_notebooks`` from this module would cycle (``_notebooks``
+        # imports ``_source.upload_payloads``, which runs ``_source/__init__``).
+        params = [notebook_id, None, build_template_block(), None, 0]
         notebook = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -353,8 +353,7 @@ class UnknownRPCMethodError(DecodingError):
     """RPC response structure doesn't match expectations.
 
     This often indicates Google has changed the API. Check for library updates.
-
-    Carries structured context to help diagnose schema drift:
+    Carries structured context to help diagnose schema drift.
 
     Attributes:
         method_id: The RPC method ID that was requested (or that drifted).
@@ -364,12 +363,11 @@ class UnknownRPCMethodError(DecodingError):
             this error (e.g. ``"_notebooks.list"``).
         found_ids: When raised by the response-level decoder, the list of RPC
             IDs actually present in the response.
-        raw_response: First 80 chars of the raw response, when available
-            (``NOTEBOOKLM_DEBUG=1`` preserves the full body). The string branch
-            is secret-scrubbed before truncation; non-string payloads are stored
-            as-is on this subclass.
-        data_at_failure: Truncated repr (~200 chars) of the data the helper
-            was attempting to index into when descent failed.
+        raw_response: As for :class:`RPCError` (secret-scrubbed, ~80 chars or
+            full body under ``NOTEBOOKLM_DEBUG=1``); non-string payloads are
+            stored as-is on this subclass.
+        data_at_failure: Secret-scrubbed repr of the data indexed into at
+            failure; the caller passes a ``reprlib``-bounded preview (not capped here).
     """
 
     def __init__(
@@ -415,7 +413,9 @@ class UnknownRPCMethodError(DecodingError):
         # class's ``str | None`` contract entirely.
         if not isinstance(raw_response, str):
             self.raw_response = raw_response
-        self.data_at_failure = data_at_failure
+        # Scrub at STORE time: ``data_at_failure`` is ``!r``-spliced into
+        # ``str``/``repr``/tracebacks, bypassing the ``RedactingFilter`` (#1518).
+        self.data_at_failure = None if data_at_failure is None else scrub_secrets(data_at_failure)
 
     def __str__(self) -> str:
         base = super().__str__()

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -86,7 +86,10 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # already at its ceiling, so any explanation grows it; splitting is out of
     # scope for a maintenance backport.
     "cli/services/playwright_login.py": 995,
-    "_artifact/downloads.py": 1033,
+    # +8 LOC backporting per-redirect-hop revalidation (#1532): the new logic
+    # lives in ``_artifact/_redirect_guard.py``; the residual downloads.py
+    # growth is only hook wiring plus the percent-encoded-host guard comment.
+    "_artifact/downloads.py": 1041,
     "client.py": 986,
     "_research.py": 969,
     "cli/services/generate.py": 954,

--- a/tests/_guardrails/test_runtime_secret_registry_parity.py
+++ b/tests/_guardrails/test_runtime_secret_registry_parity.py
@@ -1,0 +1,142 @@
+"""Parity guard: runtime redaction registry stays in lockstep with the cassette
+sanitizer on EVERY must-scrub axis (cookie names, secure/host umbrellas, and
+credential shapes).
+
+The runtime secret registry (``src/notebooklm/_secrets.py``) is the single
+source of truth that the logging redaction patterns and exception scrubbing
+derive from. The cassette sanitizer (``tests/cassette_patterns.py``) is the
+separate, test-only source of truth for what counts as a must-scrub credential
+in a recorded HTTP cassette.
+
+Runtime code cannot import from ``tests/`` (the test tree is not shipped), so
+the two registries are necessarily re-stated. This guard closes the drift that
+motivated issue #1517 and the three findings from its codex security review:
+
+1. **Bare session-cookie names.** The runtime set must be a SUPERSET of the
+   cassette registry's bare ``SESSION_COOKIES``. ``NID`` / ``LSOLH`` were on the
+   cassette must-scrub list but ABSENT from the runtime alternation, so a bare
+   ``NID=g.a000-...`` token logged at DEBUG round-tripped verbatim through
+   ``scrub_secrets``.
+
+2. **``__Secure-*`` / ``__Host-*`` umbrellas.** Rather than enumerate every
+   secure/host name, the runtime registry redacts them by prefix umbrella so a
+   FUTURE name (``SECURE_COOKIES.append("__Secure-NEWSESSION")``) fails closed
+   by construction. This test proves every cassette ``SECURE_COOKIES`` /
+   ``HOST_COOKIES`` name is actually matched by the runtime umbrella regex —
+   so the umbrella can never silently stop covering one.
+
+3. **Credential shapes.** The runtime ``AUTH_TOKEN_SHAPE_PATTERNS`` must be
+   regex-string-EQUAL to the cassette registry's token-shape patterns plus its
+   Google API-key shape. If the cassette registry gains a fourth shape (e.g.
+   an ``oauth2rt_…`` refresh-token pattern), this test fails until the runtime
+   registry lists it too — closing the gap where runtime would silently miss a
+   newly-recognized credential family in the refresh-DEBUG / ``data_at_failure``
+   sinks.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tests.cassette_patterns import (
+    _AUTH_TOKEN_PATTERNS,
+    _GOOGLE_API_KEY_PATTERN,
+    HOST_COOKIES,
+    SECURE_COOKIES,
+    SESSION_COOKIES,
+)
+
+from notebooklm._secrets import (
+    AUTH_TOKEN_SHAPE_PATTERNS,
+    RUNTIME_SESSION_COOKIES,
+    SECURE_HOST_UMBRELLA_PATTERNS,
+)
+
+
+def test_runtime_redaction_superset_of_cassette_bare_session_cookies() -> None:
+    """Every cassette bare ``SESSION_COOKIES`` name is in the runtime set.
+
+    ``SESSION_COOKIES`` is the cassette registry's list of bare (non-prefixed)
+    cookie names whose VALUES must never survive into a committed cassette; the
+    same names must be redacted at RUNTIME (log lines, exception surfaces) or a
+    token carried by one of them leaks through ``scrub_secrets``. ``__Secure-*``
+    / ``__Host-*`` names are covered by the umbrella test below instead.
+    """
+    runtime = set(RUNTIME_SESSION_COOKIES)
+    missing = set(SESSION_COOKIES) - runtime
+    assert missing == set(), (
+        "Runtime redaction registry (notebooklm._secrets.RUNTIME_SESSION_COOKIES) "
+        "is missing bare cookie name(s) the cassette sanitizer "
+        "(tests/cassette_patterns.py SESSION_COOKIES) classifies as must-scrub. A "
+        "token carried by these would leak through scrub_secrets (issue #1517). "
+        f"Add them to RUNTIME_SESSION_COOKIES: {sorted(missing)}"
+    )
+
+
+def test_runtime_umbrella_covers_every_cassette_secure_and_host_cookie() -> None:
+    """The ``__Secure-*`` / ``__Host-*`` umbrellas match every cassette name.
+
+    Proves the prefix-umbrella approach (codex review finding 3) actually covers
+    each enumerated ``SECURE_COOKIES`` / ``HOST_COOKIES`` name — and, because it
+    matches by prefix, any FUTURE name with the same prefix too. A regression
+    (e.g. tightening the umbrella so it stops matching a real name) fails here.
+    """
+    umbrellas = [re.compile(p) for p in SECURE_HOST_UMBRELLA_PATTERNS]
+    for name in (*SECURE_COOKIES, *HOST_COOKIES):
+        # Both the bare and the RFC 6265 double-quoted value forms must match —
+        # a quoted value (``__Secure-X="opaque"``) leaked before the umbrella
+        # gained the optional surrounding quotes (gemini review of #1530).
+        for sample in (
+            f"{name}=opaqueOAuthOpaqueValue1234567890",
+            f'{name}="opaqueOAuthOpaqueValue1234567890"',
+        ):
+            assert any(u.search(sample) for u in umbrellas), (
+                f"Cassette secure/host cookie {name!r} is NOT matched by any "
+                "runtime umbrella in "
+                "notebooklm._secrets.SECURE_HOST_UMBRELLA_PATTERNS for sample "
+                f"{sample!r}. A value carried by it would leak through "
+                "scrub_secrets (codex review of #1517 / gemini review of #1530)."
+            )
+
+
+def test_runtime_credential_shapes_equal_cassette_shapes() -> None:
+    """Runtime shape patterns are regex-string-equal to the cassette set.
+
+    The cassette registry's ``_AUTH_TOKEN_PATTERNS`` + ``_GOOGLE_API_KEY_PATTERN``
+    are the canonical Google credential shapes (``g.a000-`` / ``sidts-`` /
+    ``ya29.`` tokens + the ``AIza…`` API key). ``AUTH_TOKEN_SHAPE_PATTERNS`` must
+    list the SAME regex strings so the runtime redaction (refresh-cmd DEBUG sink,
+    ``data_at_failure`` / ``payload_preview`` exception surfaces) cannot drift
+    from the cassette scrubber. Set equality (not order) is asserted; if the
+    cassette registry gains a new shape, add the identical regex here.
+    """
+    cassette_shapes = {*_AUTH_TOKEN_PATTERNS, _GOOGLE_API_KEY_PATTERN}
+    runtime_shapes = set(AUTH_TOKEN_SHAPE_PATTERNS)
+    missing = cassette_shapes - runtime_shapes
+    extra = runtime_shapes - cassette_shapes
+    assert missing == set() and extra == set(), (
+        "notebooklm._secrets.AUTH_TOKEN_SHAPE_PATTERNS has drifted from the "
+        "cassette registry's credential-shape set (tests/cassette_patterns.py "
+        "_AUTH_TOKEN_PATTERNS + _GOOGLE_API_KEY_PATTERN). If the cassette registry "
+        "gained a shape, add the IDENTICAL regex string to the runtime registry. "
+        f"missing-from-runtime={sorted(missing)} extra-in-runtime={sorted(extra)}"
+    )
+
+
+def test_runtime_registry_regression_anchors_present() -> None:
+    """Pin the #1517 leak carriers so a future trim can't silently drop them.
+
+    The axis tests above would also catch a removal, but this explicit anchor
+    documents WHY each is load-bearing: every name/shape below was a confirmed
+    (or reviewer-flagged) runtime leak carrier.
+    """
+    runtime_cookies = set(RUNTIME_SESSION_COOKIES)
+    for name in ("NID", "LSOLH", "OSID"):
+        assert name in runtime_cookies, (
+            f"{name!r} dropped from RUNTIME_SESSION_COOKIES (issue #1517)"
+        )
+    runtime_shapes = set(AUTH_TOKEN_SHAPE_PATTERNS)
+    # The Google API-key shape is the codex-review finding-1 leak carrier; pin it.
+    assert r"AIza[0-9A-Za-z_\-]{35,}" in runtime_shapes, (
+        "Google API-key shape dropped from AUTH_TOKEN_SHAPE_PATTERNS (codex #1517 finding)"
+    )

--- a/tests/_guardrails/test_runtime_secret_registry_parity.py
+++ b/tests/_guardrails/test_runtime_secret_registry_parity.py
@@ -37,20 +37,23 @@ motivated issue #1517 and the three findings from its codex security review:
 from __future__ import annotations
 
 import re
-
-from tests.cassette_patterns import (
-    _AUTH_TOKEN_PATTERNS,
-    _GOOGLE_API_KEY_PATTERN,
-    HOST_COOKIES,
-    SECURE_COOKIES,
-    SESSION_COOKIES,
-)
+import runpy
+from pathlib import Path
 
 from notebooklm._secrets import (
     AUTH_TOKEN_SHAPE_PATTERNS,
     RUNTIME_SESSION_COOKIES,
     SECURE_HOST_UMBRELLA_PATTERNS,
 )
+
+_CASSETTE_PATTERNS = runpy.run_path(
+    str(Path(__file__).resolve().parents[1] / "cassette_patterns.py")
+)
+_AUTH_TOKEN_PATTERNS = _CASSETTE_PATTERNS["_AUTH_TOKEN_PATTERNS"]
+_GOOGLE_API_KEY_PATTERN = _CASSETTE_PATTERNS["_GOOGLE_API_KEY_PATTERN"]
+HOST_COOKIES = _CASSETTE_PATTERNS["HOST_COOKIES"]
+SECURE_COOKIES = _CASSETTE_PATTERNS["SECURE_COOKIES"]
+SESSION_COOKIES = _CASSETTE_PATTERNS["SESSION_COOKIES"]
 
 
 def test_runtime_redaction_superset_of_cassette_bare_session_cookies() -> None:

--- a/tests/cassettes/artifacts_generate_flashcards.yaml
+++ b/tests/cassettes/artifacts_generate_flashcards.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312251394&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312251394&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_quiz.yaml
+++ b/tests/cassettes/artifacts_generate_quiz.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312248942&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312248942&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_report.yaml
+++ b/tests/cassettes/artifacts_generate_report.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312243895&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312243895&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_generate_study_guide.yaml
+++ b/tests/cassettes/artifacts_generate_study_guide.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312246464&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312246464&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list.yaml
+++ b/tests/cassettes/artifacts_list.yaml
@@ -2381,7 +2381,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list_data_tables.yaml
+++ b/tests/cassettes/artifacts_list_data_tables.yaml
@@ -2238,7 +2238,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/artifacts_list_infographics.yaml
+++ b/tests/cassettes/artifacts_list_infographics.yaml
@@ -2238,7 +2238,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/chat_ask.yaml
+++ b/tests/cassettes/chat_ask.yaml
@@ -1861,7 +1861,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934741655&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934741655&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/chat_ask_with_references.yaml
+++ b/tests/cassettes/chat_ask_with_references.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934754822&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934754822&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/cli_notebook_rename.yaml
+++ b/tests/cassettes/cli_notebook_rename.yaml
@@ -1956,7 +1956,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22ea4da50c-7138-47e1-a760-80dbf4f3535f%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780267425032&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22ea4da50c-7138-47e1-a760-80dbf4f3535f%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780267425032&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/generate_mind_map_interactive.yaml
+++ b/tests/cassettes/generate_mind_map_interactive.yaml
@@ -1858,7 +1858,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f7d1e2b6-2334-4016-b81d-aded7b3fa9b6%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780152877667&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f7d1e2b6-2334-4016-b81d-aded7b3fa9b6%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1780152877667&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebook_zero_sources.yaml
+++ b/tests/cassettes/notebook_zero_sources.yaml
@@ -1857,7 +1857,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%224d79940d-5f20-4d77-a918-5d04d08ce789%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778873027933&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%224d79940d-5f20-4d77-a918-5d04d08ce789%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778873027933&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_get.yaml
+++ b/tests/cassettes/notebooks_get.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963936973&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963936973&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_get_raw.yaml
+++ b/tests/cassettes/notebooks_get_raw.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312218683&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312218683&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/notebooks_rename.yaml
+++ b/tests/cassettes/notebooks_rename.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'
@@ -1788,7 +1788,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'
@@ -2021,7 +2021,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22f66923f0-1df4-4ffe-9822-3ed63c558b1c%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312219118&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/real_api_get_notebook.yaml
+++ b/tests/cassettes/real_api_get_notebook.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914367&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914367&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/real_api_list_sources.yaml
+++ b/tests/cassettes/real_api_list_sources.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914818&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312914818&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_check_freshness.yaml
+++ b/tests/cassettes/sources_check_freshness.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963669810&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963669810&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_check_freshness_drive.yaml
+++ b/tests/cassettes/sources_check_freshness_drive.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%225bb31d9f-a2cb-4a9e-9249-41629c7dcb64%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1769105994268&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%225bb31d9f-a2cb-4a9e-9249-41629c7dcb64%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1769105994268&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_get_fulltext.yaml
+++ b/tests/cassettes/sources_get_fulltext.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312222253&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312222253&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_get_guide.yaml
+++ b/tests/cassettes/sources_get_guide.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22167481cd-23a3-4331-9a45-c8948900bf91%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_list.yaml
+++ b/tests/cassettes/sources_list.yaml
@@ -1555,7 +1555,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312220727&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312220727&
     headers:
       Accept:
       - '*/*'
@@ -1648,7 +1648,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768312221241&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_refresh.yaml
+++ b/tests/cassettes/sources_refresh.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963703846&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963703846&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/sources_rename.yaml
+++ b/tests/cassettes/sources_rename.yaml
@@ -1566,7 +1566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963681446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%2206f0c5bd-108f-4c8b-8911-34b2acc656de%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1768963681446&
     headers:
       Accept:
       - '*/*'

--- a/tests/cassettes/workflow_tracer_bullet.yaml
+++ b/tests/cassettes/workflow_tracer_bullet.yaml
@@ -2566,7 +2566,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'
@@ -2665,7 +2665,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'
@@ -3479,7 +3479,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
+    body: f.req=%5B%5B%5B%22rLM1Ne%22%2C%22%5B%5C%22e9747be8-41ea-4ba7-a358-0845e1dcfeb2%5C%22%2Cnull%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%2Cnull%2C0%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934808446&
     headers:
       Accept:
       - '*/*'

--- a/tests/unit/test_artifact_downloads_coverage.py
+++ b/tests/unit/test_artifact_downloads_coverage.py
@@ -77,6 +77,40 @@ def test_is_trusted_download_host_none_returns_false():
     assert _is_trusted_download_host(None) is False
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "evil%2egoogleapis.com",  # %2e decodes to '.' -> evil.googleapis.com
+        "evil%2Egoogleapis.com",  # uppercase variant
+        "storage.googleapis.com%2eevil.example",  # encoded dot mid-host
+        "storage.googleapis.com%00",  # any percent-escape is suspect
+    ],
+)
+def test_is_trusted_download_host_rejects_percent_encoded(host):
+    """Percent-encoded hosts are never trusted (parser-differential bypass, #1521).
+
+    httpx connects to the RAW host; the guard must validate that same raw
+    string and never percent-decode it, or ``evil%2egoogleapis.com`` would be
+    judged trusted while the connection goes to a non-Google host.
+    """
+    assert _is_trusted_download_host(host) is False
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "storage.googleapis.com",
+        "lh3.googleusercontent.com",
+        "www.google.com",
+        "google.com",
+        "googleapis.com",
+    ],
+)
+def test_is_trusted_download_host_accepts_legitimate_google_hosts(host):
+    """Removing the percent-decode must not reject any real Google download host."""
+    assert _is_trusted_download_host(host) is True
+
+
 def test_download_display_host_falls_back_to_netloc():
     """Line 149: with no parsed hostname, strip userinfo from netloc."""
     from urllib.parse import urlparse

--- a/tests/unit/test_download_redirect_revalidation.py
+++ b/tests/unit/test_download_redirect_revalidation.py
@@ -1,0 +1,427 @@
+"""Per-redirect-hop host/scheme revalidation for artifact downloads (#1521).
+
+Both download clients (``download_url`` single + ``download_urls_batch``)
+use ``follow_redirects=True``. The initial host+scheme allowlist gate only
+checks the URL the caller passed, so a *trusted* Google URL whose
+``Location`` points off-allowlist — a non-HTTPS hop, or a private/link-local
+host such as ``169.254.169.254`` — would otherwise be followed and its body
+written to ``output_path``. That is an SSRF-style fetch that defeats the
+allowlist.
+
+These tests drive a *real* ``httpx.AsyncClient`` wired to an
+``httpx.MockTransport`` so the production ``event_hooks`` run against
+httpx's own redirect machinery. They assert:
+
+* a trusted→off-allowlist 30x is rejected with ``ArtifactDownloadError`` and
+  nothing is written (covers ``169.254.169.254`` and ``evil.example``),
+* a trusted→non-HTTPS (https→http downgrade) hop is rejected,
+* an open-redirect that stays on a *trusted* host still succeeds,
+* a multi-hop trusted→trusted→off-allowlist chain is rejected on the bad hop,
+* a legitimate trusted→trusted redirect still downloads.
+
+Covers BOTH the single-download and the batch surfaces.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+import notebooklm._artifact.downloads as _downloads_mod
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm.types import ArtifactDownloadError
+
+
+@pytest.fixture
+def mock_artifacts_api(tmp_path):
+    """ArtifactsAPI wired to mocks -- no real network, real httpx clients."""
+    from _fixtures.fake_core import make_fake_core
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
+
+    mock_core = make_fake_core(
+        rpc_call=AsyncMock(),
+        get_source_ids=AsyncMock(return_value=[]),
+    )
+    api = ArtifactsAPI(
+        rpc=mock_core,
+        drain=mock_core,
+        lifecycle=mock_core,
+        notebooks=AsyncMock(),
+        mind_maps=AsyncMock(spec=NoteBackedMindMapService),
+        note_service=AsyncMock(spec=NoteService),
+        storage_path=tmp_path / "storage.json",
+    )
+    return api
+
+
+def _patch_real_client_with_transport(handler: Callable[[httpx.Request], httpx.Response]):
+    """Patch the seams so a *real* ``httpx.AsyncClient`` runs over a MockTransport.
+
+    The production code constructs ``httpx.AsyncClient(..., event_hooks=...)``;
+    we forward every real kwarg (crucially ``event_hooks`` and
+    ``follow_redirects``) and only inject ``transport=MockTransport(handler)``
+    so the actual redirect machinery + the production request hook execute.
+    """
+    real_cls = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", httpx.MockTransport(handler))
+        return real_cls(*args, **kwargs)
+
+    return (
+        patch.object(httpx, "AsyncClient", side_effect=_factory),
+        # Freeze the PUBLIC ``load_httpx_cookies`` import, not the private
+        # ``_load_httpx_cookies`` wrapper: both the single (downloads.py:717) and
+        # batch (:817) paths call ``_load_httpx_cookies``, which delegates to this
+        # name — so patching it here covers BOTH surfaces. Patching the private
+        # ``_load_httpx_cookies`` alias directly would trip the ADR-0007
+        # private-attribute monkeypatch guardrail.
+        patch.object(_downloads_mod, "load_httpx_cookies", return_value=httpx.Cookies()),
+    )
+
+
+# A trusted host accepted by ``_is_trusted_download_host``.
+_TRUSTED_HOST = "storage.googleapis.com"
+_TRUSTED_URL = f"https://{_TRUSTED_HOST}/start"
+
+
+def _redirect_handler(
+    *,
+    location: str,
+    body: bytes = b"PAYLOAD",
+    content_type: str = "video/mp4",
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Return a transport handler: trusted ``/start`` 302s to ``location``."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == _TRUSTED_HOST and request.url.path == "/start":
+            return httpx.Response(302, headers={"location": location})
+        # Any other (the redirect target) serves a body. If the hop is
+        # off-allowlist the production hook must have already aborted, so
+        # reaching here for an untrusted host is itself a test failure.
+        return httpx.Response(200, content=body, headers={"content-type": content_type})
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Single-download path: download_url
+# ---------------------------------------------------------------------------
+
+
+class TestSingleDownloadRedirectRevalidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "evil_location",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://evil.example/payload",
+            "https://localhost/payload",
+        ],
+    )
+    async def test_offallowlist_redirect_rejected_nothing_written(
+        self, mock_artifacts_api, tmp_path, evil_location
+    ):
+        """trusted→off-allowlist 30x → ArtifactDownloadError, no file/temp left."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=evil_location)
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_non_https_redirect_hop_rejected(self, mock_artifacts_api, tmp_path):
+        """https→http downgrade to a same-host hop is rejected (no plaintext fetch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"http://{_TRUSTED_HOST}/payload")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "non-HTTPS" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_multihop_trusted_then_offallowlist_rejected(self, mock_artifacts_api, tmp_path):
+        """trusted→trusted→evil: rejected on the off-allowlist hop, nothing written."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == _TRUSTED_HOST and request.url.path == "/start":
+                # First hop -> another trusted host (a CDN already on the
+                # allowlist).
+                return httpx.Response(
+                    302, headers={"location": "https://cdn.googleusercontent.com/hop2"}
+                )
+            if request.url.host == "cdn.googleusercontent.com":
+                # Second (trusted) hop -> an off-allowlist host.
+                return httpx.Response(302, headers={"location": "https://evil.example/payload"})
+            return httpx.Response(200, content=b"EVIL", headers={"content-type": "video/mp4"})
+
+        client_patch, cookies_patch = _patch_real_client_with_transport(handler)
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted download domain" in str(exc_info.value)
+        assert "evil.example" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    async def test_trusted_to_trusted_redirect_still_succeeds(self, mock_artifacts_api, tmp_path):
+        """A legitimate signed-URL CDN redirect (trusted→trusted) downloads fine."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        # storage.googleapis.com -> googleusercontent.com signed CDN (both trusted).
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location="https://lh3.googleusercontent.com/signed/file.mp4",
+                body=b"REAL MEDIA BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert result == str(output_path)
+        assert output_path.read_bytes() == b"REAL MEDIA BYTES"
+
+    @pytest.mark.asyncio
+    async def test_open_redirect_staying_on_trusted_host_succeeds(
+        self, mock_artifacts_api, tmp_path
+    ):
+        """An open-redirect that stays on a trusted host is not over-blocked."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location=f"https://{_TRUSTED_HOST}/redirected/file.mp4",
+                body=b"SAME HOST BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert result == str(output_path)
+        assert output_path.read_bytes() == b"SAME HOST BYTES"
+
+
+# ---------------------------------------------------------------------------
+# Batch path: download_urls_batch
+# ---------------------------------------------------------------------------
+
+
+class TestBatchDownloadRedirectRevalidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "evil_location",
+        [
+            "https://169.254.169.254/latest/meta-data/",
+            "https://evil.example/payload",
+        ],
+    )
+    async def test_offallowlist_redirect_aggregated_into_failed_nothing_written(
+        self, mock_artifacts_api, tmp_path, evil_location
+    ):
+        """trusted→off-allowlist 30x → failed entry, no file written for it."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=evil_location)
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == _TRUSTED_URL
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_non_https_redirect_hop_rejected(self, mock_artifacts_api, tmp_path):
+        """https→http downgrade hop aggregated into ``failed`` for the batch."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"http://{_TRUSTED_HOST}/payload")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        _, failed_exc = result.failed[0]
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "non-HTTPS" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_bad_redirect_isolated_from_good_sibling(self, mock_artifacts_api, tmp_path):
+        """A redirect-to-evil URL fails while a clean sibling still succeeds."""
+        api = mock_artifacts_api
+        bad_url = f"https://{_TRUSTED_HOST}/start"
+        good_url = f"https://{_TRUSTED_HOST}/clean.mp4"
+        bad_path = tmp_path / "bad.mp4"
+        good_path = tmp_path / "good.mp4"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/start":
+                return httpx.Response(302, headers={"location": "https://evil.example/payload"})
+            if request.url.path == "/clean.mp4":
+                return httpx.Response(
+                    200, content=b"GOOD BYTES", headers={"content-type": "video/mp4"}
+                )
+            return httpx.Response(200, content=b"EVIL", headers={"content-type": "video/mp4"})
+
+        client_patch, cookies_patch = _patch_real_client_with_transport(handler)
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch(
+                [(bad_url, str(bad_path)), (good_url, str(good_path))]
+            )
+
+        assert result.succeeded == [str(good_path)]
+        assert good_path.read_bytes() == b"GOOD BYTES"
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == bad_url
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert not bad_path.exists()
+        assert result.partial
+
+    @pytest.mark.asyncio
+    async def test_trusted_to_trusted_redirect_still_succeeds(self, mock_artifacts_api, tmp_path):
+        """A legitimate trusted→trusted redirect downloads in the batch path too."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(
+                location="https://lh3.googleusercontent.com/signed/file.mp4",
+                body=b"REAL MEDIA BYTES",
+            )
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == [str(output_path)]
+        assert result.failed == []
+        assert output_path.read_bytes() == b"REAL MEDIA BYTES"
+
+
+# ---------------------------------------------------------------------------
+# Percent-encoded host parser-differential bypass (#1521 re-review)
+# ---------------------------------------------------------------------------
+
+# ``_is_trusted_download_host`` previously percent-decoded the hostname before
+# matching, so ``evil%2egoogleapis.com`` decoded to ``evil.googleapis.com`` and
+# was judged TRUSTED — but httpx connects to the RAW host
+# ``evil%2egoogleapis.com``. The guard validated a *different* host than the
+# one actually connected to (a parser differential), letting the body land on
+# disk. These hosts must be rejected at every gate: the initial URL and any
+# redirect target, single and batch.
+_PERCENT_ENCODED_HOSTS = [
+    "evil%2egoogleapis.com",  # %2e -> '.' under the old unquote()
+    "evil%2Egoogleapis.com",  # uppercase variant
+    "storage.googleapis.com%2eevil.example",  # encoded dot mid-host
+]
+
+
+class TestPercentEncodedHostBypass:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_single_initial_url_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A percent-encoded host as the INITIAL url is rejected (single)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        # No redirect needed: the bad host is the initial URL itself.
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            lambda request: httpx.Response(200, content=b"EVIL")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(f"https://{host}/payload", str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_single_redirect_target_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A trusted URL redirecting to a percent-encoded host is rejected (single)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"https://{host}/payload")
+        )
+
+        with client_patch, cookies_patch, pytest.raises(ArtifactDownloadError) as exc_info:
+            await api._download_url(_TRUSTED_URL, str(output_path))
+
+        assert "Untrusted" in str(exc_info.value)
+        assert not output_path.exists()
+        assert list(tmp_path.glob("file.mp4.*.tmp")) == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_batch_initial_url_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A percent-encoded host as the INITIAL url is rejected (batch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        url = f"https://{host}/payload"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            lambda request: httpx.Response(200, content=b"EVIL")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(url, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        failed_url, failed_exc = result.failed[0]
+        assert failed_url == url
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("host", _PERCENT_ENCODED_HOSTS)
+    async def test_batch_redirect_target_rejected(self, mock_artifacts_api, tmp_path, host):
+        """A trusted URL redirecting to a percent-encoded host is rejected (batch)."""
+        api = mock_artifacts_api
+        output_path = tmp_path / "file.mp4"
+        client_patch, cookies_patch = _patch_real_client_with_transport(
+            _redirect_handler(location=f"https://{host}/payload")
+        )
+
+        with client_patch, cookies_patch:
+            result = await api._download_urls_batch([(_TRUSTED_URL, str(output_path))])
+
+        assert result.succeeded == []
+        assert len(result.failed) == 1
+        _, failed_exc = result.failed[0]
+        assert isinstance(failed_exc, ArtifactDownloadError)
+        assert "Untrusted" in str(failed_exc)
+        assert not output_path.exists()

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -690,6 +690,89 @@ class TestRPCErrorAttributes:
         assert secret not in str(spliced)
         assert secret not in repr(spliced)
 
+    def test_unknown_rpc_method_error_scrubs_secrets_in_data_at_failure(self, monkeypatch):
+        """``data_at_failure`` is scrubbed at store time so str()/repr() are safe.
+
+        Red-first: ``data_at_failure`` was spliced verbatim with ``!r`` into
+        ``__str__`` / ``__repr__`` / tracebacks (a string splice that bypasses
+        the logging ``RedactingFilter``), unlike the sibling ``raw_response``
+        which was already scrubbed. A credential-shaped value therefore leaked
+        through every rendering regardless of ``NOTEBOOKLM_DEBUG`` (#1518).
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "AF1_QpN-supersecretcsrftoken1234567890abcdefghij"
+        e = UnknownRPCMethodError(
+            "safe_index drift",
+            method_id="abc123",
+            data_at_failure=repr({"SNlM0e": secret}),
+        )
+        # Scrubbed at STORE time: the attribute itself carries no secret.
+        assert secret not in str(e.data_at_failure)
+        assert "***" in str(e.data_at_failure)
+        # And both render paths that splice it stay clean.
+        assert secret not in str(e)
+        assert secret not in repr(e)
+
+    def test_unknown_rpc_method_error_data_at_failure_token_shape_scrubbed(self, monkeypatch):
+        """A token-shaped value under an unknown carrier is scrubbed in str()/repr().
+
+        Defense in depth: even a raw ``g.a000-`` SID token embedded in the
+        indexed data (no recognizable cookie/key name around it) is neutralized
+        by the shared ``scrub_secrets`` catch-all before it reaches any surface.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        token = "g.a000-leakytokenburiedindata"
+        e = UnknownRPCMethodError(
+            "safe_index drift",
+            method_id="x",
+            data_at_failure=repr(["unrelated", token, 42]),
+        )
+        assert token not in str(e)
+        assert token not in repr(e)
+        assert e.data_at_failure is not None and "g.a000-" not in e.data_at_failure
+
+    def test_unknown_rpc_method_error_data_at_failure_api_key_scrubbed(self, monkeypatch):
+        """A Google API key (``AIza…``) in data_at_failure is scrubbed (codex #1517).
+
+        Red-first: the API-key shape was missing from the runtime catch-alls, so
+        ``UnknownRPCMethodError(data_at_failure=repr({"JrWMbf": api_key}))`` —
+        the WIZ_global_data key that the cassette registry already treats as
+        must-scrub — leaked the key verbatim through str()/repr().
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        api_key = "AIza" + "B" * 35
+        e = UnknownRPCMethodError(
+            "safe_index drift",
+            method_id="x",
+            data_at_failure=repr({"JrWMbf": api_key}),
+        )
+        assert api_key not in str(e)
+        assert api_key not in repr(e)
+        assert e.data_at_failure is not None and "AIza" not in e.data_at_failure
+
+    def test_unknown_rpc_method_error_data_at_failure_dotted_secure_cookie_scrubbed(
+        self, monkeypatch
+    ):
+        """A ``__Secure-NEW.SESSION=…`` pair in data_at_failure is scrubbed.
+
+        Red-first: a too-narrow umbrella NAME charset leaks RFC 6265
+        ``token``-set secure/host cookie names containing ``.`` (codex re-review
+        of #1517). The value rides into ``data_at_failure`` (e.g. a captured
+        Set-Cookie line) and must not survive str()/repr().
+        """
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        secret = "opaqueDottedSecureCookieValueXYZ"
+        # No ``Set-Cookie:`` prefix — exercises the umbrella directly, not the
+        # whole-jar ``Set-Cookie:`` header pattern.
+        e = UnknownRPCMethodError(
+            "safe_index drift",
+            method_id="x",
+            data_at_failure=repr({"cookie": f"__Secure-NEW.SESSION={secret}"}),
+        )
+        assert secret not in str(e)
+        assert secret not in repr(e)
+        assert e.data_at_failure is not None and secret not in e.data_at_failure
+
     def test_rpc_error_stores_found_ids(self):
         """RPCError stores found_ids list."""
         e = RPCError("Failed", found_ids=["id1", "id2"])
@@ -969,6 +1052,23 @@ class TestAuthExtractionErrorScrubbing:
 
         assert "SECRET_NEAR_BOUNDARY" not in exc.payload_preview
         assert "SECRET_NEAR_BOUNDARY" not in str(exc)
+
+    def test_auth_extraction_error_scrubs_google_api_key(self):
+        """payload_preview must not leak a Google API key (``AIza…``) (codex #1517).
+
+        Red-first: the WIZ_global_data page embeds a Google API key
+        (``JrWMbf`` / ``B8SWKb`` / ``VqImj``); a drift preview captured during
+        token extraction renders it verbatim until the API-key shape is in the
+        shared ``scrub_secrets`` catch-alls. ``payload_preview`` already routes
+        through ``scrub_secrets``, so the registry addition covers it.
+        """
+        api_key = "AIza" + "C" * 35
+        payload = f'<script>WIZ_global_data={{"JrWMbf":"{api_key}"}}</script>'
+        exc = AuthExtractionError("SNlM0e", payload)
+
+        assert api_key not in exc.payload_preview
+        assert api_key not in str(exc)
+        assert "AIza" not in exc.payload_preview
 
 
 class TestCatchAllPattern:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -147,6 +147,216 @@ def test_formatter_scrubs_google_session_cookies():
         assert secret not in out
 
 
+#: Session / host cookies that #1517 added to the runtime redaction set. Each
+#: previously round-tripped VERBATIM through ``scrub_secrets`` because the
+#: cookie-name alternation omitted them (``NID`` / ``LSOLH`` are not substrings
+#: of any prior alternative; ``__Host-GAPS`` had no umbrella). The real leak
+#: sink is ``_auth.refresh._run_refresh_cmd`` logging refresh-cmd stdout/stderr
+#: at DEBUG through the redacting logger.
+_ISSUE_1517_COOKIE_PAIRS = [
+    ("NID", "g.a000-nidsecrettokenvalue123"),
+    ("LSOLH", "g.a000-lsolhsecrettokenvalue"),
+    ("__Host-GAPS", "gapssecretcookievalue456"),
+]
+
+
+@pytest.mark.parametrize(("cookie_name", "secret"), _ISSUE_1517_COOKIE_PAIRS)
+def test_formatter_scrubs_issue_1517_session_cookies(cookie_name, secret):
+    """Bare ``NID`` / ``LSOLH`` / ``__Host-GAPS`` tokens are redacted (#1517).
+
+    Red-first: before the runtime registry, the cookie-name alternation omitted
+    these three names, so a refresh-cmd stdout line like ``NID=g.a000-...`` (the
+    DEBUG sink in ``_auth.refresh``) passed through ``scrub_secrets`` verbatim.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record(f"refresh stdout: {cookie_name}={secret}")
+    out = fmt.format(rec)
+    assert secret not in out, f"{cookie_name} value leaked: {out!r}"
+    assert f"{cookie_name}=***" in out, f"missing {cookie_name}=***: {out!r}"
+
+
+#: ``(carrier-name, token, residual-prefix)`` triples. The carrier name is NOT
+#: on the cookie alternation, so only the field-agnostic auth-token-shape
+#: catch-all can redact these — defense in depth so disclosure fails closed
+#: regardless of which field carries the value (#1517).
+_AUTH_TOKEN_SHAPE_CASES = [
+    ("X_UNKNOWN", "g.a000-leakytokenunderunknownfield", "g.a000-"),
+    ("X_UNKNOWN", "sidts-1234567890abcdefghij", "sidts-"),
+    ("X_UNKNOWN", "ya29.aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789", "ya29."),
+    # Google API key (``AIza`` + 35-char tail). Red-first: the key shape was
+    # absent from the runtime catch-alls, so ``JrWMbf``-carried keys routed
+    # through data_at_failure / payload_preview leaked (codex review of #1517).
+    ("X_UNKNOWN", "AIza" + "A" * 35, "AIza"),
+]
+
+
+@pytest.mark.parametrize(("carrier", "token", "prefix"), _AUTH_TOKEN_SHAPE_CASES)
+def test_formatter_scrubs_auth_token_shape_under_unknown_carrier(carrier, token, prefix):
+    """A token-shaped value under an UNKNOWN carrier name is still redacted.
+
+    Red-first: the cookie-name alternation only fires on known cookie names, so
+    ``X_UNKNOWN=g.a000-...`` would leak without the carrier-agnostic token-shape
+    catch-all ported from the cassette registry's ``_AUTH_TOKEN_PATTERNS``.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record(f"payload: {carrier}={token}")
+    out = fmt.format(rec)
+    assert token not in out, f"token leaked under unknown carrier: {out!r}"
+    assert prefix not in out, f"token prefix survived: {out!r}"
+    assert "***" in out
+
+
+def test_formatter_still_scrubs_osid_cookie():
+    """OSID stays redacted — it is caught by the ``SID`` alternative (#1517 regression guard).
+
+    The #1517 fix must not regress the cookies already covered; ``OSID`` was
+    incidentally caught by the ``SID`` alternation before the registry refactor
+    and must remain caught after it.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record("cookie jar: OSID=osidsecretvalue789")
+    out = fmt.format(rec)
+    assert "osidsecretvalue789" not in out
+    assert "OSID=***" in out
+
+
+#: ``(cookie-name, opaque-value)`` for ``__Secure-*`` / ``__Host-*`` cookies
+#: NOT enumerated in any name list — including a hypothetical future name with
+#: an OPAQUE (non-token-shaped) value, which only the prefix umbrella can catch.
+_UMBRELLA_COOKIE_CASES = [
+    ("__Secure-NEWSESSION", "opaqueBase64ValueNoTokenShape123"),
+    ("__Host-NEWTHING", "anotherOpaqueValue456nottoken"),
+    # Enumerated names still covered by the umbrella (they were dropped from the
+    # bare name list once the umbrella became the mechanism).
+    ("__Secure-OSID", "opaqueSecureOsidValue789"),
+    ("__Host-GAPS", "opaqueGapsValueabc"),
+    # RFC 6265 ``token``-charset names containing ``.`` / ``+`` / ``_`` and the
+    # rarer token punctuation (``! # $ % & ' * ^ ` | ~``). A name class narrower
+    # than "any run up to ``=``" (e.g. ``[A-Za-z0-9_-]+``) leaks these because
+    # the first non-class char (``.`` / ``+`` / ``'``) breaks the match early —
+    # codex re-review of #1517.
+    ("__Secure-NEW.SESSION", "opaqueDottedNameValue1"),
+    ("__Host-GAPS.v2", "opaqueDottedHostValue2"),
+    ("__Secure-A+B", "opaquePlusNameValue3"),
+    ("__Secure-x.y_z", "opaqueMixedNameValue4"),
+    ("__Host-a!#$%&'*+.^_`|~b", "opaqueFullTokenCharValue5"),
+]
+
+
+@pytest.mark.parametrize(("cookie_name", "opaque"), _UMBRELLA_COOKIE_CASES)
+def test_formatter_scrubs_secure_host_umbrella_cookies(cookie_name, opaque):
+    """ANY ``__Secure-*`` / ``__Host-*`` cookie value is redacted by prefix.
+
+    Red-first: with the secure/host names dropped from the enumerated list (the
+    umbrella is the mechanism), a name-list-only guard would leak a future
+    ``__Secure-NEWSESSION=opaqueBase64`` carrying an opaque, non-token-shaped
+    value (codex review of #1517). A too-narrow NAME charset additionally leaks
+    RFC 6265 ``token``-set names like ``__Secure-NEW.SESSION`` (codex re-review).
+    The umbrella's "any run up to ``=``" name class fails closed by construction.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record(f"refresh stdout: {cookie_name}={opaque}; Path=/")
+    out = fmt.format(rec)
+    assert opaque not in out, f"{cookie_name} opaque value leaked: {out!r}"
+    assert f"{cookie_name}=***" in out, f"missing {cookie_name}=***: {out!r}"
+    # The trailing cookie attribute is preserved (umbrella stops at ``;``).
+    assert "Path=/" in out
+
+
+#: ``(cookie-name, value)`` whose value the log line wraps in RFC 6265 double
+#: quotes (``cookie-value = … / DQUOTE *cookie-octet DQUOTE``). Covers a bare
+#: session cookie, both umbrellas, and a quoted TOKEN (caught two ways). Each
+#: leaked before the value classes gained an optional surrounding quote: the
+#: leading ``"`` was excluded by the value class so the whole name-anchored
+#: pattern failed to match and the value round-tripped verbatim.
+_QUOTED_VALUE_CASES = [
+    ("SID", "opaqueQuotedSessionValue1"),
+    ("__Secure-NEWSESSION", "opaqueQuotedSecureValue2"),
+    ("__Host-GAPS", "opaqueQuotedHostValue3"),
+    ("NID", "g.a000-quotedtokenvalue"),
+]
+
+
+@pytest.mark.parametrize(("cookie_name", "value"), _QUOTED_VALUE_CASES)
+def test_formatter_scrubs_double_quoted_cookie_values(cookie_name, value):
+    """An RFC 6265 double-quoted cookie value is redacted (gemini review of #1530).
+
+    Red-first: the value class excluded ``"``, so a quoted value's leading quote
+    made the name-anchored cookie / umbrella pattern fail to match entirely and
+    the (opaque, non-token-shaped) value LEAKED. The shared quote-aware suffix
+    now redacts the inner value while preserving the surrounding quotes.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record(f'refresh stdout: {cookie_name}="{value}"; Path=/')
+    out = fmt.format(rec)
+    assert value not in out, f"{cookie_name} quoted value leaked: {out!r}"
+    # Quotes preserved, value collapsed to ``***``.
+    assert f'{cookie_name}="***"' in out, f'missing {cookie_name}="***": {out!r}'
+    assert "Path=/" in out
+
+
+def test_formatter_double_quote_in_prose_not_swallowed():
+    """A double-quote in surrounding prose is not over-redacted (gemini #1530).
+
+    The optional outer quotes must not let the cookie pattern reach across
+    unrelated quoted prose; only the cookie value collapses to ``***``.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record('note "see the docs" then SID=plainvalue and more text')
+    out = fmt.format(rec)
+    assert "see the docs" in out, f"prose quote swallowed: {out!r}"
+    assert "plainvalue" not in out
+    assert "SID=***" in out
+
+
+#: ``(rendered-fragment, secret, expected-substring)`` for the query / form /
+#: header value patterns when the value is RFC 6265 / JSON double-quoted. These
+#: share the cookie patterns' root cause: the value class excluded ``"``, so a
+#: quoted value made the whole ``name=`` pattern miss and the value LEAKED
+#: (gemini review of #1530). Extended for consistency across ALL value-bearing
+#: name-anchored patterns, not just cookies.
+_QUOTED_QUERY_CASES = [
+    ('body at="SECRET_AT_TOKEN"', "SECRET_AT_TOKEN", 'at="***"'),
+    ('csrf="SECRET_CSRF_TOKEN"', "SECRET_CSRF_TOKEN", 'csrf="***"'),
+    ('f.sid="SECRET_FSID_VAL"', "SECRET_FSID_VAL", 'f.sid="***"'),
+    ('upload_id="SECRET_UPLOAD"', "SECRET_UPLOAD", 'upload_id="***"'),
+    ('refresh_token="SECRET_RT_VAL"', "SECRET_RT_VAL", 'refresh_token="***"'),
+    ('Authorization: Bearer "SECRET_BEARER_TOK"', "SECRET_BEARER_TOK", 'Bearer "***"'),
+]
+
+
+@pytest.mark.parametrize(("fragment", "secret", "expected"), _QUOTED_QUERY_CASES)
+def test_formatter_scrubs_double_quoted_query_and_header_values(fragment, secret, expected):
+    """Double-quoted query / form / header values are redacted (gemini #1530).
+
+    Red-first: the value classes excluded ``"``, so a JSON/prose fragment like
+    ``f.sid="opaque"`` or ``Bearer "token"`` round-tripped verbatim. The shared
+    optional-quote suffix now redacts the inner value, preserving the quotes.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    rec = _record(fragment)
+    out = fmt.format(rec)
+    assert secret not in out, f"quoted value leaked: {out!r}"
+    assert expected in out, f"missing {expected!r}: {out!r}"
+
+
+def test_formatter_scrubs_google_api_key():
+    """A Google API key (``AIza…``) is redacted wherever it appears (codex #1517).
+
+    Red-first: the API-key shape was missing from the runtime catch-alls, so a
+    ``WIZ_global_data`` key (``JrWMbf`` / ``B8SWKb`` / ``VqImj``) surfaced in a
+    log line or — via the now-scrubbed ``data_at_failure`` — an exception leaked
+    the key verbatim. Mirrors the cassette registry's ``AIza`` + 35-char shape.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    key = "AIza" + "Z" * 35
+    rec = _record(f'WIZ field {{"JrWMbf":"{key}"}}')
+    out = fmt.format(rec)
+    assert key not in out, f"API key leaked: {out!r}"
+    assert "AIza" not in out
+    assert "***" in out
+
+
 def test_formatter_scrubs_fsid_query_param():
     fmt = RedactingFormatter(logging.Formatter("%(message)s"))
     rec = _record("requesting f.sid=tok-xyz-123")
@@ -416,11 +626,15 @@ def test_formatter_scrubs_papisid_with_correct_captured_name():
     correct.
     """
     from notebooklm._logging import _REDACT_PATTERNS
+    from notebooklm._secrets import COOKIE_VALUE_REPLACEMENT
 
-    # Find the cookie pattern (the one whose replacement is "\1=***" and
-    # whose source mentions __Secure-). Don't hardcode an index.
+    # Find the cookie pattern (the one whose replacement is the shared
+    # quote-aware cookie replacement and whose source mentions __Secure-).
+    # Don't hardcode an index.
     cookie_pattern = next(
-        p for p, repl in _REDACT_PATTERNS if repl == r"\1=***" and "__Secure" in p.pattern
+        p
+        for p, repl in _REDACT_PATTERNS
+        if repl == COOKIE_VALUE_REPLACEMENT and "__Secure" in p.pattern
     )
 
     # group(1) must be the FULL cookie name, not the APISID suffix.

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from notebooklm._notebooks import NotebooksAPI, build_create_notebook_params
+from notebooklm._notebooks import (
+    NotebooksAPI,
+    build_create_notebook_params,
+    build_get_notebook_params,
+)
 from notebooklm._source.listing import SourceLister
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -79,6 +83,20 @@ def test_build_create_notebook_params_matches_live_payload() -> None:
         None,
         None,
         [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+    ]
+
+
+def test_build_get_notebook_params_matches_live_payload() -> None:
+    # #1549: the read-path tail also migrated to the nested template block.
+    # Live-verified forward-compatible (decoded notebook + sources byte-identical
+    # to the old flat ``[2]`` on an un-migrated account). The trailing ``None, 0``
+    # is unchanged — only position 2 migrates.
+    assert build_get_notebook_params("nb_abc") == [
+        "nb_abc",
+        None,
+        [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+        None,
+        0,
     ]
 
 

--- a/tests/unit/test_notebook_metadata.py
+++ b/tests/unit/test_notebook_metadata.py
@@ -180,7 +180,14 @@ async def test_default_source_lister_uses_phase8_listing_service() -> None:
     assert rpc.calls == [
         (
             RPCMethod.GET_NOTEBOOK,
-            ["nb_123", None, [2], None, 0],
+            # #1549: GET_NOTEBOOK tail migrated to the nested template block.
+            [
+                "nb_123",
+                None,
+                [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+                None,
+                0,
+            ],
             "/notebook/nb_123",
         )
     ]

--- a/tests/unit/test_refresh_cmd_redaction.py
+++ b/tests/unit/test_refresh_cmd_redaction.py
@@ -105,12 +105,14 @@ def test_refresh_failure_routes_full_output_to_debug_log(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Full stdout/stderr is available at DEBUG level for diagnosis.
+    """stdout/stderr is routed to DEBUG for diagnosis, with secrets scrubbed.
 
-    The package logger has a redaction filter installed at import time, so
-    even when we capture the raw record here the user-facing handler scrubs
-    well-known token shapes. This test confirms the data path exists; the
-    redaction filter is unit-tested separately in ``test_logging.py``.
+    The package logger has a redaction filter installed at import time, so the
+    captured record carries the diagnostic ``stdout=``/``stderr=`` structure
+    (proving the data path exists) while the credential SHAPES are scrubbed in
+    place. After #1517 the redaction covers the ``ya29.`` access-token shape and
+    the ``SID=`` cookie, so this DEBUG sink — the leak path the issue calls out —
+    fails closed; the full redaction filter is unit-tested in ``test_logging.py``.
     """
     _stub_subprocess_run_with_leaky_output(monkeypatch)
     with caplog.at_level(logging.DEBUG, logger="notebooklm.auth"), pytest.raises(RuntimeError):
@@ -118,11 +120,24 @@ def test_refresh_failure_routes_full_output_to_debug_log(
 
     debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
     debug_text = "\n".join(r.getMessage() for r in debug_records)
-    # The secret output should be present in the DEBUG-level data path so
-    # developers can diagnose subprocess failures with ``--verbose``.
-    assert _SECRET_STDOUT in debug_text or _SECRET_STDERR in debug_text, (
-        "Expected refresh-cmd stdout/stderr to be routed to DEBUG log"
+    # The data path delivers SANITIZED CONTENT, not just empty labels: the
+    # non-secret diagnostic context around each secret survives so ``--verbose``
+    # users can still see what failed, with the credential collapsed to ``***``.
+    # ``_SECRET_STDOUT`` is ``"Bearer ya29.…"``  -> ``stdout='Bearer ***'``;
+    # ``_SECRET_STDERR`` is ``"rotate-cookie failed: SID=…"``
+    #                                            -> ``stderr='rotate-cookie failed: SID=***'``.
+    assert "stdout='Bearer ***'" in debug_text, (
+        f"Expected scrubbed-but-present stdout content in DEBUG log: {debug_text!r}"
     )
+    assert "stderr='rotate-cookie failed: SID=***'" in debug_text, (
+        f"Expected scrubbed-but-present stderr content in DEBUG log: {debug_text!r}"
+    )
+    # And the raw credential shapes never survive (#1517): the ``ya29.`` access
+    # token and the ``SID=`` cookie value are gone.
+    assert _SECRET_STDOUT not in debug_text
+    assert _SECRET_STDERR not in debug_text
+    assert "ya29.SECRET-TOKEN" not in debug_text
+    assert "SECRET-SID-VALUE" not in debug_text
 
 
 def test_error_handler_prints_only_exc_args_for_unexpected_exception(

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -58,7 +58,14 @@ async def test_list_uses_exact_get_notebook_rpc_shape() -> None:
     assert rpc.calls == [
         (
             RPCMethod.GET_NOTEBOOK,
-            ["nb_123", None, [2], None, 0],
+            # #1549: GET_NOTEBOOK tail migrated to the nested template block.
+            [
+                "nb_123",
+                None,
+                [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+                None,
+                0,
+            ],
             "/notebook/nb_123",
         )
     ]


### PR DESCRIPTION
## Summary
- Backport #1532 / `0a6e28a0`: re-validate every artifact download redirect hop before following it, including percent-encoded-host rejection.
- Backport #1530 / `fcef3912`: derive runtime secret redaction from a canonical registry and scrub `data_at_failure` exception surfaces.
- Backport #1582 / `067d9632`: migrate `GET_NOTEBOOK` read calls to the nested template-block wire shape for `notebooks.get`, `get_raw`, and source listing.
- Keep the 0.7.x branch docs/tests fresh for the new private modules and guardrail layout.

## Why
0.7.3 already has the matching write-path nested-shape backport, but not the read-path migration. The security fixes close runtime credential leakage and artifact-download redirect SSRF exposure on the supported 0.7.x line.

## Test plan
- `uv run --extra dev pytest tests/unit/test_download_redirect_revalidation.py tests/unit/test_artifact_downloads_coverage.py tests/unit/test_logging.py tests/unit/test_exceptions.py tests/unit/test_refresh_cmd_redaction.py tests/unit/test_notebook_api.py tests/unit/test_notebook_metadata.py tests/unit/test_source_listing_service.py tests/_guardrails/test_runtime_secret_registry_parity.py tests/_guardrails/test_module_size_ratchet.py` -> 321 passed
- `uv run --extra dev pytest` -> 8457 passed, 135 skipped, 1 xfailed
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> passed
- `uv run --extra dev mypy src/notebooklm` -> passed
- `uv run --extra dev pre-commit run --all-files` -> passed

## Polish
- Code-simplifier: no code changes needed.
- Triple review: Claude + Codex + agy found 0 Critical / 0 Important findings; 2 agy wording suggestions were applied.
- Ultrathink: no remaining concerns, none deferred.
