### PR TITLE
fix(mcp): first-class human/mobile upload path in upload_required (closes #1801)

### DIFF
--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 import time
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from fastmcp import Context
@@ -387,14 +388,14 @@ def register(mcp: Any) -> None:
         * ``file``    — over **stdio**, requires ``path`` (a local file path on the
           server host). Over the **remote (http) connector** the server's
           filesystem is unreachable, so instead the tool returns
-          ``{"status": "upload_required", "url": …, "agent_upload": {…}}``. A human
-          opens the short-lived signed URL in a browser and uploads the file; an
-          **agent that already holds the bytes** skips the browser and POSTs them as
-          the raw request body to the same URL (see the ``agent_upload`` recipe in
-          the response — with ``Accept: application/json`` it returns
-          ``{"status": "added", "source_id": …}``). Then confirm with ``source_wait``
-          / ``source_list``. ``title`` / ``mime_type`` (carried in the signed URL)
-          and the supplied ``path`` (its basename seeds the default title) are honored.
+          ``upload_required`` with two first-class actor paths: ``human_upload``
+          (open the signed URL in a browser — works on mobile — and pick the file) and
+          ``agent_upload`` (an agent holding the bytes POSTs them as the raw body;
+          ``Accept: application/json`` → ``{"status": "added", …}``).
+          ``agent_instructions`` is the rule: try ``agent_upload``, fall back to
+          ``human_upload.url`` on a network error. ``mime_locked`` is true when
+          ``mime_type`` was supplied; ``expires_at_iso`` / ``expires_in_seconds`` give
+          the expiry; top-level ``url`` is **deprecated** for ``human_upload.url``.
         * ``drive``   — requires ``document_id`` (Google Drive file id); ``title``
           and ``mime_type`` (one of google-doc|google-slides|google-sheets|pdf,
           default google-doc) optional.
@@ -573,6 +574,13 @@ def _broker_upload(
     survive the browser round-trip and cannot be tampered with). When ``title`` is
     unset, the supplied ``path``'s basename seeds the default. The signer injects
     expiry; ``expires_at`` mirrors the upload TTL for the caller.
+
+    Returns the ``upload_required`` payload (#1801): two first-class actor paths —
+    ``human_upload`` (browser/mobile) and ``agent_upload`` (raw-body POST) — plus an
+    ``agent_instructions`` try-then-fallback rule, a ``mime_locked`` flag (true only
+    when a mime was signed, so the request ``Content-Type`` is ignored), and
+    ``expires_at_iso`` / ``expires_in_seconds`` beside the unix ``expires_at``. The
+    top-level ``url`` is retained but deprecated in favor of ``human_upload.url``.
     """
     default_title = title
     if not default_title and path:
@@ -586,26 +594,63 @@ def _broker_upload(
     if mime_type:
         payload["mime"] = mime_type
     url = cfg.upload_url(payload)
+    expires_at = int(time.time()) + UPLOAD_TTL
+    expires_iso = (
+        datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    approx_minutes = UPLOAD_TTL // 60
+    # The signed token's mime wins server-side; a request Content-Type is honored
+    # ONLY when no mime was signed (see _fileroutes upload_route). So expose
+    # Content-Type as an agent knob only in the unlocked case, and flag the locked
+    # case with ``mime_locked`` instead of the old confusing header prose. Mirror the
+    # exact truthiness that gates signing ``mime`` above (``if mime_type``) so the
+    # flag can't claim locked while the token carried no mime (e.g. mime_type == "").
+    mime_locked = bool(mime_type)
+    agent_headers: dict[str, str] = {"Accept": "application/json"}
+    # When unlocked, the request Content-Type is the ONLY mime signal (no
+    # extension sniffing server-side), so the example must set it too — an agent
+    # is as likely to copy the curl example as to read ``headers``.
+    example_ct = "" if mime_locked else '-H "Content-Type: application/pdf" '
+    if not mime_locked:
+        agent_headers["Content-Type"] = "<mime-type of the file, e.g. application/pdf>"
     return {
         "status": "upload_required",
         "notebook_id": notebook_id,
+        # DEPRECATED (kept for backward compat): use human_upload.url instead.
         "url": url,
-        "expires_at": int(time.time()) + UPLOAD_TTL,
+        "expires_at": expires_at,
+        "expires_at_iso": expires_iso,
+        "expires_in_seconds": UPLOAD_TTL,
+        "mime_locked": mime_locked,
+        # Human/browser path, first-class so an agent that cannot upload the bytes
+        # itself reliably surfaces the link to the user (the mobile case).
+        "human_upload": {
+            "url": url,
+            "instructions": (
+                "Open this link in a browser on the device that has the file, then "
+                "pick the file to upload. Works on mobile (photo library / Files). "
+                f"Link expires in ~{approx_minutes} min."
+            ),
+        },
         # An agent holding the bytes skips the browser: POST them as the raw body here.
         "agent_upload": {
             "method": "POST",
             "url": f"{url}?filename=<basename>",
-            "headers": {
-                "Accept": "application/json",
-                "Content-Type": "<mime-type> (fallback only; ignored when mime_type was passed)",
-            },
+            "headers": agent_headers,
             "body": "the raw file bytes (not multipart/form-data)",
             "returns": '{"status": "added", "source_id": ...}',
             "example": (
-                'curl -X POST -H "Accept: application/json" --data-binary @report.pdf '
-                f'"{url}?filename=report.pdf"'
+                f'curl -X POST -H "Accept: application/json" {example_ct}'
+                f'--data-binary @report.pdf "{url}?filename=report.pdf"'
             ),
         },
+        # One authoritative rule instead of asking the agent to predict its own
+        # environment: attempt the machine path, fall back to the human path.
+        "agent_instructions": (
+            "If you hold the file bytes, try agent_upload first (POST the raw bytes). "
+            "If that fails with a network/egress error, surface human_upload.url to "
+            "the user and ask them to open it in a browser and upload the file."
+        ),
     }
 
 

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -594,7 +593,9 @@ def _broker_upload(
     if mime_type:
         payload["mime"] = mime_type
     url = cfg.upload_url(payload)
-    expires_at = int(time.time()) + UPLOAD_TTL
+    # Read the deadline back from the signed token so expires_at / _iso match the
+    # token's ``exp`` exactly, rather than recomputing now() a hair later (drift).
+    expires_at = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
     expires_iso = (
         datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
     )
@@ -620,6 +621,7 @@ def _broker_upload(
         "url": url,
         "expires_at": expires_at,
         "expires_at_iso": expires_iso,
+        # Nominal TTL at mint time — expires_at / expires_at_iso are the authoritative deadline.
         "expires_in_seconds": UPLOAD_TTL,
         "mime_locked": mime_locked,
         # Human/browser path, first-class so an agent that cannot upload the bytes

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -103,18 +103,38 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     assert sc["url"].startswith(f"{BASE}/files/ul/")
     assert sc["notebook_id"] == NB_ID
     assert isinstance(sc["expires_at"], int)
+    # Human-friendly expiry mirrors the unix timestamp (#1801).
+    assert sc["expires_in_seconds"] == 15 * 60
+    assert sc["expires_at_iso"].endswith("Z")
+    # ISO string round-trips to the same instant as the unix expires_at.
+    from datetime import datetime, timezone
+
+    parsed = datetime.fromisoformat(sc["expires_at_iso"].replace("Z", "+00:00"))
+    assert parsed == datetime.fromtimestamp(sc["expires_at"], tz=timezone.utc)
     # The signed token carries the title + mime (so the browser round-trip keeps them).
     token = sc["url"].rsplit("/", 1)[1]
     payload = config.signer.verify(token, op="ul")
     assert payload["title"] == "My Doc"
     assert payload["mime"] == "application/pdf"
+    # Human/browser path is first-class (a named object, not prose) so an agent that
+    # can't upload the bytes itself reliably surfaces it to the user (#1801).
+    human = sc["human_upload"]
+    assert human["url"] == sc["url"]
+    assert "browser" in human["instructions"]
+    # mime was supplied → the request Content-Type is ignored, so no Content-Type hint.
+    assert sc["mime_locked"] is True
     # The response self-documents the agent-direct path so an agent doesn't fall
     # back to the human "open in a browser" flow it can't perform.
     agent = sc["agent_upload"]
     assert agent["method"] == "POST"
     assert agent["headers"]["Accept"] == "application/json"
+    assert "Content-Type" not in agent["headers"]
+    # Locked → the example must NOT carry Content-Type either (server ignores it).
+    assert "Content-Type" not in agent["example"]
     assert agent["url"].startswith(sc["url"])
     assert sc["url"] in agent["example"]
+    # One authoritative try-then-fallback rule, not a per-environment prediction.
+    assert "human_upload.url" in sc["agent_instructions"]
 
 
 async def test_source_add_file_default_title_from_path_basename(mock_client, config) -> None:
@@ -125,8 +145,29 @@ async def test_source_add_file_default_title_from_path_basename(mock_client, con
         "source_add",
         {"notebook": NB_ID, "source_type": "file", "path": "/home/me/report.pdf"},
     )
-    token = result.structured_content["url"].rsplit("/", 1)[1]
+    sc = result.structured_content
+    token = sc["url"].rsplit("/", 1)[1]
     assert config.signer.verify(token, op="ul")["title"] == "report.pdf"
+    # No mime supplied → not locked, so the agent path exposes a Content-Type knob (#1801).
+    assert sc["mime_locked"] is False
+    assert "Content-Type" in sc["agent_upload"]["headers"]
+    # Unlocked → the copy-paste example must set Content-Type too (no server sniffing).
+    assert "Content-Type" in sc["agent_upload"]["example"]
+
+
+async def test_source_add_file_empty_mime_is_not_locked(mock_client, config) -> None:
+    # An empty mime_type is falsy, so it is NOT signed into the token — mime_locked
+    # must mirror that (bool, not `is not None`) or it would lie to the agent (#1801).
+    result = await _call(
+        mock_client,
+        config,
+        "source_add",
+        {"notebook": NB_ID, "source_type": "file", "title": "Doc", "mime_type": ""},
+    )
+    sc = result.structured_content
+    assert "mime" not in config.signer.verify(sc["url"].rsplit("/", 1)[1], op="ul")
+    assert sc["mime_locked"] is False
+    assert "Content-Type" in sc["agent_upload"]["headers"]
 
 
 async def test_source_add_file_http_without_config_is_not_configured_error(

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -107,8 +107,6 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     assert sc["expires_in_seconds"] == 15 * 60
     assert sc["expires_at_iso"].endswith("Z")
     # ISO string round-trips to the same instant as the unix expires_at.
-    from datetime import datetime, timezone
-
     parsed = datetime.fromisoformat(sc["expires_at_iso"].replace("Z", "+00:00"))
     assert parsed == datetime.fromtimestamp(sc["expires_at"], tz=timezone.utc)
     # The signed token carries the title + mime (so the browser round-trip keeps them).
@@ -121,6 +119,8 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     human = sc["human_upload"]
     assert human["url"] == sc["url"]
     assert "browser" in human["instructions"]
+    # The mobile case is what makes the human path first-class — lock it in (#1801).
+    assert "mobile" in human["instructions"]
     # mime was supplied → the request Content-Type is ignored, so no Content-Type hint.
     assert sc["mime_locked"] is True
     # The response self-documents the agent-direct path so an agent doesn't fall


### PR DESCRIPTION
## What & why

Closes #1801 (Layer 1 — the ergonomics half the issue marks "ships now").

Over the remote (http) MCP connector, `source_add(source_type="file")` returns `upload_required` with a signed URL. Today the only structured affordance is the agent POST recipe (`agent_upload`); the human/browser path — the one that actually works on **mobile** — exists only as prose. A network-boxed agent (blocked egress) that can't perform the upload is far less likely to reliably surface that link to the user when it isn't a named field. This restructures the payload so every consumer (CLI agent, browser-holding human, network-boxed agent) is served by condition-independent, self-describing fields.

## Changes to the `upload_required` payload

- **`human_upload` `{url, instructions}`** — the browser/mobile path is now a first-class named object, not prose. Single biggest lever for getting an agent to relay the link.
- **`agent_instructions`** — one authoritative try-then-fallback rule (attempt `agent_upload`, fall back to `human_upload.url` on a network/egress error) instead of asking the agent to predict its own environment.
- **`mime_locked` (bool)** — replaces the confusing *"Content-Type … ignored when mime_type was passed"* header prose. Mirrors the exact `if mime_type` gate that signs the token (via `bool()`, **not** `is not None`) so it can't claim locked while the token carried no mime (e.g. `mime_type == ""`). The `Content-Type` hint — in **both** `agent_upload.headers` and the curl `example` — appears only when **unlocked** (the server does no extension sniffing, so an agent copying the example must set it).
- **`expires_at_iso` / `expires_in_seconds`** beside the existing unix `expires_at`, so a relayed message can say "expires in ~15 min" instead of echoing a raw timestamp.
- **Top-level `url`** retained (`== human_upload.url`) but marked **deprecated**. `expires_at` stays backward-compatible. **Note:** `agent_upload.headers` *does* change shape — the `Content-Type` key is absent when `mime_locked` is true (the flag replaces that placeholder as the mime signal). Fresh v0.8.0a1 surface, no released consumer.

Verified `mime_locked` semantics against the server: `_fileroutes.py` `upload_route` resolves `payload.get("mime") or request.headers.get("content-type")` — signed-token mime wins, request `Content-Type` is fallback-only, so `mime_locked=true` correctly means "your Content-Type is ignored".

## Tests

`tests/unit/mcp/test_file_tools.py`: asserts the new fields (locked + unlocked shapes), an empty-`mime_type` regression (the `bool()` vs `is not None` fix), the example-mirrors-lock behavior, and an `expires_at_iso` ↔ `expires_at` round-trip.

## Out of scope — follow-up

Layer 2 (a channel byte-upload, e.g. optional `bytes_base64` on `source_add`, for the true dead-zone where bytes live only on a network-boxed agent's disk) is larger and tracked separately.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy src/notebooklm` clean (302 files)
- `tests/unit/mcp` — 753 passed; ADR-0025 schema-char budget passes (docstring trimmed to stay under the ceiling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB8mwAvNpxq228pSLp5QaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote file upload responses with more precise expiry metadata (ISO timestamps and remaining time) and consistent upload details.
  * Refined upload instructions to support both human- and agent-facing flows, including improved fallback wording.
  * Enhanced file type handling so upload headers and example requests adapt based on whether a MIME type is locked.
* **Tests**
  * Expanded unit coverage to validate expiry fields, token metadata, and conditional header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->