### PR TITLE
feat(video): add short video format across client, CLI, MCP, REST (closes #1805)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 | Type | Options | Download Format |
 |------|---------|-----------------|
 | **Audio Overview** | 4 formats (deep-dive, brief, critique, debate), 3 lengths, 50+ languages | MP3 |
-| **Video Overview** | 3 formats (explainer, brief, cinematic), 8 visual styles (+ auto/custom), plus a dedicated `cinematic-video` CLI alias | MP4 |
+| **Video Overview** | 4 formats (explainer, brief, cinematic, short), 8 visual styles (+ auto/custom), plus a dedicated `cinematic-video` CLI alias | MP4 |
 | **Slide Deck** | Detailed or presenter format, adjustable length; individual slide revision | PDF, PPTX |
 | **Infographic** | 3 orientations, 3 detail levels | PNG |
 | **Quiz** | Configurable quantity and difficulty | JSON, Markdown, HTML |

--- a/SKILL.md
+++ b/SKILL.md
@@ -321,7 +321,7 @@ Common generate options vary by subcommand:
 | Type | Command | Options | Download |
 |------|---------|---------|----------|
 | Podcast | `generate audio` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]` | .mp3 |
-| Video | `generate video` | `--format [explainer\|brief\|cinematic]` (⁴), `--style [auto\|custom\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--style-prompt` with `--style custom` | .mp4 |
+| Video | `generate video` | `--format [explainer\|brief\|cinematic\|short]` (⁴), `--style [auto\|custom\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--style-prompt` with `--style custom` | .mp4 |
 | Slide Deck | `generate slide-deck` | `--format [detailed\|presenter]`, `--length [default\|short]` (²) | .pdf / .pptx |
 | Slide Revision | `generate revise-slide "prompt" --artifact <id> --slide N` | `--wait`, `--notebook` | *(re-downloads parent deck)* |
 | Infographic | `generate infographic` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]` | .png |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -230,7 +230,7 @@ Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`,
 | Command | Arguments | Type-specific options | Example |
 |---------|-----------|-----------------------|---------|
 | `audio [description]` | Instructions | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]` | `generate audio "Focus on history"` |
-| `video [description]` | Instructions | `--format [explainer\|brief\|cinematic]`, `--style [auto\|custom\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--style-prompt TEXT` (required with `--style custom`; rejected with `--format cinematic`) | `generate video "Explainer for kids"` |
+| `video [description]` | Instructions | `--format [explainer\|brief\|cinematic\|short]`, `--style [auto\|custom\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--style-prompt TEXT` (required with `--style custom`; rejected with `--format cinematic`) | `generate video "Explainer for kids"` |
 | `cinematic-video [description]` | Instructions | Alias for `video --format cinematic` | `generate cinematic-video "Documentary about quantum physics"` |
 | `slide-deck [description]` | Instructions | `--format [detailed\|presenter]`, `--length [default\|short]` | `generate slide-deck` |
 | `revise-slide <description>` | Revision instructions | `-a/--artifact <id>` (required), `--slide N` (required) | `generate revise-slide "Move title up" --artifact <id> --slide 0` |
@@ -1105,7 +1105,7 @@ notebooklm generate video [description] [OPTIONS]
 
 **Options:**
 - `-n, --notebook ID` - Notebook ID (uses current if not set)
-- `--format [explainer|brief|cinematic]` - Video format
+- `--format [explainer|brief|cinematic|short]` - Video format (`short` is a vertical short-form video)
 - `--style [auto|custom|classic|whiteboard|kawaii|anime|watercolor|retro-print|heritage|paper-craft]` - Visual style
 - `--style-prompt TEXT` - Custom visual style prompt (required when `--style custom`; rejected with `--format cinematic`)
 - `--language LANG` - Output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1330,7 +1330,7 @@ status = await client.artifacts.generate_video(
     notebook_id,
     source_ids=None,
     instructions="...",
-    video_format=VideoFormat.EXPLAINER,  # EXPLAINER, BRIEF, CINEMATIC
+    video_format=VideoFormat.EXPLAINER,  # EXPLAINER, BRIEF, CINEMATIC, SHORT
     video_style=VideoStyle.AUTO_SELECT,  # AUTO_SELECT, CLASSIC, WHITEBOARD, KAWAII, ANIME, etc.
     language="en"
 )
@@ -2335,6 +2335,7 @@ class VideoFormat(Enum):
     EXPLAINER = 1
     BRIEF = 2
     CINEMATIC = 3
+    SHORT = 4  # vertical short-form video
 
 class VideoStyle(Enum):
     AUTO_SELECT = 1

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1059,7 +1059,7 @@ Live Studio tiles on 2026-06-15:
 |------------|--------------------|--------------|
 | Audio Overview | `.create-artifact-button-container[aria-label='Audio Overview'] .option-icon` | Format: Deep Dive, Brief, Critique, Debate; language; Length: Short, Default, Long; prompt textarea `aria-label='What should the AI hosts focus on in this episode?'` |
 | Slide Deck | `.create-artifact-button-container[aria-label='Slide Deck'] .option-icon` | Format: Detailed Deck, Presenter Slides; language; Length: Short, Default; prompt textarea `aria-label='Describe the slide deck you want to create'` |
-| Video Overview | `.create-artifact-button-container[aria-label='Video Overview'] .option-icon` | Format: Cinematic, Explainer, Brief; prompt textarea `aria-label='How would you like the video to be customized?'` |
+| Video Overview | `.create-artifact-button-container[aria-label='Video Overview'] .option-icon` | Format: Cinematic, Explainer, Brief, Short; prompt textarea `aria-label='How would you like the video to be customized?'` |
 | Mind Map | `.create-artifact-button-container[aria-label='Mind Map'] .option-icon` | Prompt textarea `aria-label='Text area for custom topic'` |
 | Reports | `.create-artifact-button-container[aria-label='Reports'] .option-icon` | Root format picker: Create Your Own, Briefing Doc, Study Guide, Blog Post, plus dynamic suggested formats; each format can open a report prompt form |
 | Flashcards | `.create-artifact-button-container[aria-label='Flashcards'] .option-icon` | Number of Cards: Fewer, Standard (Default), More; Difficulty: Easy, Medium (Default), Hard; prompt textarea `aria-label='Text area for custom topic'` |
@@ -1192,14 +1192,14 @@ params = [
 **Source:** `_artifacts.py::generate_video()`
 
 ```python
-# Build the inner video config. Explainer and Brief expose visual styles;
-# Cinematic hides the visual-style selector.
+# Build the inner video config. Explainer, Brief, and Short expose visual
+# styles; Cinematic hides the visual-style selector.
 video_config = [
     source_ids_double,
     language,             # "en"
     instructions,          # Focus/customization prompt
     None,
-    format_code,          # 1=EXPLAINER, 2=BRIEF, 3=CINEMATIC
+    format_code,          # 1=EXPLAINER, 2=BRIEF, 3=CINEMATIC, 4=SHORT
     style_code,           # None=CUSTOM, 1=AUTO_SELECT, 2=CLASSIC, 3=WHITEBOARD, ...
 ]
 if video_style == VideoStyle.CUSTOM and style_prompt:

--- a/examples/video.py
+++ b/examples/video.py
@@ -48,6 +48,8 @@ async def main():
         # video_format:
         #   - EXPLAINER: Full explanatory video (default)
         #   - BRIEF: Shorter summary video
+        #   - CINEMATIC: AI-generated documentary footage (Veo 3)
+        #   - SHORT: Vertical short-form video
         #
         # video_style:
         #   - AUTO_SELECT: Let AI choose the best style (default)

--- a/src/notebooklm/_app/generate_plans.py
+++ b/src/notebooklm/_app/generate_plans.py
@@ -140,6 +140,10 @@ _VIDEO_FORMAT_MAP: Mapping[str, VideoFormat] = {
     "explainer": VideoFormat.EXPLAINER,
     "brief": VideoFormat.BRIEF,
     "cinematic": VideoFormat.CINEMATIC,
+    # ponytail: "short" rides the standard video path (build_video_artifact_params,
+    # style-capable) — NOT the cinematic special-case builder. Append last: the
+    # MCP/server _KIND_OPTIONS tuples are pinned to this dict's key order.
+    "short": VideoFormat.SHORT,
 }
 
 _VIDEO_STYLE_MAP: Mapping[str, VideoStyle] = {

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -381,9 +381,12 @@ def generate_audio(
 @click.option(
     "--format",
     "video_format",
-    type=click.Choice(["explainer", "brief", "cinematic"]),
+    type=click.Choice(["explainer", "brief", "cinematic", "short"]),
     default="explainer",
-    help="Video format; 'cinematic' uses Veo 3 footage (default: explainer)",
+    help=(
+        "Video format; 'cinematic' uses Veo 3 footage, 'short' is a vertical "
+        "short-form video (default: explainer)"
+    ),
 )
 @click.option(
     "--style",

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -105,7 +105,7 @@ _KIND_OPTIONS: dict[str, dict[str, tuple[str, ...] | None]] = {
         "audio_length": ("short", "default", "long"),
     },
     "video": {
-        "video_format": ("explainer", "brief", "cinematic"),
+        "video_format": ("explainer", "brief", "cinematic", "short"),
         "style": (
             "auto",
             "custom",
@@ -293,7 +293,7 @@ def register(mcp: Any) -> None:
         audio_length: Literal["short", "default", "long"] | None = None,
         quantity: Literal["fewer", "standard", "more"] | None = None,
         difficulty: Literal["easy", "medium", "hard"] | None = None,
-        video_format: Literal["explainer", "brief", "cinematic"] | None = None,
+        video_format: Literal["explainer", "brief", "cinematic", "short"] | None = None,
         # ``style`` is shared by ``video`` and ``infographic`` with DIFFERENT value
         # sets (overlap only auto/anime/kawaii). One param carries one Literal, so this
         # is the UNION of both kinds' values; the runtime ``_KIND_OPTIONS`` loop narrows
@@ -340,10 +340,10 @@ def register(mcp: Any) -> None:
         * ``audio``        — podcast-style overview (``audio_format``:
           deep-dive|brief|critique|debate, ``audio_length``: short|default|long).
         * ``video``        — video overview (``video_format``:
-          explainer|brief|cinematic, ``style``: auto|custom|classic|whiteboard|
+          explainer|brief|cinematic|short, ``style``: auto|custom|classic|whiteboard|
           kawaii|anime|watercolor|retro-print|heritage|paper-craft, ``style_prompt``:
           free-text custom-style prompt — requires ``style=custom``).
-        * ``cinematic-video`` — AI-generated documentary video (no per-kind options).
+        * ``cinematic-video`` — AI-generated documentary video.
         * ``slide-deck``   — slide deck (``deck_format``: detailed|presenter,
           ``deck_length``: default|short).
         * ``quiz`` / ``flashcards`` — study aids (``quantity``:
@@ -352,7 +352,7 @@ def register(mcp: Any) -> None:
           landscape|portrait|square, ``detail``: concise|standard|detailed,
           ``style``: auto|sketch-note|professional|bento-grid|editorial|
           instructional|bricks|clay|anime|kawaii|scientific).
-        * ``data-table``   — extracted data table (no per-kind options).
+        * ``data-table``   — extracted data table.
         * ``mind-map``     — mind map (``map_kind``: interactive|note-backed).
         * ``report``       — text report (``report_format``:
           briefing-doc|study-guide|blog-post|custom).

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -257,6 +257,7 @@ class VideoFormat(int, Enum):
     EXPLAINER = 1
     BRIEF = 2
     CINEMATIC = 3
+    SHORT = 4  # vertical short-form video (Google bundle label "Short")
 
 
 class VideoStyle(int, Enum):

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -140,7 +140,7 @@ _KIND_OPTIONS: dict[str, dict[str, tuple[str, ...] | None]] = {
         "audio_length": ("short", "default", "long"),
     },
     "video": {
-        "video_format": ("explainer", "brief", "cinematic"),
+        "video_format": ("explainer", "brief", "cinematic", "short"),
         "style": (
             "auto",
             "custom",

--- a/tests/_guardrails/test_studio_enum_manifest.py
+++ b/tests/_guardrails/test_studio_enum_manifest.py
@@ -83,7 +83,7 @@ _RPC_ENUM_SNAPSHOT: dict[str, dict[str, int]] = {
     "SlideDeckFormat": {"DETAILED_DECK": 1, "PRESENTER_SLIDES": 2},
     "SlideDeckLength": {"DEFAULT": 1, "SHORT": 2},
     "SourceStatus": {"PROCESSING": 1, "READY": 2, "ERROR": 3, "PREPARING": 5},
-    "VideoFormat": {"EXPLAINER": 1, "BRIEF": 2, "CINEMATIC": 3},
+    "VideoFormat": {"EXPLAINER": 1, "BRIEF": 2, "CINEMATIC": 3, "SHORT": 4},
     "VideoStyle": {
         "AUTO_SELECT": 1,
         "CUSTOM": 0,

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -4230,7 +4230,7 @@
           "default": "explainer",
           "envvar": null,
           "has_custom_shell_complete": false,
-          "help": "Video format; 'cinematic' uses Veo 3 footage (default: explainer)",
+          "help": "Video format; 'cinematic' uses Veo 3 footage, 'short' is a vertical short-form video (default: explainer)",
           "is_flag": false,
           "kind": "option",
           "multiple": false,
@@ -4245,7 +4245,8 @@
             "choices": [
               "explainer",
               "brief",
-              "cinematic"
+              "cinematic",
+              "short"
             ],
             "name": "choice"
           }
@@ -6149,7 +6150,7 @@
           "default": "explainer",
           "envvar": null,
           "has_custom_shell_complete": false,
-          "help": "Video format; 'cinematic' uses Veo 3 footage (default: explainer)",
+          "help": "Video format; 'cinematic' uses Veo 3 footage, 'short' is a vertical short-form video (default: explainer)",
           "is_flag": false,
           "kind": "option",
           "multiple": false,
@@ -6164,7 +6165,8 @@
             "choices": [
               "explainer",
               "brief",
-              "cinematic"
+              "cinematic",
+              "short"
             ],
             "name": "choice"
           }

--- a/tests/unit/app/test_app_generate_plans.py
+++ b/tests/unit/app/test_app_generate_plans.py
@@ -136,6 +136,20 @@ class TestPerKindEnumMapping:
         assert plan.params["video_style"] == VideoStyle.WHITEBOARD
         assert plan.params["style_prompt"] is None
 
+    def test_video_short_format_mapping(self):
+        # "short" is a standard (style-capable) video format, not cinematic (#1805).
+        plan = build_generation_plan(
+            "video",
+            {
+                "notebook_id": "nb_1",
+                "video_format": "short",
+                "style": "classic",
+            },
+        )
+        assert plan.kind == "video"
+        assert plan.params["video_format"] == VideoFormat.SHORT
+        assert plan.params["video_style"] == VideoStyle.CLASSIC
+
     def test_slide_deck_enum_mapping(self):
         plan = build_generation_plan(
             "slide-deck",

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -370,6 +370,14 @@ _OPTION_CASES = [
         ["--style", "custom", "--style-prompt", "hand-drawn"],
     ),
     (
+        "video-short",
+        "video",
+        "video",
+        "generate_video",
+        {"video_format": "short"},
+        ["--format", "short"],
+    ),
+    (
         "slide-deck",
         "slide-deck",
         "slide-deck",

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -164,11 +164,14 @@ def test_main_json_includes_unmapped_family(
 # ---------------------------------------------------------------------------
 
 # Minimal int-enum fixtures mirroring rpc/types.py's VideoFormat / AudioFormat.
+# SHORT (4) is implemented (#1805); only Whiteboard Animation (5) / Lecture (5)
+# remain as bundle codes we lack.
 _ENUM_TYPES = """
 class VideoFormat(int, Enum):
     EXPLAINER = 1
     BRIEF = 2
     CINEMATIC = 3
+    SHORT = 4
 
 class AudioFormat(int, Enum):
     DEEP_DIVE = 1
@@ -177,9 +180,10 @@ class AudioFormat(int, Enum):
     DEBATE = 4
 """
 
-# A bundle with the two anchored switch blocks (each carries a NEW trailing label
-# our enums lack — Short / Whiteboard Animation / Lecture), the Yp quota map, and
-# a proto required-field assertion. Whitespace/quote style mirrors the live shapes.
+# A bundle with the two anchored switch blocks. Short (code 4) is now implemented
+# (#1805) so it MATCHES our enum; Whiteboard Animation / Lecture (code 5) remain
+# trailing labels our enums lack. Also carries the Yp quota map and a proto
+# required-field assertion. Whitespace/quote style mirrors the live shapes.
 _ENUM_BUNDLE = (
     'f=function(a){switch(a){case 1:return"Explainer";case 2:return"Brief";'
     'case 3:return"Cinematic";case 4:return"Short";case 5:return"Whiteboard Animation"}};'
@@ -227,6 +231,7 @@ def test_parse_enum_members_from_text() -> None:
         "EXPLAINER": 1,
         "BRIEF": 2,
         "CINEMATIC": 3,
+        "SHORT": 4,
     }
     # Unknown class -> empty (scoped to the named class body).
     assert parse_enum_members_from_text(_ENUM_TYPES, "Nonexistent") == {}
@@ -253,10 +258,10 @@ def test_diff_enums_new_is_report_only() -> None:
     assert buckets["changed"] == []
     assert buckets["stale"] == []
     assert buckets["unparsed"] == []
-    # Short (4) / Whiteboard Animation (5) / Lecture (5) are bundle codes we lack.
+    # Whiteboard Animation (5) / Lecture (5) are bundle codes we lack; Short (4) is
+    # now implemented (#1805) so it matches instead of showing as NEW.
     new_pairs = {(r["enum"], r["code"], r["label"]) for r in buckets["new"]}
     assert new_pairs == {
-        ("VideoFormat", 4, "Short"),
         ("VideoFormat", 5, "Whiteboard Animation"),
         ("AudioFormat", 5, "Lecture"),
     }
@@ -338,7 +343,10 @@ class VideoFormat(int, Enum):
 def test_diff_enums_unparsed_when_no_block() -> None:
     """A known enum (we hold an anchor) with no switch block parsed -> UNPARSED."""
     # Only VideoFormat is present; AudioFormat has no block to attribute.
-    bundle = 'switch(a){case 1:return"Explainer";case 2:return"Brief";case 3:return"Cinematic"}'
+    bundle = (
+        'switch(a){case 1:return"Explainer";case 2:return"Brief";'
+        'case 3:return"Cinematic";case 4:return"Short"}'
+    )
     live = extract_switch_enums(bundle)
     buckets = diff_enums(_ENUM_TYPES, live)
 
@@ -359,7 +367,7 @@ def test_check_enums_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture[st
     out = capsys.readouterr().out
     assert rc == 0  # NEW labels never fail the enum gate
     assert "STUDIO ENUM DRIFT" in out
-    assert "NEW: 3" in out
+    assert "NEW: 2" in out
 
     # CHANGED -> exit 1.
     types.write_text(

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -403,6 +403,36 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
             ],
         ),
         (
+            # #1805: SHORT (code 4) rides the STANDARD builder — format_code at
+            # slot [4] == 4 with the style_code (AUTO_SELECT=1) still present,
+            # NOT the cinematic special shape (which drops the style slot).
+            "video_short_format",
+            build_video_artifact_params(
+                "nb_payload",
+                ["src_alpha"],
+                language="en",
+                instructions=None,
+                video_format=VideoFormat.SHORT,
+                video_style=None,
+                style_prompt=None,
+            ),
+            [
+                _ARTIFACT_CLIENT_OPTIONS,
+                "nb_payload",
+                [
+                    None,
+                    None,
+                    3,
+                    [[["src_alpha"]]],
+                    None,
+                    None,
+                    None,
+                    None,
+                    [None, None, [[["src_alpha"]], "en", None, None, 4, 1]],
+                ],
+            ],
+        ),
+        (
             "video_non_contiguous_preset_style",
             build_video_artifact_params(
                 "nb_payload",


### PR DESCRIPTION
## Summary

Exposes NotebookLM's short-form **video** format (`VideoFormat.SHORT = 4`) through the whole stack — closes #1805:

- **Core**: `VideoFormat.SHORT` + shared `_VIDEO_FORMAT_MAP["short"]`
- **CLI**: `generate video --format short`
- **MCP**: `studio_generate(kind="video", video_format="short")`
- **REST**: `POST /v1/notebooks/{id}/artifacts` with `video_format: "short"`

`short` rides the **standard, style-capable** `build_video_artifact_params` (not the cinematic special-case builder). A golden payload pins the shape: `format_code=4` with the `style_code` slot present.

## Why code 4 = "Short" (not a speculative enum)

This repo's #1 rule is *never add a speculative `VideoFormat` member* (silent wrong-output history, #1597). Two independent lines of evidence:

1. **Google's own JS bundle** switch-label for code 4 is literally `"Short"` — already pinned in `tests/unit/test_capture_rpc_registry.py` (code 5 = `"Whiteboard Animation"`).
2. **Live A/B probe** on a real account, same source/language/style, only the format code varied:

   | format | wire code | resolution | aspect | duration |
   |---|---|---|---|---|
   | explainer (baseline) | 1 | 1280×720 | 16:9 landscape | 275.9s |
   | **short** | **4** | **406×720** | **9:16 portrait** | **77.4s** |

   Code 5 returned a gated null (`ArtifactFeatureUnavailableError`), so it is explicitly **not** added.

## Changes

- `rpc/types.py`, `_app/generate_plans.py`, `cli/generate_cmd.py`, `mcp/tools/studio.py`, `server/routes/artifacts.py` — wire `short` (appended **last** to satisfy the `_KIND_OPTIONS` tuple-order pins).
- `tests/_guardrails/test_studio_enum_manifest.py` — freeze `SHORT: 4` wire value.
- `tests/unit/test_capture_rpc_registry.py` — drift-machinery cascade: `SHORT` now *matches* the bundle instead of surfacing as a code we lack.
- New tests: golden payload (`video_short_format`), CLI↔MCP parity (`video-short`), app-plan mapping.
- Regen'd `cli_contract_baseline.json`; docs (README, SKILL, cli-reference, python-api, rpc-reference, examples).
- MCP docstring trimmed (dropped two redundant "(no per-kind options)" phrases) to stay under the ADR-0025 schema-char budget.

## Test plan

- [x] Full suite green (`11759 passed`), mypy, ruff, ADR-0025 schema-char gate
- [x] Polish: code-simplifier (0 findings) + claude/codex review (0 critical/important; 3 minor fixed) + ultrathink

## Deferred / monitor-only

- `short` accepts non-auto `--style` (consistent with explainer/brief), but the probe only exercised `style=auto`. If the backend ignores style for short, a styled short would render auto-styled — a backend behavior, not a client payload bug. Monitor-only; no speculative client-side restriction added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new **short-form video** format across video generation tools and interfaces.
  * Video generation now accepts **Short** alongside the existing format options.

* **Documentation**
  * Updated CLI, API, RPC, README, and example docs to include the new video format and its usage details.

* **Tests**
  * Refreshed automated coverage and contract snapshots to reflect the new supported video format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->