### PR TITLE
chore: release v0.8.0a4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`studio_download` `download_ready` now carries `filename` / `mime` /
+  `size_bytes`.** The MCP download-ready payload previously returned only the
+  local path, so an agent had to stat the file to learn what it got; the
+  artifact's server filename, content type, and byte size now travel in the
+  envelope. ([#1835](https://github.com/teng-lin/notebooklm-py/issues/1835))
+- **Explicit per-state counts in the `source_wait` aggregate.** The wait
+  aggregate now reports how many sources finished `ready` vs `error` vs still
+  `pending` (rather than a single rolled-up status), so a caller waiting on a
+  batch can see partial progress and act on the failures.
+  ([#1834](https://github.com/teng-lin/notebooklm-py/issues/1834))
 - **`notebooklm skill package` — Claude-uploadable skill archive** (#1856 item 2;
   the docs half landed in #1857). Builds a deterministic ZIP whose root contains
   the `notebooklm/SKILL.md` skill folder (version-stamped, frontmatter-first),
@@ -33,6 +43,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upload-only Drive file types auto-route to the file-upload path.** Adding a
+  Drive file whose type NotebookLM only accepts as an upload (not an add-by-URL)
+  used to fail at the RPC; the add-from-Drive path now detects those types and
+  routes them through the upload flow, and when a Drive add can't be recovered the
+  error now names the file-upload path as the remedy instead of a generic failure.
+  ([#1887](https://github.com/teng-lin/notebooklm-py/issues/1887),
+  [#1885](https://github.com/teng-lin/notebooklm-py/issues/1885))
+- **Loopback MCP HTTP transport rejects non-loopback `Host` headers.** The
+  loopback-bound HTTP transport now refuses requests whose `Host` header is not a
+  loopback name, closing a DNS-rebinding vector against a locally bound MCP server.
+  ([#1876](https://github.com/teng-lin/notebooklm-py/issues/1876))
+- **Null-conversation chat asks are serialized with explicit follow-ups.**
+  Consecutive asks against a fresh (null) conversation could race the
+  conversation-id assignment; they are now serialized and threaded as explicit
+  follow-ups so each ask lands on the intended conversation.
+  ([#1880](https://github.com/teng-lin/notebooklm-py/issues/1880))
+- **Multi-source `source_wait` no longer polls O(N²).** Waiting on N sources took
+  one snapshot per source per tick; the wait now reads a single notebook snapshot
+  per tick and derives every source's state from it, and the overall wait duration
+  is bounded. ([#1882](https://github.com/teng-lin/notebooklm-py/issues/1882))
+- **Raised the streamed chat-response size cap.** Long answers were truncated at
+  the previous streamed-response ceiling; the cap is raised so full responses come
+  through. ([#1852](https://github.com/teng-lin/notebooklm-py/issues/1852))
+- **Aggregate retry deadline threaded through the RPC path; OAuth `fsync`
+  offloaded.** The aggregate retry now honors a single deadline across attempts
+  instead of resetting per call, and the OAuth token `fsync` is moved off the event
+  loop so it can't stall concurrent requests.
+  ([#1881](https://github.com/teng-lin/notebooklm-py/issues/1881))
+- **`studio_download` rejects an unknown `output_format` self-documentingly.** An
+  invalid `output_format` now returns an error that lists the accepted formats
+  instead of an opaque rejection.
+  ([#1833](https://github.com/teng-lin/notebooklm-py/issues/1833))
+- **MCP source waits stay JSON-first.** `source_wait` output is emitted as
+  structured JSON rather than prose, matching the rest of the MCP source surface.
+  ([#1830](https://github.com/teng-lin/notebooklm-py/issues/1830))
+- **Deep-research null-start no longer leaks an internal method id.** A failed
+  deep-research start surfaced the obfuscated RPC method id in the error; it is now
+  hidden. ([#1851](https://github.com/teng-lin/notebooklm-py/issues/1851))
+- **REST server resource-limit hardening.** Several bounds were added to the
+  experimental REST server so a single client can't exhaust it: per-route JSON
+  request-body size caps ([#1846](https://github.com/teng-lin/notebooklm-py/issues/1846)),
+  route-group backpressure to cap concurrent in-flight requests
+  ([#1847](https://github.com/teng-lin/notebooklm-py/issues/1847)), a bounded fanout
+  for multi-source waits ([#1844](https://github.com/teng-lin/notebooklm-py/issues/1844)),
+  a shared suggest-surface map so the suggest routes don't each rebuild it
+  ([#1843](https://github.com/teng-lin/notebooklm-py/issues/1843)), and
+  `PendingRegistry.drop()` now removes the stale FIFO tuple so the pending queue
+  can't leak entries ([#1879](https://github.com/teng-lin/notebooklm-py/issues/1879)).
+  Diagnostics endpoints also stay live when auth is stale instead of failing with
+  the guarded routes ([#1845](https://github.com/teng-lin/notebooklm-py/issues/1845)),
+  and the account block is fetched with a single `GET_USER_SETTINGS` call instead of
+  two ([#1862](https://github.com/teng-lin/notebooklm-py/issues/1862)).
 - **Artifact-generation validation footguns** ([#1874]). Three input-validation
   hardenings on the artifact surface: (A) the REST `POST /artifacts`
   (`ArtifactGenerate`) body now rejects unknown fields (`extra="forbid"`) with a

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0a3",
+  "version": "0.8.0a4",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0a3"
+version = "0.8.0a4"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -210,6 +210,7 @@ TOOL_COVERAGE: dict[str, str] = {
     "source_wait": "TestMcpSources.test_source_roundtrip",
     "source_add_and_wait": "tests/unit/mcp/test_sources.py (add+wait composite; unit)",
     "source_upload_bytes": "tests/unit/mcp/test_file_tools.py (in-channel bytes upload; unit)",
+    "source_add_drive_file": "tests/unit/mcp/test_sources_drive.py (Drive-doc auto-route; unit — needs a real Drive document_id)",
     # chat
     "chat_ask": "TestMcpChat.test_configure_then_ask",
     "chat_configure": "TestMcpChat.test_configure_then_ask",

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0a3"
+version = "0.8.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -375,14 +375,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Release v0.8.0a4 — fourth alpha in the 0.8.0 pre-release cycle.

Accumulates the post-`v0.8.0a3` fixes under the in-progress `## [0.8.0]` /
`[Unreleased]` changelog heading (no dated alpha section, per the pre-release
policy in docs/releasing.md). Highlights:

- **Sources:** Drive upload-only auto-routing + clearer failure guidance (#1887/#1885),
  O(N²) multi-source wait fix (#1882), per-state `source_wait` counts (#1834).
- **REST server hardening:** body caps, route-group backpressure, bounded wait
  fanout, PendingRegistry leak fix, stale-auth diagnostics (#1846/#1847/#1844/#1879/#1845/#1862).
- **MCP:** loopback Host-header guard (#1876), richer `studio_download` ready
  payload (#1835), self-documenting format rejection (#1833), JSON-first waits (#1830).
- **Chat/RPC/OAuth:** null-conversation ask serialization (#1880), raised streamed
  cap (#1852), retry-deadline threading + OAuth fsync offload (#1881).

Version bumped in pyproject.toml + desktop-extension/manifest.json, uv.lock re-locked.
Public-API audit clean (150 allowlisted breaks vs v0.7.0 baseline, no new breaks);
pre-commit, mypy (311 files), and full pytest (12139 passed) all green locally.

See CHANGELOG.md for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download-ready notifications now include filename, MIME type, and file size.
  * Source waiting results now report explicit per-state counts (ready, error, pending).
* **Bug Fixes**
  * Improved studio download output validation, Drive upload routing, MCP loopback security, and retry deadline handling.
  * Enhanced multi-source waiting performance and standardized JSON-first source-wait formatting and error handling.
* **Tests**
  * Updated MCP E2E tool coverage to include `source_add_drive_file`.
* **Chores**
  * Bumped app and desktop extension version to `0.8.0a4`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->