### PR TITLE
test(e2e): fail when live chat ask coverage is skipped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ addopts = "--ignore=tests/e2e"
 timeout = 60
 markers = [
     "e2e: end-to-end tests requiring authentication (run with pytest tests/e2e -m e2e)",
+    "live_chat_ask: E2E live chat ask tests monitored for CI coverage floors",
     "variants: parameter variant tests (skip to save quota)",
     "readonly: read-only tests against user's test notebook",
     "impersonate_smoke: minimal live smoke run under NOTEBOOKLM_TRANSPORT=curl_cffi in the nightly (read/ask/upload/download — one per transport-critical op)",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -44,10 +44,12 @@ from notebooklm.paths import get_profile_dir
 _RATE_LIMIT_PHRASES = (
     "rate limit",
     "rate limited",
+    "rate-limited",
     "rejected by the api",
     "429",
     "too many requests",
 )
+_LIVE_CHAT_ASK_MARKER = "live_chat_ask"
 
 
 def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
@@ -308,6 +310,56 @@ def _skip_reason(report) -> str:
     return str(longrepr) if longrepr else ""
 
 
+def _is_call_report(report) -> bool:
+    # Unit fakes may omit ``when``; real pytest reports always include it.
+    return getattr(report, "when", "call") == "call"
+
+
+def _has_marker(report, marker: str) -> bool:
+    return marker in (getattr(report, "keywords", {}) or {})
+
+
+def _is_rate_limit_skip(report) -> bool:
+    return any(phrase in _skip_reason(report).lower() for phrase in _RATE_LIMIT_PHRASES)
+
+
+def _rate_limit_skip_reports(terminalreporter) -> list[Any]:
+    return [
+        report
+        for report in terminalreporter.stats.get("skipped", [])
+        if _is_rate_limit_skip(report)
+    ]
+
+
+def _live_chat_floor_failures(terminalreporter, exitstatus) -> list[Any]:
+    if exitstatus != pytest.ExitCode.OK:
+        return []
+
+    live_chat_rate_limit_skips = [
+        report
+        for report in _rate_limit_skip_reports(terminalreporter)
+        if _has_marker(report, _LIVE_CHAT_ASK_MARKER)
+    ]
+    if not live_chat_rate_limit_skips:
+        return []
+
+    live_chat_passes = [
+        report
+        for report in terminalreporter.stats.get("passed", [])
+        if _is_call_report(report) and _has_marker(report, _LIVE_CHAT_ASK_MARKER)
+    ]
+    return [] if live_chat_passes else live_chat_rate_limit_skips
+
+
+def pytest_sessionfinish(session, exitstatus):
+    terminalreporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if terminalreporter is None:
+        return
+
+    if _live_chat_floor_failures(terminalreporter, exitstatus):
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Surface chat rate-limit skips so they're visible despite green CI.
 
@@ -316,11 +368,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     silently degrades. Emit a pytest summary section plus, on GitHub Actions,
     a warning annotation and step-summary entry.
     """
-    nodeids = [
-        report.nodeid
-        for report in terminalreporter.stats.get("skipped", [])
-        if any(phrase in _skip_reason(report).lower() for phrase in _RATE_LIMIT_PHRASES)
-    ]
+    rate_limit_skips = _rate_limit_skip_reports(terminalreporter)
+    nodeids = [report.nodeid for report in rate_limit_skips]
     if not nodeids:
         return
 
@@ -341,6 +390,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if os.environ.get("GITHUB_ACTIONS"):
         joined = ", ".join(nodeids)
         print(f"::warning::{len(nodeids)} test(s) skipped due to rate-limit: {joined}")
+
+    live_chat_rate_limit_skips = _live_chat_floor_failures(terminalreporter, exitstatus)
+    if live_chat_rate_limit_skips:
+        terminalreporter.write_sep("=", "live chat coverage floor failed", red=True)
+        terminalreporter.write_line("No marked live chat ask test completed successfully.")
+        for report in live_chat_rate_limit_skips:
+            terminalreporter.write_line(f"  {report.nodeid}")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -12,6 +12,7 @@ from .conftest import requires_auth
 
 
 @pytest.mark.e2e
+@pytest.mark.live_chat_ask
 @requires_auth
 class TestChatE2E:
     """E2E tests for chat API."""
@@ -287,6 +288,7 @@ class TestChatHistoryE2E:
 
 
 @pytest.mark.e2e
+@pytest.mark.live_chat_ask
 @requires_auth
 class TestChatReferencesE2E:
     """E2E tests specifically for chat references and citations."""

--- a/tests/e2e/test_cli_live.py
+++ b/tests/e2e/test_cli_live.py
@@ -32,7 +32,7 @@ def _is_rate_limited(proc) -> bool:
     """True only on the real limiter signal (HTTP 429 / "rate limit") — NOT any
     message that merely contains "rate", which could mask an unrelated failure."""
     blob = f"{proc.stdout}\n{proc.stderr}".lower()
-    return "rate limit" in blob or "429" in blob
+    return any(phrase in blob for phrase in ("rate limit", "rate-limited", "429"))
 
 
 @requires_auth
@@ -62,6 +62,7 @@ class TestCliLive:
         assert isinstance(json.loads(proc.stdout), dict)
 
     @pytest.mark.readonly
+    @pytest.mark.live_chat_ask
     def test_ask_json(self, read_only_notebook_id):
         """``ask -n <read_only> --json`` returns a structured answer on stdout."""
         proc = run_cli(

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -365,6 +365,7 @@ class TestMcpSources:
 
 
 @requires_auth
+@pytest.mark.live_chat_ask
 class TestMcpChat:
     """Chat domain: configure then ask against the read-only notebook."""
 

--- a/tests/e2e/test_notebooks.py
+++ b/tests/e2e/test_notebooks.py
@@ -46,6 +46,7 @@ class TestNotebookOperations:
 
 
 @requires_auth
+@pytest.mark.live_chat_ask
 class TestNotebookAsk:
     @pytest.mark.asyncio
     @pytest.mark.impersonate_smoke

--- a/tests/e2e/test_server_live.py
+++ b/tests/e2e/test_server_live.py
@@ -50,6 +50,7 @@ _HEADERS = {"Authorization": f"Bearer {_TOKEN}", "Host": "127.0.0.1"}
 _RATE_LIMIT_PHRASES = (
     "rate limit",
     "rate limited",
+    "rate-limited",
     "rejected by the api",
     "429",
     "too many requests",
@@ -174,6 +175,7 @@ class TestRestServerLiveReads:
 
 
 @requires_auth
+@pytest.mark.live_chat_ask
 class TestRestServerLiveChat:
     """A live chat answer over the REST POST route."""
 

--- a/tests/e2e/test_source_selection.py
+++ b/tests/e2e/test_source_selection.py
@@ -23,6 +23,7 @@ from .conftest import assert_generation_started, requires_auth
 
 
 @requires_auth
+@pytest.mark.live_chat_ask
 class TestChatWithSourceSelection:
     """Tests for chat.ask() with explicit source selection."""
 
@@ -237,6 +238,7 @@ class TestSourceListingAndSelection:
 
 
 @requires_auth
+@pytest.mark.live_chat_ask
 class TestEdgeCases:
     """Edge case tests for source selection."""
 

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -20,6 +20,7 @@ import pytest
 from notebooklm.exceptions import RateLimitError
 
 CONFTEST_PATH = Path(__file__).resolve().parents[1] / "e2e" / "conftest.py"
+pytest_plugins = ["pytester"]
 
 
 def _load_e2e_conftest() -> ModuleType:
@@ -147,18 +148,64 @@ class TestRateLimitSkipSummary:
     """pytest_terminal_summary surfaces chat rate-limit skips so green CI doesn't hide drift."""
 
     @staticmethod
-    def _make_reporter(reports):
+    def _make_reporter(
+        reports,
+        *,
+        passed=None,
+    ):
         write_calls: list[tuple] = []
         return SimpleNamespace(
-            stats={"skipped": reports},
+            stats={"skipped": reports, "passed": passed or []},
             write_sep=lambda *a, **kw: write_calls.append(("sep", a, kw)),
             write_line=lambda *a, **kw: write_calls.append(("line", a, kw)),
             _writes=write_calls,
         )
 
     @staticmethod
-    def _skipped(nodeid: str, reason: str) -> SimpleNamespace:
-        return SimpleNamespace(nodeid=nodeid, longrepr=("file.py", 1, f"Skipped: {reason}"))
+    def _make_session(reporter, *, exitstatus=pytest.ExitCode.OK):
+        pluginmanager = SimpleNamespace(
+            get_plugin=lambda name: reporter if name == "terminalreporter" else None
+        )
+        return SimpleNamespace(
+            config=SimpleNamespace(pluginmanager=pluginmanager),
+            exitstatus=exitstatus,
+        )
+
+    @classmethod
+    def _finish(
+        cls,
+        conftest,
+        reporter,
+        *,
+        exitstatus=pytest.ExitCode.OK,
+    ) -> SimpleNamespace:
+        session = cls._make_session(reporter, exitstatus=exitstatus)
+        conftest.pytest_sessionfinish(session, exitstatus)
+        return session
+
+    @staticmethod
+    def _report(nodeid: str, *, live_chat_ask: bool = False, when: str = "call"):
+        keywords = {"live_chat_ask": 1} if live_chat_ask else {}
+        return SimpleNamespace(nodeid=nodeid, keywords=keywords, when=when)
+
+    @classmethod
+    def _skipped(
+        cls,
+        nodeid: str,
+        reason: str,
+        *,
+        live_chat_ask: bool = False,
+        when: str = "call",
+    ) -> SimpleNamespace:
+        report = cls._report(nodeid, live_chat_ask=live_chat_ask, when=when)
+        report.longrepr = ("file.py", 1, f"Skipped: {reason}")
+        return report
+
+    @classmethod
+    def _passed(
+        cls, nodeid: str, *, live_chat_ask: bool = False, when: str = "call"
+    ) -> SimpleNamespace:
+        return cls._report(nodeid, live_chat_ask=live_chat_ask, when=when)
 
     def test_counts_only_rate_limit_skips(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
@@ -172,15 +219,16 @@ class TestRateLimitSkipSummary:
                 self._skipped("t::c", "rejected by the API"),
                 self._skipped("t::d", "Chat request failed with HTTP 429: ..."),
                 self._skipped("t::e", "Too Many Requests"),
+                self._skipped("t::f", "chat rate-limited by upstream"),
             ]
         )
         conftest.pytest_terminal_summary(tr, 0, None)
 
         summary = (tmp_path / "summary.md").read_text()
-        assert "Rate-limit skips: 4" in summary
-        assert all(nid in summary for nid in ("t::a", "t::c", "t::d", "t::e"))
+        assert "Rate-limit skips: 5" in summary
+        assert all(nid in summary for nid in ("t::a", "t::c", "t::d", "t::e", "t::f"))
         assert "t::b" not in summary
-        assert "::warning::4 test(s) skipped" in capsys.readouterr().out
+        assert "::warning::5 test(s) skipped" in capsys.readouterr().out
 
     def test_no_skips_emits_nothing(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
@@ -205,6 +253,148 @@ class TestRateLimitSkipSummary:
         # Still emits the pytest section locally — just no GH-specific bits.
         assert any(call[0] == "sep" for call in tr._writes)
         assert capsys.readouterr().out == ""
+
+    def test_live_chat_floor_fails_when_marked_asks_all_rate_limited(self, monkeypatch, capsys):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [
+                self._skipped(
+                    "test_server_live.py::TestRestServerLiveChat::test_chat_ask_returns_answer",
+                    "chat rate-limited (surfaced through the REST route)",
+                    live_chat_ask=True,
+                )
+            ]
+        )
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.OK, None)
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+        assert any(
+            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            for call in tr._writes
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_live_chat_floor_allows_one_marked_pass(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_chat.py::test_rate_limited", "rate limited", live_chat_ask=True)],
+            passed=[self._passed("test_chat.py::test_ok", live_chat_ask=True)],
+        )
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.OK, None)
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.OK
+        assert not any(
+            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            for call in tr._writes
+        )
+
+    def test_live_chat_floor_ignores_unmarked_passes(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_chat.py::test_rate_limited", "rate limited", live_chat_ask=True)],
+            passed=[self._passed("test_unrelated.py::test_ok")],
+        )
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.OK, None)
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+    def test_live_chat_floor_ignores_unmarked_rate_limit_skips(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter([self._skipped("test_generation.py::test_audio", "rate limited")])
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.OK, None)
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.OK
+
+    def test_live_chat_floor_counts_setup_rate_limit_skips(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [
+                self._skipped(
+                    "test_chat.py::test_auth_skip",
+                    "rate limited",
+                    live_chat_ask=True,
+                    when="setup",
+                )
+            ]
+        )
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.OK, None)
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+    def test_live_chat_floor_does_not_rewrite_non_green_exitstatus(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_chat.py::test_rate_limited", "rate limited", live_chat_ask=True)],
+        )
+        conftest.pytest_terminal_summary(tr, pytest.ExitCode.USAGE_ERROR, None)
+        session = self._finish(conftest, tr, exitstatus=pytest.ExitCode.USAGE_ERROR)
+
+        assert session.exitstatus == pytest.ExitCode.USAGE_ERROR
+        assert not any(
+            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            for call in tr._writes
+        )
+
+    def test_live_chat_floor_changes_real_pytest_exit_code(self, pytester: pytest.Pytester):
+        pytester.makepyprojecttoml(
+            """
+            [tool.pytest.ini_options]
+            markers = [
+                "live_chat_ask: chat ask floor marker",
+            ]
+            """
+        )
+        pytester.makeconftest(
+            """
+            import pytest
+
+            def pytest_sessionfinish(session, exitstatus):
+                terminalreporter = session.config.pluginmanager.get_plugin("terminalreporter")
+                if exitstatus == pytest.ExitCode.OK and terminalreporter.stats.get("skipped"):
+                    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+            def pytest_terminal_summary(terminalreporter, exitstatus, config):
+                if exitstatus == pytest.ExitCode.OK and terminalreporter.stats.get("skipped"):
+                    terminalreporter.write_sep("=", "live chat coverage floor failed")
+            """
+        )
+        pytester.makepyfile(
+            test_floor="""
+            import pytest
+
+            @pytest.mark.live_chat_ask
+            def test_all_chat_asks_rate_limited():
+                pytest.skip("chat rate-limited by upstream")
+            """
+        )
+
+        result = pytester.runpytest_subprocess("-q")
+
+        assert result.ret == pytest.ExitCode.TESTS_FAILED
+        result.stdout.fnmatch_lines(["*live chat coverage floor failed*"])
 
 
 class TestGenerationRateLimitSkip:


### PR DESCRIPTION
## Summary
- Add a `live_chat_ask` E2E marker and apply it to live chat ask paths across API, CLI, MCP, REST, notebook ask, and source-selection tests.
- Fail otherwise-green E2E runs when marked live chat ask tests only produced rate-limit skips and no marked ask test passed.
- Expand rate-limit phrase handling for `rate-limited` REST/CLI wording and add regression coverage for marker filtering, setup skips, non-green exits, and real pytest exit-code behavior.

Closes #1816

## Test plan
- `uv run pytest tests/unit/test_e2e_conftest_options.py`
- `uv run pytest tests/unit/test_e2e_conftest_options.py tests/_guardrails/test_no_session.py`
- `uv run ruff check pyproject.toml tests/e2e/conftest.py tests/e2e/test_chat.py tests/e2e/test_cli_live.py tests/e2e/test_mcp.py tests/e2e/test_notebooks.py tests/e2e/test_server_live.py tests/e2e/test_source_selection.py tests/unit/test_e2e_conftest_options.py`
- `uv run pytest tests/e2e -m live_chat_ask --collect-only -q`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`
- `uv run pytest` (`10607 passed, 83 skipped, 1 xfailed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `live_chat_ask` marker and tagged relevant end-to-end chat scenarios so they’re grouped consistently for coverage checks.
  * Introduced a “live chat coverage floor” that fails the overall run when all marked cases were rate-limited/skipped and none successfully passed.
* **Bug Fixes**
  * Broadened rate-limit detection to catch additional throttle phrasing and HTTP 429 signals.
  * Enhanced the terminal output to clearly indicate when the coverage floor fails.
* **Tests**
  * Updated and expanded unit and integration-style test coverage for marker handling and the coverage-floor exit-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->