### PR TITLE
feat(sources): make Drive-add failures point to the file-upload path

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1546,6 +1546,8 @@ Codex does not consume the `skill` subcommand. In this repository it reads the r
 
 Add a Google Drive document, slide deck, sheet, or PDF as a source. The Drive `--mime-type` selects which Drive document type to import (Google Doc / Slides / Sheets / PDF). This is distinct from the file-source `--mime-type` documented above, which sets the resumable-upload content-type for a locally-uploaded file.
 
+> **By-reference vs upload-only:** NotebookLM's Drive import only ingests Google-native Docs/Slides/Sheets + PDF by reference — the four `--mime-type` choices above. An upload-only file that merely *lives* in Drive (e.g. `epub`/`docx`/`txt`/`md`/`rtf`/`odt`/`csv`/`html`) cannot be imported this way; download it and add it with `source add <path> --type file` instead.
+
 > **Python equivalent:** [`client.sources.add_drive(nb_id, file_id, title, mime_type=...)`](python-api.md#sourcesapi-clientsources).
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1546,8 +1546,8 @@ Codex does not consume the `skill` subcommand. In this repository it reads the r
 
 Add a Google Drive document, slide deck, sheet, or PDF as a source. The Drive `--mime-type` selects which Drive document type to import (Google Doc / Slides / Sheets / PDF). This is distinct from the file-source `--mime-type` documented above, which sets the resumable-upload content-type for a locally-uploaded file.
 
-> **By-reference vs upload-only:** NotebookLM's Drive import only ingests Google-native Docs/Slides/Sheets + PDF by reference — the four `--mime-type` choices above. An upload-only file that merely *lives* in Drive (e.g. `epub`/`docx`/`txt`/`md`/`rtf`/`odt`/`csv`/`html`) cannot be imported this way; download it and add it with `source add <path> --type file` instead.
-
+> **By-reference vs upload-only:** NotebookLM's Drive import only ingests Google-native Docs/Slides/Sheets + PDF by reference — the four `--mime-type` choices above. An upload-only file that merely *lives* in Drive (e.g. `epub`/`docx`/`txt`/`md`/`rtf`/`odt`/`csv`) cannot be imported this way; download it and add it with `source add <path> --type file` instead.
+>
 > **Python equivalent:** [`client.sources.add_drive(nb_id, file_id, title, mime_type=...)`](python-api.md#sourcesapi-clientsources).
 
 ```bash

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -265,6 +265,10 @@ source_wait(notebook="Quantum Computing")
 `document_id` + a **required** `mime_type`, one of
 `google-doc`/`google-slides`/`google-sheets`/`pdf` — there is no default, since
 defaulting a non-Doc Drive file to `google-doc` fails the import), or `youtube`.
+NotebookLM's Drive import only ingests those four by reference (Google-native
+Docs/Slides/Sheets + PDF); an upload-only Drive file (e.g. epub/docx/txt/md/rtf/
+odt/csv/html) cannot be added via `drive` — download it and add it as a `file`
+source instead.
 URL and YouTube adds reject
 internal/loopback hosts by default; pass `allow_internal=true` only for
 deliberate local NotebookLM tests. `chat_ask` continues the most-recent

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -267,7 +267,7 @@ source_wait(notebook="Quantum Computing")
 defaulting a non-Doc Drive file to `google-doc` fails the import), or `youtube`.
 NotebookLM's Drive import only ingests those four by reference (Google-native
 Docs/Slides/Sheets + PDF); an upload-only Drive file (e.g. epub/docx/txt/md/rtf/
-odt/csv/html) cannot be added via `drive` — download it and add it as a `file`
+odt/csv) cannot be added via `drive` — download it and add it as a `file`
 source instead.
 URL and YouTube adds reject
 internal/loopback hosts by default; pass `allow_internal=true` only for

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -605,7 +605,10 @@ async def execute_source_add_drive(
     """
     if plan.mime_type not in _DRIVE_MIME_MAP:
         raise ValidationError(
-            f"Invalid mime_type {plan.mime_type!r}; expected one of {sorted(_DRIVE_MIME_MAP)}"
+            f"Invalid mime_type {plan.mime_type!r}; expected one of {sorted(_DRIVE_MIME_MAP)}. "
+            "NotebookLM's Drive import only ingests Google-native Docs/Slides/Sheets + PDF; "
+            "an upload-only Drive file (e.g. epub/docx/txt/md/rtf/odt/csv/html) must be "
+            "downloaded and added as a `file` source instead."
         )
     mime = _DRIVE_MIME_MAP[plan.mime_type]
 

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -607,7 +607,7 @@ async def execute_source_add_drive(
         raise ValidationError(
             f"Invalid mime_type {plan.mime_type!r}; expected one of {sorted(_DRIVE_MIME_MAP)}. "
             "NotebookLM's Drive import only ingests Google-native Docs/Slides/Sheets + PDF; "
-            "an upload-only Drive file (e.g. epub/docx/txt/md/rtf/odt/csv/html) must be "
+            "an upload-only Drive file (e.g. epub/docx/txt/md/rtf/odt/csv) must be "
             "downloaded and added as a `file` source instead."
         )
     mime = _DRIVE_MIME_MAP[plan.mime_type]

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -254,7 +254,7 @@ class SourceAddService:
                         f"(mime_type={mime_type!r}). This Drive file type may not be "
                         "importable via Drive — NotebookLM's Drive import supports "
                         "Google-native Docs/Slides/Sheets + PDF only. If it is an "
-                        "upload-only type (e.g. epub/docx/txt/md/rtf/odt/csv/html), "
+                        "upload-only type (e.g. epub/docx/txt/md/rtf/odt/csv), "
                         "download it and add it as a `file` source instead."
                     ),
                 )

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -248,7 +248,15 @@ class SourceAddService:
 
             if result is None:
                 raise SourceAddError(
-                    title, message=f"API returned no data for Drive source: {title}"
+                    title,
+                    message=(
+                        f"API returned no data for Drive source: {title} "
+                        f"(mime_type={mime_type!r}). This Drive file type may not be "
+                        "importable via Drive — NotebookLM's Drive import supports "
+                        "Google-native Docs/Slides/Sheets + PDF only. If it is an "
+                        "upload-only type (e.g. epub/docx/txt/md/rtf/odt/csv/html), "
+                        "download it and add it as a `file` source instead."
+                    ),
                 )
             return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -466,13 +466,31 @@ def source_refresh(ctx, source_id, notebook_id, json_output, client_auth):
     return _run()
 
 
+class _DriveMimeChoice(click.Choice):
+    """``--mime-type`` choice that, on an unsupported value, steers the user to the
+    file-upload path (NotebookLM's Drive import is Google-native + PDF only)."""
+
+    def convert(self, value: Any, param: Any, ctx: Any) -> Any:
+        try:
+            return super().convert(value, param, ctx)
+        except click.BadParameter:
+            raise click.BadParameter(
+                f"{value!r} is not importable via Drive. NotebookLM's Drive import "
+                "supports google-doc/google-slides/google-sheets/pdf only; download an "
+                "upload-only file (epub/docx/txt/md/rtf/odt/csv) and add it via "
+                "`source add <path> --type file` instead.",
+                ctx=ctx,
+                param=param,
+            ) from None
+
+
 @source.command("add-drive")
 @click.argument("file_id")
 @click.argument("title")
 @notebook_option
 @click.option(
     "--mime-type",
-    type=click.Choice(["google-doc", "google-slides", "google-sheets", "pdf"]),
+    type=_DriveMimeChoice(["google-doc", "google-slides", "google-sheets", "pdf"]),
     default="google-doc",
     help="Document type (default: google-doc)",
 )

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -479,7 +479,11 @@ def source_refresh(ctx, source_id, notebook_id, json_output, client_auth):
 @json_option
 @with_client
 def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, client_auth):
-    """Add a Google Drive document as a source."""
+    """Add a Google Drive document as a source.
+
+    Only Google-native Docs/Slides/Sheets + PDF import by reference; download an
+    upload-only Drive file (epub/docx/txt/md) and add it via `source add` instead.
+    """
     nb_id = require_notebook(notebook_id)
 
     async def _run():

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -474,7 +474,7 @@ class _DriveMimeChoice(click.Choice):
         try:
             return super().convert(value, param, ctx)
         except click.BadParameter:
-            raise click.BadParameter(
+            raise click.BadParameter(  # cli-input-validation: unsupported --mime-type steered to file-upload path
                 f"{value!r} is not importable via Drive. NotebookLM's Drive import "
                 "supports google-doc/google-slides/google-sheets/pdf only; download an "
                 "upload-only file (epub/docx/txt/md/rtf/odt/csv) and add it via "

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -72,26 +72,26 @@ def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
     """Require an explicit, supported ``mime_type`` for a Drive add (#1827).
 
     A Drive add no longer defaults an omitted ``mime_type`` to ``google-doc``: a
-    non-Doc Drive file (e.g. a raw ``.md``) so routed through the Google Docs
-    converter failed the import and left an error source stub behind. The client
-    can't sniff Drive metadata from a bare ``document_id``, so the caller must
-    declare the type; rejecting BEFORE ``resolve_notebook`` / the add RPC persists
-    no source row. A no-op for non-Drive types (``mime_type`` is dual-use free-text
-    for ``source_type="file"``).
+    non-Doc Drive file so routed through the Google Docs converter failed the
+    import and left an error source stub. The caller must declare the type;
+    rejecting BEFORE the add RPC persists no source row. No-op for non-Drive types.
     """
     if source_type != "drive":
         return
     if mime_type is None:
         raise ValidationError(
             "source_type 'drive' requires 'mime_type'; pass one of "
-            f"{_DRIVE_MIME_CHOICES_STR} (e.g. 'pdf' for a Drive-hosted PDF, "
-            "'google-doc' for a native Google Doc). An omitted type is no longer "
-            "defaulted to 'google-doc' — a non-Doc Drive file would fail the import "
-            "and leave an error source stub behind (#1827)."
+            f"{_DRIVE_MIME_CHOICES_STR} (e.g. 'pdf' for a Drive-hosted PDF). "
+            "NotebookLM's Drive import only ingests Google-native Docs/Slides/"
+            "Sheets + PDF; upload-only Drive files (epub/docx/txt/md/rtf/odt/csv/"
+            "html) must be downloaded and added as a `file` source (#1827)."
         )
     if mime_type not in _DRIVE_MIME_CHOICES:
         raise ValidationError(
-            f"Invalid mime_type {mime_type!r} for drive; expected one of {_DRIVE_MIME_CHOICES_STR}"
+            f"Invalid mime_type {mime_type!r} for drive; expected one of "
+            f"{_DRIVE_MIME_CHOICES_STR}. Drive import supports Google-native "
+            "Docs/Slides/Sheets + PDF only — download an upload-only file "
+            "(epub/docx/txt/md/rtf/odt/csv/html) and add it as a `file` source."
         )
 
 

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -83,15 +83,15 @@ def _validate_drive_mime(source_type: str, mime_type: str | None) -> None:
             "source_type 'drive' requires 'mime_type'; pass one of "
             f"{_DRIVE_MIME_CHOICES_STR} (e.g. 'pdf' for a Drive-hosted PDF). "
             "NotebookLM's Drive import only ingests Google-native Docs/Slides/"
-            "Sheets + PDF; upload-only Drive files (epub/docx/txt/md/rtf/odt/csv/"
-            "html) must be downloaded and added as a `file` source (#1827)."
+            "Sheets + PDF; upload-only Drive files (epub/docx/txt/md/rtf/odt/"
+            "csv) must be downloaded and added as a `file` source (#1827)."
         )
     if mime_type not in _DRIVE_MIME_CHOICES:
         raise ValidationError(
             f"Invalid mime_type {mime_type!r} for drive; expected one of "
             f"{_DRIVE_MIME_CHOICES_STR}. Drive import supports Google-native "
             "Docs/Slides/Sheets + PDF only — download an upload-only file "
-            "(epub/docx/txt/md/rtf/odt/csv/html) and add it as a `file` source."
+            "(epub/docx/txt/md/rtf/odt/csv) and add it as a `file` source."
         )
 
 

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, get_args
 
 import pydantic
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
@@ -115,6 +115,24 @@ class SourceAddDrive(BaseModel):
     document_id: str
     title: str | None = None
     mime_type: mut_core.DriveMimeChoice
+
+    # ``field_validator`` (not the v1-compat ``_field_validator`` alias) so mypy
+    # sees the v2 ``mode="before"`` overload — the hint must run BEFORE the
+    # ``Literal`` core check rejects an unsupported value with a bare enum error.
+    @pydantic.field_validator("mime_type", mode="before")
+    def _guide_unsupported_mime(cls, value: object) -> object:
+        """Give an unsupported ``mime_type`` (e.g. ``epub``) the upload hint before
+        the ``Literal`` check rejects it with a bare enum error. Google-native +
+        PDF are the only by-reference Drive types; other Drive files must be
+        downloaded and added as a ``file`` source (#1827)."""
+        if isinstance(value, str) and value not in get_args(mut_core.DriveMimeChoice):
+            raise ValueError(
+                f"{value!r} is not importable via Drive. NotebookLM's Drive import "
+                "supports google-doc/google-slides/google-sheets/pdf only; download an "
+                "upload-only file (epub/docx/txt/md/rtf/odt/csv) and add it as a `file` "
+                "source instead."
+            )
+        return value
 
 
 class SourceAddBatch(BaseModel):

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -459,12 +459,17 @@ def test_add_drive_pdf_kind_not_spreadsheet(
 
 
 def test_add_drive_bad_mime_is_422(authed_client: TestClient) -> None:
-    # mime_type is a Literal → rejected at the schema boundary.
+    # mime_type is a Literal → rejected at the schema boundary. A before-validator
+    # enriches the 422 with the file-upload hint (Google-native + PDF only).
     resp = authed_client.post(
         "/v1/notebooks/nb-1/sources/drive",
         json={"document_id": "doc-1", "mime_type": "bogus"},
     )
     assert resp.status_code == 422
+    body = resp.text.lower()
+    assert "not importable via drive" in body
+    assert "download" in body
+    assert "file" in body
 
 
 # --- Phase 4: batch URL add --------------------------------------------------

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -504,6 +504,10 @@ async def test_add_drive_bad_mime_raises_validation_error() -> None:
     )
     with pytest.raises(ValidationError) as excinfo:
         await execute_source_add_drive(client, plan)
+    msg = str(excinfo.value)
     # The message lists the valid keys so the caller can self-correct.
-    assert "google-doc" in str(excinfo.value)
+    assert "google-doc" in msg
+    # ...and steers upload-only Drive files (e.g. epub) to the `file` source path.
+    assert "file" in msg
+    assert "download" in msg.lower()
     client.sources.add_drive.assert_not_called()

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -1083,6 +1083,19 @@ class TestSourceAddDrive:
 
         assert result.exit_code == 0
 
+    def test_source_add_drive_unsupported_mime_hints_upload(self, runner, mock_auth):
+        """An unsupported Drive mime (e.g. ``epub``) is rejected at the CLI boundary
+        with the file-upload hint, not a bare Click choice error (#1827)."""
+        result = runner.invoke(
+            cli,
+            ["source", "add-drive", "file_id", "Book", "--mime-type", "epub", "-n", "nb_123"],
+        )
+        assert result.exit_code == 2
+        out = result.output.lower()
+        assert "not importable via drive" in out
+        assert "download" in out
+        assert "file" in out
+
     def test_source_add_drive_mime_type_no_deprecation_warning(self, runner, mock_auth):
         """Regression guard: Drive ``--mime-type`` MUST stay deprecation-free.
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1383,7 +1383,11 @@ async def test_source_add_drive_bad_mime_is_validation_error(mcp_call, mock_clie
                 "mime_type": "bogus",
             },
         )
-    assert "VALIDATION" in str(excinfo.value)
+    msg = str(excinfo.value)
+    assert "VALIDATION" in msg
+    # The error steers the user to the upload path for non-importable Drive types.
+    assert "file" in msg
+    assert "download" in msg.lower()
     mock_client.sources.add_drive.assert_not_called()
 
 
@@ -1406,6 +1410,9 @@ async def test_source_add_drive_missing_mime_is_validation_error(
     msg = str(excinfo.value)
     assert "VALIDATION" in msg
     assert "mime_type" in msg
+    # The message also points at the upload path for non-importable Drive types.
+    assert "file" in msg
+    assert "download" in msg.lower()
     # Rejected before resolve_notebook / the add RPC — nothing is persisted.
     mock_client.sources.add_drive.assert_not_called()
     mock_client.notebooks.get.assert_not_called()

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -334,7 +334,14 @@ async def test_add_drive_raises_source_add_error_on_null_result(
         )
 
     assert exc_info.value.url == "Drive Doc"
-    assert "API returned no data for Drive source: Drive Doc" in str(exc_info.value)
+    msg = str(exc_info.value)
+    assert "API returned no data for Drive source: Drive Doc" in msg
+    # The message names the attempted mime and hints (not asserts) that the type
+    # may not be importable via Drive, steering the user to the `file` upload path.
+    assert "mime_type=" in msg
+    assert "may not be importable" in msg
+    assert "file" in msg
+    assert "download" in msg.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

NotebookLM's Drive import (`REFERENCE`) only ingests **Google-native Docs/Slides/Sheets + PDF**. A file that merely *lives* in Drive but is an upload-only type (`epub`/`docx`/`txt`/`md`/`rtf`/`odt`/`csv`/`html`) can't be imported by reference — a Drive add of, e.g., a Drive-hosted epub returns `SourceAddError: API returned no data for Drive source`, while the same folder's PDF imports fine (verified live). The 4-type allowlist (`google-doc|google-slides|google-sheets|pdf`) is therefore **correct**; this PR only makes the failures **actionable**, telling users to download the file and add it as a `file` source.

This is the **UX-guidance half**. The capability fix (importing upload-only Drive files by reference) is tracked separately as **#1884** and is intentionally *not* implemented here. No behavior change beyond message text.

## The 3 error sites

1. **`src/notebooklm/mcp/tools/sources.py` → `_validate_drive_mime`** — both the missing-`mime_type` and invalid-`mime_type` `ValidationError`s now carry the upload guidance.
2. **`src/notebooklm/_app/source_mutations.py` → `execute_source_add_drive`** — the shared-core invalid-mime `ValidationError` (the CLI/HTTP path) carries the same guidance.
3. **`src/notebooklm/_source/add.py` → `add_drive` (`result is None`)** — the `SourceAddError` now names the attempted `mime_type` and **hints** ("may not be importable via Drive") rather than over-claiming, since `result is None` can also arise from transient causes. `SourceAddError` type preserved; url/text "no data" paths left unchanged (Drive-specific).

Plus: `source add-drive` CLI help clarified, and the by-reference vs upload-only split documented in `docs/mcp-guide.md` and `docs/cli-reference.md`. Tests extended for all three sites.

## Ratchet note

`mcp/tools/sources.py` is allowlisted in the module-size ratchet at exactly **1020** lines and must not grow. The added guidance text was offset by tightening the `_validate_drive_mime` docstring, so the file lands at **exactly 1020** (verified via `tests/_guardrails/test_module_size_ratchet.py`).

## Verification

- `pytest` targeted suites + ratchet + freshness: **295 passed**
- `ruff check`, `ruff format --check`, `mypy src/notebooklm`: clean
- pre-commit `ruff` / `ruff-format` hooks: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Drive imports only supported Google-native Docs/Slides/Sheets and PDFs, imported by reference.
  * Added guidance that upload-only Drive file types must be downloaded and added via `source add <path> --type file`.
* **Bug Fixes**
  * Improved `mime_type` validation and error messaging for Drive sources across CLI and API to clearly indicate unsupported types and the correct workaround.
* **Tests**
  * Strengthened and added CLI/API tests to confirm invalid Drive `mime_type` values fail with helpful “download then file” guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->