### PR TITLE
docs: document sandboxed agents (Claude Cowork / headless) (#1856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read-path half of the fix started in #1831 (the add path).
   ([#1832](https://github.com/teng-lin/notebooklm-py/issues/1832))
 
+### Documentation
+
+- **Sandboxed agents (Claude Cowork / headless).** Documented running
+  `notebooklm-py` from Claude Cowork and similar no-display sandboxes in
+  `SKILL.md` and `docs/installation.md`: per-session `pip install` bootstrap (no
+  `[browser]` needed for queries — that extra is only for the interactive
+  `login`, which runs on a host machine), and reusing a host-generated
+  `storage_state.json` via the root `--storage` flag or `NOTEBOOKLM_AUTH_JSON`.
+  ([#1856](https://github.com/teng-lin/notebooklm-py/issues/1856))
+
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,6 +86,30 @@ For automated environments, multiple accounts, or parallel agent workflows:
 3. **Per-agent isolation via home:** Set unique `NOTEBOOKLM_HOME` per agent: `export NOTEBOOKLM_HOME=/tmp/agent-$ID`
 4. **Use full UUIDs:** Avoid partial IDs in automation (they can become ambiguous)
 
+### Sandboxed Agents (Claude Cowork / Headless)
+
+Sandboxed, no-display agent environments — **Claude Cowork** (Anthropic's desktop agent for non-developers) and similar headless sandboxes — can't run `notebooklm login` (it needs a browser), and they reset between sessions. Everything else works with two adjustments:
+
+1. **Bootstrap each session.** The sandbox resets, so install at the start of every session. You do **not** need `[browser]`/Playwright here — that extra exists only for the interactive `login` flow, which you run on a host machine, not in the sandbox. Chat, sources, generation, and download all run on the base install:
+   ```bash
+   pip install notebooklm-py   # no [browser] needed for queries/generation
+   ```
+   (This is the one place the mandatory `[browser]` install at the top of this file does not apply — you are reusing auth, not logging in here.)
+2. **Reuse a host-generated `storage_state.json`.** Log in once on a machine with a display (`notebooklm login`), then bring the resulting `storage_state.json` into a sandbox-accessible folder and point at it either way:
+   ```bash
+   # Per-invocation root flag (a persistent, sandbox-accessible path):
+   notebooklm --storage /path/to/storage_state.json list
+   # OR inline via env var (no file needed — e.g. from a Cowork-stored secret):
+   export NOTEBOOKLM_AUTH_JSON="$(cat /path/to/storage_state.json)"
+   notebooklm list
+   ```
+
+**Verify** as in [Agent Setup Verification](#agent-setup-verification) below — e.g. `notebooklm --storage <path> auth check --test --json` (require `"status": "ok"` AND `"checks.token_fetch": true`).
+
+**Context does not survive a reset** either: the selected-notebook context (`context.json`) is gone each session, so pass an explicit `-n/--notebook <id>` on notebook-scoped commands instead of relying on `notebooklm use`.
+
+If Cowork reads `~/.claude/skills/`, `notebooklm skill install` registers this skill there automatically; otherwise add it through Cowork's own capability UI. Full recipe (extras matrix, headless auth, CI env-var notes): [installation.md § AI Agent](https://github.com/teng-lin/notebooklm-py/blob/main/docs/installation.md#a-ai-agent-primary-persona).
+
 ## Agent Setup Verification
 
 Before starting workflows, verify auth is in place. **Use `--test --json` (not bare `--json`)** — bare `--json` only proves the cookie file parses; `--test` makes a network call and proves the cookies still authenticate against Google.

--- a/SKILL.md
+++ b/SKILL.md
@@ -104,6 +104,8 @@ Sandboxed, no-display agent environments — **Claude Cowork** (Anthropic's desk
    notebooklm list
    ```
 
+   > ⚠️ **`storage_state.json` / `NOTEBOOKLM_AUTH_JSON` are bearer credentials** — anyone holding them can act as your Google account. Keep the file `0600`, load it from the sandbox's secret store rather than a committed file, never print or log it, and `unset NOTEBOOKLM_AUTH_JSON` when finished.
+
 **Verify** as in [Agent Setup Verification](#agent-setup-verification) below — e.g. `notebooklm --storage <path> auth check --test --json` (require `"status": "ok"` AND `"checks.token_fetch": true`).
 
 **Context does not survive a reset** either: the selected-notebook context (`context.json`) is gone each session, so pass an explicit `-n/--notebook <id>` on notebook-scoped commands instead of relying on `notebooklm use`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,6 +136,8 @@ If the agent is in a no-display sandbox AND `[cookies]` isn't installed (Python 
   notebooklm list
   ```
 
+> ⚠️ **Security:** `storage_state.json` and `NOTEBOOKLM_AUTH_JSON` are bearer credentials for your Google account — store the file `0600` or in the sandbox's secret store, never commit or log them, and `unset NOTEBOOKLM_AUTH_JSON` after use.
+
 Pass an explicit `-n/--notebook <id>` on notebook-scoped commands — the selected-notebook context does not survive a session reset. If Cowork reads `~/.claude/skills/`, `notebooklm skill install` registers the skill there; otherwise add it through Cowork's own capability UI.
 
 **Verification (machine-parseable):**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-07-11
 
 This is the canonical installation guide for `notebooklm-py`. The README has a quickstart; everything else lives here.
 
@@ -117,6 +117,26 @@ notebooklm login --browser-cookies auto    # rookiepy autodetects an installed b
 ```
 
 If the agent is in a no-display sandbox AND `[cookies]` isn't installed (Python 3.13+ skipped it), ask the user to run `notebooklm login` on a workstation and copy the resulting `~/.notebooklm/profiles/default/storage_state.json` to the agent's environment (or set `NOTEBOOKLM_AUTH_JSON`).
+
+#### Sandboxed agents (Claude Cowork)
+
+**Claude Cowork** (Anthropic's sandboxed desktop agent for non-developers) and similar no-display sandboxes are a special case of the headless path above: there is no browser for `notebooklm login`, and the sandbox resets between sessions. Two adjustments make everything except `login` work:
+
+- **Bootstrap each session** with the base install — `[browser]`/Playwright is *not* needed here, only for `login` (which you run elsewhere, once):
+  <!-- not mirrored: Cowork per-session bootstrap; not part of the contributor flow -->
+  ```bash
+  pip install notebooklm-py    # queries/generation/download need no extras
+  ```
+- **Reuse a host-generated `storage_state.json`.** Run `notebooklm login` once on a machine with a display, then bring the file into a sandbox-accessible folder. Point at it with the root `--storage` flag or `NOTEBOOKLM_AUTH_JSON` — the same mechanism as [Persona D](#d-headless-server-or-ci):
+  <!-- not mirrored: Cowork auth reuse; not part of the contributor flow -->
+  ```bash
+  notebooklm --storage /path/to/storage_state.json list             # per-invocation flag
+  # OR inline via env var (no file needed — e.g. from a Cowork-stored secret):
+  export NOTEBOOKLM_AUTH_JSON="$(cat /path/to/storage_state.json)"
+  notebooklm list
+  ```
+
+Pass an explicit `-n/--notebook <id>` on notebook-scoped commands — the selected-notebook context does not survive a session reset. If Cowork reads `~/.claude/skills/`, `notebooklm skill install` registers the skill there; otherwise add it through Cowork's own capability UI.
 
 **Verification (machine-parseable):**
 


### PR DESCRIPTION
## Summary

Documents how to run `notebooklm-py` inside **Claude Cowork** (Anthropic's sandboxed, no-display desktop agent) and similar headless sandboxes. These environments can't run `notebooklm login` (it needs a browser) and reset between sessions — but every other command works by reusing a host-generated `storage_state.json`. The mechanisms already exist (`--storage`, `NOTEBOOKLM_AUTH_JSON`); this just documents them for that persona, which the installed skill previously assumed away.

## Related Issue

Closes #1856

## Changes

- **`SKILL.md`** — new "Sandboxed Agents (Claude Cowork / Headless)" subsection under `## Prerequisites` (after the CI/CD table that already documents `NOTEBOOKLM_AUTH_JSON`): per-session `pip install` bootstrap, an explicit note that `[browser]`/Playwright is **login-only** (reconciling the "`[browser]` mandatory" line at the top of the file), the `--storage` / `NOTEBOOKLM_AUTH_JSON` auth-reuse recipe, and the `-n/--notebook` caveat since the selected-notebook context does not survive a session reset. Cross-references the existing Agent Setup Verification block rather than duplicating it.
- **`docs/installation.md`** — parallel "Sandboxed agents (Claude Cowork)" `####` subsection under Persona A (correct nesting; mirrors the master-token `####` under Persona D), cross-linking Persona D for the shared storage_state mechanism. `--storage` is net-new to this file. Bumped "Last Updated".
- **`CHANGELOG.md`** — `[Unreleased]` → `### Documentation` entry referencing #1856.

Scope is **docs-only**, matching the issue's single checked Target Surface. The optional `.skill` zip / `skill install --target cowork` is deferred as follow-up — it's net-new build/test surface, and the existing `notebooklm skill install` → `~/.claude/skills/` path likely already serves Cowork.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass — `10636 passed, 83 skipped, 0 failed` (see Notes on the coverage gate)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports` — clean, 305 files)
- [ ] N/A — docs-only, no architectural shape change, so no ADR.

## Notes

- **Docs guardrails pass.** `tests/_guardrails/test_install_docs.py` (extras matrix, anchor resolution, required install strings) and `tests/unit/test_skill_packaging.py` (the wheel carries `SKILL.md` verbatim into package data) both pass — the new `(installation.md#...)` cross-links use slugs that resolve (`a-ai-agent-primary-persona`, `d-headless-server-or-ci`).
- **Coverage gate caveat:** running the exact `--cov-fail-under=90` command in the contributor extras subset (`browser,dev,markdown`) reports **83%** because the `server`/`mcp`/`headless`/`cookies` modules are imported-but-untested (their tests skip without those extras) — an environment artifact, not a regression. This PR adds **zero source lines**, so it does not change coverage; CI installs the full extras matrix and clears the gate.
- Reviewed adversarially by an internal multi-model review panel (scope, user-facing consistency, fact-check) before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9NhFjXMkxuosyKVjC1RaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9NhFjXMkxuosyKVjC1RaE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Sandboxed Agents (Claude Cowork / Headless)” guide for running NotebookLM in no-display, reset-between-sessions environments.
  * Included per-session bootstrap steps with a base install that avoids interactive browser features.
  * Documented reusing host-generated `storage_state.json` via `--storage` or `NOTEBOOKLM_AUTH_JSON`, with a security warning that these are bearer credentials.
  * Clarified auth verification expectations and that notebook context does not persist, requiring explicit `-n/--notebook` for notebook-scoped commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->