### PR TITLE
chore: release v0.8.0a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,34 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **MCP research tools now accept the poll id under one name, `poll_task_id`.**
-  `research_status`, `research_import`, and `research_cancel` previously took the
-  value that `research_start` / `research_status` surface as `poll_task_id` under
-  mismatched parameter names (`task_id` on status/import, `run_id` on cancel),
-  forcing docstring warnings about which id goes where and inviting copy-paste
-  mistakes. All three now accept it as `poll_task_id`, so the value pastes
-  verbatim from one tool's output into the next. The old `task_id` / `run_id`
-  names still work as **deprecated aliases** (removed in v0.9.0): passing one
-  emits a `DeprecationWarning` and adds a `deprecation` note to the result;
-  passing both names with different values is a validation error.
-  ([#1789](https://github.com/teng-lin/notebooklm-py/issues/1789))
-
-### Fixed
-
-- **The `.mcpb` desktop bundle now ships for pre-releases and launches the
-  pinned pre-release.** The bundled launcher (`run_server.py`) always ran
-  `uvx --from "notebooklm-py[mcp]"`, which resolves the latest *stable* server —
-  so a pre-release bundle would have run the stable release, not the
-  pre-release (which is why `publish-mcpb.yml` skipped pre-releases). The
-  launcher now reads its version from the bundled `manifest.json` and, for a
-  `vX.Y.ZaN` bundle, pins the exact version (`uvx --from
-  "notebooklm-py[mcp]==X.Y.ZaN"` — the explicit `==` pin resolves the pre-release
-  under uv's default resolver, without loosening transitive dependency
-  resolution); stable bundles stay unpinned and track the latest stable server.
-  `publish-mcpb.yml` now ships a bundle for pre-releases too.
-
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI
@@ -59,9 +31,40 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Added
 
+- **Short-form video format** across the client, CLI, MCP, and REST
+  ([#1805](https://github.com/teng-lin/notebooklm-py/issues/1805)). Video
+  generation now takes a format selector so you can request a **short** video in
+  addition to the default full-length one. The server ignores a custom style on
+  the short format, so passing one is rejected up front rather than silently
+  dropped ([#1805](https://github.com/teng-lin/notebooklm-py/issues/1805)
+  follow-up).
+
+- **MCP `source_upload_bytes`** — in-channel small-file upload
+  ([#1803](https://github.com/teng-lin/notebooklm-py/issues/1803)). Adds a source
+  by sending the file bytes directly through the tool call, for network-boxed
+  agents that cannot reach the signed browser-upload URL.
+
+- **MCP `source_add_and_wait`** — a single-call composite of `source_add` +
+  `source_wait` for single-source adds
+  ([#1807](https://github.com/teng-lin/notebooklm-py/issues/1807)).
+
+- **Compact roster mode for `source_list` and `studio_list`**
+  ([#1806](https://github.com/teng-lin/notebooklm-py/issues/1806)) — a terser
+  listing shape that fits more entries into an agent's context window.
+
+- **MCP strict IDs-only mode + canonical-id echoes**
+  ([#1808](https://github.com/teng-lin/notebooklm-py/issues/1808)). Opt into
+  rejecting name-based refs and having tools echo the canonical id they resolved,
+  so an agent can pin every subsequent call to an unambiguous id.
+
+- **Near-miss candidates on failed name lookups**
+  ([#1787](https://github.com/teng-lin/notebooklm-py/issues/1787)). When a
+  notebook/source/note/artifact name doesn't resolve, the error now lists the
+  closest matches instead of a bare not-found.
+
 - **Experimental: MCP server** (#1484, opt-in via the `mcp` extra). A
   [Model Context Protocol](https://modelcontextprotocol.io) server exposing
-  NotebookLM to MCP clients (Claude Desktop / Code, Cursor, Windsurf) as 28 tools
+  NotebookLM to MCP clients (Claude Desktop / Code, Cursor, Windsurf) as 34 tools
   across notebooks, sources, chat, notes, studio artifacts, and research — built
   as a transport-neutral sibling adapter over the `_app/` layer (ADR-0021), so it
   behaves identically to the equivalent `notebooklm` CLI command. Run it with the
@@ -298,6 +301,24 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Changed
 
+- **MCP name refs resolve by unique title prefix** (#1786). Notebook, source,
+  note, and artifact name arguments now match on a unique title *prefix*, not
+  just an exact title, so an agent can address an entity by the shortest
+  unambiguous fragment; an ambiguous prefix is a resolution error listing the
+  candidates.
+
+- **MCP research tools now accept the poll id under one name, `poll_task_id`.**
+  `research_status`, `research_import`, and `research_cancel` previously took the
+  value that `research_start` / `research_status` surface as `poll_task_id` under
+  mismatched parameter names (`task_id` on status/import, `run_id` on cancel),
+  forcing docstring warnings about which id goes where and inviting copy-paste
+  mistakes. All three now accept it as `poll_task_id`, so the value pastes
+  verbatim from one tool's output into the next. The old `task_id` / `run_id`
+  names still work as **deprecated aliases** (removed in v0.9.0): passing one
+  emits a `DeprecationWarning` and adds a `deprecation` note to the result;
+  passing both names with different values is a validation error.
+  ([#1789](https://github.com/teng-lin/notebooklm-py/issues/1789))
+
 - **MCP `source_wait` now returns one unified per-source aggregate** (#1669).
   Both modes — waiting for a single `source` or for every source in the notebook
   — return the same shape: `{notebook_id, ok, ready, timed_out, failed,
@@ -378,6 +399,28 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   [docs/deprecations.md](docs/deprecations.md).
 
 ### Fixed
+
+- **First-class human/mobile upload path in `upload_required`**
+  ([#1801](https://github.com/teng-lin/notebooklm-py/issues/1801)). When a source
+  add needs a browser upload, the `upload_required` response now surfaces the
+  human/mobile hand-off path as a first-class option rather than burying it.
+
+- **`server_info` and the profile probe report the resolved profile, not the
+  raw active one** ([#1790](https://github.com/teng-lin/notebooklm-py/issues/1790)).
+  The REST server's `server_info` and its startup profile probe now bind and
+  report the profile that was actually resolved for the request.
+
+- **The `.mcpb` desktop bundle now ships for pre-releases and launches the
+  pinned pre-release.** The bundled launcher (`run_server.py`) always ran
+  `uvx --from "notebooklm-py[mcp]"`, which resolves the latest *stable* server —
+  so a pre-release bundle would have run the stable release, not the
+  pre-release (which is why `publish-mcpb.yml` skipped pre-releases). The
+  launcher now reads its version from the bundled `manifest.json` and, for a
+  `vX.Y.ZaN` bundle, pins the exact version (`uvx --from
+  "notebooklm-py[mcp]==X.Y.ZaN"` — the explicit `==` pin resolves the pre-release
+  under uv's default resolver, without loosening transitive dependency
+  resolution); stable bundles stay unpinned and track the latest stable server.
+  `publish-mcpb.yml` now ships a bundle for pre-releases too.
 
 - **`notebooklm doctor` no longer greenlights a session that is missing
   `__Secure-1PSIDTS`** (#1753). The auth check previously passed on `SID`

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0a1",
+  "version": "0.8.0a2",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0a1"
+version = "0.8.0a2"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -208,6 +208,8 @@ TOOL_COVERAGE: dict[str, str] = {
     "source_rename": "TestMcpSources.test_source_roundtrip",
     "source_delete": "TestMcpSources.test_source_roundtrip",
     "source_wait": "TestMcpSources.test_source_roundtrip",
+    "source_add_and_wait": "tests/unit/mcp/test_sources.py (add+wait composite; unit)",
+    "source_upload_bytes": "tests/unit/mcp/test_file_tools.py (in-channel bytes upload; unit)",
     # chat
     "chat_ask": "TestMcpChat.test_configure_then_ask",
     "chat_configure": "TestMcpChat.test_configure_then_ask",

--- a/uv.lock
+++ b/uv.lock
@@ -1264,7 +1264,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0a1"
+version = "0.8.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release **v0.8.0a2** — second alpha of the 0.8.0 cycle.

Serial bump `a1 → a2` (no patch bump per the pre-release track). Reconciles the CHANGELOG for all post-a1 user-facing changes into the in-progress `[0.8.0]` section so the aggregate release notes are complete.

### Changes since v0.8.0a1
**Added** — short video format (#1805), MCP `source_upload_bytes` (#1803), `source_add_and_wait` (#1807), compact roster mode (#1806), strict IDs-only mode + canonical-id echoes (#1808), near-miss candidates on name lookups (#1787).
**Changed** — MCP name refs resolve by unique title prefix (#1786), research tools unify on `poll_task_id` (#1789).
**Fixed** — human/mobile upload path in `upload_required` (#1801), `server_info` reports resolved profile (#1790), `.mcpb` bundle ships for pre-releases (#1783).

Also bumps the `#1484` tool-count headline 28 → 34 to match the shipped surface.

See CHANGELOG.md for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB8mwAvNpxq228pSLp5QaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple new MCP/CLI capabilities for media format selection, additional source upload/composite tools, roster compact mode, strict IDs-only mode, and near-miss name suggestions.
* **Changed**
  * Updated MCP name resolution behavior to use unique title prefix matching.
  * Increased the documented Experimental MCP server tool count (28 → 34).
* **Bug Fixes**
  * Improved human/mobile upload handoff visibility.
  * Fixed reporting to reflect the actually resolved profile during probing.
* **Documentation**
  * Reorganized and refined the 0.8.0 release notes content.
* **Tests**
  * Expanded E2E tool coverage mapping for newly registered MCP tools.
* **Chores**
  * Bumped app and desktop extension version to `0.8.0a2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->