### PR TITLE
Fix Drive source add: require mime_type (#1827) and correct PDF kind (#1828)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -235,7 +235,10 @@ chat_ask(notebook="Quantum Computing", question="What are the open problems?")
 ```
 
 `source_type` is one of `url`, `text`, `file` (local `path`), `drive` (a
-`document_id` + `mime_type`), or `youtube`. URL and YouTube adds reject
+`document_id` + a **required** `mime_type`, one of
+`google-doc`/`google-slides`/`google-sheets`/`pdf` — there is no default, since
+defaulting a non-Doc Drive file to `google-doc` fails the import), or `youtube`.
+URL and YouTube adds reject
 internal/loopback hosts by default; pass `allow_internal=true` only for
 deliberate local NotebookLM tests. `chat_ask` continues the most-recent
 conversation unless you pass a `conversation_id`.

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -546,6 +546,22 @@ _DRIVE_MIME_MAP: dict[DriveMimeChoice, str] = {
     "pdf": DriveMimeType.PDF.value,
 }
 
+#: The declared Drive MIME choice → the source *type code* that labels the
+#: imported file (:data:`notebooklm._types.sources._SOURCE_TYPE_CODE_MAP`).
+#:
+#: The NotebookLM backend returns an ambiguous type code for Drive imports: a
+#: Drive-hosted PDF comes back as code ``14``, which the client otherwise maps to
+#: :attr:`~notebooklm.types.SourceType.GOOGLE_SPREADSHEET`, mislabeling PDFs as
+#: spreadsheets (#1828). On the Drive add path the caller's declared ``mime_type``
+#: is authoritative for the imported file, so we stamp the corresponding type code
+#: onto the returned source rather than exposing the raw (ambiguous) backend code.
+_DRIVE_MIME_TYPE_CODE: dict[DriveMimeChoice, int] = {
+    "google-doc": 1,  # SourceType.GOOGLE_DOCS
+    "google-slides": 2,  # SourceType.GOOGLE_SLIDES
+    "google-sheets": 14,  # SourceType.GOOGLE_SPREADSHEET
+    "pdf": 3,  # SourceType.PDF
+}
+
 
 @dataclass(frozen=True)
 class SourceAddDrivePlan:
@@ -577,6 +593,13 @@ async def execute_source_add_drive(
     mime = _DRIVE_MIME_MAP[plan.mime_type]
 
     src = await client.sources.add_drive(plan.notebook_id, plan.file_id, plan.title, mime)
+    # Stamp the declared type onto the returned source. The backend returns an
+    # ambiguous type code for Drive imports (a Drive-hosted PDF comes back as
+    # ``14`` → GOOGLE_SPREADSHEET), so the caller's declared ``mime_type`` — not the
+    # raw backend code — is authoritative for how the source is labeled (#1828). The
+    # freshly returned ``Source`` is ours to finalize; ``kind`` derives from
+    # ``_type_code``, so overwriting it is the whole fix.
+    src._type_code = _DRIVE_MIME_TYPE_CODE[plan.mime_type]
     return SourceAddDriveResult(
         source=src,
         notebook_id=plan.notebook_id,

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -45,7 +45,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 from ..exceptions import NotebookLMError, ValidationError
-from ..types import DriveMimeType, Source
+from ..types import DriveMimeType, Source, SourceType
 from .resolve import FULL_ID_PATTERN
 from .resolve import validate_id as _neutral_validate_id
 
@@ -546,8 +546,8 @@ _DRIVE_MIME_MAP: dict[DriveMimeChoice, str] = {
     "pdf": DriveMimeType.PDF.value,
 }
 
-#: The declared Drive MIME choice → the source *type code* that labels the
-#: imported file (:data:`notebooklm._types.sources._SOURCE_TYPE_CODE_MAP`).
+#: The declared Drive MIME choice → the :class:`~notebooklm.types.SourceType` that
+#: labels the imported file.
 #:
 #: The NotebookLM backend returns an ambiguous type code for Drive imports: a
 #: Drive-hosted PDF comes back as code ``14``, which the client otherwise maps to
@@ -555,12 +555,29 @@ _DRIVE_MIME_MAP: dict[DriveMimeChoice, str] = {
 #: spreadsheets (#1828). On the Drive add path the caller's declared ``mime_type``
 #: is authoritative for the imported file, so we stamp the corresponding type code
 #: onto the returned source rather than exposing the raw (ambiguous) backend code.
-_DRIVE_MIME_TYPE_CODE: dict[DriveMimeChoice, int] = {
-    "google-doc": 1,  # SourceType.GOOGLE_DOCS
-    "google-slides": 2,  # SourceType.GOOGLE_SLIDES
-    "google-sheets": 14,  # SourceType.GOOGLE_SPREADSHEET
-    "pdf": 3,  # SourceType.PDF
+_DRIVE_MIME_SOURCE_TYPE: dict[DriveMimeChoice, SourceType] = {
+    "google-doc": SourceType.GOOGLE_DOCS,
+    "google-slides": SourceType.GOOGLE_SLIDES,
+    "google-sheets": SourceType.GOOGLE_SPREADSHEET,
+    "pdf": SourceType.PDF,
 }
+
+#: :class:`SourceType` → the numeric ``_type_code`` the wire decoder assigns it.
+#: These four mirror ``notebooklm._types.sources._SOURCE_TYPE_CODE_MAP``; the
+#: ``_app`` boundary forbids importing that private map to invert it at runtime, so
+#: they are pinned via the public enum here (no bare "magic" integer keys) and a
+#: parity test asserts they never drift from the decoder map.
+_SOURCE_TYPE_TO_CODE: dict[SourceType, int] = {
+    SourceType.GOOGLE_DOCS: 1,
+    SourceType.GOOGLE_SLIDES: 2,
+    SourceType.PDF: 3,
+    SourceType.GOOGLE_SPREADSHEET: 14,
+}
+
+
+def drive_mime_type_code(mime: DriveMimeChoice) -> int:
+    """The ``Source._type_code`` a declared Drive ``mime`` should carry (#1828)."""
+    return _SOURCE_TYPE_TO_CODE[_DRIVE_MIME_SOURCE_TYPE[mime]]
 
 
 @dataclass(frozen=True)
@@ -599,7 +616,7 @@ async def execute_source_add_drive(
     # raw backend code — is authoritative for how the source is labeled (#1828). The
     # freshly returned ``Source`` is ours to finalize; ``kind`` derives from
     # ``_type_code``, so overwriting it is the whole fix.
-    src._type_code = _DRIVE_MIME_TYPE_CODE[plan.mime_type]
+    src._type_code = drive_mime_type_code(plan.mime_type)
     return SourceAddDriveResult(
         source=src,
         notebook_id=plan.notebook_id,
@@ -622,6 +639,7 @@ __all__ = [
     "SourceRenamePlan",
     "SourceRenameResult",
     "build_id_ambiguity_error",
+    "drive_mime_type_code",
     "execute_source_add_drive",
     "execute_source_delete",
     "execute_source_delete_by_title",

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -63,8 +63,37 @@ _SOURCE_TYPES = ("url", "text", "file", "drive", "youtube")
 #: Drive MIME choices the backend accepts (mirrors the CLI ``--mime-type``).
 _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
-#: The default Drive MIME choice when the caller does not specify one.
-_DEFAULT_DRIVE_MIME = "google-doc"
+
+def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
+    """Enforce that a Drive add carries an explicit, supported ``mime_type``.
+
+    A Drive add no longer defaults an omitted ``mime_type`` to ``google-doc``
+    (#1827): for a Drive file that is not a native Google Doc (e.g. a raw ``.md``
+    with Drive MIME ``text/markdown``) the ``google-doc`` default silently routed
+    the import through the Google Docs converter, the import failed, and an error
+    source stub was left behind. The client cannot sniff Drive metadata from a
+    bare ``document_id``, so the caller must declare the type. Rejecting here —
+    BEFORE ``resolve_notebook`` and the add RPC — guarantees no source row is
+    persisted for a malformed Drive add.
+
+    A no-op for non-Drive source types (``mime_type`` is dual-use free-text for
+    ``source_type="file"`` — see the call-site note in ``source_add``).
+    """
+    if source_type != "drive":
+        return
+    if mime_type is None:
+        raise ValidationError(
+            "source_type 'drive' requires 'mime_type'; pass one of "
+            f"{list(_DRIVE_MIME_CHOICES)} (e.g. 'pdf' for a Drive-hosted PDF, "
+            "'google-doc' for a native Google Doc). An omitted type is no longer "
+            "defaulted to 'google-doc' — a non-Doc Drive file would fail the import "
+            "and leave an error source stub behind (#1827)."
+        )
+    if mime_type not in _DRIVE_MIME_CHOICES:
+        raise ValidationError(
+            f"Invalid mime_type {mime_type!r} for drive; "
+            f"expected one of {list(_DRIVE_MIME_CHOICES)}"
+        )
 
 
 # ``_source_view`` (Source → dict with string ``kind`` / ``status_label`` labels)
@@ -434,9 +463,9 @@ def register(mcp: Any) -> None:
           ``human_upload.url`` on a network error. ``mime_locked`` is true when
           ``mime_type`` was supplied; ``expires_at_iso`` / ``expires_in_seconds`` give
           the expiry; top-level ``url`` is **deprecated** for ``human_upload.url``.
-        * ``drive``   — requires ``document_id`` (Google Drive file id); ``title``
-          and ``mime_type`` (one of google-doc|google-slides|google-sheets|pdf,
-          default google-doc) optional.
+        * ``drive``   — requires ``document_id`` + ``mime_type`` (one of
+          google-doc|google-slides|google-sheets|pdf; required, no default — a
+          wrong default fails non-Doc imports, #1827); ``title`` optional.
 
         The single-mode named inputs are mutually exclusive — supply only the one
         your ``source_type`` requires.
@@ -515,20 +544,12 @@ def register(mcp: Any) -> None:
             # ``mime_type`` deliberately stays a free-text ``str`` (NOT a ``Literal``):
             # it is DUAL-USE — for ``source_type="file"`` it carries an arbitrary,
             # open-ended MIME type (in the signed upload URL), and only for
-            # ``source_type="drive"`` is it restricted to ``_DRIVE_MIME_CHOICES``.
-            # A ``Literal`` would wrongly reject valid ``file`` MIME types; splitting a
-            # dedicated ``drive_mime_type`` param would grow the ``source_add`` surface
-            # for a niche 4-value option. So the drive choice set is enforced here at
-            # runtime (and listed in the docstring) instead (issue #1759).
-            if (
-                mime_type is not None
-                and source_type == "drive"
-                and mime_type not in _DRIVE_MIME_CHOICES
-            ):
-                raise ValidationError(
-                    f"Invalid mime_type {mime_type!r} for drive; "
-                    f"expected one of {list(_DRIVE_MIME_CHOICES)}"
-                )
+            # ``source_type="drive"`` is it restricted to ``_DRIVE_MIME_CHOICES`` AND
+            # required (no ``google-doc`` default — #1827). A ``Literal`` would wrongly
+            # reject valid ``file`` MIME types; splitting a dedicated ``drive_mime_type``
+            # param would grow the ``source_add`` surface for a niche 4-value option. So
+            # the drive choice set is enforced here at runtime (issue #1759).
+            _validate_drive_mime(source_type, mime_type)
             # Content-scalar exclusivity (fail-closed): reject any content scalar
             # this source_type does not consume. title/mime_type are untouched —
             # they are optional metadata, not content.
@@ -564,8 +585,9 @@ def register(mcp: Any) -> None:
                     mut_core.SourceAddDrivePlan(
                         notebook_id=nb_id,
                         file_id=document_id,
+                        # Non-None + a valid choice, guaranteed by _validate_drive_mime above.
+                        mime_type=mime_type,  # type: ignore[arg-type]
                         title=title or "",
-                        mime_type=mime_type or _DEFAULT_DRIVE_MIME,  # type: ignore[arg-type]
                     ),
                 )
                 return _add_result_payload(
@@ -625,18 +647,10 @@ def register(mcp: Any) -> None:
             if interval <= 0:
                 raise ValidationError(f"interval must be > 0; got {interval}")
             # The same single-add guards source_add applies, all BEFORE any notebook
-            # I/O so a malformed call never pays a round-trip. Kept in sync with
-            # source_add's copies (the drive-mime check + _reject_single_content_scalars):
-            # if _CONTENT_SCALAR_OWNERS / _DRIVE_MIME_CHOICES change, update both sites.
-            if (
-                mime_type is not None
-                and source_type == "drive"
-                and mime_type not in _DRIVE_MIME_CHOICES
-            ):
-                raise ValidationError(
-                    f"Invalid mime_type {mime_type!r} for drive; "
-                    f"expected one of {list(_DRIVE_MIME_CHOICES)}"
-                )
+            # I/O so a malformed call never pays a round-trip. Shares the drive-mime
+            # validator + _reject_single_content_scalars with source_add so the two
+            # tools stay in lockstep.
+            _validate_drive_mime(source_type, mime_type)
             _reject_single_content_scalars(
                 source_type, url=url, text=text, path=path, document_id=document_id
             )
@@ -936,7 +950,9 @@ async def _add_source_to_wait_on(
                 notebook_id=notebook_id,
                 file_id=document_id,
                 title=title or "",
-                mime_type=mime_type or _DEFAULT_DRIVE_MIME,  # type: ignore[arg-type]
+                # Non-None + a valid choice, guaranteed by _validate_drive_mime in the
+                # source_add_and_wait tool body before this helper is reached (#1827).
+                mime_type=mime_type,  # type: ignore[arg-type]
             ),
         )
         return drive_result.source

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -68,19 +68,15 @@ _DRIVE_MIME_CHOICES_STR = ", ".join(f"'{choice}'" for choice in _DRIVE_MIME_CHOI
 
 
 def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
-    """Enforce that a Drive add carries an explicit, supported ``mime_type``.
+    """Require an explicit, supported ``mime_type`` for a Drive add (#1827).
 
-    A Drive add no longer defaults an omitted ``mime_type`` to ``google-doc``
-    (#1827): for a Drive file that is not a native Google Doc (e.g. a raw ``.md``
-    with Drive MIME ``text/markdown``) the ``google-doc`` default silently routed
-    the import through the Google Docs converter, the import failed, and an error
-    source stub was left behind. The client cannot sniff Drive metadata from a
-    bare ``document_id``, so the caller must declare the type. Rejecting here —
-    BEFORE ``resolve_notebook`` and the add RPC — guarantees no source row is
-    persisted for a malformed Drive add.
-
-    A no-op for non-Drive source types (``mime_type`` is dual-use free-text for
-    ``source_type="file"`` — see the call-site note in ``source_add``).
+    A Drive add no longer defaults an omitted ``mime_type`` to ``google-doc``: a
+    non-Doc Drive file (e.g. a raw ``.md``) so routed through the Google Docs
+    converter failed the import and left an error source stub behind. The client
+    can't sniff Drive metadata from a bare ``document_id``, so the caller must
+    declare the type; rejecting BEFORE ``resolve_notebook`` / the add RPC persists
+    no source row. A no-op for non-Drive types (``mime_type`` is dual-use free-text
+    for ``source_type="file"``).
     """
     if source_type != "drive":
         return
@@ -678,10 +674,9 @@ def register(mcp: Any) -> None:
                 ),
             )
             # ``wait_until_ready`` re-reads the source from GET_NOTEBOOK, where a Drive
-            # PDF again decodes to the ambiguous type code 14 → GOOGLE_SPREADSHEET. The
-            # freshly-added ``src`` already carries the declared-authoritative code
-            # (#1828), so carry it onto the ready outcome before aggregating — otherwise
-            # add-and-wait would relabel the source that source_add labels correctly.
+            # PDF again decodes to the ambiguous code 14 → GOOGLE_SPREADSHEET; carry the
+            # already-stamped code from ``src`` onto the ready outcome so add-and-wait
+            # labels it the same as source_add (#1828).
             if source_type == "drive" and isinstance(outcome, wait_core.SourceWaitReady):
                 outcome.source._type_code = src._type_code
             result = await _aggregate_wait_outcomes(client, nb_id, [outcome])
@@ -959,8 +954,7 @@ async def _add_source_to_wait_on(
                 notebook_id=notebook_id,
                 file_id=document_id,
                 title=title or "",
-                # Non-None + a valid choice, guaranteed by _validate_drive_mime in the
-                # source_add_and_wait tool body before this helper is reached (#1827).
+                # Non-None + valid: _validate_drive_mime ran in the tool body (#1827).
                 mime_type=mime_type,  # type: ignore[arg-type]
             ),
         )

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -63,6 +63,9 @@ _SOURCE_TYPES = ("url", "text", "file", "drive", "youtube")
 #: Drive MIME choices the backend accepts (mirrors the CLI ``--mime-type``).
 _DRIVE_MIME_CHOICES = ("google-doc", "google-slides", "google-sheets", "pdf")
 
+#: The choices as a clean, comma-separated quoted string for user-facing errors.
+_DRIVE_MIME_CHOICES_STR = ", ".join(f"'{choice}'" for choice in _DRIVE_MIME_CHOICES)
+
 
 def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
     """Enforce that a Drive add carries an explicit, supported ``mime_type``.
@@ -84,15 +87,14 @@ def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
     if mime_type is None:
         raise ValidationError(
             "source_type 'drive' requires 'mime_type'; pass one of "
-            f"{list(_DRIVE_MIME_CHOICES)} (e.g. 'pdf' for a Drive-hosted PDF, "
+            f"{_DRIVE_MIME_CHOICES_STR} (e.g. 'pdf' for a Drive-hosted PDF, "
             "'google-doc' for a native Google Doc). An omitted type is no longer "
             "defaulted to 'google-doc' — a non-Doc Drive file would fail the import "
             "and leave an error source stub behind (#1827)."
         )
     if mime_type not in _DRIVE_MIME_CHOICES:
         raise ValidationError(
-            f"Invalid mime_type {mime_type!r} for drive; "
-            f"expected one of {list(_DRIVE_MIME_CHOICES)}"
+            f"Invalid mime_type {mime_type!r} for drive; expected one of {_DRIVE_MIME_CHOICES_STR}"
         )
 
 
@@ -675,6 +677,13 @@ def register(mcp: Any) -> None:
                     notebook_id=nb_id, source_id=src.id, timeout=timeout, interval=interval
                 ),
             )
+            # ``wait_until_ready`` re-reads the source from GET_NOTEBOOK, where a Drive
+            # PDF again decodes to the ambiguous type code 14 → GOOGLE_SPREADSHEET. The
+            # freshly-added ``src`` already carries the declared-authoritative code
+            # (#1828), so carry it onto the ready outcome before aggregating — otherwise
+            # add-and-wait would relabel the source that source_add labels correctly.
+            if source_type == "drive" and isinstance(outcome, wait_core.SourceWaitReady):
+                outcome.source._type_code = src._type_code
             result = await _aggregate_wait_outcomes(client, nb_id, [outcome])
             # The created source persists regardless of the wait outcome — surface its id
             # at the top level so a timed-out / failed caller can retry or delete it.

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -93,11 +93,17 @@ class SourceAddText(BaseModel):
 
 
 class SourceAddDrive(BaseModel):
-    """Request body for adding a Google Drive document source."""
+    """Request body for adding a Google Drive document source.
+
+    ``mime_type`` is REQUIRED (no ``google-doc`` default): defaulting a non-Doc
+    Drive file to ``google-doc`` silently routes it through the Google Docs
+    converter, fails the import, and leaves an error source stub behind (#1827).
+    An omitted value is rejected by Pydantic (422) before any add RPC runs.
+    """
 
     document_id: str
     title: str | None = None
-    mime_type: mut_core.DriveMimeChoice = "google-doc"
+    mime_type: mut_core.DriveMimeChoice
 
 
 class SourceAddBatch(BaseModel):
@@ -370,10 +376,12 @@ async def add_drive(
 ) -> dict[str, Any]:
     """Add a Google Drive document as a source.
 
-    ``mime_type`` is one of ``google-doc`` (default) / ``google-slides`` /
-    ``google-sheets`` / ``pdf`` (validated by the neutral core, which 400s on an
-    unknown value). Flows through ``_app.source_mutations.execute_source_add_drive``
-    (the neutral ``source_add`` core has no Drive path).
+    ``mime_type`` is REQUIRED — one of ``google-doc`` / ``google-slides`` /
+    ``google-sheets`` / ``pdf`` (an omitted value is rejected with 422; an unknown
+    value is 400ed by the neutral core). There is no ``google-doc`` default because
+    it silently fails non-Doc Drive imports and leaves an error stub behind (#1827).
+    Flows through ``_app.source_mutations.execute_source_add_drive`` (the neutral
+    ``source_add`` core has no Drive path).
     """
     result = await mut_core.execute_source_add_drive(
         client,

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -377,11 +377,13 @@ async def add_drive(
     """Add a Google Drive document as a source.
 
     ``mime_type`` is REQUIRED — one of ``google-doc`` / ``google-slides`` /
-    ``google-sheets`` / ``pdf`` (an omitted value is rejected with 422; an unknown
-    value is 400ed by the neutral core). There is no ``google-doc`` default because
-    it silently fails non-Doc Drive imports and leaves an error stub behind (#1827).
-    Flows through ``_app.source_mutations.execute_source_add_drive`` (the neutral
-    ``source_add`` core has no Drive path).
+    ``google-sheets`` / ``pdf``. It is a ``Literal``, so an omitted OR unknown value
+    is rejected with 422 by Pydantic at the schema boundary (the neutral core's
+    ``ValidationError`` guard is a defense-in-depth backstop that this route never
+    reaches). There is no ``google-doc`` default because it silently fails non-Doc
+    Drive imports and leaves an error stub behind (#1827). Flows through
+    ``_app.source_mutations.execute_source_add_drive`` (the neutral ``source_add``
+    core has no Drive path).
     """
     result = await mut_core.execute_source_add_drive(
         client,

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -399,11 +399,24 @@ def test_add_drive_source(authed_client: TestClient, fake_client: FakeClient) ->
     assert mime == "application/vnd.google-apps.document"
 
 
-def test_add_drive_default_mime(authed_client: TestClient, fake_client: FakeClient) -> None:
+def test_add_drive_missing_mime_is_422(authed_client: TestClient, fake_client: FakeClient) -> None:
+    """``mime_type`` is required — an omitted value is rejected (422) with no add
+    RPC, so no error source stub is left behind (#1827)."""
     resp = authed_client.post("/v1/notebooks/nb-1/sources/drive", json={"document_id": "doc-1"})
+    assert resp.status_code == 422
+    assert fake_client.added_drive == []
+
+
+def test_add_drive_pdf_kind_not_spreadsheet(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """A Drive PDF add surfaces as ``kind='pdf'``, not ``google_spreadsheet`` (#1828)."""
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/drive",
+        json={"document_id": "doc-pdf", "title": "Report.pdf", "mime_type": "pdf"},
+    )
     assert resp.status_code == 201
-    # Default choice ``google-doc`` → Google Docs MIME.
-    assert fake_client.added_drive[0][3] == "application/vnd.google-apps.document"
+    assert resp.json()["kind"] == "pdf"
 
 
 def test_add_drive_bad_mime_is_422(authed_client: TestClient) -> None:

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -44,7 +44,7 @@ from notebooklm._app.source_mutations import (
     resolve_source_for_delete,
 )
 from notebooklm.exceptions import NotebookLMError, ValidationError
-from notebooklm.types import DriveMimeType, Source
+from notebooklm.types import DriveMimeType, Source, SourceType
 
 _FULL_UUID = "11111111-2222-3333-4444-555555555555"
 
@@ -410,15 +410,17 @@ async def test_refresh_resolves_then_refreshes() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("choice", "expected_mime"),
+    ("choice", "expected_mime", "expected_kind"),
     [
-        ("google-doc", DriveMimeType.GOOGLE_DOC.value),
-        ("google-slides", DriveMimeType.GOOGLE_SLIDES.value),
-        ("google-sheets", DriveMimeType.GOOGLE_SHEETS.value),
-        ("pdf", DriveMimeType.PDF.value),
+        ("google-doc", DriveMimeType.GOOGLE_DOC.value, SourceType.GOOGLE_DOCS),
+        ("google-slides", DriveMimeType.GOOGLE_SLIDES.value, SourceType.GOOGLE_SLIDES),
+        ("google-sheets", DriveMimeType.GOOGLE_SHEETS.value, SourceType.GOOGLE_SPREADSHEET),
+        ("pdf", DriveMimeType.PDF.value, SourceType.PDF),
     ],
 )
-async def test_add_drive_maps_mime(choice: str, expected_mime: str) -> None:
+async def test_add_drive_maps_mime(
+    choice: str, expected_mime: str, expected_kind: SourceType
+) -> None:
     client = _client()
     added = Source(id="src_drive", title="Drive Doc")
     client.sources.add_drive = AsyncMock(return_value=added)
@@ -432,7 +434,34 @@ async def test_add_drive_maps_mime(choice: str, expected_mime: str) -> None:
     assert result.source is added
     assert result.file_id == "fid"
     assert result.mime_type == choice
+    # The declared mime stamps the source's kind (#1828).
+    assert result.source.kind == expected_kind
     client.sources.add_drive.assert_awaited_once_with("nb_1", "fid", "Drive Doc", expected_mime)
+
+
+@pytest.mark.asyncio
+async def test_add_drive_pdf_not_mislabeled_as_spreadsheet() -> None:
+    """A Drive PDF add must not surface as ``kind='google_spreadsheet'`` (#1828).
+
+    The NotebookLM backend returns an ambiguous type code for Drive-hosted PDFs —
+    code ``14``, which the client otherwise maps to GOOGLE_SPREADSHEET. The declared
+    ``mime_type='pdf'`` is authoritative, so ``execute_source_add_drive`` re-stamps
+    the returned source's type code to PDF.
+    """
+    client = _client()
+    # Simulate the backend's ambiguous code (14 → GOOGLE_SPREADSHEET) on the raw add.
+    added = Source(id="src_pdf", title="Report.pdf", _type_code=14)
+    assert added.kind is SourceType.GOOGLE_SPREADSHEET  # the bug, pre-stamp
+    client.sources.add_drive = AsyncMock(return_value=added)
+    plan = SourceAddDrivePlan(
+        notebook_id="nb_1",
+        file_id="fid",
+        title="Report.pdf",
+        mime_type="pdf",
+    )
+    result = await execute_source_add_drive(client, plan)
+    assert result.source.kind == SourceType.PDF
+    assert result.source.kind != SourceType.GOOGLE_SPREADSHEET
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -439,6 +439,18 @@ async def test_add_drive_maps_mime(
     client.sources.add_drive.assert_awaited_once_with("nb_1", "fid", "Drive Doc", expected_mime)
 
 
+def test_drive_mime_maps_have_matching_keys() -> None:
+    """The two Drive-mime dicts are both keyed by ``DriveMimeChoice`` and indexed on
+    the same add path: validation checks ``_DRIVE_MIME_MAP`` but the type-code stamp
+    indexes ``_DRIVE_MIME_SOURCE_TYPE``. If a future choice is added to one but not the
+    other, a validated add would raise ``KeyError`` (→ UNEXPECTED) instead of the clean
+    ``VALIDATION`` the code promises. Guard their key sets together (a module-level
+    ``assert`` would be stripped under ``python -O``)."""
+    from notebooklm._app.source_mutations import _DRIVE_MIME_MAP, _DRIVE_MIME_SOURCE_TYPE
+
+    assert _DRIVE_MIME_MAP.keys() == _DRIVE_MIME_SOURCE_TYPE.keys()
+
+
 def test_source_type_to_code_matches_decoder_map() -> None:
     """``_SOURCE_TYPE_TO_CODE`` is pinned by hand (the ``_app`` boundary forbids
     importing the private decoder map to invert it), so guard it against drift: each

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -439,6 +439,17 @@ async def test_add_drive_maps_mime(
     client.sources.add_drive.assert_awaited_once_with("nb_1", "fid", "Drive Doc", expected_mime)
 
 
+def test_source_type_to_code_matches_decoder_map() -> None:
+    """``_SOURCE_TYPE_TO_CODE`` is pinned by hand (the ``_app`` boundary forbids
+    importing the private decoder map to invert it), so guard it against drift: each
+    (SourceType → code) entry must round-trip through the canonical decoder map."""
+    from notebooklm._app.source_mutations import _SOURCE_TYPE_TO_CODE
+    from notebooklm._types.sources import _SOURCE_TYPE_CODE_MAP
+
+    for source_type, code in _SOURCE_TYPE_TO_CODE.items():
+        assert _SOURCE_TYPE_CODE_MAP[code] == source_type
+
+
 @pytest.mark.asyncio
 async def test_add_drive_pdf_not_mislabeled_as_spreadsheet() -> None:
     """A Drive PDF add must not surface as ``kind='google_spreadsheet'`` (#1828).

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -34,7 +34,7 @@ from notebooklm.mcp.tools._content_sanity import (  # noqa: E402 - after importo
     _THIN_SOURCE_CHAR_THRESHOLD,
 )
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
-from notebooklm.types import Label  # noqa: E402 - after importorskip guard
+from notebooklm.types import Label, Source  # noqa: E402 - after importorskip guard
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -2076,6 +2076,38 @@ async def test_source_add_and_wait_drive_ready(mcp_call, mock_client) -> None:
     assert sc["source_id"] == SRC_ID
     assert sc["ok"] is True
     mock_client.sources.add_drive.assert_awaited_once()
+
+
+async def test_source_add_and_wait_drive_pdf_kind_not_spreadsheet(mcp_call, mock_client) -> None:
+    """The ready aggregate labels a Drive PDF as ``pdf``, not ``google_spreadsheet``.
+
+    ``wait_until_ready`` re-reads the source from GET_NOTEBOOK, where a Drive PDF
+    again decodes to the ambiguous type code 14 (→ GOOGLE_SPREADSHEET). The declared
+    ``mime_type='pdf'`` must still win on the final waited/aggregated source (#1828),
+    just as it does for plain ``source_add``.
+    """
+    # add_drive returns the raw ambiguous code; the core re-stamps it to PDF.
+    mock_client.sources.add_drive = AsyncMock(
+        return_value=Source(id=SRC_ID, title="Report.pdf", _type_code=14)
+    )
+    # wait_until_ready re-reads the source and again gets the ambiguous code 14.
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=Source(id=SRC_ID, title="Report.pdf", _type_code=14)
+    )
+    result = await mcp_call(
+        "source_add_and_wait",
+        {
+            "notebook": NB_ID,
+            "source_type": "drive",
+            "document_id": "drivefile123",
+            "mime_type": "pdf",
+        },
+    )
+    sc = result.structured_content
+    assert sc["ok"] is True
+    (ready_row,) = sc["ready"]
+    assert ready_row["kind"] == "pdf"
+    assert ready_row["kind"] != "google_spreadsheet"
 
 
 async def test_source_add_and_wait_stdio_file_ready(mcp_call, mock_client, tmp_path) -> None:

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1342,6 +1342,30 @@ async def test_source_add_drive_bad_mime_is_validation_error(mcp_call, mock_clie
     mock_client.sources.add_drive.assert_not_called()
 
 
+@pytest.mark.parametrize("tool", ["source_add", "source_add_and_wait"])
+async def test_source_add_drive_missing_mime_is_validation_error(
+    tool, mcp_call, mock_client
+) -> None:
+    """An omitted drive mime_type is rejected (no google-doc default) and no add
+    RPC runs, so no error source stub is left behind (#1827)."""
+    mock_client.sources.add_drive = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            tool,
+            {
+                "notebook": NB_ID,
+                "source_type": "drive",
+                "document_id": "drivefile123",
+            },
+        )
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    assert "mime_type" in msg
+    # Rejected before resolve_notebook / the add RPC — nothing is persisted.
+    mock_client.sources.add_drive.assert_not_called()
+    mock_client.notebooks.get.assert_not_called()
+
+
 async def test_source_add_mime_type_has_no_schema_enum(mcp_list_tools) -> None:
     """``mime_type`` deliberately stays a free-text ``str`` — NOT a ``Literal`` — so its
     schema carries NO ``enum`` (issue #1759, decision b). It is dual-use: ``source_type=
@@ -1372,10 +1396,12 @@ async def test_source_add_mime_type_has_no_schema_enum(mcp_list_tools) -> None:
         ("file", {"path": "/tmp/doc.pdf"}, {"url": "https://example.com/a"}),
         ("file", {"path": "/tmp/doc.pdf"}, {"text": "hi"}),
         ("file", {"path": "/tmp/doc.pdf"}, {"document_id": "drivefile123"}),
-        # drive consumes `document_id`; url/text/path are foreign.
-        ("drive", {"document_id": "drivefile123"}, {"url": "https://example.com/a"}),
-        ("drive", {"document_id": "drivefile123"}, {"text": "hi"}),
-        ("drive", {"document_id": "drivefile123"}, {"path": "/tmp/x"}),
+        # drive consumes `document_id`; url/text/path are foreign. ``mime_type`` is
+        # required for drive (#1827), so it rides along in ``good`` to reach the
+        # foreign-scalar check (it is metadata, not a content scalar).
+        ("drive", {"document_id": "drivefile123", "mime_type": "pdf"}, {"url": "https://e.com/a"}),
+        ("drive", {"document_id": "drivefile123", "mime_type": "pdf"}, {"text": "hi"}),
+        ("drive", {"document_id": "drivefile123", "mime_type": "pdf"}, {"path": "/tmp/x"}),
         # youtube consumes `url`; text/path/document_id are foreign.
         ("youtube", {"url": "https://www.youtube.com/watch?v=abc"}, {"text": "hi"}),
         ("youtube", {"url": "https://www.youtube.com/watch?v=abc"}, {"path": "/tmp/x"}),


### PR DESCRIPTION
## Summary

Two related fixes to the Google Drive source-add path on the programmatic (MCP + REST) surfaces:

- **#1827** — Drive adds no longer silently default an omitted `mime_type` to `google-doc` (which failed non-Doc Drive imports and left an error source stub behind). `mime_type` is now **required** for `source_type="drive"`.
- **#1828** — Drive PDF imports no longer surface as `kind="google_spreadsheet"`. The declared `mime_type` now stamps the returned source's type code, so a Drive PDF reports `kind="pdf"`.

## Related Issue

Closes #1827
Closes #1828

## Changes

**#1827 — require `mime_type` for Drive adds**
- Added a shared `_validate_drive_mime(source_type, mime_type)` helper in `mcp/tools/sources.py` that rejects both an **omitted** and an **unknown** Drive mime with a self-documenting `VALIDATION` error, positioned **before** `resolve_notebook` and the add RPC — so a malformed Drive add never persists a source row (no stub to clean up).
- Wired it into both `source_add` and `source_add_and_wait`; removed the `_DEFAULT_DRIVE_MIME = "google-doc"` fallback.
- REST `POST /v1/notebooks/{id}/sources/drive`: `SourceAddDrive.mime_type` lost its `"google-doc"` default, so an omitted value is rejected by Pydantic (422) before the route body runs.
- Metadata sniffing (the issue's preferred option) wasn't viable — the client only holds a bare `document_id` with no Drive-metadata read path — so the "make it required" fallback was taken.

**#1828 — correct Drive PDF `kind`**
- `execute_source_add_drive` (transport-neutral core) now stamps the returned source's `_type_code` from the caller's declared `mime_type` via a new `_DRIVE_MIME_TYPE_CODE` map. The backend returns an ambiguous code (`14` → `GOOGLE_SPREADSHEET`) for Drive-hosted PDFs; the declared mime is authoritative, so this only ever corrects a code. MCP, REST, and CLI all benefit.

**Docs / tests**
- `docs/mcp-guide.md`: documents that Drive `mime_type` is required.
- Regression tests: parametrized MCP omitted-mime rejection (both tools, `add_drive` not called), REST 422, `_app`-core + server-route assertions that a Drive PDF reports `kind="pdf"` not `google_spreadsheet`, and the add-drive mime-mapping test now asserts `kind` per declared mime.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (full non-e2e suite green: 5800 passed, 81 skipped, 1 xfailed — including the `test_surface_schema_cost_within_budget` schema ratchet)
- [x] Linting and formatting pass (`ruff format` + `ruff check` clean on changed files)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports` — no issues, 304 files)
- [x] If this PR changes architectural shape, an ADR has been added or updated. (No architectural change — behavior fix within existing layers.)

## Notes

- **Scope:** the CLI `source add-drive --mime-type` keeps its explicit `google-doc` default — a human deliberately picks the flag and sees the default in `--help`; the footgun #1827 is about is the *silent, agent-invisible* default on the MCP/REST surfaces, which is what's removed.
- **Known limitation (#1828):** `source_list` re-derives `kind` from `GET_NOTEBOOK`, where only the ambiguous code `14` is available (no record of the declared mime), so a Drive PDF still lists as `google_spreadsheet` there. Disambiguating at list time needs a real wire signal (e.g. source-URL shape) that I don't want to guess without a live capture per the cohort-gating policy. Can follow up with a `scripts/scrub_rpc_har.py` capture if list-path normalization is wanted.
- I did not run the exact `--cov-fail-under=90` invocation from the template; the fixes add net-new tests and remove no coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drive imports now fail fast when `mime_type` is missing or unsupported, avoiding incorrect defaults.
  * Drive-hosted PDFs are consistently labeled as PDFs (not spreadsheets), including after add-and-wait flows.
* **Documentation**
  * Updated the MCP guide to clearly document required Drive ingestion fields and the allowed `mime_type` values.
* **Tests**
  * Expanded coverage for Drive `mime_type` validation and for correct kind labeling when backend decoding is ambiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->