### PR TITLE
perf(server): fetch REST account block via one GET_USER_SETTINGS call

### DIFF
--- a/src/notebooklm/server/routes/meta.py
+++ b/src/notebooklm/server/routes/meta.py
@@ -23,7 +23,6 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Query, Request
@@ -71,10 +70,10 @@ async def _account_block(client: NotebookLMClient, *, authenticated: bool) -> di
     if not authenticated:
         return {**identity, "available": False, "reason": "not authenticated"}
     try:
-        limits, output_language = await asyncio.gather(
-            client.settings.get_account_limits(),
-            client.settings.get_output_language(),
-        )
+        # Both limits + language ride one GET_USER_SETTINGS response (#1724):
+        # a single fetch instead of two identical POSTs (mirrors the MCP tool).
+        settings = await client.settings.get_user_settings()
+        limits, output_language = settings.limits, settings.output_language
     except NotebookLMError as exc:  # degrade, don't sink the whole response
         return {**identity, "available": False, "reason": redact(str(exc))}
     return {

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from notebooklm._types.artifacts import Artifact, GenerationState, GenerationStatus
 from notebooklm._types.chat import AskResult, ChatSettings
-from notebooklm._types.common import AccountLimits
+from notebooklm._types.common import AccountLimits, UserSettings
 from notebooklm._types.notebooks import Notebook, PromptSuggestion
 from notebooklm._types.notes import Note
 from notebooklm._types.research import (
@@ -573,6 +573,12 @@ class FakeSettings:
 
     async def get_output_language(self) -> str | None:
         return self._s.output_language
+
+    async def get_user_settings(self) -> UserSettings:
+        return UserSettings(
+            limits=self._s.account_limits,
+            output_language=self._s.output_language,
+        )
 
 
 class FakeClient:

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -215,7 +215,7 @@ def test_server_info_include_account_degrades_on_settings_error(
     async def _raise() -> Any:
         raise RPCError("session expired")
 
-    fake_client.settings.get_user_settings = _raise  # type: ignore[method-assign]
+    monkeypatch.setattr(fake_client.settings, "get_user_settings", _raise)
 
     body = authed_client.get("/v1/server/info", params={"include_account": True}).json()
     account = body["account"]

--- a/tests/server/test_meta.py
+++ b/tests/server/test_meta.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from notebooklm.exceptions import RPCError
 from notebooklm.server.app import create_app
 from notebooklm.server.routes import meta as meta_route
 
@@ -201,6 +202,28 @@ def test_server_info_include_account(
     assert account["source_limit"] == 50
     assert account["tier"] == 1
     assert account["output_language"] == "en"
+
+
+def test_server_info_include_account_degrades_on_settings_error(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live session whose GET_USER_SETTINGS fetch fails degrades the account block
+    to available:False (scrubbed reason) while auth/version stay intact — covers the
+    single-fetch error branch in _account_block."""
+    _patch_auth(monkeypatch, all_passed=True)
+
+    async def _raise() -> Any:
+        raise RPCError("session expired")
+
+    fake_client.settings.get_user_settings = _raise  # type: ignore[method-assign]
+
+    body = authed_client.get("/v1/server/info", params={"include_account": True}).json()
+    account = body["account"]
+    assert account["available"] is False
+    assert "session expired" in account["reason"]
+    # Identity + the auth diagnostic survive the quota-read failure.
+    assert account["email"] == "user@example.com"
+    assert body["auth"]["authenticated"] is True
 
 
 def test_server_info_include_account_unauthenticated_degrades(


### PR DESCRIPTION
## Summary

Follow-up to #1861. The REST `server_info` account block fetched account limits and output language with `asyncio.gather(get_account_limits(), get_output_language())` — **two identical `GET_USER_SETTINGS` POSTs**. This mirrors the MCP tool (#1724) by calling `get_user_settings()` **once** and reading both payloads off the single response:

- Halves the network round-trips for `server_info(include_account=True)` on the REST side.
- Reads `limits` + `output_language` from **one consistent snapshot** (the two independent fetches could, in principle, disagree).
- Drops the now-unused `import asyncio`.
- Test fake `FakeSettings` gains `get_user_settings()`; a **new test** covers the single-fetch error-degrade branch (`RPCError` → `available: False` + scrubbed reason), which was previously uncovered on the REST side.

Behavior is otherwise unchanged — same `NotebookLMError` degrade path, same `redact` chokepoint, same account-block keys (including the `tier` field from #1861).

## Test plan

- [x] `pytest tests/server/test_meta.py` — 10 passed (was 9; +1 degrade-path test)
- [x] `ruff check` + `mypy src/notebooklm` — clean
- Reviewed via `/polish` (code-simplifier + triple review claude/codex + ultrathink): 0 critical, 0 important. (This refactor was recommended by the reviewer during #1861.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how account details are retrieved for server information requests when account data is included.
  * Server details continue to load even if account settings can’t be fetched, with the account section marked unavailable and the reason retained.
* **Tests**
  * Added regression coverage for degraded `/v1/server/info?include_account=true` responses when settings retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->