### PR TITLE
feat(server): add route group backpressure

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -698,6 +698,10 @@ from `_app.errors.classify` onto an HTTP status plus the
 `{"error": {"category": "...", "message": "..."}}` envelope. It imports no `click` / `rich` /
 `cli` (enforced by `tests/_guardrails/test_server_boundary.py`). Launch and
 configuration: [`docs/installation.md`](./installation.md#rest-api-server).
+Expensive route groups have lifespan-owned concurrency limiters, tuned by
+`NOTEBOOKLM_SERVER_*_CONCURRENCY` env vars, so source mutation/wait, artifact
+generation/download, research, and blocking chat work cannot unboundedly starve
+cheap reads or `/healthz`.
 
 ## Middleware chain (ADR-0009)
 
@@ -1292,6 +1296,7 @@ src/notebooklm/
     ├── __main__.py              # `notebooklm-server` entry: argparse + NOTEBOOKLM_SERVER_* env defaults + loopback-bind guard + fail-closed token check
     ├── app.py                   # create_app(*, client_factory=None) -> FastAPI; ASGI lifespan binds one client; public /healthz; auth-gated /v1 mount (docs/redoc/openapi disabled)
     ├── _context.py              # AppState (lifespan-bound client + pending registry) + get_client / get_pending FastAPI dependencies
+    ├── _limits.py               # Lifespan-owned REST route-group concurrency limiters for expensive source/chat/research/artifact work
     ├── _auth.py                 # Bearer-token (constant-time, 401) + loopback-Host (DNS-rebinding guard, 403) dependency for /v1
     ├── _errors.py               # ErrorCategory -> HTTP status table + _redact + the classify-once exception handler emitting {error:{category,message}}
     ├── _pagination.py           # Opt-in, non-breaking list-route envelope: paginate_envelope(items, key=…, limit, offset, **extra) — default (no limit) returns the full list under its existing key unchanged; ?limit= slices via _app.pagination.paginate + adds a meta:{total,has_more,limit,offset} block (Option B-lite)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,12 @@ automatically.
 | `NOTEBOOKLM_SERVER_HOST` | REST server bind host; non-loopback refused unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1` | `127.0.0.1` |
 | `NOTEBOOKLM_SERVER_PORT` | REST server bind port | `8000` |
 | `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND` | Allow REST server to bind a non-loopback host. Use only behind a trusted proxy. | `0` |
+| `NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY` | Max concurrent REST source create/rename/delete/batch handlers. | `4` |
+| `NOTEBOOKLM_SERVER_SOURCE_WAIT_CONCURRENCY` | Max concurrent REST source wait handlers. | `4` |
+| `NOTEBOOKLM_SERVER_GENERATION_CONCURRENCY` | Max concurrent REST artifact generation/retry handlers. | `2` |
+| `NOTEBOOKLM_SERVER_DOWNLOAD_CONCURRENCY` | Max concurrent REST artifact download handlers. | `2` |
+| `NOTEBOOKLM_SERVER_RESEARCH_CONCURRENCY` | Max concurrent REST research start/cancel/import handlers. | `2` |
+| `NOTEBOOKLM_SERVER_CHAT_CONCURRENCY` | Max concurrent REST blocking chat ask handlers. | `4` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress the project's public-API `DeprecationWarning`s (the one-off warnings routed through `warn_deprecated`, e.g. awaiting `from_storage(...)`). Set to a truthy value (`1` / `true` / `yes` / `on`, case-insensitive) to silence them; see `docs/deprecations.md`. | (warnings emitted) |
 | `NOTEBOOKLM_FUTURE_ERRORS` | **Retired (removed in v0.8.0; ignored).** It was the v0.7.0 forward-compat preview gate for the v0.8.0 error contract; now that every break it staged is the default, the flag is a no-op — setting it has no effect. See `docs/deprecations.md`. | (ignored) |
 | `NOTEBOOKLM_VCR_RECORD_ERRORS` | Synthetic-error injection mode for VCR test cassettes (`429`, `5xx`, `expired_csrf`) | - |
@@ -230,6 +236,12 @@ be audited from one location.
 | `NOTEBOOKLM_SERVER_HOST` | REST server bind host. Non-loopback refused unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1`. | `--host` flag → env var → `127.0.0.1` | `server.__main__._build_parser` / `_serving.check_bind_allowed` |
 | `NOTEBOOKLM_SERVER_PORT` | REST server bind port. | `--port` flag → env var → `8000` | `server.__main__._build_parser` / `_resolve_port` |
 | `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND` | Allow REST server to bind a non-loopback host. Use only behind a trusted proxy. | Literal `1` enables; all other values disabled. | `server.__main__._check_bind_allowed` → `_serving.check_bind_allowed` |
+| `NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY` | Max concurrent REST source create/rename/delete/batch handlers. | Env var → `4`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
+| `NOTEBOOKLM_SERVER_SOURCE_WAIT_CONCURRENCY` | Max concurrent REST source wait handlers. | Env var → `4`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
+| `NOTEBOOKLM_SERVER_GENERATION_CONCURRENCY` | Max concurrent REST artifact generation/retry handlers. | Env var → `2`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
+| `NOTEBOOKLM_SERVER_DOWNLOAD_CONCURRENCY` | Max concurrent REST artifact download handlers. | Env var → `2`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
+| `NOTEBOOKLM_SERVER_RESEARCH_CONCURRENCY` | Max concurrent REST research start/cancel/import handlers. | Env var → `2`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
+| `NOTEBOOKLM_SERVER_CHAT_CONCURRENCY` | Max concurrent REST blocking chat ask handlers. | Env var → `4`; blank uses default; must be integer `>=1`. | `server._limits.ServerLimiters.from_env` |
 | `NOTEBOOKLM_VCR_RECORD_ERRORS` | Synthetic-error injection mode for VCR test cassettes. Lowercase-normalized; valid values are `429` (rate limit), `5xx` (server error), or `expired_csrf` (CSRF token expiration). Used to record synthetic error cassettes under VCR. | Process env on each request, evaluated by `ErrorInjectionMiddleware` to intercept and synthesize failures. | `_error_injection._get_error_injection_mode` |
 
 **Boolean handling.** `NOTEBOOKLM_DEBUG_RPC` treats `1` / `true` / `yes`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -380,6 +380,14 @@ Configuration is read from `NOTEBOOKLM_SERVER_*` env vars (overridable by the ma
 | `NOTEBOOKLM_SERVER_HOST` | `127.0.0.1` | Bind host. Non-loopback is refused unless the elevated-risk override below is set. |
 | `NOTEBOOKLM_SERVER_PORT` | `8000` | Bind port. |
 | `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND` | *(unset)* | ⚠️ Set to `1` to bind a non-loopback interface. Only behind a trusted reverse proxy — this exposes account-fronting credentials to the network. |
+| `NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY` | `4` | Max concurrent source create/rename/delete/batch handlers. |
+| `NOTEBOOKLM_SERVER_SOURCE_WAIT_CONCURRENCY` | `4` | Max concurrent source wait handlers. |
+| `NOTEBOOKLM_SERVER_GENERATION_CONCURRENCY` | `2` | Max concurrent artifact generation/retry handlers. |
+| `NOTEBOOKLM_SERVER_DOWNLOAD_CONCURRENCY` | `2` | Max concurrent artifact download handlers. |
+| `NOTEBOOKLM_SERVER_RESEARCH_CONCURRENCY` | `2` | Max concurrent research start/cancel/import handlers. |
+| `NOTEBOOKLM_SERVER_CHAT_CONCURRENCY` | `4` | Max concurrent blocking chat ask handlers. |
+
+The concurrency knobs are route-group backpressure for expensive work. They do not gate `/healthz` or cheap read/list/poll routes.
 
 **Surface:** every route is under `/v1` and requires `Authorization: Bearer <token>` plus a loopback `Host` header (a DNS-rebinding guard). `/healthz` is the one public, token-less route. The auto-generated `/docs` / `/openapi.json` schema UI is disabled (it would otherwise be reachable token-less).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ mcp = ["fastmcp==3.4.2"]
 # compatibly with the base install's httpx<0.29 / anyio<5 (resolved against
 # uv.lock at build time).
 server = [
-    "fastapi>=0.115,<1",
+    "fastapi>=0.118,<1",
     "uvicorn[standard]>=0.34,<1",
     "python-multipart>=0.0.20,<1",
 ]

--- a/src/notebooklm/server/_context.py
+++ b/src/notebooklm/server/_context.py
@@ -14,17 +14,31 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from fastapi import Request
 
+from ._limits import LimitGroup, ServerLimiters
 from ._pending import PendingRegistry
 
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
-__all__ = ["AppState", "get_client", "get_client_error", "get_pending"]
+__all__ = [
+    "AppState",
+    "get_client",
+    "get_client_error",
+    "get_pending",
+    "limit_chat",
+    "limit_download",
+    "limit_generation",
+    "limit_research",
+    "limit_source_mutation",
+    "limit_source_wait",
+]
 
 
 @dataclass
@@ -37,6 +51,7 @@ class AppState:
 
     client: NotebookLMClient | None
     pending: PendingRegistry
+    limiters: ServerLimiters
     client_error: BaseException | None = None
 
 
@@ -67,6 +82,48 @@ def get_client_error(request: Request) -> BaseException | None:
 def get_pending(request: Request) -> PendingRegistry:
     """Return the process-lifetime pending-id registry for the current request."""
     return _state(request).pending
+
+
+async def limit_source_mutation(request: Request) -> AsyncIterator[None]:
+    """Backpressure source create/rename/delete routes."""
+    async with _limit(request, "source_mutation"):
+        yield
+
+
+async def limit_source_wait(request: Request) -> AsyncIterator[None]:
+    """Backpressure source wait routes."""
+    async with _limit(request, "source_wait"):
+        yield
+
+
+async def limit_generation(request: Request) -> AsyncIterator[None]:
+    """Backpressure artifact generation routes."""
+    async with _limit(request, "generation"):
+        yield
+
+
+async def limit_download(request: Request) -> AsyncIterator[None]:
+    """Backpressure artifact download routes."""
+    async with _limit(request, "download"):
+        yield
+
+
+async def limit_research(request: Request) -> AsyncIterator[None]:
+    """Backpressure research mutation/import routes."""
+    async with _limit(request, "research"):
+        yield
+
+
+async def limit_chat(request: Request) -> AsyncIterator[None]:
+    """Backpressure blocking chat ask routes."""
+    async with _limit(request, "chat"):
+        yield
+
+
+@asynccontextmanager
+async def _limit(request: Request, group: LimitGroup) -> AsyncIterator[None]:
+    async with _state(request).limiters.acquire(group):
+        yield
 
 
 def _state(request: Request) -> AppState:

--- a/src/notebooklm/server/_limits.py
+++ b/src/notebooklm/server/_limits.py
@@ -1,0 +1,161 @@
+"""Route-group concurrency limiters for the REST server.
+
+The server is single-tenant but can receive many simultaneous local requests.
+These semaphores bound expensive route groups without putting cheap reads or
+``/healthz`` behind a process-wide lock.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .._loop_affinity import assert_bound_loop
+from .._loop_bound import LoopBoundPrimitive
+
+__all__ = [
+    "DEFAULT_CHAT_CONCURRENCY",
+    "DEFAULT_DOWNLOAD_CONCURRENCY",
+    "DEFAULT_GENERATION_CONCURRENCY",
+    "DEFAULT_RESEARCH_CONCURRENCY",
+    "DEFAULT_SOURCE_MUTATION_CONCURRENCY",
+    "DEFAULT_SOURCE_WAIT_CONCURRENCY",
+    "LIMIT_ENV_VARS",
+    "LimitGroup",
+    "ServerLimiters",
+]
+
+LimitGroup = Literal[
+    "source_mutation",
+    "source_wait",
+    "generation",
+    "download",
+    "research",
+    "chat",
+]
+
+SOURCE_MUTATION_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY"
+SOURCE_WAIT_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_SOURCE_WAIT_CONCURRENCY"
+GENERATION_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_GENERATION_CONCURRENCY"
+DOWNLOAD_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_DOWNLOAD_CONCURRENCY"
+RESEARCH_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_RESEARCH_CONCURRENCY"
+CHAT_CONCURRENCY_ENV = "NOTEBOOKLM_SERVER_CHAT_CONCURRENCY"
+
+DEFAULT_SOURCE_MUTATION_CONCURRENCY = 4
+DEFAULT_SOURCE_WAIT_CONCURRENCY = 4
+DEFAULT_GENERATION_CONCURRENCY = 2
+DEFAULT_DOWNLOAD_CONCURRENCY = 2
+DEFAULT_RESEARCH_CONCURRENCY = 2
+DEFAULT_CHAT_CONCURRENCY = 4
+
+LIMIT_ENV_VARS: dict[LimitGroup, tuple[str, int]] = {
+    "source_mutation": (SOURCE_MUTATION_CONCURRENCY_ENV, DEFAULT_SOURCE_MUTATION_CONCURRENCY),
+    "source_wait": (SOURCE_WAIT_CONCURRENCY_ENV, DEFAULT_SOURCE_WAIT_CONCURRENCY),
+    "generation": (GENERATION_CONCURRENCY_ENV, DEFAULT_GENERATION_CONCURRENCY),
+    "download": (DOWNLOAD_CONCURRENCY_ENV, DEFAULT_DOWNLOAD_CONCURRENCY),
+    "research": (RESEARCH_CONCURRENCY_ENV, DEFAULT_RESEARCH_CONCURRENCY),
+    "chat": (CHAT_CONCURRENCY_ENV, DEFAULT_CHAT_CONCURRENCY),
+}
+
+
+@dataclass
+class ServerLimiters(LoopBoundPrimitive):
+    """Lifespan-owned semaphores for expensive REST route groups."""
+
+    source_mutation_limit: int
+    source_wait_limit: int
+    generation_limit: int
+    download_limit: int
+    research_limit: int
+    chat_limit: int
+    _source_mutation: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+    _source_wait: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+    _generation: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+    _download: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+    _research: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+    _chat: asyncio.Semaphore | None = field(default=None, init=False, repr=False)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ServerLimiters:
+        """Build route-group limiters from ``NOTEBOOKLM_SERVER_*`` env vars.
+
+        Unset or blank values keep the conservative defaults. Invalid values fail
+        during ASGI lifespan startup, before the app accepts traffic.
+        """
+        source = os.environ if env is None else env
+        return cls(
+            source_mutation_limit=_positive_int(source, "source_mutation"),
+            source_wait_limit=_positive_int(source, "source_wait"),
+            generation_limit=_positive_int(source, "generation"),
+            download_limit=_positive_int(source, "download"),
+            research_limit=_positive_int(source, "research"),
+            chat_limit=_positive_int(source, "chat"),
+        )
+
+    @asynccontextmanager
+    async def acquire(self, group: LimitGroup) -> AsyncIterator[None]:
+        """Hold the semaphore for ``group`` for the duration of a route handler."""
+        async with self._semaphore_for(group):
+            yield
+
+    def _semaphore_for(self, group: LimitGroup) -> asyncio.Semaphore:
+        assert_bound_loop(self._bound_loop)
+        if group == "source_mutation":
+            if self._source_mutation is None:
+                self._source_mutation = asyncio.Semaphore(self.source_mutation_limit)
+            return self._source_mutation
+        if group == "source_wait":
+            if self._source_wait is None:
+                self._source_wait = asyncio.Semaphore(self.source_wait_limit)
+            return self._source_wait
+        if group == "generation":
+            if self._generation is None:
+                self._generation = asyncio.Semaphore(self.generation_limit)
+            return self._generation
+        if group == "download":
+            if self._download is None:
+                self._download = asyncio.Semaphore(self.download_limit)
+            return self._download
+        if group == "research":
+            if self._research is None:
+                self._research = asyncio.Semaphore(self.research_limit)
+            return self._research
+        if self._chat is None:
+            self._chat = asyncio.Semaphore(self.chat_limit)
+        return self._chat
+
+    def reset_after_open(self) -> None:
+        """Discard loop-bound semaphores after a lifespan loop bind/rebind."""
+        self._source_mutation = None
+        self._source_wait = None
+        self._generation = None
+        self._download = None
+        self._research = None
+        self._chat = None
+
+    def _on_loop_rebind(
+        self,
+        _old: asyncio.AbstractEventLoop | None,
+        _new: asyncio.AbstractEventLoop | None,
+    ) -> None:
+        self.reset_after_open()
+
+
+def _positive_int(env: Mapping[str, str], group: LimitGroup) -> int:
+    name, default = LIMIT_ENV_VARS[group]
+    raw = env.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer >= 1; got {raw!r}") from None
+    if value < 1:
+        raise ValueError(f"{name} must be an integer >= 1; got {raw!r}")
+    return value

--- a/src/notebooklm/server/_limits.py
+++ b/src/notebooklm/server/_limits.py
@@ -126,9 +126,11 @@ class ServerLimiters(LoopBoundPrimitive):
             if self._research is None:
                 self._research = asyncio.Semaphore(self.research_limit)
             return self._research
-        if self._chat is None:
-            self._chat = asyncio.Semaphore(self.chat_limit)
-        return self._chat
+        if group == "chat":
+            if self._chat is None:
+                self._chat = asyncio.Semaphore(self.chat_limit)
+            return self._chat
+        raise ValueError(f"Unknown limit group: {group}")
 
     def reset_after_open(self) -> None:
         """Discard loop-bound semaphores after a lifespan loop bind/rebind."""

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -24,6 +24,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -38,6 +39,7 @@ from ..paths import get_active_profile, resolve_profile, set_active_profile
 from ._auth import require_auth
 from ._context import AppState
 from ._errors import http_error_response, install_exception_handlers
+from ._limits import ServerLimiters
 from ._pending import PendingRegistry
 from .routes import artifacts, chat, meta, notebooks, notes, research, share, sources
 from .routes.sources import MAX_UPLOAD_BYTES
@@ -309,10 +311,17 @@ def create_app(
         pending = PendingRegistry()
         client_started = False
         try:
+            limiters = ServerLimiters.from_env()
+            limiters.set_bound_loop(asyncio.get_running_loop())
+            limiters.reset_after_open()
             try:
                 async with factory() as client:
                     client_started = True
-                    app.state.notebooklm = AppState(client=client, pending=pending)
+                    app.state.notebooklm = AppState(
+                        client=client,
+                        pending=pending,
+                        limiters=limiters,
+                    )
                     try:
                         yield
                     finally:
@@ -326,6 +335,7 @@ def create_app(
                 app.state.notebooklm = AppState(
                     client=None,
                     pending=pending,
+                    limiters=limiters,
                     client_error=startup_error,
                 )
                 try:

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -261,14 +261,11 @@ def _is_source_file_upload(request: Request) -> bool:
     if request.method != "POST":
         return False
     path = str(request.scope.get("path", request.url.path))
-    parts = path.strip("/").split("/")
-    return (
-        len(parts) == 5
-        and parts[0] == "v1"
-        and parts[1] == "notebooks"
-        and parts[3] == "sources"
-        and parts[4] == "file"
-    )
+    match path.strip("/").split("/"):
+        case ["v1", "notebooks", _, "sources", "file"]:
+            return True
+        case _:
+            return False
 
 
 def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[NotebookLMClient]:

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from fastapi import APIRouter, Depends, FastAPI, Request, Response
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from ..client import NotebookLMClient
 from ..exceptions import AuthError, NotebookLMError
@@ -256,18 +257,6 @@ _STALE_AUTH_STARTUP_MARKERS = (
 )
 
 
-def _is_source_file_upload(request: Request) -> bool:
-    """Return true for the authenticated REST file-upload route."""
-    if request.method != "POST":
-        return False
-    path = str(request.scope.get("path", request.url.path))
-    match path.strip("/").split("/"):
-        case ["v1", "notebooks", _, "sources", "file"]:
-            return True
-        case _:
-            return False
-
-
 def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[NotebookLMClient]:
     # ``from_storage`` returns a dual awaitable / async-context-manager; we use
     # only the async-context-manager protocol (the canonical, non-deprecated path).
@@ -393,6 +382,10 @@ def create_app(
                 return http_error_response(411, "A valid Content-Length is required for uploads")
             if declared > MAX_UPLOAD_BYTES:
                 return http_error_response(413, "Request body exceeds the size limit")
+            try:
+                await require_auth(request)
+            except StarletteHTTPException as exc:
+                return http_error_response(exc.status_code, exc.detail)
             state = getattr(request.app.state, "notebooklm", None)
             if state is not None:
                 async with state.limiters.acquire("source_mutation"):

--- a/src/notebooklm/server/app.py
+++ b/src/notebooklm/server/app.py
@@ -256,6 +256,21 @@ _STALE_AUTH_STARTUP_MARKERS = (
 )
 
 
+def _is_source_file_upload(request: Request) -> bool:
+    """Return true for the authenticated REST file-upload route."""
+    if request.method != "POST":
+        return False
+    path = str(request.scope.get("path", request.url.path))
+    parts = path.strip("/").split("/")
+    return (
+        len(parts) == 5
+        and parts[0] == "v1"
+        and parts[1] == "notebooks"
+        and parts[3] == "sources"
+        and parts[4] == "file"
+    )
+
+
 def _default_factory(profile: str | None = None) -> AbstractAsyncContextManager[NotebookLMClient]:
     # ``from_storage`` returns a dual awaitable / async-context-manager; we use
     # only the async-context-manager protocol (the canonical, non-deprecated path).
@@ -381,6 +396,10 @@ def create_app(
                 return http_error_response(411, "A valid Content-Length is required for uploads")
             if declared > MAX_UPLOAD_BYTES:
                 return http_error_response(413, "Request body exceeds the size limit")
+            state = getattr(request.app.state, "notebooklm", None)
+            if state is not None:
+                async with state.limiters.acquire("source_mutation"):
+                    return await call_next(request)
         elif limit := _json_body_limit(request.method, path, content_type):
             # Without Content-Length, a chunked JSON body could exceed the cap
             # while FastAPI is already buffering/parsing it. Require the same

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -50,7 +50,7 @@ from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from ...exceptions import ValidationError
 from ...types import ArtifactType, GenerationState
-from .._context import get_client, get_pending
+from .._context import get_client, get_pending, limit_download, limit_generation
 from .._errors import safe_detail
 from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
@@ -362,7 +362,7 @@ async def list_artifacts(
     )
 
 
-@router.post("", status_code=202)
+@router.post("", status_code=202, dependencies=[Depends(limit_generation)])
 async def generate(
     notebook_id: str, body: ArtifactGenerate, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
@@ -505,7 +505,7 @@ async def rename(
     }
 
 
-@router.post("/{artifact_id}/retry")
+@router.post("/{artifact_id}/retry", dependencies=[Depends(limit_generation)])
 async def retry(
     notebook_id: str, artifact_id: str, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
@@ -567,7 +567,7 @@ class _CleanupFileResponse(FileResponse):
             _cleanup(self._temp_dir)
 
 
-@router.post("/download")
+@router.post("/download", dependencies=[Depends(limit_download)])
 async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) -> FileResponse:
     """Download a completed artifact, streaming from a server-generated temp path."""
     spec = DOWNLOAD_SPECS.get(body.type)

--- a/src/notebooklm/server/routes/chat.py
+++ b/src/notebooklm/server/routes/chat.py
@@ -24,7 +24,7 @@ from ..._app.chat import ChatModeChoice, ResponseLengthChoice
 from ..._app.serialize import to_jsonable
 from ..._app.views import ask_result_view
 from ...client import NotebookLMClient
-from .._context import get_client
+from .._context import get_client, limit_chat
 
 __all__ = ["router"]
 
@@ -58,7 +58,7 @@ class ChatConfigure(BaseModel):
     response_length: ResponseLengthChoice | None = None
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(limit_chat)])
 async def ask(notebook_id: str, body: ChatAsk, client: ClientDep) -> dict[str, Any]:
     """Ask the notebook's sources a question and return the full answer.
 

--- a/src/notebooklm/server/routes/research.py
+++ b/src/notebooklm/server/routes/research.py
@@ -37,7 +37,7 @@ from ..._app import research as research_core
 from ..._app.serialize import to_jsonable
 from ...client import NotebookLMClient
 from ...exceptions import DecodingError, ValidationError
-from .._context import get_client, get_pending
+from .._context import get_client, get_pending, limit_research
 from .._pending import PendingRegistry
 
 __all__ = ["router"]
@@ -56,7 +56,7 @@ class ResearchStartBody(BaseModel):
     mode: Literal["fast", "deep"] = "fast"
 
 
-@router.post("", status_code=202)
+@router.post("", status_code=202, dependencies=[Depends(limit_research)])
 async def start_research(
     notebook_id: str, body: ResearchStartBody, client: ClientDep
 ) -> dict[str, Any]:
@@ -129,7 +129,7 @@ async def research_status(notebook_id: str, run_id: str, client: ClientDep) -> d
     }
 
 
-@router.delete("/{run_id}")
+@router.delete("/{run_id}", dependencies=[Depends(limit_research)])
 async def cancel_research(notebook_id: str, run_id: str, client: ClientDep) -> dict[str, Any]:
     """Cancel an in-flight research run (fire-and-forget).
 
@@ -142,7 +142,7 @@ async def cancel_research(notebook_id: str, run_id: str, client: ClientDep) -> d
     return {"status": "cancelled", "notebook_id": notebook_id, "run_id": run_id, "cancelled": True}
 
 
-@router.post("/{run_id}/import", status_code=201)
+@router.post("/{run_id}/import", status_code=201, dependencies=[Depends(limit_research)])
 async def import_research(
     notebook_id: str, run_id: str, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -42,7 +42,7 @@ from ..._app.errors import classify
 from ..._app.views import source_view
 from ...client import NotebookLMClient
 from ...exceptions import ValidationError
-from .._context import get_client, get_pending
+from .._context import get_client, get_pending, limit_source_mutation, limit_source_wait
 from .._errors import CATEGORY_STATUS, error_item, safe_detail
 from .._pagination import MAX_LIMIT, paginate_envelope
 from .._pending import PendingRegistry
@@ -234,7 +234,7 @@ async def get_source(
     return source_view(source)
 
 
-@router.post("/url", status_code=201)
+@router.post("/url", status_code=201, dependencies=[Depends(limit_source_mutation)])
 async def add_url(
     notebook_id: str, body: SourceAddUrl, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
@@ -250,7 +250,7 @@ async def add_url(
     )
 
 
-@router.post("/text", status_code=201)
+@router.post("/text", status_code=201, dependencies=[Depends(limit_source_mutation)])
 async def add_text(
     notebook_id: str, body: SourceAddText, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
@@ -265,7 +265,7 @@ async def add_text(
     )
 
 
-@router.post("/file", status_code=201)
+@router.post("/file", status_code=201, dependencies=[Depends(limit_source_mutation)])
 async def add_file(
     notebook_id: str,
     client: ClientDep,
@@ -392,7 +392,7 @@ async def get_source_content(
     }
 
 
-@router.post("/drive", status_code=201)
+@router.post("/drive", status_code=201, dependencies=[Depends(limit_source_mutation)])
 async def add_drive(
     notebook_id: str, body: SourceAddDrive, client: ClientDep, pending: PendingDep
 ) -> dict[str, Any]:
@@ -439,7 +439,7 @@ def _batch_item_is_fatal(exc: BaseException) -> bool:
     return status in (401, 429) or status >= 500
 
 
-@router.post("/batch", status_code=201)
+@router.post("/batch", status_code=201, dependencies=[Depends(limit_source_mutation)])
 async def add_batch(
     notebook_id: str,
     body: SourceAddBatch,
@@ -524,7 +524,7 @@ async def add_batch(
     }
 
 
-@router.post("/wait")
+@router.post("/wait", dependencies=[Depends(limit_source_wait)])
 async def wait_sources(notebook_id: str, body: SourceWaitBody, client: ClientDep) -> dict[str, Any]:
     """Wait for source(s) to finish processing (mirrors MCP ``source_wait``).
 
@@ -576,7 +576,7 @@ async def wait_sources(notebook_id: str, body: SourceWaitBody, client: ClientDep
     return _aggregate_wait_outcomes(notebook_id, outcomes)
 
 
-@router.patch("/{source_id}")
+@router.patch("/{source_id}", dependencies=[Depends(limit_source_mutation)])
 async def rename_source(
     notebook_id: str, source_id: str, body: SourceRename, client: ClientDep
 ) -> dict[str, Any]:
@@ -591,7 +591,7 @@ async def rename_source(
     return source_view(result.source)
 
 
-@router.delete("/{source_id}", status_code=204)
+@router.delete("/{source_id}", status_code=204, dependencies=[Depends(limit_source_mutation)])
 async def delete_source(
     notebook_id: str, source_id: str, client: ClientDep, pending: PendingDep
 ) -> Response:

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -49,6 +49,7 @@ from .._pending import PendingRegistry
 from ._passthrough import passthrough_source_id
 
 __all__ = [
+    "MAX_BATCH_URLS",
     "MAX_UPLOAD_BYTES",
     "MAX_WAIT_CONCURRENT_SOURCES",
     "MAX_WAIT_SOURCE_IDS",
@@ -67,6 +68,11 @@ _field_validator = getattr(pydantic, "field_validator", pydantic.validator)
 #: completion. 200 MiB comfortably covers documents/audio while staying
 #: single-user-safe.
 MAX_UPLOAD_BYTES = 200 * 1024 * 1024
+
+#: Max URL entries accepted by the REST batch-add endpoint. Each entry is added
+#: sequentially under the source-mutation limiter, so the cap bounds how long a
+#: single request can occupy one shared mutation slot.
+MAX_BATCH_URLS = 20
 
 #: Chunk size when streaming an upload to the temp file.
 _UPLOAD_CHUNK = 1024 * 1024
@@ -127,6 +133,12 @@ class SourceAddBatch(BaseModel):
 
     urls: list[str]
     allow_internal: bool = False
+
+    @_field_validator("urls")
+    def _limit_urls(cls, value: list[str]) -> list[str]:
+        if len(value) > MAX_BATCH_URLS:
+            raise ValueError(f"urls must contain at most {MAX_BATCH_URLS} entries")
+        return value
 
 
 class SourceRename(BaseModel):
@@ -265,7 +277,7 @@ async def add_text(
     )
 
 
-@router.post("/file", status_code=201, dependencies=[Depends(limit_source_mutation)])
+@router.post("/file", status_code=201)
 async def add_file(
     notebook_id: str,
     client: ClientDep,

--- a/tests/server/test_backpressure.py
+++ b/tests/server/test_backpressure.py
@@ -1,0 +1,168 @@
+"""Backpressure tests for expensive REST route groups."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from notebooklm._types.chat import AskResult  # noqa: E402
+from notebooklm.server.app import create_app  # noqa: E402
+
+from .conftest import TEST_TOKEN  # noqa: E402
+from .fakes import FakeClient  # noqa: E402
+
+
+class ActiveHold:
+    """Track concurrent fake-handler entries and hold them until released."""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.active = 0
+        self.max_active = 0
+        self._lock = asyncio.Lock()
+
+    async def enter(self) -> None:
+        async with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            self.entered.set()
+
+    async def leave(self) -> None:
+        async with self._lock:
+            self.active -= 1
+
+
+def _factory_for(fake_client: FakeClient) -> Any:
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        yield fake_client
+
+    return factory
+
+
+@asynccontextmanager
+async def _async_client(fake_client: FakeClient) -> AsyncIterator[httpx.AsyncClient]:
+    app = create_app(client_factory=_factory_for(fake_client))
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False)
+    async with (
+        app.router.lifespan_context(app),
+        httpx.AsyncClient(
+            transport=transport, base_url="http://127.0.0.1", headers=headers
+        ) as client,
+    ):
+        yield client
+
+
+async def test_chat_backpressure_bounds_concurrency_and_leaves_healthz_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_CHAT_CONCURRENCY", "1")
+    fake_client = FakeClient()
+    hold = ActiveHold()
+
+    async def slow_ask(
+        notebook_id: str, question: str, *, conversation_id: str | None = None
+    ) -> AskResult:
+        await hold.enter()
+        try:
+            await hold.release.wait()
+            return AskResult(
+                answer=f"answer to: {question}",
+                conversation_id=conversation_id or "conv-1",
+                turn_number=1,
+                is_follow_up=conversation_id is not None,
+            )
+        finally:
+            await hold.leave()
+
+    monkeypatch.setattr(fake_client.chat, "ask", slow_ask)
+
+    async with _async_client(fake_client) as client:
+        first = asyncio.create_task(
+            client.post("/v1/notebooks/nb-1/chat", json={"question": "one"})
+        )
+        await asyncio.wait_for(hold.entered.wait(), timeout=1)
+
+        second = asyncio.create_task(
+            client.post("/v1/notebooks/nb-1/chat", json={"question": "two"})
+        )
+        try:
+            await asyncio.sleep(0.05)
+            health = await asyncio.wait_for(client.get("/healthz"), timeout=1)
+            assert health.status_code == 200
+            assert health.json() == {"ok": True}
+        finally:
+            hold.release.set()
+
+        first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert hold.max_active == 1
+
+
+async def test_source_mutation_backpressure_bounds_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY", "1")
+    fake_client = FakeClient()
+    hold = ActiveHold()
+    original_add_text = fake_client.sources.add_text
+
+    async def slow_add_text(notebook_id: str, title: str, content: str) -> Any:
+        await hold.enter()
+        try:
+            await hold.release.wait()
+            return await original_add_text(notebook_id, title, content)
+        finally:
+            await hold.leave()
+
+    monkeypatch.setattr(fake_client.sources, "add_text", slow_add_text)
+
+    async with _async_client(fake_client) as client:
+        first = asyncio.create_task(
+            client.post(
+                "/v1/notebooks/nb-1/sources/text",
+                json={"title": "one", "text": "one"},
+            )
+        )
+        await asyncio.wait_for(hold.entered.wait(), timeout=1)
+
+        second = asyncio.create_task(
+            client.post(
+                "/v1/notebooks/nb-1/sources/text",
+                json={"title": "two", "text": "two"},
+            )
+        )
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            hold.release.set()
+
+        first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+    assert hold.max_active == 1
+
+
+async def test_invalid_backpressure_env_fails_lifespan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_CHAT_CONCURRENCY", "0")
+    app = create_app(client_factory=_factory_for(FakeClient()))
+
+    with pytest.raises(
+        ValueError, match="NOTEBOOKLM_SERVER_CHAT_CONCURRENCY must be an integer >= 1"
+    ):
+        async with app.router.lifespan_context(app):
+            pass

--- a/tests/server/test_backpressure.py
+++ b/tests/server/test_backpressure.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -13,6 +13,7 @@ pytest.importorskip("fastapi")
 httpx = pytest.importorskip("httpx")
 
 from notebooklm._types.chat import AskResult  # noqa: E402
+from notebooklm.server._limits import LimitGroup, ServerLimiters  # noqa: E402
 from notebooklm.server.app import create_app  # noqa: E402
 
 from .conftest import TEST_TOKEN  # noqa: E402
@@ -155,6 +156,57 @@ async def test_source_mutation_backpressure_bounds_concurrency(
     assert hold.max_active == 1
 
 
+async def test_file_upload_backpressure_bounds_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_SERVER_SOURCE_MUTATION_CONCURRENCY", "1")
+    fake_client = FakeClient()
+    hold = ActiveHold()
+    original_add_file = fake_client.sources.add_file
+
+    async def slow_add_file(
+        notebook_id: str,
+        path: str,
+        mime_type: str | None = None,
+        *,
+        title: str | None = None,
+    ) -> Any:
+        await hold.enter()
+        try:
+            await hold.release.wait()
+            return await original_add_file(notebook_id, path, mime_type, title=title)
+        finally:
+            await hold.leave()
+
+    monkeypatch.setattr(fake_client.sources, "add_file", slow_add_file)
+
+    async with _async_client(fake_client) as client:
+        first = asyncio.create_task(
+            client.post(
+                "/v1/notebooks/nb-1/sources/file",
+                files={"file": ("one.txt", b"one", "text/plain")},
+            )
+        )
+        await asyncio.wait_for(hold.entered.wait(), timeout=1)
+
+        second = asyncio.create_task(
+            client.post(
+                "/v1/notebooks/nb-1/sources/file",
+                files={"file": ("two.txt", b"two", "text/plain")},
+            )
+        )
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            hold.release.set()
+
+        first_response, second_response = await asyncio.gather(first, second)
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+    assert hold.max_active == 1
+
+
 async def test_invalid_backpressure_env_fails_lifespan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -166,3 +218,13 @@ async def test_invalid_backpressure_env_fails_lifespan(
     ):
         async with app.router.lifespan_context(app):
             pass
+
+
+async def test_unknown_limit_group_fails_fast() -> None:
+    limiters = ServerLimiters.from_env({})
+    limiters.set_bound_loop(asyncio.get_running_loop())
+
+    with pytest.raises(ValueError, match="Unknown limit group: typo"):
+        limiters._semaphore_for(cast(LimitGroup, "typo"))
+
+    assert limiters._chat is None

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -72,6 +72,41 @@ def test_upload_over_limit_is_413(authed_client: TestClient, monkeypatch: object
     assert resp.status_code == 413
 
 
+def test_unauthenticated_file_upload_rejected_before_mutation_limiter(
+    monkeypatch: object,
+) -> None:
+    from collections.abc import AsyncIterator
+    from contextlib import asynccontextmanager
+
+    import pytest
+
+    from notebooklm.server._limits import ServerLimiters
+    from notebooklm.server.app import create_app
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+
+    @asynccontextmanager
+    async def _forbid_acquire(self: ServerLimiters, group: object) -> AsyncIterator[None]:
+        raise AssertionError(f"unauthenticated upload acquired {group} limiter")
+        yield
+
+    @asynccontextmanager
+    async def _factory() -> AsyncIterator[FakeClient]:
+        yield FakeClient()
+
+    monkeypatch.setattr(ServerLimiters, "acquire", _forbid_acquire)
+    app = create_app(client_factory=_factory)
+    with TestClient(app, client=("127.0.0.1", 5555), raise_server_exceptions=False) as client:
+        resp = client.post(
+            "/v1/notebooks/nb-1/sources/file",
+            headers={"Host": "127.0.0.1"},
+            files={"file": ("doc.txt", io.BytesIO(b"file-bytes"), "text/plain")},
+        )
+
+    assert resp.status_code == 401
+    assert resp.json()["error"]["category"] == "auth"
+
+
 def test_poll_known_source_returns_200_pending_then_ready(
     authed_client: TestClient, fake_client: FakeClient
 ) -> None:

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -10,7 +10,11 @@ from notebooklm._types.notebooks import Notebook
 from notebooklm._types.sources import Source
 from notebooklm.rpc.types import SourceStatus
 from notebooklm.server._pagination import MAX_LIMIT
-from notebooklm.server.routes.sources import MAX_WAIT_CONCURRENT_SOURCES, MAX_WAIT_SOURCE_IDS
+from notebooklm.server.routes.sources import (
+    MAX_BATCH_URLS,
+    MAX_WAIT_CONCURRENT_SOURCES,
+    MAX_WAIT_SOURCE_IDS,
+)
 
 from .fakes import FakeClient
 
@@ -607,6 +611,16 @@ def test_add_batch_per_item_error_is_redacted(
 def test_add_batch_empty_is_400(authed_client: TestClient) -> None:
     resp = authed_client.post("/v1/notebooks/nb-1/sources/batch", json={"urls": []})
     assert resp.status_code == 400
+
+
+def test_add_batch_over_limit_is_422(authed_client: TestClient, fake_client: FakeClient) -> None:
+    _seed_notebook(fake_client)
+    urls = [f"https://{i}.example.com" for i in range(MAX_BATCH_URLS + 1)]
+
+    resp = authed_client.post("/v1/notebooks/nb-1/sources/batch", json={"urls": urls})
+
+    assert resp.status_code == 422
+    assert not fake_client.sources_store.get("nb-1")
 
 
 # --- Phase 4: source_wait ----------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1381,7 +1381,7 @@ server = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "curl-cffi", marker = "extra == 'impersonate'", specifier = ">=0.11,<1" },
-    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115,<1" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.118,<1" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = "==3.4.2" },
     { name = "filelock", specifier = ">=3.13,<4" },
     { name = "gpsoauth", marker = "extra == 'headless'", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary
- Add lifespan-owned route-group semaphores for expensive REST operations: source mutation, source wait, generation, download, research, and chat.
- Expose conservative NOTEBOOKLM_SERVER_* concurrency env knobs and document them.
- Cover bounded concurrency, healthz staying free, and invalid limiter config.

Closes #1840

## Verification
- rtk uv run --extra server --extra dev pytest tests/server/test_backpressure.py -q
- rtk uv run --extra server --extra dev pytest tests/server/test_backpressure.py tests/server/test_app_lifecycle.py tests/server/test_sources.py tests/server/test_artifacts.py tests/server/test_chat.py tests/server/test_research.py -q
- rtk uv run --extra server --extra dev pytest tests/server -q
- rtk uv run --extra server --extra dev ruff check docs/architecture.md docs/configuration.md docs/installation.md src/notebooklm/server/_context.py src/notebooklm/server/_limits.py src/notebooklm/server/app.py src/notebooklm/server/routes/artifacts.py src/notebooklm/server/routes/chat.py src/notebooklm/server/routes/research.py src/notebooklm/server/routes/sources.py tests/server/test_backpressure.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable REST-server concurrency limits (via environment variables) for route groups covering source mutations/waits, artifact generation & download, research start/cancel/import, and blocking chat to provide backpressure.
  * Enforced a maximum of **20** URLs per source batch request; oversized batches return **422**.
* **Bug Fixes**
  * Improved request handling so long-running/expensive work can’t starve lightweight endpoints (including health checks).
* **Documentation**
  * Documented the new concurrency controls, defaults, and behavior.
* **Tests**
  * Expanded backpressure and configuration validation tests, plus batch-size enforcement coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->