### PR TITLE
fix(e2e): cover all CREATE_ARTIFACT paths for rate-limit skip; split coverage floors by job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -307,6 +307,11 @@ jobs:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
+        # Enforce here too: a marked test that failed on the main run and turns into
+        # a rate-limit skip after the cool-down would otherwise leave no PASS event
+        # for its surface. Appends PASS/SKIP events to the same job-level sentinel
+        # (the main step's rm -f already cleared any stale one). (codex/coderabbit)
+        E2E_ENFORCE_COVERAGE_FLOOR: "1"
       shell: bash
       run: |
         # Missing lastfailed after a failed e2e step means pytest crashed
@@ -357,9 +362,19 @@ jobs:
       shell: bash
       run: |
         sentinel="$E2E_COVERAGE_FLOOR_SENTINEL"
-        if [ -f "$sentinel" ]; then
-          echo "::error::E2E coverage floor breached — a live surface produced zero coverage (all rate-limited):"
-          sort -u "$sentinel"
+        if [ ! -f "$sentinel" ]; then
+          echo "Coverage floors satisfied (no monitored surface emitted a skip)."
+          exit 0
+        fi
+        # Reconcile PASS/SKIP events accumulated across the main run + retry: a
+        # surface breaches only if it was SKIP-ped somewhere and PASSed nowhere.
+        passed="$(awk -F'\t' '$1=="PASS"{print $2}' "$sentinel" | sort -u)"
+        skipped="$(awk -F'\t' '$1=="SKIP"{print $2}' "$sentinel" | sort -u)"
+        breach="$(comm -23 <(printf '%s\n' "$skipped" | sed '/^$/d') \
+                            <(printf '%s\n' "$passed" | sed '/^$/d'))"
+        if [ -n "$breach" ]; then
+          echo "::error::E2E coverage floor breached — surface(s) rate-limited with zero real coverage:"
+          printf '  %s\n' "$breach"
           exit 1
         fi
-        echo "Coverage floors satisfied (no monitored surface was fully rate-limited)."
+        echo "Coverage floors satisfied (every skipped surface also had a passing test)."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,6 +118,10 @@ jobs:
       # path on every OS — see test.yml for the rationale (sidesteps the
       # actions/cache@v6 Windows dual-path restore flake).
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+      # Single source of truth for the coverage-floor sentinel path, referenced by
+      # both the E2E step (writes it) and the "Enforce coverage floors" step (gates
+      # on it). Harmless when unset-enforcement steps run — they never write it.
+      E2E_COVERAGE_FLOOR_SENTINEL: ${{ github.workspace }}/.e2e-coverage-floor-failed
 
     concurrency:
       group: nightly-${{ needs.resolve-branch.outputs.branch }}-${{ matrix.os }}
@@ -253,9 +257,9 @@ jobs:
         # because every marked test was rate-limited, record it to the sentinel that
         # the "Enforce coverage floors" step below gates on. Written (not raised) so
         # a pure-skip run stays exit 0 and doesn't trip the continue-on-error retry.
-        # The release job (verify-package) leaves these unset → skip-only (#1819).
+        # The release job (verify-package) leaves this unset → skip-only (#1819).
+        # (E2E_COVERAGE_FLOOR_SENTINEL is defined once at job level.)
         E2E_ENFORCE_COVERAGE_FLOOR: "1"
-        E2E_COVERAGE_FLOOR_SENTINEL: ${{ github.workspace }}/.e2e-coverage-floor-failed
         # Route every workflow_dispatch input + upstream needs.* value through
         # the env block so crafted values (e.g. ``"; echo PWN``) reach pytest
         # as literal strings, not as inlined shell. ``TARGET_BRANCH`` is
@@ -277,6 +281,10 @@ jobs:
           # ``--`` separator forces $TEST_FILTER to be parsed as positional
           # file/path args, never as pytest options (e.g. a crafted ``--co``
           # or ``-k "expr"`` value cannot inject pytest flags).
+          # The coverage floor is a whole-surface guarantee — meaningless for a
+          # single filtered test, and a marked-but-throttled pick would false-red
+          # the run — so disable enforcement for filtered dispatches (codex).
+          unset E2E_ENFORCE_COVERAGE_FLOOR
           uv run pytest -s -v --tb=short --reruns 1 --reruns-delay 30 -- "$TEST_FILTER"
         elif [ "$MATRIX_OS" = "ubuntu-latest" ]; then
           # Linux: run all E2E tests except variants
@@ -348,7 +356,7 @@ jobs:
       if: ${{ always() && needs.resolve-branch.outputs.is_standard == 'true' }}
       shell: bash
       run: |
-        sentinel="${{ github.workspace }}/.e2e-coverage-floor-failed"
+        sentinel="$E2E_COVERAGE_FLOOR_SENTINEL"
         if [ -f "$sentinel" ]; then
           echo "::error::E2E coverage floor breached — a live surface produced zero coverage (all rate-limited):"
           sort -u "$sentinel"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,6 +248,14 @@ jobs:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
+        # Enforce the live coverage floors on the nightly only (fresh quota): if a
+        # monitored surface (live chat / live generation) produced zero real coverage
+        # because every marked test was rate-limited, record it to the sentinel that
+        # the "Enforce coverage floors" step below gates on. Written (not raised) so
+        # a pure-skip run stays exit 0 and doesn't trip the continue-on-error retry.
+        # The release job (verify-package) leaves these unset → skip-only (#1819).
+        E2E_ENFORCE_COVERAGE_FLOOR: "1"
+        E2E_COVERAGE_FLOOR_SENTINEL: ${{ github.workspace }}/.e2e-coverage-floor-failed
         # Route every workflow_dispatch input + upstream needs.* value through
         # the env block so crafted values (e.g. ``"; echo PWN``) reach pytest
         # as literal strings, not as inlined shell. ``TARGET_BRANCH`` is
@@ -259,6 +267,9 @@ jobs:
       shell: bash
       run: |
         echo "Testing branch: $TARGET_BRANCH"
+        # Start from a clean coverage-floor sentinel so a stale file from a prior
+        # run on a reused/self-hosted runner can't false-red the enforcement step.
+        rm -f "$E2E_COVERAGE_FLOOR_SENTINEL"
         # --reruns 1 catches sub-minute network blips; longer chat-throttle
         # recovery is handled by the cool-down retry step below.
         if [ -n "$TEST_FILTER" ]; then
@@ -325,3 +336,22 @@ jobs:
         NOTEBOOKLM_TRANSPORT: curl_cffi
       shell: bash
       run: uv run pytest tests/e2e -m impersonate_smoke -s -v --tb=short --reruns 1 --reruns-delay 30
+
+    - name: Enforce coverage floors
+      # Gate the nightly on the live coverage floors independently of the
+      # continue-on-error main run + --last-failed retry (which can't re-attempt
+      # throttled generation — those are skips, not failures). The main e2e step
+      # records a breach to the sentinel; fail here if any surface produced zero
+      # real coverage (every marked live-chat / live-generation test rate-limited).
+      # ``always()`` so a breach recorded before an unrelated later failure still
+      # surfaces. The release job never sets the sentinel, so this is nightly-only.
+      if: ${{ always() && needs.resolve-branch.outputs.is_standard == 'true' }}
+      shell: bash
+      run: |
+        sentinel="${{ github.workspace }}/.e2e-coverage-floor-failed"
+        if [ -f "$sentinel" ]; then
+          echo "::error::E2E coverage floor breached — a live surface produced zero coverage (all rate-limited):"
+          sort -u "$sentinel"
+          exit 1
+        fi
+        echo "Coverage floors satisfied (no monitored surface was fully rate-limited)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ timeout = 60
 markers = [
     "e2e: end-to-end tests requiring authentication (run with pytest tests/e2e -m e2e)",
     "live_chat_ask: E2E live chat ask tests monitored for CI coverage floors",
+    "live_generation: E2E live artifact-generation tests monitored for CI coverage floors (nightly-enforced)",
     "variants: parameter variant tests (skip to save quota)",
     "readonly: read-only tests against user's test notebook",
     "impersonate_smoke: minimal live smoke run under NOTEBOOKLM_TRANSPORT=curl_cffi in the nightly (read/ask/upload/download — one per transport-critical op)",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -73,6 +73,11 @@ _GENERATION_SKIP_TARGETS = {
     # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.
     "artifacts": lambda n: n.startswith(("generate_", "revise_")) or n == "retry_failed",
     "mind_maps": lambda n: n == "generate",
+    # client.labels.generate is the AI "Auto-label" action (CREATE_LABEL) — a
+    # generative call the decoder raises RateLimitError from on throttle, and its
+    # e2e test asserts the result directly (no assert_generation_started fallback),
+    # so it must skip like the artifact paths.
+    "labels": lambda n: n == "generate",
 }
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -73,11 +73,11 @@ _GENERATION_SKIP_TARGETS = {
     # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.
     "artifacts": lambda n: n.startswith(("generate_", "revise_")) or n == "retry_failed",
     "mind_maps": lambda n: n == "generate",
-    # client.labels.generate is the AI "Auto-label" action (CREATE_LABEL) — a
-    # generative call the decoder raises RateLimitError from on throttle, and its
-    # e2e test asserts the result directly (no assert_generation_started fallback),
-    # so it must skip like the artifact paths.
-    "labels": lambda n: n == "generate",
+    # Deliberately NOT here: client.labels.generate (CREATE_LABEL, the AI Auto-label
+    # action) and client.research.start (Deep Research). These are separate limit
+    # classes, not the daily CREATE_ARTIFACT quota — labels has no documented quota,
+    # and research already tolerates throttling via @pytest.mark.xfail. Don't lump
+    # them in on theory; add here (with evidence) only if one actually hard-fails CI.
 }
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -65,9 +65,15 @@ _COVERAGE_FLOOR_MARKERS = {
 # skip never runs). Keyed by client-namespace attr → predicate over method name.
 # Quizzes/flashcards/audio/video/etc. ride client.artifacts.generate_*/revise_*; the
 # interactive mind map goes through the separate client.mind_maps.generate path (the
-# #1819 gap that hard-failed the suite). Add new generation namespaces here — the
-# guard test test_generation_skip_registry_covers_generate_methods fails if an
-# unregistered generate_/revise_ method appears on a covered namespace's class.
+# #1819 gap that hard-failed the suite). Add new generation namespaces here — the guard
+# test TestGenerationSkipRegistryCoverage.test_registry_covers_all_generate_and_revise_methods
+# fails if an unregistered generate_/revise_/retry_ method appears on a covered class.
+#
+# Note: wrapping a whole method means a RateLimitError from a *post-create* RPC (e.g.
+# mind_maps.generate(wait=True) polling after the artifact id exists) also skips. The
+# #1819 create-time case raises before any artifact exists (no leak); the rarer
+# post-create-throttle path may leave one artifact in the test notebook uncleaned —
+# an accepted trade-off for keeping the create-time skip simple (codex).
 _GENERATION_SKIP_TARGETS = {
     # ``retry_failed`` re-runs generation and raises RateLimitError on quota, same
     # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.
@@ -420,11 +426,13 @@ def _coverage_floor_failures(terminalreporter, exitstatus, marker: str) -> list[
     # No marked test passed and some were rate-limited. A marked *failure* has its
     # real outcome deferred to the retry (may pass there → coverage), so hold off;
     # otherwise this is a final zero-coverage breach — record it even when other,
-    # unmarked tests failed.
+    # unmarked tests failed. Count a failure in ANY phase (setup/call/teardown):
+    # ``--last-failed`` retries a test that failed in any phase, so a setup-phase
+    # failure of a marked test is just as deferrable as a call-phase one (gemini/codex).
     marked_failures = [
         report
         for report in terminalreporter.stats.get("failed", [])
-        if _is_call_report(report) and _has_marker(report, marker)
+        if _has_marker(report, marker)
     ]
     if marked_failures:
         return []
@@ -458,27 +466,40 @@ def pytest_sessionfinish(session, exitstatus):
     # exit status alone (a pure-skip run stays exit 0, avoiding a spurious retry).
     # Without a sentinel path (local runs, simple jobs, unit tests) we gate inline.
     sentinel = os.environ.get("E2E_COVERAGE_FLOOR_SENTINEL")
-    if sentinel:
-        _write_coverage_floor_sentinel(sentinel, breached)
-    else:
-        session.exitstatus = pytest.ExitCode.TESTS_FAILED
+    # Sentinel delivery (nightly): record the breach for the gating step and leave
+    # exit status alone (a pure-skip run stays exit 0, avoiding a spurious retry).
+    # If the write fails, fall back to the inline exit-code path — best-effort, since
+    # continue-on-error may mask it, but paired with the loud ::error:: it's better
+    # than a silent hollow-green (codex). Without a sentinel path we gate inline.
+    if sentinel and _write_coverage_floor_sentinel(sentinel, breached):
+        return
+    session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
-def _write_coverage_floor_sentinel(path: str, labels: list[str]) -> None:
-    """Append breached-floor labels to the sentinel a nightly gating step reads."""
+def _write_coverage_floor_sentinel(path: str, labels: list[str]) -> bool:
+    """Append breached-floor labels to the sentinel a nightly gating step reads.
+
+    Returns True on success. Creates the parent directory first so a missing
+    directory can't turn the enforcement signal into a silent no-op (gemini).
+    """
     try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         with open(path, "a", encoding="utf-8") as f:
             for label in labels:
                 f.write(f"{label} coverage floor failed\n")
+        return True
     except OSError as exc:
-        # The sentinel IS the enforcement signal — a silent write failure would
-        # let a hollow-green nightly pass. We can't fall back to session.exitstatus
-        # (masked by continue-on-error), so at least fail loud in the log.
+        # The sentinel IS the enforcement signal — a silent write failure would let a
+        # hollow-green nightly pass. Fail loud AND signal the caller to fall back to
+        # the inline exit-code path.
         print(
             f"::error::could not write coverage-floor sentinel {path!r} "
             f"({exc}); breached floors: {', '.join(labels)}",
             file=sys.stderr,
         )
+        return False
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -50,6 +50,30 @@ _RATE_LIMIT_PHRASES = (
     "too many requests",
 )
 _LIVE_CHAT_ASK_MARKER = "live_chat_ask"
+_LIVE_GENERATION_MARKER = "live_generation"
+# Coverage-floor markers → human label. A floor "fails" when at least one marked
+# test was rate-limit-skipped and none passed (hollow-green coverage). Enforced
+# only when E2E_ENFORCE_COVERAGE_FLOOR=1 (the nightly), so a shared daily-quota
+# exhaustion never reds a release job — see #1819 / _coverage_floor_enforced.
+_COVERAGE_FLOOR_MARKERS = {
+    _LIVE_CHAT_ASK_MARKER: "live chat",
+    _LIVE_GENERATION_MARKER: "live generation",
+}
+
+# Every live entrypoint that issues CREATE_ARTIFACT and can raise a quota
+# RateLimitError *before* any GenerationStatus exists (so assert_generation_started's
+# skip never runs). Keyed by client-namespace attr → predicate over method name.
+# Quizzes/flashcards/audio/video/etc. ride client.artifacts.generate_*/revise_*; the
+# interactive mind map goes through the separate client.mind_maps.generate path (the
+# #1819 gap that hard-failed the suite). Add new generation namespaces here — the
+# guard test test_generation_skip_registry_covers_generate_methods fails if an
+# unregistered generate_/revise_ method appears on a covered namespace's class.
+_GENERATION_SKIP_TARGETS = {
+    # ``retry_failed`` re-runs generation and raises RateLimitError on quota, same
+    # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.
+    "artifacts": lambda n: n.startswith(("generate_", "revise_")) or n == "retry_failed",
+    "mind_maps": lambda n: n == "generate",
+}
 
 
 def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
@@ -72,7 +96,7 @@ def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
 
 
 def _install_generation_rate_limit_skip(client: NotebookLMClient) -> None:
-    """Wrap ``client.artifacts.generate_*``/``revise_*`` so ``RateLimitError`` becomes a skip.
+    """Wrap every live CREATE_ARTIFACT entrypoint so ``RateLimitError`` becomes a skip.
 
     The RPC layer raises a typed ``RateLimitError`` when Google rejects
     CREATE_ARTIFACT with a quota error (e.g. upstream status 8, Resource
@@ -81,6 +105,10 @@ def _install_generation_rate_limit_skip(client: NotebookLMClient) -> None:
     That is server-side throttling, not a client defect. Only the precise
     typed ``RateLimitError`` skips; every other exception still raises so
     real defects stay visible.
+
+    Covers every namespace in ``_GENERATION_SKIP_TARGETS`` — not just
+    ``client.artifacts`` — so paths like ``client.mind_maps.generate`` (the
+    interactive mind map, #1819) skip on quota exhaustion instead of hard-failing.
     """
 
     def _wrap(original):
@@ -95,13 +123,17 @@ def _install_generation_rate_limit_skip(client: NotebookLMClient) -> None:
 
         return _with_skip
 
-    for name in dir(client.artifacts):
-        if not (name.startswith("generate_") or name.startswith("revise_")):
+    for ns_name, matches in _GENERATION_SKIP_TARGETS.items():
+        namespace = getattr(client, ns_name, None)
+        if namespace is None:
             continue
-        original = getattr(client.artifacts, name)
-        if not callable(original):
-            continue
-        setattr(client.artifacts, name, _wrap(original))
+        for name in dir(namespace):
+            if not matches(name):
+                continue
+            original = getattr(namespace, name)
+            if not callable(original):
+                continue
+            setattr(namespace, name, _wrap(original))
 
 
 def _emit_auth_route_diagnostic(auth_tokens: AuthTokens) -> None:
@@ -331,24 +363,68 @@ def _rate_limit_skip_reports(terminalreporter) -> list[Any]:
     ]
 
 
-def _live_chat_floor_failures(terminalreporter, exitstatus) -> list[Any]:
-    if exitstatus != pytest.ExitCode.OK:
+def _coverage_floor_enforced() -> bool:
+    """Whether coverage floors escalate to a suite failure.
+
+    Off by default so a shared daily-quota exhaustion can never red a release job
+    (e.g. Verify Package, #1819) — the release path skips rate-limited
+    generation/chat freely. The nightly sets ``E2E_ENFORCE_COVERAGE_FLOOR=1`` to
+    turn hollow-green (every marked test skipped, none passed) into a red where
+    the quota is fresh and the signal is real.
+    """
+    return os.environ.get("E2E_ENFORCE_COVERAGE_FLOOR") == "1"
+
+
+def _coverage_floor_failures(terminalreporter, exitstatus, marker: str) -> list[Any]:
+    """Rate-limit skips that breach the coverage floor for ``marker``.
+
+    Non-empty only when at least one ``marker`` test was rate-limit-skipped and no
+    ``marker`` test passed — i.e. that live surface produced zero real coverage.
+    """
+    # Only meaningful for a *completed* run: everything passed (OK) or some tests
+    # failed (TESTS_FAILED). A broken run (usage/internal/interrupt/no-tests) is its
+    # own signal — don't evaluate the floor or rewrite that exit code.
+    #
+    # We deliberately do NOT bail on TESTS_FAILED. Under the nightly's
+    # ``continue-on-error`` main step + ``--last-failed`` retry, an *unrelated* test
+    # that fails on the main run and then passes on retry lands the job green — so a
+    # blanket ``exitstatus != OK`` bail would let that transient failure MASK a
+    # genuinely hollow generation/chat surface (all rate-limited, none passed). We
+    # still record the breach; only a failure of a test *with this marker* defers,
+    # since the retry may re-run it into a pass (real coverage). Caught by
+    # test_generation_floor_records_breach_despite_unrelated_failure (#1819).
+    if exitstatus not in (pytest.ExitCode.OK, pytest.ExitCode.TESTS_FAILED):
         return []
 
-    live_chat_rate_limit_skips = [
+    marked_skips = [
         report
         for report in _rate_limit_skip_reports(terminalreporter)
-        if _has_marker(report, _LIVE_CHAT_ASK_MARKER)
+        if _has_marker(report, marker)
     ]
-    if not live_chat_rate_limit_skips:
+    if not marked_skips:
         return []
 
-    live_chat_passes = [
+    marked_passes = [
         report
         for report in terminalreporter.stats.get("passed", [])
-        if _is_call_report(report) and _has_marker(report, _LIVE_CHAT_ASK_MARKER)
+        if _is_call_report(report) and _has_marker(report, marker)
     ]
-    return [] if live_chat_passes else live_chat_rate_limit_skips
+    if marked_passes:
+        return []
+
+    # No marked test passed and some were rate-limited. A marked *failure* has its
+    # real outcome deferred to the retry (may pass there → coverage), so hold off;
+    # otherwise this is a final zero-coverage breach — record it even when other,
+    # unmarked tests failed.
+    marked_failures = [
+        report
+        for report in terminalreporter.stats.get("failed", [])
+        if _is_call_report(report) and _has_marker(report, marker)
+    ]
+    if marked_failures:
+        return []
+
+    return marked_skips
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -356,8 +432,48 @@ def pytest_sessionfinish(session, exitstatus):
     if terminalreporter is None:
         return
 
-    if _live_chat_floor_failures(terminalreporter, exitstatus):
+    # Coverage floors are advisory unless the nightly opts in (see
+    # _coverage_floor_enforced), so a rate-limited release job stays green (#1819).
+    if not _coverage_floor_enforced():
+        return
+
+    breached = [
+        label
+        for marker, label in _COVERAGE_FLOOR_MARKERS.items()
+        if _coverage_floor_failures(terminalreporter, exitstatus, marker)
+    ]
+    if not breached:
+        return
+
+    # Two delivery modes. The nightly's main e2e step is ``continue-on-error`` and
+    # its retry only re-runs ``--last-failed`` (throttled tests are *skips*, never
+    # failures, so they never enter the retry) — a ``session.exitstatus`` override
+    # would be silently masked there. So when a sentinel path is provided we record
+    # the breach to a file that a dedicated workflow step gates on, and leave the
+    # exit status alone (a pure-skip run stays exit 0, avoiding a spurious retry).
+    # Without a sentinel path (local runs, simple jobs, unit tests) we gate inline.
+    sentinel = os.environ.get("E2E_COVERAGE_FLOOR_SENTINEL")
+    if sentinel:
+        _write_coverage_floor_sentinel(sentinel, breached)
+    else:
         session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+
+def _write_coverage_floor_sentinel(path: str, labels: list[str]) -> None:
+    """Append breached-floor labels to the sentinel a nightly gating step reads."""
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            for label in labels:
+                f.write(f"{label} coverage floor failed\n")
+    except OSError as exc:
+        # The sentinel IS the enforcement signal — a silent write failure would
+        # let a hollow-green nightly pass. We can't fall back to session.exitstatus
+        # (masked by continue-on-error), so at least fail loud in the log.
+        print(
+            f"::error::could not write coverage-floor sentinel {path!r} "
+            f"({exc}); breached floors: {', '.join(labels)}",
+            file=sys.stderr,
+        )
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
@@ -391,11 +507,24 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         joined = ", ".join(nodeids)
         print(f"::warning::{len(nodeids)} test(s) skipped due to rate-limit: {joined}")
 
-    live_chat_rate_limit_skips = _live_chat_floor_failures(terminalreporter, exitstatus)
-    if live_chat_rate_limit_skips:
-        terminalreporter.write_sep("=", "live chat coverage floor failed", red=True)
-        terminalreporter.write_line("No marked live chat ask test completed successfully.")
-        for report in live_chat_rate_limit_skips:
+    enforced = _coverage_floor_enforced()
+    for marker, label in _COVERAGE_FLOOR_MARKERS.items():
+        breaches = _coverage_floor_failures(terminalreporter, exitstatus, marker)
+        if not breaches:
+            continue
+        if enforced:
+            terminalreporter.write_sep("=", f"{label} coverage floor failed", red=True)
+            terminalreporter.write_line(
+                f"No marked {label} test completed successfully (all rate-limited)."
+            )
+        else:
+            terminalreporter.write_sep(
+                "=", f"{label} coverage floor breached (not enforced)", yellow=True
+            )
+            terminalreporter.write_line(
+                f"No marked {label} test passed; not failing (E2E_ENFORCE_COVERAGE_FLOOR unset)."
+            )
+        for report in breaches:
             terminalreporter.write_line(f"  {report.nodeid}")
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -430,14 +430,36 @@ def _coverage_floor_failures(terminalreporter, exitstatus, marker: str) -> list[
     # ``--last-failed`` retries a test that failed in any phase, so a setup-phase
     # failure of a marked test is just as deferrable as a call-phase one (gemini/codex).
     marked_failures = [
-        report
-        for report in terminalreporter.stats.get("failed", [])
-        if _has_marker(report, marker)
+        report for report in terminalreporter.stats.get("failed", []) if _has_marker(report, marker)
     ]
     if marked_failures:
         return []
 
     return marked_skips
+
+
+def _coverage_events(terminalreporter, exitstatus) -> list[str]:
+    """Per-marker ``PASS``/``SKIP`` events for cross-run coverage-floor accumulation.
+
+    One tab-separated line per monitored surface that produced a signal this run:
+    ``PASS\t<label>`` when a marked test passed (real coverage), else
+    ``SKIP\t<label>`` when a marked test was rate-limit-skipped (candidate breach).
+    A surface that neither passed nor skipped emits nothing.
+    """
+    if exitstatus not in (pytest.ExitCode.OK, pytest.ExitCode.TESTS_FAILED):
+        return []
+    skip_reports = _rate_limit_skip_reports(terminalreporter)
+    events: list[str] = []
+    for marker, label in _COVERAGE_FLOOR_MARKERS.items():
+        passed = any(
+            _is_call_report(r) and _has_marker(r, marker)
+            for r in terminalreporter.stats.get("passed", [])
+        )
+        if passed:
+            events.append(f"PASS\t{label}")
+        elif any(_has_marker(r, marker) for r in skip_reports):
+            events.append(f"SKIP\t{label}")
+    return events
 
 
 def pytest_sessionfinish(session, exitstatus):
@@ -450,53 +472,53 @@ def pytest_sessionfinish(session, exitstatus):
     if not _coverage_floor_enforced():
         return
 
-    breached = [
-        label
-        for marker, label in _COVERAGE_FLOOR_MARKERS.items()
-        if _coverage_floor_failures(terminalreporter, exitstatus, marker)
-    ]
-    if not breached:
-        return
-
-    # Two delivery modes. The nightly's main e2e step is ``continue-on-error`` and
-    # its retry only re-runs ``--last-failed`` (throttled tests are *skips*, never
-    # failures, so they never enter the retry) — a ``session.exitstatus`` override
-    # would be silently masked there. So when a sentinel path is provided we record
-    # the breach to a file that a dedicated workflow step gates on, and leave the
-    # exit status alone (a pure-skip run stays exit 0, avoiding a spurious retry).
-    # Without a sentinel path (local runs, simple jobs, unit tests) we gate inline.
     sentinel = os.environ.get("E2E_COVERAGE_FLOOR_SENTINEL")
-    # Sentinel delivery (nightly): record the breach for the gating step and leave
-    # exit status alone (a pure-skip run stays exit 0, avoiding a spurious retry).
-    # If the write fails, fall back to the inline exit-code path — best-effort, since
-    # continue-on-error may mask it, but paired with the loud ::error:: it's better
-    # than a silent hollow-green (codex). Without a sentinel path we gate inline.
-    if sentinel and _write_coverage_floor_sentinel(sentinel, breached):
+    if sentinel:
+        # Sentinel delivery (nightly). The main e2e step is ``continue-on-error`` and
+        # its ``--last-failed`` retry re-runs only failures, so a ``session.exitstatus``
+        # override would be masked. Instead every enforcing run (main AND retry)
+        # appends PASS/SKIP events; the "Enforce coverage floors" step breaches a
+        # surface seen SKIP but never PASS across all runs. This closes the retry gap
+        # (a marked test that fails on main then skips on retry) WITHOUT false-breaching
+        # when coverage was achieved in another run (codex/coderabbit). Exit status is
+        # left alone so a pure-skip run stays exit 0 and doesn't trip a spurious retry;
+        # a write failure falls back to the inline exit code (best-effort).
+        events = _coverage_events(terminalreporter, exitstatus)
+        if not events or _append_sentinel(sentinel, events):
+            return
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
         return
-    session.exitstatus = pytest.ExitCode.TESTS_FAILED
+
+    # Inline delivery (local runs, simple jobs, unit tests): no retry, so decide from
+    # this single run.
+    breached = any(
+        _coverage_floor_failures(terminalreporter, exitstatus, marker)
+        for marker in _COVERAGE_FLOOR_MARKERS
+    )
+    if breached:
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
-def _write_coverage_floor_sentinel(path: str, labels: list[str]) -> bool:
-    """Append breached-floor labels to the sentinel a nightly gating step reads.
+def _append_sentinel(path: str, lines: list[str]) -> bool:
+    """Append lines to the coverage-floor sentinel. Returns True on success.
 
-    Returns True on success. Creates the parent directory first so a missing
-    directory can't turn the enforcement signal into a silent no-op (gemini).
+    Creates the parent directory first so a missing directory can't turn the
+    enforcement signal into a silent no-op (gemini).
     """
     try:
         parent = os.path.dirname(path)
         if parent:
             os.makedirs(parent, exist_ok=True)
         with open(path, "a", encoding="utf-8") as f:
-            for label in labels:
-                f.write(f"{label} coverage floor failed\n")
+            for line in lines:
+                f.write(line + "\n")
         return True
     except OSError as exc:
         # The sentinel IS the enforcement signal — a silent write failure would let a
         # hollow-green nightly pass. Fail loud AND signal the caller to fall back to
         # the inline exit-code path.
         print(
-            f"::error::could not write coverage-floor sentinel {path!r} "
-            f"({exc}); breached floors: {', '.join(labels)}",
+            f"::error::could not write coverage-floor sentinel {path!r} ({exc})",
             file=sys.stderr,
         )
         return False

--- a/tests/e2e/test_generation.py
+++ b/tests/e2e/test_generation.py
@@ -28,6 +28,13 @@ from notebooklm import (
 
 from .conftest import assert_generation_started, requires_auth
 
+# Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
+# floor (tests/e2e/conftest.py, #1819): a fully-throttled run where every marked
+# generation test skipped and none passed reds the nightly instead of hollow-green.
+# INVARIANT: keep this module generation-only — a passing non-generation test here
+# would satisfy the floor and mask a genuinely throttled generation surface.
+pytestmark = pytest.mark.live_generation
+
 
 @requires_auth
 class TestAudioGeneration:

--- a/tests/e2e/test_interactive_mind_map.py
+++ b/tests/e2e/test_interactive_mind_map.py
@@ -16,6 +16,11 @@ import pytest
 
 from notebooklm.types import MindMapKind
 
+# Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
+# floor so a fully-throttled run (every generation skipped) reds the nightly
+# instead of passing hollow-green. See tests/e2e/conftest.py (#1819).
+pytestmark = pytest.mark.live_generation
+
 
 @pytest.mark.e2e
 @pytest.mark.asyncio

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -554,7 +554,16 @@ class TestGenerationRateLimitSkip:
             async def list(self, notebook_id):
                 raise RateLimitError("read path — should never be wrapped")
 
-        return SimpleNamespace(artifacts=FakeArtifacts(), mind_maps=FakeMindMaps())
+        class FakeLabels:
+            async def generate(self, notebook_id, scope="unlabeled"):
+                raise RateLimitError("Resource exhausted (status 8): quota")
+
+            async def create(self, notebook_id, name, emoji):
+                raise RateLimitError("plain CRUD create — should never be wrapped")
+
+        return SimpleNamespace(
+            artifacts=FakeArtifacts(), mind_maps=FakeMindMaps(), labels=FakeLabels()
+        )
 
     async def test_rate_limit_error_becomes_skip(self):
         conftest = _load_e2e_conftest()
@@ -622,6 +631,25 @@ class TestGenerationRateLimitSkip:
         with pytest.raises(pytest.skip.Exception):
             await client.artifacts.retry_failed("nb-1", "art-1")
 
+    async def test_labels_generate_becomes_skip(self):
+        # client.labels.generate (AI Auto-label, CREATE_LABEL) asserts its result
+        # directly with no assert_generation_started fallback, so a throttle must
+        # skip via this fixture rather than hard-fail the suite.
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(pytest.skip.Exception):
+            await client.labels.generate("nb-1", scope="unlabeled")
+
+    async def test_labels_crud_create_is_not_wrapped(self):
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(RateLimitError):
+            await client.labels.create("nb-1", "Papers", "\U0001f4c4")
+
 
 class TestGenerationSkipRegistryCoverage:
     """The skip registry must cover every live generate/revise entrypoint.
@@ -634,10 +662,15 @@ class TestGenerationSkipRegistryCoverage:
 
     def test_registry_covers_all_generate_and_revise_methods(self):
         from notebooklm._artifacts import ArtifactsAPI
+        from notebooklm._labels import LabelsAPI
         from notebooklm._mind_maps_api import MindMapsAPI
 
         conftest = _load_e2e_conftest()
-        classes = {"artifacts": ArtifactsAPI, "mind_maps": MindMapsAPI}
+        classes = {
+            "artifacts": ArtifactsAPI,
+            "mind_maps": MindMapsAPI,
+            "labels": LabelsAPI,
+        }
 
         # Registry namespaces and the known generation-capable classes must stay in
         # lockstep — adding one without the other trips this guard.

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -152,10 +152,11 @@ class TestRateLimitSkipSummary:
         reports,
         *,
         passed=None,
+        failed=None,
     ):
         write_calls: list[tuple] = []
         return SimpleNamespace(
-            stats={"skipped": reports, "passed": passed or []},
+            stats={"skipped": reports, "passed": passed or [], "failed": failed or []},
             write_sep=lambda *a, **kw: write_calls.append(("sep", a, kw)),
             write_line=lambda *a, **kw: write_calls.append(("line", a, kw)),
             _writes=write_calls,
@@ -183,9 +184,27 @@ class TestRateLimitSkipSummary:
         conftest.pytest_sessionfinish(session, exitstatus)
         return session
 
+    @pytest.fixture(autouse=True)
+    def _enforce_floor(self, monkeypatch):
+        # Default these tests to the enforced path (nightly semantics) with inline
+        # exit-status delivery (no sentinel), matching the pre-existing assertions.
+        # Individual tests override (delenv the flag, or set the sentinel path).
+        monkeypatch.setenv("E2E_ENFORCE_COVERAGE_FLOOR", "1")
+        monkeypatch.delenv("E2E_COVERAGE_FLOOR_SENTINEL", raising=False)
+
     @staticmethod
-    def _report(nodeid: str, *, live_chat_ask: bool = False, when: str = "call"):
-        keywords = {"live_chat_ask": 1} if live_chat_ask else {}
+    def _report(
+        nodeid: str,
+        *,
+        live_chat_ask: bool = False,
+        live_generation: bool = False,
+        when: str = "call",
+    ):
+        keywords: dict[str, int] = {}
+        if live_chat_ask:
+            keywords["live_chat_ask"] = 1
+        if live_generation:
+            keywords["live_generation"] = 1
         return SimpleNamespace(nodeid=nodeid, keywords=keywords, when=when)
 
     @classmethod
@@ -195,17 +214,27 @@ class TestRateLimitSkipSummary:
         reason: str,
         *,
         live_chat_ask: bool = False,
+        live_generation: bool = False,
         when: str = "call",
     ) -> SimpleNamespace:
-        report = cls._report(nodeid, live_chat_ask=live_chat_ask, when=when)
+        report = cls._report(
+            nodeid, live_chat_ask=live_chat_ask, live_generation=live_generation, when=when
+        )
         report.longrepr = ("file.py", 1, f"Skipped: {reason}")
         return report
 
     @classmethod
     def _passed(
-        cls, nodeid: str, *, live_chat_ask: bool = False, when: str = "call"
+        cls,
+        nodeid: str,
+        *,
+        live_chat_ask: bool = False,
+        live_generation: bool = False,
+        when: str = "call",
     ) -> SimpleNamespace:
-        return cls._report(nodeid, live_chat_ask=live_chat_ask, when=when)
+        return cls._report(
+            nodeid, live_chat_ask=live_chat_ask, live_generation=live_generation, when=when
+        )
 
     def test_counts_only_rate_limit_skips(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
@@ -358,6 +387,98 @@ class TestRateLimitSkipSummary:
             for call in tr._writes
         )
 
+    def test_floor_not_enforced_without_flag_stays_green(self, monkeypatch):
+        # Release-path semantics (#1819): with E2E_ENFORCE_COVERAGE_FLOOR unset, a
+        # fully-throttled surface skips freely and never reds the job.
+        monkeypatch.delenv("E2E_ENFORCE_COVERAGE_FLOOR", raising=False)
+        monkeypatch.delenv("E2E_COVERAGE_FLOOR_SENTINEL", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter([self._skipped("t::a", "rate limited", live_chat_ask=True)])
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.OK
+
+    def test_generation_floor_fails_when_all_marked_rate_limited(self, monkeypatch):
+        conftest = _load_e2e_conftest()
+        tr = self._make_reporter(
+            [
+                self._skipped(
+                    "test_interactive_mind_map.py::t", "Rate limit: quota", live_generation=True
+                )
+            ]
+        )
+        session = self._finish(conftest, tr)
+        assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+    def test_generation_floor_allows_one_marked_pass(self, monkeypatch):
+        conftest = _load_e2e_conftest()
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::t_audio", "Rate limit: q", live_generation=True)],
+            passed=[self._passed("test_generation.py::t_report", live_generation=True)],
+        )
+        session = self._finish(conftest, tr)
+        assert session.exitstatus == pytest.ExitCode.OK
+
+    def test_floor_sentinel_records_breach_without_failing_exit(self, monkeypatch, tmp_path):
+        # Nightly delivery: with a sentinel path set, the breach is recorded to the
+        # file (a workflow step gates on it) and the exit status is left untouched so
+        # a pure-skip run stays exit 0 and doesn't trip the continue-on-error retry.
+        sentinel = tmp_path / "floor"
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::t", "Rate limit: q", live_generation=True)]
+        )
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.OK
+        assert "live generation coverage floor failed" in sentinel.read_text()
+
+    def test_generation_floor_records_breach_despite_unrelated_failure(self, monkeypatch, tmp_path):
+        # Masking guard (#1819): a hollow generation surface (all rate-limited, none
+        # passed) must still be recorded even when an UNRELATED test failed on the
+        # main run — otherwise a transient failure that recovers on the --last-failed
+        # retry would mask the breach and green the nightly.
+        sentinel = tmp_path / "floor"
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::t", "Rate limit: q", live_generation=True)],
+            failed=[self._report("test_notebooks.py::unrelated", when="call")],
+        )
+        self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
+
+        assert "live generation coverage floor failed" in sentinel.read_text()
+
+    def test_generation_floor_defers_when_marked_test_failed(self, monkeypatch, tmp_path):
+        # A FAILURE of a marked test is deferred to the retry (it may pass there →
+        # coverage), so it must NOT be recorded as a floor breach.
+        sentinel = tmp_path / "floor"
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::a", "Rate limit: q", live_generation=True)],
+            failed=[self._report("test_generation.py::b", live_generation=True, when="call")],
+        )
+        self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
+
+        assert not sentinel.exists()
+
+    def test_floor_ignores_broken_run_exit_codes(self, monkeypatch):
+        # A usage/internal error is its own signal — the floor must not evaluate or
+        # rewrite that exit code (claude review).
+        conftest = _load_e2e_conftest()
+        tr = self._make_reporter(
+            [self._skipped("t::a", "rate limited", live_chat_ask=True)],
+        )
+        session = self._finish(conftest, tr, exitstatus=pytest.ExitCode.USAGE_ERROR)
+
+        assert session.exitstatus == pytest.ExitCode.USAGE_ERROR
+
     def test_live_chat_floor_changes_real_pytest_exit_code(self, pytester: pytest.Pytester):
         pytester.makepyprojecttoml(
             """
@@ -420,10 +541,20 @@ class TestGenerationRateLimitSkip:
             async def revise_slide(self, notebook_id):
                 raise ValueError("not a rate limit")
 
+            async def retry_failed(self, notebook_id, artifact_id):
+                raise RateLimitError("Resource exhausted (status 8): quota")
+
             async def delete(self, notebook_id, artifact_id):
                 raise RateLimitError("should never be wrapped")
 
-        return SimpleNamespace(artifacts=FakeArtifacts())
+        class FakeMindMaps:
+            async def generate(self, notebook_id):
+                raise RateLimitError("Resource exhausted (status 8): quota")
+
+            async def list(self, notebook_id):
+                raise RateLimitError("read path — should never be wrapped")
+
+        return SimpleNamespace(artifacts=FakeArtifacts(), mind_maps=FakeMindMaps())
 
     async def test_rate_limit_error_becomes_skip(self):
         conftest = _load_e2e_conftest()
@@ -461,3 +592,71 @@ class TestGenerationRateLimitSkip:
 
         with pytest.raises(RateLimitError):
             await client.artifacts.delete("nb-1", "art-1")
+
+    async def test_mind_maps_generate_becomes_skip(self):
+        # The #1819 gap: the interactive mind map creates via client.mind_maps.generate,
+        # a different namespace than client.artifacts.generate_* — it must skip too.
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(pytest.skip.Exception) as excinfo:
+            await client.mind_maps.generate("nb-1")
+        assert any(p in str(excinfo.value).lower() for p in conftest._RATE_LIMIT_PHRASES)
+
+    async def test_mind_maps_read_methods_are_not_wrapped(self):
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(RateLimitError):
+            await client.mind_maps.list("nb-1")
+
+    async def test_retry_failed_becomes_skip(self):
+        # retry_failed re-runs generation and raises RateLimitError on quota, so it
+        # must skip like generate_* (claude review — same #1819 regression class).
+        conftest = _load_e2e_conftest()
+        client = self._make_client()
+        conftest._install_generation_rate_limit_skip(client)
+
+        with pytest.raises(pytest.skip.Exception):
+            await client.artifacts.retry_failed("nb-1", "art-1")
+
+
+class TestGenerationSkipRegistryCoverage:
+    """The skip registry must cover every live generate/revise entrypoint.
+
+    Guards against a new CREATE_ARTIFACT method (or namespace) landing without
+    being wrapped for the RateLimitError→skip fixture — the exact regression class
+    that caused #1819 (mind_maps.generate was created after the artifacts-only
+    wrapper and slipped through).
+    """
+
+    def test_registry_covers_all_generate_and_revise_methods(self):
+        from notebooklm._artifacts import ArtifactsAPI
+        from notebooklm._mind_maps_api import MindMapsAPI
+
+        conftest = _load_e2e_conftest()
+        classes = {"artifacts": ArtifactsAPI, "mind_maps": MindMapsAPI}
+
+        # Registry namespaces and the known generation-capable classes must stay in
+        # lockstep — adding one without the other trips this guard.
+        assert set(conftest._GENERATION_SKIP_TARGETS) == set(classes)
+
+        for ns_name, cls in classes.items():
+            matches = conftest._GENERATION_SKIP_TARGETS[ns_name]
+            # generate*/revise*/retry* are the CREATE_ARTIFACT-quota surfaces that
+            # raise RateLimitError before a GenerationStatus exists (retry_failed
+            # re-runs generation, so it raises on quota too).
+            gen_methods = [
+                name
+                for name in dir(cls)
+                if not name.startswith("_")
+                and name.startswith(("generate", "revise", "retry"))
+                and callable(getattr(cls, name))
+            ]
+            assert gen_methods, f"{ns_name}: expected at least one generate/revise/retry method"
+            uncovered = [name for name in gen_methods if not matches(name)]
+            assert not uncovered, (
+                f"{ns_name}: generate/revise/retry methods not in skip registry: {uncovered}"
+            )

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -420,10 +420,10 @@ class TestRateLimitSkipSummary:
         session = self._finish(conftest, tr)
         assert session.exitstatus == pytest.ExitCode.OK
 
-    def test_floor_sentinel_records_breach_without_failing_exit(self, monkeypatch, tmp_path):
-        # Nightly delivery: with a sentinel path set, the breach is recorded to the
-        # file (a workflow step gates on it) and the exit status is left untouched so
-        # a pure-skip run stays exit 0 and doesn't trip the continue-on-error retry.
+    def test_sentinel_records_skip_event_without_failing_exit(self, monkeypatch, tmp_path):
+        # Nightly delivery: a hollow surface (marked skip, no marked pass) appends a
+        # SKIP event and leaves exit status alone, so a pure-skip run stays exit 0 and
+        # doesn't trip the continue-on-error retry. The enforce step reconciles later.
         sentinel = tmp_path / "floor"
         monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
         conftest = _load_e2e_conftest()
@@ -434,13 +434,12 @@ class TestRateLimitSkipSummary:
         session = self._finish(conftest, tr)
 
         assert session.exitstatus == pytest.ExitCode.OK
-        assert "live generation coverage floor failed" in sentinel.read_text()
+        assert "SKIP\tlive generation" in sentinel.read_text()
 
-    def test_generation_floor_records_breach_despite_unrelated_failure(self, monkeypatch, tmp_path):
-        # Masking guard (#1819): a hollow generation surface (all rate-limited, none
-        # passed) must still be recorded even when an UNRELATED test failed on the
-        # main run — otherwise a transient failure that recovers on the --last-failed
-        # retry would mask the breach and green the nightly.
+    def test_sentinel_records_skip_despite_unrelated_failure(self, monkeypatch, tmp_path):
+        # Masking guard (#1819): the SKIP event is still recorded when an UNRELATED
+        # test failed on the main run, so a transient failure that recovers on retry
+        # can't mask a hollow surface.
         sentinel = tmp_path / "floor"
         monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
         conftest = _load_e2e_conftest()
@@ -451,26 +450,31 @@ class TestRateLimitSkipSummary:
         )
         self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
 
-        assert "live generation coverage floor failed" in sentinel.read_text()
+        assert "SKIP\tlive generation" in sentinel.read_text()
 
-    def test_generation_floor_defers_when_marked_test_failed(self, monkeypatch, tmp_path):
-        # A FAILURE of a marked test is deferred to the retry (it may pass there →
-        # coverage), so it must NOT be recorded as a floor breach.
+    def test_sentinel_records_pass_event_when_marked_test_passed(self, monkeypatch, tmp_path):
+        # A marked pass records PASS (real coverage) even when another marked test
+        # rate-limit-skipped in the same run — the enforce step reconciles SKIP vs PASS
+        # so this surface does NOT breach.
         sentinel = tmp_path / "floor"
         monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
         conftest = _load_e2e_conftest()
 
         tr = self._make_reporter(
             [self._skipped("test_generation.py::a", "Rate limit: q", live_generation=True)],
-            failed=[self._report("test_generation.py::b", live_generation=True, when="call")],
+            passed=[self._passed("test_generation.py::b", live_generation=True)],
         )
-        self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
+        self._finish(conftest, tr)
 
-        assert not sentinel.exists()
+        text = sentinel.read_text()
+        assert "PASS\tlive generation" in text
+        assert "SKIP\tlive generation" not in text
 
-    def test_generation_floor_defers_when_marked_test_failed_in_setup(self, monkeypatch, tmp_path):
-        # A marked failure in the SETUP phase is retried by --last-failed just like a
-        # call-phase failure, so it defers the floor too (gemini/codex).
+    def test_sentinel_records_skip_when_marked_test_failed(self, monkeypatch, tmp_path):
+        # A marked FAILURE is not a pass, so the surface still records SKIP (a breach
+        # candidate). The retry step appends its own PASS/SKIP, and the enforce step
+        # reconciles — so a marked test that fails on main then passes on retry clears
+        # the surface, while one that fails then skips keeps it breached (codex/coderabbit).
         sentinel = tmp_path / "floor"
         monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
         conftest = _load_e2e_conftest()
@@ -481,7 +485,7 @@ class TestRateLimitSkipSummary:
         )
         self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
 
-        assert not sentinel.exists()
+        assert "SKIP\tlive generation" in sentinel.read_text()
 
     def test_floor_falls_back_to_exitstatus_when_sentinel_unwritable(self, monkeypatch, tmp_path):
         # If the sentinel write fails, don't silently hollow-green: fall back to the
@@ -512,7 +516,7 @@ class TestRateLimitSkipSummary:
         session = self._finish(conftest, tr)
 
         assert session.exitstatus == pytest.ExitCode.OK
-        assert "live generation coverage floor failed" in sentinel.read_text()
+        assert "SKIP\tlive generation" in sentinel.read_text()
 
     def test_floor_ignores_broken_run_exit_codes(self, monkeypatch):
         # A usage/internal error is its own signal — the floor must not evaluate or

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -554,16 +554,7 @@ class TestGenerationRateLimitSkip:
             async def list(self, notebook_id):
                 raise RateLimitError("read path — should never be wrapped")
 
-        class FakeLabels:
-            async def generate(self, notebook_id, scope="unlabeled"):
-                raise RateLimitError("Resource exhausted (status 8): quota")
-
-            async def create(self, notebook_id, name, emoji):
-                raise RateLimitError("plain CRUD create — should never be wrapped")
-
-        return SimpleNamespace(
-            artifacts=FakeArtifacts(), mind_maps=FakeMindMaps(), labels=FakeLabels()
-        )
+        return SimpleNamespace(artifacts=FakeArtifacts(), mind_maps=FakeMindMaps())
 
     async def test_rate_limit_error_becomes_skip(self):
         conftest = _load_e2e_conftest()
@@ -631,25 +622,6 @@ class TestGenerationRateLimitSkip:
         with pytest.raises(pytest.skip.Exception):
             await client.artifacts.retry_failed("nb-1", "art-1")
 
-    async def test_labels_generate_becomes_skip(self):
-        # client.labels.generate (AI Auto-label, CREATE_LABEL) asserts its result
-        # directly with no assert_generation_started fallback, so a throttle must
-        # skip via this fixture rather than hard-fail the suite.
-        conftest = _load_e2e_conftest()
-        client = self._make_client()
-        conftest._install_generation_rate_limit_skip(client)
-
-        with pytest.raises(pytest.skip.Exception):
-            await client.labels.generate("nb-1", scope="unlabeled")
-
-    async def test_labels_crud_create_is_not_wrapped(self):
-        conftest = _load_e2e_conftest()
-        client = self._make_client()
-        conftest._install_generation_rate_limit_skip(client)
-
-        with pytest.raises(RateLimitError):
-            await client.labels.create("nb-1", "Papers", "\U0001f4c4")
-
 
 class TestGenerationSkipRegistryCoverage:
     """The skip registry must cover every live generate/revise entrypoint.
@@ -662,15 +634,10 @@ class TestGenerationSkipRegistryCoverage:
 
     def test_registry_covers_all_generate_and_revise_methods(self):
         from notebooklm._artifacts import ArtifactsAPI
-        from notebooklm._labels import LabelsAPI
         from notebooklm._mind_maps_api import MindMapsAPI
 
         conftest = _load_e2e_conftest()
-        classes = {
-            "artifacts": ArtifactsAPI,
-            "mind_maps": MindMapsAPI,
-            "labels": LabelsAPI,
-        }
+        classes = {"artifacts": ArtifactsAPI, "mind_maps": MindMapsAPI}
 
         # Registry namespaces and the known generation-capable classes must stay in
         # lockstep — adding one without the other trips this guard.

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -468,6 +468,52 @@ class TestRateLimitSkipSummary:
 
         assert not sentinel.exists()
 
+    def test_generation_floor_defers_when_marked_test_failed_in_setup(self, monkeypatch, tmp_path):
+        # A marked failure in the SETUP phase is retried by --last-failed just like a
+        # call-phase failure, so it defers the floor too (gemini/codex).
+        sentinel = tmp_path / "floor"
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::a", "Rate limit: q", live_generation=True)],
+            failed=[self._report("test_generation.py::b", live_generation=True, when="setup")],
+        )
+        self._finish(conftest, tr, exitstatus=pytest.ExitCode.TESTS_FAILED)
+
+        assert not sentinel.exists()
+
+    def test_floor_falls_back_to_exitstatus_when_sentinel_unwritable(self, monkeypatch, tmp_path):
+        # If the sentinel write fails, don't silently hollow-green: fall back to the
+        # inline exit-code path (best-effort) (codex). Point the sentinel at a path
+        # whose parent is a file, so makedirs + open both fail.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(blocker / "floor"))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::a", "Rate limit: q", live_generation=True)]
+        )
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+
+    def test_floor_sentinel_creates_missing_parent_dir(self, monkeypatch, tmp_path):
+        # A missing parent directory must not turn the enforcement signal into a
+        # silent no-op — the writer creates it (gemini).
+        sentinel = tmp_path / "nested" / "sub" / "floor"
+        monkeypatch.setenv("E2E_COVERAGE_FLOOR_SENTINEL", str(sentinel))
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [self._skipped("test_generation.py::a", "Rate limit: q", live_generation=True)]
+        )
+        session = self._finish(conftest, tr)
+
+        assert session.exitstatus == pytest.ExitCode.OK
+        assert "live generation coverage floor failed" in sentinel.read_text()
+
     def test_floor_ignores_broken_run_exit_codes(self, monkeypatch):
         # A usage/internal error is its own signal — the floor must not evaluate or
         # rewrite that exit code (claude review).

--- a/uv.lock
+++ b/uv.lock
@@ -2418,11 +2418,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #1819. The E2E rate-limit-skip fixture only wrapped `client.artifacts.generate_*/revise_*`, so `client.mind_maps.generate` (the interactive mind map — a different namespace) **hard-failed** the suite when the daily artifact quota was exhausted, reding the release **Verify Package** job (observed at v0.8.0a3).

The tension this resolves: a shared daily quota must **never** red a release, yet skipping everything risks **hollow-green** coverage (#1816). Those two goals conflict on the same job, so this **splits them across jobs**.

### Part 1 — cover every CREATE_ARTIFACT path (robustness)
- Registry-driven skip (`_GENERATION_SKIP_TARGETS`): `artifacts.generate_*/revise_*/retry_failed` **and** `mind_maps.generate`. (`retry_failed` re-runs generation and raises `RateLimitError` on quota — same class, added proactively.)
- A guard test fails if a new `generate*/revise*/retry*` method lands on a covered namespace's class without being registered — the exact regression that caused #1819.

### Part 2 — split the coverage floor across jobs (the "some coverage" guarantee)
- Generalized the existing "live chat coverage floor" into a **per-marker** floor (`live_chat_ask`, `live_generation`).
- **Enforcement is nightly-only** via `E2E_ENFORCE_COVERAGE_FLOOR=1`. The release job (verify-package) leaves it unset → **skip-only, never reds on quota**. (This also de-fangs a latent bug where the chat floor could already red a release on chat-quota exhaustion.)
- **Delivery via a sentinel file** + a dedicated **"Enforce coverage floors"** nightly step — because the nightly's `continue-on-error` main run + `--last-failed` retry (throttled tests are *skips*, never re-run) would silently mask a `session.exitstatus` override.

### Review-hardening (from the pre-PR triple review)
- **Masking fix:** the floor records a breach even when an *unrelated* test failed-then-recovered on retry; only a **marked** test's failure defers (it may pass on retry → real coverage). Guarded to `{OK, TESTS_FAILED}` so a genuinely broken run (usage/internal error) is left untouched.
- Loud `::error::` diagnostic if the sentinel write ever fails (no silent `pass`).
- `rm -f` the sentinel at step start (stale-file defense on reused runners).
- Module-marker invariant documented.

## Test plan

- [x] `tests/unit/test_e2e_conftest_options.py` — **38 passed** (registry guard, mind_maps + retry_failed skips, per-marker floor, sentinel delivery, masking-despite-unrelated-failure, marked-failure-defers, broken-run-ignored, not-enforced-stays-green)
- [x] `ruff` + `ruff format --check` clean; `nightly.yml` valid YAML; `live_generation` marker resolves under strict collection
- Reviewed pre-PR via `/polish` (code-simplifier + triple review claude/codex/agy + ultrathink); the triple caught the sentinel/retry masking hole, fixed above.

Behavior on the **release path is unchanged except**: rate-limited CREATE_ARTIFACT now skips instead of hard-failing. The floor only ever gates the **nightly**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Nightly end-to-end runs now enforce “live” coverage floors for live chat and live generation.
  * Results are evaluated after the run (even on failures) with clear reporting of any coverage breaches, using a sentinel-based aggregation approach.
  * Manual filtered runs don’t trigger the enforcement, and stale sentinel data is cleared before nightly execution.

* **Test Improvements**
  * Live generation end-to-end tests are explicitly categorized.
  * Rate-limited generation operations are treated as skips, with expanded coverage checks for enforcement, reporting, sentinel recording, and exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->