### PR TITLE
fix(server): bind server_info profile probe

### DIFF
--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -25,6 +25,7 @@ from fastmcp import FastMCP
 from fastmcp.server.auth import AuthProvider
 
 from ..client import NotebookLMClient
+from ..paths import get_active_profile, set_active_profile
 from ._context import AppState
 from ._filelink import FileTransferConfig
 
@@ -76,7 +77,8 @@ def create_server(
 
     Args:
         profile: Auth profile bound for the whole process. Defaults to the active
-            profile when ``None``.
+            profile when ``None``. Also drives process-wide profile resolution
+            for diagnostics such as the ``server_info`` tool.
         client_factory: Test seam — a zero-arg callable returning an async context
             manager that yields a client. Defaults to
             ``NotebookLMClient.from_storage(profile=...)``.
@@ -109,8 +111,15 @@ def create_server(
 
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncIterator[AppState]:
-        async with factory() as client:
-            yield AppState(client=client, file_transfer=file_transfer)
+        previous_profile = get_active_profile()
+        if profile is not None:
+            set_active_profile(profile)
+        try:
+            async with factory() as client:
+                yield AppState(client=client, file_transfer=file_transfer)
+        finally:
+            if profile is not None:
+                set_active_profile(previous_profile)
 
     mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS, lifespan=lifespan, auth=auth)
     register_all(mcp)

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -25,7 +25,7 @@ from fastmcp import FastMCP
 from fastmcp.server.auth import AuthProvider
 
 from ..client import NotebookLMClient
-from ..paths import get_active_profile, set_active_profile
+from ..paths import get_active_profile, resolve_profile, set_active_profile
 from ._context import AppState
 from ._filelink import FileTransferConfig
 
@@ -112,14 +112,12 @@ def create_server(
     @asynccontextmanager
     async def lifespan(_server: FastMCP) -> AsyncIterator[AppState]:
         previous_profile = get_active_profile()
-        if profile is not None:
-            set_active_profile(profile)
+        set_active_profile(resolve_profile(profile))
         try:
             async with factory() as client:
                 yield AppState(client=client, file_transfer=file_transfer)
         finally:
-            if profile is not None:
-                set_active_profile(previous_profile)
+            set_active_profile(previous_profile)
 
     mcp = FastMCP(name=SERVER_NAME, instructions=SERVER_INSTRUCTIONS, lifespan=lifespan, auth=auth)
     register_all(mcp)

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -128,12 +128,8 @@ def register(mcp: Any) -> None:
         remote) caller, while telling the agent nothing it can act on.
         """
         with mcp_errors():
-            # Report the *resolved* profile (never ``None``) rather than the raw
-            # module-level active profile: the MCP server never sets an active
-            # profile, so ``get_active_profile()`` was always ``None`` here even
-            # though ``get_storage_path`` resolves and checks a concrete profile
-            # (#1790). ``resolve_profile()`` names the profile the auth probe
-            # actually ran against — the same value the CLI ``status`` reports.
+            # Report the *resolved* profile (never ``None``): this names the
+            # profile the auth probe actually ran against (#1790, #1791).
             profile = resolve_profile()
             storage_path = get_storage_path(profile)
             plan = AuthCheckPlan(

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -72,7 +72,8 @@ _active_profile: str | None = None
 def set_active_profile(profile: str | None) -> None:
     """Set the active profile for this process.
 
-    Called once at CLI startup. Library users should pass ``profile``
+    CLI startup and single-tenant server lifespans use this as the
+    process-wide profile binding. Library users should pass ``profile``
     explicitly to path functions instead of relying on this global.
     """
     global _active_profile

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -31,6 +31,7 @@ from typing import cast
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
 
 from ..client import NotebookLMClient
+from ..paths import get_active_profile, set_active_profile
 from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
@@ -64,7 +65,8 @@ def create_app(
 
     Args:
         profile: Auth profile bound by the default factory (``from_storage(profile=)``).
-            ``None`` resolves the active profile. Ignored when ``client_factory`` is set.
+            ``None`` resolves the active profile. Also drives process-wide profile
+            resolution for diagnostics such as ``/v1/server/info``.
         client_factory: Test seam — a zero-arg callable returning an async
             context manager that yields a client. Defaults to
             ``NotebookLMClient.from_storage(profile=profile)``.
@@ -78,12 +80,19 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        async with factory() as client:
-            app.state.notebooklm = AppState(client=client, pending=PendingRegistry())
-            try:
-                yield
-            finally:
-                app.state.notebooklm = None
+        previous_profile = get_active_profile()
+        if profile is not None:
+            set_active_profile(profile)
+        try:
+            async with factory() as client:
+                app.state.notebooklm = AppState(client=client, pending=PendingRegistry())
+                try:
+                    yield
+                finally:
+                    app.state.notebooklm = None
+        finally:
+            if profile is not None:
+                set_active_profile(previous_profile)
 
     app = FastAPI(
         title=SERVER_NAME,

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -31,7 +31,7 @@ from typing import cast
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
 
 from ..client import NotebookLMClient
-from ..paths import get_active_profile, set_active_profile
+from ..paths import get_active_profile, resolve_profile, set_active_profile
 from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
@@ -81,8 +81,7 @@ def create_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         previous_profile = get_active_profile()
-        if profile is not None:
-            set_active_profile(profile)
+        set_active_profile(resolve_profile(profile))
         try:
             async with factory() as client:
                 app.state.notebooklm = AppState(client=client, pending=PendingRegistry())
@@ -91,8 +90,7 @@ def create_app(
                 finally:
                     app.state.notebooklm = None
         finally:
-            if profile is not None:
-                set_active_profile(previous_profile)
+            set_active_profile(previous_profile)
 
     app = FastAPI(
         title=SERVER_NAME,

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -103,11 +103,8 @@ async def server_info(
     The absolute on-disk storage path is deliberately not returned (it leaks the
     host filesystem layout while telling the agent nothing actionable).
     """
-    # Report the *resolved* profile (never ``None``) rather than the raw
-    # module-level active profile: the server never sets an active profile, so
-    # ``get_active_profile()`` was always ``None`` here even though
-    # ``get_storage_path`` resolves and checks a concrete profile (#1790).
-    # ``resolve_profile()`` names the profile the auth probe actually ran against.
+    # Report the *resolved* profile (never ``None``): this names the profile the
+    # auth probe actually ran against (#1790, #1791).
     profile = resolve_profile()
     storage_path = get_storage_path(profile)
     plan = AuthCheckPlan(

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -109,6 +109,39 @@ def test_server_info_uses_bound_profile_for_probe(
     assert paths.get_active_profile() is None
 
 
+def test_server_info_locks_resolved_profile_for_lifespan(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``profile=None`` resolves once at startup, matching the lifespan-bound client."""
+    from notebooklm import paths
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_run(plan: Any, *, read_env_auth_json: Any) -> _FakeAuthResult:
+        seen["profile"] = plan.profile
+        seen["storage_path"] = plan.storage_path
+        return _FakeAuthResult(all_passed=True)
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        yield FakeClient()
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.setenv("NOTEBOOKLM_PROFILE", "work")
+    monkeypatch.setattr(paths, "_active_profile", None)
+    monkeypatch.setattr(meta_route, "run_auth_check", _fake_run)
+
+    app = create_app(client_factory=factory)
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+    with TestClient(app, headers=headers, client=("127.0.0.1", 5555)) as client:
+        monkeypatch.setenv("NOTEBOOKLM_PROFILE", "other")
+        body = client.get("/v1/server/info").json()
+
+    assert body["auth"]["profile"] == "work"
+    assert seen == {"profile": "work", "storage_path": paths.get_storage_path("work")}
+    assert paths.get_active_profile() is None
+
+
 def test_server_info_include_account(
     authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
+from notebooklm.server.app import create_app
 from notebooklm.server.routes import meta as meta_route
 
+from .conftest import TEST_TOKEN
 from .fakes import FakeClient
 
 
@@ -71,6 +75,38 @@ def test_server_info_profile_is_resolved_not_null(
     monkeypatch.setattr(paths, "_active_profile", None)
     body = authed_client.get("/v1/server/info").json()
     assert body["auth"]["profile"] == "default"
+
+
+def test_server_info_uses_bound_profile_for_probe(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``create_app(profile=X)`` makes server_info probe that same profile (#1791)."""
+    from notebooklm import paths
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_run(plan: Any, *, read_env_auth_json: Any) -> _FakeAuthResult:
+        seen["profile"] = plan.profile
+        seen["storage_path"] = plan.storage_path
+        return _FakeAuthResult(all_passed=True)
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        yield FakeClient()
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.setattr(paths, "_active_profile", None)
+    monkeypatch.setattr(meta_route, "run_auth_check", _fake_run)
+
+    app = create_app(profile="work", client_factory=factory)
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+    with TestClient(app, headers=headers, client=("127.0.0.1", 5555)) as client:
+        body = client.get("/v1/server/info").json()
+
+    assert body["auth"]["profile"] == "work"
+    assert seen == {"profile": "work", "storage_path": paths.get_storage_path("work")}
+    assert paths.get_active_profile() is None
 
 
 def test_server_info_include_account(

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -192,6 +192,45 @@ async def test_server_info_uses_bound_profile_for_probe(mock_client, tmp_path, m
     assert paths.get_active_profile() is None
 
 
+async def test_server_info_locks_resolved_profile_for_lifespan(
+    mock_client, tmp_path, monkeypatch
+) -> None:
+    """``profile=None`` resolves once at startup, matching the lifespan-bound client."""
+    from notebooklm import paths
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_run(plan: Any, *, read_env_auth_json: Any) -> Any:
+        seen["profile"] = plan.profile
+        seen["storage_path"] = plan.storage_path
+        return SimpleNamespace(
+            all_passed=True,
+            checks={
+                "storage_exists": True,
+                "json_valid": True,
+                "cookies_present": True,
+                "sid_cookie": True,
+            },
+        )
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[MagicMock]:
+        yield mock_client
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.setenv("NOTEBOOKLM_PROFILE", "work")
+    monkeypatch.setattr(paths, "_active_profile", None)
+    monkeypatch.setattr(meta_tool, "run_auth_check", _fake_run)
+
+    async with Client(create_server(client_factory=factory)) as client:
+        monkeypatch.setenv("NOTEBOOKLM_PROFILE", "other")
+        result = await client.call_tool("server_info")
+
+    assert result.structured_content["auth"]["profile"] == "work"
+    assert seen == {"profile": "work", "storage_path": paths.get_storage_path("work")}
+    assert paths.get_active_profile() is None
+
+
 async def test_server_info_default_omits_account(
     mcp_call, mock_client, tmp_path, monkeypatch
 ) -> None:

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -9,7 +9,11 @@ honors.
 
 from __future__ import annotations
 
+import contextlib
 import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,8 +21,12 @@ import pytest
 # Skip cleanly when the `mcp` extra (fastmcp) is absent; see conftest.py.
 pytest.importorskip("fastmcp")
 
+from fastmcp import Client  # noqa: E402 - after importorskip guard
+
 from notebooklm._version_info import version_string  # noqa: E402 - after importorskip guard
 from notebooklm.exceptions import RPCError  # noqa: E402 - after importorskip guard
+from notebooklm.mcp.server import create_server  # noqa: E402 - after importorskip guard
+from notebooklm.mcp.tools import meta as meta_tool  # noqa: E402 - after importorskip guard
 from notebooklm.types import (  # noqa: E402 - after importorskip guard
     AccountLimits,
     UserSettings,
@@ -146,6 +154,42 @@ async def test_server_info_profile_reflects_named_profile(
     monkeypatch.setattr(paths, "_active_profile", None)
     result = await mcp_call("server_info")
     assert result.structured_content["auth"]["profile"] == "work"
+
+
+async def test_server_info_uses_bound_profile_for_probe(mock_client, tmp_path, monkeypatch) -> None:
+    """``create_server(profile=X)`` makes server_info probe that same profile (#1791)."""
+    from notebooklm import paths
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_run(plan: Any, *, read_env_auth_json: Any) -> Any:
+        seen["profile"] = plan.profile
+        seen["storage_path"] = plan.storage_path
+        return SimpleNamespace(
+            all_passed=True,
+            checks={
+                "storage_exists": True,
+                "json_valid": True,
+                "cookies_present": True,
+                "sid_cookie": True,
+            },
+        )
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[MagicMock]:
+        yield mock_client
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.setattr(paths, "_active_profile", None)
+    monkeypatch.setattr(meta_tool, "run_auth_check", _fake_run)
+
+    async with Client(create_server(profile="work", client_factory=factory)) as client:
+        result = await client.call_tool("server_info")
+
+    assert result.structured_content["auth"]["profile"] == "work"
+    assert seen == {"profile": "work", "storage_path": paths.get_storage_path("work")}
+    assert paths.get_active_profile() is None
 
 
 async def test_server_info_default_omits_account(


### PR DESCRIPTION
## Summary
- Bind explicit REST/MCP server profiles into process-wide profile resolution for each server lifespan.
- Keep `server_info` auth.profile and auth-health storage probes aligned with the bound server client profile.
- Add REST and MCP regressions for `profile="work"` with env/default profile resolution cleared.

## Task
Fixes #1791

## Test plan
- [x] `uv run pytest`
- [x] `uv run pytest tests/server/test_meta.py tests/unit/mcp/test_meta.py -q`
- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Optional: unify REST/MCP test mock return helpers if more duplicate tests accumulate.
- Optional: add explicit `profile=None` non-overwrite coverage if this profile binding grows more branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server startup/diagnostics now scope the process-wide “active profile” to the server lifespan, ensuring the auth probe uses the bound (or resolved) profile, then restores the prior setting afterward.
  * `/v1/server/info` reports the resolved profile that the auth check actually ran against.

* **Documentation**
  * Updated docstrings/comments clarifying how `profile=None` resolves the active profile and what profile details are reported.

* **Tests**
  * Added coverage for probe profile correctness, storage path matching, lifespan “locking,” and cleanup of the active profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->