### PR TITLE
fix(mcp): keep source waits JSON-first

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -164,6 +164,10 @@ bearer-only deploy → the two file tools return a clear "not configured" error
 
 These conventions hold across every tool:
 
+- **JSON by default.** Read/wait tools, including `source_read`, `source_wait`, and
+  `source_add_and_wait`, return a JSON text content block plus the same
+  `structured_content`. A `resource_link` appears only when a tool explicitly brokers
+  file transfer, such as `studio_download`.
 - **Name *or* ID.** Every `notebook`/`source`/`note`/`artifact` argument accepts a human title **or**
   an ID. Both resolve by prefix: an exact title wins, otherwise a **unique title prefix** matches
   (so `"Scientific"` finds `"Scientific PDF Parsing — …"`), and likewise a full ID or a unique ID

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -18,10 +18,13 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, Literal
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
+from fastmcp.tools.tool import ToolResult
+from mcp.types import TextContent
 
 from ..._app import labels as labels_core
 from ..._app import source_add as add_core
@@ -68,6 +71,20 @@ _DEFAULT_DRIVE_MIME = "google-doc"
 # now lives in the shared, transport-neutral ``_app.views`` so the REST source
 # list/get routes emit the identical enriched shape (Option B). Imported above
 # under its historical private name so the tool bodies below are unchanged.
+
+
+def _json_tool_result(payload: dict[str, Any]) -> ToolResult:
+    """Return JSON as the first-class client-visible content block."""
+    jsonable_payload = to_jsonable(payload)
+    return ToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(jsonable_payload, ensure_ascii=False, sort_keys=True),
+            )
+        ],
+        structured_content=jsonable_payload,
+    )
 
 
 #: Fields kept in a ``source_list(detail="compact")`` roster row — a strict subset of
@@ -165,7 +182,7 @@ def register(mcp: Any) -> None:
         output_format: Literal["text", "markdown"] = "text",
         max_chars: int | None = None,
         offset: int = 0,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         """Read a source at one of two detail levels. Accepts a notebook/source name or ID.
 
         ``detail`` selects what you get back (two distinct shapes):
@@ -214,12 +231,14 @@ def register(mcp: Any) -> None:
                 guide = await content_core.execute_source_guide(
                     client, content_core.SourceGuidePlan(notebook_id=nb_id, source_id=src_id)
                 )
-                return {
-                    "notebook_id": nb_id,
-                    "source_id": guide.source_id,
-                    "summary": guide.summary,
-                    "keywords": list(guide.keywords),
-                }
+                return _json_tool_result(
+                    {
+                        "notebook_id": nb_id,
+                        "source_id": guide.source_id,
+                        "summary": guide.summary,
+                        "keywords": list(guide.keywords),
+                    }
+                )
 
             # detail == "full": the existence/ready gate + ready-only fulltext fetch
             # + max_chars/offset windowing live in the shared ``execute_source_read``
@@ -237,15 +256,17 @@ def register(mcp: Any) -> None:
                     offset=offset,
                 ),
             )
-            return {
-                "notebook_id": nb_id,
-                "source_id": src_id,
-                "source": _source_view(read.source),
-                "content": read.content,
-                "char_count": read.char_count,
-                "truncated": read.truncated,
-                "output_format": output_format,
-            }
+            return _json_tool_result(
+                {
+                    "notebook_id": nb_id,
+                    "source_id": src_id,
+                    "source": _source_view(read.source),
+                    "content": read.content,
+                    "char_count": read.char_count,
+                    "truncated": read.truncated,
+                    "output_format": output_format,
+                }
+            )
 
     @mcp.tool
     async def source_rename(
@@ -300,7 +321,7 @@ def register(mcp: Any) -> None:
         sources: list[str] | str | None = None,
         timeout: float = 120.0,
         interval: float = 1.0,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         """Wait for sources to finish processing. Accepts a notebook name or ID.
 
         Waits for a subset when ``sources`` (list or comma/JSON string) is given, a
@@ -354,7 +375,7 @@ def register(mcp: Any) -> None:
                 outcomes = await _wait_all_sources(
                     client, nb_id, src_ids, timeout=timeout, interval=interval
                 )
-                return await _aggregate_wait_outcomes(client, nb_id, outcomes)
+                return _json_tool_result(await _aggregate_wait_outcomes(client, nb_id, outcomes))
             elif source is not None:
                 src_id = await resolve_source(client, nb_id, source)
                 outcome = await wait_core.execute_source_wait(
@@ -366,7 +387,7 @@ def register(mcp: Any) -> None:
                         interval=interval,
                     ),
                 )
-                return await _aggregate_wait_outcomes(client, nb_id, [outcome])
+                return _json_tool_result(await _aggregate_wait_outcomes(client, nb_id, [outcome]))
             else:
                 sources_list = await client.sources.list(nb_id)
                 outcomes = await _wait_all_sources(
@@ -376,7 +397,7 @@ def register(mcp: Any) -> None:
                     timeout=timeout,
                     interval=interval,
                 )
-                return await _aggregate_wait_outcomes(client, nb_id, outcomes)
+                return _json_tool_result(await _aggregate_wait_outcomes(client, nb_id, outcomes))
 
     @mcp.tool
     async def source_add(
@@ -579,7 +600,7 @@ def register(mcp: Any) -> None:
         allow_internal: bool = False,
         timeout: float = 120.0,
         interval: float = 1.0,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         """Add ONE source and block until it finishes processing, in a single call.
 
         Composes single-mode ``source_add`` + ``source_wait`` so an agent skips the
@@ -644,7 +665,7 @@ def register(mcp: Any) -> None:
             # The created source persists regardless of the wait outcome — surface its id
             # at the top level so a timed-out / failed caller can retry or delete it.
             result["source_id"] = src.id
-            return result
+            return _json_tool_result(result)
 
     @mcp.tool
     async def source_upload_bytes(

--- a/tests/unit/mcp/test_source_json_contract.py
+++ b/tests/unit/mcp/test_source_json_contract.py
@@ -1,0 +1,170 @@
+"""Client-visible JSON-first contract tests for source read/wait MCP tools."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+# Skip cleanly when the `mcp` extra (fastmcp) is absent; see conftest.py.
+pytest.importorskip("fastmcp")
+
+from notebooklm._types.sources import SourceType  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import SourceTimeoutError  # noqa: E402 - after importorskip guard
+from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
+
+from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
+
+NB_ID = "11111111-1111-1111-1111-111111111111"
+SRC_ID = "22222222-2222-2222-2222-222222222222"
+
+
+@dataclass
+class FakeSource:
+    id: str
+    title: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return True
+
+    @property
+    def is_error(self) -> bool:
+        return False
+
+    @property
+    def kind(self) -> SourceType:
+        return SourceType.PASTED_TEXT
+
+    @property
+    def status(self) -> SourceStatus:
+        return SourceStatus.READY
+
+
+@dataclass
+class FakeFulltext:
+    content: str
+    char_count: int
+
+
+@dataclass
+class FakeGuide:
+    summary: str
+    keywords: list[str]
+
+
+def assert_json_first_content(result: Any) -> None:
+    """The model-visible content block is one parseable JSON text block."""
+    assert len(result.content) == 1
+    block = result.content[0]
+    assert block.type == "text"
+    assert block.model_dump(mode="json", exclude_none=True) == {
+        "type": "text",
+        "text": block.text,
+    }
+    assert json.loads(block.text) == result.structured_content
+
+
+async def test_source_read_full_is_json_first(mcp_call, mock_client) -> None:
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="hello world", char_count=11)
+    )
+
+    result = await mcp_call("source_read", {"notebook": NB_ID, "source": SRC_ID})
+
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "source_id": SRC_ID,
+        "source": {
+            "id": SRC_ID,
+            "title": "Doc",
+            "kind": "pasted_text",
+            "status_label": "ready",
+        },
+        "content": "hello world",
+        "char_count": 11,
+        "truncated": False,
+        "output_format": "text",
+    }
+    assert_json_first_content(result)
+
+
+async def test_source_read_summary_is_json_first(mcp_call, mock_client) -> None:
+    mock_client.sources.get_or_none = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Doc"))
+    mock_client.sources.get_guide = AsyncMock(
+        return_value=FakeGuide(summary="Short digest", keywords=["alpha", "beta"])
+    )
+
+    result = await mcp_call(
+        "source_read",
+        {"notebook": NB_ID, "source": SRC_ID, "detail": "summary"},
+    )
+
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "source_id": SRC_ID,
+        "summary": "Short digest",
+        "keywords": ["alpha", "beta"],
+    }
+    assert_json_first_content(result)
+
+
+async def test_source_wait_is_json_first(mcp_call, mock_client) -> None:
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Doc")
+    )
+
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "ok": True,
+        "ready": [{"id": SRC_ID, "title": "Doc", "kind": "pasted_text", "status_label": "ready"}],
+        "timed_out": [],
+        "failed": [],
+        "not_found": [],
+    }
+    assert_json_first_content(result)
+
+
+async def test_source_wait_timeout_is_json_first(mcp_call, mock_client) -> None:
+    err = SourceTimeoutError(SRC_ID, 5.0, last_status=1)
+    mock_client.sources.wait_until_ready = AsyncMock(side_effect=err)
+
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "ok": False,
+        "ready": [],
+        "timed_out": [{"source_id": SRC_ID, "error": str(err)}],
+        "failed": [],
+        "not_found": [],
+    }
+    assert_json_first_content(result)
+
+
+async def test_source_add_and_wait_is_json_first(mcp_call, mock_client) -> None:
+    mock_client.sources.add_text = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Notes"))
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Notes")
+    )
+
+    result = await mcp_call(
+        "source_add_and_wait",
+        {"notebook": NB_ID, "source_type": "text", "text": "hello world", "title": "Notes"},
+    )
+
+    assert result.structured_content == {
+        "notebook_id": NB_ID,
+        "ok": True,
+        "ready": [{"id": SRC_ID, "title": "Notes", "kind": "pasted_text", "status_label": "ready"}],
+        "timed_out": [],
+        "failed": [],
+        "not_found": [],
+        "source_id": SRC_ID,
+    }
+    assert_json_first_content(result)


### PR DESCRIPTION
## Summary
- Return explicit JSON text content blocks plus matching structured content for source_read, source_wait, and source_add_and_wait.
- Add MCP contract tests for successful and timed-out JSON-first source results.
- Document the JSON-default/resource-link-only-for-file-transfer MCP rule.

Fixes #1821

## Test plan
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/notebooklm --ignore-missing-imports
- uv run pytest

## Deferred polish findings
- Optional: restore a generic outputSchema for ToolResult-returning source tools if manifest symmetry becomes valuable; current inferred dict schema was not meaningful and manifest tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP source tools now return a consistent JSON text response alongside structured data.
  * Source read, wait, and add-and-wait flows now present the same information in both machine-readable and text form.

* **Bug Fixes**
  * Improved response consistency so clients can reliably parse source tool output.
  * Clarified when file download links appear in tool responses.

* **Tests**
  * Added coverage for JSON response format, summary and full reads, wait success and timeout cases, and add-and-wait behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->