### PR TITLE
feat(mcp): enrich studio_download download_ready with filename/mime/size (#1826)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -155,6 +155,14 @@ bearer-only deploy → the two file tools return a clear "not configured" error
   signed-URL flow above.
 - **Download an artifact:** `studio_download` returns a `download_ready` link (a
   clickable `resource_link`); open it to stream the podcast/video/PDF to your device.
+  The `download_ready` payload is self-describing so a client can render a download
+  affordance *before* opening the URL: alongside `url` / `expires_at` / `artifact_type`
+  / `artifact_id` it carries `filename` (the artifact title — or the type name on a
+  latest-by-type download — plus the format-resolved extension), `mime_type` (from a
+  central per-type/format table the `/files/dl` route serves with, so the advertised
+  type and the streamed `Content-Type` can't drift), and `size_bytes` (`null` — the
+  size isn't known without eagerly fetching the artifact, which the broker won't do;
+  the route sets the real `Content-Length` when the link is opened).
 - Links are HMAC-signed and short-lived (upload 15 min, download 30 min) and expire on
   a server restart. Google Drive (`source_add` with a Drive id) remains a no-browser
   alternative for adding files. stdio (local) installs are unchanged — they still read

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -49,7 +49,12 @@ from ..exceptions import NotebookLMError, ValidationError
 from ._context import get_client_from_app
 from ._errors import redact
 from ._filelink import FileLinkError, FileTransferConfig
-from .tools._studio_download import _DOWNLOAD_SPECS, _resolve_artifact_id
+from .tools._studio_download import (
+    _DOWNLOAD_SPECS,
+    _resolve_artifact_id,
+    download_filename,
+    download_mime_type,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -372,15 +377,17 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 return PlainTextResponse(
                     "Download produced an unexpected output path.", status_code=500
                 )
-            # Hand the user a meaningful name (the core wrote ``artifact<ext>``): the
-            # artifact title + the served file's actual extension.
-            title = str((result.artifact or {}).get("title") or spec.name)
-            download_name = download_core.artifact_title_to_filename(
-                title, Path(served).suffix, set()
-            )
+            # Hand the user a meaningful name + Content-Type via the SAME shared
+            # helpers the studio_download tool payload advertises, so the browser
+            # download matches the ``filename`` / ``mime_type`` the agent was told
+            # (the core wrote ``artifact<ext>``; the title falls back to the type
+            # name when the artifact carries none).
+            title = (result.artifact or {}).get("title")
+            download_name = download_filename(spec, title, fmt)
             response = _SlotHeldFileResponse(
                 served,
                 filename=download_name,
+                media_type=download_mime_type(spec, fmt),
                 temp_dir=temp_dir,
                 headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
             )

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -37,6 +37,9 @@ __all__ = [
     "_is_http_transport",
     "_passthrough_download_notebook",
     "_resolve_artifact_id",
+    "download_extension",
+    "download_filename",
+    "download_mime_type",
 ]
 
 #: The downloadable artifact-type keys (the ``artifact_type`` param's enum).
@@ -160,6 +163,60 @@ _KIND_TO_DOWNLOAD_KEY: dict[Any, DownloadType] = {
     spec.kind: cast(DownloadType, key) for key, spec in _DOWNLOAD_SPECS.items()
 }
 
+#: The ONE file-extension → MIME-type table. Both the ``studio_download`` tool
+#: payload (:func:`_broker_download`) and the ``/files/dl`` route derive their
+#: Content-Type from this via :func:`download_mime_type`, so the advertised
+#: ``mime_type`` and the byte stream's ``Content-Type`` can never drift. Keyed by
+#: the extension the spec+format already resolve to, so a new download type only
+#: needs its extension mapped here.
+_EXTENSION_MIME_TYPES: dict[str, str] = {
+    ".mp3": "audio/mpeg",
+    ".mp4": "video/mp4",
+    ".pdf": "application/pdf",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".png": "image/png",
+    ".md": "text/markdown",
+    ".json": "application/json",
+    ".csv": "text/csv",
+    ".html": "text/html",
+}
+
+#: Fallback when an extension isn't in the table (unreachable for minted tokens —
+#: every spec extension is mapped — but keeps the helpers total).
+_DEFAULT_MIME = "application/octet-stream"
+
+
+def download_extension(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
+    """The file extension a download of ``spec`` in ``output_format`` will carry.
+
+    ``output_format`` selects the extension for the format-bearing types
+    (slide-deck pdf/pptx; quiz/flashcards json/markdown/html) via the spec's
+    ``format_extension_map``; ``None`` (or a leaf with no format axis) yields the
+    spec's default ``extension`` (which is already the default format's extension).
+    """
+    if output_format:
+        return spec.format_extension_map.get(output_format, spec.extension)
+    return spec.extension
+
+
+def download_filename(
+    spec: download_core.DownloadTypeSpec, title: str | None, output_format: str | None
+) -> str:
+    """The download filename for ``spec`` — the artifact ``title`` (falling back to
+    the type name when unknown, e.g. the latest-by-type path) plus the
+    format-resolved extension, sanitized by the shared
+    :func:`~notebooklm._app.download.artifact_title_to_filename`.
+    """
+    base = title if title else spec.name
+    return download_core.artifact_title_to_filename(
+        base, download_extension(spec, output_format), set()
+    )
+
+
+def download_mime_type(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
+    """The MIME type for a download of ``spec`` in ``output_format`` (central table)."""
+    return _EXTENSION_MIME_TYPES.get(download_extension(spec, output_format), _DEFAULT_MIME)
+
 
 async def _passthrough_download_notebook(notebook_id: str) -> str:
     """Async pass-through notebook resolver for the download core."""
@@ -221,6 +278,8 @@ def _broker_download(
     artifact_type: str,
     output_format: str | None,
     artifact_id: str | None = None,
+    *,
+    title: str | None = None,
 ) -> ToolResult:
     """Mint a signed download URL + a clickable ``resource_link`` for a remote
     ``studio_download``.
@@ -228,7 +287,16 @@ def _broker_download(
     Returns a :class:`ToolResult` carrying BOTH a ``resource_link`` content item
     (claude.ai renders it clickable) and the structured ``download_ready`` payload.
     The signer injects expiry; ``expires_at`` mirrors the download TTL.
+
+    The payload is self-describing so a client can render a download affordance
+    before opening the URL: ``filename`` (the artifact ``title`` — falling back to
+    the type name on the latest-by-type path where no id was resolved — plus the
+    format-resolved extension) and ``mime_type`` both come from the SAME central
+    helpers the ``/files/dl`` route serves with, so the advertised metadata and the
+    streamed bytes can't drift. ``size_bytes`` is ``None``: it can't be known
+    without eagerly fetching the artifact, which this must not do.
     """
+    spec = _DOWNLOAD_SPECS[artifact_type]
     payload: dict[str, Any] = {
         "nb": notebook_id,
         "atype": artifact_type,
@@ -242,6 +310,11 @@ def _broker_download(
         "status": "download_ready",
         "notebook_id": notebook_id,
         "artifact_type": artifact_type,
+        "filename": download_filename(spec, title, output_format),
+        "mime_type": download_mime_type(spec, output_format),
+        # Unknown without eagerly downloading (which we refuse to do); the route
+        # sets the real Content-Length when the link is opened.
+        "size_bytes": None,
         "url": url,
         "expires_at": int(time.time()) + DOWNLOAD_TTL,
     }

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -549,6 +549,12 @@ def register(mcp: Any) -> None:
         client = get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
+            # Title of the resolved target, when known cheaply (the ref path and the
+            # explicit-id pre-validation both already list, so they capture it) —
+            # threaded into the broker payload's ``filename``. The latest-by-type
+            # path lists nothing, so it stays None and the filename falls back to the
+            # type name.
+            resolved_title: str | None = None
             # Two addressing modes (exactly one): an `artifact` name-or-id ref
             # (resolved to its type + id, matching the sibling artifact_* tools) OR
             # an explicit `artifact_type` (+ optional `artifact_id`; else latest of
@@ -588,6 +594,7 @@ def register(mcp: Any) -> None:
                         f"(status: {match.status_str}); wait for it to complete."
                     )
                 artifact_id = resolved_id
+                resolved_title = match.title
             elif artifact_type is None:
                 raise ValidationError("Provide `artifact` (name/id) or `artifact_type`.")
             # Strict IDs-only mode: only the explicit `artifact_id` path needs the
@@ -641,6 +648,9 @@ def register(mcp: Any) -> None:
                     candidates = [{"id": a.id, "title": a.title} for a in typed if a.is_completed]
                     try:
                         artifact_id = _resolve_artifact_id(candidates, artifact_id)
+                        resolved_title = next(
+                            (c["title"] for c in candidates if c["id"] == artifact_id), None
+                        )
                     except ValidationError:
                         # The is_completed filter drops a still-generating artifact from the
                         # candidates, so a full id for one surfaces as a bare "not found".
@@ -662,7 +672,9 @@ def register(mcp: Any) -> None:
                                 f"(status: {incomplete.status_str}); wait for it to complete."
                             ) from None
                         raise
-                return _broker_download(cfg, nb_id, artifact_type, output_format, artifact_id)
+                return _broker_download(
+                    cfg, nb_id, artifact_type, output_format, artifact_id, title=resolved_title
+                )
             # No file-transfer config. On the remote (http) connector the server
             # filesystem is unreachable REGARDLESS of `path`, so fail clearly here —
             # mirroring source_add type=file — BEFORE any server-side download (else a

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -506,6 +506,12 @@ async def test_artifact_download_with_config_returns_resource_link(mock_client, 
     assert sc["status"] == "download_ready"
     assert sc["url"].startswith(f"{BASE}/files/dl/")
     assert sc["artifact_type"] == "audio"
+    # Presentation metadata enriches the payload (#1826): a latest-by-type download
+    # has no known title, so the filename falls back to the type name + extension,
+    # the mime comes from the central table, and size is unknown up front.
+    assert sc["filename"] == "audio.mp3"
+    assert sc["mime_type"] == "audio/mpeg"
+    assert sc["size_bytes"] is None
     # A clickable resource_link content item is included for claude.ai.
     assert any(getattr(block, "type", None) == "resource_link" for block in result.content)
     token = sc["url"].rsplit("/", 1)[1]
@@ -522,6 +528,67 @@ async def test_artifact_download_with_config_carries_format(mock_client, config)
     )
     token = result.structured_content["url"].rsplit("/", 1)[1]
     assert config.signer.verify(token, op="dl")["fmt"] == "markdown"
+
+
+async def test_artifact_download_slide_deck_pptx_metadata(mock_client, config) -> None:
+    # A slide-deck pptx download advertises the pptx extension + Office MIME (#1826).
+    # Latest-by-type (no id) → the type-name filename fallback, no list issued.
+    mock_client.artifacts.list = AsyncMock(return_value=[])
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "slide-deck", "output_format": "pptx"},
+    )
+    sc = result.structured_content
+    assert sc["filename"] == "slide-deck.pptx"
+    assert sc["mime_type"] == (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
+    assert sc["size_bytes"] is None
+    mock_client.artifacts.list.assert_not_awaited()
+
+
+async def test_artifact_download_quiz_markdown_metadata(mock_client, config) -> None:
+    # A quiz markdown download advertises the .md extension + text/markdown MIME (#1826).
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "quiz", "output_format": "markdown"},
+    )
+    sc = result.structured_content
+    assert sc["filename"] == "quiz.md"
+    assert sc["mime_type"] == "text/markdown"
+
+
+async def test_artifact_download_explicit_id_pptx_uses_title(mock_client, config) -> None:
+    # Explicit id + a format override: the filename combines the resolved title with
+    # the format-selected extension, and the MIME matches (#1826).
+    deck = Artifact(
+        id=_AID_A,
+        title="Q3 Deck",
+        _artifact_type=ArtifactTypeCode.SLIDE_DECK.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.list = AsyncMock(return_value=[deck])
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {
+            "notebook": NB_ID,
+            "artifact_type": "slide-deck",
+            "artifact_id": _AID_A,
+            "output_format": "pptx",
+        },
+    )
+    sc = result.structured_content
+    assert sc["filename"] == "Q3 Deck.pptx"
+    assert sc["mime_type"] == (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
 
 
 async def test_artifact_download_config_rejects_bad_format(mock_client, config) -> None:
@@ -613,6 +680,10 @@ async def test_artifact_download_remote_tool_encodes_aid(mock_client, config) ->
     # The structured payload echoes the targeted id (self-describing), not only the
     # token.
     assert sc["artifact_id"] == _AID_A
+    # An explicit id resolves the artifact's title cheaply from the same list, so the
+    # advertised filename is derived from it (not the type-name fallback) (#1826).
+    assert sc["filename"] == "Podcast.mp3"
+    assert sc["mime_type"] == "audio/mpeg"
     url = sc["url"]
     token = url.split("/")[-1]
     payload = config.signer.verify(token, op="dl")


### PR DESCRIPTION
## Summary

Remote `studio_download` returned a signed URL but no presentation metadata, so a client couldn't render a good download affordance before opening the link. This makes the `download_ready` structured payload self-describing (additive/backward compatible) and shares the filename + MIME decisions with the `/files/dl` route so they can't drift.

New payload fields:
- **`filename`** — the target artifact title (or the type name on the latest-by-type path, where no id is resolved cheaply) + the format-resolved extension.
- **`mime_type`** — from a central extension→MIME table in `_studio_download.py`.
- **`size_bytes`** — `null`: unknown without eagerly fetching the artifact, which the broker refuses to do. The `/files/dl` route sets the real `Content-Length` when the link is opened.

Existing `url` / `expires_at` / `artifact_type` / `artifact_id` are unchanged.

## Related Issue

Closes #1826

## Changes

- `src/notebooklm/mcp/tools/_studio_download.py`: added the central `_EXTENSION_MIME_TYPES` table plus shared `download_extension` / `download_filename` / `download_mime_type` helpers; `_broker_download` now takes an optional `title` and emits `filename` / `mime_type` / `size_bytes`.
- `src/notebooklm/mcp/tools/studio.py`: threads the resolved artifact title into `_broker_download` on the `artifact` ref path (`match.title`) and the explicit `artifact_id` pre-validation path (from the already-fetched list). The latest-by-type path issues no extra list and falls back to the type name.
- `src/notebooklm/mcp/_fileroutes.py`: the `/files/dl` route derives its download filename **and** `Content-Type` (`media_type`) from the same shared helpers, so the advertised metadata matches the streamed bytes.
- `docs/mcp-guide.md`: documented the enriched `download_ready` payload.
- `tests/unit/mcp/test_file_tools.py`: latest-by-type metadata, explicit-artifact-id title-derived filename, slide-deck `pptx`, quiz `markdown`, and explicit-id + `pptx` variants.

## Test Plan

- `uv run mypy src/notebooklm --ignore-missing-imports` → passes.
- `python -m pytest tests/unit/mcp/test_file_tools.py tests/unit/mcp/test_studio.py tests/_guardrails/test_module_size_ratchet.py tests/unit/mcp/test_tool_eval.py -q` → 159 passed.
- `python -m pytest tests/unit/mcp/test_fileroutes.py -q` → 59 passed.
- `uv run ruff format` / `uv run ruff check` on changed files → clean.

## Notes

- The central MIME table is keyed by the extension that a type+format already resolves to (via the spec's `format_extension_map`), so a new download type only needs its extension mapped once and both surfaces stay consistent.
- Per the coordination note, edits are confined to the success `download_ready` payload + the shared helper + `_fileroutes.py`; the `output_format` validation-error text (#1823) is untouched.
- Module-size ratchet: all three touched `mcp/` modules stay well under the 1000-line budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfsdQfyNdnh6NRpf8BuNf8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download responses now include clearer file details up front, such as filename and file type, so clients can show a download option before opening the link.
  * Download metadata now reflects the selected format and, when available, the artifact’s title for more natural filenames.

* **Bug Fixes**
  * Improved download handling for audio, slide decks, and quizzes so filenames and file types are returned consistently across download paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->