### PR TITLE
fix(server): keep diagnostics live on stale auth

### DIFF
--- a/src/notebooklm/server/_context.py
+++ b/src/notebooklm/server/_context.py
@@ -5,7 +5,9 @@ The REST server binds exactly one
 ASGI lifespan (one client, bound to the server's event loop, satisfying the
 ADR-0004 loop-affinity contract). Route handlers reach it through the
 :func:`get_client` FastAPI dependency, so they never touch app-state internals
-directly.
+directly. If startup could not bind a live client, diagnostics can still inspect
+the recorded failure while client-dependent routes receive the normal structured
+REST error response.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -22,7 +24,7 @@ from ._pending import PendingRegistry
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
-__all__ = ["AppState", "get_client", "get_pending"]
+__all__ = ["AppState", "get_client", "get_client_error", "get_pending"]
 
 
 @dataclass
@@ -33,22 +35,32 @@ class AppState:
     source / artifact poll handlers (see :mod:`._pending`).
     """
 
-    client: NotebookLMClient
+    client: NotebookLMClient | None
     pending: PendingRegistry
+    client_error: BaseException | None = None
 
 
 def get_client(request: Request) -> NotebookLMClient:
     """Return the lifespan-bound client for the current request.
 
-    The client is stowed on ``app.state`` by the lifespan in :mod:`.app`; it is
-    always present during a real request (the lifespan runs before any request
-    is served).
+    The client, or the startup failure that prevented creating it, is stowed on
+    ``app.state`` by the lifespan in :mod:`.app`.
 
     Raises:
         RuntimeError: If no client was bound (the lifespan did not run — should
             never happen during a real request).
     """
-    return _state(request).client
+    state = _state(request)
+    if state.client_error is not None:
+        raise state.client_error
+    if state.client is None:  # pragma: no cover - defensive invariant guard
+        raise RuntimeError("no client bound to the server")
+    return state.client
+
+
+def get_client_error(request: Request) -> BaseException | None:
+    """Return the startup failure that prevented binding a live client, if any."""
+    return _state(request).client_error
 
 
 def get_pending(request: Request) -> PendingRegistry:

--- a/src/notebooklm/server/_context.py
+++ b/src/notebooklm/server/_context.py
@@ -52,7 +52,7 @@ def get_client(request: Request) -> NotebookLMClient:
     """
     state = _state(request)
     if state.client_error is not None:
-        raise state.client_error
+        raise _fresh_exception(state.client_error)
     if state.client is None:  # pragma: no cover - defensive invariant guard
         raise RuntimeError("no client bound to the server")
     return state.client
@@ -60,7 +60,8 @@ def get_client(request: Request) -> NotebookLMClient:
 
 def get_client_error(request: Request) -> BaseException | None:
     """Return the startup failure that prevented binding a live client, if any."""
-    return _state(request).client_error
+    error = _state(request).client_error
+    return _fresh_exception(error) if error is not None else None
 
 
 def get_pending(request: Request) -> PendingRegistry:
@@ -73,3 +74,8 @@ def _state(request: Request) -> AppState:
     if state is None:  # pragma: no cover - lifespan always binds before requests
         raise RuntimeError("no client bound to the server (lifespan did not run)")
     return state
+
+
+def _fresh_exception(exc: BaseException) -> BaseException:
+    """Clone a stored startup error so repeated requests do not mutate traceback state."""
+    return exc.__class__(*exc.args)

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -65,7 +65,7 @@ def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[
     )
 
 
-def _normalize_client_startup_error(exc: Exception) -> Exception:
+def _normalize_client_startup_error(exc: Exception) -> AuthError | None:
     """Project stale auth bootstrap ``ValueError``s onto the library auth category.
 
     The auth bootstrap path historically raises plain ``ValueError`` for stale
@@ -73,13 +73,15 @@ def _normalize_client_startup_error(exc: Exception) -> Exception:
     only normalizes the exception it records in app state so its existing error
     projector can return an auth envelope instead of a generic unexpected bug.
     """
+    if isinstance(exc, AuthError):
+        return AuthError(str(exc))
     if isinstance(exc, NotebookLMError):
-        return exc
+        return None
     if isinstance(exc, ValueError):
         message = " ".join(str(exc).split()).casefold()
         if any(marker in message for marker in _STALE_AUTH_STARTUP_MARKERS):
             return AuthError(str(exc))
-    return exc
+    return None
 
 
 def create_app(
@@ -120,10 +122,13 @@ def create_app(
             except Exception as exc:
                 if client_started:
                     raise
+                startup_error = _normalize_client_startup_error(exc)
+                if startup_error is None:
+                    raise
                 app.state.notebooklm = AppState(
                     client=None,
                     pending=pending,
-                    client_error=_normalize_client_startup_error(exc),
+                    client_error=startup_error,
                 )
                 try:
                     yield

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -2,11 +2,11 @@
 
 Design highlights:
 
-- **One client per process, bound at lifespan.** The ASGI lifespan opens a
+- **One client per process, attempted at lifespan.** The ASGI lifespan opens a
   single :class:`~notebooklm.client.NotebookLMClient` via ``from_storage()``
   inside the server loop (satisfies the ADR-0004 loop-affinity contract) and
-  stows it on ``app.state`` for the process lifetime. Its keepalive task gives
-  long sessions cookie rotation for free.
+  stows it on ``app.state`` for the process lifetime. If startup auth is stale,
+  the app records that failure so diagnostics can still be served.
 - **Transport-neutral.** Routes are thin adapters over the ``_app/`` cores and
   the public client namespaces; this package imports NO ``click`` / ``rich`` /
   ``cli`` (enforced by ``tests/_guardrails/test_server_boundary.py``).
@@ -31,6 +31,7 @@ from typing import cast
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
 
 from ..client import NotebookLMClient
+from ..exceptions import AuthError, NotebookLMError
 from ..paths import get_active_profile, resolve_profile, set_active_profile
 from ._auth import require_auth
 from ._context import AppState
@@ -48,6 +49,12 @@ SERVER_NAME = "notebooklm-server"
 #: yielding a fake client so no real auth/network is needed.
 ClientFactory = Callable[[], AbstractAsyncContextManager[NotebookLMClient]]
 
+_STALE_AUTH_STARTUP_MARKERS = (
+    "authentication expired",
+    "authentication expired or invalid",
+    "run 'notebooklm login'",
+)
+
 
 def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[NotebookLMClient]:
     # ``from_storage`` returns a dual awaitable / async-context-manager; we use
@@ -56,6 +63,23 @@ def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[
         "AbstractAsyncContextManager[NotebookLMClient]",
         NotebookLMClient.from_storage(profile=profile),
     )
+
+
+def _normalize_client_startup_error(exc: Exception) -> Exception:
+    """Project stale auth bootstrap ``ValueError``s onto the library auth category.
+
+    The auth bootstrap path historically raises plain ``ValueError`` for stale
+    local profiles. Keep that compatibility at the SDK layer; the REST server
+    only normalizes the exception it records in app state so its existing error
+    projector can return an auth envelope instead of a generic unexpected bug.
+    """
+    if isinstance(exc, NotebookLMError):
+        return exc
+    if isinstance(exc, ValueError):
+        message = " ".join(str(exc).split()).casefold()
+        if any(marker in message for marker in _STALE_AUTH_STARTUP_MARKERS):
+            return AuthError(str(exc))
+    return exc
 
 
 def create_app(
@@ -82,9 +106,25 @@ def create_app(
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         previous_profile = get_active_profile()
         set_active_profile(resolve_profile(profile))
+        pending = PendingRegistry()
+        client_started = False
         try:
-            async with factory() as client:
-                app.state.notebooklm = AppState(client=client, pending=PendingRegistry())
+            try:
+                async with factory() as client:
+                    client_started = True
+                    app.state.notebooklm = AppState(client=client, pending=pending)
+                    try:
+                        yield
+                    finally:
+                        app.state.notebooklm = None
+            except Exception as exc:
+                if client_started:
+                    raise
+                app.state.notebooklm = AppState(
+                    client=None,
+                    pending=pending,
+                    client_error=_normalize_client_startup_error(exc),
+                )
                 try:
                     yield
                 finally:

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -86,6 +86,20 @@ async def _account_block(client: NotebookLMClient, *, authenticated: bool) -> di
     }
 
 
+def _persisted_account_identity(account: object) -> dict[str, Any]:
+    """Return persisted ``email`` / ``authuser`` from auth-check details when present."""
+    if not isinstance(account, dict):
+        return {}
+    identity: dict[str, Any] = {}
+    email = account.get("email")
+    if email is not None:
+        identity["email"] = email
+    authuser = account.get("authuser")
+    if authuser is not None:
+        identity["authuser"] = authuser
+    return identity
+
+
 @router.get("/info")
 async def server_info(
     request: Request,
@@ -137,6 +151,7 @@ async def server_info(
     if include_account:
         if startup_error_item is not None:
             info["account"] = {
+                **_persisted_account_identity(result.details.get("account")),
                 "available": False,
                 "reason": startup_error_item["message"],
             }

--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -16,7 +16,7 @@ than failing the whole call).
 The absolute on-disk storage path is deliberately **not** returned — it leaks the
 server-host OS username / filesystem layout to the caller while telling it nothing
 actionable (the MCP surface scrubs it identically). This is a single-tenant
-server, so the info reflects the one lifespan-bound client.
+server, so the info reflects the one lifespan client/startup state.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -26,7 +26,7 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Query, Request
 
 from ..._app.auth_check import AuthCheckPlan, run_auth_check
 from ..._redact import redact
@@ -34,7 +34,8 @@ from ..._version_info import version_string
 from ...client import NotebookLMClient
 from ...exceptions import NotebookLMError
 from ...paths import get_storage_path, resolve_profile
-from .._context import get_client
+from .._context import get_client, get_client_error
+from .._errors import error_item
 
 __all__ = ["router"]
 
@@ -44,8 +45,6 @@ __all__ = ["router"]
 SERVER_NAME = "notebooklm-server"
 
 router = APIRouter(prefix="/server", tags=["server"])
-
-ClientDep = Annotated[NotebookLMClient, Depends(get_client)]
 
 
 def _no_env_auth_json() -> str:
@@ -89,7 +88,7 @@ async def _account_block(client: NotebookLMClient, *, authenticated: bool) -> di
 
 @router.get("/info")
 async def server_info(
-    client: ClientDep,
+    request: Request,
     include_account: Annotated[bool, Query()] = False,
 ) -> dict[str, Any]:
     """Report the server version and local authentication health.
@@ -117,18 +116,30 @@ async def server_info(
         json_output=True,
     )
     result = await run_auth_check(plan, read_env_auth_json=_no_env_auth_json)
+    startup_error = get_client_error(request)
+    startup_error_item = error_item(startup_error) if startup_error is not None else None
+    authenticated = result.all_passed and startup_error is None
+    auth: dict[str, Any] = {
+        "authenticated": authenticated,
+        "storage_exists": bool(result.checks.get("storage_exists")),
+        "json_valid": bool(result.checks.get("json_valid")),
+        "cookies_present": bool(result.checks.get("cookies_present")),
+        "sid_cookie": bool(result.checks.get("sid_cookie")),
+        "profile": profile,
+    }
+    if startup_error_item is not None:
+        auth["startup_error"] = startup_error_item
     info: dict[str, Any] = {
         "server": SERVER_NAME,
         "version": version_string(),
-        "auth": {
-            "authenticated": result.all_passed,
-            "storage_exists": bool(result.checks.get("storage_exists")),
-            "json_valid": bool(result.checks.get("json_valid")),
-            "cookies_present": bool(result.checks.get("cookies_present")),
-            "sid_cookie": bool(result.checks.get("sid_cookie")),
-            "profile": profile,
-        },
+        "auth": auth,
     }
     if include_account:
-        info["account"] = await _account_block(client, authenticated=result.all_passed)
+        if startup_error_item is not None:
+            info["account"] = {
+                "available": False,
+                "reason": startup_error_item["message"],
+            }
+        else:
+            info["account"] = await _account_block(get_client(request), authenticated=authenticated)
     return info

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -15,8 +15,8 @@ DNS-rebinding (loopback-Host) guard.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any
 
 import pytest
@@ -33,6 +33,11 @@ from .fakes import FakeClient  # noqa: E402
 
 #: The bearer token the test server validates against.
 TEST_TOKEN = "test-secret-token"
+
+STALE_AUTH_MESSAGE = (
+    "Authentication expired or invalid. Redirected to: https://accounts.google.com/signin. "
+    "Run 'notebooklm login' to re-authenticate."
+)
 
 
 @pytest.fixture
@@ -51,6 +56,15 @@ def _factory_for(client: FakeClient) -> Any:
     @asynccontextmanager
     async def factory() -> Any:
         yield client
+
+    return factory
+
+
+def stale_auth_factory() -> Callable[[], AbstractAsyncContextManager[FakeClient]]:
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        raise ValueError(STALE_AUTH_MESSAGE)
+        yield FakeClient()  # pragma: no cover - makes this an async context manager
 
     return factory
 

--- a/tests/server/test_app_lifecycle.py
+++ b/tests/server/test_app_lifecycle.py
@@ -83,6 +83,38 @@ def test_stale_auth_startup_projects_client_routes_to_auth_error() -> None:
     assert err["hint"] == "Re-authenticate and retry."
 
 
+def test_stale_auth_startup_raises_fresh_client_error_per_request() -> None:
+    """The stored startup error must not grow tracebacks across repeated requests."""
+    app = create_app(client_factory=stale_auth_factory())
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
+        stored_error = app.state.notebooklm.client_error
+        assert stored_error is not None
+        assert stored_error.__traceback__ is None
+
+        assert client.get("/v1/notebooks").status_code == 401
+        assert stored_error.__traceback__ is None
+
+        assert client.get("/v1/notebooks").status_code == 401
+        assert stored_error.__traceback__ is None
+
+
+def test_non_auth_client_startup_failure_is_not_swallowed() -> None:
+    """Only normalized auth bootstrap failures are degraded into diagnostic state."""
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        raise FileNotFoundError("missing storage_state.json")
+        yield FakeClient()  # pragma: no cover - makes this an async context manager
+
+    app = create_app(client_factory=factory)
+    with pytest.raises(FileNotFoundError, match="missing storage_state.json"), TestClient(app):
+        pass
+
+
 def test_create_app_default_factory_threads_profile(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """#1769: create_app(profile=X) must reach from_storage(profile=X) through the real
     default-factory closure — not just the create_app boundary. Guards the mocked-boundary

--- a/tests/server/test_app_lifecycle.py
+++ b/tests/server/test_app_lifecycle.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 
+import pytest
 from fastapi.testclient import TestClient
 
+from notebooklm import paths
 from notebooklm.client import NotebookLMClient
 from notebooklm.server.app import create_app
 
+from .conftest import TEST_TOKEN, stale_auth_factory
 from .fakes import FakeClient
 
 
@@ -45,6 +48,39 @@ def test_lifespan_opens_exactly_one_client_and_closes_it() -> None:
     # Context exit shuts the lifespan down.
     assert opens == 1
     assert closed is True
+
+
+def test_stale_auth_startup_still_serves_healthz(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale profile must not keep the process from serving liveness diagnostics."""
+    monkeypatch.setattr(paths, "_active_profile", "before")
+
+    app = create_app(profile="work", client_factory=stale_auth_factory())
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert paths.get_active_profile() == "work"
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert paths.get_active_profile() == "before"
+
+
+def test_stale_auth_startup_projects_client_routes_to_auth_error() -> None:
+    """Live-client routes fail through the structured auth envelope, not startup."""
+    app = create_app(client_factory=stale_auth_factory())
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
+        resp = client.get("/v1/notebooks")
+
+    assert resp.status_code == 401
+    err = resp.json()["error"]
+    assert err["category"] == "auth"
+    assert err["retriable"] is False
+    assert err["hint"] == "Re-authenticate and retry."
 
 
 def test_create_app_default_factory_threads_profile(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from notebooklm.server.app import create_app
 from notebooklm.server.routes import meta as meta_route
 
-from .conftest import TEST_TOKEN
+from .conftest import TEST_TOKEN, stale_auth_factory
 from .fakes import FakeClient
 
 
@@ -140,6 +140,49 @@ def test_server_info_locks_resolved_profile_for_lifespan(
     assert body["auth"]["profile"] == "work"
     assert seen == {"profile": "work", "storage_path": paths.get_storage_path("work")}
     assert paths.get_active_profile() is None
+
+
+def test_server_info_reports_startup_auth_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A startup auth failure is diagnostic state, not an ASGI startup failure."""
+    _patch_auth(monkeypatch, all_passed=True)
+    app = create_app(client_factory=stale_auth_factory())
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
+        resp = client.get("/v1/server/info")
+
+    assert resp.status_code == 200
+    auth = resp.json()["auth"]
+    assert auth["authenticated"] is False
+    assert auth["storage_exists"] is True
+    assert auth["sid_cookie"] is True
+    startup_error = auth["startup_error"]
+    assert startup_error["category"] == "auth"
+    assert startup_error["message"].startswith("Authentication expired or invalid")
+    assert startup_error["retriable"] is False
+    assert startup_error["hint"] == "Re-authenticate and retry."
+
+
+def test_server_info_include_account_degrades_when_startup_auth_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_auth(monkeypatch, all_passed=True)
+    app = create_app(client_factory=stale_auth_factory())
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+
+    with TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    ) as client:
+        body = client.get("/v1/server/info", params={"include_account": True}).json()
+
+    assert body["auth"]["authenticated"] is False
+    account = body["account"]
+    assert account["available"] is False
+    assert account["reason"].startswith("Authentication expired or invalid")
 
 
 def test_server_info_include_account(

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -25,6 +25,7 @@ class _FakeAuthResult:
             "cookies_present": True,
             "sid_cookie": all_passed,
         }
+        self.details = {"account": {"email": "user@example.com", "authuser": 0}}
 
 
 def _patch_auth(monkeypatch: pytest.MonkeyPatch, *, all_passed: bool) -> None:
@@ -181,6 +182,8 @@ def test_server_info_include_account_degrades_when_startup_auth_failed(
 
     assert body["auth"]["authenticated"] is False
     account = body["account"]
+    assert account["email"] == "user@example.com"
+    assert account["authuser"] == 0
     assert account["available"] is False
     assert account["reason"].startswith("Authentication expired or invalid")
 


### PR DESCRIPTION
## Summary
- Keep notebooklm-server startup alive when the bound profile has stale auth, so /healthz and /v1/server/info remain available.
- Store the startup failure in app state and project client-dependent routes through the existing structured auth envelope.
- Include startup auth failure details in server_info and make include_account degrade instead of failing the whole response.

Closes #1837

## Verification
- rtk uv run --extra server --extra dev pytest tests/server/test_app_lifecycle.py tests/server/test_meta.py -q
- rtk uv run --extra server --extra dev pytest tests/server -q
- rtk uv run --extra server --extra dev ruff check src/notebooklm/server/_context.py src/notebooklm/server/app.py src/notebooklm/server/routes/meta.py tests/server/conftest.py tests/server/test_app_lifecycle.py tests/server/test_meta.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup authentication failures are now preserved and surfaced in server status responses.
  * Server info responses can include startup error details and show account availability as unavailable when startup auth fails.
* **Bug Fixes**
  * Client-dependent routes now return a structured authentication error instead of failing during startup.
  * Health checks continue to work even if client initialization encounters a stale or expired authentication state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->