### PR TITLE
test(sources): regression guard for #1878 overall-duration bound

### DIFF
--- a/tests/unit/test_source_polling_service.py
+++ b/tests/unit/test_source_polling_service.py
@@ -441,6 +441,77 @@ async def test_wait_all_until_ready_timeout_reports_each_sources_own_last_status
 
 
 @pytest.mark.asyncio
+async def test_wait_all_until_ready_bounds_overall_duration_regardless_of_source_count(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """Regression for #1878: the OVERALL multi-source wait is bounded by ONE
+    ``timeout``, not ``N * timeout``.
+
+    The issue was filed against the pre-#1870 bounded-concurrency wait pool, where
+    each queued source got the full ``timeout`` so the overall wait grew with N
+    (~``ceil(N / workers) * timeout``). #1870 rewrote this into a single-snapshot
+    loop over one shared :class:`RuntimeDeadline`, so N never multiplies the wait.
+
+    Drive 25 sources that ALL stay PROCESSING forever (``list_sources`` always
+    returns the same PROCESSING snapshot) against an injected fake clock whose only
+    time source is the loop's own clamped sleeps. Assert the total *simulated*
+    elapsed time is bounded by ~one ``timeout`` (NOT 25 * timeout), that all 25 come
+    back as :class:`SourceTimeoutError`, and that each carries its own last status.
+    """
+    source_count = 25
+    timeout = 5.0
+    ids = [f"s{i}" for i in range(source_count)]
+    # Every source is stuck PROCESSING and never leaves that state.
+    stuck = [Source(id=sid, status=SourceStatus.PROCESSING) for sid in ids]
+    # The same PROCESSING snapshot on every tick — nothing ever becomes ready.
+    list_sources = _sequenced_list_sources([stuck])
+
+    sleeps: list[float] = []
+    clock = 0.0
+
+    def monotonic() -> float:
+        return clock
+
+    async def sleep(seconds: float) -> None:
+        nonlocal clock
+        sleeps.append(seconds)
+        clock += seconds
+
+    results = await poller.wait_all_until_ready(
+        "nb_1",
+        ids,
+        timeout=timeout,
+        initial_interval=1.0,
+        max_interval=10.0,
+        list_sources=list_sources,
+        sleep=sleep,
+        monotonic=monotonic,
+        logger=logger,
+    )
+
+    # (a) The overall wait is bounded by ~one timeout, NOT source_count * timeout.
+    # Every tick resolves ALL still-pending sources against ONE shared deadline, so
+    # the accumulated sleep budget can never exceed the single ``timeout`` — with 25
+    # sources the old per-source pool would have burned up to 25 * timeout here.
+    assert sum(sleeps) <= timeout
+    assert clock <= timeout
+    assert clock < source_count * timeout
+    # One whole-notebook snapshot per tick (never one-per-source): a handful of
+    # ticks under backoff, not 25 independent per-source waits.
+    assert list_sources.await_count <= 10
+
+    # (b) All 25 stuck sources come back as timeouts, in input order.
+    assert len(results) == source_count
+    assert all(isinstance(result, SourceTimeoutError) for result in results)
+    # (c) Each timeout carries its OWN id and last observed status (PROCESSING).
+    for sid, result in zip(ids, results, strict=True):
+        assert isinstance(result, SourceTimeoutError)
+        assert result.source_id == sid
+        assert result.last_status == SourceStatus.PROCESSING
+
+
+@pytest.mark.asyncio
 async def test_wait_all_until_ready_empty_returns_empty(
     poller: SourcePoller,
     logger: logging.Logger,


### PR DESCRIPTION
## Summary

GitHub issue #1878 ("source_wait: bound overall request duration, not just per-source timeout") was filed against the OLD bounded-concurrency wait pool, where each queued source received the full `timeout`, so the overall multi-source wait scaled with N (~`ceil(N/workers)*timeout`).

**#1878 was already resolved by #1870 (merged as PR #1882).** That PR rewrote the multi-source path into a single-snapshot loop (`SourcePoller.wait_all_until_ready`) driven by ONE shared `RuntimeDeadline.start(timeout)`:

- Every poll tick fetches the whole notebook source list ONCE and resolves every still-pending source against that single snapshot (no per-source fan-out).
- On `deadline.expired()`, every still-pending source is resolved to its own `SourceTimeoutError` at once via `_fill_timeouts`.
- The per-tick sleep is clamped with `deadline.clamp_sleep`, so accumulated sleeps can never exceed the single `timeout`.

The overall wait is therefore bounded by ~one `timeout` regardless of N. Both typed adapters — the MCP `source_wait` / `source_add_and_wait` tools (via `mcp/tools/_waitagg.py`) and the REST `POST /sources/wait` route — route through `_app.source_wait.wait_all_sources` → `client.sources.wait_all_until_ready`, so they inherit the bound. `MAX_WAIT_CONCURRENT_SOURCES` is gone.

## Why this PR

The existing timeout test (`test_wait_all_until_ready_timeout_reports_each_sources_own_last_status`) only exercised **2 sources in a single tick**, so it did not pin the N-independence the issue is specifically about. This adds a focused, deterministic regression guard:

- Drives `wait_all_until_ready` with **25 sources** that all stay `PROCESSING` forever (`list_sources` always returns the same PROCESSING snapshot), against an injected fake clock whose only time source is the loop's own clamped sleeps.
- Asserts (a) total simulated elapsed time is bounded by ~one `timeout` (NOT `N*timeout`), (b) all 25 come back as `SourceTimeoutError`, (c) each carries its own id and last status.

Test-only; no production change.

Closes #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that source readiness polling applies one overall timeout across multiple pending sources.
  * Confirmed polling remains efficient and bounded, regardless of the number of sources.
  * Verified timed-out sources report the correct identifier and processing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->