### PR TITLE
test(e2e): decode CLI subprocess output as UTF-8 (Windows cp1252 crash)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1098,14 +1098,28 @@ def run_cli(
     ``notebooklm use`` (that mutates shared profile state).
     """
     env = os.environ.copy()
+    # Belt for the child's *encode* side: force UTF-8 stdout so a non-Latin-1
+    # char in a live answer can't crash the child on a non-UTF-8-locale runner.
+    # (On Windows the CLI already does this itself via
+    # ``notebooklm_cli._configure_windows_runtime``; this mirrors it for any
+    # other locale.) Set as a base default so ``extra_env`` can override it.
+    env.setdefault("PYTHONUTF8", "1")
     if notebook is not None:
         env["NOTEBOOKLM_NOTEBOOK"] = notebook
     if extra_env:
         env.update(extra_env)
+    # The load-bearing fix is our *decode* side: without ``encoding=``,
+    # ``text=True`` decodes the child's UTF-8 stdout with the locale codec
+    # (cp1252 on Windows), which raises ``UnicodeDecodeError`` on an undefined
+    # byte (e.g. 0x9d, the tail of a closing curly quote U+201D → ``E2 80 9D``);
+    # the reader thread dies, ``proc.stdout`` becomes ``None``, and
+    # ``json.loads(None)`` fails with a misleading ``TypeError``. Pin the decode
+    # to UTF-8; ``errors="replace"`` guarantees a ``str`` (never ``None``).
     return subprocess.run(
         [sys.executable, "-m", "notebooklm.notebooklm_cli", *args],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         env=env,
         timeout=timeout,
     )

--- a/tests/unit/test_e2e_run_cli_encoding.py
+++ b/tests/unit/test_e2e_run_cli_encoding.py
@@ -1,0 +1,54 @@
+"""Regression guard for the e2e ``run_cli`` subprocess-capture encoding.
+
+Lives in the normal unit suite (``tests/e2e`` is ``--ignore``d and auth-gated, so
+it never runs in ordinary CI) and needs no network: it monkeypatches
+``subprocess.run`` and asserts the load-bearing UTF-8 capture kwargs survive.
+
+Without them, ``run_cli`` decoded the CLI child's UTF-8 stdout with the locale
+codec (cp1252 on Windows); a non-Latin-1 char in a live answer (e.g. a closing
+curly quote ``”`` → ``E2 80 9D``) then crashed the reader thread, ``proc.stdout``
+came back ``None``, and ``json.loads(None)`` raised a misleading ``TypeError``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from tests.e2e.conftest import run_cli
+
+
+def test_run_cli_pins_utf8_capture(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_cli("list", "--json")
+
+    kwargs = captured["kwargs"]
+    # Our decode is pinned to UTF-8 with a never-None fallback...
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+    # ...and the child is defaulted to UTF-8 output too.
+    assert kwargs["env"]["PYTHONUTF8"] == "1"
+
+
+def test_run_cli_child_utf8_is_overridable(monkeypatch) -> None:
+    """``PYTHONUTF8`` is a base default, so ``extra_env`` can still override it."""
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_cli("list", extra_env={"PYTHONUTF8": "0"})
+
+    assert captured["kwargs"]["env"]["PYTHONUTF8"] == "0"
+    # The decode kwargs are not env-driven — they stay pinned regardless.
+    assert captured["kwargs"]["encoding"] == "utf-8"

--- a/tests/unit/test_e2e_run_cli_encoding.py
+++ b/tests/unit/test_e2e_run_cli_encoding.py
@@ -18,6 +18,9 @@ from tests.e2e.conftest import run_cli
 
 
 def test_run_cli_pins_utf8_capture(monkeypatch) -> None:
+    # run_cli defaults the child via setdefault, so an ambient PYTHONUTF8!="1"
+    # would no-op the default and fail this spuriously — isolate the default.
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
     captured: dict[str, object] = {}
 
     def fake_run(cmd, **kwargs):


### PR DESCRIPTION
## Summary

A scheduled **Windows** e2e run failed in `tests/e2e/test_cli_live.py::TestCliLive::test_ask_json` with:

```
payload = json.loads(proc.stdout)
E   TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

The real cause is one frame up, in the subprocess reader thread:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d ... cp1252.py
```

`run_cli` (in `tests/e2e/conftest.py`) captured the CLI child's stdout with `subprocess.run(..., text=True)` and **no `encoding=`**, so on Windows it decoded with the locale codec (**cp1252**). The live answer contained a closing curly quote `"` (UTF-8 `E2 80 9D`); cp1252 has no mapping for byte `0x9D`, so the reader thread raised `UnicodeDecodeError`, `proc.stdout` came back `None`, and `json.loads(None)` raised the misleading `TypeError`.

## Why it stayed hidden until now

- **cp1252 rarely *raises*** — only 5 byte values are undefined (`0x81, 0x8D, 0x8F, 0x90, 0x9D`); everything else decodes to mojibake, and since JSON's structural chars are ASCII, `json.loads` still parsed. Answers with accents (`café`) passed silently for months.
- Of common LLM punctuation, essentially only the **closing curly quote `"`** contributes byte `0x9D`. `"` `'` `'` `–` `—` `…` `™` and accents don't trip it.
- The answer comes from the **live** model (non-deterministic), and e2e only runs on a schedule (it's `--ignore`d in normal CI and gated on auth secrets), and only **Windows** defaults to a non-UTF-8 codec — so the stochastic trigger rarely had a chance to fire.

It's a **latent harness bug since `run_cli` was introduced**, not a regression.

## Changes

`tests/e2e/conftest.py` — `run_cli`:
- **Decode side (the fix):** `subprocess.run(..., encoding="utf-8", errors="replace")`. `errors="replace"` guarantees a `str` is always returned, so a stray byte can never again surface as a `None`-stdout `TypeError`. (`text=True` was dropped — `encoding=` already implies text mode.)
- **Encode side (belt):** `env.setdefault("PYTHONUTF8", "1")` so the child emits UTF-8 on any non-UTF-8-locale runner. This mirrors what the CLI already does on Windows in production (`notebooklm_cli._configure_windows_runtime` → `setdefault("PYTHONUTF8", "1")` + reconfigures stdout to UTF-8), so it's representative, not masking. Set before `extra_env` so a caller can still override.

## Test Plan

- [x] Reproduced the mechanism locally: decoding a UTF-8 payload containing `"` as cp1252 raises the exact `byte 0x9d` error; `encoding="utf-8", errors="replace"` decodes it and `json.loads` succeeds.
- [x] `ruff format` / `ruff check` pass; `tests/e2e/test_cli_live.py` still collects (skips locally without the `mcp` extra).
- [ ] N/A — e2e requires live auth and can't run in a PR; this touches only the e2e capture harness (no product code).

## Notes

- **Scope:** `run_cli` is the only vulnerable capture. The other `tests/e2e` subprocess (`test_server_process_live.py`) redirects to log files opened `encoding="utf-8"` and reads them back with `errors="replace"`, so it's immune — left unchanged.
- Reviewed adversarially by an internal multi-model panel (correctness + fact-check) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9NhFjXMkxuosyKVjC1RaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9NhFjXMkxuosyKVjC1RaE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure the e2e CLI subprocess output is consistently captured as UTF-8 with invalid characters replaced.
  * Added checks that the helper defaults the child process to UTF-8 mode while still allowing explicit overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->