### PR TITLE
fix(chat): serialize null-conversation asks with explicit follow-ups (#1875)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -972,6 +972,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_chat/notes.py` | Chat-adjacent note saving workflow adapter |
 | `_chat/wire.py` | Streamed-chat wire request construction + response parsing for the chat client |
 | `_chat/transport.py` | Chat-specific error mapping over the shared transport pipeline |
+| `_chat/deleted_tracker.py` | Bounded `RecentlyDeletedConversations` set — `delete_conversation` records the id (under the conversation lock) so a concurrent null-conversation ask, after acquiring that lock, detects a mid-flight delete and drops `resolved_id_override` to recover the server's real conversation id post-POST (#1875) |
 | `_middleware/chain.py` | Constructs the middleware chain in the canonical ADR-0009 order |
 | `_middleware/*.py` | Modular middleware implementations (drain, metrics, semaphore, retry, auth, error injection, tracing) |
 | `rpc/types.py` | RPC method IDs (source of truth) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1139,7 +1139,8 @@ src/notebooklm/
 │   ├── api.py                   # ChatAPI facade (was _chat.py)
 │   ├── notes.py                 # Note saving workflow adapter
 │   ├── wire.py                  # Streamed-chat wire request/response parser
-│   └── transport.py             # Chat error mapping
+│   ├── transport.py             # Chat error mapping
+│   └── deleted_tracker.py       # Bounded RecentlyDeletedConversations set — serializes null-ask vs delete (#1875)
 ├── _auth/                       # Auth subpackage (forwarded through auth.py facade)
 │   ├── __init__.py
 │   ├── paths.py                 # Storage paths and filesystem helpers

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -27,6 +27,7 @@ from .._row_adapters.chat import (
 from .._runtime.config import DEFAULT_CHAT_RESPONSE_MAX_BYTES, DEFAULT_CHAT_TIMEOUT
 from .._runtime.contracts import LoopGuard, RpcCaller
 from ..exceptions import ChatError, NetworkError, UnknownRPCMethodError, ValidationError
+from .deleted_tracker import RecentlyDeletedConversations
 from .notes import save_chat_answer_as_note
 from .transport import chat_aware_authed_post
 from .wire import (
@@ -188,6 +189,9 @@ class ChatAPI(LoopBoundPrimitive):
         self._new_conversation_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
+        # Recently deleted conversation ids (see ``deleted_tracker``); a null ask
+        # that resolved a since-deleted id re-checks here after taking its lock.
+        self._deleted_conversations = RecentlyDeletedConversations()
         # Event-loop binding for the two lazy lock maps. ``set_bound_loop`` comes
         # from :class:`~notebooklm._loop_bound.LoopBoundPrimitive`; this API
         # overrides :meth:`_on_loop_rebind` to clear the maps on a loop change so
@@ -438,48 +442,40 @@ class ChatAPI(LoopBoundPrimitive):
                 turn_number = len(turns)
             return turn_number
 
-        # Null-conversation asks carry no caller id, but the server appends
-        # them to the notebook's *current* conversation (params[4]=null). We
-        # resolve that id under the notebook lock and, when it exists, run the
-        # POST + cache under its per-conversation lock so a null ask and an
-        # explicit follow-up on that conversation serialize (issue #1875).
+        # Null-conversation asks carry no caller id; the server appends them to
+        # the notebook's *current* conversation (params[4]=null). Resolve that id
+        # under the notebook lock, then serialize the POST on it like an explicit
+        # follow-up (#1875). Residual assumption: a follow-up to a *different*
+        # conversation won't move the server's current pointer between the
+        # resolve and this POST.
         if is_new_conversation:
             async with self._get_new_conversation_lock(notebook_id):
-                # Resolve the server's current conversation while holding the
-                # notebook lock, so concurrent null asks cannot move the
-                # pointer out from under us before the POST. Residual
-                # assumption: an explicit follow-up to a *different*
-                # conversation does not move the server's current-conversation
-                # pointer between this resolve and the null POST.
                 current_id = await self.get_conversation_id(notebook_id)
-                if current_id is not None:
-                    # Existing conversation: POST + cache under its lock, the
-                    # same lock an explicit follow-up on it would take.
-                    async with self._get_conversation_lock(current_id):
-                        (
-                            answer_text,
-                            references,
-                            resolved_conversation_id,
-                            raw_response,
-                        ) = await perform_request(
-                            conversation_history=None,
-                            active_conversation_id=None,
-                            resolved_id_override=current_id,
-                        )
-                        turn_number = cache_turn(resolved_conversation_id, answer_text)
-                else:
-                    # New conversation: POST under the notebook lock, recover
-                    # the id via post-POST hPTbtc, cache under its lock below.
-                    (
-                        answer_text,
-                        references,
-                        resolved_conversation_id,
-                        raw_response,
-                    ) = await perform_request(
+                if current_id is None:
+                    # First-ever conversation: no id to lock on, so serialize the
+                    # create under the notebook lock; recover the id post-POST.
+                    posted = await perform_request(
+                        conversation_history=None, active_conversation_id=None
+                    )
+                    answer_text, references, resolved_conversation_id, raw_response = posted
+            # Existing conversation: release the notebook lock and serialize on the
+            # conversation lock alone, so other null asks on this notebook resolve
+            # in parallel yet still serialize here on that shared lock.
+            if current_id is not None:
+                async with self._get_conversation_lock(current_id):
+                    # A delete_conversation for current_id may have finished while
+                    # we blocked on this lock; the server then starts a fresh
+                    # conversation for the null POST, so drop the override and
+                    # recover the real id post-POST, not the deleted one (#1875).
+                    override = None if current_id in self._deleted_conversations else current_id
+                    posted = await perform_request(
                         conversation_history=None,
                         active_conversation_id=None,
+                        resolved_id_override=override,
                     )
-            if current_id is None:
+                    answer_text, references, resolved_conversation_id, raw_response = posted
+                    turn_number = cache_turn(resolved_conversation_id, answer_text)
+            else:
                 async with self._get_conversation_lock(resolved_conversation_id):
                     turn_number = cache_turn(resolved_conversation_id, answer_text)
         else:
@@ -723,6 +719,10 @@ class ChatAPI(LoopBoundPrimitive):
             )
             # Clear the cache only after a successful RPC (failure raises above).
             self._cache.clear(conversation_id)
+            # Record under the conversation lock so a null ask blocked on this
+            # same lock learns, on wake, not to pin its POST to the deleted id
+            # (see ``ask`` null-conversation path, #1875).
+            self._deleted_conversations.record(conversation_id)
         # v0.8.0 (#1290): the uninformative always-``True`` return becomes ``None``.
         return None
 

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -315,6 +315,7 @@ class ChatAPI(LoopBoundPrimitive):
             *,
             conversation_history: list[Any] | None,
             active_conversation_id: str | None,
+            resolved_id_override: str | None = None,
         ) -> tuple[str, list[ChatReference], str, str]:
             # Capture into closure-local variables so the nested ``build_request``
             # closure carries explicit types — mypy doesn't propagate flow
@@ -372,7 +373,12 @@ class ChatAPI(LoopBoundPrimitive):
             )
 
             resolved_conversation_id = active_conversation_id
-            if is_new_conversation:
+            if resolved_id_override is not None:
+                # Caller resolved the current id under the notebook lock and
+                # holds its conversation lock; skip the post-POST hPTbtc
+                # recovery — the id is known and re-fetching is redundant.
+                resolved_conversation_id = resolved_id_override
+            elif is_new_conversation:
                 # The real conversation_id is not present anywhere in the
                 # streamed chat response. The only way to recover it is to
                 # query ``hPTbtc`` (GET_LAST_CONVERSATION_ID), which returns
@@ -432,30 +438,50 @@ class ChatAPI(LoopBoundPrimitive):
                 turn_number = len(turns)
             return turn_number
 
-        # Follow-ups use the per-conversation lock from history build through
-        # cache update. Null-conversation asks have no id to lock on yet, but
-        # the server still appends them to the notebook's current conversation.
-        # Serialize those by notebook until hPTbtc returns the real id; then
-        # release the notebook path and use the existing conversation-id lock
-        # for the local cache update.
-        #
-        # A null ask cannot serialize its streamed POST against an explicit
-        # follow-up that already knows the same eventual conversation id; the
-        # null path does not know that key until hPTbtc returns. The handoff
-        # below still serializes the local cache update with that follow-up.
+        # Null-conversation asks carry no caller id, but the server appends
+        # them to the notebook's *current* conversation (params[4]=null). We
+        # resolve that id under the notebook lock and, when it exists, run the
+        # POST + cache under its per-conversation lock so a null ask and an
+        # explicit follow-up on that conversation serialize (issue #1875).
         if is_new_conversation:
             async with self._get_new_conversation_lock(notebook_id):
-                (
-                    answer_text,
-                    references,
-                    resolved_conversation_id,
-                    raw_response,
-                ) = await perform_request(
-                    conversation_history=None,
-                    active_conversation_id=None,
-                )
-            async with self._get_conversation_lock(resolved_conversation_id):
-                turn_number = cache_turn(resolved_conversation_id, answer_text)
+                # Resolve the server's current conversation while holding the
+                # notebook lock, so concurrent null asks cannot move the
+                # pointer out from under us before the POST. Residual
+                # assumption: an explicit follow-up to a *different*
+                # conversation does not move the server's current-conversation
+                # pointer between this resolve and the null POST.
+                current_id = await self.get_conversation_id(notebook_id)
+                if current_id is not None:
+                    # Existing conversation: POST + cache under its lock, the
+                    # same lock an explicit follow-up on it would take.
+                    async with self._get_conversation_lock(current_id):
+                        (
+                            answer_text,
+                            references,
+                            resolved_conversation_id,
+                            raw_response,
+                        ) = await perform_request(
+                            conversation_history=None,
+                            active_conversation_id=None,
+                            resolved_id_override=current_id,
+                        )
+                        turn_number = cache_turn(resolved_conversation_id, answer_text)
+                else:
+                    # New conversation: POST under the notebook lock, recover
+                    # the id via post-POST hPTbtc, cache under its lock below.
+                    (
+                        answer_text,
+                        references,
+                        resolved_conversation_id,
+                        raw_response,
+                    ) = await perform_request(
+                        conversation_history=None,
+                        active_conversation_id=None,
+                    )
+            if current_id is None:
+                async with self._get_conversation_lock(resolved_conversation_id):
+                    turn_number = cache_turn(resolved_conversation_id, answer_text)
         else:
             assert conversation_id is not None  # narrowed by is_new_conversation
             async with self._get_conversation_lock(conversation_id):

--- a/src/notebooklm/_chat/deleted_tracker.py
+++ b/src/notebooklm/_chat/deleted_tracker.py
@@ -1,0 +1,43 @@
+"""Bounded record of recently deleted conversation ids.
+
+``ChatAPI.ask``'s null-conversation path (issue #1875) resolves the notebook's
+current conversation, then serializes its POST on that conversation's lock. If a
+``delete_conversation`` for that same id completes while the null ask is blocked
+on the lock, the server starts a *fresh* conversation for the null POST — so the
+ask must NOT pin its result to the now-deleted id. ``delete_conversation``
+records each deleted id here (under the conversation lock) and the null ask
+re-checks after acquiring that lock; a hit means "drop the override and recover
+the id the server actually used post-POST".
+
+Conversation ids are unique and never reused, so a recorded id is deleted
+forever — membership never yields a false positive. Only ids deleted in the
+brief lock-handoff window are ever consulted, so a small bounded FIFO keeps
+memory flat without losing a still-relevant marker.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+_DEFAULT_CAPACITY = 1024
+
+
+class RecentlyDeletedConversations:
+    """FIFO-bounded membership set of recently deleted conversation ids."""
+
+    def __init__(self, capacity: int = _DEFAULT_CAPACITY) -> None:
+        self._capacity = capacity
+        self._ids: OrderedDict[str, None] = OrderedDict()
+
+    def record(self, conversation_id: str) -> None:
+        """Mark ``conversation_id`` as deleted, evicting the oldest if over cap."""
+        self._ids[conversation_id] = None
+        self._ids.move_to_end(conversation_id)
+        while len(self._ids) > self._capacity:
+            self._ids.popitem(last=False)
+
+    def __contains__(self, conversation_id: str) -> bool:
+        return conversation_id in self._ids
+
+    def clear(self) -> None:
+        self._ids.clear()

--- a/tests/cassettes/chat_ask_oversized_rejection.yaml
+++ b/tests/cassettes/chat_ask_oversized_rejection.yaml
@@ -97,6 +97,104 @@ interactions:
       code: 200
       message: OK
 - request:
+    body: f.req=%5B%5B%5B%22hPTbtc%22%2C%22%5B%5B%5D%2Cnull%2C%5C%2264832f19-cce2-4d59-a69e-4763c5ca57ea%5C%22%2C1%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778934741655&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=SCRUBBED; _ga=SCRUBBED;
+        _ga_W0LDH41ZCB=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=hPTbtc&source-path=%2Fnotebook%2F64832f19-cce2-4d59-a69e-4763c5ca57ea&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        149
+
+        [["wrb.fr","hPTbtc","[[[\"bc0666c8-34b5-4bf8-817f-554867ea6ee8\"]]]",null,null,null,"generic"],["di",172],["af.httprm",172,"5342204833051653672",10]]
+
+        23
+
+        [["e",4,null,null,187]]
+
+        '
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Sat, 16 May 2026 12:32:34 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sun, 16-May-2027 12:32:34 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '187'
+    status:
+      code: 200
+      message: OK
+- request:
     body: f.req=%5Bnull%2C%22%5B%5B%5D%2C%5C%22Summarize%20the%20following%20requirement%20in%20detail%3A%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%20encoder%20envelope%20batchexecute%20rpc%20agent%20loop%20context%20window%20subagent%20skill%20orchestration%20retrieval%20citation%20notebook%20source%20artifact%20podcast%20transcript%20embedding%20token%20prompt%20latency%20concurrency%20idempotency%20schema%20decoder%5C%22%2Cnull%2C%5B2%2Cnull%2C%5B1%5D%2C%5B1%5D%5D%2Cnull%2Cnull%2Cnull%2C%5C%2264832f19-cce2-4d59-a69e-4763c5ca57ea%5C%22%2C1%5D%22%5D&at=SCRUBBED_CSRF%3A1782537130637&
     headers:
       accept:

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -530,9 +530,7 @@ async def test_null_ask_serializes_with_explicit_current_conversation(auth_token
 
     client = _make_client(transport, auth_tokens)
     try:
-        client.chat._cache.cache_conversation_turn(
-            conversation_id, "q0", "answer-0", turn_number=1
-        )
+        client.chat._cache.cache_conversation_turn(conversation_id, "q0", "answer-0", turn_number=1)
         await asyncio.gather(
             client.chat.ask(notebook_id, "q-null", source_ids=["src_001"]),
             client.chat.ask(
@@ -579,9 +577,7 @@ async def test_null_ask_parallel_with_followup_on_other_conversation(auth_tokens
 
     client = _make_client(transport, auth_tokens)
     try:
-        client.chat._cache.cache_conversation_turn(
-            conversation_y, "q0", "answer-0", turn_number=1
-        )
+        client.chat._cache.cache_conversation_turn(conversation_y, "q0", "answer-0", turn_number=1)
         await asyncio.gather(
             client.chat.ask(notebook_id, "q-null", source_ids=["src_001"]),
             client.chat.ask(

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -447,13 +447,16 @@ async def test_different_notebook_new_conversation_asks_run_in_parallel(auth_tok
 async def test_new_conversation_cache_update_waits_for_resolved_conversation_lock(
     auth_tokens,
 ) -> None:
-    """After hPTbtc returns, a null ask must use the conversation-id lock.
+    """A null ask resolving to a conversation shares that conversation's lock.
 
-    The explicit follow-up below holds ``_conversation_locks[conversation_id]``
-    while its delayed response is in flight. The null ask resolves to that
-    same id sooner; if it wrote the cache without taking the conversation lock,
-    it would land before the already-running follow-up. The expected cache
-    order proves the null ask waits for the follow-up's existing lock.
+    The explicit follow-up contends ``_conversation_locks[conversation_id]``.
+    Under the #1875 two-phase design the null ask resolves that same id under
+    the notebook lock and then holds the conversation lock across BOTH its POST
+    and its cache write — so the two serialize on one lock (peak in-flight 1)
+    and produce contiguous, non-corrupted turns. Which of the two wins the lock
+    is a scheduling detail; the invariant is that neither clobbers the other's
+    turn. Pre-fix the null ask POSTed under the notebook lock and only took the
+    conversation lock for the cache write, so the two POSTs overlapped.
     """
     notebook_id = "nb_new_followup"
     conversation_id = "conv_new_followup"
@@ -490,6 +493,108 @@ async def test_new_conversation_cache_update_waits_for_resolved_conversation_loc
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
+    # Both asks serialize on the resolved conversation's lock: peak in-flight 1.
+    assert transport.peak_chat_inflight() == 1, (
+        "a null ask resolving to the follow-up's conversation must serialize "
+        f"on its lock; got peak_chat_inflight={transport.peak_chat_inflight()}"
+    )
+    # Serialized under one lock → contiguous turns, no lost update, both present
+    # (exact order depends on which task wins the lock and is not asserted).
     cached_turns = client.chat.get_cached_turns(conversation_id)
-    assert [turn.query for turn in cached_turns] == ["q0", "q-follow", "q-new"]
     assert [turn.turn_number for turn in cached_turns] == [1, 2, 3]
+    assert {turn.query for turn in cached_turns} == {"q0", "q-new", "q-follow"}
+
+
+@pytest.mark.asyncio
+async def test_null_ask_serializes_with_explicit_current_conversation(auth_tokens) -> None:
+    """A null ask and an explicit follow-up on the *current* conversation serialize.
+
+    Regression for #1875: the server appends a ``conversation_id=None`` ask to
+    the notebook's current conversation (``params[4]=null``). When that current
+    conversation is the same one an explicit follow-up targets, the two must
+    hold the SAME per-conversation lock so their streamed POSTs serialize.
+    Pre-fix the null ask POSTed under the notebook lock while the follow-up
+    POSTed under the conversation lock — disjoint locks, peak in-flight 2.
+    Post-fix the null ask resolves the current id under the notebook lock and
+    takes that conversation's lock around POST + cache — peak in-flight 1.
+    """
+    notebook_id = "nb_1875_same"
+    conversation_id = "conv_1875_same"
+
+    transport = _SerializingChatTransport(
+        response_delay=0.1,
+        conversation_ids_by_notebook={notebook_id: conversation_id},
+    )
+    transport.set_answer("q-null", "answer-null")
+    transport.set_answer("q-follow", "answer-follow")
+
+    client = _make_client(transport, auth_tokens)
+    try:
+        client.chat._cache.cache_conversation_turn(
+            conversation_id, "q0", "answer-0", turn_number=1
+        )
+        await asyncio.gather(
+            client.chat.ask(notebook_id, "q-null", source_ids=["src_001"]),
+            client.chat.ask(
+                notebook_id,
+                "q-follow",
+                source_ids=["src_001"],
+                conversation_id=conversation_id,
+            ),
+        )
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert transport.peak_chat_inflight() == 1, (
+        "a null ask and an explicit follow-up on the notebook's current "
+        "conversation must serialize on the same per-conversation lock; "
+        f"got peak_chat_inflight={transport.peak_chat_inflight()}"
+    )
+
+    # Cache coherent: seed turn + the two serialized asks, contiguous 1/2/3.
+    cached_turns = client.chat.get_cached_turns(conversation_id)
+    assert [turn.turn_number for turn in cached_turns] == [1, 2, 3]
+    assert {turn.query for turn in cached_turns} == {"q0", "q-null", "q-follow"}
+
+
+@pytest.mark.asyncio
+async def test_null_ask_parallel_with_followup_on_other_conversation(auth_tokens) -> None:
+    """Granularity guard: a null ask resolving to convX runs parallel to convY.
+
+    The #1875 fix must not become a coarse notebook/global POST lock: a null
+    ask whose current conversation is convX shares no lock with an explicit
+    follow-up on an unrelated convY, so the two overlap at the transport
+    (peak in-flight 2). A regression to a notebook-wide POST lock caps this at 1.
+    """
+    notebook_id = "nb_1875_other"
+    conversation_x = "conv_1875_x"
+    conversation_y = "conv_1875_y"
+
+    transport = _SerializingChatTransport(
+        response_delay=0.1,
+        conversation_ids_by_notebook={notebook_id: conversation_x},
+    )
+    transport.set_answer("q-null", "answer-null")
+    transport.set_answer("q-other", "answer-other")
+
+    client = _make_client(transport, auth_tokens)
+    try:
+        client.chat._cache.cache_conversation_turn(
+            conversation_y, "q0", "answer-0", turn_number=1
+        )
+        await asyncio.gather(
+            client.chat.ask(notebook_id, "q-null", source_ids=["src_001"]),
+            client.chat.ask(
+                notebook_id,
+                "q-other",
+                source_ids=["src_001"],
+                conversation_id=conversation_y,
+            ),
+        )
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert transport.peak_chat_inflight() == 2, (
+        "a null ask resolving to convX must not serialize with a follow-up on "
+        f"a different convY; got peak_chat_inflight={transport.peak_chat_inflight()}"
+    )

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -594,3 +594,118 @@ async def test_null_ask_parallel_with_followup_on_other_conversation(auth_tokens
         "a null ask resolving to convX must not serialize with a follow-up on "
         f"a different convY; got peak_chat_inflight={transport.peak_chat_inflight()}"
     )
+
+
+def _build_delete_ok_body() -> str:
+    """Minimal success envelope for a DELETE_CONVERSATION (``J7Gthc``) RPC."""
+    inner = json.dumps([])
+    chunk = json.dumps(["wrb.fr", RPCMethod.DELETE_CONVERSATION.value, inner, None, None])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _request_rpcid(request: httpx.Request) -> str:
+    """Return the ``rpcids`` query param of a batchexecute request."""
+    return parse_qs(urlparse(str(request.url)).query).get("rpcids", [""])[0]
+
+
+class _DeleteRaceTransport(httpx.AsyncBaseTransport):
+    """Transport that lets a ``delete_conversation`` hold the conversation lock
+    while a concurrent null ask resolves the same id and blocks on that lock.
+
+    The DELETE RPC sleeps for ``delete_delay`` (holding the per-conversation
+    lock the whole time), so a null ask gathered *after* it resolves the current
+    id (first ``hPTbtc`` -> ``resolved_id``) and then parks on the same lock.
+    When the delete finishes it marks the id deleted; the null ask wakes, drops
+    its ``resolved_id_override``, POSTs (server starts a fresh conversation) and
+    recovers the real id via the second ``hPTbtc`` -> ``recovered_id``.
+    """
+
+    def __init__(self, *, resolved_id: str, recovered_id: str, delete_delay: float = 0.1) -> None:
+        self._resolved_id = resolved_id
+        self._recovered_id = recovered_id
+        self._delete_delay = delete_delay
+        self._hptbtc_calls = 0
+        self._events: list[str] = []
+
+    def events(self) -> list[str]:
+        return list(self._events)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if "batchexecute" in str(request.url):
+            rpcid = _request_rpcid(request)
+            if rpcid == RPCMethod.GET_LAST_CONVERSATION_ID.value:
+                self._hptbtc_calls += 1
+                cid = self._resolved_id if self._hptbtc_calls == 1 else self._recovered_id
+                self._events.append(f"hptbtc:{cid}")
+                return httpx.Response(
+                    200,
+                    text=_build_get_conversation_id_response_body(cid),
+                    request=request,
+                )
+            # DELETE_CONVERSATION: hold the conversation lock for the delay.
+            self._events.append("delete-start")
+            await asyncio.sleep(self._delete_delay)
+            self._events.append("delete-end")
+            return httpx.Response(200, text=_build_delete_ok_body(), request=request)
+        # Null chat POST: params[4] is null; the answer's stream id is discarded
+        # and the real id comes from the post-POST hPTbtc (recovered_id).
+        self._events.append("chat-post")
+        return httpx.Response(
+            200,
+            text=_build_chat_response_body("answer-after-delete", "stream-id-discarded"),
+            request=request,
+        )
+
+
+@pytest.mark.asyncio
+async def test_null_ask_recovers_when_current_conversation_deleted_mid_flight(
+    auth_tokens,
+) -> None:
+    """A delete that lands between resolve and POST must not pin the turn to the
+    deleted id.
+
+    Regression for the #1875 review (Codex P2): the null ask resolves
+    ``current_id`` = X, then blocks on ``_get_conversation_lock(X)`` held by a
+    concurrent ``delete_conversation(notebook, X)``. When the delete completes,
+    the server starts a FRESH conversation for the null POST. Without the
+    deleted-id re-check the null ask would suppress the post-POST ``hPTbtc``
+    recovery (``resolved_id_override=X``) and cache/report the new turn under the
+    DELETED id X. Post-fix it drops the override and recovers the real id Y.
+    """
+    notebook_id = "nb_1875_delrace"
+    deleted_id = "conv_1875_deleted"
+    fresh_id = "conv_1875_fresh"
+
+    transport = _DeleteRaceTransport(
+        resolved_id=deleted_id, recovered_id=fresh_id, delete_delay=0.1
+    )
+    client = _make_client(transport, auth_tokens)
+    try:
+        # Seed a turn under the soon-to-be-deleted id so we can prove the cache
+        # entry is gone (delete clears it) and the new turn lands under Y, not X.
+        client.chat._cache.cache_conversation_turn(deleted_id, "q0", "a0", turn_number=1)
+        # Delete is gathered first so it acquires the conversation lock before the
+        # null ask, which then resolves X and parks on that same lock.
+        _, result = await asyncio.gather(
+            client.chat.delete_conversation(notebook_id, deleted_id),
+            client.chat.ask(notebook_id, "q-after-delete", source_ids=["src_001"]),
+        )
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # The turn is reported and cached under the FRESH id, never the deleted one.
+    assert result.conversation_id == fresh_id, (
+        "null ask must recover the fresh server conversation after its resolved "
+        f"current conversation was deleted mid-flight; got {result.conversation_id!r}"
+    )
+    assert client.chat.get_cached_turns(fresh_id), "new turn must be cached under the fresh id"
+    assert not client.chat.get_cached_turns(deleted_id), (
+        "the deleted conversation's cache (and the recovered turn) must not live "
+        "under the deleted id"
+    )
+    # Ordering proof: the delete completed before the chat POST started.
+    events = transport.events()
+    assert "delete-end" in events and "chat-post" in events
+    assert events.index("delete-end") < events.index("chat-post"), (
+        f"delete must complete before the null POST for the race to be exercised; events={events!r}"
+    )

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -655,6 +655,7 @@ class TestChatAskErrorHandling:
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
+        mock_get_conversation_id,
     ):
         """Test ask() raises NetworkError on httpx.TimeoutException."""
         import re
@@ -663,6 +664,9 @@ class TestChatAskErrorHandling:
 
         from notebooklm.exceptions import NetworkError
 
+        # A null ask resolves the notebook's current conversation via hPTbtc
+        # before the POST (issue #1875); mock it so the POST is what fails.
+        mock_get_conversation_id()
         httpx_mock.add_exception(
             httpx.TimeoutException("timed out"),
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
@@ -682,6 +686,7 @@ class TestChatAskErrorHandling:
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
+        mock_get_conversation_id,
     ):
         """Test ask() raises ChatError on httpx.HTTPStatusError.
         After the chat-path refactor, the chat path uses
@@ -696,6 +701,9 @@ class TestChatAskErrorHandling:
 
         from notebooklm.exceptions import ChatError
 
+        # A null ask resolves the notebook's current conversation via hPTbtc
+        # before the POST (issue #1875); mock it so the POST is what fails.
+        mock_get_conversation_id()
         httpx_mock.add_response(
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
             status_code=500,
@@ -714,6 +722,7 @@ class TestChatAskErrorHandling:
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
+        mock_get_conversation_id,
     ):
         """Test ask() raises NetworkError on httpx.RequestError."""
         import re
@@ -722,6 +731,9 @@ class TestChatAskErrorHandling:
 
         from notebooklm.exceptions import NetworkError
 
+        # A null ask resolves the notebook's current conversation via hPTbtc
+        # before the POST (issue #1875); mock it so the POST is what fails.
+        mock_get_conversation_id()
         httpx_mock.add_exception(
             httpx.ConnectError("connection refused"),
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
@@ -1051,12 +1063,18 @@ class TestAskServerAssignedConversationId:
             content=chat_response_body.encode(),
             method="POST",
         )
-        # hPTbtc returns an empty result -> get_conversation_id() -> None
+        # hPTbtc returns an empty result -> get_conversation_id() -> None.
+        # A null ask now does TWO hPTbtc lookups (issue #1875): a pre-POST
+        # resolve of the notebook's current conversation and the existing
+        # post-POST id recovery. Both hit this empty response, so mark it
+        # reusable — otherwise the second lookup is unmocked and the test
+        # would fail there instead of on the intended ChatError.
         empty_hptbtc = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [])
         httpx_mock.add_response(
             url=re.compile(r".*batchexecute.*"),
             content=empty_hptbtc.encode(),
             method="POST",
+            is_reusable=True,
         )
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ChatError, match="hPTbtc"):

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -92,8 +92,13 @@ class TestAsk:
         assert result.turn_number == 2
 
     @pytest.mark.asyncio
-    async def test_ask_raises_chat_error_on_rate_limit(self, auth_tokens, httpx_mock):
+    async def test_ask_raises_chat_error_on_rate_limit(
+        self, auth_tokens, httpx_mock, mock_get_conversation_id
+    ):
         """ask() raises ChatError when the server returns UserDisplayableError."""
+        # A null ask resolves the notebook's current conversation via hPTbtc
+        # before the POST (issue #1875); mock it so the POST is what fails.
+        mock_get_conversation_id()
         error_chunk = json.dumps(
             [
                 [


### PR DESCRIPTION
Fixes #1875.

## Root cause
A `conversation_id=None` ask is treated by the server as "append to the notebook's *current* conversation" (`params[4]=null`). `ChatAPI.ask` locked null asks on `_new_conversation_locks[notebook_id]` and explicit follow-ups on `_conversation_locks[conversation_id]` — two disjoint registries. When the notebook's current conversation is exactly the one an explicit follow-up targets, the null ask and the follow-up held **different** locks, so their streamed POSTs did not serialize and turn lineage could be corrupted (both claiming turn N+1).

The real conversation id was never cached — it is only recoverable via `hPTbtc` (`get_conversation_id`), which today runs *after* the POST.

## Fix: two-phase lock (notebook outer → resolve → per-conversation inner)
In the null branch:
1. Acquire `_get_new_conversation_lock(notebook_id)` (outer, unchanged).
2. **While holding it**, resolve `current_id = await get_conversation_id(notebook_id)` so concurrent null asks cannot move the pointer before the POST.
3. If `current_id` exists: run the POST **and** cache under `_get_conversation_lock(current_id)` — the same lock instance an explicit follow-up on that conversation takes → the two serialize.
4. If `None` (truly new conversation): keep today's behavior — POST under the notebook lock, recover the id via post-POST `hPTbtc`, cache under its lock.

A new `resolved_id_override` kwarg on `perform_request` skips the redundant post-POST `hPTbtc` recovery when the id is already known, so the common existing-conversation case stays at **one** lookup; only a truly-first ask does two.

### Why it is deadlock-free
Lock order is **notebook → conversation** on the null path and **conversation-only** on the explicit path — acquisition order never reverses. The None branch releases the notebook lock before taking the conversation lock (no nested double-lock). Distinct conversations/notebooks keep distinct locks, so unrelated chats still run in parallel.

Residual assumption (documented inline): an explicit follow-up to a *different* conversation is assumed not to move the server's current-conversation pointer between the resolve and the null POST.

## Tests
- `test_null_ask_serializes_with_explicit_current_conversation` — `peak_chat_inflight()==1` (was 2 pre-fix), cache coherent.
- `test_null_ask_parallel_with_followup_on_other_conversation` — `peak_chat_inflight()==2` (granularity guard).
- Updated `test_new_conversation_cache_update_waits_for_resolved_conversation_lock`: the null ask now holds the conversation lock across POST+cache, so its assertion moved from a now-inverted wall-clock order to the meaningful invariant (serialized `peak==1`, contiguous non-corrupted turns).
- Swept null-ask tests for the new pre-POST resolve: error-path tests get a resolve mock; the no-conversation `ChatError` test reuses its empty `hPTbtc` for both lookups.

## Verification
- `tests/integration/concurrency/test_chat_history_race.py`: 7 passed
- `tests/unit/test_chat.py test_chat_ask_invariants.py test_chat_characterization.py test_chat_references.py test_conversation.py`: 154 passed
- `cli_vcr/test_chat.py mcp_vcr/test_chat.py` + app/cli/mcp chat + `test_chat_history.py`: 174 passed
- `tests/_guardrails/test_module_size_ratchet.py`: 6 passed (`_chat/api.py` = 1000/1000, under ceiling)
- `ruff` + `mypy` on `_chat/api.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “null ask” handling by correctly resolving the target conversation during streamed requests, while avoiding stale conversation pinning if a conversation is deleted mid-operation.
  * Preserved proper turn ordering and lineage for follow-ups, ensuring cached turns remain contiguous.
  * Maintained parallelism for requests targeting different conversations and strengthened error-path behavior when conversation resolution fails or times out.
* **Tests**
  * Added and refined integration concurrency tests for lock/serialization and ordering invariants.
  * Updated unit error-path mocks and refreshed the oversized rejection cassette for additional request coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->