### PR TITLE
fix(server): cap JSON request bodies by route

### DIFF
--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -24,8 +24,10 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
 from typing import cast
 
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
@@ -42,6 +44,182 @@ from .routes.sources import MAX_UPLOAD_BYTES
 __all__ = ["SERVER_NAME", "create_app"]
 
 SERVER_NAME = "notebooklm-server"
+
+DEFAULT_JSON_BODY_BYTES = 1024 * 1024
+SOURCE_TEXT_JSON_BODY_BYTES = 10 * 1024 * 1024
+NOTE_JSON_BODY_BYTES = 5 * 1024 * 1024
+BATCH_JSON_BODY_BYTES = 256 * 1024
+WAIT_JSON_BODY_BYTES = 64 * 1024
+SHORT_JSON_BODY_BYTES = 16 * 1024
+MEDIUM_JSON_BODY_BYTES = 64 * 1024
+
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH"})
+_NOTEBOOK_ID = r"[^/]+"
+_RESOURCE_ID = r"[^/]+"
+_FILE_UPLOAD_PATH = re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/file$")
+
+
+@dataclass(frozen=True)
+class _BodyLimit:
+    method: str
+    path: re.Pattern[str]
+    max_bytes: int
+    name: str
+
+
+JSON_BODY_LIMITS: tuple[_BodyLimit, ...] = (
+    _BodyLimit("POST", re.compile(r"^/v1/notebooks$"), SHORT_JSON_BODY_BYTES, "notebook create"),
+    _BodyLimit(
+        "PATCH",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}$"),
+        SHORT_JSON_BODY_BYTES,
+        "notebook rename",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/url$"),
+        MEDIUM_JSON_BODY_BYTES,
+        "source URL add",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/text$"),
+        SOURCE_TEXT_JSON_BODY_BYTES,
+        "source text add",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/drive$"),
+        MEDIUM_JSON_BODY_BYTES,
+        "source Drive add",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/batch$"),
+        BATCH_JSON_BODY_BYTES,
+        "source URL batch add",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/wait$"),
+        WAIT_JSON_BODY_BYTES,
+        "source wait",
+    ),
+    _BodyLimit(
+        "PATCH",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/{_RESOURCE_ID}$"),
+        SHORT_JSON_BODY_BYTES,
+        "source rename",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/notes$"),
+        NOTE_JSON_BODY_BYTES,
+        "note create",
+    ),
+    _BodyLimit(
+        "PUT",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/notes/{_RESOURCE_ID}$"),
+        NOTE_JSON_BODY_BYTES,
+        "note update",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/chat$"),
+        DEFAULT_JSON_BODY_BYTES,
+        "chat ask",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/chat/configure$"),
+        MEDIUM_JSON_BODY_BYTES,
+        "chat configure",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/artifacts$"),
+        DEFAULT_JSON_BODY_BYTES,
+        "artifact generate",
+    ),
+    _BodyLimit(
+        "PATCH",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/artifacts/{_RESOURCE_ID}$"),
+        SHORT_JSON_BODY_BYTES,
+        "artifact rename",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/artifacts/download$"),
+        SHORT_JSON_BODY_BYTES,
+        "artifact download",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/research$"),
+        DEFAULT_JSON_BODY_BYTES,
+        "research start",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/share/public$"),
+        SHORT_JSON_BODY_BYTES,
+        "share public",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/share/users$"),
+        MEDIUM_JSON_BODY_BYTES,
+        "share user add",
+    ),
+    _BodyLimit(
+        "PATCH",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/share/users/{_RESOURCE_ID}$"),
+        SHORT_JSON_BODY_BYTES,
+        "share user update",
+    ),
+    _BodyLimit(
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/share/view-level$"),
+        SHORT_JSON_BODY_BYTES,
+        "share view-level",
+    ),
+)
+
+
+def _media_type(content_type: str) -> str:
+    return content_type.split(";", 1)[0].strip().lower()
+
+
+def _is_json_content_type(content_type: str) -> bool:
+    media_type = _media_type(content_type)
+    return media_type == "application/json" or media_type.endswith("+json")
+
+
+def _json_body_limit(method: str, path: str, content_type: str) -> _BodyLimit | None:
+    method = method.upper()
+    for limit in JSON_BODY_LIMITS:
+        if method == limit.method and limit.path.fullmatch(path):
+            return limit
+    if (
+        method in _MUTATING_METHODS
+        and path.startswith("/v1/")
+        and _is_json_content_type(content_type)
+    ):
+        return _BodyLimit(method, re.compile(r".*"), DEFAULT_JSON_BODY_BYTES, "JSON")
+    return None
+
+
+def _is_file_upload_route(method: str, path: str) -> bool:
+    return method.upper() == "POST" and _FILE_UPLOAD_PATH.fullmatch(path) is not None
+
+
+def _parse_content_length(value: str) -> int | None:
+    try:
+        declared = int(value)
+    except ValueError:
+        return None
+    return declared if declared >= 0 else None
+
 
 #: A factory returns an async-context-manager that yields the client. The default
 #: factory binds ``NotebookLMClient.from_storage()``; tests inject a factory
@@ -109,34 +287,41 @@ def create_app(
     async def _limit_request_body(
         request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        # Reject an oversized upload by its declared Content-Length BEFORE the
-        # route reads/parses the body — Starlette's multipart parser spools file
-        # parts to disk unbounded, so a post-parse check is too late (the body is
-        # already on disk). This Content-Length pre-check is the actual disk-
-        # exhaustion mitigation. Nothing legitimate exceeds the upload cap, so
-        # applying it to every request is safe.
+        # Reject oversized request bodies by declared Content-Length BEFORE the
+        # route reads/parses them. Multipart keeps the large upload cap; JSON
+        # mutation routes get much smaller route-specific caps so a caller cannot
+        # allocate upload-sized Pydantic payloads.
         content_type = request.headers.get("content-type", "")
-        is_multipart = content_type.lstrip().lower().startswith("multipart/form-data")
+        is_multipart = _media_type(content_type) == "multipart/form-data"
+        path = request.scope.get("path", request.url.path)
         content_length = request.headers.get("content-length")
-        if content_length is None:
+        if is_multipart and _is_file_upload_route(request.method, path):
             # A chunked (no-Content-Length) multipart upload would otherwise let
             # Starlette spool the full part to disk before any per-chunk cap runs.
             # Require an up-front declared length for multipart so the size can be
-            # bounded before a byte is spooled; other verbs (GET/JSON) are
-            # unaffected. Route through the shared projector for a uniform envelope.
-            if is_multipart:
+            # bounded before a byte is spooled.
+            if content_length is None:
                 return http_error_response(411, "Content-Length is required for multipart uploads")
-        else:
-            try:
-                declared = int(content_length)
-            except ValueError:
-                declared = -1
-            if declared < 0 and is_multipart:
+            declared = _parse_content_length(content_length)
+            if declared is None:
                 return http_error_response(411, "A valid Content-Length is required for uploads")
             if declared > MAX_UPLOAD_BYTES:
-                # Route through the shared projector so the envelope shape +
-                # lowercase category match every other error response.
                 return http_error_response(413, "Request body exceeds the size limit")
+        elif limit := _json_body_limit(request.method, path, content_type):
+            # Without Content-Length, a chunked JSON body could exceed the cap
+            # while FastAPI is already buffering/parsing it. Require the same
+            # predeclared length contract as multipart for body-limited routes.
+            if content_length is None:
+                return http_error_response(
+                    411, "Content-Length is required for JSON request bodies"
+                )
+            declared = _parse_content_length(content_length)
+            if declared is None:
+                return http_error_response(
+                    411, "A valid Content-Length is required for JSON request bodies"
+                )
+            if declared > limit.max_bytes:
+                return http_error_response(413, f"{limit.name} request body exceeds the size limit")
         return await call_next(request)
 
     @app.get("/healthz")

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -54,7 +54,6 @@ SHORT_JSON_BODY_BYTES = 16 * 1024
 MEDIUM_JSON_BODY_BYTES = 64 * 1024
 
 _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH"})
-_FORM_CONTENT_TYPES = frozenset({"multipart/form-data", "application/x-www-form-urlencoded"})
 _NOTEBOOK_ID = r"[^/]+"
 _RESOURCE_ID = r"[^/]+"
 _FILE_UPLOAD_PATH = re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/file$")
@@ -196,10 +195,6 @@ def _is_json_content_type(content_type: str) -> bool:
     return media_type == "application/json" or media_type.endswith("+json")
 
 
-def _is_form_content_type(content_type: str) -> bool:
-    return _media_type(content_type) in _FORM_CONTENT_TYPES
-
-
 def _json_body_limit(method: str, path: str, content_type: str) -> _BodyLimit | None:
     method = method.upper()
     for limit in JSON_BODY_LIMITS:
@@ -299,13 +294,13 @@ def create_app(
         content_type = request.headers.get("content-type", "")
         path = request.scope.get("path", request.url.path)
         content_length = request.headers.get("content-length")
-        if _is_form_content_type(content_type) and _is_file_upload_route(request.method, path):
-            # A chunked (no-Content-Length) form upload would otherwise let
+        if _is_file_upload_route(request.method, path):
+            # A chunked (no-Content-Length) upload request would otherwise let
             # Starlette parse or spool the full request before any per-chunk cap
-            # runs. Require an up-front declared length for upload forms so the
-            # size can be bounded before parsing starts.
+            # runs. Require an up-front declared length for the upload route so
+            # the size can be bounded before parsing starts.
             if content_length is None:
-                return http_error_response(411, "Content-Length is required for upload forms")
+                return http_error_response(411, "Content-Length is required for uploads")
             declared = _parse_content_length(content_length)
             if declared is None:
                 return http_error_response(411, "A valid Content-Length is required for uploads")

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -57,6 +57,16 @@ _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH"})
 _NOTEBOOK_ID = r"[^/]+"
 _RESOURCE_ID = r"[^/]+"
 _FILE_UPLOAD_PATH = re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/file$")
+_NO_BODY_MUTATION_ROUTES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/artifacts/{_RESOURCE_ID}/retry$"),
+    ),
+    (
+        "POST",
+        re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/research/{_RESOURCE_ID}/import$"),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -195,11 +205,21 @@ def _is_json_content_type(content_type: str) -> bool:
     return media_type == "application/json" or media_type.endswith("+json")
 
 
+def _is_no_body_mutation_route(method: str, path: str) -> bool:
+    method = method.upper()
+    return any(
+        route_method == method and route_path.fullmatch(path)
+        for route_method, route_path in _NO_BODY_MUTATION_ROUTES
+    )
+
+
 def _json_body_limit(method: str, path: str, content_type: str) -> _BodyLimit | None:
     method = method.upper()
     for limit in JSON_BODY_LIMITS:
         if method == limit.method and limit.path.fullmatch(path):
             return limit
+    if _is_no_body_mutation_route(method, path):
+        return None
     if (
         method in _MUTATING_METHODS
         and path.startswith("/v1/")

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -54,6 +54,7 @@ SHORT_JSON_BODY_BYTES = 16 * 1024
 MEDIUM_JSON_BODY_BYTES = 64 * 1024
 
 _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH"})
+_FORM_CONTENT_TYPES = frozenset({"multipart/form-data", "application/x-www-form-urlencoded"})
 _NOTEBOOK_ID = r"[^/]+"
 _RESOURCE_ID = r"[^/]+"
 _FILE_UPLOAD_PATH = re.compile(rf"^/v1/notebooks/{_NOTEBOOK_ID}/sources/file$")
@@ -195,6 +196,10 @@ def _is_json_content_type(content_type: str) -> bool:
     return media_type == "application/json" or media_type.endswith("+json")
 
 
+def _is_form_content_type(content_type: str) -> bool:
+    return _media_type(content_type) in _FORM_CONTENT_TYPES
+
+
 def _json_body_limit(method: str, path: str, content_type: str) -> _BodyLimit | None:
     method = method.upper()
     for limit in JSON_BODY_LIMITS:
@@ -292,16 +297,15 @@ def create_app(
         # mutation routes get much smaller route-specific caps so a caller cannot
         # allocate upload-sized Pydantic payloads.
         content_type = request.headers.get("content-type", "")
-        is_multipart = _media_type(content_type) == "multipart/form-data"
         path = request.scope.get("path", request.url.path)
         content_length = request.headers.get("content-length")
-        if is_multipart and _is_file_upload_route(request.method, path):
-            # A chunked (no-Content-Length) multipart upload would otherwise let
-            # Starlette spool the full part to disk before any per-chunk cap runs.
-            # Require an up-front declared length for multipart so the size can be
-            # bounded before a byte is spooled.
+        if _is_form_content_type(content_type) and _is_file_upload_route(request.method, path):
+            # A chunked (no-Content-Length) form upload would otherwise let
+            # Starlette parse or spool the full request before any per-chunk cap
+            # runs. Require an up-front declared length for upload forms so the
+            # size can be bounded before parsing starts.
             if content_length is None:
-                return http_error_response(411, "Content-Length is required for multipart uploads")
+                return http_error_response(411, "Content-Length is required for upload forms")
             declared = _parse_content_length(content_length)
             if declared is None:
                 return http_error_response(411, "A valid Content-Length is required for uploads")

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -47,7 +47,11 @@ from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
 from ._passthrough import passthrough_source_id
 
-__all__ = ["MAX_UPLOAD_BYTES", "MAX_WAIT_TIMEOUT", "router"]
+__all__ = [
+    "MAX_UPLOAD_BYTES",
+    "MAX_WAIT_TIMEOUT",
+    "router",
+]
 
 router = APIRouter(prefix="/notebooks/{notebook_id}/sources", tags=["sources"])
 
@@ -68,7 +72,6 @@ _UPLOAD_CHUNK = 1024 * 1024
 #: backstop that turns a ``timeout=inf`` (valid JSON) into a clean 400 rather
 #: than a request that never returns.
 MAX_WAIT_TIMEOUT = 3600.0
-
 
 #: Safe-basename sanitizer for a spooled upload. Aliased to the shared neutral
 #: helper (:func:`notebooklm._app.source_add.safe_upload_name`) so the REST

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
@@ -327,6 +328,24 @@ def test_retry_artifact_returns_task_id_and_status(
     assert body["status"] == "pending"
     # The kicked-off task is now pollable.
     assert authed_client.get("/v1/notebooks/nb-1/artifacts/a1").json()["status"] == "pending"
+
+
+def test_retry_accepts_json_content_type_without_content_length(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+
+    def _empty_body() -> Iterator[bytes]:
+        if False:
+            yield b""
+
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts/a1/retry",
+        content=_empty_body(),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["task_id"] == "a1"
 
 
 def test_retry_records_task_in_pending_registry(

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -11,6 +11,7 @@ Covers the review findings fixed after the initial implementation:
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
 
 import pytest
@@ -111,6 +112,138 @@ class TestUploadPreBufferLimit:
         assert resp.status_code == 413
         assert called["add_file"] is False
         assert resp.json()["error"]["category"] == "validation"
+
+
+class TestJsonBodyLimits:
+    def test_oversized_json_content_length_is_413_before_handler(
+        self, app: Any, fake_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        called = {"ask": False}
+        orig = fake_client.chat.ask
+
+        async def spy(*args: Any, **kwargs: Any) -> Any:
+            called["ask"] = True
+            return await orig(*args, **kwargs)
+
+        monkeypatch.setattr(fake_client.chat, "ask", spy)
+        monkeypatch.setattr(
+            app_module,
+            "JSON_BODY_LIMITS",
+            (
+                app_module._BodyLimit(
+                    "POST",
+                    re.compile(r"^/v1/notebooks/[^/]+/chat$"),
+                    32,
+                    "chat ask",
+                ),
+            ),
+        )
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post(
+                "/v1/notebooks/nb-1/chat",
+                content=b'{"question":"' + (b"x" * 64) + b'"}',
+            )
+        assert resp.status_code == 413
+        assert called["ask"] is False
+        assert resp.json()["error"]["category"] == "validation"
+
+    def test_chunked_json_to_capped_route_is_411_before_handler(
+        self, app: Any, fake_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        called = {"ask": False}
+        orig = fake_client.chat.ask
+
+        async def spy(*args: Any, **kwargs: Any) -> Any:
+            called["ask"] = True
+            return await orig(*args, **kwargs)
+
+        def chunks() -> Any:
+            yield b'{"question":"'
+            yield b"hello"
+            yield b'"}'
+
+        monkeypatch.setattr(fake_client.chat, "ask", spy)
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/json",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post("/v1/notebooks/nb-1/chat", content=chunks())
+        assert resp.status_code == 411
+        assert called["ask"] is False
+        assert resp.json()["error"]["category"] == "validation"
+
+    def test_multipart_upload_ignores_json_caps(
+        self, app: Any, fake_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(app_module, "DEFAULT_JSON_BODY_BYTES", 8)
+
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post(
+                "/v1/notebooks/nb-1/sources/file",
+                files={"file": ("ok.txt", b"x" * 4096, "text/plain")},
+            )
+        assert resp.status_code == 201
+        assert len(fake_client.uploaded_paths) == 1
+
+    def test_multipart_to_json_route_uses_route_cap(
+        self, app: Any, fake_client: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        called = {"ask": False}
+        orig = fake_client.chat.ask
+
+        async def spy(*args: Any, **kwargs: Any) -> Any:
+            called["ask"] = True
+            return await orig(*args, **kwargs)
+
+        monkeypatch.setattr(fake_client.chat, "ask", spy)
+        monkeypatch.setattr(
+            app_module,
+            "JSON_BODY_LIMITS",
+            (
+                app_module._BodyLimit(
+                    "POST",
+                    re.compile(r"^/v1/notebooks/[^/]+/chat$"),
+                    32,
+                    "chat ask",
+                ),
+            ),
+        )
+
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post(
+                "/v1/notebooks/nb-1/chat",
+                files={"file": ("not-json.txt", b"x" * 4096, "text/plain")},
+            )
+        assert resp.status_code == 413
+        assert called["ask"] is False
+        assert len(fake_client.uploaded_paths) == 0
 
 
 class TestChunkedMultipartRejected:

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -113,6 +113,24 @@ class TestUploadPreBufferLimit:
         assert called["add_file"] is False
         assert resp.json()["error"]["category"] == "validation"
 
+    def test_oversized_urlencoded_upload_form_is_413_before_parse(
+        self, app: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 8)
+
+        headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post(
+                "/v1/notebooks/nb-1/sources/file",
+                data={"file": "x" * 64},
+            )
+        assert resp.status_code == 413
+        assert resp.json()["error"]["category"] == "validation"
+
 
 class TestJsonBodyLimits:
     def test_oversized_json_content_length_is_413_before_handler(
@@ -260,6 +278,25 @@ class TestChunkedMultipartRejected:
             "Authorization": f"Bearer {TEST_TOKEN}",
             "Host": "127.0.0.1",
             "Content-Type": "multipart/form-data; boundary=b",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post("/v1/notebooks/nb-1/sources/file", content=_chunks())
+        assert resp.status_code == 411
+        assert resp.json()["error"]["category"] == "validation"
+
+    def test_urlencoded_upload_form_without_content_length_is_411(self, app: Any) -> None:
+        from fastapi.testclient import TestClient
+
+        def _chunks() -> Any:
+            yield b"file="
+            yield b"x" * 32
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "application/x-www-form-urlencoded",
         }
         with TestClient(
             app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -131,6 +131,28 @@ class TestUploadPreBufferLimit:
         assert resp.status_code == 413
         assert resp.json()["error"]["category"] == "validation"
 
+    def test_oversized_non_form_upload_route_body_is_413_before_parse(
+        self, app: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 8)
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "text/plain",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post(
+                "/v1/notebooks/nb-1/sources/file",
+                content=b"x" * 64,
+            )
+        assert resp.status_code == 413
+        assert resp.json()["error"]["category"] == "validation"
+
 
 class TestJsonBodyLimits:
     def test_oversized_json_content_length_is_413_before_handler(
@@ -297,6 +319,24 @@ class TestChunkedMultipartRejected:
             "Authorization": f"Bearer {TEST_TOKEN}",
             "Host": "127.0.0.1",
             "Content-Type": "application/x-www-form-urlencoded",
+        }
+        with TestClient(
+            app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+        ) as c:
+            resp = c.post("/v1/notebooks/nb-1/sources/file", content=_chunks())
+        assert resp.status_code == 411
+        assert resp.json()["error"]["category"] == "validation"
+
+    def test_non_form_upload_route_body_without_content_length_is_411(self, app: Any) -> None:
+        from fastapi.testclient import TestClient
+
+        def _chunks() -> Any:
+            yield b"x" * 32
+
+        headers = {
+            "Authorization": f"Bearer {TEST_TOKEN}",
+            "Host": "127.0.0.1",
+            "Content-Type": "text/plain",
         }
         with TestClient(
             app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False

--- a/tests/server/test_research.py
+++ b/tests/server/test_research.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -50,6 +52,28 @@ def test_start_status_import_happy_path(authed_client: TestClient, fake_client: 
     # The import is keyed on the poll id, not the notebook's current task.
     assert fake_client.imported_research[0][0] == "nb-1"
     assert fake_client.imported_research[0][1] == poll_id
+
+
+def test_import_accepts_json_content_type_without_content_length(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    resp = authed_client.post("/v1/notebooks/nb-1/research", json={"query": "topic"})
+    poll_id = resp.json()["poll_id"]
+    fake_client.set_research_completed(
+        "nb-1", poll_id, sources=[{"url": "https://a.example", "title": "A"}]
+    )
+
+    def _empty_body() -> Iterator[bytes]:
+        if False:
+            yield b""
+
+    resp = authed_client.post(
+        f"/v1/notebooks/nb-1/research/{poll_id}/import",
+        content=_empty_body(),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "imported"
 
 
 def test_deep_start_poll_id_is_report_id(authed_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Add route-specific JSON Content-Length caps instead of applying upload-sized limits to every request.
- Require Content-Length for capped JSON mutation routes so chunked bodies cannot bypass the pre-parse guard.
- Preserve the multipart upload guard and add regression tests for JSON caps, chunked JSON, and multipart behavior.

Closes #1839

## Verification
- rtk uv run --extra server --extra dev pytest tests/server/test_hardening.py tests/server/test_sources.py -q
- rtk uv run --extra server --extra dev pytest tests/server -q
- rtk uv run --extra server --extra dev ruff check src/notebooklm/server/app.py src/notebooklm/server/routes/sources.py tests/server/test_hardening.py tests/server/test_sources.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened request-size validation across endpoints, including proper handling for missing/invalid `Content-Length` (returns `411`) and oversized bodies (returns `413`).
  * Enforced route-specific limits for JSON requests while keeping file uploads restricted to their dedicated upload constraints.
  * Ensured oversized payloads are rejected before server-side processing.
* **Tests**
  * Added regression coverage for oversized and chunked JSON requests, multipart behavior, and additional no-`Content-Length` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->