### PR TITLE
fix(sources): decode Drive-hosted PDF type_code 14 by MIME, not URL (#1832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Drive-hosted PDFs no longer list as `google_spreadsheet`.** The backend
+  returns type code `14` for both native Google Sheets and Drive-hosted PDFs,
+  and Drive sources carry no URL, so the read paths (`source_list` /
+  `GET_NOTEBOOK` **and** `source fulltext` / `source_read` / `GET_SOURCE`)
+  mislabeled Drive PDFs as `kind="google_spreadsheet"`. `kind` now disambiguates
+  code `14` by the source MIME (`metadata[19]` / `metadata[9][2]` from a live
+  capture): `application/pdf` → `pdf`, while real Google Sheets
+  (`application/vnd.google-apps.spreadsheet`) are unchanged. This completes the
+  read-path half of the fix started in #1831 (the add path).
+  ([#1832](https://github.com/teng-lin/notebooklm-py/issues/1832))
+
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -101,11 +101,13 @@ Internal integer codes returned by `GET_NOTEBOOK` / `LIST_SOURCES` and consumed 
 | 10 | `MEDIA` | Audio / video upload |
 | 11 | `DOCX` | Word document |
 | 13 | `IMAGE` | Image upload |
-| 14 | `GOOGLE_SPREADSHEET` | Google Sheets source |
+| 14 | `GOOGLE_SPREADSHEET` | Google Sheets source **and** Drive-hosted binaries (see overload note) |
 | 16 | `CSV` | CSV upload |
 | 17 | `EPUB` | EPUB upload (added in v0.4.0) |
 
 > Codes outside this map are surfaced as `SourceType.UNKNOWN` and emit `UnknownTypeWarning` on first occurrence so unmapped types don't crash callers.
+
+> **Code `14` is overloaded** (live-captured #1828/#1832): the backend returns `14` for a native Google Sheet *and* for a Drive-hosted PDF. Drive sources carry no URL (`metadata[0]/[5]/[7]` are all null), so the two are disambiguated by the MIME at `metadata[19]` (fallback `metadata[9][2]`): `application/vnd.google-apps.spreadsheet` → `GOOGLE_SPREADSHEET`, `application/pdf` → `PDF`. See `_disambiguate_type_code` in `src/notebooklm/_types/sources.py`.
 
 ---
 

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -102,6 +102,11 @@ class SourceRow:
     7      url block; ``[7][0]`` is the canonical source URL when
            present (takes precedence over ``metadata[5][0]`` and
            ``metadata[0]``).
+    9      Drive-file descriptor for Drive-hosted sources:
+           ``[drive_id, kind_int, mime, ""]``; ``[9][2]`` is the MIME.
+    19     top-level MIME string for Drive-hosted sources. Used with
+           ``[9][2]`` to disambiguate the type-code ``14`` overload
+           (native Sheet vs Drive-hosted PDF) — see :attr:`mime`.
     =====  ============================================================
 
     Position knowledge is centralised here. Consumer sites should NEVER
@@ -153,6 +158,15 @@ class SourceRow:
     _META_TYPE_POS: ClassVar[int] = 4
     _META_YOUTUBE_POS: ClassVar[int] = 5
     _META_URL_POS: ClassVar[int] = 7
+    # Drive-hosted sources carry the true file MIME here (#1832 live capture):
+    # the drive-file descriptor ``[drive_id, kind_int, mime, ""]`` at [9] and a
+    # top-level MIME string at [19]. Used to disambiguate the type_code==14
+    # overload (native Sheet vs Drive-hosted binary like a PDF), which the URL
+    # slots can't — Drive sources carry no URL (metadata[0]/[5]/[7] all null).
+    _META_DRIVE_DESCRIPTOR_POS: ClassVar[int] = 9
+    _META_MIME_POS: ClassVar[int] = 19
+    # Position of the MIME string inside the drive-file descriptor at [9].
+    _DRIVE_DESCRIPTOR_MIME_POS: ClassVar[int] = 2
 
     # Id-envelope inner positions (the three layouts at ``self._raw[0]``).
     _ID_ENVELOPE_PLAIN_POS: ClassVar[int] = 0
@@ -376,6 +390,50 @@ class SourceRow:
             return None
         value = metadata[self._META_TYPE_POS]
         return value if isinstance(value, int) else None
+
+    @property
+    def mime(self) -> str | None:
+        """Source MIME type for Drive-hosted sources — ``None`` when absent.
+
+        Precedence:
+
+        1. :meth:`_mime_from_top_level` — ``metadata[19]`` (top-level slot).
+        2. :meth:`_mime_from_drive_descriptor` — ``metadata[9][2]`` (MIME
+           inside the drive-file descriptor).
+
+        Only Drive-hosted sources populate these; native uploads / web pages
+        leave them empty. Used to disambiguate the ``type_code == 14`` overload
+        (native Google Sheet vs Drive-hosted PDF) at decode time — see
+        :func:`notebooklm._types.sources._disambiguate_type_code` (#1832).
+        """
+        metadata = self.metadata
+        if metadata is None:
+            return None
+        return self._mime_from_top_level(metadata) or self._mime_from_drive_descriptor(metadata)
+
+    def _mime_from_top_level(self, metadata: list[Any]) -> str | None:
+        """Extract the MIME from ``metadata[19]`` (top-level slot).
+
+        Returns ``None`` when position 19 is absent or not a non-empty string.
+        """
+        if len(metadata) <= self._META_MIME_POS:
+            return None
+        value = metadata[self._META_MIME_POS]
+        return value if isinstance(value, str) and value else None
+
+    def _mime_from_drive_descriptor(self, metadata: list[Any]) -> str | None:
+        """Extract the MIME from ``metadata[9][2]`` (drive-file descriptor).
+
+        Returns ``None`` unless position 9 is a list long enough to hold the
+        descriptor MIME and that slot is a non-empty string.
+        """
+        if len(metadata) <= self._META_DRIVE_DESCRIPTOR_POS:
+            return None
+        descriptor = metadata[self._META_DRIVE_DESCRIPTOR_POS]
+        if not isinstance(descriptor, list) or len(descriptor) <= self._DRIVE_DESCRIPTOR_MIME_POS:
+            return None
+        value = descriptor[self._DRIVE_DESCRIPTOR_MIME_POS]
+        return value if isinstance(value, str) and value else None
 
     @property
     def url(self) -> str | None:

--- a/src/notebooklm/_source/content.py
+++ b/src/notebooklm/_source/content.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from .._row_adapters.sources import SourceFulltextRow, SourceGuideRow
 from .._runtime.contracts import RpcCaller
 from .._types.research import SourceGuide
+from .._types.sources import _disambiguate_type_code
 from ..rpc import RPCMethod
 from ..types import SourceFulltext, SourceNotFoundError, _extract_source_url
 
@@ -93,7 +94,16 @@ class SourceContentRenderer:
             # value into ``SourceFulltext._type_code`` (#1485
             # absence-vs-malformed policy).
             source_row = fulltext_row.source_row
-            source_type = source_row.type_code if source_row is not None else None
+            # Disambiguate the type_code==14 native-Sheet/Drive-PDF overload by
+            # the row MIME, mirroring ``Source.from_row`` so ``source fulltext``
+            # / ``source_read`` decode a Drive-hosted PDF as PDF, not
+            # GOOGLE_SPREADSHEET (#1832). GET_SOURCE carries the same MIME at
+            # metadata[19] / metadata[9][2] as GET_NOTEBOOK (live-captured).
+            source_type = (
+                _disambiguate_type_code(source_row.type_code, source_row.mime)
+                if source_row is not None
+                else None
+            )
             type_slot = fulltext_row.raw_metadata_type_slot
             if source_type is None and type_slot is not None:
                 self._logger.warning(

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -81,6 +81,33 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 }
 
 
+# The type_code==14 overload (#1828/#1832): the backend returns 14 for BOTH a
+# native Google Sheet AND a Drive-hosted binary file (e.g. a PDF). Live capture
+# showed Drive sources carry no URL (metadata[0]/[5]/[7] are null), so the only
+# disambiguation signal is the MIME at metadata[19] / metadata[9][2]. A native
+# Sheet carries "application/vnd.google-apps.spreadsheet" (→ stay 14); a Drive
+# PDF carries "application/pdf" (→ 3). Only MIMEs proven by live capture are
+# mapped; anything else under 14 is left as GOOGLE_SPREADSHEET (conservative —
+# never relabel a real Sheet, never introduce UNKNOWN). Extend as more
+# Drive-hosted-binary-under-14 collisions are captured.
+_TYPE_CODE_14_MIME_OVERRIDE: dict[str, int] = {
+    "application/pdf": 3,  # Drive-hosted PDF → PDF
+}
+
+
+def _disambiguate_type_code(type_code: int | None, mime: str | None) -> int | None:
+    """Correct the ambiguous ``type_code == 14`` using the row MIME (#1832).
+
+    Returns the effective type code: a Drive-hosted binary whose MIME maps in
+    :data:`_TYPE_CODE_14_MIME_OVERRIDE` is remapped (PDF → 3); every other case
+    (native Sheet MIME, no MIME, or an unrecognized MIME) is returned unchanged
+    so real Google Sheets keep decoding as ``GOOGLE_SPREADSHEET``.
+    """
+    if type_code == 14 and mime is not None:
+        return _TYPE_CODE_14_MIME_OVERRIDE.get(mime, type_code)
+    return type_code
+
+
 def _safe_source_type(type_code: int | None) -> SourceType:
     """Convert internal type code to user-facing SourceType enum."""
     if type_code is None:
@@ -193,7 +220,10 @@ class Source:
             id=row.id,
             title=row.title,
             url=row.url,
-            _type_code=row.type_code,
+            # Correct the type_code==14 native-Sheet/Drive-PDF overload by the
+            # row MIME before it reaches ``kind`` (#1832). No-op for every other
+            # type code and for real Sheets.
+            _type_code=_disambiguate_type_code(row.type_code, row.mime),
             created_at=row.created_at,
             status=row.status,
         )

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1239,6 +1239,11 @@ class TestSourceRowPositionContract:
         assert SourceRow._META_TYPE_POS == 4
         assert SourceRow._META_YOUTUBE_POS == 5
         assert SourceRow._META_URL_POS == 7
+        # Drive-hosted MIME positions used to disambiguate the type_code==14
+        # overload (native Sheet vs Drive PDF) — live-captured #1832.
+        assert SourceRow._META_DRIVE_DESCRIPTOR_POS == 9
+        assert SourceRow._META_MIME_POS == 19
+        assert SourceRow._DRIVE_DESCRIPTOR_MIME_POS == 2
 
     def test_id_envelope_positions(self) -> None:
         """Id-envelope positions: plain id at [0]; drive-backed at [2][0]."""
@@ -1267,11 +1272,14 @@ class TestSourceRowPositionContract:
             SourceRow._META_TYPE_POS,
             SourceRow._META_YOUTUBE_POS,
             SourceRow._META_URL_POS,
+            SourceRow._META_DRIVE_DESCRIPTOR_POS,
+            SourceRow._META_MIME_POS,
+            SourceRow._DRIVE_DESCRIPTOR_MIME_POS,
             SourceRow._ID_ENVELOPE_PLAIN_POS,
             SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
             SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
             SourceRow._LIST_FIRST_POS,
-        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 0, 2, 0, 0)
+        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 2, 0, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_source_content_renderer.py
+++ b/tests/unit/test_source_content_renderer.py
@@ -207,6 +207,50 @@ async def test_malformed_type_code_warns_and_degrades_to_none(
 
 
 @pytest.mark.asyncio
+async def test_drive_pdf_type_code_14_fulltext_decodes_to_pdf() -> None:
+    """A Drive-hosted PDF read via GET_SOURCE decodes as PDF, not spreadsheet (#1832).
+
+    Real GET_SOURCE metadata (live capture): ``type_code == 14`` collides with a
+    native Google Sheet, but the row's MIME (``metadata[19]`` / ``metadata[9][2]``)
+    is ``application/pdf`` — so the fulltext path must disambiguate to PDF exactly
+    like ``Source.from_row`` does for the list path.
+    """
+    from notebooklm.types import SourceType
+
+    meta = [None] * 20
+    meta[4] = 14
+    meta[9] = ["drive-id", 5, "application/pdf", ""]
+    meta[19] = "application/pdf"
+    renderer = SourceContentRenderer(
+        RecordingRpc([["src_pdf", "Report.pdf", meta], None, None, [[["Body."]]]])
+    )
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_pdf")
+
+    assert fulltext._type_code == 3
+    assert fulltext.kind == SourceType.PDF
+
+
+@pytest.mark.asyncio
+async def test_native_sheet_type_code_14_fulltext_stays_spreadsheet() -> None:
+    """A native Sheet read via GET_SOURCE stays GOOGLE_SPREADSHEET (no regression, #1832)."""
+    from notebooklm.types import SourceType
+
+    meta = [None] * 20
+    meta[4] = 14
+    meta[9] = ["sheet-id", 8, "application/vnd.google-apps.spreadsheet", ""]
+    meta[19] = "application/vnd.google-apps.spreadsheet"
+    renderer = SourceContentRenderer(
+        RecordingRpc([["src_sheet", "Budget", meta], None, None, [[["Body."]]]])
+    )
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_sheet")
+
+    assert fulltext._type_code == 14
+    assert fulltext.kind == SourceType.GOOGLE_SPREADSHEET
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "metadata",
     [

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -335,3 +335,95 @@ def test_source_fulltext_row_raw_metadata_type_slot() -> None:
     # Metadata too short to carry the slot.
     short = SourceFulltextRow([[["id"], "T", [0, 1, 2, 3]]])
     assert short.raw_metadata_type_slot is None
+
+
+# --- #1832: disambiguate the type_code==14 overload (native Sheet vs Drive PDF) ---
+
+
+def _meta_with(*, type_code, mime=None, descriptor_mime=None):
+    """Build a length-20 metadata array with the positions #1832 relies on.
+
+    ``type_code`` at [4]; top-level MIME at [19]; the Drive-file descriptor
+    ``[id, kind_int, mime, ""]`` at [9] when ``descriptor_mime`` is given.
+    """
+    meta = [None] * 20
+    meta[4] = type_code
+    if descriptor_mime is not None:
+        meta[9] = ["drive-id", 8, descriptor_mime, ""]
+    if mime is not None:
+        meta[19] = mime
+    return meta
+
+
+def _row(meta):
+    return SourceRow.from_entry([["src-id"], "Title", meta, [None, 2]])
+
+
+def test_source_row_mime_reads_metadata_19() -> None:
+    assert _row(_meta_with(type_code=14, mime="application/pdf")).mime == "application/pdf"
+
+
+def test_source_row_mime_falls_back_to_drive_descriptor() -> None:
+    # Top-level [19] absent but the drive descriptor [9][2] carries the mime.
+    assert (
+        _row(_meta_with(type_code=14, descriptor_mime="application/pdf")).mime == "application/pdf"
+    )
+
+
+def test_source_row_mime_none_when_absent() -> None:
+    assert _row(_meta_with(type_code=14)).mime is None
+
+
+def test_drive_pdf_type_code_14_decodes_to_pdf() -> None:
+    """Real Drive-PDF row (captured #1832): type_code 14 + application/pdf → PDF."""
+    from notebooklm._types.sources import Source, SourceType
+
+    src = Source.from_row(
+        _row(_meta_with(type_code=14, mime="application/pdf", descriptor_mime="application/pdf"))
+    )
+    assert src.kind == SourceType.PDF
+
+
+def test_native_sheet_type_code_14_stays_spreadsheet() -> None:
+    """Real native-Sheet row (captured #1832): type_code 14 + google-apps mime → GOOGLE_SPREADSHEET (no regression)."""
+    from notebooklm._types.sources import Source, SourceType
+
+    src = Source.from_row(
+        _row(
+            _meta_with(
+                type_code=14,
+                mime="application/vnd.google-apps.spreadsheet",
+                descriptor_mime="application/vnd.google-apps.spreadsheet",
+            )
+        )
+    )
+    assert src.kind == SourceType.GOOGLE_SPREADSHEET
+
+
+def test_type_code_14_no_mime_stays_spreadsheet() -> None:
+    """type_code 14 with no MIME signal stays GOOGLE_SPREADSHEET (conservative)."""
+    from notebooklm._types.sources import Source, SourceType
+
+    src = Source.from_row(_row(_meta_with(type_code=14)))
+    assert src.kind == SourceType.GOOGLE_SPREADSHEET
+
+
+def test_type_code_14_unknown_binary_mime_stays_spreadsheet() -> None:
+    """An unrecognized MIME under 14 is left as GOOGLE_SPREADSHEET, not relabeled/UNKNOWN."""
+    from notebooklm._types.sources import Source, SourceType
+
+    src = Source.from_row(_row(_meta_with(type_code=14, mime="application/x-mystery")))
+    assert src.kind == SourceType.GOOGLE_SPREADSHEET
+
+
+def test_non_14_type_code_with_pdf_mime_is_untouched() -> None:
+    """The MIME override only fires for type_code==14; other codes pass through.
+
+    A native web page (code 5) carrying a stray ``application/pdf`` MIME must NOT
+    be remapped — the disambiguation is gated on the ambiguous code 14 alone.
+    """
+    from notebooklm._types.sources import Source, SourceType
+
+    src = Source.from_row(_row(_meta_with(type_code=5, mime="application/pdf")))
+    assert src._type_code == 5
+    assert src.kind == SourceType.WEB_PAGE


### PR DESCRIPTION
## Summary

Fixes #1832. The NotebookLM backend returns source `type_code == 14` for **both** a native Google Sheet **and** a Drive-hosted PDF, so the read paths (`source_list` / `GET_NOTEBOOK` **and** `source fulltext` / `source_read` / `GET_SOURCE`) mislabeled Drive PDFs as `kind="google_spreadsheet"`. This completes the **read-path** half of the fix that #1831 started on the add path.

## Why not disambiguate by URL (the issue's original proposal)

A live capture (authed account) showed a Drive-hosted source carries **no URL on the wire** — `metadata[0]`, `[5]`, `[7]` (the URL precedence slots the adapter reads) are all `null`, and there's no `drive.google.com/file/d/…` anywhere in the row. So URL-based disambiguation has nothing to key on.

## The real signal: MIME

The wire already carries the true type as MIME, at the same positions for every Drive-hosted source:

| type_code | `metadata[19]` | `metadata[9]` (drive-file descriptor) |
|---|---|---|
| Drive PDF `14` | `"application/pdf"` | `["<id>", 5, "application/pdf", ""]` |
| Native Sheet `14` | `"application/vnd.google-apps.spreadsheet"` | `["<id>", 8, "application/vnd.google-apps.spreadsheet", ""]` |

## Change

- **`SourceRow.mime`** — reads `metadata[19]`, falling back to the drive-file descriptor `metadata[9][2]`.
- **`_disambiguate_type_code(type_code, mime)`** — for `type_code == 14`, remaps only live-verified MIMEs (`_TYPE_CODE_14_MIME_OVERRIDE = {"application/pdf": 3}`); native Sheets (google-apps mime), no MIME, and unrecognized MIMEs all stay `GOOGLE_SPREADSHEET` (conservative — never relabels a real Sheet, never emits `UNKNOWN`).
- Wired into `Source.from_row` (list path) **and** `SourceContentRenderer.get_fulltext` (the `GET_SOURCE` / `source_read` path, live-confirmed to carry the same `type_code=14 + mime` shape), and complements #1831's declared-mime stamping on the **add path** (no conflict — all resolve a Drive PDF to `PDF`).
- Position constants + canary contract (`TestSourceRowPositionContract`) updated for `metadata[9]`/`[19]`.
- `docs/rpc-reference.md` documents the code-`14` overload; CHANGELOG note added.

## Testing

- Regression tests for **both** `type_code=14` rows (Drive PDF → `pdf`, native Sheet → `google_spreadsheet`), plus MIME-accessor and conservative-fallback cases.
- Full unit + guardrail suite green (10,723 passed); mypy + ruff clean.
- **Verified live** against a real notebook: Drive PDF now lists as `kind=pdf`, native Sheet stays `google_spreadsheet`, native Doc unchanged.

> Note: the issue is labeled `do-not-implement-yet`; opening this PR was explicitly authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drive-hosted PDFs are now correctly identified as PDFs instead of spreadsheets.
  * Source and full-text views now use MIME information to resolve ambiguous source types more accurately.
* **Documentation**
  * Updated the source type code reference to explain the overloaded type and how it is distinguished.
  * Clarified metadata expectations for source records.
* **Tests**
  * Added coverage for PDF and spreadsheet disambiguation, plus fallback behavior when MIME data is missing or unexpected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->