### PR TITLE
fix(server): bound source wait fanout

### DIFF
--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -30,6 +30,7 @@ import shutil
 import tempfile
 from typing import Annotated, Any, Literal
 
+import pydantic
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from pydantic import BaseModel
 
@@ -49,6 +50,8 @@ from ._passthrough import passthrough_source_id
 
 __all__ = [
     "MAX_UPLOAD_BYTES",
+    "MAX_WAIT_CONCURRENT_SOURCES",
+    "MAX_WAIT_SOURCE_IDS",
     "MAX_WAIT_TIMEOUT",
     "router",
 ]
@@ -57,6 +60,7 @@ router = APIRouter(prefix="/notebooks/{notebook_id}/sources", tags=["sources"])
 
 ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
 PendingDep = Annotated[PendingRegistry, Depends(get_pending)]
+_field_validator = getattr(pydantic, "field_validator", pydantic.validator)
 
 #: Max accepted upload size. Bounds temp-file disk pressure under concurrent
 #: uploads; an upload exceeding it is rejected with 413 before it is spooled to
@@ -72,6 +76,15 @@ _UPLOAD_CHUNK = 1024 * 1024
 #: backstop that turns a ``timeout=inf`` (valid JSON) into a clean 400 rather
 #: than a request that never returns.
 MAX_WAIT_TIMEOUT = 3600.0
+
+#: Max source ids accepted by one ``source_wait`` request. NotebookLM notebooks
+#: are source-limited; this cap preserves normal all-source waits while blocking
+#: pathological route fanout.
+MAX_WAIT_SOURCE_IDS = 100
+
+#: Max simultaneous per-source wait pollers spawned by one REST wait request.
+MAX_WAIT_CONCURRENT_SOURCES = 8
+
 
 #: Safe-basename sanitizer for a spooled upload. Aliased to the shared neutral
 #: helper (:func:`notebooklm._app.source_add.safe_upload_name`) so the REST
@@ -132,6 +145,12 @@ class SourceWaitBody(BaseModel):
     source_ids: list[str] | None = None
     timeout: float = 120.0
     interval: float = 1.0
+
+    @_field_validator("source_ids")
+    def _limit_source_ids(cls, value: list[str] | None) -> list[str] | None:
+        if value is not None and len(value) > MAX_WAIT_SOURCE_IDS:
+            raise ValueError(f"source_ids must contain at most {MAX_WAIT_SOURCE_IDS} entries")
+        return value
 
 
 async def _add_source(
@@ -543,9 +562,14 @@ async def wait_sources(notebook_id: str, body: SourceWaitBody, client: ClientDep
             raise ValidationError(
                 "source_ids must not be empty; omit it entirely to wait for all sources"
             )
-        ids = list(body.source_ids)
+        ids = _dedupe_source_ids(body.source_ids)
     else:
-        ids = [s.id for s in await client.sources.list(notebook_id)]
+        ids = _dedupe_source_ids([s.id for s in await client.sources.list(notebook_id)])
+        if len(ids) > MAX_WAIT_SOURCE_IDS:
+            raise ValidationError(
+                f"notebook has {len(ids)} sources; wait-all is capped at "
+                f"{MAX_WAIT_SOURCE_IDS}. Pass source_ids to wait for a smaller subset."
+            )
     outcomes = await _wait_all_sources(
         client, notebook_id, ids, timeout=body.timeout, interval=body.interval
     )
@@ -594,25 +618,48 @@ async def _wait_all_sources(
     still-running sibling pollers before re-raising (it then flows through the
     server's classify-once handler) rather than leaking coroutines.
     """
-    tasks = [
-        asyncio.create_task(
-            wait_core.execute_source_wait(
+    if not source_ids:
+        return []
+
+    outcomes: list[wait_core.SourceWaitOutcome | None] = [None] * len(source_ids)
+    source_iter = iter(enumerate(source_ids))
+
+    async def _worker() -> None:
+        for index, sid in source_iter:
+            outcomes[index] = await wait_core.execute_source_wait(
                 client,
                 wait_core.SourceWaitPlan(
-                    notebook_id=notebook_id, source_id=sid, timeout=timeout, interval=interval
+                    notebook_id=notebook_id,
+                    source_id=sid,
+                    timeout=timeout,
+                    interval=interval,
                 ),
             )
-        )
-        for sid in source_ids
+
+    tasks = [
+        asyncio.create_task(_worker())
+        for _ in range(min(len(source_ids), MAX_WAIT_CONCURRENT_SOURCES))
     ]
     try:
-        return list(await asyncio.gather(*tasks))
+        await asyncio.gather(*tasks)
     except BaseException:
         for task in tasks:
             if not task.done():
                 task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         raise
+
+    ready_outcomes: list[wait_core.SourceWaitOutcome] = []
+    for outcome in outcomes:
+        if outcome is None:
+            raise AssertionError("source wait worker exited without producing an outcome")
+        ready_outcomes.append(outcome)
+    return ready_outcomes
+
+
+def _dedupe_source_ids(source_ids: list[str]) -> list[str]:
+    """Return source ids in first-seen order with duplicates removed."""
+    return list(dict.fromkeys(source_ids))
 
 
 def _aggregate_wait_outcomes(

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -13,6 +13,7 @@ record the calls each namespace received.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
@@ -167,18 +168,26 @@ class FakeSources:
     async def wait_until_ready(
         self, notebook_id: str, source_id: str, *, timeout: float, initial_interval: float
     ) -> Source:
-        # Scriptable per-source outcome; default "ready".
-        outcome = self._s.wait_outcomes.get(source_id, "ready")
-        if outcome == "timeout":
-            raise SourceTimeoutError(source_id, timeout)
-        if outcome == "processing":
-            raise SourceProcessingError(source_id)
-        if outcome == "not_found":
-            raise SourceNotFoundError(source_id)
-        src = self._s.sources_store.get(notebook_id, {}).get(source_id)
-        title = src.title if src is not None else "src"
-        url = src.url if src is not None else None
-        return Source(id=source_id, title=title, url=url, status=SourceStatus.READY)
+        self._s.wait_calls.append(source_id)
+        self._s.wait_active += 1
+        self._s.wait_max_active = max(self._s.wait_max_active, self._s.wait_active)
+        try:
+            if self._s.wait_delay:
+                await asyncio.sleep(self._s.wait_delay)
+            # Scriptable per-source outcome; default "ready".
+            outcome = self._s.wait_outcomes.get(source_id, "ready")
+            if outcome == "timeout":
+                raise SourceTimeoutError(source_id, timeout)
+            if outcome == "processing":
+                raise SourceProcessingError(source_id)
+            if outcome == "not_found":
+                raise SourceNotFoundError(source_id)
+            src = self._s.sources_store.get(notebook_id, {}).get(source_id)
+            title = src.title if src is not None else "src"
+            url = src.url if src is not None else None
+            return Source(id=source_id, title=title, url=url, status=SourceStatus.READY)
+        finally:
+            self._s.wait_active -= 1
 
     async def delete(self, notebook_id: str, source_id: str) -> None:
         self._s.sources_store.get(notebook_id, {}).pop(source_id, None)
@@ -589,6 +598,10 @@ class FakeClient:
         self.renamed_mind_maps: list[tuple[str, str, str, Any]] = []
         self.last_mind_map_generate: dict[str, Any] | None = None
         self.wait_outcomes: dict[str, str] = {}
+        self.wait_calls: list[str] = []
+        self.wait_delay = 0.0
+        self.wait_active = 0
+        self.wait_max_active = 0
         self.suggest_rows: list[PromptSuggestion] = [
             PromptSuggestion(title="Q1", prompt="Ask about X"),
             PromptSuggestion(title="Q2", prompt="Ask about Y"),

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -10,6 +10,7 @@ from notebooklm._types.notebooks import Notebook
 from notebooklm._types.sources import Source
 from notebooklm.rpc.types import SourceStatus
 from notebooklm.server._pagination import MAX_LIMIT
+from notebooklm.server.routes.sources import MAX_WAIT_CONCURRENT_SOURCES, MAX_WAIT_SOURCE_IDS
 
 from .fakes import FakeClient
 
@@ -626,6 +627,62 @@ def test_wait_specific_source_ready(authed_client: TestClient, fake_client: Fake
     assert body["ready_count"] == 1
     assert body["timed_out_count"] == body["failed_count"] == body["not_found_count"] == 0
     assert body["total_count"] == 1
+
+
+def test_wait_explicit_source_ids_over_max_is_validation_error(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    source_ids = [f"src-{i}" for i in range(MAX_WAIT_SOURCE_IDS + 1)]
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"source_ids": source_ids})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["category"] == "validation"
+    assert fake_client.wait_calls == []
+
+
+def test_wait_duplicate_source_ids_are_deduped(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    _seed_source(fake_client, "nb-1", "src-1")
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait",
+        json={"source_ids": ["src-1", "src-1", "src-1"], "timeout": 1.0},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [source["id"] for source in body["ready"]] == ["src-1"]
+    assert fake_client.wait_calls == ["src-1"]
+
+
+def test_wait_all_sources_over_max_is_validation_error(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    for i in range(MAX_WAIT_SOURCE_IDS + 1):
+        _seed_source(fake_client, "nb-1", f"src-{i}")
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/wait", json={"timeout": 1.0})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["category"] == "validation"
+    assert fake_client.wait_calls == []
+
+
+def test_wait_uses_bounded_per_request_concurrency(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    source_ids = [f"src-{i}" for i in range(MAX_WAIT_CONCURRENT_SOURCES + 3)]
+    for source_id in source_ids:
+        _seed_source(fake_client, "nb-1", source_id)
+    fake_client.wait_delay = 0.01
+
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/wait",
+        json={"source_ids": source_ids, "timeout": 1.0},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {source["id"] for source in body["ready"]} == set(source_ids)
+    assert len(fake_client.wait_calls) == len(source_ids)
+    assert set(fake_client.wait_calls) == set(source_ids)
+    assert fake_client.wait_max_active == MAX_WAIT_CONCURRENT_SOURCES
 
 
 def test_wait_all_sources_partial(authed_client: TestClient, fake_client: FakeClient) -> None:


### PR DESCRIPTION
## Summary
- Cap explicit REST source_wait source_ids, dedupe repeated ids, and reject wait-all when the notebook exceeds the route cap.
- Replace one-task-per-id fanout with bounded per-request wait concurrency.
- Add fake-client concurrency instrumentation and regression coverage.

Closes #1838

## Verification
- rtk uv run --extra server --extra dev pytest tests/server/test_sources.py -q
- rtk uv run --extra server --extra dev ruff check src/notebooklm/server/routes/sources.py tests/server/fakes.py tests/server/test_sources.py

## Caveat
- Full tests/server on this branch still hits the pre-existing no-MCP-extra failure fixed by #1843. The source_wait slice is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for source waiting: max total source IDs per request and max concurrent waiting.

* **Bug Fixes**
  * Deduplicates requested source IDs (preserving first-seen order) before waiting.
  * “Wait all” now enforces the request size cap and validates before starting any wait operations.
  * Waiting now uses bounded concurrency to keep responses stable for large source sets.

* **Tests**
  * Added/updated tests for oversized requests, deduplication behavior, wait-all validation, and concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->