### PR TITLE
feat(mcp): source_upload_bytes — in-channel small-file upload for the network-boxed-agent dead-zone (closes #1803)

### DIFF
--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -26,7 +26,12 @@ MCP itself offers no help here:
 
 - **No upload affordance.** claude.ai does not stream a user-selected local file
   into a tool call. Tool arguments are JSON; base64-in-a-string has no client UI,
-  is not wired to chat-attached files, and dies on request-size limits.
+  is not wired to chat-attached files, and dies on request-size limits. (#1803 later
+  added `source_upload_bytes` for the narrow case where an agent already *holds* the
+  bytes and neither the browser nor the `agent_upload` POST can move them: it passes
+  ≤10,000 chars of base64 in-channel — ≈7 KB — and the connector adds it server-side.
+  The request-size limit is exactly why that cap is so small; anything larger still
+  takes the signed-URL flow this ADR defines.)
 - **No usable download affordance.** A tool *result* can carry base64
   image/audio/`EmbeddedResource`, but a podcast/video is tens of MB; base64'd
   through JSON-RPC it blows the channel and claude.ai will not materialize it as a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1191,12 +1191,13 @@ src/notebooklm/
 │   └── tools/                   # Per-domain tool modules; each exposes register(mcp) wired by server.register_all
 │       ├── __init__.py          # Tools package marker (no click/rich/cli)
 │       ├── _content_sanity.py   # _annotate_thin_warnings/_thin_content_warning — advisory thin/soft-404 web-page warning over _app.source_content (used by source_wait + source_add batch)
+│       ├── _fileupload.py       # file-transfer slice of the source tools: _broker_upload (signed-URL upload_required) + _decode_upload_b64/_add_bytes (in-channel base64 byte upload for source_upload_bytes) + the shared _add_one plan/execute seam (split from sources.py for the ADR-0008 size budget)
 │       ├── _passthrough.py      # Shared pass-through resolvers (passthrough_notebook_id/passthrough_child_id) for the CLI-shaped _app executors
 │       ├── _preview.py          # title_for_id() — shared id→title lookup for the delete tools' needs_confirmation previews
 │       ├── _studio_items.py     # cross-type Studio plumbing: studio_items (merge notes+artifacts into one items list) + resolve_studio_item (cross-type ref → StudioResolvedItem) for studio_list/studio_rename/studio_delete (split from studio.py for the ADR-0008 size budget)
 │       ├── _studio_download.py  # download plumbing shared by studio.py + _fileroutes.py: _DOWNLOAD_SPECS registry (rebuilt from _app.download) + DownloadType + _resolve_artifact_id / _broker_download / _is_http_transport / _passthrough_download_notebook (split from studio.py for the ADR-0008 size budget)
 │       ├── notebooks.py         # notebook_list/create/describe/rename/delete over _app.notebooks
-│       ├── sources.py           # source_list/read/rename/delete/wait/add over _app.source_* (add: url/text/file/youtube via source_add, drive via source_mutations)
+│       ├── sources.py           # source_list/read/rename/delete/wait/add over _app.source_* (add: url/text/file/youtube via source_add, drive via source_mutations) + source_upload_bytes (in-channel small-file byte upload via _fileupload)
 │       ├── chat.py              # chat_ask (client.chat.ask + get_history recall + suggest_followups) + chat_configure (_app.chat.execute_configure) + suggest_prompts (client.notebooks.suggest_prompts surface selector)
 │       ├── notes.py             # note_save (create-or-update upsert) over _app.notes; note reading/renaming/deleting fold into the cross-type Studio tools
 │       ├── studio.py            # hosts the Studio tools: studio_list (merges notes+artifacts via _studio_items.studio_items) / generate / status / download (via _studio_download) / rename / retry / get_prompt / studio_delete — both rename and delete are cross-type via _studio_items.resolve_studio_item (note→_app.notes.execute_note_rename/execute_note_delete, artifact→_app.artifacts kind-aware core); enum dispatch over _app.generate + _app.download; stateless poll via _app.artifacts.poll_artifact

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -127,12 +127,13 @@ full-account credential. Multi-tenant hosting is out of scope for this single-te
 
 ### File upload & download (remote)
 
-The MCP/JSON-RPC channel can't carry binaries, so over a remote connector
+The MCP/JSON-RPC channel can't carry large binaries, so over a remote connector
 `source_add type=file` and `studio_download` broker a **short-lived signed URL**
 served by the same container; your browser does the byte transfer (see
 [ADR-0024](adr/0024-mcp-remote-file-transfer.md)). This is the standard pattern for
 remote MCP file transfer — MCP has no native file-upload primitive, and its native
-download (binary Resources) is capped far below a podcast/video.
+download (binary Resources) is capped far below a podcast/video. (A **small** file
+can skip the signed URL entirely — see `source_upload_bytes` below.)
 
 **Enable it:** set `NOTEBOOKLM_MCP_PUBLIC_URL` to your bare public origin (the same
 host as the tunnel, no `/mcp`). It falls back to `NOTEBOOKLM_MCP_OAUTH_BASE_URL`, so
@@ -145,6 +146,13 @@ bearer-only deploy → the two file tools return a clear "not configured" error
   also `PUT` a file it already holds to that link from its **code-execution sandbox** —
   but that requires Code Execution enabled **and your server domain whitelisted** in
   claude.ai Settings → Capabilities → additional allowed domains, or the `PUT` fails.)
+- **Hand a small file's bytes in-channel (no signed URL):** when an agent holds the
+  bytes but can complete *neither* upload path — e.g. its egress is blocked, so the
+  `agent_upload` POST fails, and no human device has the file — `source_upload_bytes`
+  takes the file as base64 (≤ 10,000 chars, ≈ 7 KB) and the connector adds it
+  server-side, returning the source directly. It works on any transport and needs no
+  `NOTEBOOKLM_MCP_PUBLIC_URL`; a larger file must use the `source_add type=file`
+  signed-URL flow above.
 - **Download an artifact:** `studio_download` returns a `download_ready` link (a
   clickable `resource_link`); open it to stream the podcast/video/PDF to your device.
 - Links are HMAC-signed and short-lived (upload 15 min, download 30 min) and expire on

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -1,0 +1,249 @@
+"""File-transfer helpers for the source MCP tools.
+
+Split out of :mod:`.sources` to keep that module under the ADR-0008 size budget:
+this is the file-specific slice of ``source_add`` / ``source_upload_bytes`` — the
+signed-URL broker (:func:`_broker_upload`), the in-channel base64 decode
+(:func:`_decode_upload_b64`) + byte-spool (:func:`_add_bytes`), and the shared
+plan-build/execute seam (:func:`_add_one`) they and the URL/text/batch paths reuse.
+
+Imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from ..._app import source_add as add_core
+from ...exceptions import ValidationError
+from .._filelink import UPLOAD_TTL, FileTransferConfig
+
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
+    from ...types import Source
+
+#: Cap on ``source_upload_bytes``' base64 payload — measured on the base64 STRING
+#: (what rides in the MCP message), NOT the decoded size. 10,000 chars ≈ 7.3 KiB of
+#: real file (base64 inflates ~4/3). Chosen so the whole ``tools/call`` request
+#: (~1.36× the file, envelope included) stays well under the ~13–16 KiB argument
+#: ceiling MCP clients enforce before transit (claude-code#55923); a bigger file
+#: must take the signed-URL flow (``source_add(source_type="file")`` →
+#: ``upload_required``), which caps at 200 MiB.
+_MAX_UPLOAD_B64_CHARS = 10_000
+
+
+def _upload_too_large(n_chars: int) -> ValidationError:
+    """Build the over-cap rejection, naming the signed-URL fallback to take instead."""
+    return ValidationError(
+        f"bytes_base64 is {n_chars} chars; the in-channel cap is {_MAX_UPLOAD_B64_CHARS} "
+        "(~7 KB of file). For a larger file call source_add(source_type='file') to get "
+        "an upload_required signed URL."
+    )
+
+
+def _decode_upload_b64(bytes_base64: str) -> bytes:
+    """Validate + decode a base64 upload payload from the MCP channel.
+
+    Fail-fast, whitespace-tolerant, then strict — in that order:
+
+    * a fast length pre-check rejects a grossly oversized payload BEFORE the O(n)
+      whitespace strip allocates. The ~10% headroom tolerates line-wrapping
+      whitespace (76-col base64 adds ~1.3% newlines) without over-allocating;
+    * whitespace is stripped so wrapped / MIME base64 decodes, then the CLEANED
+      length is checked against the cap — so wrapping can neither smuggle bytes
+      past the cap NOR get a valid near-cap payload rejected for its newlines;
+    * ``validate=True`` rejects non-alphabet garbage; an empty decode is rejected.
+
+    The cap is on the base64 STRING (what rides in the MCP message), not the decoded
+    byte count — see :data:`_MAX_UPLOAD_B64_CHARS`. Raises :class:`ValidationError`.
+    """
+    if len(bytes_base64) > _MAX_UPLOAD_B64_CHARS + _MAX_UPLOAD_B64_CHARS // 10:
+        raise _upload_too_large(len(bytes_base64))
+    cleaned = "".join(bytes_base64.split())
+    if len(cleaned) > _MAX_UPLOAD_B64_CHARS:
+        raise _upload_too_large(len(cleaned))
+    try:
+        raw = base64.b64decode(cleaned, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValidationError("bytes_base64 is not valid base64") from exc
+    if not raw:
+        raise ValidationError("bytes_base64 decoded to no bytes (empty file)")
+    return raw
+
+
+def _broker_upload(
+    cfg: FileTransferConfig,
+    notebook_id: str,
+    *,
+    title: str | None,
+    mime_type: str | None,
+    path: str | None,
+) -> dict[str, Any]:
+    """Mint a signed upload URL for a remote ``source_add type=file``.
+
+    The agent-supplied ``title`` / ``mime_type`` ride in the signed token (so they
+    survive the browser round-trip and cannot be tampered with). When ``title`` is
+    unset, the supplied ``path``'s basename seeds the default. The signer injects
+    expiry; ``expires_at`` mirrors the upload TTL for the caller.
+
+    Returns the ``upload_required`` payload (#1801): two first-class actor paths —
+    ``human_upload`` (browser/mobile) and ``agent_upload`` (raw-body POST) — plus an
+    ``agent_instructions`` try-then-fallback rule, a ``mime_locked`` flag (true only
+    when a mime was signed, so the request ``Content-Type`` is ignored), and
+    ``expires_at_iso`` / ``expires_in_seconds`` beside the unix ``expires_at``. The
+    top-level ``url`` is retained but deprecated in favor of ``human_upload.url``.
+    """
+    default_title = title
+    if not default_title and path:
+        # The agent's path may be Windows-style (``C:\\Users\\me\\report.pdf``) even
+        # though this server runs on Linux, where ``os.path.basename`` won't split on
+        # ``\\`` — normalize first so the default title is the real leaf.
+        default_title = os.path.basename(path.replace("\\", "/")) or None
+    payload: dict[str, Any] = {"nb": notebook_id}  # op stamped by upload_url
+    if default_title:
+        payload["title"] = default_title
+    if mime_type:
+        payload["mime"] = mime_type
+    url = cfg.upload_url(payload)
+    # Read the deadline back from the signed token so expires_at / _iso match the
+    # token's ``exp`` exactly, rather than recomputing now() a hair later (drift).
+    expires_at = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
+    expires_iso = (
+        datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    approx_minutes = UPLOAD_TTL // 60
+    # The signed token's mime wins server-side; a request Content-Type is honored
+    # ONLY when no mime was signed (see _fileroutes upload_route). So expose
+    # Content-Type as an agent knob only in the unlocked case, and flag the locked
+    # case with ``mime_locked`` instead of the old confusing header prose. Mirror the
+    # exact truthiness that gates signing ``mime`` above (``if mime_type``) so the
+    # flag can't claim locked while the token carried no mime (e.g. mime_type == "").
+    mime_locked = bool(mime_type)
+    agent_headers: dict[str, str] = {"Accept": "application/json"}
+    # When unlocked, the request Content-Type is the ONLY mime signal (no
+    # extension sniffing server-side), so the example must set it too — an agent
+    # is as likely to copy the curl example as to read ``headers``.
+    example_ct = "" if mime_locked else '-H "Content-Type: application/pdf" '
+    if not mime_locked:
+        agent_headers["Content-Type"] = "<mime-type of the file, e.g. application/pdf>"
+    return {
+        "status": "upload_required",
+        "notebook_id": notebook_id,
+        # DEPRECATED (kept for backward compat): use human_upload.url instead.
+        "url": url,
+        "expires_at": expires_at,
+        "expires_at_iso": expires_iso,
+        # Nominal TTL at mint time — expires_at / expires_at_iso are the authoritative deadline.
+        "expires_in_seconds": UPLOAD_TTL,
+        "mime_locked": mime_locked,
+        # Human/browser path, first-class so an agent that cannot upload the bytes
+        # itself reliably surfaces the link to the user (the mobile case).
+        "human_upload": {
+            "url": url,
+            "instructions": (
+                "Open this link in a browser on the device that has the file, then "
+                "pick the file to upload. Works on mobile (photo library / Files). "
+                f"Link expires in ~{approx_minutes} min."
+            ),
+        },
+        # An agent holding the bytes skips the browser: POST them as the raw body here.
+        "agent_upload": {
+            "method": "POST",
+            "url": f"{url}?filename=<basename>",
+            "headers": agent_headers,
+            "body": "the raw file bytes (not multipart/form-data)",
+            "returns": '{"status": "added", "source_id": ...}',
+            "example": (
+                f'curl -X POST -H "Accept: application/json" {example_ct}'
+                f'--data-binary @report.pdf "{url}?filename=report.pdf"'
+            ),
+        },
+        # One authoritative rule instead of asking the agent to predict its own
+        # environment: attempt the machine path, fall back to the human path.
+        "agent_instructions": (
+            "If you hold the file bytes, try agent_upload first (POST the raw bytes). "
+            "If that fails with a network/egress error, surface human_upload.url to "
+            "the user and ask them to open it in a browser and upload the file."
+        ),
+    }
+
+
+async def _add_bytes(
+    client: NotebookLMClient,
+    notebook_id: str,
+    raw: bytes,
+    *,
+    filename: str | None,
+    title: str | None,
+    mime_type: str | None,
+) -> Source:
+    """Spool decoded in-channel bytes to a private temp file, then add it as a file source.
+
+    The neutral add path (:func:`_add_one` → ``build_source_add_plan`` +
+    ``execute_source_add``) only accepts a filesystem path, so the bytes are written
+    to a ``0600`` file under a ``0700`` ``mkdtemp`` dir — the same spool-then-add
+    shape the ``/files/ul`` upload route uses, minus the signed-token / single-use /
+    concurrency machinery that guards that PUBLIC internet-facing route (this path is
+    already authenticated by the MCP session, so none of it applies). ``filename`` is
+    sanitized to a safe basename (traversal / control-char / empty defenses shared
+    with the upload route via ``safe_upload_name``). The temp tree is always removed —
+    on success, a rejected add, or an error.
+    """
+    safe = add_core.safe_upload_name(filename)
+    temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ulb-")
+    try:
+        temp_path = os.path.join(temp_dir, safe)
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as out:
+            out.write(raw)
+        return await _add_one(
+            client,
+            notebook_id,
+            os.path.realpath(temp_path),
+            source_type="file",
+            title=title,
+            mime_type=mime_type,
+            allow_internal=False,
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+async def _add_one(
+    client: NotebookLMClient,
+    notebook_id: str,
+    content: str,
+    *,
+    source_type: add_core.SourceAddType,
+    title: str | None,
+    mime_type: str | None,
+    allow_internal: bool,
+) -> Source:
+    """Build the source-add plan + execute it, returning the created ``Source``.
+
+    The single seam shared by single-mode and batch-mode ``source_add`` (and the
+    point #1679 layers add-time failure-signaling onto). Callers do their own
+    presence / host validation BEFORE reaching here — single mode via
+    ``_select_content`` (which keeps the YouTube-host guard), batch mode via
+    the explicit ``source_type="url"`` that forces :func:`add_core.validate_url`.
+    """
+    plan = add_core.build_source_add_plan(
+        content=content,
+        source_type=source_type,
+        title=title,
+        mime_type=mime_type,
+        follow_symlinks=False,
+        validate_path=add_core.validate_upload_path,
+        looks_path_shaped=add_core.looks_like_path,
+        allow_internal=allow_internal,
+    )
+    result = await add_core.execute_source_add(
+        client,
+        add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan),
+    )
+    return result.source

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -19,7 +19,11 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import os
+import shutil
+import tempfile
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -66,6 +70,15 @@ _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
 #: The default Drive MIME choice when the caller does not specify one.
 _DEFAULT_DRIVE_MIME = "google-doc"
+
+#: Cap on ``source_upload_bytes``' base64 payload — measured on the base64 STRING
+#: (what rides in the MCP message), NOT the decoded size. 10,000 chars ≈ 7.3 KiB of
+#: real file (base64 inflates ~4/3). Chosen so the whole ``tools/call`` request
+#: (~1.36× the file, envelope included) stays well under the ~13–16 KiB argument
+#: ceiling MCP clients enforce before transit (claude-code#55923); a bigger file
+#: must take the signed-URL flow (``source_add(source_type="file")`` →
+#: ``upload_required``), which caps at 200 MiB.
+_MAX_UPLOAD_B64_CHARS = 10_000
 
 
 # ``_source_view`` (Source → dict with string ``kind`` / ``status_label`` labels)
@@ -543,6 +556,63 @@ def register(mcp: Any) -> None:
             )
             return _add_result_payload(src, to_jsonable(add_core.SourceAddResult(source=src)))
 
+    @mcp.tool
+    async def source_upload_bytes(
+        ctx: Context,
+        notebook: str,
+        bytes_base64: str,
+        filename: str | None = None,
+        mime_type: str | None = None,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        """Add a SMALL file to a notebook from raw bytes, in-channel. Accepts a notebook name or ID.
+
+        For when an agent HOLDS the file bytes but cannot complete the signed-URL
+        upload — e.g. over the remote (http) connector with egress blocked, the
+        ``upload_required`` ``agent_upload`` POST fails and no human device has the
+        file. Pass the bytes as base64; the connector decodes and adds them
+        server-side, returning the created source directly — no signed URL, no
+        browser hop. Works on any transport and needs no file-transfer config.
+
+        SMALL FILES ONLY: ``bytes_base64`` must be ≤ 10,000 characters (≈ 7 KB of
+        file; base64 inflates ~33%). A larger payload exceeds the MCP message limit
+        and is rejected — use ``source_add(source_type="file")`` instead, whose
+        ``upload_required`` signed URL carries large files (≤ 200 MiB) via the
+        browser or a raw-body agent POST.
+
+        ``filename`` seeds the default title and extension (sanitized to a basename);
+        ``mime_type`` / ``title`` are optional. The added source is echoed under
+        ``source`` with ``kind`` / ``status_label`` labels, exactly like
+        ``source_add`` (imports are async — confirm with ``source_wait`` /
+        ``source_list(status="error")``).
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            # Cheapest-first, all BEFORE any notebook I/O: an over-cap or malformed
+            # payload never pays a round-trip. The cap is on the base64 STRING (what
+            # rides in the MCP message), not the decoded byte count — see
+            # _MAX_UPLOAD_B64_CHARS.
+            if len(bytes_base64) > _MAX_UPLOAD_B64_CHARS:
+                raise ValidationError(
+                    f"bytes_base64 is {len(bytes_base64)} chars; the in-channel cap is "
+                    f"{_MAX_UPLOAD_B64_CHARS} (~7 KB of file). For a larger file call "
+                    "source_add(source_type='file') to get an upload_required signed URL."
+                )
+            # Tolerate wrapped/whitespaced base64 (some encoders emit 76-char lines)
+            # but reject genuine garbage: strip ASCII whitespace, then decode strictly.
+            try:
+                raw = base64.b64decode("".join(bytes_base64.split()), validate=True)
+            except (binascii.Error, ValueError) as exc:
+                raise ValidationError("bytes_base64 is not valid base64") from exc
+            if not raw:
+                raise ValidationError("bytes_base64 decoded to no bytes (empty file)")
+
+            nb_id = await resolve_notebook(client, notebook)
+            src = await _add_bytes(
+                client, nb_id, raw, filename=filename, title=title, mime_type=mime_type
+            )
+            return _add_result_payload(src, to_jsonable(add_core.SourceAddResult(source=src)))
+
 
 def _is_http_transport() -> bool:
     """Whether the current tool call arrived over the http transport.
@@ -654,6 +724,47 @@ def _broker_upload(
             "the user and ask them to open it in a browser and upload the file."
         ),
     }
+
+
+async def _add_bytes(
+    client: NotebookLMClient,
+    notebook_id: str,
+    raw: bytes,
+    *,
+    filename: str | None,
+    title: str | None,
+    mime_type: str | None,
+) -> Source:
+    """Spool decoded in-channel bytes to a private temp file, then add it as a file source.
+
+    The neutral add path (:func:`_add_one` → ``build_source_add_plan`` +
+    ``execute_source_add``) only accepts a filesystem path, so the bytes are written
+    to a ``0600`` file under a ``0700`` ``mkdtemp`` dir — the same spool-then-add
+    shape the ``/files/ul`` upload route uses, minus the signed-token / single-use /
+    concurrency machinery that guards that PUBLIC internet-facing route (this path is
+    already authenticated by the MCP session, so none of it applies). ``filename`` is
+    sanitized to a safe basename (traversal / control-char / empty defenses shared
+    with the upload route via ``safe_upload_name``). The temp tree is always removed —
+    on success, a rejected add, or an error.
+    """
+    safe = add_core.safe_upload_name(filename)
+    temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ulb-")
+    try:
+        temp_path = os.path.join(temp_dir, safe)
+        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "wb") as out:
+            out.write(raw)
+        return await _add_one(
+            client,
+            notebook_id,
+            os.path.realpath(temp_path),
+            source_type="file",
+            title=title,
+            mime_type=mime_type,
+            allow_internal=False,
+        )
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 async def _add_one(

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -560,10 +560,10 @@ def register(mcp: Any) -> None:
         browser hop. Works on any transport and needs no file-transfer config.
 
         SMALL FILES ONLY: ``bytes_base64`` must be ≤ 10,000 characters (≈ 7 KB of
-        file; base64 inflates ~33%). A larger payload exceeds the MCP message limit
-        and is rejected — use ``source_add(source_type="file")`` instead, whose
-        ``upload_required`` signed URL carries large files (≤ 200 MiB) via the
-        browser or a raw-body agent POST.
+        file). A larger payload exceeds the MCP message limit and is rejected — use
+        ``source_add(source_type="file")`` instead, whose ``upload_required`` signed
+        URL carries large files (≤ 200 MiB) via the browser or a raw-body agent POST.
+        Standard base64 only, not URL-safe (``-``/``_``).
 
         ``filename`` seeds the default title and extension (sanitized to a basename);
         ``mime_type`` / ``title`` are optional. The added source is echoed under

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -19,12 +19,6 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 from __future__ import annotations
 
 import asyncio
-import base64
-import binascii
-import os
-import shutil
-import tempfile
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from fastmcp import Context
@@ -50,10 +44,10 @@ from .._coerce import coerce_list
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
 from .._errors import mcp_errors, tool_error_payload
-from .._filelink import UPLOAD_TTL, FileTransferConfig
 from .._paginate import DEFAULT_LIMIT, paginate
 from .._resolve import resolve_notebook, resolve_source, resolve_sources
 from ._content_sanity import _annotate_thin_warnings
+from ._fileupload import _add_bytes, _add_one, _broker_upload, _decode_upload_b64
 from ._passthrough import passthrough_child_id
 from ._preview import title_for_id
 
@@ -70,15 +64,6 @@ _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
 #: The default Drive MIME choice when the caller does not specify one.
 _DEFAULT_DRIVE_MIME = "google-doc"
-
-#: Cap on ``source_upload_bytes``' base64 payload — measured on the base64 STRING
-#: (what rides in the MCP message), NOT the decoded size. 10,000 chars ≈ 7.3 KiB of
-#: real file (base64 inflates ~4/3). Chosen so the whole ``tools/call`` request
-#: (~1.36× the file, envelope included) stays well under the ~13–16 KiB argument
-#: ceiling MCP clients enforce before transit (claude-code#55923); a bigger file
-#: must take the signed-URL flow (``source_add(source_type="file")`` →
-#: ``upload_required``), which caps at 200 MiB.
-_MAX_UPLOAD_B64_CHARS = 10_000
 
 
 # ``_source_view`` (Source → dict with string ``kind`` / ``status_label`` labels)
@@ -588,25 +573,9 @@ def register(mcp: Any) -> None:
         """
         client = get_client(ctx)
         with mcp_errors():
-            # Cheapest-first, all BEFORE any notebook I/O: an over-cap or malformed
-            # payload never pays a round-trip. The cap is on the base64 STRING (what
-            # rides in the MCP message), not the decoded byte count — see
-            # _MAX_UPLOAD_B64_CHARS.
-            if len(bytes_base64) > _MAX_UPLOAD_B64_CHARS:
-                raise ValidationError(
-                    f"bytes_base64 is {len(bytes_base64)} chars; the in-channel cap is "
-                    f"{_MAX_UPLOAD_B64_CHARS} (~7 KB of file). For a larger file call "
-                    "source_add(source_type='file') to get an upload_required signed URL."
-                )
-            # Tolerate wrapped/whitespaced base64 (some encoders emit 76-char lines)
-            # but reject genuine garbage: strip ASCII whitespace, then decode strictly.
-            try:
-                raw = base64.b64decode("".join(bytes_base64.split()), validate=True)
-            except (binascii.Error, ValueError) as exc:
-                raise ValidationError("bytes_base64 is not valid base64") from exc
-            if not raw:
-                raise ValidationError("bytes_base64 decoded to no bytes (empty file)")
-
+            # Decode + cap + empty guard run BEFORE any notebook I/O, so an over-cap or
+            # malformed payload never pays a round-trip (see _decode_upload_b64).
+            raw = _decode_upload_b64(bytes_base64)
             nb_id = await resolve_notebook(client, notebook)
             src = await _add_bytes(
                 client, nb_id, raw, filename=filename, title=title, mime_type=mime_type
@@ -627,179 +596,6 @@ def _is_http_transport() -> bool:
     except RuntimeError:
         return False
     return True
-
-
-def _broker_upload(
-    cfg: FileTransferConfig,
-    notebook_id: str,
-    *,
-    title: str | None,
-    mime_type: str | None,
-    path: str | None,
-) -> dict[str, Any]:
-    """Mint a signed upload URL for a remote ``source_add type=file``.
-
-    The agent-supplied ``title`` / ``mime_type`` ride in the signed token (so they
-    survive the browser round-trip and cannot be tampered with). When ``title`` is
-    unset, the supplied ``path``'s basename seeds the default. The signer injects
-    expiry; ``expires_at`` mirrors the upload TTL for the caller.
-
-    Returns the ``upload_required`` payload (#1801): two first-class actor paths —
-    ``human_upload`` (browser/mobile) and ``agent_upload`` (raw-body POST) — plus an
-    ``agent_instructions`` try-then-fallback rule, a ``mime_locked`` flag (true only
-    when a mime was signed, so the request ``Content-Type`` is ignored), and
-    ``expires_at_iso`` / ``expires_in_seconds`` beside the unix ``expires_at``. The
-    top-level ``url`` is retained but deprecated in favor of ``human_upload.url``.
-    """
-    default_title = title
-    if not default_title and path:
-        # The agent's path may be Windows-style (``C:\\Users\\me\\report.pdf``) even
-        # though this server runs on Linux, where ``os.path.basename`` won't split on
-        # ``\\`` — normalize first so the default title is the real leaf.
-        default_title = os.path.basename(path.replace("\\", "/")) or None
-    payload: dict[str, Any] = {"nb": notebook_id}  # op stamped by upload_url
-    if default_title:
-        payload["title"] = default_title
-    if mime_type:
-        payload["mime"] = mime_type
-    url = cfg.upload_url(payload)
-    # Read the deadline back from the signed token so expires_at / _iso match the
-    # token's ``exp`` exactly, rather than recomputing now() a hair later (drift).
-    expires_at = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
-    expires_iso = (
-        datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
-    )
-    approx_minutes = UPLOAD_TTL // 60
-    # The signed token's mime wins server-side; a request Content-Type is honored
-    # ONLY when no mime was signed (see _fileroutes upload_route). So expose
-    # Content-Type as an agent knob only in the unlocked case, and flag the locked
-    # case with ``mime_locked`` instead of the old confusing header prose. Mirror the
-    # exact truthiness that gates signing ``mime`` above (``if mime_type``) so the
-    # flag can't claim locked while the token carried no mime (e.g. mime_type == "").
-    mime_locked = bool(mime_type)
-    agent_headers: dict[str, str] = {"Accept": "application/json"}
-    # When unlocked, the request Content-Type is the ONLY mime signal (no
-    # extension sniffing server-side), so the example must set it too — an agent
-    # is as likely to copy the curl example as to read ``headers``.
-    example_ct = "" if mime_locked else '-H "Content-Type: application/pdf" '
-    if not mime_locked:
-        agent_headers["Content-Type"] = "<mime-type of the file, e.g. application/pdf>"
-    return {
-        "status": "upload_required",
-        "notebook_id": notebook_id,
-        # DEPRECATED (kept for backward compat): use human_upload.url instead.
-        "url": url,
-        "expires_at": expires_at,
-        "expires_at_iso": expires_iso,
-        # Nominal TTL at mint time — expires_at / expires_at_iso are the authoritative deadline.
-        "expires_in_seconds": UPLOAD_TTL,
-        "mime_locked": mime_locked,
-        # Human/browser path, first-class so an agent that cannot upload the bytes
-        # itself reliably surfaces the link to the user (the mobile case).
-        "human_upload": {
-            "url": url,
-            "instructions": (
-                "Open this link in a browser on the device that has the file, then "
-                "pick the file to upload. Works on mobile (photo library / Files). "
-                f"Link expires in ~{approx_minutes} min."
-            ),
-        },
-        # An agent holding the bytes skips the browser: POST them as the raw body here.
-        "agent_upload": {
-            "method": "POST",
-            "url": f"{url}?filename=<basename>",
-            "headers": agent_headers,
-            "body": "the raw file bytes (not multipart/form-data)",
-            "returns": '{"status": "added", "source_id": ...}',
-            "example": (
-                f'curl -X POST -H "Accept: application/json" {example_ct}'
-                f'--data-binary @report.pdf "{url}?filename=report.pdf"'
-            ),
-        },
-        # One authoritative rule instead of asking the agent to predict its own
-        # environment: attempt the machine path, fall back to the human path.
-        "agent_instructions": (
-            "If you hold the file bytes, try agent_upload first (POST the raw bytes). "
-            "If that fails with a network/egress error, surface human_upload.url to "
-            "the user and ask them to open it in a browser and upload the file."
-        ),
-    }
-
-
-async def _add_bytes(
-    client: NotebookLMClient,
-    notebook_id: str,
-    raw: bytes,
-    *,
-    filename: str | None,
-    title: str | None,
-    mime_type: str | None,
-) -> Source:
-    """Spool decoded in-channel bytes to a private temp file, then add it as a file source.
-
-    The neutral add path (:func:`_add_one` → ``build_source_add_plan`` +
-    ``execute_source_add``) only accepts a filesystem path, so the bytes are written
-    to a ``0600`` file under a ``0700`` ``mkdtemp`` dir — the same spool-then-add
-    shape the ``/files/ul`` upload route uses, minus the signed-token / single-use /
-    concurrency machinery that guards that PUBLIC internet-facing route (this path is
-    already authenticated by the MCP session, so none of it applies). ``filename`` is
-    sanitized to a safe basename (traversal / control-char / empty defenses shared
-    with the upload route via ``safe_upload_name``). The temp tree is always removed —
-    on success, a rejected add, or an error.
-    """
-    safe = add_core.safe_upload_name(filename)
-    temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ulb-")
-    try:
-        temp_path = os.path.join(temp_dir, safe)
-        fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        with os.fdopen(fd, "wb") as out:
-            out.write(raw)
-        return await _add_one(
-            client,
-            notebook_id,
-            os.path.realpath(temp_path),
-            source_type="file",
-            title=title,
-            mime_type=mime_type,
-            allow_internal=False,
-        )
-    finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-
-
-async def _add_one(
-    client: NotebookLMClient,
-    notebook_id: str,
-    content: str,
-    *,
-    source_type: add_core.SourceAddType,
-    title: str | None,
-    mime_type: str | None,
-    allow_internal: bool,
-) -> Source:
-    """Build the source-add plan + execute it, returning the created ``Source``.
-
-    The single seam shared by single-mode and batch-mode ``source_add`` (and the
-    point #1679 layers add-time failure-signaling onto). Callers do their own
-    presence / host validation BEFORE reaching here — single mode via
-    :func:`_select_content` (which keeps the YouTube-host guard), batch mode via
-    the explicit ``source_type="url"`` that forces :func:`add_core.validate_url`.
-    """
-    plan = add_core.build_source_add_plan(
-        content=content,
-        source_type=source_type,
-        title=title,
-        mime_type=mime_type,
-        follow_symlinks=False,
-        validate_path=add_core.validate_upload_path,
-        looks_path_shaped=add_core.looks_like_path,
-        allow_internal=allow_internal,
-    )
-    result = await add_core.execute_source_add(
-        client,
-        add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan),
-    )
-    return result.source
 
 
 def _reject_batch_scalars(

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone  # noqa: E402 - after importorskip guard
 from fastmcp import Client  # noqa: E402 - after importorskip guard
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
+import notebooklm.mcp.tools._fileupload as fileupload_mod  # noqa: E402 - after importorskip guard
 import notebooklm.mcp.tools._studio_download as art_mod  # noqa: E402 - after importorskip guard
 import notebooklm.mcp.tools.sources as src_mod  # noqa: E402 - after importorskip guard
 from notebooklm._types.artifacts import (  # noqa: E402 - after importorskip guard
@@ -340,11 +341,38 @@ async def test_source_upload_bytes_tolerates_wrapped_base64(mock_client) -> None
     assert seen["bytes"] == raw
 
 
+async def test_source_upload_bytes_accepts_wrapped_base64_near_cap(mock_client) -> None:
+    # Regression: the cap is applied to the WHITESPACE-STRIPPED base64, not the raw
+    # string. A valid wrapped payload whose raw length (incl. newlines) exceeds the
+    # cap but whose cleaned length is within it must be ACCEPTED — an earlier draft
+    # checked the raw length and wrongly rejected near-cap wrapped payloads.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        with open(path, "rb") as fh:
+            seen["bytes"] = fh.read()
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    raw = os.urandom(7425)  # -> 9900 base64 chars (divisible by 3, no padding)
+    wrapped = "\n".join(textwrap.wrap(base64.b64encode(raw).decode(), 76))
+    cap = fileupload_mod._MAX_UPLOAD_B64_CHARS
+    assert len(wrapped) > cap  # raw (with newlines) exceeds the cap ...
+    assert len("".join(wrapped.split())) <= cap  # ... but the cleaned base64 is within it
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {"notebook": NB_ID, "bytes_base64": wrapped, "filename": "b.bin"},
+    )
+    assert seen["bytes"] == raw
+
+
 async def test_source_upload_bytes_rejects_oversized_before_add(mock_client) -> None:
     # A payload over the base64-char cap is rejected up front — no add_file call.
     mock_client.sources.add_file = AsyncMock()
     big = base64.b64encode(os.urandom(9000)).decode()  # ~12000 chars > 10000 cap
-    assert len(big) > src_mod._MAX_UPLOAD_B64_CHARS
+    assert len(big) > fileupload_mod._MAX_UPLOAD_B64_CHARS
     with pytest.raises(ToolError) as excinfo:
         await _call(
             mock_client, None, "source_upload_bytes", {"notebook": NB_ID, "bytes_base64": big}
@@ -398,7 +426,7 @@ async def test_source_upload_bytes_accepts_exact_cap_boundary(mock_client) -> No
 
     mock_client.sources.add_file = AsyncMock(side_effect=_capture)
     payload = base64.b64encode(os.urandom(7500)).decode()
-    assert len(payload) == src_mod._MAX_UPLOAD_B64_CHARS
+    assert len(payload) == fileupload_mod._MAX_UPLOAD_B64_CHARS
     await _call(
         mock_client,
         None,

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -9,7 +9,10 @@ the http-without-config branch is exercised by patching it to a fake request.
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import os
+import textwrap
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
@@ -31,11 +34,13 @@ from notebooklm._types.artifacts import (  # noqa: E402 - after importorskip gua
     ArtifactStatus,
     ArtifactTypeCode,
 )
+from notebooklm._types.sources import SourceType  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._filelink import (  # noqa: E402 - after importorskip guard
     FileLinkSigner,
     FileTransferConfig,
 )
 from notebooklm.mcp.server import create_server  # noqa: E402 - after importorskip guard
+from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
 from notebooklm.types import Artifact, ArtifactType  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
@@ -61,6 +66,32 @@ def _audio_artifact(art_id: str, title: str = "Podcast", *, completed: bool = Tr
 class FakeSource:
     id: str
     title: str | None = None
+
+
+@dataclass
+class FakeReadyPdf:
+    """A READY pdf ``Source`` for the ``source_upload_bytes`` happy path — carries the
+    ``kind`` / ``status`` / ``is_error`` properties ``_source_view`` reads (the plain
+    ``FakeSource`` above lacks them, so it can't flow through ``_add_result_payload``)."""
+
+    id: str
+    title: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return True
+
+    @property
+    def is_error(self) -> bool:
+        return False
+
+    @property
+    def kind(self) -> SourceType:
+        return SourceType.PDF
+
+    @property
+    def status(self) -> SourceStatus:
+        return SourceStatus.READY
 
 
 @pytest.fixture
@@ -195,6 +226,237 @@ async def test_source_add_file_stdio_keeps_path_behavior(mock_client) -> None:
     with pytest.raises(ToolError) as excinfo:
         await _call(mock_client, None, "source_add", {"notebook": NB_ID, "source_type": "file"})
     assert "requires 'path'" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# source_upload_bytes (in-channel small-file byte upload — #1803)
+# --------------------------------------------------------------------------- #
+async def test_source_upload_bytes_adds_and_echoes_source(mock_client) -> None:
+    # The decoded bytes are spooled to a private 0600 temp file and handed to the
+    # SAME add_file path source_add uses; the added source is echoed with labels.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["nb"] = nb_id
+        seen["path"] = path
+        seen["mime"] = mime
+        seen["title"] = title
+        with open(path, "rb") as fh:
+            seen["bytes"] = fh.read()
+        seen["mode"] = oct(os.stat(path).st_mode & 0o777)
+        return FakeReadyPdf(id="src-1", title="report.pdf")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    result = await _call(
+        mock_client,
+        None,  # transport-agnostic: needs no file-transfer config
+        "source_upload_bytes",
+        {
+            "notebook": NB_ID,
+            "bytes_base64": base64.b64encode(b"%PDF-1.4 hello").decode(),
+            "filename": "report.pdf",
+            "mime_type": "application/pdf",
+        },
+    )
+    sc = result.structured_content
+    assert sc["status"] == "added"
+    assert sc["source"]["id"] == "src-1"
+    # Same enriched echo as source_add (kind + status_label), not a bare id.
+    assert sc["source"]["kind"] == "pdf"
+    assert sc["source"]["status_label"] == "ready"
+    # The exact decoded bytes reached disk, 0600, under the spooled basename.
+    assert seen["bytes"] == b"%PDF-1.4 hello"
+    assert seen["mode"] == "0o600"
+    assert seen["nb"] == NB_ID
+    assert os.path.isabs(seen["path"])
+    assert os.path.basename(seen["path"]) == "report.pdf"
+    assert seen["mime"] == "application/pdf"
+    assert seen["title"] is None
+    # The temp tree is cleaned up after the add returns (nothing left on disk).
+    assert not os.path.exists(seen["path"])
+
+
+async def test_source_upload_bytes_default_filename_and_no_mime(mock_client) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        seen["mime"] = mime
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {"notebook": NB_ID, "bytes_base64": base64.b64encode(b"data").decode()},
+    )
+    # No filename → the shared safe-name default; no mime → None passed through.
+    assert os.path.basename(seen["path"]) == "upload.bin"
+    assert seen["mime"] is None
+
+
+async def test_source_upload_bytes_sanitizes_traversal_filename(mock_client) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {
+            "notebook": NB_ID,
+            "bytes_base64": base64.b64encode(b"x").decode(),
+            "filename": "../../etc/passwd",
+        },
+    )
+    # safe_upload_name basenames the path — no escape from the temp dir.
+    assert os.path.basename(seen["path"]) == "passwd"
+    assert "/etc/passwd" not in seen["path"]
+
+
+async def test_source_upload_bytes_tolerates_wrapped_base64(mock_client) -> None:
+    # 76-col-wrapped (MIME-style) base64 with newlines still decodes to the exact bytes.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        with open(path, "rb") as fh:
+            seen["bytes"] = fh.read()
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    raw = bytes(range(120)) * 3
+    wrapped = "\n".join(textwrap.wrap(base64.b64encode(raw).decode(), 76))
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {"notebook": NB_ID, "bytes_base64": wrapped, "filename": "blob.bin"},
+    )
+    assert seen["bytes"] == raw
+
+
+async def test_source_upload_bytes_rejects_oversized_before_add(mock_client) -> None:
+    # A payload over the base64-char cap is rejected up front — no add_file call.
+    mock_client.sources.add_file = AsyncMock()
+    big = base64.b64encode(os.urandom(9000)).decode()  # ~12000 chars > 10000 cap
+    assert len(big) > src_mod._MAX_UPLOAD_B64_CHARS
+    with pytest.raises(ToolError) as excinfo:
+        await _call(
+            mock_client, None, "source_upload_bytes", {"notebook": NB_ID, "bytes_base64": big}
+        )
+    msg = str(excinfo.value)
+    assert "cap" in msg
+    # The error names the signed-URL fallback the agent should take instead.
+    assert "source_add" in msg
+    mock_client.sources.add_file.assert_not_awaited()
+
+
+async def test_source_upload_bytes_rejects_malformed_base64(mock_client) -> None:
+    mock_client.sources.add_file = AsyncMock()
+    with pytest.raises(ToolError) as excinfo:
+        await _call(
+            mock_client,
+            None,
+            "source_upload_bytes",
+            {"notebook": NB_ID, "bytes_base64": "!!! not base64 !!!"},
+        )
+    assert "not valid base64" in str(excinfo.value)
+    mock_client.sources.add_file.assert_not_awaited()
+
+
+@pytest.mark.parametrize("payload", ["", "   \n\t  "])
+async def test_source_upload_bytes_rejects_empty_or_whitespace_payload(
+    mock_client, payload
+) -> None:
+    # Both an empty AND an all-whitespace payload decode to zero bytes (whitespace is
+    # stripped before decode) — rejected before any add.
+    mock_client.sources.add_file = AsyncMock()
+    with pytest.raises(ToolError) as excinfo:
+        await _call(
+            mock_client,
+            None,
+            "source_upload_bytes",
+            {"notebook": NB_ID, "bytes_base64": payload},
+        )
+    assert "no bytes" in str(excinfo.value)
+    mock_client.sources.add_file.assert_not_awaited()
+
+
+async def test_source_upload_bytes_accepts_exact_cap_boundary(mock_client) -> None:
+    # The cap is `> _MAX_UPLOAD_B64_CHARS` — a payload of EXACTLY that length is
+    # accepted (7500 bytes → 10000 base64 chars, no padding). Guards the >/>= boundary.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["ok"] = True
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    payload = base64.b64encode(os.urandom(7500)).decode()
+    assert len(payload) == src_mod._MAX_UPLOAD_B64_CHARS
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {"notebook": NB_ID, "bytes_base64": payload, "filename": "b.bin"},
+    )
+    assert seen.get("ok")
+
+
+async def test_source_upload_bytes_passes_title_through(mock_client) -> None:
+    # An explicit title reaches the add path (vs the filename-derived default).
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["title"] = title
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_upload_bytes",
+        {
+            "notebook": NB_ID,
+            "bytes_base64": base64.b64encode(b"x").decode(),
+            "filename": "x.bin",
+            "title": "My Title",
+        },
+    )
+    assert seen["title"] == "My Title"
+
+
+async def test_source_upload_bytes_cleans_up_temp_on_add_error(mock_client) -> None:
+    # The finally rmtree is this tool's core safety guarantee — the docstring promises
+    # removal "on success, a rejected add, or an error". Capture the spool path, then
+    # make the add itself raise, and assert both the file and its mkdtemp parent are gone.
+    captured: dict[str, Any] = {}
+
+    async def _boom(nb_id, path, mime, *, title=None):
+        captured["path"] = path
+        assert os.path.exists(path)  # the spooled file is present DURING the add
+        raise RuntimeError("upstream add blew up")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_boom)
+    with pytest.raises(ToolError):
+        await _call(
+            mock_client,
+            None,
+            "source_upload_bytes",
+            {
+                "notebook": NB_ID,
+                "bytes_base64": base64.b64encode(b"data").decode(),
+                "filename": "x.bin",
+            },
+        )
+    assert "path" in captured  # the add was actually reached
+    assert not os.path.exists(captured["path"])
+    assert not os.path.exists(os.path.dirname(captured["path"]))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -265,9 +265,12 @@ async def test_source_upload_bytes_adds_and_echoes_source(mock_client) -> None:
     # Same enriched echo as source_add (kind + status_label), not a bare id.
     assert sc["source"]["kind"] == "pdf"
     assert sc["source"]["status_label"] == "ready"
-    # The exact decoded bytes reached disk, 0600, under the spooled basename.
+    # The exact decoded bytes reached disk, under the spooled basename.
     assert seen["bytes"] == b"%PDF-1.4 hello"
-    assert seen["mode"] == "0o600"
+    # 0600 is a POSIX guarantee; Windows doesn't honor Unix mode bits (os.open there
+    # yields 0o666), so only assert the spool file's perms off-Windows.
+    if os.name != "nt":
+        assert seen["mode"] == "0o600"
     assert seen["nb"] == NB_ID
     assert os.path.isabs(seen["path"])
     assert os.path.basename(seen["path"]) == "report.pdf"

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -33,13 +33,14 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "notebook_describe",
         "notebook_rename",
         "notebook_delete",
-        # Sources (6)
+        # Sources (7)
         "source_list",
         "source_read",
         "source_rename",
         "source_delete",
         "source_wait",
         "source_add",
+        "source_upload_bytes",
         # Chat (3)
         "chat_ask",
         "chat_configure",

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -30,7 +30,7 @@ pytest.importorskip("fastmcp")
 #: Ratchet ceilings — calibrated to the current surface (Tier-1 read-merge took it
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
-SCHEMA_CHAR_BUDGET = 37_020  # total serialized inputSchema + description chars (current 36_934)
+SCHEMA_CHAR_BUDGET = 38_620  # total serialized inputSchema + description chars (current 38_572)
 # ^ Raised from 36_250 for #1741: research_status gained include_report /
 # report_max_chars / source_limit / source_offset windowing params, and the four
 # research tools' docstrings speak one `poll_task_id` id (tightened to stay lean).
@@ -39,6 +39,11 @@ SCHEMA_CHAR_BUDGET = 37_020  # total serialized inputSchema + description chars 
 # param each), absorbed by trimming the now-redundant id-routing prose from those
 # docstrings; measured full-surface cost is 36_934. The ceiling is a deliberately
 # minimal buffer (ADR-0025) — trim before adding more.
+# #1803 added source_upload_bytes (the in-channel small-file byte-upload for the
+# network-boxed-agent dead-zone) — a NEW discrete tool (+1_581 chars, 5 params),
+# not growth of an existing one; ADR-0025 prefers a discrete verb over widening the
+# source_add mega-tool, whose schema-budget headroom this would otherwise consume.
+# Measured full-surface cost is 38_572.
 MAX_PARAMS_PER_TOOL = 22  # studio_generate is the current high-water mark
 
 


### PR DESCRIPTION
## What & why

Closes #1803 — **Layer 2** of #1801 (Layer 1 shipped in #1802).

Layer 1 made the `upload_required` human/agent paths first-class. It still strands the **true dead-zone**: the bytes live only on a **network-boxed agent's disk** — not on any human device — so *neither* the browser path *nor* the egress-blocked `agent_upload` POST can move them. Since the connector itself has connectivity to Google, this lets the agent hand the bytes to the connector **through the MCP channel**.

This is the issue's **Option B**, refined to a **tokenless one-hop** shape (the token buys nothing *inside* the already-authenticated MCP channel — its single-use/jti and tamper-proof title/mime defenses exist for the *public* `/files/ul` route, and a token TTL would only add an expiry failure mode).

## The tool

```
source_upload_bytes(notebook, bytes_base64, filename?, mime_type?, title?)
  -> {status: "added", source: {... kind, status_label ...}}   (same echo as source_add)
```

Fail-fast, cheapest-first: **size cap** (≤ 10,000 base64 chars) → **whitespace-tolerant strict decode** (`validate=True`) → **empty guard** → resolve notebook → **spool to a `0600` temp file under `mkdtemp`** → reuse the existing `_add_one` / `build_source_add_plan` / `execute_source_add` path. This is the **same spool-then-add shape `_fileroutes.py`'s `upload_route` uses**, minus the signed-token / jti / concurrency machinery that guards that **public internet-facing** route — this path is authenticated by the MCP session, and the ~7 KB cap makes aggregate temp disk trivial. Works on **any transport** and needs **no** `NOTEBOOKLM_MCP_PUBLIC_URL`.

## Why 10,000 chars (≈ 7 KB file)

The cap is measured on the **base64 string** (what rides in the MCP message), *not* the decoded size. Empirically, MCP clients reject tool-call string arguments before transit somewhere around **13–16 KB** ([claude-code#55923](https://github.com/anthropics/claude-code/issues/55923)); base64 inflates ~33% and the full `tools/call` envelope is ~1.36× the file. A 10,000-char cap keeps the whole request at ~10.4 KB — comfortably under the wall — for ~7.3 KB of real file. A **larger file still takes the 200 MiB signed-URL flow** (`source_add(source_type="file")` → `upload_required`); the tool's error and docstring point there explicitly.

## Tests

`tests/unit/mcp/test_file_tools.py`: happy path (exact decoded bytes on disk, `0600` perms, post-call cleanup, enriched `kind`/`status_label` echo); default + traversal-sanitized filenames; wrapped (76-col) base64; over-cap rejection (before any add); malformed base64; empty **and** whitespace-only; exact cap boundary; title passthrough; and **cleanup-on-upstream-error** (the `finally` rmtree guarantee). Manifest allowlist updated; ADR-0025 schema-char budget raised **+1,581** for the new discrete verb (ADR-0025 prefers a discrete verb over widening the `source_add` mega-tool, whose 41-char budget headroom Option A would have consumed).

## Docs
- `docs/mcp-guide.md`: nuanced the "can't carry binaries" line + a bullet for the in-channel small-file path.
- `docs/adr/0024`: a note that #1803 revives base64-upload under this narrow small-file scope (so the ADR doesn't read as contradicting the shipped code).

## Verification
- `ruff` + `ruff-format` (pre-commit) clean · `mypy src/notebooklm` clean
- `tests/unit/mcp` — 764 passed; full `tests/unit` — 9537 passed (2 unrelated failures are local package-metadata/auth-state harness artifacts that pass in a normal install)
- Polish pass (code-simplifier + Claude/Codex/Antigravity review + ultrathink): **unanimous SHIP, no code changes**; the converged test-coverage additions above were applied.

## Known limitation
URL-safe base64 (`-`/`_`) is rejected (standard base64 only) — the reasonable default an agent produces; a lenient fallback is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MCP read-only tool (`source_upload_bytes`) for uploading small files via in-channel base64 content.
* **Documentation**
  * Updated the MCP file transfer guide and ADR to clarify when the base64 upload path applies versus the signed-URL flow for larger files.
* **Bug Fixes**
  * Improved base64 decoding/validation, enforced upload size limits, and strengthened filename sanitization and temporary cleanup behavior.
* **Tests**
  * Added unit tests for `source_upload_bytes`, updated the expected tool surface, and adjusted the schema-cost budget assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->