### PR TITLE
chore: release v0.8.0a3 — pin fastmcp==3.4.2 (fix claude.ai connector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,16 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Fixed
 
+- **Remote MCP connector: pin `fastmcp==3.4.2` so claude.ai can connect.**
+  fastmcp 3.4.3 regressed the RFC 9728 protected-resource-metadata route
+  (`/.well-known/oauth-protected-resource/mcp` started returning **404**), which
+  dead-ends the claude.ai remote-connector OAuth discovery — the connector fails
+  with *"Couldn't connect to the server."* Because the `mcp` extra previously
+  allowed `fastmcp>=3.0,<4`, the published `0.8.0a2` Docker image floated to the
+  broken 3.4.3 at build time even though the client code was unchanged. The
+  `mcp` extra is now pinned to the last-good `fastmcp==3.4.2`; the pin will be
+  lifted once a fixed fastmcp ships.
+
 - **First-class human/mobile upload path in `upload_required`**
   ([#1801](https://github.com/teng-lin/notebooklm-py/issues/1801)). When a source
   add needs a browser upload, the `upload_required` response now surfaces the

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0a2",
+  "version": "0.8.0a3",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0a2"
+version = "0.8.0a3"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -54,7 +54,11 @@ impersonate = ["curl_cffi>=0.11,<1"]
 headless = ["gpsoauth>=1.1.0"]
 # >=3.0: the remote-transport bearer auth (FastMCP(auth=...) + TokenVerifier)
 # landed in fastmcp 3.0; 2.x lacks it and would ImportError in mcp/_auth.py.
-mcp = ["fastmcp>=3.0,<4"]
+# Pinned ==3.4.2: fastmcp 3.4.3 broke the RFC 9728 protected-resource-metadata
+# route (/.well-known/oauth-protected-resource/mcp → 404), which dead-ends
+# claude.ai's remote-connector OAuth discovery ("Couldn't connect to the
+# server"). 3.4.2 is the last-good; lift the pin once a fixed release ships.
+mcp = ["fastmcp==3.4.2"]
 # Optional single-tenant REST server (the third _app adapter, after cli/ and
 # mcp/). EXPERIMENTAL: the /v1 surface may change in a minor release; it is
 # excluded from the public-API compatibility gate. python-multipart is REQUIRED

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -9,7 +9,10 @@ register→authorize→login→token→verify flow.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import re
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -36,6 +39,7 @@ from notebooklm.mcp._oauth import (  # noqa: E402
     build_oauth_provider,
     get_oauth_config,
 )
+from notebooklm.mcp.server import create_server  # noqa: E402
 
 _PW = "a-strong-random-password-1234567890"
 
@@ -164,6 +168,91 @@ def test_metadata_advertises_registration_endpoint() -> None:
     with TestClient(app) as c:
         meta = c.get("/.well-known/oauth-authorization-server").json()
     assert meta.get("registration_endpoint")  # DCR enabled → claude.ai can register
+
+
+# ------------------------------------------------- connector discovery (RFC 9728)
+# These drive the FULL FastMCP ``http_app()`` — not just the AS provider routes —
+# because the protected-resource-metadata endpoint is mounted by the MCP app, and
+# that is exactly what fastmcp 3.4.3 regressed: its Host/Origin guard rejected any
+# request whose Host wasn't its (localhost/``testserver``) allowlist — including
+# the deployment's own public origin — so claude.ai's discovery fetch got a
+# non-200 and dead-ended ("Couldn't connect to the server"). pyproject pins
+# ``fastmcp==3.4.2``; these fail loudly (under a realistic Host) if a float breaks it.
+_HOST = "host.example.com"
+
+
+def _oauth_http_app():
+    """The real FastMCP ``http_app()`` in OAuth mode, client bound to a stub."""
+
+    @contextlib.asynccontextmanager
+    async def factory():
+        yield MagicMock()
+
+    server = create_server(client_factory=factory, auth=build_auth(None, _provider()))
+    return server.http_app()
+
+
+def _path(url: str) -> str:
+    """Strip the public origin → the route path the in-process TestClient hits."""
+    return url.split(_HOST, 1)[-1]
+
+
+# The connector reaches the server under its OWN public origin (behind the
+# tunnel), NOT ``testserver``. This Host header is load-bearing: fastmcp 3.4.3's
+# Host/Origin guard allowlisted ``testserver``/localhost but not the deployment
+# origin, so it rejected the real request (→ 421) while a default TestClient Host
+# sailed through. Every request below sends the realistic Host so the guard is
+# actually exercised.
+_H = {"host": _HOST}
+
+
+def test_mcp_401_resource_metadata_is_fetchable() -> None:
+    """The ``/mcp`` 401 must advertise a resource-metadata URL that returns 200
+    when fetched under the deployment's own Host.
+
+    Precise regression guard for fastmcp 3.4.3: its Host-protection returned a
+    non-200 (421/404) for ``/.well-known/oauth-protected-resource/mcp`` under the
+    real connector Host, so claude.ai could not discover the auth server
+    ("Couldn't connect to the server"). pyproject pins ``fastmcp==3.4.2``.
+    """
+    with TestClient(_oauth_http_app()) as c:
+        r = c.post(
+            "/mcp",
+            headers={**_H, "Accept": "application/json, text/event-stream"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        )
+        assert r.status_code == 401, f"/mcp under Host={_HOST!r} -> {r.status_code}"
+        m = re.search(r'resource_metadata="([^"]+)"', r.headers.get("www-authenticate", ""))
+        assert m, f"no resource_metadata in WWW-Authenticate: {r.headers.get('www-authenticate')!r}"
+        meta = c.get(_path(m.group(1)), headers=_H)
+        assert meta.status_code == 200, (
+            f"{_path(m.group(1))} under Host={_HOST!r} -> {meta.status_code}; the 401 "
+            "points at an unreachable metadata doc (fastmcp host-guard regression?)"
+        )
+        assert meta.json().get("authorization_servers")
+
+
+def test_dynamic_client_registration_succeeds() -> None:
+    """claude.ai registers a client via DCR before connecting; ``/register`` → 201
+    under the deployment's own Host (guards the same fastmcp 3.4.3 host regression)."""
+    with TestClient(_oauth_http_app()) as c:
+        meta = c.get("/.well-known/oauth-authorization-server", headers=_H)
+        assert meta.status_code == 200, f"AS metadata under Host={_HOST!r} -> {meta.status_code}"
+        reg = c.post(
+            _path(meta.json()["registration_endpoint"]),
+            headers=_H,
+            json={
+                "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_post",
+                "client_name": "test",
+            },
+        )
+        assert reg.status_code == 201, (
+            f"register under Host={_HOST!r} -> {reg.status_code}: {reg.text}"
+        )
+        assert reg.json().get("client_id")
 
 
 # --------------------------------------------------------------------------- DCR cap

--- a/uv.lock
+++ b/uv.lock
@@ -687,34 +687,65 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.0"
+version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -793,6 +824,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -1264,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0a2"
+version = "0.8.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1342,7 +1382,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "curl-cffi", marker = "extra == 'impersonate'", specifier = ">=0.11,<1" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115,<1" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0,<4" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = "==3.4.2" },
     { name = "filelock", specifier = ">=3.13,<4" },
     { name = "gpsoauth", marker = "extra == 'headless'", specifier = ">=1.1.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.29" },


### PR DESCRIPTION
Release **v0.8.0a3** — hotfix for the remote MCP connector.

### Problem
claude.ai fails to connect to the self-hosted connector on `0.8.0a2` with *"Couldn't connect to the server."* Root cause: **fastmcp 3.4.3** added a Host/Origin guard that rejects any request whose `Host` isn't its localhost/`testserver` allowlist — including the deployment's own public origin — so claude.ai's OAuth discovery fetch of `/.well-known/oauth-protected-resource/mcp` gets a non-200 and dead-ends. The `mcp` extra was unpinned (`fastmcp>=3.0,<4`), so the published `0.8.0a2` Docker image floated to 3.4.3 at build time even though the client code was unchanged from a working `0.8.0a1` (which built against 3.4.2).

### Fix
- Pin `mcp = ["fastmcp==3.4.2"]` (last-good); re-lock `uv.lock`.
- **Regression guards** (`tests/unit/mcp/test_selfhosted_oauth.py`): drive the full `http_app()` under a realistic `Host` header and assert the RFC 9728 protected-resource metadata + dynamic client registration succeed. Verified **pass on 3.4.2, fail on 3.4.3**.

### Verification
Full claude.ai connector handshake against the live deployment on 3.4.2 — `register → authorize → password-login → token → initialize → tools/list` returned **34 tools**. Endpoint that 404/421'd on a2 now returns 200.

See CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB8mwAvNpxq228pSLp5QaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an OAuth discovery issue that could prevent remote MCP connections from working correctly.
  * Improved compatibility by pinning a dependency to a known-good version until a fixed release is available.
  * Added coverage for OAuth metadata discovery and client registration flows to help prevent regressions.
* **Chores**
  * Updated the app and extension version to the next pre-release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->