### PR TITLE
fix(server): share suggest surface map

### DIFF
--- a/src/notebooklm/_app/notebooks.py
+++ b/src/notebooklm/_app/notebooks.py
@@ -62,7 +62,7 @@ SuggestSurface = Literal[
     "flashcards",
 ]
 
-_SUGGEST_SURFACE: dict[SuggestSurface, int] = {
+SUGGEST_SURFACE_MAP: dict[SuggestSurface, int] = {
     "ask": 4,
     "audio-deep-dive": 1,
     "audio-brief": 2,
@@ -265,8 +265,8 @@ __all__ = [
     "NotebookMetadataResult",
     "NotebookRenameResult",
     "ResolveNotebookIdFn",
+    "SUGGEST_SURFACE_MAP",
     "SuggestSurface",
-    "_SUGGEST_SURFACE",
     "execute_notebook_create",
     "execute_notebook_delete",
     "execute_notebook_describe",

--- a/src/notebooklm/_app/notebooks.py
+++ b/src/notebooklm/_app/notebooks.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
@@ -41,6 +41,38 @@ logger = logging.getLogger(__name__)
 #: injects ``cli.resolve.resolve_notebook_id``; it is read off the wrapper at
 #: call time so the ``monkeypatch`` test seam keeps landing.
 ResolveNotebookIdFn = Callable[..., Awaitable[str]]
+
+#: ``suggest_prompts`` / ``suggested-prompts`` surface → the ``otmP3b``
+#: (GeneratePromptSuggestions) ``mode`` int. The mode selects the product
+#: surface + format the prompts are written for.
+#:
+#: Map established by the #1726 live investigation (2026-07-01): audio formats
+#: browser-verified (each Customize-dialog format card decoded its otmP3b mode),
+#: video from real web captures, quiz/flashcards client-probed. Supersedes the
+#: earlier output-based #1612 guess. ``ask`` (4) is the web chat default.
+SuggestSurface = Literal[
+    "ask",
+    "audio-deep-dive",
+    "audio-brief",
+    "audio-critique",
+    "audio-debate",
+    "video-explainer",
+    "video-short",
+    "quiz",
+    "flashcards",
+]
+
+_SUGGEST_SURFACE: dict[SuggestSurface, int] = {
+    "ask": 4,
+    "audio-deep-dive": 1,
+    "audio-brief": 2,
+    "audio-critique": 5,
+    "audio-debate": 6,
+    "video-explainer": 3,
+    "video-short": 10,
+    "quiz": 8,
+    "flashcards": 9,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +265,8 @@ __all__ = [
     "NotebookMetadataResult",
     "NotebookRenameResult",
     "ResolveNotebookIdFn",
+    "SuggestSurface",
+    "_SUGGEST_SURFACE",
     "execute_notebook_create",
     "execute_notebook_delete",
     "execute_notebook_describe",

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -45,6 +45,7 @@ from .._resolve import resolve_notebook, resolve_sources
 #: bloat for a typical agent, so they are dropped unless ``references="full"``.
 _LITE_REFERENCE_FIELDS = ("source_id", "citation_number", "cited_text")
 
+
 def register(mcp: Any) -> None:
     """Register the chat tools on ``mcp``."""
 

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -29,7 +29,7 @@ from fastmcp import Context
 
 from ..._app import chat as core
 from ..._app.chat import ChatModeChoice, ResponseLengthChoice
-from ..._app.notebooks import _SUGGEST_SURFACE, SuggestSurface
+from ..._app.notebooks import SUGGEST_SURFACE_MAP, SuggestSurface
 from ..._app.serialize import to_jsonable
 from ..._app.views import ask_result_view
 from ...exceptions import ValidationError
@@ -324,7 +324,7 @@ def register(mcp: Any) -> None:
             rows = await client.notebooks.suggest_prompts(
                 nb_id,
                 source_ids=resolved_source_ids,
-                mode=_SUGGEST_SURFACE[surface],
+                mode=SUGGEST_SURFACE_MAP[surface],
                 query=query,
             )
             payload: dict[str, Any] = {"notebook_id": nb_id}

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -29,6 +29,7 @@ from fastmcp import Context
 
 from ..._app import chat as core
 from ..._app.chat import ChatModeChoice, ResponseLengthChoice
+from ..._app.notebooks import _SUGGEST_SURFACE, SuggestSurface
 from ..._app.serialize import to_jsonable
 from ..._app.views import ask_result_view
 from ...exceptions import ValidationError
@@ -43,39 +44,6 @@ from .._resolve import resolve_notebook, resolve_sources
 #: ``passage_id`` / ``score`` — useful for deep citation tooling but pure context
 #: bloat for a typical agent, so they are dropped unless ``references="full"``.
 _LITE_REFERENCE_FIELDS = ("source_id", "citation_number", "cited_text")
-
-SuggestSurface = Literal[
-    "ask",
-    "audio-deep-dive",
-    "audio-brief",
-    "audio-critique",
-    "audio-debate",
-    "video-explainer",
-    "video-short",
-    "quiz",
-    "flashcards",
-]
-
-#: ``suggest_prompts`` surface → the ``otmP3b`` (GeneratePromptSuggestions) ``mode``
-#: int. The mode selects the product surface + format the prompts are written for.
-#: Map established by the #1726 live investigation (2026-07-01): audio formats
-#: browser-verified (each Customize-dialog format card decoded its otmP3b mode),
-#: video from real web captures, quiz/flashcards client-probed. Supersedes the
-#: earlier output-based #1612 guess. ``ask`` (4) is the web chat default. Keyed by
-#: ``SuggestSurface`` so mypy rejects any key not in the Literal; a Literal member
-#: missing from the map is caught by the per-surface test in ``test_chat.py``.
-_SUGGEST_SURFACE: dict[SuggestSurface, int] = {
-    "ask": 4,
-    "audio-deep-dive": 1,
-    "audio-brief": 2,
-    "audio-critique": 5,
-    "audio-debate": 6,
-    "video-explainer": 3,
-    "video-short": 10,
-    "quiz": 8,
-    "flashcards": 9,
-}
-
 
 def register(mcp: Any) -> None:
     """Register the chat tools on ``mcp``."""

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -15,12 +15,13 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel
 
 from ..._app import notebooks as core
+from ..._app.notebooks import _SUGGEST_SURFACE, SuggestSurface
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
@@ -32,36 +33,6 @@ __all__ = ["router"]
 router = APIRouter(prefix="/notebooks", tags=["notebooks"])
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
-
-#: ``suggested-prompts`` ``surface`` → the ``otmP3b`` (GeneratePromptSuggestions)
-#: ``mode`` int selecting the product surface/format the prompts are written for.
-#: DUPLICATED from the MCP ``suggest_prompts`` tool's ``_SUGGEST_SURFACE`` (the
-#: server layer must not import ``mcp/``); ``tests/server/test_notebooks.py`` pins
-#: the two equal so they cannot drift. Map established by the #1726 live probe.
-SuggestSurface = Literal[
-    "ask",
-    "audio-deep-dive",
-    "audio-brief",
-    "audio-critique",
-    "audio-debate",
-    "video-explainer",
-    "video-short",
-    "quiz",
-    "flashcards",
-]
-
-_SUGGEST_SURFACE: dict[str, int] = {
-    "ask": 4,
-    "audio-deep-dive": 1,
-    "audio-brief": 2,
-    "audio-critique": 5,
-    "audio-debate": 6,
-    "video-explainer": 3,
-    "video-short": 10,
-    "quiz": 8,
-    "flashcards": 9,
-}
-
 
 class NotebookCreate(BaseModel):
     """Request body for creating a notebook."""

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel
 
 from ..._app import notebooks as core
-from ..._app.notebooks import _SUGGEST_SURFACE, SuggestSurface
+from ..._app.notebooks import SUGGEST_SURFACE_MAP, SuggestSurface
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from .._context import get_client
@@ -106,7 +106,7 @@ async def suggested_prompts(
     rows = await client.notebooks.suggest_prompts(
         notebook_id,
         source_ids=list(source_ids) if source_ids else None,
-        mode=_SUGGEST_SURFACE[surface],
+        mode=SUGGEST_SURFACE_MAP[surface],
         query=query,
     )
     return {

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -34,6 +34,7 @@ router = APIRouter(prefix="/notebooks", tags=["notebooks"])
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
 
+
 class NotebookCreate(BaseModel):
     """Request body for creating a notebook."""
 

--- a/tests/server/test_notebooks.py
+++ b/tests/server/test_notebooks.py
@@ -132,9 +132,20 @@ def test_suggested_prompts_bad_surface_is_422(authed_client: TestClient) -> None
     assert resp.status_code == 422
 
 
-def test_suggest_surface_map_matches_mcp() -> None:
-    """The REST surface→mode map is pinned equal to the MCP tool's copy."""
-    from notebooklm.mcp.tools.chat import _SUGGEST_SURFACE as mcp_map
+def test_suggest_surface_map_is_shared_neutral_contract() -> None:
+    """The REST surface→mode map is imported from the neutral app contract."""
+    from notebooklm._app.notebooks import _SUGGEST_SURFACE as neutral_map
     from notebooklm.server.routes.notebooks import _SUGGEST_SURFACE as rest_map
 
-    assert rest_map == dict(mcp_map)
+    assert rest_map is neutral_map
+    assert rest_map == {
+        "ask": 4,
+        "audio-deep-dive": 1,
+        "audio-brief": 2,
+        "audio-critique": 5,
+        "audio-debate": 6,
+        "video-explainer": 3,
+        "video-short": 10,
+        "quiz": 8,
+        "flashcards": 9,
+    }

--- a/tests/server/test_notebooks.py
+++ b/tests/server/test_notebooks.py
@@ -134,8 +134,8 @@ def test_suggested_prompts_bad_surface_is_422(authed_client: TestClient) -> None
 
 def test_suggest_surface_map_is_shared_neutral_contract() -> None:
     """The REST surface→mode map is imported from the neutral app contract."""
-    from notebooklm._app.notebooks import _SUGGEST_SURFACE as neutral_map
-    from notebooklm.server.routes.notebooks import _SUGGEST_SURFACE as rest_map
+    from notebooklm._app.notebooks import SUGGEST_SURFACE_MAP as neutral_map
+    from notebooklm.server.routes.notebooks import SUGGEST_SURFACE_MAP as rest_map
 
     assert rest_map is neutral_map
     assert rest_map == {


### PR DESCRIPTION
## Summary

- Move the suggested-prompts surface mode map into transport-neutral `_app.notebooks`.
- Import the shared map from both REST and MCP so the contracts cannot drift.
- Update the server parity test to avoid importing `notebooklm.mcp` under server-only extras.

Fixes #1841.

## Test plan

- `uv run --extra server --extra dev pytest tests/server/test_notebooks.py -q`
- `uv run --extra server --extra dev pytest tests/server -q`
- `uv run --extra server --extra mcp --extra dev pytest tests/server -q`
- `uv run --extra mcp --extra dev pytest tests/unit/mcp/test_chat.py -q`
- `uv run ruff check src/notebooklm/_app/notebooks.py src/notebooklm/server/routes/notebooks.py src/notebooklm/mcp/tools/chat.py tests/server/test_notebooks.py`
- `uv run mypy src/notebooklm`

## Deferred polish findings

None. Claude CLI was unavailable (`Not logged in`) and Antigravity escalation was interrupted; native Codex polish found no critical or important issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized the supported prompt-suggestion “surface” definitions and the associated surface-to-mode mapping for consistent behavior across the app and server.
  * Updated prompt-suggestion flows to use the shared mapping when computing the request mode.

* **Tests**
  * Updated notebook “suggested prompts” tests to validate the server and app mappings match the expected surface set and values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->