### PR TITLE
feat(sources): auto-route add-from-Drive for upload-only file types (#1884)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -958,6 +958,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact/polling.py` | Poll coordination service for artifact generation tasks |
 | `_source/add.py` | Core service layer for adding text, URL, or Google Drive sources |
+| `_source/drive_import.py` | Auto-route add-from-Drive (#1884): download + upload the upload-only Drive types (epub/docx/txt/…) NotebookLM's native import can't ingest; header-first cookie-authed streaming fetch behind injected seams |
 | `_source/content.py` | Core service layer for fetching source HTML/markdown content |
 | `_source/listing.py` | Core service layer for listing notebook sources |
 | `_source/polling.py` | Poll coordination service for active source conversions |
@@ -1109,6 +1110,7 @@ src/notebooklm/
 │   ├── _upload_decode.py        # Pure URL/source-id/content-type decode + validation helpers (extracted from upload.py)
 │   ├── add.py                   # Source addition coordinator
 │   ├── content.py               # Source content fetcher
+│   ├── drive_import.py          # Auto-route add-from-Drive (#1884): DriveImportService + DriveFetcher — parse id/URL, cookie-authed header-first streaming download of the upload-only Drive types (epub/docx/txt/…), confirm-token handling + 0600 temp cleanup, then hand to add_file (native Docs/Slides/Sheets → pointer error)
 │   ├── listing.py               # Source listing helper
 │   ├── polling.py               # Source polling coordinator
 │   ├── upload.py                # Gated source upload service
@@ -1209,6 +1211,7 @@ src/notebooklm/
 │       ├── _waitagg.py          # source-wait outcome aggregation shared by source_wait + source_add_and_wait: _wait_all_sources (concurrent per-source wait) + _aggregate_wait_outcomes (typed SourceWaitOutcome → {ok, ready, timed_out, failed, not_found} + thin-warning annotation) (split from sources.py for the ADR-0008 size budget)
 │       ├── notebooks.py         # notebook_list/create/describe/rename/delete over _app.notebooks
 │       ├── sources.py           # source_list/read/rename/delete/wait/add over _app.source_* (add: url/text/file/youtube via source_add, drive via source_mutations) + source_add_and_wait (single-mode add + wait composed via _waitagg) + source_upload_bytes (in-channel small-file byte upload via _fileupload)
+│       ├── sources_drive.py     # source_add_drive_file tool (#1884): discrete verb over _app.source_mutations.execute_source_add_drive_file — downloads + uploads the upload-only Drive types (kept out of the ceiling'd sources.py; own register())
 │       ├── chat.py              # chat_ask (client.chat.ask + get_history recall + suggest_followups) + chat_configure (_app.chat.execute_configure) + suggest_prompts (client.notebooks.suggest_prompts surface selector)
 │       ├── notes.py             # note_save (create-or-update upsert) over _app.notes; note reading/renaming/deleting fold into the cross-type Studio tools
 │       ├── studio.py            # hosts the Studio tools: studio_list (merges notes+artifacts via _studio_items.studio_items) / generate / status / download (via _studio_download) / rename / retry / get_prompt / studio_delete — both rename and delete are cross-type via _studio_items.resolve_studio_item (note→_app.notes.execute_note_rename/execute_note_delete, artifact→_app.artifacts kind-aware core); enum dispatch over _app.generate + _app.download; stateless poll via _app.artifacts.poll_artifact

--- a/src/notebooklm/_app/source_mutations.py
+++ b/src/notebooklm/_app/source_mutations.py
@@ -628,7 +628,65 @@ async def execute_source_add_drive(
     )
 
 
+# ---------------------------------------------------------------------------
+# source add-drive-file (auto-route: download + upload upload-only Drive types)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceAddDriveFileResult:
+    """Outcome of ``source add-drive-file`` (#1884).
+
+    Typed-fields-only (§11): the ``--json`` envelope is built by the surface
+    adapter (the CLI renderer / MCP tool) from these fields. ``document_id`` is
+    the raw id/URL the caller passed, echoed for provenance.
+    """
+
+    source: Source
+    notebook_id: str
+    document_id: str
+
+
+@dataclass(frozen=True)
+class SourceAddDriveFilePlan:
+    """Prepared inputs for ``execute_source_add_drive_file``."""
+
+    notebook_id: str
+    document_id: str
+    title: str | None = None
+    wait: bool = False
+    wait_timeout: float = 120.0
+
+
+async def execute_source_add_drive_file(
+    client: NotebookLMClient,
+    plan: SourceAddDriveFilePlan,
+) -> SourceAddDriveFileResult:
+    """Auto-route an upload-only Drive file: download it server-side, then upload.
+
+    Thin executor over the public client (boundary-legal): the download +
+    classification + resumable upload live in ``SourcesAPI.add_drive_file``. A
+    native Google Doc/Slides/Sheet (not directly downloadable), an unsupported
+    type, or expired Drive auth surface as :class:`ValidationError` from the
+    client, which the surface adapters render.
+    """
+    src = await client.sources.add_drive_file(
+        plan.notebook_id,
+        plan.document_id,
+        title=plan.title,
+        wait=plan.wait,
+        wait_timeout=plan.wait_timeout,
+    )
+    return SourceAddDriveFileResult(
+        source=src,
+        notebook_id=plan.notebook_id,
+        document_id=plan.document_id,
+    )
+
+
 __all__ = [
+    "SourceAddDriveFilePlan",
+    "SourceAddDriveFileResult",
     "SourceAddDrivePlan",
     "SourceAddDriveResult",
     "SourceDeleteByTitlePlan",
@@ -644,6 +702,7 @@ __all__ = [
     "build_id_ambiguity_error",
     "drive_mime_type_code",
     "execute_source_add_drive",
+    "execute_source_add_drive_file",
     "execute_source_delete",
     "execute_source_delete_by_title",
     "execute_source_refresh",

--- a/src/notebooklm/_source/__init__.py
+++ b/src/notebooklm/_source/__init__.py
@@ -5,9 +5,10 @@ Re-exports the cluster's public service classes; importers may also reach submod
 directly (``from .._source.upload import SourceUploadPipeline``).
 """
 
-from . import add, content, listing, polling, upload, upload_payloads
+from . import add, content, drive_import, listing, polling, upload, upload_payloads
 from .add import SourceAddService
 from .content import SourceContentRenderer
+from .drive_import import DriveFetcher, DriveImportService
 from .listing import SourceLister
 from .polling import SourcePoller
 from .upload import SourceUploadPipeline
@@ -21,10 +22,13 @@ from .upload_payloads import (
 __all__ = [
     "add",
     "content",
+    "drive_import",
     "listing",
     "polling",
     "upload",
     "upload_payloads",
+    "DriveFetcher",
+    "DriveImportService",
     "SourceAddService",
     "SourceContentRenderer",
     "SourceLister",

--- a/src/notebooklm/_source/drive_import.py
+++ b/src/notebooklm/_source/drive_import.py
@@ -36,9 +36,12 @@ no live Drive access.
 
 from __future__ import annotations
 
+import asyncio
 import os
+import queue
 import re
 import tempfile
+import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from html.parser import HTMLParser
@@ -50,6 +53,7 @@ import httpx
 
 from .._artifact._download_client import _is_trusted_download_host
 from .._artifact._redirect_guard import redirect_revalidation_hooks
+from .._artifact.downloads import _await_writer_exit
 from ..exceptions import ValidationError
 from ._upload_decode import _validate_upload_file_supported
 
@@ -77,6 +81,14 @@ _HTML_SNIFF_CAP_BYTES = 256 * 1024
 
 _STREAM_CHUNK_BYTES = 65536
 
+# Bounded queue between the async chunk producer and the single writer thread that
+# drains it to disk — so ``handle.write()`` never runs on the event loop (this
+# fetch is SERVER-SIDE on a possibly-shared loop, streaming up to the cap). Small
+# enough to keep back-pressure (the producer awaits when the writer falls behind),
+# large enough to stay hot across a brief read stall. Mirrors
+# ``_artifact/downloads.py::download_url``'s writer/queue split.
+_DRIVE_WRITER_QUEUE_SIZE = 8
+
 # A raw Drive file id, or the id embedded in a share URL. Drive ids are long
 # base64url-ish tokens; the 20-char floor rejects obviously-too-short junk.
 _DRIVE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
@@ -96,7 +108,9 @@ _BROWSER_UA = (
     "Chrome/125.0.0.0 Safari/537.36"
 )
 
-_ACCEPTED_EXTS_HINT = "epub, docx, doc, txt, md, rtf, odt, csv, tsv, pdf"
+# Derived from the supported set (never hand-maintained) so the user-facing
+# accepted-types message can't drift from what the router actually accepts.
+_ACCEPTED_EXTS_HINT = ", ".join(sorted(_UPLOAD_SUPPORTED_EXTS))
 
 
 @dataclass(frozen=True)
@@ -195,8 +209,10 @@ def _filename_from_disposition(disposition: str) -> str:
     """Extract the filename from a Content-Disposition header, if present."""
     if not disposition:
         return ""
-    # RFC 5987 ``filename*=UTF-8''...`` takes precedence over a plain ``filename=``.
-    ext_match = re.search(r"filename\*\s*=\s*[^']*''([^;]+)", disposition, re.IGNORECASE)
+    # RFC 5987 ``filename*=<charset>'<lang>'<pct-encoded>`` takes precedence over a
+    # plain ``filename=``. The language tag between the quotes is OPTIONAL and may be
+    # non-empty (e.g. ``UTF-8'en'file.txt``), so match ``[^']*`` for it, not ``''``.
+    ext_match = re.search(r"filename\*\s*=\s*[^']*'[^']*'([^;]+)", disposition, re.IGNORECASE)
     if ext_match:
         from urllib.parse import unquote
 
@@ -280,6 +296,11 @@ async def _read_capped_text(response: httpx.Response, cap: int) -> str:
     chunks: list[bytes] = []
     total = 0
     async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+        # Slice the final chunk so the buffer never exceeds ``cap`` by up to one
+        # whole chunk (a body far larger than the sniff cap would otherwise pull a
+        # full extra 64 KiB into memory).
+        if total + len(chunk) > cap:
+            chunk = chunk[: cap - total]
         chunks.append(chunk)
         total += len(chunk)
         if total >= cap:
@@ -395,7 +416,7 @@ class DriveFetcher:
         if declared > self._max_bytes:
             raise ValidationError(
                 f"Drive file {file_id} is {declared} bytes, over the "
-                f"{_MAX_DRIVE_DOWNLOAD_MIB} MiB download cap."
+                f"{self._max_bytes // (1024 * 1024)} MiB download cap."
             )
 
     async def _stream_to_temp(
@@ -411,25 +432,100 @@ class DriveFetcher:
         fd, temp_name = tempfile.mkstemp(prefix="nlm-drive-", suffix=suffix)
         os.close(fd)  # mkstemp already created it 0600
         temp_path = Path(temp_name)
-        total = 0
         try:
-            with open(temp_path, "wb") as handle:
-                async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
-                    total += len(chunk)
-                    if total > self._max_bytes:
-                        raise ValidationError(
-                            f"Drive download exceeded the {_MAX_DRIVE_DOWNLOAD_MIB} MiB cap "
-                            f"for {filename or 'the file'}."
-                        )
-                    handle.write(chunk)
-            if total == 0:
-                raise ValidationError(
-                    "Drive returned 0 bytes — the file may be empty or inaccessible."
-                )
+            await self._drain_to_temp(response, temp_path, filename)
             return temp_path
         except BaseException:
             temp_path.unlink(missing_ok=True)
             raise
+
+    async def _drain_to_temp(
+        self, response: httpx.Response, temp_path: Path, filename: str
+    ) -> None:
+        """Drain the streamed body to ``temp_path`` via a dedicated writer thread.
+
+        A single writer thread performs every blocking ``handle.write()`` off the
+        event loop, draining a bounded queue the async producer feeds — so this
+        server-side fetch never starves a shared loop even while streaming up to
+        the cap. Modelled on ``_artifact/downloads.py::download_url``. The running
+        byte cap is enforced producer-side (before the queue) so an over-cap body
+        aborts + cleans up without ever hitting disk beyond one queued chunk.
+        """
+        chunk_q: queue.Queue[bytes | None] = queue.Queue(maxsize=_DRIVE_WRITER_QUEUE_SIZE)
+        writer_failed = threading.Event()
+        writer_error: list[BaseException] = []
+
+        def _writer_loop() -> None:
+            # On failure, drain the queue in ``finally`` so a producer parked in
+            # ``queue.put`` unblocks and can observe ``writer_failed``.
+            try:
+                with open(temp_path, "wb") as handle:
+                    while True:
+                        item = chunk_q.get()
+                        if item is None:
+                            return
+                        handle.write(item)
+            except BaseException as exc:  # noqa: BLE001 - surfaced via writer_error below
+                writer_error.append(exc)
+                writer_failed.set()
+            finally:
+                while True:
+                    try:
+                        chunk_q.get_nowait()
+                    except queue.Empty:
+                        break
+
+        writer_thread = threading.Thread(
+            target=_writer_loop,
+            name=f"drive-dl-writer-{temp_path.name}",
+            daemon=True,
+        )
+        writer_thread.start()
+        total = 0
+        try:
+            async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+                if writer_failed.is_set():
+                    break
+                total += len(chunk)
+                if total > self._max_bytes:
+                    raise ValidationError(
+                        f"Drive download exceeded the {self._max_bytes // (1024 * 1024)} MiB "
+                        f"cap for {filename or 'the file'}."
+                    )
+                # ``put_nowait`` fast-paths the common case; fall back to a
+                # ``to_thread(put)`` only when the queue is full so the producer
+                # suspends cleanly under back-pressure (never blocking the loop).
+                try:
+                    chunk_q.put_nowait(chunk)
+                except queue.Full:
+                    await asyncio.to_thread(chunk_q.put, chunk)
+            if not writer_failed.is_set():
+                try:
+                    chunk_q.put_nowait(None)
+                except queue.Full:
+                    await asyncio.to_thread(chunk_q.put, None)
+            await _await_writer_exit(writer_thread, re_raise_cancel=True)
+            if writer_error:
+                raise next(iter(writer_error))  # one-slot exception box
+        except BaseException:
+            # Ensure the writer sees a sentinel and exits even if the queue is
+            # saturated (drop one item to make room, then put the sentinel) before
+            # the outer handler unlinks the temp file — a bare unlink would race
+            # the writer's still-open file handle.
+            while True:
+                try:
+                    chunk_q.put_nowait(None)
+                    break
+                except queue.Full:
+                    pass
+                try:
+                    chunk_q.get_nowait()
+                except queue.Empty:
+                    pass
+            await _await_writer_exit(writer_thread)
+            raise
+        if total == 0:
+            raise ValidationError("Drive returned 0 bytes — the file may be empty or inaccessible.")
 
 
 class DriveImportService:

--- a/src/notebooklm/_source/drive_import.py
+++ b/src/notebooklm/_source/drive_import.py
@@ -54,7 +54,14 @@ import httpx
 from .._artifact._download_client import _is_trusted_download_host
 from .._artifact._redirect_guard import redirect_revalidation_hooks
 from .._artifact.downloads import _await_writer_exit
-from ..exceptions import ValidationError
+from ..exceptions import (
+    ArtifactDownloadError,
+    AuthError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
 from ._upload_decode import _validate_upload_file_supported
 
 if TYPE_CHECKING:
@@ -127,11 +134,12 @@ class DriveDownload:
     content_type: str | None
 
 
-#: The fetch seam: classify + (on success) download a Drive file id to a temp
-#: path. Raises :class:`~notebooklm.exceptions.ValidationError` for the
-#: unsupported / HTML / native-doc / expired-auth cases. Injected so the routing
-#: table and confirm discriminator are testable with a fake HTTP client.
-DriveFetch = Callable[[str], Awaitable[DriveDownload]]
+#: The fetch seam: classify + (on success) download a Drive ref to a temp path.
+#: Raises the typed library errors — ``AuthError`` (expired session),
+#: ``RateLimitError`` / ``ServerError`` / ``NetworkError`` (transient), or
+#: ``ValidationError`` (unsupported / native-doc / permission pointer). Injected
+#: so the routing table + discriminator are testable with a fake HTTP client.
+DriveFetch = Callable[["DriveRef"], Awaitable[DriveDownload]]
 
 
 class AddFile(Protocol):
@@ -172,28 +180,41 @@ def _default_streaming_client(cookies: httpx.Cookies, timeout: httpx.Timeout) ->
     )
 
 
-def extract_drive_file_id(id_or_url: str) -> str:
-    """Parse a raw Drive file id or a Drive share URL into the bare file id.
+@dataclass(frozen=True)
+class DriveRef:
+    """A parsed Drive reference: the file id plus an optional resource key.
+
+    Link-shared files carry a ``resourcekey`` in the share URL that the download
+    request MUST echo back, or Drive refuses the fetch (403 / permission page).
+    """
+
+    file_id: str
+    resource_key: str | None = None
+
+
+def parse_drive_ref(id_or_url: str) -> DriveRef:
+    """Parse a raw Drive file id or a Drive share URL into a :class:`DriveRef`.
 
     Accepts a raw id, or a ``https://…`` URL of the ``/d/<id>``,
-    ``/file/d/<id>/…``, or ``?id=<id>`` shapes. Rejects anything that does not
-    yield a valid Drive id.
+    ``/file/d/<id>/…``, or ``?id=<id>`` shapes, preserving a ``resourcekey``
+    query param when present. Rejects anything that does not yield a valid id.
     """
     candidate = (id_or_url or "").strip()
     if not candidate:
         raise ValidationError("A Google Drive file id or share URL is required.")
     if _DRIVE_ID_RE.fullmatch(candidate):
-        return candidate
+        return DriveRef(file_id=candidate)
 
     parsed = urlparse(candidate)
     if parsed.scheme in ("http", "https"):
-        query_ids = parse_qs(parsed.query).get("id", [])
-        for value in query_ids:
+        query = parse_qs(parsed.query)
+        resource_key = next((v for v in query.get("resourcekey", []) if v), None)
+        for value in query.get("id", []):
             if _DRIVE_ID_RE.fullmatch(value):
-                return value
+                return DriveRef(file_id=value, resource_key=resource_key)
         path_match = _DRIVE_URL_PATH_ID_RE.search(parsed.path)
         if path_match:
-            return path_match.group(1)
+            return DriveRef(file_id=path_match.group(1), resource_key=resource_key)
 
     raise ValidationError(
         f"Could not parse a Google Drive file id from {id_or_url!r}. Pass a raw file id "
@@ -201,8 +222,25 @@ def extract_drive_file_id(id_or_url: str) -> str:
     )
 
 
-def _download_url(file_id: str) -> str:
-    return f"{_DRIVE_DOWNLOAD_URL}?{urlencode({'id': file_id, 'export': 'download'})}"
+def extract_drive_file_id(id_or_url: str) -> str:
+    """Parse a raw Drive file id or a Drive share URL into the bare file id."""
+    return parse_drive_ref(id_or_url).file_id
+
+
+def _download_url(
+    file_id: str, *, authuser: str | None = None, resource_key: str | None = None
+) -> str:
+    """Build the cookie-authed download URL, routing to the SELECTED account.
+
+    ``authuser`` disambiguates the account in a multi-login cookie jar (else Drive
+    serves authuser=0's view); ``resourcekey`` is required for link-shared files.
+    """
+    params = {"id": file_id, "export": "download"}
+    if authuser is not None:
+        params["authuser"] = authuser
+    if resource_key:
+        params["resourcekey"] = resource_key
+    return f"{_DRIVE_DOWNLOAD_URL}?{urlencode(params)}"
 
 
 def _filename_from_disposition(disposition: str) -> str:
@@ -278,9 +316,18 @@ def _find_confirm_params(html_text: str, file_id: str) -> dict[str, str] | None:
     return None
 
 
-def _confirm_url(confirm_params: dict[str, str]) -> str:
+def _confirm_url(
+    confirm_params: dict[str, str], *, authuser: str | None = None, resource_key: str | None = None
+) -> str:
     params = dict(confirm_params)
     action = params.pop("__action__")
+    # The interstitial form rarely echoes authuser/resourcekey, so re-attach the
+    # account routing + resource key for the confirmed re-request (unless the form
+    # already carried them).
+    if authuser is not None:
+        params.setdefault("authuser", authuser)
+    if resource_key:
+        params.setdefault("resourcekey", resource_key)
     return f"{action}?{urlencode(params)}"
 
 
@@ -323,80 +370,117 @@ class DriveFetcher:
         cookies_provider: Callable[[], httpx.Cookies],
         client_factory: StreamingClientFactory = _default_streaming_client,
         max_bytes: int = _MAX_DRIVE_DOWNLOAD_BYTES,
+        authuser: str | None = None,
+        temp_dir: Path | None = None,
     ) -> None:
         self._cookies_provider = cookies_provider
         self._client_factory = client_factory
         self._max_bytes = max_bytes
+        # Routes a multi-login cookie jar to the SELECTED account (else authuser=0).
+        self._authuser = authuser
+        # Where temp downloads land; ``None`` = the system temp dir. Injectable so
+        # concurrent downloads (and tests) can scope their own directory.
+        self._temp_dir = temp_dir
 
-    async def __call__(self, file_id: str) -> DriveDownload:
-        result = await self._request(_download_url(file_id), file_id, allow_confirm=True)
+    async def __call__(self, ref: DriveRef) -> DriveDownload:
+        url = _download_url(ref.file_id, authuser=self._authuser, resource_key=ref.resource_key)
+        result = await self._request(url, ref, allow_confirm=True)
         if isinstance(result, _ConfirmRedirect):
             # Re-request with the confirm token; a second interstitial is treated
             # as a hard failure (no unbounded confirm loop).
-            result = await self._request(result.url, file_id, allow_confirm=False)
+            result = await self._request(result.url, ref, allow_confirm=False)
         if isinstance(result, _ConfirmRedirect):  # pragma: no cover - defensive
             raise ValidationError(
-                f"Drive kept returning the download-confirmation page for {file_id}; "
+                f"Drive kept returning the download-confirmation page for {ref.file_id}; "
                 "it may be too large to fetch or temporarily unavailable."
             )
         return result
 
     async def _request(
-        self, url: str, file_id: str, *, allow_confirm: bool
+        self, url: str, ref: DriveRef, *, allow_confirm: bool
     ) -> DriveDownload | _ConfirmRedirect:
+        file_id = ref.file_id
         timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
         client = self._client_factory(self._cookies_provider(), timeout)
-        async with client:  # noqa: SIM117 - stream() nested so the client is entered first
-            async with client.stream("GET", url) as response:
-                status = response.status_code
-                if status in (401, 403):
-                    raise ValidationError(
-                        "Drive authentication expired — run `notebooklm login`, then retry."
-                    )
-                if status >= 400:
-                    raise ValidationError(
-                        f"Drive returned HTTP {status} while fetching file {file_id}."
-                    )
+        try:
+            async with client:  # noqa: SIM117 - stream() nested so the client is entered first
+                async with client.stream("GET", url) as response:
+                    return await self._handle_response(response, ref, allow_confirm=allow_confirm)
+        except (httpx.HTTPError, ArtifactDownloadError) as exc:
+            # Transport-level faults (timeout, DNS, connection reset, or a
+            # redirect-guard policy rejection escaping the streaming GET) map to a
+            # retriable NETWORK error — never a bare httpx traceback surfacing as
+            # UNEXPECTED in MCP / an internal-bug CLI exit.
+            raise NetworkError(
+                f"Network error fetching Drive file {file_id} ({exc.__class__.__name__})",
+                original_error=exc if isinstance(exc, Exception) else None,
+            ) from exc
 
-                content_type = response.headers.get("content-type", "")
-                if "text/html" in content_type.lower():
-                    return await self._classify_html(response, file_id, allow_confirm=allow_confirm)
+    async def _handle_response(
+        self, response: httpx.Response, ref: DriveRef, *, allow_confirm: bool
+    ) -> DriveDownload | _ConfirmRedirect:
+        file_id = ref.file_id
+        status = response.status_code
+        # 401 → expired session (re-auth path). 403 is NOT decided here: Drive
+        # returns 403 + an HTML permission page, which the discriminator handles.
+        if status == 401:
+            raise AuthError("Drive authentication expired — run `notebooklm login`, then retry.")
+        if status == 429:
+            raise RateLimitError(
+                f"Drive throttled the download (HTTP 429) for {file_id}; retry after a delay."
+            )
+        if status >= 500:
+            raise ServerError(
+                f"Drive returned HTTP {status} while fetching {file_id}; retry after a delay.",
+                status_code=status,
+            )
 
-                # Attachment / binary route — inspect headers BEFORE the body.
-                filename = _filename_from_disposition(
-                    response.headers.get("content-disposition", "")
-                )
-                extension = _extension(filename)
-                if extension in _HTML_EXTS:
-                    raise ValidationError(
-                        "HTML isn't supported by NotebookLM upload; convert the page to "
-                        ".txt, .md, or .pdf first, then retry."
-                    )
-                if extension not in _UPLOAD_SUPPORTED_EXTS:
-                    raise ValidationError(
-                        f"Drive file {filename or file_id!r} has an unsupported type for "
-                        f"NotebookLM upload. Accepted: {_ACCEPTED_EXTS_HINT}."
-                    )
-                self._reject_oversize_header(response, file_id)
-                path = await self._stream_to_temp(response, filename, extension)
-                return DriveDownload(
-                    path=path, filename=filename, content_type=content_type or None
-                )
+        content_type = response.headers.get("content-type", "")
+        if "text/html" in content_type.lower():
+            return await self._classify_html(response, ref, allow_confirm=allow_confirm)
+        if status >= 400:
+            # A non-HTML 4xx (e.g. 403/404) is a hard caller/permission error.
+            raise ValidationError(
+                f"Drive returned HTTP {status} while fetching file {file_id}; confirm the "
+                "id is correct and the file is accessible to this account."
+            )
+
+        # Attachment / binary route — inspect headers BEFORE the body.
+        filename = _filename_from_disposition(response.headers.get("content-disposition", ""))
+        extension = _extension(filename)
+        if extension in _HTML_EXTS:
+            raise ValidationError(
+                "HTML isn't supported by NotebookLM upload; convert the page to "
+                ".txt, .md, or .pdf first, then retry."
+            )
+        if extension not in _UPLOAD_SUPPORTED_EXTS:
+            raise ValidationError(
+                f"Drive file {filename or file_id!r} has an unsupported type for "
+                f"NotebookLM upload. Accepted: {_ACCEPTED_EXTS_HINT}."
+            )
+        self._reject_oversize_header(response, file_id)
+        path = await self._stream_to_temp(response, filename, extension)
+        return DriveDownload(path=path, filename=filename, content_type=content_type or None)
 
     async def _classify_html(
-        self, response: httpx.Response, file_id: str, *, allow_confirm: bool
+        self, response: httpx.Response, ref: DriveRef, *, allow_confirm: bool
     ) -> _ConfirmRedirect:
         """Discriminate an HTML response: expired-auth / confirm page / not-downloadable."""
+        file_id = ref.file_id
         final_host = (response.url.host or "").lower()
         if final_host == "accounts.google.com":
-            raise ValidationError(
-                "Drive authentication expired — run `notebooklm login`, then retry."
-            )
+            raise AuthError("Drive authentication expired — run `notebooklm login`, then retry.")
         body = await _read_capped_text(response, _HTML_SNIFF_CAP_BYTES)
         if allow_confirm:
             confirm_params = _find_confirm_params(body, file_id)
             if confirm_params is not None:
-                return _ConfirmRedirect(url=_confirm_url(confirm_params))
+                return _ConfirmRedirect(
+                    url=_confirm_url(
+                        confirm_params,
+                        authuser=self._authuser,
+                        resource_key=ref.resource_key,
+                    )
+                )
         raise ValidationError(
             f"Drive did not return downloadable bytes for {file_id}. If it's a native "
             "Google Doc/Slides/Sheet, add it with source_add(source_type='drive', "
@@ -429,7 +513,8 @@ class DriveFetcher:
         unlinks it after the upload on success.
         """
         suffix = f".{extension}" if extension else ""
-        fd, temp_name = tempfile.mkstemp(prefix="nlm-drive-", suffix=suffix)
+        temp_dir = str(self._temp_dir) if self._temp_dir is not None else None
+        fd, temp_name = tempfile.mkstemp(prefix="nlm-drive-", suffix=suffix, dir=temp_dir)
         os.close(fd)  # mkstemp already created it 0600
         temp_path = Path(temp_name)
         try:
@@ -549,8 +634,8 @@ class DriveImportService:
         wait: bool = False,
         wait_timeout: float = 120.0,
     ) -> Source:
-        file_id = extract_drive_file_id(id_or_url)
-        download = await self._fetch(file_id)
+        ref = parse_drive_ref(id_or_url)
+        download = await self._fetch(ref)
         try:
             # Second defense: even if the fetch mislabeled the type, an HTML file
             # (by extension or content-type) is rejected before it reaches upload.

--- a/src/notebooklm/_source/drive_import.py
+++ b/src/notebooklm/_source/drive_import.py
@@ -1,0 +1,472 @@
+"""Auto-route "add from Drive": download + upload the upload-only Drive types.
+
+NotebookLM's native Drive import (``client.sources.add_drive``) only ingests
+Google-native Docs/Slides/Sheets + PDF. Everything else NotebookLM *can* accept
+as an uploaded file (epub/docx/txt/md/rtf/odt/csv/tsv/…) has to be fetched from
+Drive and pushed through the resumable-upload leg instead. This module owns that
+route (#1884).
+
+Design (see ``.sisyphus/plans/1884-drive-auto-route.md``):
+
+* **Server-side download.** The fetch runs where the profile + cookies already
+  live (the client host / MCP server), authenticated by the SAME ``.google.com``
+  master jar the upload leg uses. So it works in stdio AND remote MCP mode with
+  no ``upload_required`` detour — a Drive source has no client-side bytes, so
+  both the Drive→server fetch and the server→NotebookLM push are server-local.
+
+* **One cookie-authed request classifies AND downloads.** A single GET to
+  ``drive.usercontent.google.com/download?id=<id>&export=download`` returns the
+  bytes with a ``Content-Disposition: attachment; filename="X.ext"`` for a
+  directly-downloadable file; the extension routes it. A native Google Doc (or a
+  permissions/expired-auth failure) comes back as HTML instead — classified via
+  the :func:`_find_confirm_params` discriminator (r3 Fix A) into the >25 MB
+  virus-scan interstitial (re-request with the confirm token), an expired-auth
+  redirect, or a non-committal "not downloadable" pointer error.
+
+* **Header-first streaming (r3 Fix B).** The fetch inspects headers BEFORE the
+  body: an unsupported/HTML extension or an over-cap ``Content-Length`` closes
+  the stream immediately (no download); otherwise the body streams to a 0600
+  temp file under a running byte cap. The temp file is unlinked on every exit
+  path (success, upload failure, cancellation).
+
+All I/O sits behind injected seams (``fetch`` + ``add_file``) so the routing
+table, id/URL parsing, and the confirm-form discriminator are unit-tested with
+no live Drive access.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from .._artifact._download_client import _is_trusted_download_host
+from .._artifact._redirect_guard import redirect_revalidation_hooks
+from ..exceptions import ValidationError
+from ._upload_decode import _validate_upload_file_supported
+
+if TYPE_CHECKING:
+    from ..types import Source
+
+# The cookie-authed download endpoint that returns BOTH the type (via the
+# Content-Disposition filename) and the bytes in one request (validated live).
+_DRIVE_DOWNLOAD_URL = "https://drive.usercontent.google.com/download"
+
+# Hosts a legitimate confirm-form action may target (r3 Fix A). A form pointing
+# anywhere else is NOT the virus-scan interstitial and must not be followed.
+_DRIVE_DOWNLOAD_HOSTS = frozenset({"drive.usercontent.google.com", "drive.google.com"})
+
+# Size cap for a Drive download (matches the MCP file-transfer cap in
+# ``mcp/tools/_fileupload.py``). Enforced header-first via Content-Length and
+# again as a running byte cap for unknown-length bodies.
+_MAX_DRIVE_DOWNLOAD_MIB = 200
+_MAX_DRIVE_DOWNLOAD_BYTES = _MAX_DRIVE_DOWNLOAD_MIB * 1024 * 1024
+
+# How much of an HTML classification body to read before deciding (r3 Fix B: read
+# only the small body needed for the form parse, then close — never stream HTML
+# to a file). The confirm interstitial is a few KiB; 256 KiB is generous slack.
+_HTML_SNIFF_CAP_BYTES = 256 * 1024
+
+_STREAM_CHUNK_BYTES = 65536
+
+# A raw Drive file id, or the id embedded in a share URL. Drive ids are long
+# base64url-ish tokens; the 20-char floor rejects obviously-too-short junk.
+_DRIVE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{20,}$")
+_DRIVE_URL_PATH_ID_RE = re.compile(r"/(?:file/)?d/([A-Za-z0-9_-]{20,})")
+
+# Extensions NotebookLM's resumable upload accepts → download + upload route.
+_UPLOAD_SUPPORTED_EXTS = frozenset(
+    {"epub", "docx", "doc", "txt", "md", "markdown", "rtf", "odt", "csv", "tsv", "pdf"}
+)
+# HTML-family extensions the upload endpoint rejects (kept explicit so the fetch
+# gives the convert-first guidance instead of the generic unsupported error).
+_HTML_EXTS = frozenset({"html", "htm", "xhtml", "xht"})
+
+# A plausible browser UA — the Drive download endpoint is a browser surface.
+_BROWSER_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/125.0.0.0 Safari/537.36"
+)
+
+_ACCEPTED_EXTS_HINT = "epub, docx, doc, txt, md, rtf, odt, csv, tsv, pdf"
+
+
+@dataclass(frozen=True)
+class DriveDownload:
+    """A Drive file streamed to a local temp path, ready for resumable upload.
+
+    ``path`` carries the source file's extension (so ``add_file``'s content-type
+    resolution + HTML-reject gate fire as a second defense); the caller unlinks
+    it after the upload completes.
+    """
+
+    path: Path
+    filename: str
+    content_type: str | None
+
+
+#: The fetch seam: classify + (on success) download a Drive file id to a temp
+#: path. Raises :class:`~notebooklm.exceptions.ValidationError` for the
+#: unsupported / HTML / native-doc / expired-auth cases. Injected so the routing
+#: table and confirm discriminator are testable with a fake HTTP client.
+DriveFetch = Callable[[str], Awaitable[DriveDownload]]
+
+
+class AddFile(Protocol):
+    """The resumable-upload seam (``SourcesAPI.add_file``)."""
+
+    async def __call__(
+        self,
+        notebook_id: str,
+        file_path: Path,
+        *,
+        title: str | None,
+        wait: bool,
+        wait_timeout: float,
+    ) -> Source: ...
+
+
+#: Builds the streaming download client. Always httpx (never the buffering
+#: curl_cffi ``get_guarded`` — Fix B forces a potentially 200 MiB body through
+#: streaming httpx) with the #1521 per-hop redirect-revalidation hooks + the
+#: shared ``.google.com`` trusted-host allowlist. Injected for testing.
+StreamingClientFactory = Callable[[httpx.Cookies, httpx.Timeout], httpx.AsyncClient]
+
+
+def _default_streaming_client(cookies: httpx.Cookies, timeout: httpx.Timeout) -> httpx.AsyncClient:
+    """Build the httpx streaming download client (reuses the download wiring).
+
+    Mirrors the httpx branch of ``_artifact/_download_client.py::_make_download_client``
+    (auto-follow redirects + the #1521 revalidation event hook + the shared
+    ``.google.com`` trusted-host guard) but is consumed via ``client.stream(...)``
+    rather than the buffering GET, so an over-cap body is never buffered.
+    """
+    return httpx.AsyncClient(
+        cookies=cookies,
+        follow_redirects=True,
+        timeout=timeout,
+        headers={"User-Agent": _BROWSER_UA},
+        event_hooks=redirect_revalidation_hooks(_is_trusted_download_host),
+    )
+
+
+def extract_drive_file_id(id_or_url: str) -> str:
+    """Parse a raw Drive file id or a Drive share URL into the bare file id.
+
+    Accepts a raw id, or a ``https://…`` URL of the ``/d/<id>``,
+    ``/file/d/<id>/…``, or ``?id=<id>`` shapes. Rejects anything that does not
+    yield a valid Drive id.
+    """
+    candidate = (id_or_url or "").strip()
+    if not candidate:
+        raise ValidationError("A Google Drive file id or share URL is required.")
+    if _DRIVE_ID_RE.fullmatch(candidate):
+        return candidate
+
+    parsed = urlparse(candidate)
+    if parsed.scheme in ("http", "https"):
+        query_ids = parse_qs(parsed.query).get("id", [])
+        for value in query_ids:
+            if _DRIVE_ID_RE.fullmatch(value):
+                return value
+        path_match = _DRIVE_URL_PATH_ID_RE.search(parsed.path)
+        if path_match:
+            return path_match.group(1)
+
+    raise ValidationError(
+        f"Could not parse a Google Drive file id from {id_or_url!r}. Pass a raw file id "
+        "or a Drive URL like https://drive.google.com/file/d/<id>/view."
+    )
+
+
+def _download_url(file_id: str) -> str:
+    return f"{_DRIVE_DOWNLOAD_URL}?{urlencode({'id': file_id, 'export': 'download'})}"
+
+
+def _filename_from_disposition(disposition: str) -> str:
+    """Extract the filename from a Content-Disposition header, if present."""
+    if not disposition:
+        return ""
+    # RFC 5987 ``filename*=UTF-8''...`` takes precedence over a plain ``filename=``.
+    ext_match = re.search(r"filename\*\s*=\s*[^']*''([^;]+)", disposition, re.IGNORECASE)
+    if ext_match:
+        from urllib.parse import unquote
+
+        return unquote(ext_match.group(1).strip()).strip('"')
+    match = re.search(r'filename\s*=\s*"?([^";]+)"?', disposition, re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def _extension(filename: str) -> str:
+    suffix = Path(filename).suffix
+    return suffix[1:].lower() if suffix else ""
+
+
+class _DownloadFormParser(HTMLParser):
+    """Collect ``<form>`` actions + their hidden-input name→value pairs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.forms: list[tuple[str, dict[str, str]]] = []
+        self._current: dict[str, str] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr = {key: (value or "") for key, value in attrs}
+        if tag == "form":
+            self._current = {}
+            self.forms.append((attr.get("action", ""), self._current))
+        elif tag == "input" and self._current is not None:
+            name = attr.get("name")
+            if name:
+                self._current[name] = attr.get("value", "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "form":
+            self._current = None
+
+
+def _find_confirm_params(html_text: str, file_id: str) -> dict[str, str] | None:
+    """Detect the >25 MB virus-scan interstitial and return its re-request params.
+
+    Qualifies as the confirm page ONLY when a form's action resolves to a Drive
+    download host AND its hidden inputs carry ``id`` (== the requested id),
+    ``export=download``, and a NON-EMPTY ``confirm`` token (r3 Fix A). Arbitrary
+    hidden fields do not qualify. Carries ``uuid`` when present.
+    """
+    parser = _DownloadFormParser()
+    parser.feed(html_text)
+    for action, inputs in parser.forms:
+        host = (urlparse(action).hostname or "").lower()
+        if host not in _DRIVE_DOWNLOAD_HOSTS:
+            continue
+        if inputs.get("id") != file_id or inputs.get("export") != "download":
+            continue
+        confirm = inputs.get("confirm", "")
+        if not confirm:
+            continue
+        params = {"id": file_id, "export": "download", "confirm": confirm}
+        uuid = inputs.get("uuid")
+        if uuid:
+            params["uuid"] = uuid
+        return {"__action__": action or _DRIVE_DOWNLOAD_URL, **params}
+    return None
+
+
+def _confirm_url(confirm_params: dict[str, str]) -> str:
+    params = dict(confirm_params)
+    action = params.pop("__action__")
+    return f"{action}?{urlencode(params)}"
+
+
+@dataclass(frozen=True)
+class _ConfirmRedirect:
+    """Sentinel: the response was the confirm interstitial; re-request this URL."""
+
+    url: str
+
+
+async def _read_capped_text(response: httpx.Response, cap: int) -> str:
+    """Read at most ``cap`` bytes of a streamed body, then decode as text."""
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+        chunks.append(chunk)
+        total += len(chunk)
+        if total >= cap:
+            break
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+class DriveFetcher:
+    """Default :data:`DriveFetch`: cookie-authed header-first streaming fetch.
+
+    Holds a cookie provider (the live kernel jar) and a streaming-client factory
+    (both injected). Never buffers the body: HTML is read only far enough to
+    classify, an unsupported/over-cap binary is rejected before the body is read,
+    and a supported binary streams to a 0600 temp file under a running byte cap.
+    """
+
+    def __init__(
+        self,
+        *,
+        cookies_provider: Callable[[], httpx.Cookies],
+        client_factory: StreamingClientFactory = _default_streaming_client,
+        max_bytes: int = _MAX_DRIVE_DOWNLOAD_BYTES,
+    ) -> None:
+        self._cookies_provider = cookies_provider
+        self._client_factory = client_factory
+        self._max_bytes = max_bytes
+
+    async def __call__(self, file_id: str) -> DriveDownload:
+        result = await self._request(_download_url(file_id), file_id, allow_confirm=True)
+        if isinstance(result, _ConfirmRedirect):
+            # Re-request with the confirm token; a second interstitial is treated
+            # as a hard failure (no unbounded confirm loop).
+            result = await self._request(result.url, file_id, allow_confirm=False)
+        if isinstance(result, _ConfirmRedirect):  # pragma: no cover - defensive
+            raise ValidationError(
+                f"Drive kept returning the download-confirmation page for {file_id}; "
+                "it may be too large to fetch or temporarily unavailable."
+            )
+        return result
+
+    async def _request(
+        self, url: str, file_id: str, *, allow_confirm: bool
+    ) -> DriveDownload | _ConfirmRedirect:
+        timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
+        client = self._client_factory(self._cookies_provider(), timeout)
+        async with client:  # noqa: SIM117 - stream() nested so the client is entered first
+            async with client.stream("GET", url) as response:
+                status = response.status_code
+                if status in (401, 403):
+                    raise ValidationError(
+                        "Drive authentication expired — run `notebooklm login`, then retry."
+                    )
+                if status >= 400:
+                    raise ValidationError(
+                        f"Drive returned HTTP {status} while fetching file {file_id}."
+                    )
+
+                content_type = response.headers.get("content-type", "")
+                if "text/html" in content_type.lower():
+                    return await self._classify_html(response, file_id, allow_confirm=allow_confirm)
+
+                # Attachment / binary route — inspect headers BEFORE the body.
+                filename = _filename_from_disposition(
+                    response.headers.get("content-disposition", "")
+                )
+                extension = _extension(filename)
+                if extension in _HTML_EXTS:
+                    raise ValidationError(
+                        "HTML isn't supported by NotebookLM upload; convert the page to "
+                        ".txt, .md, or .pdf first, then retry."
+                    )
+                if extension not in _UPLOAD_SUPPORTED_EXTS:
+                    raise ValidationError(
+                        f"Drive file {filename or file_id!r} has an unsupported type for "
+                        f"NotebookLM upload. Accepted: {_ACCEPTED_EXTS_HINT}."
+                    )
+                self._reject_oversize_header(response, file_id)
+                path = await self._stream_to_temp(response, filename, extension)
+                return DriveDownload(
+                    path=path, filename=filename, content_type=content_type or None
+                )
+
+    async def _classify_html(
+        self, response: httpx.Response, file_id: str, *, allow_confirm: bool
+    ) -> _ConfirmRedirect:
+        """Discriminate an HTML response: expired-auth / confirm page / not-downloadable."""
+        final_host = (response.url.host or "").lower()
+        if final_host == "accounts.google.com":
+            raise ValidationError(
+                "Drive authentication expired — run `notebooklm login`, then retry."
+            )
+        body = await _read_capped_text(response, _HTML_SNIFF_CAP_BYTES)
+        if allow_confirm:
+            confirm_params = _find_confirm_params(body, file_id)
+            if confirm_params is not None:
+                return _ConfirmRedirect(url=_confirm_url(confirm_params))
+        raise ValidationError(
+            f"Drive did not return downloadable bytes for {file_id}. If it's a native "
+            "Google Doc/Slides/Sheet, add it with source_add(source_type='drive', "
+            "mime_type='google-doc'|'google-slides'|'google-sheets') (or the `add-drive` "
+            "CLI); if it's a permissions/not-found issue, confirm the file is accessible "
+            "to this account."
+        )
+
+    def _reject_oversize_header(self, response: httpx.Response, file_id: str) -> None:
+        raw = response.headers.get("content-length")
+        if raw is None:
+            return
+        try:
+            declared = int(raw)
+        except ValueError:
+            return
+        if declared > self._max_bytes:
+            raise ValidationError(
+                f"Drive file {file_id} is {declared} bytes, over the "
+                f"{_MAX_DRIVE_DOWNLOAD_MIB} MiB download cap."
+            )
+
+    async def _stream_to_temp(
+        self, response: httpx.Response, filename: str, extension: str
+    ) -> Path:
+        """Stream a supported binary body to a 0600 temp file under a running cap.
+
+        The temp file keeps the source extension so ``add_file``'s content-type
+        resolution + HTML-reject gate fire. Unlinked on any failure; the caller
+        unlinks it after the upload on success.
+        """
+        suffix = f".{extension}" if extension else ""
+        fd, temp_name = tempfile.mkstemp(prefix="nlm-drive-", suffix=suffix)
+        os.close(fd)  # mkstemp already created it 0600
+        temp_path = Path(temp_name)
+        total = 0
+        try:
+            with open(temp_path, "wb") as handle:
+                async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+                    total += len(chunk)
+                    if total > self._max_bytes:
+                        raise ValidationError(
+                            f"Drive download exceeded the {_MAX_DRIVE_DOWNLOAD_MIB} MiB cap "
+                            f"for {filename or 'the file'}."
+                        )
+                    handle.write(chunk)
+            if total == 0:
+                raise ValidationError(
+                    "Drive returned 0 bytes — the file may be empty or inaccessible."
+                )
+            return temp_path
+        except BaseException:
+            temp_path.unlink(missing_ok=True)
+            raise
+
+
+class DriveImportService:
+    """Route a Drive file id/URL: download the upload-only types, then upload.
+
+    All I/O is behind the injected ``fetch`` + ``add_file`` seams; this class
+    owns only the id parse, the pre-upload HTML second-defense, and the
+    guaranteed temp-file cleanup.
+    """
+
+    def __init__(self, *, fetch: DriveFetch, add_file: AddFile) -> None:
+        self._fetch = fetch
+        self._add_file = add_file
+
+    async def add_drive_file(
+        self,
+        notebook_id: str,
+        id_or_url: str,
+        *,
+        title: str | None = None,
+        wait: bool = False,
+        wait_timeout: float = 120.0,
+    ) -> Source:
+        file_id = extract_drive_file_id(id_or_url)
+        download = await self._fetch(file_id)
+        try:
+            # Second defense: even if the fetch mislabeled the type, an HTML file
+            # (by extension or content-type) is rejected before it reaches upload.
+            _validate_upload_file_supported(download.path, download.content_type or "")
+            return await self._add_file(
+                notebook_id,
+                download.path,
+                title=title if title else (download.filename or None),
+                wait=wait,
+                wait_timeout=wait_timeout,
+            )
+        finally:
+            # Temp file unlinked on every exit path (success, upload failure,
+            # cancellation) — the upload ran inside this guard.
+            download.path.unlink(missing_ok=True)

--- a/src/notebooklm/_source/drive_import.py
+++ b/src/notebooklm/_source/drive_import.py
@@ -195,9 +195,11 @@ class DriveRef:
 def parse_drive_ref(id_or_url: str) -> DriveRef:
     """Parse a raw Drive file id or a Drive share URL into a :class:`DriveRef`.
 
-    Accepts a raw id, or a ``https://…`` URL of the ``/d/<id>``,
-    ``/file/d/<id>/…``, or ``?id=<id>`` shapes, preserving a ``resourcekey``
-    query param when present. Rejects anything that does not yield a valid id.
+    Accepts a raw id, or a ``https://…`` URL (on a Google host) of the ``/d/<id>``,
+    ``/file/d/<id>/…``, or ``?id=<id>`` shapes, preserving a ``resourcekey`` query
+    param when present. A URL on a NON-Google host is rejected — an id-shaped path
+    segment under ``evil.example`` is not a Drive reference. Rejects anything that
+    does not yield a valid id.
     """
     candidate = (id_or_url or "").strip()
     if not candidate:
@@ -206,7 +208,10 @@ def parse_drive_ref(id_or_url: str) -> DriveRef:
         return DriveRef(file_id=candidate)
 
     parsed = urlparse(candidate)
-    if parsed.scheme in ("http", "https"):
+    # Only extract from a URL that is actually a Google host (reuses the download
+    # trusted-host allowlist: *.google.com / *.googleusercontent.com / …); a bare
+    # id with no scheme/host stays accepted via the fullmatch above.
+    if parsed.scheme in ("http", "https") and _is_trusted_download_host(parsed.hostname):
         query = parse_qs(parsed.query)
         resource_key = next((v for v in query.get("resourcekey", []) if v), None)
         for value in query.get("id", []):

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -92,10 +92,9 @@ if TYPE_CHECKING:
 class AuthMetadata(Protocol):
     """Selected-account routing metadata required by upload flows.
 
-    Inlined from ``_runtime.contracts`` in issue #1327: the upload
-    pipeline is the only consumer, so this single-consumer Protocol lives
-    local to its owner per the ADR-0013 ≥2-feature promotion bar.
-    ``AuthTokens`` structurally satisfies it.
+    Inlined from ``_runtime.contracts`` (#1327): the upload pipeline is the only
+    consumer, so this single-consumer Protocol lives local to its owner (ADR-0013
+    ≥2-feature promotion bar). ``AuthTokens`` structurally satisfies it.
     """
 
     @property
@@ -244,8 +243,7 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         self._async_client_factory = async_client_factory
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
-        # Bounds concurrent Drive auto-route downloads (#1884); loop-bound like the
-        # upload semaphore (reset on rebind / reopen).
+        # Bounds concurrent Drive auto-route downloads (#1884); loop-bound.
         self._download_semaphore: asyncio.Semaphore | None = None
         # ``_bound_loop`` + ``set_bound_loop`` come from the
         # :class:`~notebooklm._loop_bound.LoopBoundPrimitive` base; this pipeline
@@ -352,9 +350,8 @@ class SourceUploadPipeline(LoopBoundPrimitive):
     def get_upload_semaphore(self) -> asyncio.Semaphore:
         """Return the Sources-owned upload semaphore, creating it on first use.
 
-        Caps the section that opens the source FD, registers the source, starts
-        the resumable upload, and streams the body. Lazy construction keeps the
-        pipeline usable outside a running event loop.
+        Caps the FD-open + register + resumable-upload + body-stream section. Lazy
+        construction keeps the pipeline usable outside a running event loop.
         """
         if self._upload_semaphore is None:
             self._upload_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
@@ -363,9 +360,12 @@ class SourceUploadPipeline(LoopBoundPrimitive):
     def get_download_semaphore(self) -> asyncio.Semaphore:
         """Return the Drive auto-route download semaphore (#1884), lazily built.
 
-        A SEPARATE pool from the upload semaphore — gating the whole
-        download→upload op can't deadlock against ``add_file``'s own upload slot.
+        A SEPARATE pool from the upload semaphore (gating the whole download→upload
+        op can't deadlock against ``add_file``'s own slot). Asserts loop ownership
+        FIRST (the download seam, as ``add_file`` is the upload seam) so a
+        cross-loop ``add_drive_file`` fails before it touches this primitive (#1196).
         """
+        self._lifecycle.assert_bound_loop()
         if self._download_semaphore is None:
             self._download_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
         return self._download_semaphore

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -313,6 +313,16 @@ class SourceUploadPipeline(LoopBoundPrimitive):
             return httpx.Cookies()
         return cast(httpx.Cookies, cookies)
 
+    def live_cookies(self) -> httpx.Cookies:
+        """Public accessor for the freshest live cookie jar (post-rotation, #1884).
+
+        Exposes :meth:`_live_cookies` so ``SourcesAPI.add_drive_file`` can
+        authenticate a SERVER-SIDE Drive download with the SAME ``.google.com``
+        master jar the upload leg uses (kept fresh by keepalive rotation, unlike
+        the on-disk cookies) — without reaching a private method across the seam.
+        """
+        return self._live_cookies()
+
     def _on_loop_rebind(
         self,
         old: asyncio.AbstractEventLoop | None,
@@ -322,32 +332,22 @@ class SourceUploadPipeline(LoopBoundPrimitive):
 
         Fires from :meth:`~notebooklm._loop_bound.LoopBoundPrimitive.set_bound_loop`
         only on a real loop change (and before ``_bound_loop`` is updated), so a
-        stale semaphore bound to the old loop is never reused after a rebind.
-        ``set_bound_loop`` is thus self-consistent even when called outside the
-        ``open()`` path; production also calls :meth:`reset_after_open` right
-        after, making the discard idempotent there. This hook only governs the
-        semaphore *rebuild*; cross-loop *use* is rejected by the lifecycle's
-        ``assert_bound_loop`` at the top of :meth:`add_file`.
+        stale semaphore bound to the old loop is never reused after a rebind
+        (production also calls :meth:`reset_after_open` right after, making the
+        discard idempotent). This hook only governs the semaphore *rebuild*;
+        cross-loop *use* is rejected by the lifecycle's ``assert_bound_loop``.
         """
         self._upload_semaphore = None
 
     def reset_after_open(self) -> None:
         """Discard the lazy upload semaphore so a reopened client rebinds it.
 
-        Called from :meth:`ClientLifecycle.open` (alongside the
-        per-collaborator ``set_bound_loop`` propagation) so a client that was
-        closed and reopened on a *different* event loop builds a fresh
-        ``asyncio.Semaphore`` on the new loop instead of reusing the stale one
-        bound to the old (now-dead) loop. On Python 3.10/3.11 reusing the
-        stale semaphore can raise "bound to a different event loop" or mispark
-        waiters; on 3.12+ the breakage is largely masked, but resetting keeps
-        the behaviour consistent across versions.
-
-        Mirrors :meth:`notebooklm._client_composed.ClientComposed.reset_after_open`.
-        Deliberately narrow: dropping the reference is enough because the
-        semaphore is reconstructed lazily on the next
-        :meth:`get_upload_semaphore` call from inside the new loop.
-        ``max_concurrent_uploads`` is left untouched.
+        Called from :meth:`ClientLifecycle.open` so a client closed and reopened
+        on a *different* event loop builds a fresh ``asyncio.Semaphore`` on the new
+        loop instead of reusing the stale one bound to the old (now-dead) loop
+        (which on 3.10/3.11 can raise "bound to a different event loop" or mispark
+        waiters). Mirrors ``ClientComposed.reset_after_open``; the semaphore is
+        rebuilt lazily on the next :meth:`get_upload_semaphore` call.
         """
         self._upload_semaphore = None
 

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -108,13 +108,11 @@ class AuthMetadata(Protocol):
 class RpcCallback(Protocol):
     """RPC callback shape used by upload registration.
 
-    Structurally distinct from :class:`notebooklm._runtime.contracts.RpcCaller`:
-    this is a **callable** Protocol (``async def __call__(...)``) passed as a
-    keyword argument into :meth:`SourceUploadPipeline.register_file_source`,
-    while the shared ``RpcCaller`` is an **object** Protocol with an
-    ``.rpc_call(...)`` method. They are NOT interchangeable — the local
-    callable form is kept as a structural Protocol (not a ``Callable[...]``
-    alias) so mypy can flag keyword-name typos at call sites.
+    A **callable** Protocol (``async def __call__(...)``) passed as a keyword arg
+    into :meth:`SourceUploadPipeline.register_file_source` — distinct from the
+    shared **object** Protocol ``RpcCaller`` (``.rpc_call(...)``); kept as a
+    structural Protocol (not a ``Callable[...]`` alias) so mypy flags keyword-name
+    typos at call sites.
     """
 
     async def __call__(
@@ -246,6 +244,9 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         self._async_client_factory = async_client_factory
         self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
         self._upload_semaphore: asyncio.Semaphore | None = None
+        # Bounds concurrent Drive auto-route downloads (#1884); loop-bound like the
+        # upload semaphore (reset on rebind / reopen).
+        self._download_semaphore: asyncio.Semaphore | None = None
         # ``_bound_loop`` + ``set_bound_loop`` come from the
         # :class:`~notebooklm._loop_bound.LoopBoundPrimitive` base; this pipeline
         # overrides :meth:`_on_loop_rebind` to discard the cached
@@ -270,14 +271,10 @@ class SourceUploadPipeline(LoopBoundPrimitive):
     ) -> None:
         """Adopt ``SourcesAPI``'s shared lister/poller as the single owner.
 
-        Called from ``SourcesAPI.__init__``
-        (alongside :meth:`configure_source_limit_lookup`) so the pipeline's
-        source-lifecycle verbs (``list_sources`` / ``get_source`` /
-        ``wait_until_ready`` / ``wait_until_registered``) delegate to the
-        SAME ``SourceLister`` / ``SourcePoller`` instances the public
-        ``SourcesAPI`` uses, instead of parallel copies built in the
-        pipeline constructor. Direct callers that never run through
-        ``SourcesAPI`` keep the freshly-constructed defaults.
+        Called from ``SourcesAPI.__init__`` so the pipeline's source-lifecycle
+        verbs delegate to the SAME ``SourceLister`` / ``SourcePoller`` instances
+        the public ``SourcesAPI`` uses, not parallel copies. Direct callers that
+        never run through ``SourcesAPI`` keep the freshly-constructed defaults.
         """
         self._lister = lister
         self._poller = poller
@@ -328,16 +325,16 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         old: asyncio.AbstractEventLoop | None,
         new: asyncio.AbstractEventLoop | None,
     ) -> None:
-        """Discard the cached upload semaphore when the bound loop changes.
+        """Discard the cached upload/download semaphores when the bound loop changes.
 
         Fires from :meth:`~notebooklm._loop_bound.LoopBoundPrimitive.set_bound_loop`
-        only on a real loop change (and before ``_bound_loop`` is updated), so a
-        stale semaphore bound to the old loop is never reused after a rebind
-        (production also calls :meth:`reset_after_open` right after, making the
-        discard idempotent). This hook only governs the semaphore *rebuild*;
-        cross-loop *use* is rejected by the lifecycle's ``assert_bound_loop``.
+        only on a real loop change, so a stale semaphore bound to the old loop is
+        never reused after a rebind (production also calls :meth:`reset_after_open`
+        right after, making the discard idempotent). Cross-loop *use* is rejected
+        by the lifecycle's ``assert_bound_loop``.
         """
         self._upload_semaphore = None
+        self._download_semaphore = None
 
     def reset_after_open(self) -> None:
         """Discard the lazy upload semaphore so a reopened client rebinds it.
@@ -350,19 +347,32 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         rebuilt lazily on the next :meth:`get_upload_semaphore` call.
         """
         self._upload_semaphore = None
+        self._download_semaphore = None
 
     def get_upload_semaphore(self) -> asyncio.Semaphore:
         """Return the Sources-owned upload semaphore, creating it on first use.
 
-        The semaphore caps the section that opens the source FD, registers the
-        source, starts the resumable upload, and streams the body. Lazy
-        construction keeps ``SourceUploadPipeline`` usable outside a running
-        event loop. On post-finalize cancellation, the shielded finalize task
-        may briefly keep an FD open after ``add_file`` exits the semaphore.
+        Caps the section that opens the source FD, registers the source, starts
+        the resumable upload, and streams the body. Lazy construction keeps the
+        pipeline usable outside a running event loop.
         """
         if self._upload_semaphore is None:
             self._upload_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
         return self._upload_semaphore
+
+    def get_download_semaphore(self) -> asyncio.Semaphore:
+        """Return the Drive auto-route download semaphore (#1884), lazily built.
+
+        A SEPARATE pool from the upload semaphore — gating the whole
+        download→upload op can't deadlock against ``add_file``'s own upload slot.
+        """
+        if self._download_semaphore is None:
+            self._download_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
+        return self._download_semaphore
+
+    def authuser_value(self) -> str:
+        """Account-routing value for Google URLs (#1884), matching the upload leg."""
+        return format_authuser_value(self._auth.authuser, self._auth.account_email)
 
     async def add_file(
         self,
@@ -513,21 +523,13 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         """Register a file source intent and get SOURCE_ID.
 
         Uses the same probe-then-create idempotency pattern as ``add_url`` /
-        ``add_drive``. The ADD_SOURCE_FILE RPC is mutating: a
-        5xx / network failure between server-side commit and client-side
-        response could otherwise duplicate the source on a naive retry.
-
-        Probe semantics: unlike ``add_url`` (where URL equality is a stable
-        dedupe key) or ``add_drive`` (where the Drive file_id is unique
-        server-side), filenames are NOT identity-bearing — two distinct
-        uploads of ``report.pdf`` are legitimately two separate sources.
-        To avoid mis-matching a pre-existing source from an earlier upload,
-        the probe captures a baseline of source IDs *before* the first
-        create attempt and filters probe matches to IDs that are NOT in
-        the baseline (the "new since the create started" set). An
-        ambiguous match (>1 new source with the same filename, e.g. a
-        concurrent uploader added one) raises ``SourceAddError`` rather
-        than guessing.
+        ``add_drive`` (the ADD_SOURCE_FILE RPC is mutating, so a 5xx/network
+        failure between commit and response could duplicate on a naive retry).
+        Because filenames are NOT identity-bearing (two uploads of ``report.pdf``
+        are legitimately distinct), the probe captures a baseline of source IDs
+        BEFORE the first create and only matches IDs new since then; an ambiguous
+        match (>1 new source, e.g. a concurrent uploader) raises ``SourceAddError``
+        rather than guessing.
         """
         params = build_register_file_source_params(filename, notebook_id)
         if rpc_call is None:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -608,12 +608,20 @@ class SourcesAPI:
                 (HTML/other), or a native (non-downloadable) Google Doc/Slides/Sheet.
         """
         service = DriveImportService(
-            fetch=DriveFetcher(cookies_provider=self._uploader.live_cookies),
+            fetch=DriveFetcher(
+                cookies_provider=self._uploader.live_cookies,
+                authuser=self._uploader.authuser_value(),
+            ),
             add_file=self.add_file,
         )
-        return await service.add_drive_file(
-            notebook_id, document_id, title=title, wait=wait, wait_timeout=wait_timeout
-        )
+        # Gate the whole download→upload op on a DEDICATED download semaphore (not
+        # the upload one — ``add_file`` needs that, so reusing it would deadlock) so
+        # concurrent remote-MCP calls can't each buffer a 200 MiB temp and exhaust
+        # disk; at most ``max_concurrent_uploads`` temps exist at once.
+        async with self._uploader.get_download_semaphore():
+            return await service.add_drive_file(
+                notebook_id, document_id, title=title, wait=wait, wait_timeout=wait_timeout
+            )
 
     async def delete(self, notebook_id: str, source_id: str) -> None:
         """Delete a source from a notebook.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -19,6 +19,7 @@ from ._settings import build_get_user_settings_params, extract_account_limits
 from ._source import upload as _source_upload
 from ._source.add import SourceAddService
 from ._source.content import SourceContentRenderer
+from ._source.drive_import import DriveFetcher, DriveImportService
 from ._source.listing import SourceLister
 from ._source.polling import SourcePoller, SourceWaitResult
 from ._source.upload import SourceUploadPipeline
@@ -575,6 +576,45 @@ class SourcesAPI:
             logger=logger,
         )
 
+    async def add_drive_file(
+        self,
+        notebook_id: str,
+        document_id: str,
+        *,
+        title: str | None = None,
+        wait: bool = False,
+        wait_timeout: float = 120.0,
+    ) -> Source:
+        """Auto-route an upload-only Google Drive file: download it, then upload (#1884).
+
+        Covers the Drive file types NotebookLM's native import (:meth:`add_drive`)
+        can't ingest (epub/docx/txt/md/rtf/odt/csv/tsv/pdf): fetches the file
+        SERVER-SIDE using the same live ``.google.com`` cookie jar the upload leg
+        uses (so it works in stdio AND remote MCP mode with no ``upload_required``
+        detour), then streams it through :meth:`add_file`. Native Docs/Slides/
+        Sheets are out of scope (not downloadable) — they raise a
+        :class:`~notebooklm.exceptions.ValidationError` pointing at :meth:`add_drive`.
+
+        Args:
+            notebook_id: The notebook ID.
+            document_id: A raw Drive file id or a Drive share URL (``/d/<id>``,
+                ``/file/d/<id>/…``, or ``?id=<id>``).
+            title: Optional display title; defaults to the file's Drive name.
+            wait: If True, wait for the source to be ready before returning.
+            wait_timeout: Maximum seconds to wait if ``wait=True`` (default: 120).
+
+        Raises:
+            ValidationError: unparseable id/URL, an upload-unsupported type
+                (HTML/other), or a native (non-downloadable) Google Doc/Slides/Sheet.
+        """
+        service = DriveImportService(
+            fetch=DriveFetcher(cookies_provider=self._uploader.live_cookies),
+            add_file=self.add_file,
+        )
+        return await service.add_drive_file(
+            notebook_id, document_id, title=title, wait=wait, wait_timeout=wait_timeout
+        )
+
     async def delete(self, notebook_id: str, source_id: str) -> None:
         """Delete a source from a notebook.
 
@@ -902,60 +942,22 @@ class SourcesAPI:
     ) -> None:
         """Stream upload file content to the resumable upload URL.
 
-        Uses streaming to avoid loading the entire file into memory,
-        which is important for large PDFs and documents.
-
-        File-descriptor contract:
-          When called from ``add_file`` (the production path), ``file_obj``
-          is an already-open ``IO[bytes]`` and this helper TAKES OWNERSHIP
-          of the FD lifecycle: a done-callback on the shielded finalize
-          task closes the FD when streaming completes — success, error,
-          OR after the post-finalize background-drain branch from the
-          cancellation contract below. Ownership transfer is required
-          because the shielded background task may outlive the caller's
-          ``add_file`` invocation under post-finalize cancel; if the
-          caller closed the FD on cancel, the still-running background
-          POST would read from a closed FD and abort, breaking the
-          dangling-session guarantee.
-
-          A legacy ``Path`` argument is still accepted; the helper opens
-          + closes the FD itself in that branch. ``add_file`` never
-          takes that path — the Path branch exists only for the
-          existing direct-call unit tests in
-          ``tests/unit/test_sources_upload.py``.
-
-        Cancellation contract:
-          - The finalize POST is wrapped in ``asyncio.shield``. If a
-            ``CancelledError`` arrives while the finalize POST is in
-            flight, the inner Task keeps running so the server-side
-            session reaches a known terminal state instead of dangling.
-            The cancel is then re-raised to the caller.
-          - If the cancel arrives BEFORE the finalize POST is dispatched
-            (e.g. while the local ``httpx.AsyncClient`` is being
-            constructed), a best-effort ``X-Goog-Upload-Command: cancel``
-            POST is fired against the same resumable upload URL via
-            ``asyncio.create_task``. The cleanup task is not awaited —
-            re-raising must not block on best-effort cleanup. The cleanup
-            runs on a detached task with no outer await chain, so a
-            caller-level cancel cannot reach it; no explicit shield is
-            needed at that layer (see ``_cancel_upload_session`` docstring).
+        Thin delegator to :meth:`SourceUploadPipeline.upload_file_streaming`,
+        which owns and documents the full contract: memory-safe streaming, the
+        file-descriptor ownership transfer under the shielded finalize task, and
+        the two-branch cancellation handling (in-flight finalize shielded +
+        re-raised; pre-dispatch cancel fires a best-effort Scotty cancel POST).
+        The legacy ``Path`` ``file_obj`` branch exists only for the direct-call
+        unit tests in ``tests/unit/test_sources_upload.py``.
 
         Args:
-            upload_url: The resumable upload URL from _start_resumable_upload.
-            file_obj: An open binary file object positioned at the bytes to
-                upload, or (legacy) a ``Path`` the helper will open itself.
-                When ``add_file`` is the caller, this is always the open
-                FD and OWNERSHIP TRANSFERS to this helper (see
-                file-descriptor contract above). Passing a ``Path`` is
-                only supported for direct unit tests that bypass
-                ``add_file``.
-            filename: Optional filename used for diagnostic logging.
-                Defaults to ``"<file>"`` when not supplied.
-            on_progress: Optional sync or async callback invoked as
-                ``on_progress(bytes_sent, total_bytes)`` as chunks are yielded.
-            total_bytes: Total bytes expected. Required for the add_file FD
-                path; inferred from the path for legacy direct-call tests when
-                omitted.
+            upload_url: The resumable upload URL from ``_start_resumable_upload``.
+            file_obj: An open binary file object (ownership transfers to the
+                pipeline) positioned at the bytes to upload, or a legacy ``Path``.
+            filename: Optional filename for diagnostic logging.
+            on_progress: Optional ``on_progress(bytes_sent, total_bytes)`` callback.
+            total_bytes: Total bytes expected (required for the FD path; inferred
+                from the path for legacy direct-call tests).
         """
         return await self._uploader.upload_file_streaming(
             upload_url,

--- a/src/notebooklm/cli/_source_render.py
+++ b/src/notebooklm/cli/_source_render.py
@@ -43,6 +43,7 @@ from .rendering import (
     json_output_response,
 )
 from .services.source_mutations import (
+    SourceAddDriveFileResult,
     SourceAddDriveResult,
     SourceDeleteByTitleResult,
     SourceDeleteResult,
@@ -567,6 +568,30 @@ def _render_source_add_drive_result(
         return
 
     cli_print(f"[green]Added Drive source:[/green] {result.source.id}", ctx=ctx)
+    cli_print(f"[bold]Title:[/bold] {result.source.title}", ctx=ctx)
+
+
+def _render_source_add_drive_file_result(
+    result: SourceAddDriveFileResult,
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
+    if json_output:
+        # Mirrors the add-drive envelope: the ``source_summary_payload`` serializer
+        # is presentation, so the envelope is built here rather than on the neutral
+        # result. ``document_id`` echoes the raw id/URL the caller passed.
+        json_output_response(
+            {
+                "action": "add-drive-file",
+                "source": source_summary_payload(result.source),
+                "document_id": result.document_id,
+                "notebook_id": result.notebook_id,
+            }
+        )
+        return
+
+    cli_print(f"[green]Added Drive file source:[/green] {result.source.id}", ctx=ctx)
     cli_print(f"[bold]Title:[/bold] {result.source.title}", ctx=ctx)
 
 

--- a/src/notebooklm/cli/services/source_mutations.py
+++ b/src/notebooklm/cli/services/source_mutations.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 
 from ..._app.source_mutations import (
     DriveMimeChoice,
+    SourceAddDriveFilePlan,
+    SourceAddDriveFileResult,
     SourceAddDrivePlan,
     SourceAddDriveResult,
     SourceDeleteByTitlePlan,
@@ -40,6 +42,7 @@ from ..._app.source_mutations import (
     SourceRenameResult,
     build_id_ambiguity_error,
     execute_source_add_drive,
+    execute_source_add_drive_file,
     looks_like_full_source_id,
     require_yes_in_json,
 )
@@ -128,6 +131,8 @@ async def execute_source_refresh(
 
 __all__ = [
     "DriveMimeChoice",
+    "SourceAddDriveFilePlan",
+    "SourceAddDriveFileResult",
     "SourceAddDrivePlan",
     "SourceAddDriveResult",
     "SourceDeleteByTitlePlan",
@@ -142,6 +147,7 @@ __all__ = [
     "SourceRenameResult",
     "build_id_ambiguity_error",
     "execute_source_add_drive",
+    "execute_source_add_drive_file",
     "execute_source_delete",
     "execute_source_delete_by_title",
     "execute_source_refresh",

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -1,21 +1,11 @@
 """Source management CLI commands — thin Click-handler layer (ADR-0008).
 
-Each command builds a plan or command-layer input values and delegates to
-transport-neutral ``_app/source_*`` cores, with CLI service adapters kept
-where they provide presentation-pipeline glue or compatibility imports:
-
-* ``_app/source_content.py``       — data fetchers for get, fulltext, guide, stale
-* ``_app/source_wait.py``          — wait
-* ``_app/source_add.py``           — add
-* ``_app/source_clean.py``         — clean (pure orchestration: classify +
-  batched delete; rendering + exit codes live here in the command layer)
-* ``_app/source_listing.py`` via ``services/source_listing.py`` — list
-* ``_app/source_mutations.py`` via ``services/source_mutations.py`` — delete, delete-by-title, rename,
-  refresh, add-drive
-* ``_app/source_research.py`` via ``services/source_research.py`` — add-research
-
-The full per-command listing lives in the ``source`` click group docstring
-below (it is what ``notebooklm source --help`` shows).
+Each command builds a plan (or command-layer inputs) and delegates to the
+transport-neutral ``_app/source_*`` cores — ``source_content`` / ``source_wait``
+/ ``source_add`` / ``source_clean`` directly, and ``source_listing`` /
+``source_mutations`` (delete/delete-by-title/rename/refresh/add-drive/
+add-drive-file) / ``source_research`` via their ``services/`` adapters. The full
+per-command listing is the ``source`` click group docstring below.
 """
 
 import asyncio  # noqa: F401 — re-exported for regression tests that patch source_cmd.asyncio.sleep
@@ -62,6 +52,7 @@ from ._source_render import (  # noqa: F401
     _print_add_research_task_ids,
     _print_clean_candidates,
     _render_add_research_result,
+    _render_source_add_drive_file_result,
     _render_source_add_drive_result,
     _render_source_delete_result,
     _render_source_fulltext_result,
@@ -99,6 +90,7 @@ from .runtime import is_quiet
 from .services.label_listing import LabelResolutionError
 from .services.source_listing import SourceListPlan, execute_source_list
 from .services.source_mutations import (
+    SourceAddDriveFilePlan,
     SourceAddDrivePlan,
     SourceDeleteByTitlePlan,
     SourceDeletePlan,
@@ -106,6 +98,7 @@ from .services.source_mutations import (
     SourceRefreshPlan,
     SourceRenamePlan,
     execute_source_add_drive,
+    execute_source_add_drive_file,
     execute_source_delete,
     execute_source_delete_by_title,
     execute_source_refresh,
@@ -127,7 +120,8 @@ def source():
     Commands:
       list             List sources in a notebook
       add              Add a source (url, text, file, youtube)
-      add-drive        Add a Google Drive document
+      add-drive        Add a Google Drive document (native Docs/Slides/Sheets + PDF)
+      add-drive-file   Add an upload-only Drive file (epub/docx/txt/...) via download
       add-research     Search web/drive and add sources from results
       get              Get source details
       fulltext         Get full indexed text content
@@ -210,9 +204,8 @@ def source_list(ctx, notebook_id, json_output, label_filter, limit, no_truncate,
     help="MIME type for uploaded file sources. Overrides filename-extension inference.",
 )
 @click.option(
-    # ``--request-timeout`` is the self-documenting canonical name (per-request
-    # HTTP socket timeout, not a poll/wait budget); ``--timeout`` stays as a
-    # back-compat alias. See the matching wiring on ``chat ask``.
+    # ``--request-timeout`` is the canonical name (per-request HTTP socket
+    # timeout, not a poll/wait budget); ``--timeout`` is a back-compat alias.
     "--request-timeout",
     "--timeout",
     "timeout",
@@ -523,6 +516,38 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
     return _run()
 
 
+@source.command("add-drive-file")
+@click.argument("document_id")
+@notebook_option
+@click.option("--title", default=None, help="Custom title (default: the file's Drive name)")
+@click.option("--wait", is_flag=True, default=False, help="Wait for processing to finish")
+@json_option
+@with_client
+def source_add_drive_file(ctx, document_id, notebook_id, title, wait, json_output, client_auth):
+    """Add an upload-only Google Drive file (epub/docx/txt/md/rtf/odt/csv/tsv/pdf).
+
+    Downloads the file from Drive (server-side, using your session) and uploads it
+    — for the types NotebookLM's native Drive import can't ingest. DOCUMENT_ID is a
+    raw file id or share URL; use `source add-drive` for native Docs/Slides/Sheets.
+    """
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with resolve_client_factory(ctx)(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            plan = SourceAddDriveFilePlan(
+                notebook_id=nb_id_resolved, document_id=document_id, title=title, wait=wait
+            )
+            if json_output:
+                result = await execute_source_add_drive_file(client, plan)
+            else:
+                with cli_status("Downloading + adding Drive file...", ctx=ctx):
+                    result = await execute_source_add_drive_file(client, plan)
+            _render_source_add_drive_file_result(result, json_output=json_output, ctx=ctx)
+
+    return _run()
+
+
 @source.command("add-research")
 @click.argument("query", default="", required=False)
 @prompt_file_option
@@ -751,16 +776,12 @@ def source_guide(ctx, source_id, notebook_id, json_output, client_auth):
 def source_stale(ctx, source_id, notebook_id, exit_on_stale, json_output, client_auth):
     """Check if a URL/Drive source needs refresh.
 
-    Default exit codes follow the standard CLI convention: ``0`` when the
-    freshness check completes (regardless of the result), ``1`` on error
-    (validation, auth, network, not-found, etc.). Branch on the JSON
-    ``stale`` field (or stdout text) to decide whether to refresh.
-
-    Pass ``--exit-on-stale`` to opt into the back-compat inverted-predicate
-    semantics — exit ``0`` if stale, ``1`` if fresh — so the shell idiom
-    ``if notebooklm source stale --exit-on-stale ID; then refresh; fi``
-    keeps working for scripts written against the prior default. See
-    ``docs/cli-exit-codes.md`` for the full rationale.
+    Default exit codes: ``0`` when the freshness check completes (whatever the
+    result), ``1`` on error. Branch on the JSON ``stale`` field (or stdout text)
+    to decide whether to refresh. Pass ``--exit-on-stale`` for the back-compat
+    inverted-predicate semantics (exit ``0`` if stale, ``1`` if fresh) so the
+    idiom ``if notebooklm source stale --exit-on-stale ID; then refresh; fi``
+    keeps working. See ``docs/cli-exit-codes.md`` for the full rationale.
     """
     nb_id = require_notebook(notebook_id)
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -62,9 +62,29 @@ def register_all(mcp: FastMCP) -> None:
     domains; Phase 2b added the artifacts/research/meta domains; the sharing
     domain followed.
     """
-    from .tools import chat, meta, notebooks, notes, research, sharing, sources, studio
+    from .tools import (
+        chat,
+        meta,
+        notebooks,
+        notes,
+        research,
+        sharing,
+        sources,
+        sources_drive,
+        studio,
+    )
 
-    for module in (notebooks, sources, chat, notes, studio, research, sharing, meta):
+    for module in (
+        notebooks,
+        sources,
+        sources_drive,
+        chat,
+        notes,
+        studio,
+        research,
+        sharing,
+        meta,
+    ):
         module.register(mcp)
 
 

--- a/src/notebooklm/mcp/tools/sources_drive.py
+++ b/src/notebooklm/mcp/tools/sources_drive.py
@@ -1,0 +1,73 @@
+"""The ``source_add_drive_file`` MCP tool (auto-route add-from-Drive, #1884).
+
+A discrete verb, deliberately NOT folded into ``source_add(source_type="drive")``:
+that path REQUIRES an explicit ``mime_type`` and only ingests Google-native
+Docs/Slides/Sheets + PDF by reference (#1827), whereas this tool downloads the
+upload-only Drive types (epub/docx/txt/md/rtf/odt/csv/tsv/pdf) server-side and
+uploads them. Kept in its own module (with its own ``register``) so the ceiling'd
+``mcp/tools/sources.py`` doesn't grow (ADR-0025 discrete-verb rationale).
+
+The fetch runs server-side with the profile's live cookies, so — unlike a
+``source_add(source_type="file")`` on a remote (http) connector — it never emits
+``upload_required``: a Drive source has no client-side bytes.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from ..._app import source_mutations as mut_core
+from ..._app.serialize import to_jsonable
+from ..._app.views import source_view as _source_view
+from .._context import get_client
+from .._errors import mcp_errors
+from .._resolve import resolve_notebook
+
+
+def register(mcp: Any) -> None:
+    """Register the ``source_add_drive_file`` tool on ``mcp``."""
+
+    @mcp.tool
+    async def source_add_drive_file(
+        ctx: Context,
+        notebook: str,
+        document_id: str,
+        title: str | None = None,
+        wait: bool = False,
+    ) -> dict[str, Any]:
+        """Add an upload-only Google Drive file (epub/docx/txt/md/rtf/odt/csv/tsv/pdf).
+
+        Use this for the Drive file types NotebookLM's native Drive import can't
+        ingest: the file is downloaded from Drive on the server and uploaded. For
+        a Google-native Doc/Slides/Sheet (imported by reference), use
+        ``source_add(source_type='drive', mime_type=…)`` instead — this tool
+        returns a pointer error for those, since they aren't downloadable.
+
+        Accepts a notebook name or ID, and a raw Drive file id or a Drive share
+        URL (``/d/<id>``, ``/file/d/<id>/…``, or ``?id=<id>``). The fetch runs
+        server-side with the profile's session, so it works over the remote (http)
+        connector too — no ``upload_required`` step. The import is processed
+        ASYNCHRONOUSLY; pass ``wait=true`` to block until it is READY (or confirm
+        later with ``source_wait`` / ``source_list(status="error")``).
+        """
+        client = get_client(ctx)
+        with mcp_errors():
+            nb_id = await resolve_notebook(client, notebook)
+            result = await mut_core.execute_source_add_drive_file(
+                client,
+                mut_core.SourceAddDriveFilePlan(
+                    notebook_id=nb_id,
+                    document_id=document_id,
+                    title=title or None,
+                    wait=wait,
+                ),
+            )
+            payload = to_jsonable(result)
+            payload["status"] = "added"
+            payload["notebook_id"] = nb_id
+            payload["source"] = _source_view(result.source)
+            return payload

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -106,6 +106,7 @@
     "source": [
       "add",
       "add-drive",
+      "add-drive-file",
       "add-research",
       "clean",
       "delete",
@@ -9469,6 +9470,7 @@
       "commands": [
         "add",
         "add-drive",
+        "add-drive-file",
         "add-research",
         "clean",
         "delete",
@@ -9738,6 +9740,94 @@
         }
       ],
       "short_help": "Add a Google Drive document as a source."
+    },
+    "source add-drive-file": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "document_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Custom title (default: the file's Drive name)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Wait for processing to finish",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Add an upload-only Google Drive file..."
     },
     "source add-research": {
       "class": "Command",

--- a/tests/unit/app/test_app_source_mutations.py
+++ b/tests/unit/app/test_app_source_mutations.py
@@ -26,6 +26,7 @@ import pytest
 
 from notebooklm._app.resolve import resolve_ref
 from notebooklm._app.source_mutations import (
+    SourceAddDriveFilePlan,
     SourceAddDrivePlan,
     SourceDeleteByTitlePlan,
     SourceDeletePlan,
@@ -34,6 +35,7 @@ from notebooklm._app.source_mutations import (
     SourceRenamePlan,
     build_id_ambiguity_error,
     execute_source_add_drive,
+    execute_source_add_drive_file,
     execute_source_delete,
     execute_source_delete_by_title,
     execute_source_refresh,
@@ -510,4 +512,45 @@ async def test_add_drive_bad_mime_raises_validation_error() -> None:
     # ...and steers upload-only Drive files (e.g. epub) to the `file` source path.
     assert "file" in msg
     assert "download" in msg.lower()
+    client.sources.add_drive.assert_not_called()
+
+
+# ===========================================================================
+# execute_source_add_drive_file — thin delegate to the public client (#1884)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_drive_file_delegates_to_public_client() -> None:
+    """The executor forwards to ``client.sources.add_drive_file`` and echoes the id."""
+    client = _client()
+    added = Source(id="src_epub", title="Book.epub")
+    client.sources.add_drive_file = AsyncMock(return_value=added)
+    plan = SourceAddDriveFilePlan(
+        notebook_id="nb_1",
+        document_id="1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD",
+        title="Book",
+        wait=True,
+        wait_timeout=90.0,
+    )
+    result = await execute_source_add_drive_file(client, plan)
+    assert result.source is added
+    assert result.notebook_id == "nb_1"
+    assert result.document_id == "1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD"
+    client.sources.add_drive_file.assert_awaited_once_with(
+        "nb_1",
+        "1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD",
+        title="Book",
+        wait=True,
+        wait_timeout=90.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_drive_file_uses_only_the_public_surface() -> None:
+    """The executor never touches the native ``add_drive`` RPC (auto-route ≠ native)."""
+    client = _client()
+    client.sources.add_drive_file = AsyncMock(return_value=Source(id="s", title="t"))
+    plan = SourceAddDriveFilePlan(notebook_id="nb_1", document_id="a" * 33)
+    await execute_source_add_drive_file(client, plan)
     client.sources.add_drive.assert_not_called()

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 import notebooklm.auth as auth_module
 from notebooklm.cli import helpers as helpers_module
+from notebooklm.exceptions import ValidationError
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import (
     Source,
@@ -1135,6 +1136,83 @@ class TestSourceAddDrive:
                 f"Drive --mime-type={choice} unexpectedly triggered the "
                 f"file-source deprecation notice"
             )
+
+
+class TestSourceAddDriveFile:
+    """The ``source add-drive-file`` command (#1884) — auto-route upload-only types."""
+
+    def test_happy_path_text(self, runner, mock_auth):
+        mock_client = create_mock_client()
+        mock_client.sources.add_drive_file = AsyncMock(
+            return_value=Source(id="src_epub", title="Book.epub", _type_code=17)
+        )
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "add-drive-file", "drive_epub_id", "-n", "nb_123"],
+                obj=inject_client(mock_client),
+            )
+        assert result.exit_code == 0, result.output
+        assert "Added Drive file source" in result.output
+        mock_client.sources.add_drive_file.assert_awaited_once_with(
+            "nb_123", "drive_epub_id", title=None, wait=False, wait_timeout=120.0
+        )
+
+    def test_json_envelope(self, runner, mock_auth):
+        mock_client = create_mock_client()
+        mock_client.sources.add_drive_file = AsyncMock(
+            return_value=Source(id="src_epub", title="Book.epub", _type_code=17)
+        )
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "add-drive-file",
+                    "drive_epub_id",
+                    "--title",
+                    "My Book",
+                    "-n",
+                    "nb_123",
+                    "--json",
+                ],
+                obj=inject_client(mock_client),
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["action"] == "add-drive-file"
+        assert data["source"]["id"] == "src_epub"
+        assert data["source"]["type"] == "epub"
+        assert data["document_id"] == "drive_epub_id"
+        assert data["notebook_id"] == "nb_123"
+        mock_client.sources.add_drive_file.assert_awaited_once_with(
+            "nb_123", "drive_epub_id", title="My Book", wait=False, wait_timeout=120.0
+        )
+
+    def test_unsupported_type_error_exits_nonzero(self, runner, mock_auth):
+        mock_client = create_mock_client()
+        mock_client.sources.add_drive_file = AsyncMock(
+            side_effect=ValidationError(
+                "HTML isn't supported by NotebookLM upload; convert to .txt/.md/.pdf first."
+            )
+        )
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "add-drive-file", "drive_html_id", "-n", "nb_123"],
+                obj=inject_client(mock_client),
+            )
+        assert result.exit_code != 0
+        assert "HTML" in result.output or "html" in result.output
 
 
 # =============================================================================

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -33,7 +33,7 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "notebook_describe",
         "notebook_rename",
         "notebook_delete",
-        # Sources (8)
+        # Sources (9)
         "source_list",
         "source_read",
         "source_rename",
@@ -41,6 +41,7 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "source_wait",
         "source_add",
         "source_add_and_wait",
+        "source_add_drive_file",
         "source_upload_bytes",
         # Chat (3)
         "chat_ask",

--- a/tests/unit/mcp/test_sources_drive.py
+++ b/tests/unit/mcp/test_sources_drive.py
@@ -1,0 +1,101 @@
+"""Unit tests for the ``source_add_drive_file`` MCP tool (#1884).
+
+Exercised through the in-memory FastMCP client against a mocked ``NotebookLMClient``
+whose ``sources.add_drive_file`` is stubbed — so the tool's routing echo, error
+projection, and (crucially) the remote-mode contract that it NEVER emits
+``upload_required`` are pinned without any live Drive access.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
+
+from notebooklm._types.sources import SourceType  # noqa: E402 - after importorskip guard
+from notebooklm.exceptions import ValidationError  # noqa: E402 - after importorskip guard
+from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
+
+from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
+
+NB_ID = "11111111-1111-1111-1111-111111111111"
+SRC_ID = "44444444-4444-4444-4444-444444444444"
+FILE_ID = "1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD"
+
+
+@dataclass
+class FakeSource:
+    id: str
+    title: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return True
+
+    @property
+    def is_error(self) -> bool:
+        return False
+
+    @property
+    def kind(self) -> SourceType:
+        return SourceType.EPUB
+
+    @property
+    def status(self) -> SourceStatus:
+        return SourceStatus.READY
+
+
+async def test_source_add_drive_file_happy_path(mcp_call, mock_client) -> None:
+    mock_client.sources.add_drive_file = AsyncMock(return_value=FakeSource(id=SRC_ID, title="Book"))
+    result = await mcp_call(
+        "source_add_drive_file",
+        {"notebook": NB_ID, "document_id": FILE_ID, "title": "Book"},
+    )
+    assert result.structured_content == {
+        "status": "added",
+        "notebook_id": NB_ID,
+        "document_id": FILE_ID,
+        "source": {"id": SRC_ID, "title": "Book", "kind": "epub", "status_label": "ready"},
+    }
+    mock_client.sources.add_drive_file.assert_awaited_once_with(
+        NB_ID, FILE_ID, title="Book", wait=False, wait_timeout=120.0
+    )
+
+
+async def test_source_add_drive_file_passes_wait(mcp_call, mock_client) -> None:
+    mock_client.sources.add_drive_file = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    await mcp_call(
+        "source_add_drive_file",
+        {"notebook": NB_ID, "document_id": FILE_ID, "wait": True},
+    )
+    mock_client.sources.add_drive_file.assert_awaited_once_with(
+        NB_ID, FILE_ID, title=None, wait=True, wait_timeout=120.0
+    )
+
+
+async def test_unsupported_type_projects_validation_error(mcp_call, mock_client) -> None:
+    mock_client.sources.add_drive_file = AsyncMock(
+        side_effect=ValidationError("HTML isn't supported by NotebookLM upload")
+    )
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call(
+            "source_add_drive_file",
+            {"notebook": NB_ID, "document_id": FILE_ID},
+        )
+    assert "VALIDATION" in str(excinfo.value)
+
+
+async def test_remote_mode_never_emits_upload_required(mcp_call, mock_client) -> None:
+    """Unlike source_add(source_type='file'), the Drive fetch is server-side, so the
+    tool returns a normal ``added`` payload with no ``upload_required`` broker dict."""
+    mock_client.sources.add_drive_file = AsyncMock(return_value=FakeSource(id=SRC_ID))
+    result = await mcp_call(
+        "source_add_drive_file",
+        {"notebook": NB_ID, "document_id": FILE_ID},
+    )
+    assert result.structured_content["status"] == "added"
+    assert "upload_required" not in result.structured_content

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -30,7 +30,18 @@ pytest.importorskip("fastmcp")
 #: Ratchet ceilings — calibrated to the current surface (Tier-1 read-merge took it
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
-SCHEMA_CHAR_BUDGET = 40_550  # total serialized inputSchema + description chars (current 40_501; +37 for source_add's batch docstring documenting the #1871 fatal-abort semantics — a per-URL input failure isolates, a fatal service failure aborts the whole call — trimmed from +205 to the irreducible signal before this minimal bump)
+SCHEMA_CHAR_BUDGET = (
+    41_700  # total serialized inputSchema + description chars (current 41_645; +55 slack)
+)
+# #1884 added source_add_drive_file (auto-route add-from-Drive: download + upload the
+# upload-only Drive types NotebookLM's native import can't ingest) — a NEW discrete
+# tool (+1_144 chars, 4 params), not growth of an existing one. Per ADR-0025 the
+# discrete verb is preferred over widening source_add(source_type="drive"), which
+# REQUIRES an explicit mime_type (#1827) and only imports Google-native + PDF by
+# reference; auto-download is a categorically different operation. Raised from 40_550.
+# Prior baseline: current was 40_501, +37 for source_add's batch docstring documenting
+# the #1871 fatal-abort semantics (a per-URL input failure isolates, a fatal service
+# failure aborts the whole call).
 # ^ Raised from 36_250 for #1741: research_status gained include_report /
 # report_max_chars / source_limit / source_offset windowing params, and the four
 # research tools' docstrings speak one `poll_task_id` id (tightened to stay lean).

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -1,0 +1,412 @@
+"""Unit tests for the auto-route add-from-Drive service (#1884).
+
+Injection-based, NO live Drive: the ``DriveFetcher`` HTTP leg is driven by a fake
+streaming client, and ``DriveImportService`` is driven by a fake ``fetch`` +
+``add_file``. Covers the routing table per extension, id/URL parse + shape
+validation, the r3 confirm-form discriminator (matching signature vs login vs
+bogus HTML), header-first close-before-body for unsupported/over-cap, temp-file
+cleanup on success/failure/cancel, and the pre-upload HTML second defense.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._source.drive_import import (
+    _DRIVE_DOWNLOAD_URL,
+    DriveDownload,
+    DriveFetcher,
+    DriveImportService,
+    _find_confirm_params,
+    extract_drive_file_id,
+)
+from notebooklm.exceptions import ValidationError
+
+_FILE_ID = "1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD"
+
+
+# ---------------------------------------------------------------------------
+# Fake streaming HTTP client
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        body: bytes = b"",
+        url: str = _DRIVE_DOWNLOAD_URL,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._body = body
+        self.url = httpx.URL(url)
+        self.body_reads = 0  # number of aiter_bytes() iterations started
+
+    async def aiter_bytes(self, chunk_size: int = 65536) -> Any:
+        self.body_reads += 1
+        for start in range(0, len(self._body), chunk_size):
+            yield self._body[start : start + chunk_size]
+
+
+class _FakeStream:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.entered = False
+        self.closed = False
+        self.stream_urls: list[str] = []
+
+    def stream(self, method: str, url: str) -> _FakeStream:
+        self.stream_urls.append(url)
+        return _FakeStream(self._response)
+
+    async def __aenter__(self) -> _FakeClient:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        self.closed = True
+        return False
+
+
+def _factory_for(*responses: _FakeResponse):
+    """Return a (factory, clients) pair yielding one fresh client per request."""
+    clients = [_FakeClient(r) for r in responses]
+    calls = iter(clients)
+
+    def factory(_cookies: httpx.Cookies, _timeout: httpx.Timeout) -> _FakeClient:
+        return next(calls)
+
+    return factory, clients
+
+
+def _fetcher(*responses: _FakeResponse, max_bytes: int = 200 * 1024 * 1024) -> DriveFetcher:
+    factory, _clients = _factory_for(*responses)
+    return DriveFetcher(
+        cookies_provider=httpx.Cookies,
+        client_factory=factory,
+        max_bytes=max_bytes,
+    )
+
+
+def _attachment_headers(filename: str, **extra: str) -> dict[str, str]:
+    headers = {
+        "content-type": "application/octet-stream",
+        "content-disposition": f'attachment; filename="{filename}"',
+    }
+    headers.update(extra)
+    return headers
+
+
+# ===========================================================================
+# extract_drive_file_id
+# ===========================================================================
+
+
+class TestExtractDriveFileId:
+    def test_raw_id(self) -> None:
+        assert extract_drive_file_id(_FILE_ID) == _FILE_ID
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            f"https://drive.google.com/file/d/{_FILE_ID}/view?usp=sharing",
+            f"https://drive.google.com/open?id={_FILE_ID}",
+            f"https://docs.google.com/document/d/{_FILE_ID}/edit",
+            f"https://drive.usercontent.google.com/download?id={_FILE_ID}&export=download",
+        ],
+    )
+    def test_url_forms(self, url: str) -> None:
+        assert extract_drive_file_id(url) == _FILE_ID
+
+    @pytest.mark.parametrize("bad", ["", "   ", "short", "not a url", "https://example.com/x"])
+    def test_rejects_unparseable(self, bad: str) -> None:
+        with pytest.raises(ValidationError):
+            extract_drive_file_id(bad)
+
+
+# ===========================================================================
+# _find_confirm_params — r3 Fix A discriminator
+# ===========================================================================
+
+
+_CONFIRM_HTML = (
+    "<html><body><form action='https://drive.usercontent.google.com/download' method='get'>"
+    f"<input type='hidden' name='id' value='{_FILE_ID}'>"
+    "<input type='hidden' name='export' value='download'>"
+    "<input type='hidden' name='confirm' value='t'>"
+    "<input type='hidden' name='uuid' value='abc-uuid-123'>"
+    "</form></body></html>"
+)
+
+
+class TestFindConfirmParams:
+    def test_matching_signature(self) -> None:
+        params = _find_confirm_params(_CONFIRM_HTML, _FILE_ID)
+        assert params is not None
+        assert params["confirm"] == "t"
+        assert params["uuid"] == "abc-uuid-123"
+        assert params["id"] == _FILE_ID
+        assert params["export"] == "download"
+
+    def test_wrong_host_rejected(self) -> None:
+        html = _CONFIRM_HTML.replace("drive.usercontent.google.com", "evil.example.com")
+        assert _find_confirm_params(html, _FILE_ID) is None
+
+    def test_wrong_id_rejected(self) -> None:
+        assert _find_confirm_params(_CONFIRM_HTML, "some-other-id-000000000") is None
+
+    def test_empty_confirm_rejected(self) -> None:
+        html = _CONFIRM_HTML.replace("value='t'", "value=''")
+        assert _find_confirm_params(html, _FILE_ID) is None
+
+    def test_plain_login_html_has_no_form(self) -> None:
+        html = "<html><body>Sign in to continue</body></html>"
+        assert _find_confirm_params(html, _FILE_ID) is None
+
+
+# ===========================================================================
+# DriveFetcher — routing table per extension
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestDriveFetcherRouting:
+    @pytest.mark.parametrize(
+        "ext", ["epub", "docx", "txt", "md", "rtf", "odt", "csv", "tsv", "pdf"]
+    )
+    async def test_supported_ext_downloads(self, ext: str) -> None:
+        body = b"payload-bytes-" + ext.encode()
+        response = _FakeResponse(headers=_attachment_headers(f"book.{ext}"), body=body)
+        download = await _fetcher(response)(_FILE_ID)
+        try:
+            assert download.filename == f"book.{ext}"
+            assert download.path.suffix == f".{ext}"
+            assert download.path.read_bytes() == body
+        finally:
+            download.path.unlink(missing_ok=True)
+
+    @pytest.mark.parametrize("ext", ["html", "htm", "xhtml"])
+    async def test_html_extension_rejected_before_body(self, ext: str) -> None:
+        response = _FakeResponse(headers=_attachment_headers(f"page.{ext}"), body=b"<html>")
+        with pytest.raises(ValidationError, match="HTML"):
+            await _fetcher(response)(_FILE_ID)
+        assert response.body_reads == 0  # header-first: body never streamed
+
+    @pytest.mark.parametrize("ext", ["png", "exe", "zip", "bin"])
+    async def test_unsupported_ext_rejected_before_body(self, ext: str) -> None:
+        response = _FakeResponse(headers=_attachment_headers(f"file.{ext}"), body=b"xxxx")
+        with pytest.raises(ValidationError, match="unsupported|Accepted"):
+            await _fetcher(response)(_FILE_ID)
+        assert response.body_reads == 0
+
+    async def test_over_cap_content_length_rejected_before_body(self) -> None:
+        response = _FakeResponse(
+            headers=_attachment_headers("big.pdf", **{"content-length": str(500 * 1024 * 1024)}),
+            body=b"x",
+        )
+        with pytest.raises(ValidationError, match="cap"):
+            await _fetcher(response)(_FILE_ID)
+        assert response.body_reads == 0
+
+    async def test_running_byte_cap_aborts_and_cleans(self) -> None:
+        # No Content-Length header, but the streamed body exceeds the cap.
+        response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"x" * 5000)
+        with pytest.raises(ValidationError, match="cap"):
+            await _fetcher(response, max_bytes=1000)(_FILE_ID)
+        # No temp file leaks: only our own would remain, and the fetch unlinks it.
+
+    async def test_zero_byte_download_rejected(self) -> None:
+        response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"")
+        with pytest.raises(ValidationError, match="0 bytes"):
+            await _fetcher(response)(_FILE_ID)
+
+
+# ===========================================================================
+# DriveFetcher — HTML classification (r3 Fix A) + confirm re-request (Fix B)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestDriveFetcherHtmlClassification:
+    async def test_auth_expired_on_service_login_redirect(self) -> None:
+        response = _FakeResponse(
+            headers={"content-type": "text/html; charset=utf-8"},
+            body=b"<html>login</html>",
+            url="https://accounts.google.com/ServiceLogin",
+        )
+        with pytest.raises(ValidationError, match="authentication expired"):
+            await _fetcher(response)(_FILE_ID)
+
+    async def test_401_maps_to_auth_expired(self) -> None:
+        response = _FakeResponse(status_code=401, headers={"content-type": "text/html"})
+        with pytest.raises(ValidationError, match="authentication expired"):
+            await _fetcher(response)(_FILE_ID)
+
+    async def test_non_committal_pointer_for_native_doc(self) -> None:
+        # HTML, not ServiceLogin, no confirm form → non-committal pointer error.
+        response = _FakeResponse(
+            headers={"content-type": "text/html"},
+            body=b"<html><body>Google Docs</body></html>",
+            url=_DRIVE_DOWNLOAD_URL,
+        )
+        with pytest.raises(ValidationError, match="native Google Doc"):
+            await _fetcher(response)(_FILE_ID)
+
+    async def test_confirm_interstitial_re_requests_then_downloads(self) -> None:
+        first = _FakeResponse(
+            headers={"content-type": "text/html"},
+            body=_CONFIRM_HTML.encode(),
+            url=_DRIVE_DOWNLOAD_URL,
+        )
+        second = _FakeResponse(headers=_attachment_headers("big.epub"), body=b"epub-bytes")
+        factory, clients = _factory_for(first, second)
+        fetcher = DriveFetcher(cookies_provider=httpx.Cookies, client_factory=factory)
+        download = await fetcher(_FILE_ID)
+        try:
+            assert download.path.read_bytes() == b"epub-bytes"
+            # The re-request carried the parsed confirm token + uuid.
+            confirm_url = clients[1].stream_urls[0]
+            assert "confirm=t" in confirm_url
+            assert "uuid=abc-uuid-123" in confirm_url
+        finally:
+            download.path.unlink(missing_ok=True)
+
+
+# ===========================================================================
+# DriveImportService — orchestration, cleanup, second defense
+# ===========================================================================
+
+
+def _tmp_download(tmp_path: Path, name: str = "book.epub", body: bytes = b"data") -> DriveDownload:
+    path = tmp_path / f"{name}.part"
+    path.write_bytes(body)
+    return DriveDownload(path=path, filename=name, content_type="application/epub+zip")
+
+
+@pytest.mark.asyncio
+class TestDriveImportService:
+    async def test_success_downloads_uploads_and_cleans(self, tmp_path: Path) -> None:
+        download = _tmp_download(tmp_path)
+        added = object()
+        calls: dict[str, Any] = {}
+
+        async def fetch(file_id: str) -> DriveDownload:
+            calls["file_id"] = file_id
+            return download
+
+        async def add_file(notebook_id: str, path: Path, **kwargs: Any) -> Any:
+            calls["add"] = (notebook_id, path, kwargs)
+            assert path.exists()  # file still present during the upload
+            return added
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        result = await service.add_drive_file(
+            "nb_1", f"https://drive.google.com/file/d/{_FILE_ID}/view", title="My Book"
+        )
+        assert result is added
+        assert calls["file_id"] == _FILE_ID
+        nb, path, kwargs = calls["add"]
+        assert nb == "nb_1"
+        assert kwargs["title"] == "My Book"
+        assert not download.path.exists()  # unlinked in finally
+
+    async def test_default_title_is_drive_filename(self, tmp_path: Path) -> None:
+        download = _tmp_download(tmp_path, name="Report.pdf")
+
+        async def fetch(_file_id: str) -> DriveDownload:
+            return download
+
+        captured: dict[str, Any] = {}
+
+        async def add_file(_nb: str, _path: Path, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return object()
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        await service.add_drive_file("nb_1", _FILE_ID)
+        assert captured["title"] == "Report.pdf"
+
+    async def test_temp_cleaned_on_upload_failure(self, tmp_path: Path) -> None:
+        download = _tmp_download(tmp_path)
+
+        async def fetch(_file_id: str) -> DriveDownload:
+            return download
+
+        async def add_file(*_a: Any, **_k: Any) -> Any:
+            raise RuntimeError("upload boom")
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        with pytest.raises(RuntimeError, match="upload boom"):
+            await service.add_drive_file("nb_1", _FILE_ID)
+        assert not download.path.exists()
+
+    async def test_temp_cleaned_on_cancellation(self, tmp_path: Path) -> None:
+        download = _tmp_download(tmp_path)
+
+        async def fetch(_file_id: str) -> DriveDownload:
+            return download
+
+        async def add_file(*_a: Any, **_k: Any) -> Any:
+            raise asyncio.CancelledError()
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        with pytest.raises(asyncio.CancelledError):
+            await service.add_drive_file("nb_1", _FILE_ID)
+        assert not download.path.exists()
+
+    async def test_html_mislabel_hits_second_defense_before_upload(self, tmp_path: Path) -> None:
+        # A fetch that (hypothetically) returned an HTML file must still be rejected
+        # by _validate_upload_file_supported BEFORE add_file is ever called.
+        html_path = tmp_path / "page.html"
+        html_path.write_bytes(b"<html></html>")
+        download = DriveDownload(path=html_path, filename="page.html", content_type="text/html")
+        add_called = False
+
+        async def fetch(_file_id: str) -> DriveDownload:
+            return download
+
+        async def add_file(*_a: Any, **_k: Any) -> Any:
+            nonlocal add_called
+            add_called = True
+            return object()
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        with pytest.raises(ValidationError, match="HTML"):
+            await service.add_drive_file("nb_1", _FILE_ID)
+        assert add_called is False
+        assert not html_path.exists()  # still cleaned up
+
+    async def test_unparseable_id_never_fetches(self, tmp_path: Path) -> None:
+        fetched = False
+
+        async def fetch(_file_id: str) -> DriveDownload:
+            nonlocal fetched
+            fetched = True
+            return _tmp_download(tmp_path)
+
+        async def add_file(*_a: Any, **_k: Any) -> Any:
+            return object()
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        with pytest.raises(ValidationError):
+            await service.add_drive_file("nb_1", "not-a-valid-id")
+        assert fetched is False

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -11,6 +11,9 @@ cleanup on success/failure/cancel, and the pre-upload HTML second defense.
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +25,7 @@ from notebooklm._source.drive_import import (
     DriveDownload,
     DriveFetcher,
     DriveImportService,
+    _filename_from_disposition,
     _find_confirm_params,
     extract_drive_file_id,
 )
@@ -49,10 +53,14 @@ class _FakeResponse:
         self._body = body
         self.url = httpx.URL(url)
         self.body_reads = 0  # number of aiter_bytes() iterations started
+        # Thread names alive while the body is being produced — lets a test prove
+        # the disk writes run on a dedicated writer thread (off the event loop).
+        self.threads_during_stream: set[str] = set()
 
     async def aiter_bytes(self, chunk_size: int = 65536) -> Any:
         self.body_reads += 1
         for start in range(0, len(self._body), chunk_size):
+            self.threads_during_stream.update(t.name for t in threading.enumerate())
             yield self._body[start : start + chunk_size]
 
 
@@ -114,6 +122,11 @@ def _attachment_headers(filename: str, **extra: str) -> dict[str, str]:
     }
     headers.update(extra)
     return headers
+
+
+def _leaked_drive_temps() -> set[Path]:
+    """The set of ``nlm-drive-*`` temp files currently in the system temp dir."""
+    return set(Path(tempfile.gettempdir()).glob("nlm-drive-*"))
 
 
 # ===========================================================================
@@ -184,6 +197,35 @@ class TestFindConfirmParams:
 
 
 # ===========================================================================
+# _filename_from_disposition — Content-Disposition parsing (incl. RFC 5987)
+# ===========================================================================
+
+
+class TestFilenameFromDisposition:
+    def test_plain_filename(self) -> None:
+        assert _filename_from_disposition('attachment; filename="book.epub"') == "book.epub"
+
+    def test_unquoted_filename(self) -> None:
+        assert _filename_from_disposition("attachment; filename=book.epub") == "book.epub"
+
+    def test_rfc5987_no_language_tag(self) -> None:
+        assert _filename_from_disposition("attachment; filename*=UTF-8''plain.txt") == "plain.txt"
+
+    def test_rfc5987_with_language_tag_and_pct_encoding(self) -> None:
+        # A non-empty language tag (``en``) between the quotes must not defeat the
+        # match, and percent-encoding is decoded.
+        got = _filename_from_disposition("attachment; filename*=UTF-8'en'my%20book.epub")
+        assert got == "my book.epub"
+
+    def test_rfc5987_takes_precedence_over_plain(self) -> None:
+        disposition = "attachment; filename=\"fallback.txt\"; filename*=UTF-8'en'real.epub"
+        assert _filename_from_disposition(disposition) == "real.epub"
+
+    def test_empty_disposition(self) -> None:
+        assert _filename_from_disposition("") == ""
+
+
+# ===========================================================================
 # DriveFetcher — routing table per extension
 # ===========================================================================
 
@@ -228,16 +270,40 @@ class TestDriveFetcherRouting:
         assert response.body_reads == 0
 
     async def test_running_byte_cap_aborts_and_cleans(self) -> None:
-        # No Content-Length header, but the streamed body exceeds the cap.
+        # No Content-Length header, but the streamed body exceeds the cap. Force
+        # multiple chunks (small chunking) so the running cap trips mid-stream and
+        # the writer thread + temp file are torn down cleanly.
+        before = _leaked_drive_temps()
         response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"x" * 5000)
         with pytest.raises(ValidationError, match="cap"):
             await _fetcher(response, max_bytes=1000)(_FILE_ID)
-        # No temp file leaks: only our own would remain, and the fetch unlinks it.
+        assert _leaked_drive_temps() == before  # temp file unlinked on the abort
+
+    async def test_large_multichunk_body_streams_off_the_event_loop(self) -> None:
+        """A body far larger than one chunk streams byte-exact via the writer thread.
+
+        The random body spans ~11 chunks (> the 8-slot queue), so it exercises the
+        ``queue.Full`` back-pressure branch, and the assertion proves the blocking
+        disk writes ran on a dedicated ``drive-dl-writer-*`` thread — NOT inline on
+        the event loop (the #1873-class starvation this fix removes).
+        """
+        body = os.urandom(700_000)
+        response = _FakeResponse(headers=_attachment_headers("big.epub"), body=body)
+        download = await _fetcher(response)(_FILE_ID)
+        try:
+            assert download.path.read_bytes() == body
+            assert any(
+                name.startswith("drive-dl-writer-") for name in response.threads_during_stream
+            ), "disk writes must run on a dedicated writer thread, not the event loop"
+        finally:
+            download.path.unlink(missing_ok=True)
 
     async def test_zero_byte_download_rejected(self) -> None:
+        before = _leaked_drive_temps()
         response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"")
         with pytest.raises(ValidationError, match="0 bytes"):
             await _fetcher(response)(_FILE_ID)
+        assert _leaked_drive_temps() == before  # empty temp unlinked
 
 
 # ===========================================================================

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -184,6 +184,20 @@ class TestParseDriveRef:
         with pytest.raises(ValidationError):
             parse_drive_ref(bad)
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            f"https://evil.example/file/d/{_FILE_ID}/view",
+            f"https://drive.google.com.evil.example/open?id={_FILE_ID}",
+            f"http://notgoogle.test/d/{_FILE_ID}",
+        ],
+    )
+    def test_rejects_id_shaped_url_on_non_google_host(self, url: str) -> None:
+        # A valid-looking id under a non-Google host must NOT be treated as a Drive
+        # reference (host hardening) — it raises the clean parse ValidationError.
+        with pytest.raises(ValidationError):
+            parse_drive_ref(url)
+
 
 # ===========================================================================
 # _find_confirm_params — r3 Fix A discriminator

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -2,17 +2,19 @@
 
 Injection-based, NO live Drive: the ``DriveFetcher`` HTTP leg is driven by a fake
 streaming client, and ``DriveImportService`` is driven by a fake ``fetch`` +
-``add_file``. Covers the routing table per extension, id/URL parse + shape
-validation, the r3 confirm-form discriminator (matching signature vs login vs
-bogus HTML), header-first close-before-body for unsupported/over-cap, temp-file
-cleanup on success/failure/cancel, and the pre-upload HTML second defense.
+``add_file``. Covers the routing table per extension, id/URL + resourcekey parse,
+the r3 confirm-form discriminator, header-first close-before-body, the error
+taxonomy (auth / rate-limit / server / network / validation), the authuser +
+resourcekey URL routing, temp-file cleanup on every path, and the second defense.
+
+Temp downloads are pointed at each test's own ``tmp_path`` (never the shared
+system temp dir), so the leak assertions stay deterministic under parallel
+(xdist) workers.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
-import tempfile
 import threading
 from pathlib import Path
 from typing import Any
@@ -25,11 +27,19 @@ from notebooklm._source.drive_import import (
     DriveDownload,
     DriveFetcher,
     DriveImportService,
+    DriveRef,
     _filename_from_disposition,
     _find_confirm_params,
     extract_drive_file_id,
+    parse_drive_ref,
 )
-from notebooklm.exceptions import ValidationError
+from notebooklm.exceptions import (
+    AuthError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
 
 _FILE_ID = "1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD"
 
@@ -65,10 +75,13 @@ class _FakeResponse:
 
 
 class _FakeStream:
-    def __init__(self, response: _FakeResponse) -> None:
+    def __init__(self, response: _FakeResponse | BaseException) -> None:
         self._response = response
 
     async def __aenter__(self) -> _FakeResponse:
+        # A transport fault surfaces when the streaming GET is opened.
+        if isinstance(self._response, BaseException):
+            raise self._response
         return self._response
 
     async def __aexit__(self, *exc: object) -> bool:
@@ -76,10 +89,8 @@ class _FakeStream:
 
 
 class _FakeClient:
-    def __init__(self, response: _FakeResponse) -> None:
+    def __init__(self, response: _FakeResponse | BaseException) -> None:
         self._response = response
-        self.entered = False
-        self.closed = False
         self.stream_urls: list[str] = []
 
     def stream(self, method: str, url: str) -> _FakeStream:
@@ -87,15 +98,13 @@ class _FakeClient:
         return _FakeStream(self._response)
 
     async def __aenter__(self) -> _FakeClient:
-        self.entered = True
         return self
 
     async def __aexit__(self, *exc: object) -> bool:
-        self.closed = True
         return False
 
 
-def _factory_for(*responses: _FakeResponse):
+def _factory_for(*responses: _FakeResponse | BaseException):
     """Return a (factory, clients) pair yielding one fresh client per request."""
     clients = [_FakeClient(r) for r in responses]
     calls = iter(clients)
@@ -106,12 +115,19 @@ def _factory_for(*responses: _FakeResponse):
     return factory, clients
 
 
-def _fetcher(*responses: _FakeResponse, max_bytes: int = 200 * 1024 * 1024) -> DriveFetcher:
+def _fetcher(
+    *responses: _FakeResponse | BaseException,
+    max_bytes: int = 200 * 1024 * 1024,
+    temp_dir: Path | None = None,
+    authuser: str | None = None,
+) -> DriveFetcher:
     factory, _clients = _factory_for(*responses)
     return DriveFetcher(
         cookies_provider=httpx.Cookies,
         client_factory=factory,
         max_bytes=max_bytes,
+        authuser=authuser,
+        temp_dir=temp_dir,
     )
 
 
@@ -124,19 +140,20 @@ def _attachment_headers(filename: str, **extra: str) -> dict[str, str]:
     return headers
 
 
-def _leaked_drive_temps() -> set[Path]:
-    """The set of ``nlm-drive-*`` temp files currently in the system temp dir."""
-    return set(Path(tempfile.gettempdir()).glob("nlm-drive-*"))
+def _leaked_temps(temp_dir: Path) -> set[Path]:
+    """The ``nlm-drive-*`` temp files in ``temp_dir`` (a per-test isolated dir)."""
+    return set(temp_dir.glob("nlm-drive-*"))
 
 
 # ===========================================================================
-# extract_drive_file_id
+# parse_drive_ref / extract_drive_file_id
 # ===========================================================================
 
 
-class TestExtractDriveFileId:
+class TestParseDriveRef:
     def test_raw_id(self) -> None:
         assert extract_drive_file_id(_FILE_ID) == _FILE_ID
+        assert parse_drive_ref(_FILE_ID) == DriveRef(file_id=_FILE_ID, resource_key=None)
 
     @pytest.mark.parametrize(
         "url",
@@ -150,10 +167,22 @@ class TestExtractDriveFileId:
     def test_url_forms(self, url: str) -> None:
         assert extract_drive_file_id(url) == _FILE_ID
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            f"https://drive.google.com/file/d/{_FILE_ID}/view?resourcekey=0-abcDEF",
+            f"https://drive.google.com/open?id={_FILE_ID}&resourcekey=0-abcDEF",
+        ],
+    )
+    def test_resource_key_preserved(self, url: str) -> None:
+        ref = parse_drive_ref(url)
+        assert ref.file_id == _FILE_ID
+        assert ref.resource_key == "0-abcDEF"
+
     @pytest.mark.parametrize("bad", ["", "   ", "short", "not a url", "https://example.com/x"])
     def test_rejects_unparseable(self, bad: str) -> None:
         with pytest.raises(ValidationError):
-            extract_drive_file_id(bad)
+            parse_drive_ref(bad)
 
 
 # ===========================================================================
@@ -235,109 +264,140 @@ class TestDriveFetcherRouting:
     @pytest.mark.parametrize(
         "ext", ["epub", "docx", "txt", "md", "rtf", "odt", "csv", "tsv", "pdf"]
     )
-    async def test_supported_ext_downloads(self, ext: str) -> None:
+    async def test_supported_ext_downloads(self, ext: str, tmp_path: Path) -> None:
         body = b"payload-bytes-" + ext.encode()
         response = _FakeResponse(headers=_attachment_headers(f"book.{ext}"), body=body)
-        download = await _fetcher(response)(_FILE_ID)
-        try:
-            assert download.filename == f"book.{ext}"
-            assert download.path.suffix == f".{ext}"
-            assert download.path.read_bytes() == body
-        finally:
-            download.path.unlink(missing_ok=True)
+        download = await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+        assert download.filename == f"book.{ext}"
+        assert download.path.suffix == f".{ext}"
+        assert download.path.read_bytes() == body
 
     @pytest.mark.parametrize("ext", ["html", "htm", "xhtml"])
-    async def test_html_extension_rejected_before_body(self, ext: str) -> None:
+    async def test_html_extension_rejected_before_body(self, ext: str, tmp_path: Path) -> None:
         response = _FakeResponse(headers=_attachment_headers(f"page.{ext}"), body=b"<html>")
         with pytest.raises(ValidationError, match="HTML"):
-            await _fetcher(response)(_FILE_ID)
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
         assert response.body_reads == 0  # header-first: body never streamed
 
     @pytest.mark.parametrize("ext", ["png", "exe", "zip", "bin"])
-    async def test_unsupported_ext_rejected_before_body(self, ext: str) -> None:
+    async def test_unsupported_ext_rejected_before_body(self, ext: str, tmp_path: Path) -> None:
         response = _FakeResponse(headers=_attachment_headers(f"file.{ext}"), body=b"xxxx")
         with pytest.raises(ValidationError, match="unsupported|Accepted"):
-            await _fetcher(response)(_FILE_ID)
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
         assert response.body_reads == 0
 
-    async def test_over_cap_content_length_rejected_before_body(self) -> None:
+    async def test_over_cap_content_length_rejected_before_body(self, tmp_path: Path) -> None:
         response = _FakeResponse(
             headers=_attachment_headers("big.pdf", **{"content-length": str(500 * 1024 * 1024)}),
             body=b"x",
         )
         with pytest.raises(ValidationError, match="cap"):
-            await _fetcher(response)(_FILE_ID)
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
         assert response.body_reads == 0
 
-    async def test_running_byte_cap_aborts_and_cleans(self) -> None:
-        # No Content-Length header, but the streamed body exceeds the cap. Force
-        # multiple chunks (small chunking) so the running cap trips mid-stream and
-        # the writer thread + temp file are torn down cleanly.
-        before = _leaked_drive_temps()
+    async def test_running_byte_cap_aborts_and_cleans(self, tmp_path: Path) -> None:
+        # No Content-Length header, but the streamed body exceeds the cap mid-stream.
         response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"x" * 5000)
         with pytest.raises(ValidationError, match="cap"):
-            await _fetcher(response, max_bytes=1000)(_FILE_ID)
-        assert _leaked_drive_temps() == before  # temp file unlinked on the abort
+            await _fetcher(response, max_bytes=1000, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+        assert _leaked_temps(tmp_path) == set()  # temp unlinked on the abort
 
-    async def test_large_multichunk_body_streams_off_the_event_loop(self) -> None:
+    async def test_large_multichunk_body_streams_off_the_event_loop(self, tmp_path: Path) -> None:
         """A body far larger than one chunk streams byte-exact via the writer thread.
 
-        The random body spans ~11 chunks (> the 8-slot queue), so it exercises the
-        ``queue.Full`` back-pressure branch, and the assertion proves the blocking
-        disk writes ran on a dedicated ``drive-dl-writer-*`` thread — NOT inline on
-        the event loop (the #1873-class starvation this fix removes).
+        The ~11-chunk body (> the 8-slot queue) exercises the ``queue.Full``
+        back-pressure branch, and the assertion proves the blocking disk writes ran
+        on a dedicated ``drive-dl-writer-*`` thread — NOT inline on the event loop
+        (the #1873-class starvation this fix removes).
         """
-        body = os.urandom(700_000)
+        body = b"".join(bytes([i % 256]) for i in range(700_000))
         response = _FakeResponse(headers=_attachment_headers("big.epub"), body=body)
-        download = await _fetcher(response)(_FILE_ID)
-        try:
-            assert download.path.read_bytes() == body
-            assert any(
-                name.startswith("drive-dl-writer-") for name in response.threads_during_stream
-            ), "disk writes must run on a dedicated writer thread, not the event loop"
-        finally:
-            download.path.unlink(missing_ok=True)
+        download = await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+        assert download.path.read_bytes() == body
+        assert any(
+            name.startswith("drive-dl-writer-") for name in response.threads_during_stream
+        ), "disk writes must run on a dedicated writer thread, not the event loop"
 
-    async def test_zero_byte_download_rejected(self) -> None:
-        before = _leaked_drive_temps()
+    async def test_zero_byte_download_rejected(self, tmp_path: Path) -> None:
         response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"")
         with pytest.raises(ValidationError, match="0 bytes"):
-            await _fetcher(response)(_FILE_ID)
-        assert _leaked_drive_temps() == before  # empty temp unlinked
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+        assert _leaked_temps(tmp_path) == set()  # empty temp unlinked
+
+    async def test_authuser_and_resourcekey_threaded_into_url(self, tmp_path: Path) -> None:
+        response = _FakeResponse(headers=_attachment_headers("book.epub"), body=b"data")
+        factory, clients = _factory_for(response)
+        fetcher = DriveFetcher(
+            cookies_provider=httpx.Cookies,
+            client_factory=factory,
+            authuser="7",
+            temp_dir=tmp_path,
+        )
+        await fetcher(DriveRef(_FILE_ID, resource_key="0-abcDEF"))
+        url = clients[0].stream_urls[0]
+        assert "authuser=7" in url
+        assert "resourcekey=0-abcDEF" in url
+        assert f"id={_FILE_ID}" in url
 
 
 # ===========================================================================
-# DriveFetcher — HTML classification (r3 Fix A) + confirm re-request (Fix B)
+# DriveFetcher — HTML classification (r3 Fix A) + confirm re-request
 # ===========================================================================
 
 
 @pytest.mark.asyncio
 class TestDriveFetcherHtmlClassification:
-    async def test_auth_expired_on_service_login_redirect(self) -> None:
+    async def test_auth_expired_on_service_login_redirect(self, tmp_path: Path) -> None:
         response = _FakeResponse(
             headers={"content-type": "text/html; charset=utf-8"},
             body=b"<html>login</html>",
             url="https://accounts.google.com/ServiceLogin",
         )
-        with pytest.raises(ValidationError, match="authentication expired"):
-            await _fetcher(response)(_FILE_ID)
+        with pytest.raises(AuthError, match="authentication expired"):
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
 
-    async def test_401_maps_to_auth_expired(self) -> None:
+    async def test_401_maps_to_auth_error(self, tmp_path: Path) -> None:
         response = _FakeResponse(status_code=401, headers={"content-type": "text/html"})
-        with pytest.raises(ValidationError, match="authentication expired"):
-            await _fetcher(response)(_FILE_ID)
+        with pytest.raises(AuthError, match="authentication expired"):
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
 
-    async def test_non_committal_pointer_for_native_doc(self) -> None:
-        # HTML, not ServiceLogin, no confirm form → non-committal pointer error.
+    async def test_403_html_falls_through_to_pointer_not_auth(self, tmp_path: Path) -> None:
+        # A 403 permission page must NOT be declared auth-expired; it goes to the
+        # discriminator → non-committal pointer (permissions/not-found/native).
+        response = _FakeResponse(
+            status_code=403,
+            headers={"content-type": "text/html"},
+            body=b"<html><body>Access denied</body></html>",
+            url=_DRIVE_DOWNLOAD_URL,
+        )
+        with pytest.raises(ValidationError, match="did not return downloadable bytes"):
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+
+    async def test_429_maps_to_rate_limit(self, tmp_path: Path) -> None:
+        response = _FakeResponse(status_code=429)
+        with pytest.raises(RateLimitError):
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+
+    async def test_5xx_maps_to_server_error(self, tmp_path: Path) -> None:
+        response = _FakeResponse(status_code=503)
+        with pytest.raises(ServerError):
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+
+    async def test_transport_failure_maps_to_network_error(self, tmp_path: Path) -> None:
+        boom = httpx.ConnectError("dns boom")
+        with pytest.raises(NetworkError):
+            await _fetcher(boom, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+
+    async def test_non_committal_pointer_for_native_doc(self, tmp_path: Path) -> None:
         response = _FakeResponse(
             headers={"content-type": "text/html"},
             body=b"<html><body>Google Docs</body></html>",
             url=_DRIVE_DOWNLOAD_URL,
         )
         with pytest.raises(ValidationError, match="native Google Doc"):
-            await _fetcher(response)(_FILE_ID)
+            await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
 
-    async def test_confirm_interstitial_re_requests_then_downloads(self) -> None:
+    async def test_confirm_interstitial_re_requests_then_downloads(self, tmp_path: Path) -> None:
         first = _FakeResponse(
             headers={"content-type": "text/html"},
             body=_CONFIRM_HTML.encode(),
@@ -345,16 +405,17 @@ class TestDriveFetcherHtmlClassification:
         )
         second = _FakeResponse(headers=_attachment_headers("big.epub"), body=b"epub-bytes")
         factory, clients = _factory_for(first, second)
-        fetcher = DriveFetcher(cookies_provider=httpx.Cookies, client_factory=factory)
-        download = await fetcher(_FILE_ID)
-        try:
-            assert download.path.read_bytes() == b"epub-bytes"
-            # The re-request carried the parsed confirm token + uuid.
-            confirm_url = clients[1].stream_urls[0]
-            assert "confirm=t" in confirm_url
-            assert "uuid=abc-uuid-123" in confirm_url
-        finally:
-            download.path.unlink(missing_ok=True)
+        fetcher = DriveFetcher(
+            cookies_provider=httpx.Cookies, client_factory=factory, authuser="3", temp_dir=tmp_path
+        )
+        download = await fetcher(DriveRef(_FILE_ID, resource_key="rk-9"))
+        assert download.path.read_bytes() == b"epub-bytes"
+        # The confirmed re-request carried the parsed token + the account/resource routing.
+        confirm_url = clients[1].stream_urls[0]
+        assert "confirm=t" in confirm_url
+        assert "uuid=abc-uuid-123" in confirm_url
+        assert "authuser=3" in confirm_url
+        assert "resourcekey=rk-9" in confirm_url
 
 
 # ===========================================================================
@@ -375,8 +436,8 @@ class TestDriveImportService:
         added = object()
         calls: dict[str, Any] = {}
 
-        async def fetch(file_id: str) -> DriveDownload:
-            calls["file_id"] = file_id
+        async def fetch(ref: DriveRef) -> DriveDownload:
+            calls["ref"] = ref
             return download
 
         async def add_file(notebook_id: str, path: Path, **kwargs: Any) -> Any:
@@ -389,16 +450,33 @@ class TestDriveImportService:
             "nb_1", f"https://drive.google.com/file/d/{_FILE_ID}/view", title="My Book"
         )
         assert result is added
-        assert calls["file_id"] == _FILE_ID
-        nb, path, kwargs = calls["add"]
+        assert calls["ref"].file_id == _FILE_ID
+        nb, _path, kwargs = calls["add"]
         assert nb == "nb_1"
         assert kwargs["title"] == "My Book"
         assert not download.path.exists()  # unlinked in finally
 
+    async def test_resource_key_threaded_to_fetch(self, tmp_path: Path) -> None:
+        download = _tmp_download(tmp_path)
+        seen: dict[str, DriveRef] = {}
+
+        async def fetch(ref: DriveRef) -> DriveDownload:
+            seen["ref"] = ref
+            return download
+
+        async def add_file(*_a: Any, **_k: Any) -> Any:
+            return object()
+
+        service = DriveImportService(fetch=fetch, add_file=add_file)
+        await service.add_drive_file(
+            "nb_1", f"https://drive.google.com/file/d/{_FILE_ID}/view?resourcekey=0-xyz"
+        )
+        assert seen["ref"].resource_key == "0-xyz"
+
     async def test_default_title_is_drive_filename(self, tmp_path: Path) -> None:
         download = _tmp_download(tmp_path, name="Report.pdf")
 
-        async def fetch(_file_id: str) -> DriveDownload:
+        async def fetch(_ref: DriveRef) -> DriveDownload:
             return download
 
         captured: dict[str, Any] = {}
@@ -414,7 +492,7 @@ class TestDriveImportService:
     async def test_temp_cleaned_on_upload_failure(self, tmp_path: Path) -> None:
         download = _tmp_download(tmp_path)
 
-        async def fetch(_file_id: str) -> DriveDownload:
+        async def fetch(_ref: DriveRef) -> DriveDownload:
             return download
 
         async def add_file(*_a: Any, **_k: Any) -> Any:
@@ -428,7 +506,7 @@ class TestDriveImportService:
     async def test_temp_cleaned_on_cancellation(self, tmp_path: Path) -> None:
         download = _tmp_download(tmp_path)
 
-        async def fetch(_file_id: str) -> DriveDownload:
+        async def fetch(_ref: DriveRef) -> DriveDownload:
             return download
 
         async def add_file(*_a: Any, **_k: Any) -> Any:
@@ -447,7 +525,7 @@ class TestDriveImportService:
         download = DriveDownload(path=html_path, filename="page.html", content_type="text/html")
         add_called = False
 
-        async def fetch(_file_id: str) -> DriveDownload:
+        async def fetch(_ref: DriveRef) -> DriveDownload:
             return download
 
         async def add_file(*_a: Any, **_k: Any) -> Any:
@@ -464,7 +542,7 @@ class TestDriveImportService:
     async def test_unparseable_id_never_fetches(self, tmp_path: Path) -> None:
         fetched = False
 
-        async def fetch(_file_id: str) -> DriveDownload:
+        async def fetch(_ref: DriveRef) -> DriveDownload:
             nonlocal fetched
             fetched = True
             return _tmp_download(tmp_path)

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -873,6 +873,7 @@ JSON_SUCCESS_WAIVED: dict[tuple[str, ...], str] = {
     # mutations or wait-loops.
     ("source", "add"): _MUTATION_RATIONALE_SUCCESS,
     ("source", "add-drive"): _MUTATION_RATIONALE_SUCCESS,
+    ("source", "add-drive-file"): _MUTATION_RATIONALE_SUCCESS,
     ("source", "clean"): _MUTATION_RATIONALE_SUCCESS,
     ("source", "delete"): _MUTATION_RATIONALE_SUCCESS,
     ("source", "delete-by-title"): _MUTATION_RATIONALE_SUCCESS,
@@ -960,6 +961,7 @@ JSON_ERROR_WAIVED: dict[tuple[str, ...], str] = {
     # source group — list error is covered; remaining mutations + introspection.
     ("source", "add"): _MUTATION_RATIONALE_ERROR,
     ("source", "add-drive"): _MUTATION_RATIONALE_ERROR,
+    ("source", "add-drive-file"): _MUTATION_RATIONALE_ERROR,
     ("source", "clean"): _MUTATION_RATIONALE_ERROR,
     ("source", "delete"): _MUTATION_RATIONALE_ERROR,
     ("source", "delete-by-title"): _MUTATION_RATIONALE_ERROR,

--- a/tests/unit/test_source_upload_coverage.py
+++ b/tests/unit/test_source_upload_coverage.py
@@ -451,6 +451,30 @@ async def test_add_file_asserts_bound_loop_before_work(tmp_path) -> None:
     lifecycle.assert_bound_loop.assert_called_once()
 
 
+def test_get_download_semaphore_asserts_bound_loop_before_building(tmp_path) -> None:
+    """``get_download_semaphore`` asserts loop ownership before building the primitive.
+
+    This is the Drive auto-route download seam (#1884): a cross-loop
+    ``add_drive_file`` must fail before it can acquire the lazy semaphore on the
+    wrong loop (or start a fetch), mirroring ``add_file``'s upload-seam guard.
+    """
+    lifecycle = _Lifecycle()
+    auth = MagicMock()
+    auth.authuser = 0
+    auth.account_email = None
+    pipeline = SourceUploadPipeline(
+        rpc=MagicMock(), drain=_Drain(), lifecycle=lifecycle, kernel=MagicMock(), auth=auth
+    )
+    lifecycle.assert_bound_loop = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("wrong loop")
+    )
+    with pytest.raises(RuntimeError, match="wrong loop"):
+        pipeline.get_download_semaphore()
+    lifecycle.assert_bound_loop.assert_called_once()
+    # The primitive was NOT built — the guard fired first.
+    assert pipeline._download_semaphore is None
+
+
 # =============================================================================
 # register_file_source() probe / create branches
 # =============================================================================

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -100,6 +100,21 @@ def sources_api(mock_core):
     return SourcesAPI(mock_core, uploader=uploader)
 
 
+@pytest.mark.asyncio
+async def test_add_drive_file_asserts_bound_loop_before_fetch(sources_api, mock_core):
+    """A cross-loop ``add_drive_file`` fails before any download/fetch runs (#1884).
+
+    The download-gating semaphore's ``assert_bound_loop`` is the seam: it fires
+    from ``get_download_semaphore`` BEFORE ``DriveImportService.add_drive_file``
+    (and thus any network fetch). Getting exactly that ``wrong loop`` error back —
+    not a network/httpx error — proves the fetch never ran.
+    """
+    mock_core.assert_bound_loop = MagicMock(side_effect=RuntimeError("wrong loop"))
+    with pytest.raises(RuntimeError, match="wrong loop"):
+        await sources_api.add_drive_file("nb_1", "https://drive.google.com/open?id=" + "a" * 33)
+    mock_core.assert_bound_loop.assert_called()
+
+
 def test_sources_api_makes_uploader_share_lifecycle_collaborators(sources_api):
     """SourcesAPI is the single owner of the source-lifecycle verbs.
 

--- a/tests/unit/test_sources_upload_delegation.py
+++ b/tests/unit/test_sources_upload_delegation.py
@@ -338,12 +338,16 @@ def test_sources_upload_helpers_are_pure_delegators() -> None:
     # uploader-delegating helper would be silently skipped by the loop below.
     # ``__init__`` is excluded: it only *wires* the uploader (configuring the
     # shared lister/poller and source-limit lookup), it does not delegate an
-    # upload operation to it.
+    # upload operation to it. ``add_drive_file`` (#1884) is excluded too: it only
+    # reads the ``self._uploader.live_cookies`` seam to authenticate the Drive
+    # fetch — it does not re-implement or delegate a resumable-upload operation
+    # (its upload leg goes through the public ``self.add_file``, already covered).
+    _uploader_seam_only = {"__init__", "add_drive_file"}
     uploader_methods = {
         node.name
         for node in class_def.body
         if isinstance(node, func_types)
-        and node.name != "__init__"
+        and node.name not in _uploader_seam_only
         and "self._uploader" in ast.unparse(node)
     }
     assert uploader_methods == set(expected), (


### PR DESCRIPTION
## Summary

Adds a single entry point that takes a Google Drive file id/URL and, for the Drive file types NotebookLM's **native** Drive import can't ingest (`epub`/`docx`/`txt`/`md`/`rtf`/`odt`/`csv`/`tsv`/`pdf`), downloads the file server-side and uploads it through the resumable-upload leg. Native Google Docs/Slides/Sheets keep their existing native path (a pointer error steers callers there).

New surfaces:
- **MCP tool** `source_add_drive_file(notebook, document_id, title?, wait?)` — in a new module `mcp/tools/sources_drive.py` with its own `register`, wired into `server.register_all` (the ceiling'd `mcp/tools/sources.py` is untouched).
- **CLI** `notebooklm source add-drive-file <id|url> [--title T] [--wait] [--json]`.

## Remote-mode design (crux)

The fetch runs SERVER-SIDE where the profile + cookies already live, authenticated by the **same live `.google.com` master jar** the upload leg uses (exposed via a new public `SourceUploadPipeline.live_cookies()` seam — no private-method reach). A Drive source has no client-side bytes, so both the Drive→server fetch and the server→NotebookLM push are server-local. Result: it works in **stdio AND remote (http) MCP mode with no `upload_required` detour** — categorically unlike `source_add(source_type="file")`.

## Download-endpoint classification

ONE cookie-authed request to `drive.usercontent.google.com/download?id=<id>&export=download`, inspected **header-first**:
- **Attachment** (`Content-Disposition: attachment; filename="X.ext"`) → route by `.ext`: supported → download+upload; `.html`/`.htm`/`.xhtml` → convert-first error; other → unsupported error.
- **HTML response** → r3 **Fix A** discriminator, in order: final host `accounts.google.com` (ServiceLogin) → auth-expired; an **exact** Drive download-form signature (action on a Drive download host + `id` == requested id + `export=download` + non-empty `confirm`, carrying `uuid`) → the >25 MB virus-scan interstitial, re-requested with the token; anything else → a non-committal "not downloadable — use `source_add(source_type='drive', …)` for a native Doc/Sheet" pointer error.

## Streaming + safety (r3 Fix B)

Header-first **streaming** via httpx (never the buffering curl_cffi GET) with the #1521 per-hop redirect-revalidation hooks + `.google.com` trusted-host guard. Unsupported/over-cap responses close **before** the body is read; supported bodies stream to a **0600** temp file under a **running byte cap** (200 MiB), guaranteed-unlinked on success/failure/cancel. `_validate_upload_file_supported` runs as a second defense before upload.

## Placement / boundaries

`_source/drive_import.py` (new, all I/O behind injected `fetch`+`add_file` seams) → public `SourcesAPI.add_drive_file` composes it → thin `_app/source_mutations.execute_source_add_drive_file` calls only the public client (respects the `_app` boundary). `SCHEMA_CHAR_BUDGET` raised 40_550 → 41_700 with an ADR-0025 discrete-verb justification.

## Testing

Injection-based unit tests (no live Drive): routing table per extension, id/URL parse + shape validation, the r3 confirm-form discriminator (matching signature vs login vs bogus HTML), header-first close-before-body for unsupported/over-cap, temp cleanup on success/failure/cancel, the html-mislabel second defense, `_app` executor delegation, the MCP tool (incl. remote-mode never emits `upload_required`), and the CLI happy/json/error paths. Full `-m "not e2e"` suite green (only the 2 pre-existing `test_auth_headless_reauth` playwright tests fail without `--extra browser`).

**Live validation** (teng-lin-9420 account): the real Drive epub `1W20RJpJUD2JqXSEiM9Il48_fsdOtZ5fD` added to a throwaway notebook reached **READY as `kind=EPUB`**; the notebook was then deleted.

Closes #1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upload-only Google Drive file ingestion for notebooks (server-side download, then upload) with structured results.
  * Introduced the `source add-drive-file` CLI command (supports optional title, waiting, and `--json` output).
  * Added the `source_add_drive_file` MCP tool for Drive-to-notebook ingestion.
* **Bug Fixes**
  * Strengthened Drive import reliability with early rejection of unsupported/HTML content, size caps, confirmation-interstitial handling, expired-auth detection, and safer temp-file cleanup.
* **Documentation**
  * Updated architecture documentation to cover the new Drive import workflow and components.
* **Tests**
  * Added unit and CLI/MCP coverage for the new Drive ingestion command and tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->