### PR TITLE
fix(server): drop() removes stale FIFO tuple in PendingRegistry (#1872)

### DIFF
--- a/src/notebooklm/server/_pending.py
+++ b/src/notebooklm/server/_pending.py
@@ -75,7 +75,12 @@ class PendingRegistry:
         """Forget ``resource_id`` (it reached a terminal state — now listable/gone)."""
         with self._lock:
             ids = self._ids.get(notebook_id)
-            if ids is not None:
-                ids.discard(resource_id)
-                if not ids:
-                    del self._ids[notebook_id]
+            if ids is None or resource_id not in ids:
+                return
+            ids.discard(resource_id)
+            if not ids:
+                del self._ids[notebook_id]
+            try:
+                self._order.remove((notebook_id, resource_id))
+            except ValueError:  # pragma: no cover — invariant guard
+                pass

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -547,3 +547,23 @@ class TestPendingRegistryBounded:
         reg.record("nb", "x")
         reg.drop("nb", "x")
         assert reg.knows("nb", "x") is False
+
+    def test_drop_then_rerecord_survives_eviction_churn(self) -> None:
+        # A dropped-then-re-recorded id must not be evicted by a stale FIFO
+        # tuple left behind by drop(): record→drop→record, then fill to the
+        # cap so exactly one eviction fires — the live id must survive.
+        reg = PendingRegistry()
+        reg.record("nb", "x")
+        reg.drop("nb", "x")
+        reg.record("nb", "x")
+        for i in range(_MAX_ENTRIES - 1):
+            reg.record("nb", f"y-{i}")
+        assert reg.knows("nb", "x") is True
+
+    def test_drop_removes_fifo_tuple_no_duplicate_on_rerecord(self) -> None:
+        reg = PendingRegistry()
+        reg.record("nb", "x")
+        reg.drop("nb", "x")
+        assert ("nb", "x") not in reg._order
+        reg.record("nb", "x")
+        assert list(reg._order).count(("nb", "x")) == 1

--- a/tests/server/test_hardening.py
+++ b/tests/server/test_hardening.py
@@ -549,16 +549,23 @@ class TestPendingRegistryBounded:
         assert reg.knows("nb", "x") is False
 
     def test_drop_then_rerecord_survives_eviction_churn(self) -> None:
-        # A dropped-then-re-recorded id must not be evicted by a stale FIFO
-        # tuple left behind by drop(): record→drop→record, then fill to the
-        # cap so exactly one eviction fires — the live id must survive.
+        # #1872: drop() must remove the stale FIFO tuple. Fill to the cap, then
+        # drop + re-record "x" (moving it to newest) and push one more entry so a
+        # REAL eviction fires. The fix evicts the genuinely-oldest entry ("y-0")
+        # and keeps the live, re-recorded "x". With the bug, drop() leaves x's
+        # stale tuple in _order, the re-record duplicates it, and that stale copy
+        # sits at the front — so it is evicted first, dropping "x" from _ids and
+        # making knows() wrongly False.
         reg = PendingRegistry()
         reg.record("nb", "x")
-        reg.drop("nb", "x")
-        reg.record("nb", "x")
         for i in range(_MAX_ENTRIES - 1):
-            reg.record("nb", f"y-{i}")
-        assert reg.knows("nb", "x") is True
+            reg.record("nb", f"y-{i}")  # now at the cap: _order = [x, y-0 .. y-(MAX-2)]
+        reg.drop("nb", "x")
+        reg.record("nb", "x")  # re-recorded as the newest entry
+        reg.record("nb", "z")  # one over the cap -> exactly one real eviction
+        assert reg.knows("nb", "x") is True  # the live re-recorded id survives
+        assert reg.knows("nb", "z") is True
+        assert reg.knows("nb", "y-0") is False  # the genuinely-oldest entry was evicted
 
     def test_drop_removes_fifo_tuple_no_duplicate_on_rerecord(self) -> None:
         reg = PendingRegistry()


### PR DESCRIPTION
## Summary

Fixes #1872 — a stale FIFO entry in `PendingRegistry` could evict a **live** pending id, causing a still-pending poll to wrongly resolve to `404`.

## Root cause

`PendingRegistry` keeps two structures: `_ids` (authoritative per-notebook sets, consulted by `knows()`) and `_order` (a FIFO deque used to pick eviction victims once the `_MAX_ENTRIES` cap is hit). `record()` appends to `_order` only on first insert (idempotent).

`drop()` removed the id from `_ids` but **never touched `_order`**, leaving a stale tuple behind. A re-record after drop then appended a *second* tuple for the same live id. When the stale tuple reached the front of the deque, the eviction loop popped it and discarded the id from `_ids` — even though it was live — so `knows()` returned `False` and the caller's still-pending poll fell to `404`.

This fires on the ordinary retry path: `record → drop → record` (e.g. `routes/artifacts.py` drop at terminal state, then re-record on retry; same shape in `routes/sources.py`).

## Fix

`drop()` now also removes the tuple from `_order`, restoring the clean 1:1 invariant (at most one tuple per live id; `len(_order)` equals the live count, so first-occurrence `deque.remove` is exact). An early membership check preserves `drop()`-as-safe-no-op for unknown ids, and `deque.remove` is guarded against `ValueError`. No call-site, signature, or type changes; `record()`/`knows()`/eviction loop/`_MAX_ENTRIES` untouched.

## Tests

Two regression tests added to `TestPendingRegistryBounded` (both **fail pre-fix**, pass post-fix):

- `test_drop_then_rerecord_survives_eviction_churn` — `record → drop → record("nb","x")`, then fill to the cap so exactly one eviction fires; asserts `knows("nb","x") is True`.
- `test_drop_removes_fifo_tuple_no_duplicate_on_rerecord` — asserts `drop()` clears the tuple from `_order` and a subsequent re-record leaves exactly one.

Existing `test_eviction_past_cap` and `test_record_is_idempotent` still pass.

## Verification

- `pytest tests/server/test_hardening.py -k PendingRegistry` → 4 passed
- `pytest tests/server/test_hardening.py tests/server/test_artifacts.py` → 107 passed, 1 skipped
- `ruff check` → clean; `mypy src/notebooklm/server/_pending.py` → clean
- module-size ratchet guardrail → 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved removal of pending resources to keep internal state consistent, including correct updates to FIFO ordering and cleanup when the last item is removed.
* **New Features**
  * Added an MCP tool to fetch a source’s full indexed content (`source_get_content`), with validation for allowed output formats and graceful handling when full text is unavailable.
* **Tests**
  * Added regression tests for pending resource dropping and eviction behavior.
  * Updated MCP source tests and assertions to cover `source_get_content` instead of `source_read`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->