### PR TITLE
fix(mcp): make studio_download output_format rejection self-documenting

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -340,6 +340,20 @@ studio_generate(notebook="Quantum Computing", artifact_type="video",
                   style="custom", style_prompt="hand-drawn diagrams")
 ```
 
+`studio_download`'s `output_format` overrides the download file format, but only
+some artifact types have a format axis:
+
+| `artifact_type` | Supported `output_format` |
+| --- | --- |
+| `slide-deck` | `pdf` (default), `pptx` |
+| `quiz`, `flashcards` | `json` (default), `markdown`, `html` |
+| `audio`, `video`, `infographic`, `report`, `mind-map`, `data-table` | none — omit `output_format` |
+
+Passing `output_format` to a type with no format axis (e.g. `report` +
+`markdown`) is a validation error that says `Supported formats: default only`
+rather than silently ignoring it, and the message is identical whether the
+download runs over stdio (`path`) or the remote signed-URL connector.
+
 `artifact_type` is one of `audio`, `video`, `cinematic-video`, `slide-deck`, `quiz`, `flashcards`,
 `infographic`, `data-table`, `mind-map`, `report`. Each kind's styling options are agent-settable
 (matching the CLI flags): `audio_format` / `audio_length` (audio); `video_format` / `style` /

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -350,7 +350,7 @@ some artifact types have a format axis:
 | `audio`, `video`, `infographic`, `report`, `mind-map`, `data-table` | none — omit `output_format` |
 
 Passing `output_format` to a type with no format axis (e.g. `report` +
-`markdown`) is a validation error that says `Supported formats: default only`
+`markdown`) is a validation error that says `supported formats: default only`
 rather than silently ignoring it, and the message is identical whether the
 download runs over stdio (`path`) or the remote signed-URL connector.
 

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -609,7 +609,9 @@ def register(mcp: Any) -> None:
             if output_format is not None:
                 if not spec.format_choices:
                     raise ValidationError(
-                        f"artifact_type {artifact_type!r} does not support an output_format option"
+                        f"output_format {output_format!r} is not valid for artifact_type "
+                        f"{artifact_type!r}; Supported formats: default only "
+                        f"(omit output_format)."
                     )
                 if output_format not in spec.format_choices:
                     raise ValidationError(

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -610,7 +610,7 @@ def register(mcp: Any) -> None:
                 if not spec.format_choices:
                     raise ValidationError(
                         f"output_format {output_format!r} is not valid for artifact_type "
-                        f"{artifact_type!r}; Supported formats: default only "
+                        f"{artifact_type!r}; supported formats: default only "
                         f"(omit output_format)."
                     )
                 if output_format not in spec.format_choices:

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -536,7 +536,7 @@ async def test_artifact_download_config_rejects_bad_format(mock_client, config) 
     assert "VALIDATION" in msg
     # The remote signed-URL path shares studio.py's validation, so it emits the same
     # self-documenting text as the stdio path (see the sibling test in test_studio.py).
-    assert "Supported formats: default only" in msg
+    assert "supported formats: default only" in msg
     assert "omit output_format" in msg
 
 

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -532,7 +532,12 @@ async def test_artifact_download_config_rejects_bad_format(mock_client, config) 
             "studio_download",
             {"notebook": NB_ID, "artifact_type": "audio", "output_format": "pdf"},
         )
-    assert "VALIDATION" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    # The remote signed-URL path shares studio.py's validation, so it emits the same
+    # self-documenting text as the stdio path (see the sibling test in test_studio.py).
+    assert "Supported formats: default only" in msg
+    assert "omit output_format" in msg
 
 
 async def test_artifact_download_config_rejects_invalid_format_value(mock_client, config) -> None:

--- a/tests/unit/mcp/test_studio.py
+++ b/tests/unit/mcp/test_studio.py
@@ -1213,6 +1213,61 @@ async def test_artifact_download_format_for_unsupported_type_is_validation(
     mock_client.artifacts.download_audio.assert_not_called()
 
 
+async def test_artifact_download_report_markdown_self_documenting(
+    mcp_call, mock_client, tmp_path
+) -> None:
+    """report has no format axis → the rejection tells the caller to omit output_format."""
+    out = str(tmp_path / "out.md")
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "studio_download",
+            {
+                "notebook": NB_ID,
+                "artifact_type": "report",
+                "path": out,
+                "output_format": "markdown",
+            },
+        )
+    msg = str(excinfo.value)
+    assert "Supported formats: default only" in msg
+    assert "omit output_format" in msg
+
+
+async def test_artifact_download_audio_pdf_self_documenting(
+    mcp_call, mock_client, tmp_path
+) -> None:
+    """audio has no format axis → same self-documenting rejection (pdf is in-union but wrong-type)."""
+    out = str(tmp_path / "out.mp3")
+    mock_client.artifacts.download_audio = AsyncMock(return_value=out)
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "studio_download",
+            {"notebook": NB_ID, "artifact_type": "audio", "path": out, "output_format": "pdf"},
+        )
+    msg = str(excinfo.value)
+    assert "Supported formats: default only" in msg
+    assert "omit output_format" in msg
+    mock_client.artifacts.download_audio.assert_not_called()
+
+
+async def test_artifact_download_supported_type_invalid_format_lists_choices(
+    mcp_call, mock_client, tmp_path
+) -> None:
+    """A type WITH a format axis still lists its allowed values on an invalid choice."""
+    out = str(tmp_path / "quiz.json")
+    mock_client.artifacts.list = AsyncMock(return_value=[_QUIZ_ARTIFACT])
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "studio_download",
+            {"notebook": NB_ID, "artifact_type": "quiz", "path": out, "output_format": "pdf"},
+        )
+    msg = str(excinfo.value)
+    assert "expected one of" in msg
+    assert "json" in msg and "markdown" in msg and "html" in msg
+    # The no-format-axis wording must NOT leak into a type that has a format axis.
+    assert "Supported formats: default only" not in msg
+
+
 async def test_artifact_download_no_artifacts(mcp_call, mock_client, tmp_path) -> None:
     out = str(tmp_path / "out.mp3")
     mock_client.artifacts.list = AsyncMock(return_value=[])

--- a/tests/unit/mcp/test_studio.py
+++ b/tests/unit/mcp/test_studio.py
@@ -1229,7 +1229,7 @@ async def test_artifact_download_report_markdown_self_documenting(
             },
         )
     msg = str(excinfo.value)
-    assert "Supported formats: default only" in msg
+    assert "supported formats: default only" in msg
     assert "omit output_format" in msg
 
 
@@ -1245,7 +1245,7 @@ async def test_artifact_download_audio_pdf_self_documenting(
             {"notebook": NB_ID, "artifact_type": "audio", "path": out, "output_format": "pdf"},
         )
     msg = str(excinfo.value)
-    assert "Supported formats: default only" in msg
+    assert "supported formats: default only" in msg
     assert "omit output_format" in msg
     mock_client.artifacts.download_audio.assert_not_called()
 
@@ -1265,7 +1265,7 @@ async def test_artifact_download_supported_type_invalid_format_lists_choices(
     assert "expected one of" in msg
     assert "json" in msg and "markdown" in msg and "html" in msg
     # The no-format-axis wording must NOT leak into a type that has a format axis.
-    assert "Supported formats: default only" not in msg
+    assert "supported formats: default only" not in msg
 
 
 async def test_artifact_download_no_artifacts(mcp_call, mock_client, tmp_path) -> None:


### PR DESCRIPTION
## Summary

`studio_download` rejects an `output_format` for an artifact type that has no
format axis (e.g. `report`, `audio`) with a bare, non-actionable message. This
makes that rejection **self-documenting** for agent callers: it now tells them
to omit the field. Types that *do* have a format axis (`slide-deck`,
`quiz`, `flashcards`) still list their allowed choices, unchanged.

The `output_format` validation lives at a **single shared site** in
`studio.py` that runs *before* the code branches into the stdio (`path`) and
remote signed-URL (`_broker_download`) paths, so both transports already emit
identical text — the remote `/files/dl` route in `_fileroutes.py` only forwards
the already-validated `fmt` from the signed token and never re-validates.

## Related Issue

Closes #1823

## Changes

- `src/notebooklm/mcp/tools/studio.py` — no-format-axis rejection now reads
  `output_format 'markdown' is not valid for artifact_type 'report'; Supported formats: default only (omit output_format).` (was `artifact_type 'report' does not support an output_format option`). The with-format-axis branch is untouched.
- `docs/mcp-guide.md` — added a per-artifact `output_format` support table plus a
  note that the rejection text is identical across stdio and the remote connector.
- `tests/unit/mcp/test_studio.py` — new stdio tests: `report + markdown` and
  `audio + pdf` (both assert the self-documenting text) and `quiz + pdf` (a
  supported type still lists its allowed choices and does *not* leak the
  no-format-axis wording).
- `tests/unit/mcp/test_file_tools.py` — strengthened the remote-config
  `audio + pdf` test to assert the same self-documenting text, pinning the two
  paths to identical output.

Scope kept surgical (only the `output_format` validation messages) to reconcile
cleanly with the concurrent #1826 work on the `download_ready` payload.

## Test Plan

```
uv run mypy src/notebooklm --ignore-missing-imports      # Success: no issues (304 files)
python -m pytest tests/unit/mcp/test_studio.py tests/unit/mcp/test_file_tools.py \
    tests/_guardrails/test_module_size_ratchet.py tests/unit/mcp/test_tool_eval.py -q   # 159 passed
uv run ruff format <changed>                             # clean
uv run ruff check <changed>                              # All checks passed
```

`studio.py` is 920 lines — under the 1000-line ADR-0008 ratchet threshold — and
the docstring was left unchanged, so `test_surface_schema_cost_within_budget`
stays green.

## Notes

No behavior change beyond the rejection message wording; the accepted
format sets and the download paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how `output_format` is handled across different artifact types, including a table of which types support custom formats and which must use the default.
* **Bug Fixes**
  * Improved validation messaging when `output_format` is not applicable, explicitly instructing you to omit `output_format` and confirming “default only.”
  * Kept validation behavior consistent between local and remote (signed URL) download paths.
* **Tests**
  * Expanded unit coverage for the updated self-documenting error text and ensured correct message behavior for both format-axis and non-axis artifact types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->