### PR TITLE
ci(e2e): stamp nightly runs with commit sha

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,7 @@ jobs:
         if: steps.resolve.outputs.is_standard == 'true'
         shell: bash
         run: |
+          set -euo pipefail
           SHA=$(git rev-parse HEAD)
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       branch: ${{ steps.resolve.outputs.branch }}
       is_standard: ${{ steps.resolve.outputs.is_standard }}
+      sha: ${{ steps.target.outputs.sha }}
+      short_sha: ${{ steps.target.outputs.short_sha }}
     steps:
       - name: Resolve target branch
         id: resolve
@@ -62,9 +64,26 @@ jobs:
           esac
           echo "Resolved branch: $TARGET"
 
+      - uses: actions/checkout@v7
+        if: steps.resolve.outputs.is_standard == 'true'
+        with:
+          ref: ${{ steps.resolve.outputs.branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve target commit
+        id: target
+        if: steps.resolve.outputs.is_standard == 'true'
+        shell: bash
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Resolved commit: $SHA"
+
   # Run E2E tests on the resolved branch
   e2e:
-    name: E2E Tests (${{ needs.resolve-branch.outputs.branch }}/${{ matrix.os }})
+    name: E2E Tests (${{ needs.resolve-branch.outputs.branch }}@${{ needs.resolve-branch.outputs.short_sha }}/${{ matrix.os }})
     needs: resolve-branch
     if: needs.resolve-branch.outputs.is_standard == 'true'
     runs-on: ${{ matrix.os }}
@@ -106,8 +125,28 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        ref: ${{ needs.resolve-branch.outputs.branch }}
+        ref: ${{ needs.resolve-branch.outputs.sha }}
+        fetch-depth: 1
         persist-credentials: false
+
+    - name: Stamp E2E target
+      env:
+        EXPECTED_SHA: ${{ needs.resolve-branch.outputs.sha }}
+        TARGET_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
+        MATRIX_OS: ${{ matrix.os }}
+      shell: bash
+      run: |
+        ACTUAL_SHA=$(git rev-parse HEAD)
+        if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+          echo "::error::Checked out $ACTUAL_SHA, expected $EXPECTED_SHA"
+          exit 1
+        fi
+        {
+          echo "### E2E target"
+          echo "- Branch: \`$TARGET_BRANCH\`"
+          echo "- Commit: \`$ACTUAL_SHA\`"
+          echo "- OS: \`$MATRIX_OS\`"
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- Resolve the nightly E2E target branch to a commit SHA before the matrix fans out.
- Check out that SHA in every E2E matrix leg and verify `git rev-parse HEAD` matches it.
- Add branch, commit, and OS to the GitHub step summary for each E2E leg.

## Test plan
- [x] `git diff --check`
- [x] `uv run python scripts/check_workflow_permissions.py`
- [x] `uv run python scripts/check_workflow_secret_gates.py`
- [x] `uv run python scripts/check_action_pinning.py`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest`

## Deferred polish findings
- Optional: replace the resolve-job checkout with `git ls-remote` if clone cost matters.
- Optional: adjust skipped non-standard job display name if empty short SHA ever matters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly end-to-end runs now target the exact resolved commit SHA instead of the resolved branch name, reducing mismatches and flakiness.
  * Nightly run titles now include the short commit SHA for quicker identification.
  * Added a step summary that records the branch, commit SHA, and operating system used for the tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->