### PR TITLE
feat(mcp): mobile file upload — await_upload completion signal + short-link

### DIFF
--- a/docs/experiments/2026-07-webview-upload.md
+++ b/docs/experiments/2026-07-webview-upload.md
@@ -33,7 +33,8 @@ This plan splits the probe (see `docs/plans/remote-mcp-file-upload-plan-v4.md`):
 | claude.ai web (Chrome/Edge), Claude Desktop | Blink | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
 | claude.ai web (Safari), iOS **browser** (Safari) | WebKit | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
 | Claude **iOS — in-app** WKWebView | WebKit (embedded) | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | — |
-| Claude **Android — in-app** WebView | Blink (embedded) | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | — |
+| Claude **Android — external browser** (Chrome) | Blink | ✅ | ✅ | ✅ | **GREEN — live** | on-device 2026-07-14 (below) |
+| Claude **iOS / Android — in-app** WebView | embedded | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | not tested (we used the external browser) |
 | ChatGPT (web/mobile) | — | — | — | — | feature-detect `window.openai.uploadFile` | snippet below |
 
 **Prior (unchanged, informs 2b):** iOS WKWebView presents the picker natively with zero host
@@ -46,6 +47,50 @@ app-embedding property the engine-level probe **cannot** see, so it stays a real
 **The external-browser link flow works on both engines.** That is the Phase 1 mobile story, and
 it is validated end-to-end (picker → file read → POST → source added) — not just assumed. So
 regardless of how 2b lands, mobile users have a working path today.
+
+## Live device validation — Claude **Android**, 2026-07-14 — ✅ PASSED
+
+Ran the full Phase 1 loop against a live dev deployment (`nlm-dev` stack, `peopleconf` account,
+tunnel `notebooklm-test.hantekllc.com`, image `phase1-dev` built from this branch; prod stack
+untouched throughout). Observed server-side end to end:
+
+```
+source_add(source_type="file")          → minted /files/ul/<token>   (POST /mcp)
+GET  /files/ul/<full-token>             → 200  (upload page opened in Chrome)
+POST notebooklm.google.com/upload/…resumable → 200  (bytes streamed to NotebookLM)
+POST /files/ul/<token>?filename=Sanya-Lingshui.pdf → 200  (source added; completion recorded)
+await_upload(<url>)                      → {"status":"received","source_id":"a7f1e52e-…"}
+source_wait                              → READY, ok:true, 1/1, no import error
+```
+
+Sanya-Lingshui.pdf (4.8 MB) landed and became queryable. The Phase 1 code path is confirmed live:
+the `/files/ul` POST wrote `{source_id,name,size,mime}` into the in-process completion map on
+`ConsumedJtiStore`, and `await_upload` read it back in the same process — no DB, exactly as
+designed. Opening was via the **external browser** (Chrome), so the in-app WebView cell (2b) is
+still untested.
+
+## ⚠️ Defect found (blocking UX, not a code bug): the opaque signed-URL is fragile through mobile chat
+
+Getting the ~250-char `/files/ul/<token>` URL from the chat into the browser **failed three times**
+before a byte-exact copy finally worked. Three distinct corruption modes, all server-verified:
+
+1. **Tap-truncation** → `GET /files/ul/` with the token dropped entirely → **404**.
+2. **Model re-typing the URL into prose** dropped a UUID segment (`…-4ac6-4628…`, missing `91b7-`)
+   → HMAC mismatch → **403**. (The server always signs the fully-resolved notebook id, so a short
+   nb inside the token proves the corruption is downstream of minting — the LLM garbled it.)
+3. **`O`→`0` substitution + injected `%20` spaces** (autocorrect/OCR-style) → **403**.
+
+Only the exact string copied from the **`source_add` tool result** (`human_upload.url`), not the
+model's rendered link, verified. **Conclusion:** routing a long opaque token through model text /
+a mobile tap-target is unreliable by construction.
+
+### Phase 1 follow-up (recommended next): short-link indirection
+Add a short random id (e.g. 8–12 chars) → token mapping resolved server-side, so the user-facing
+URL is `…/u/<shortid>` (the `/u/{token}` idea the v4 plan floated and v5 dropped as nonexistent —
+this live failure is the evidence to build it). Short enough to survive a mobile tap AND for the
+model to transcribe correctly; the existing signed token stays the server-side source of truth.
+Reuse the same `ConsumedJtiStore` process to hold the shortid→token map (in-process, TTL-swept),
+consistent with the no-DB architecture.
 
 ## Incidental findings (feed Phase 3)
 
@@ -73,8 +118,14 @@ the interop evidence for the Phase 5 `ui/uploadFile` proposal).
 
 ## Gate A status
 
-- **External-browser / link flow (2a):** ✅ GREEN — proceed with Phase 1 as the portable mobile
-  path (done).
-- **In-app widget (2b):** ⏳ PENDING the two on-device cells above. Build the `ui://` probe as
-  Phase 3's first commit; if the in-app picker is red on a platform, that platform keeps the
-  link flow and we escalate upstream (the `ui/uploadFile` proposal), per the plan.
+- **External-browser / link flow (2a):** ✅ GREEN — **live-validated on Android 2026-07-14** (full
+  loop above). Phase 1 is the working, portable mobile path today.
+- **In-app widget (2b):** ⏳ PENDING the two on-device cells. Build the `ui://` probe as Phase 3's
+  first commit; if the in-app picker is red on a platform, that platform keeps the link flow and we
+  escalate upstream (the `ui/uploadFile` proposal), per the plan.
+
+## Next up (priority order, from what the live test taught us)
+1. **Short-link indirection** (`…/u/<shortid>` → token) — the top Phase 1 follow-up; the opaque URL
+   is the only thing that made the working flow hard. See the defect section above.
+2. **Phase 2b** in-app WebView probe (Phase 3's first commit).
+3. Phase 5 SEP-2631 adapter (parallel, independent).

--- a/docs/experiments/2026-07-webview-upload.md
+++ b/docs/experiments/2026-07-webview-upload.md
@@ -31,7 +31,7 @@ This plan splits the probe (see `docs/plans/remote-mcp-file-upload-plan-v4.md`):
 | Surface | Engine | picker_opened | file_readable | fetch/POST ok | Verdict | Evidence |
 |---|---|:--:|:--:|:--:|---|---|
 | claude.ai web (Chrome/Edge), Claude Desktop | Blink | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
-| claude.ai web (Safari), iOS **browser** (Safari) | WebKit | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
+| WebKit **engine** (Playwright — proxy for Safari/iOS engine, NOT the iOS Safari app/device) | WebKit | ✅ | ✅ | ✅ | **GREEN (engine-level only)** | automated (`probe_2a.py`) |
 | Claude **iOS — in-app** WKWebView | WebKit (embedded) | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | — |
 | Claude **Android — external browser** (Chrome) | Blink | ✅ | ✅ | ✅ | **GREEN — live** | on-device 2026-07-14 (below) |
 | Claude **iOS / Android — in-app** WebView | embedded | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | not tested (we used the external browser) |
@@ -52,9 +52,9 @@ regardless of how 2b lands, mobile users have a working path today.
 
 Ran the full Phase 1 loop against a live dev deployment (`nlm-dev` stack, `peopleconf` account,
 tunnel `notebooklm-test.hantekllc.com`, image `phase1-dev` built from this branch; prod stack
-untouched throughout). Observed server-side end to end:
+untouched throughout). Observed server-side end-to-end:
 
-```
+```text
 source_add(source_type="file")          → minted /files/ul/<token>   (POST /mcp)
 GET  /files/ul/<full-token>             → 200  (upload page opened in Chrome)
 POST notebooklm.google.com/upload/…resumable → 200  (bytes streamed to NotebookLM)
@@ -84,13 +84,15 @@ Only the exact string copied from the **`source_add` tool result** (`human_uploa
 model's rendered link, verified. **Conclusion:** routing a long opaque token through model text /
 a mobile tap-target is unreliable by construction.
 
-### Phase 1 follow-up (recommended next): short-link indirection
-Add a short random id (e.g. 8–12 chars) → token mapping resolved server-side, so the user-facing
-URL is `…/u/<shortid>` (the `/u/{token}` idea the v4 plan floated and v5 dropped as nonexistent —
-this live failure is the evidence to build it). Short enough to survive a mobile tap AND for the
-model to transcribe correctly; the existing signed token stays the server-side source of truth.
-Reuse the same `ConsumedJtiStore` process to hold the shortid→token map (in-process, TTL-swept),
-consistent with the no-DB architecture.
+### Fix — short-link indirection (SHIPPED in this PR)
+Resolved by handing the user a short random id → token link (`…/u/<shortid>`, ~16 chars) that
+`302`-redirects to the canonical `/files/ul/<token>` page server-side. The mapping lives in a new
+in-process, TTL-swept `ShortLinkStore` on `FileTransferConfig` (no DB, same contract as
+`ConsumedJtiStore`); `_broker_upload` returns the short link for the human path and the direct
+`/files/ul` POST target for the agent path, over one token; `await_upload` accepts either.
+**Re-validated live on Android:** `/u/yvhW-egX` (9 chars) → `302` → `GET /files/ul/<token> 200` →
+`POST …?filename=main.pdf 200` → source added — on the **first** clean attempt, where the long URL
+had failed three times. The user only ever handled the short link; the server expanded it losslessly.
 
 ## Incidental findings (feed Phase 3)
 
@@ -125,7 +127,8 @@ the interop evidence for the Phase 5 `ui/uploadFile` proposal).
   escalate upstream (the `ui/uploadFile` proposal), per the plan.
 
 ## Next up (priority order, from what the live test taught us)
-1. **Short-link indirection** (`…/u/<shortid>` → token) — the top Phase 1 follow-up; the opaque URL
-   is the only thing that made the working flow hard. See the defect section above.
-2. **Phase 2b** in-app WebView probe (Phase 3's first commit).
-3. Phase 5 SEP-2631 adapter (parallel, independent).
+1. ~~Short-link indirection~~ — **DONE** (shipped in this PR; see the fix section above).
+2. **Phase 2b** in-app WebView probe (Phase 3's first commit) — the cheap gate that decides whether
+   the Phase 3 widget is worth building.
+3. Phase 3 direct-PUT widget — only if 2b is green (needs the `ui://` substrate + CORS work).
+4. Phase 5 SEP-2631 adapter (parallel, independent).

--- a/docs/experiments/2026-07-webview-upload.md
+++ b/docs/experiments/2026-07-webview-upload.md
@@ -1,0 +1,80 @@
+# WebView upload probe (Phase 2) — results
+
+**Question (Gate A):** does the `<input type="file">` picker fire and can bytes `fetch`-POST
+back, across the surfaces where a mobile user would add a file? The answer decides whether
+the Phase 3 **in-app widget** is worth building, or whether the Phase 1 **link flow** is the
+whole mobile story.
+
+This plan splits the probe (see `docs/plans/remote-mcp-file-upload-plan-v4.md`):
+
+- **2a — external-browser probe (this doc, automatable):** open the *existing* signed
+  `/files/ul/{token}` page — already an `<input type=file>` + `fetch` POST — in the device's
+  real browser. This is exactly the Phase 1 link flow. **Zero new code.**
+- **2b — in-app iframe probe:** does the picker fire *inside Claude's own app WebView*? Needs
+  a `ui://` widget iframe the repo doesn't have yet → it is Phase 3's first (throwaway-if-red)
+  commit, **not** a standalone experiment.
+
+## Method
+
+- **Automated (engine-level):** a throwaway harness
+  (`scratchpad/probe_2a.py`) starts the real FastMCP `http_app()` with the `/files/*` routes,
+  mints a real `ul` token, and drives the page headless in **both** Playwright engines —
+  Chromium (Blink) and WebKit (Safari's engine) — attaching a file and asserting the POST adds
+  a source. Fresh single-use token per engine.
+- **On-device (manual, pending):** run `notebooklm-mcp` with `NOTEBOOKLM_MCP_PUBLIC_URL` set to
+  a public HTTPS URL, connect it on the phone, call `source_add(source_type="file")` to mint a
+  link, open `human_upload.url` in the device browser AND inside Claude's app, and record each
+  cell.
+
+## Results matrix
+
+| Surface | Engine | picker_opened | file_readable | fetch/POST ok | Verdict | Evidence |
+|---|---|:--:|:--:|:--:|---|---|
+| claude.ai web (Chrome/Edge), Claude Desktop | Blink | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
+| claude.ai web (Safari), iOS **browser** (Safari) | WebKit | ✅ | ✅ | ✅ | **GREEN** | automated (`probe_2a.py`) |
+| Claude **iOS — in-app** WKWebView | WebKit (embedded) | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | — |
+| Claude **Android — in-app** WebView | Blink (embedded) | ? | ? | ? | PENDING (device) — this is **2b/Phase 3** | — |
+| ChatGPT (web/mobile) | — | — | — | — | feature-detect `window.openai.uploadFile` | snippet below |
+
+**Prior (unchanged, informs 2b):** iOS WKWebView presents the picker natively with zero host
+code — the WebKit-engine GREEN above is consistent with that. Android in-app WebView typically
+**no-ops** unless the host app implements `WebChromeClient.onShowFileChooser()` — an
+app-embedding property the engine-level probe **cannot** see, so it stays a real device unknown.
+
+## Phase 2a conclusion
+
+**The external-browser link flow works on both engines.** That is the Phase 1 mobile story, and
+it is validated end-to-end (picker → file read → POST → source added) — not just assumed. So
+regardless of how 2b lands, mobile users have a working path today.
+
+## Incidental findings (feed Phase 3)
+
+- **Page CSP is strict:** `default-src 'none'; script-src 'unsafe-inline'; style-src
+  'unsafe-inline'; connect-src 'self'; form-action 'none'; base-uri 'none'`
+  (`_fileroutes.py:_HTML_SECURITY_HEADERS`). `connect-src 'self'` means the page can only
+  `fetch` its own origin — fine for Phase 1 (same-origin POST), but **Phase 3's direct-PUT from
+  a widget iframe to the server origin will need CORS + a relaxed `connect-src` / `_meta.ui`
+  `connectDomains`**, exactly as the plan flags. (Also surfaced because the strict `no
+  'unsafe-eval'` CSP blocks Playwright's `eval_on_selector`/`wait_for_function` — the harness
+  polls via non-eval APIs.)
+- **Single-use `ul` token confirmed live:** reusing one token across the two engine runs
+  returned `403` on the second — the jti burned on first success (ADR-0024 / #1746).
+
+## ChatGPT host-upload feature-detect (Phase 5 interop signal)
+
+Run in the ChatGPT client (apps-sdk widget or console) to see if a host-brokered upload exists:
+
+```js
+typeof window.openai?.uploadFile === "function"
+```
+
+`true` → ChatGPT offers native mobile upload today (the Phase 3 fallback-ladder's top rung, and
+the interop evidence for the Phase 5 `ui/uploadFile` proposal).
+
+## Gate A status
+
+- **External-browser / link flow (2a):** ✅ GREEN — proceed with Phase 1 as the portable mobile
+  path (done).
+- **In-app widget (2b):** ⏳ PENDING the two on-device cells above. Build the `ui://` probe as
+  Phase 3's first commit; if the in-app picker is red on a platform, that platform keeps the
+  link flow and we escalate upstream (the `ui/uploadFile` proposal), per the plan.

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -47,9 +47,11 @@ from typing import Any
 __all__ = [
     "DOWNLOAD_TTL",
     "UPLOAD_TTL",
+    "ConsumedJtiStore",
     "FileLinkError",
     "FileLinkSigner",
     "FileTransferConfig",
+    "ShortLinkStore",
 ]
 
 #: Signed-URL lifetimes. Upload links are shorter-lived than downloads: an upload
@@ -264,6 +266,65 @@ class ConsumedJtiStore:
         self._active.discard(jti)
 
 
+#: Short-id length in random bytes. ``token_urlsafe(6)`` → 8 URL-safe chars (48 bits) —
+#: short enough to survive a mobile tap / model transcription, wide enough that guessing
+#: a live id within its ≤15-min window is infeasible (and the resolved token still carries
+#: the HMAC + single-use jti, so a guessed id buys nothing an attacker couldn't get anyway).
+_SHORT_ID_BYTES = 6
+#: Bound mirrors ``_MAX_SEEN_JTIS`` — one entry per file-tool call, all TTL-swept.
+_MAX_SHORT_LINKS = 8192
+
+
+@dataclass
+class ShortLinkStore:
+    """In-process ``shortid -> (token, exp)`` map backing the tap-friendly ``/u/<shortid>``
+    upload links.
+
+    The long ``/files/ul/<token>`` URL (~250 chars) is fragile through a mobile chat: it gets
+    tap-truncated, re-typed with dropped characters by the model, or autocorrected — every
+    corruption breaks the HMAC (live-confirmed). A short random id sidesteps all of that; this
+    store resolves it back to the real signed token server-side.
+
+    Same contract as :class:`ConsumedJtiStore`: single process / single tenant, every method is
+    synchronous (no ``await`` → atomic on the one event loop, no lock), TTL-swept, dies with the
+    process. No DB, no background sweeper.
+    """
+
+    #: shortid -> (signed token, exp unix seconds). exp mirrors the token's own ``exp`` so a
+    #: resolved link never outlives the token it points at.
+    _links: dict[str, tuple[str, int]] = field(default_factory=dict)
+
+    def _sweep(self, now: int) -> None:
+        for sid in [s for s, (_t, exp) in self._links.items() if exp < now]:
+            del self._links[sid]
+
+    def put(self, token: str, exp: int) -> str:
+        """Register ``token`` (valid until ``exp``) under a fresh short id and return the id.
+
+        Sweeps expired entries and enforces the size bound here (the only growing path), so
+        :meth:`get` stays O(1)."""
+        now = int(time.time())
+        self._sweep(now)
+        if len(self._links) >= _MAX_SHORT_LINKS:
+            # Evict the soonest-to-expire entry (least loss — closest to natural expiry).
+            del self._links[min(self._links, key=lambda s: self._links[s][1])]
+        shortid = secrets.token_urlsafe(_SHORT_ID_BYTES)
+        self._links[shortid] = (token, exp)
+        return shortid
+
+    def get(self, shortid: str) -> str | None:
+        """Return the token for ``shortid``, or ``None`` if unknown or its token has expired
+        (an expired entry is dropped in passing)."""
+        entry = self._links.get(shortid)
+        if entry is None:
+            return None
+        token, exp = entry
+        if int(time.time()) > exp:
+            self._links.pop(shortid, None)
+            return None
+        return token
+
+
 @dataclass(frozen=True)
 class FileTransferConfig:
     """Resolved file-transfer config: the signer + the validated public base URL.
@@ -282,6 +343,21 @@ class FileTransferConfig:
     #: mutable, dict-bearing (unhashable) object, so including it in ``__eq__``/
     #: ``__hash__`` would make every config unhashable and equality depend on live state.
     jti_store: ConsumedJtiStore = field(default_factory=ConsumedJtiStore, compare=False)
+    #: In-process ``shortid -> token`` map backing the ``/u/<shortid>`` tap-friendly links
+    #: (:meth:`short_upload_url`). ``compare=False`` for the same reason as :attr:`jti_store`.
+    short_links: ShortLinkStore = field(default_factory=ShortLinkStore, compare=False)
+
+    def short_upload_url(self, payload: dict[str, Any]) -> str:
+        """Mint an upload token for ``payload`` and return a tap-friendly ``/u/<shortid>`` URL.
+
+        Signs the same ``ul`` token :meth:`upload_url` would, registers it under a short id
+        (keyed to the token's ``exp``), and returns the short URL — the long ``/files/ul``
+        URL a ``GET /u/<shortid>`` redirects to. Robust to mobile-chat corruption (see
+        :class:`ShortLinkStore`)."""
+        token = self.signer.sign({**payload, "op": "ul"}, UPLOAD_TTL)
+        exp = int(self.signer.verify(token, op="ul")["exp"])
+        shortid = self.short_links.put(token, exp)
+        return f"{self.base_url.rstrip('/')}/u/{shortid}"
 
     def upload_url(self, payload: dict[str, Any]) -> str:
         """Sign ``payload`` with the upload TTL and build the ``/files/ul`` URL.

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -122,7 +122,7 @@ class FileLinkSigner:
         mac = hmac.new(self.key, encoded.encode("ascii"), hashlib.sha256).digest()
         return f"{encoded}.{_b64url(mac)}"
 
-    def verify(self, token: str, *, op: str) -> dict[str, Any]:
+    def verify(self, token: str, *, op: str, allow_expired: bool = False) -> dict[str, Any]:
         """Verify ``token`` and return its payload, or raise :class:`FileLinkError`.
 
         Order matters: the length cap runs BEFORE any decode, then the MAC is
@@ -134,6 +134,11 @@ class FileLinkSigner:
             op: The operation the route serves (``"ul"`` / ``"dl"``). A token
                 minted for the other operation is rejected (an upload link cannot
                 be replayed against the download route or vice-versa).
+            allow_expired: Skip ONLY the ``exp`` check (MAC + shape + ``op`` are still
+                enforced). Used exclusively to recover a *committed* upload's result
+                when ``await_upload`` is re-invoked just after the start-token expired
+                — the ``/files/ul`` POST already verified the token while it was live,
+                so honoring the result is safe. NEVER use this to authorize a new write.
         """
         if len(token) > _MAX_TOKEN_LEN:
             raise FileLinkError("token too long")
@@ -160,7 +165,9 @@ class FileLinkSigner:
         if not isinstance(payload, dict):
             raise FileLinkError("malformed token body")
         exp = payload.get("exp")
-        if not isinstance(exp, int) or isinstance(exp, bool) or time.time() > exp:
+        if not isinstance(exp, int) or isinstance(exp, bool):
+            raise FileLinkError("token expired")
+        if not allow_expired and time.time() > exp:
             raise FileLinkError("token expired")
         if payload.get("op") != op:
             raise FileLinkError("operation mismatch")
@@ -266,11 +273,12 @@ class ConsumedJtiStore:
         self._active.discard(jti)
 
 
-#: Short-id length in random bytes. ``token_urlsafe(6)`` → 8 URL-safe chars (48 bits) —
-#: short enough to survive a mobile tap / model transcription, wide enough that guessing
-#: a live id within its ≤15-min window is infeasible (and the resolved token still carries
-#: the HMAC + single-use jti, so a guessed id buys nothing an attacker couldn't get anyway).
-_SHORT_ID_BYTES = 6
+#: Short-id length in random bytes. ``token_urlsafe(12)`` → 16 URL-safe chars (96 bits) —
+#: still short enough to survive a mobile tap / model transcription, but wide enough that a
+#: ``/u/<shortid>`` link (unauthenticated, resolves to a valid write-capable upload token for
+#: its ≤15-min TTL, and the 302/404 route is an online oracle with no per-id rate limit here)
+#: cannot be feasibly guessed. 48 bits was defensible but this keeps a comfortable margin.
+_SHORT_ID_BYTES = 12
 #: Bound mirrors ``_MAX_SEEN_JTIS`` — one entry per file-tool call, all TTL-swept.
 _MAX_SHORT_LINKS = 8192
 
@@ -355,7 +363,11 @@ class FileTransferConfig:
         URL a ``GET /u/<shortid>`` redirects to. Robust to mobile-chat corruption (see
         :class:`ShortLinkStore`)."""
         token = self.signer.sign({**payload, "op": "ul"}, UPLOAD_TTL)
-        exp = int(self.signer.verify(token, op="ul")["exp"])
+        # ``sign`` stamped ``exp = now + UPLOAD_TTL``; recompute it directly rather than
+        # re-verifying the token (a full HMAC+decode) just to read one field back. This
+        # ``now`` is a hair later, so the store entry expires at-or-after the token — never
+        # before it (a short link is never live past its token). Negligible on a 15-min TTL.
+        exp = int(time.time()) + UPLOAD_TTL
         shortid = self.short_links.put(token, exp)
         return f"{self.base_url.rstrip('/')}/u/{shortid}"
 

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -197,6 +197,13 @@ class ConsumedJtiStore:
     #: the concurrent request count and always released in the route's ``finally``, so
     #: it needs no sweep or size cap.
     _active: set[str] = field(default_factory=set)
+    #: jti -> upload result ({source_id, name, size, mime}), recorded on a successful
+    #: :meth:`commit` that carries one. This is the in-process **completion map**
+    #: (Phase 1 ``await_upload``): the ``/files/ul`` POST route and the polling tool run
+    #: in the same single process (ADR-0024), so a same-loop poll reads what the route
+    #: wrote — no DB, no cross-process state. Keyed by jti and swept with :attr:`_seen`,
+    #: so a record never outlives its token's ``exp`` (≤ ``UPLOAD_TTL``).
+    _results: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     def _sweep(self, now: int) -> None:
         # ``exp < now`` (strict), matching ``verify``'s ``time.time() > exp`` rejection:
@@ -205,6 +212,13 @@ class ConsumedJtiStore:
         # window at the exact expiry second. ``now`` is the caller's ``int(time.time())``.
         for expired_jti in [j for j, exp in self._seen.items() if exp < now]:
             del self._seen[expired_jti]
+            self._results.pop(expired_jti, None)
+
+    def completed(self, jti: str) -> dict[str, Any] | None:
+        """Return the recorded upload result for ``jti``, or ``None`` if not (yet)
+        completed. ``None`` covers both "not uploaded yet" and "burned without a
+        result"; the caller treats either as *pending*."""
+        return self._results.get(jti)
 
     def try_begin(self, jti: str) -> bool:
         """Atomically claim ``jti`` for a single upload.
@@ -219,11 +233,13 @@ class ConsumedJtiStore:
         self._active.add(jti)
         return True
 
-    def commit(self, jti: str, exp: int) -> None:
+    def commit(self, jti: str, exp: int, result: dict[str, Any] | None = None) -> None:
         """Burn ``jti`` permanently (its upload succeeded).
 
-        Sweeps expired entries and enforces the size bound here — the only mutating hot
-        path — so :meth:`try_begin` stays O(1).
+        When ``result`` is given it is recorded in the completion map (:meth:`completed`)
+        so a same-process ``await_upload`` poll can surface the added source. Sweeps
+        expired entries and enforces the size bound here — the only mutating hot path —
+        so :meth:`try_begin` stays O(1).
         """
         self._active.discard(jti)
         self._sweep(int(time.time()))
@@ -235,8 +251,12 @@ class ConsumedJtiStore:
             # the soonest-to-expire entry — the least loss of protection, since it is
             # closest to natural expiry anyway. ``_seen`` is non-empty here, so ``min`` is
             # safe.
-            del self._seen[min(self._seen, key=self._seen.__getitem__)]
+            evicted = min(self._seen, key=self._seen.__getitem__)
+            del self._seen[evicted]
+            self._results.pop(evicted, None)  # keep the completion map in step with _seen
         self._seen[jti] = exp
+        if result is not None:
+            self._results[jti] = result
 
     def rollback(self, jti: str) -> None:
         """Release a claimed-but-unfinished ``jti`` (upload failed / aborted / 429) so

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -38,6 +38,7 @@ from starlette.responses import (
     HTMLResponse,
     JSONResponse,
     PlainTextResponse,
+    RedirectResponse,
     Response,
 )
 from starlette.types import Receive, Scope, Send
@@ -418,6 +419,30 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         # The page is fully static (the token already lives in location.href), so
         # there is nothing attacker-controlled to interpolate.
         return HTMLResponse(_UPLOAD_PAGE, headers=_HTML_SECURITY_HEADERS)
+
+    @mcp.custom_route("/u/{shortid}", methods=["GET"])
+    async def short_upload_redirect(request: Request) -> Response:
+        # Tap-friendly ``/u/<shortid>`` → 302 to the canonical ``/files/ul/<token>`` page.
+        # A short id survives mobile-chat corruption that mangles the long opaque token
+        # (tap-truncation, model re-typing, autocorrect — all live-confirmed). The redirect
+        # keeps the upload page + POST route as the single source of truth. The resolved
+        # token still carries the full HMAC + single-use jti, so the short id grants nothing
+        # extra; an unknown/expired id is a flat 404 (a probe learns nothing).
+        token = config.short_links.get(request.path_params["shortid"])
+        if token is None:
+            return HTMLResponse(
+                "<!doctype html><html><body style='font-family:system-ui'>"
+                "<h2>This upload link is invalid or has expired.</h2>"
+                "<p>Re-run the tool from your assistant to get a fresh link.</p>"
+                "</body></html>",
+                status_code=404,
+                headers=_HTML_SECURITY_HEADERS,
+            )
+        return RedirectResponse(
+            f"/files/ul/{token}",
+            status_code=302,
+            headers={"Referrer-Policy": "no-referrer", "Cache-Control": "no-store"},
+        )
 
     @mcp.custom_route("/files/ul/{token}", methods=["POST", "PUT"])
     async def upload_route(request: Request) -> Response:

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -528,8 +528,22 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                     # on success means a failed/aborted upload (handled by the outer
                     # ``finally`` rollback) leaves the link usable for retry, honoring
                     # ADR-0024's large-file retry window. ``exp`` was validated as an int
-                    # by ``verify``.
-                    config.jti_store.commit(jti, payload["exp"])
+                    # by ``verify``. The ``result`` payload feeds the in-process completion
+                    # map so a same-process ``await_upload`` poll surfaces the added source
+                    # (Phase 1); it is success-only by construction — a failed upload writes
+                    # nothing, so ``await_upload`` stays "pending" and the model falls back
+                    # to ``source_list``. ``sha256`` is intentionally absent until the
+                    # deferred client/stream hashing (Phase 4) lands.
+                    config.jti_store.commit(
+                        jti,
+                        payload["exp"],
+                        result={
+                            "source_id": source_id,
+                            "name": filename,
+                            "size": total,
+                            "mime": mime,
+                        },
+                    )
                     committed = True
                     # The documented sandbox-`curl`/PUT path (an agent uploading a file
                     # it holds) gets clean JSON when it asks for it; a human browser gets

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -87,6 +87,13 @@ def register_all(mcp: FastMCP) -> None:
     ):
         module.register(mcp)
 
+    # ``await_upload`` (Phase 1 upload-completion signal) lives in the ``_fileupload``
+    # sibling of the sources domain — registered here rather than from ``sources.register``
+    # so that fat module (at its ADR-0008 size cap) does not absorb the wiring.
+    from .tools._fileupload import register_file_tools
+
+    register_file_tools(mcp)
+
 
 def create_server(
     *,

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import math
 import os
 import shutil
 import tempfile
@@ -118,10 +119,11 @@ def _broker_upload(
     if mime_type:
         payload["mime"] = mime_type
     url = cfg.upload_url(payload)
-    # Read the deadline back from the signed token so expires_at / _iso match the
-    # token's ``exp`` exactly, rather than recomputing now() a hair later (drift).
     token = url.rsplit("/", 1)[1]
-    expires_at = cfg.signer.verify(token, op="ul")["exp"]
+    # ``upload_url`` just stamped ``exp = now + UPLOAD_TTL``; compute it directly rather than
+    # a full ``verify()`` (HMAC + base64 + JSON) purely to read one field back. Drift is ≤1s
+    # on a 15-min TTL — immaterial to expires_at / _iso and the short-link store window.
+    expires_at = int(time.time()) + UPLOAD_TTL
     # Tap-friendly short link over the SAME token: the human path gets ``/u/<shortid>``
     # (survives mobile-chat corruption of the long token — live-confirmed), the agent path
     # keeps the direct ``/files/ul`` URL (a ``/u/`` id only serves GET→redirect, not the raw
@@ -272,6 +274,10 @@ async def _add_one(
 #: timing test.
 _AWAIT_TIMEOUT_S = 45.0
 _AWAIT_POLL_INTERVAL_S = 2.0
+#: Hard ceiling on a single ``await_upload`` poll — kept just under the ~60s connector
+#: watchdog so the tool always returns a clean ``pending`` (→ re-invoke) before the transport
+#: cuts the call. A caller asking for more is clamped, not honored.
+_AWAIT_MAX_TIMEOUT_S = 55.0
 
 
 def _extract_ul_token(token_or_url: str) -> str:
@@ -327,12 +333,30 @@ async def _await_upload(
         "hint": "this upload link is invalid or expired — call "
         'source_add(source_type="file") to get a fresh one',
     }
+    # Bound the poll window: a non-finite timeout would never satisfy the deadline check
+    # (an unbounded loop), and one past the ~60s connector watchdog would let the request
+    # die instead of returning a clean ``pending`` — breaking the re-invoke loop the design
+    # relies on. Clamp to [0, _AWAIT_MAX_TIMEOUT_S]; reject NaN/inf outright.
+    if not math.isfinite(timeout_s):
+        raise ValidationError("timeout must be a finite number of seconds")
+    timeout_s = max(0.0, min(timeout_s, _AWAIT_MAX_TIMEOUT_S))
     token = _resolve_upload_token(cfg, token_or_url)
     if token is None:  # unknown/expired short id
         return invalid
     try:
         payload = cfg.signer.verify(token, op="ul")
     except FileLinkError:
+        # The start-token may have expired WHILE a large upload finished — but the
+        # ``/files/ul`` POST verified it live and committed a result. Recover that result
+        # (MAC + op still enforced via allow_expired) rather than lose a successful add; a
+        # truly bad/forged token, or an expired one with nothing committed, stays invalid.
+        try:
+            expired_payload = cfg.signer.verify(token, op="ul", allow_expired=True)
+        except FileLinkError:
+            return invalid
+        done = cfg.jti_store.completed(str(expired_payload.get("jti") or ""))
+        if done is not None:
+            return {"status": "received", "source_id": done.get("source_id"), "file": done}
         return invalid
     jti = str(payload.get("jti") or "")
     deadline = time.monotonic() + timeout_s

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -120,7 +120,13 @@ def _broker_upload(
     url = cfg.upload_url(payload)
     # Read the deadline back from the signed token so expires_at / _iso match the
     # token's ``exp`` exactly, rather than recomputing now() a hair later (drift).
-    expires_at = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
+    token = url.rsplit("/", 1)[1]
+    expires_at = cfg.signer.verify(token, op="ul")["exp"]
+    # Tap-friendly short link over the SAME token: the human path gets ``/u/<shortid>``
+    # (survives mobile-chat corruption of the long token — live-confirmed), the agent path
+    # keeps the direct ``/files/ul`` URL (a ``/u/`` id only serves GET→redirect, not the raw
+    # POST). await_upload accepts either.
+    short_url = f"{cfg.base_url.rstrip('/')}/u/{cfg.short_links.put(token, expires_at)}"
     expires_iso = (
         datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat().replace("+00:00", "Z")
     )
@@ -150,9 +156,10 @@ def _broker_upload(
         "expires_in_seconds": UPLOAD_TTL,
         "mime_locked": mime_locked,
         # Human/browser path, first-class so an agent that cannot upload the bytes
-        # itself reliably surfaces the link to the user (the mobile case).
+        # itself reliably surfaces the link to the user (the mobile case). Uses the SHORT
+        # ``/u/<shortid>`` link — a long opaque token gets mangled in a mobile chat.
         "human_upload": {
-            "url": url,
+            "url": short_url,
             "instructions": (
                 "Open this link in a browser on the device that has the file, then "
                 "pick the file to upload. Works on mobile (photo library / Files). "
@@ -269,9 +276,8 @@ _AWAIT_POLL_INTERVAL_S = 2.0
 
 def _extract_ul_token(token_or_url: str) -> str:
     """Return the bare ``ul`` token from either a raw token or a full
-    ``{base}/files/ul/{token}`` URL (what ``source_add(source_type="file")`` hands the
-    model). Tokens are ``base64url . base64url`` (no ``/``, ``?`` or ``#``), so trimming
-    at the first of those is safe."""
+    ``{base}/files/ul/{token}`` URL. Tokens are ``base64url . base64url`` (no ``/``, ``?``
+    or ``#``), so trimming at the first of those is safe."""
     text = token_or_url.strip()
     marker = "/files/ul/"
     if marker in text:
@@ -279,6 +285,20 @@ def _extract_ul_token(token_or_url: str) -> str:
     for sep in ("?", "#", "/"):
         text = text.split(sep, 1)[0]
     return text
+
+
+def _resolve_upload_token(cfg: FileTransferConfig, token_or_url: str) -> str | None:
+    """Resolve any of the three link shapes ``await_upload`` accepts to the signed token:
+    a tap-friendly ``{base}/u/<shortid>`` (looked up in the in-process short-link store), a
+    full ``{base}/files/ul/<token>``, or a bare token. Returns ``None`` only for an unknown
+    or expired short id (the caller reports it as expired/invalid, same as a bad token)."""
+    text = token_or_url.strip()
+    if "/u/" in text:
+        shortid = text.split("/u/", 1)[1]
+        for sep in ("?", "#", "/"):
+            shortid = shortid.split(sep, 1)[0]
+        return cfg.short_links.get(shortid)
+    return _extract_ul_token(text)
 
 
 async def _await_upload(
@@ -302,15 +322,18 @@ async def _await_upload(
     ``progress`` (best-effort) is awaited at t=0 and each tick as a keepalive; the design
     does not depend on it.
     """
-    token = _extract_ul_token(token_or_url)
+    invalid = {
+        "status": "expired_or_invalid",
+        "hint": "this upload link is invalid or expired — call "
+        'source_add(source_type="file") to get a fresh one',
+    }
+    token = _resolve_upload_token(cfg, token_or_url)
+    if token is None:  # unknown/expired short id
+        return invalid
     try:
         payload = cfg.signer.verify(token, op="ul")
     except FileLinkError:
-        return {
-            "status": "expired_or_invalid",
-            "hint": "this upload link is invalid or expired — call "
-            'source_add(source_type="file") to get a fresh one',
-        }
+        return invalid
     jti = str(payload.get("jti") or "")
     deadline = time.monotonic() + timeout_s
     if progress is not None:

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -371,7 +371,9 @@ async def _await_upload(
                 "status": "pending",
                 "hint": "upload not detected yet — re-invoke await_upload with the same link",
             }
-        await asyncio.sleep(poll_interval_s)
+        # Never sleep past the deadline — cap the tick to the time remaining so a small
+        # custom timeout returns ``pending`` on time instead of overshooting by an interval.
+        await asyncio.sleep(min(poll_interval_s, max(0.0, deadline - time.monotonic())))
         if progress is not None:
             await progress()
 

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -11,17 +11,25 @@ Imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import os
 import shutil
 import tempfile
+import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from fastmcp import Context
+
 from ..._app import source_add as add_core
 from ...exceptions import ValidationError
-from .._filelink import UPLOAD_TTL, FileTransferConfig
+from .._confirm import READ_ONLY
+from .._context import get_file_transfer
+from .._errors import mcp_errors
+from .._filelink import UPLOAD_TTL, FileLinkError, FileTransferConfig
 
 if TYPE_CHECKING:
     from ...client import NotebookLMClient
@@ -247,3 +255,108 @@ async def _add_one(
         add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan),
     )
     return result.source
+
+
+#: Default poll window for :func:`_await_upload`. Kept safely under the ~60s
+#: connector-timeout watchdog observed on claude.ai's remote MCP transport (which
+#: measures time-to-first-response-byte); on timeout the tool returns ``pending`` so
+#: the model re-invokes next turn — the re-invoke loop, not any keepalive, is the
+#: load-bearing completion mechanism (ADR-0024 / Phase 1). Raise only after a live
+#: timing test.
+_AWAIT_TIMEOUT_S = 45.0
+_AWAIT_POLL_INTERVAL_S = 2.0
+
+
+def _extract_ul_token(token_or_url: str) -> str:
+    """Return the bare ``ul`` token from either a raw token or a full
+    ``{base}/files/ul/{token}`` URL (what ``source_add(source_type="file")`` hands the
+    model). Tokens are ``base64url . base64url`` (no ``/``, ``?`` or ``#``), so trimming
+    at the first of those is safe."""
+    text = token_or_url.strip()
+    marker = "/files/ul/"
+    if marker in text:
+        text = text.split(marker, 1)[1]
+    for sep in ("?", "#", "/"):
+        text = text.split(sep, 1)[0]
+    return text
+
+
+async def _await_upload(
+    cfg: FileTransferConfig,
+    token_or_url: str,
+    *,
+    timeout_s: float = _AWAIT_TIMEOUT_S,
+    poll_interval_s: float = _AWAIT_POLL_INTERVAL_S,
+    progress: Callable[[], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    """Poll the in-process completion map for the upload behind ``token_or_url``.
+
+    Returns one of:
+    - ``{"status": "received", "source_id": ..., "file": {...}}`` — the browser/agent
+      upload committed a source (same process wrote it; ADR-0024).
+    - ``{"status": "pending", "hint": ...}`` — nothing yet after ``timeout_s``; the
+      model should re-invoke with the same link.
+    - ``{"status": "expired_or_invalid", "hint": ...}`` — the link failed signature/
+      expiry/op checks; mint a fresh one via ``source_add(source_type="file")``.
+
+    ``progress`` (best-effort) is awaited at t=0 and each tick as a keepalive; the design
+    does not depend on it.
+    """
+    token = _extract_ul_token(token_or_url)
+    try:
+        payload = cfg.signer.verify(token, op="ul")
+    except FileLinkError:
+        return {
+            "status": "expired_or_invalid",
+            "hint": "this upload link is invalid or expired — call "
+            'source_add(source_type="file") to get a fresh one',
+        }
+    jti = str(payload.get("jti") or "")
+    deadline = time.monotonic() + timeout_s
+    if progress is not None:
+        await progress()
+    while True:
+        result = cfg.jti_store.completed(jti)
+        if result is not None:
+            return {"status": "received", "source_id": result.get("source_id"), "file": result}
+        if time.monotonic() >= deadline:
+            return {
+                "status": "pending",
+                "hint": "upload not detected yet — re-invoke await_upload with the same link",
+            }
+        await asyncio.sleep(poll_interval_s)
+        if progress is not None:
+            await progress()
+
+
+def register_file_tools(mcp: Any) -> None:
+    """Register the file-transfer MCP tools that live in this sibling module.
+
+    Currently just ``await_upload`` (Phase 1). Called from ``tools.sources.register``
+    so the sources domain keeps a single manifest entry point while this module holds
+    the file-specific overflow (ADR-0008 size budget)."""
+
+    @mcp.tool(annotations=READ_ONLY)
+    async def await_upload(ctx: Context, upload_link: str, timeout: float = 45.0) -> dict[str, Any]:
+        """Wait for a file uploaded via a ``source_add(source_type="file")`` link to land.
+
+        Pass the ``human_upload.url`` (or the bare token) that ``source_add`` returned.
+        Polls the server in-process until the browser/agent upload commits the source:
+
+        * ``{"status":"received","source_id",...,"file":{...}}`` — the upload landed.
+        * ``{"status":"pending",...}`` — nothing yet after ~``timeout`` s; **re-invoke with
+          the same link** (the wait resumes; a transport reset does not lose it).
+        * ``{"status":"expired_or_invalid",...}`` — the link failed; mint a fresh one via
+          ``source_add(source_type="file")``.
+        """
+        with mcp_errors():
+            cfg = get_file_transfer(ctx)
+            if cfg is None:
+                raise ValidationError(
+                    "await_upload needs the remote signed-URL transport; set "
+                    "NOTEBOOKLM_MCP_PUBLIC_URL on the server to enable it"
+                )
+            # ponytail: no ctx.report_progress keepalive yet — the re-invoke loop is the
+            # load-bearing completion path; add one only if a live claude.ai timing test
+            # shows the ~45s poll needs it (ADR-0024 / Phase 1 plan).
+            return await _await_upload(cfg, upload_link, timeout_s=timeout)

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -84,6 +84,9 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # ``tool_error_payload``), so extracting it would only trade a size trip for a
     # circular import. Pinned at its measured LOC; ratchet down when the tool
     # surface is next reorganized.
+    # Phase 1 (remote MCP file upload) added the ``await_upload`` tool entirely in the
+    # ``_fileupload`` sibling (``register_file_tools``, wired from ``server.register_all``,
+    # NOT ``sources.register``) precisely so this at-cap module stays untouched at 1020.
     "mcp/tools/sources.py": 1020,
 }
 

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -211,6 +211,7 @@ TOOL_COVERAGE: dict[str, str] = {
     "source_add_and_wait": "tests/unit/mcp/test_sources.py (add+wait composite; unit)",
     "source_upload_bytes": "tests/unit/mcp/test_file_tools.py (in-channel bytes upload; unit)",
     "source_add_drive_file": "tests/unit/mcp/test_sources_drive.py (Drive-doc auto-route; unit — needs a real Drive document_id)",
+    "await_upload": "tests/unit/mcp/test_await_upload.py (completion-map poll) + test_fileroutes.py (POST records result; unit — remote signed-URL side-channel, no live browser upload)",
     # chat
     "chat_ask": "TestMcpChat.test_configure_then_ask",
     "chat_configure": "TestMcpChat.test_configure_then_ask",

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -1,0 +1,84 @@
+"""Unit tests for the Phase 1 ``await_upload`` core helper (``_await_upload``).
+
+The helper is transport-agnostic: it takes a resolved :class:`FileTransferConfig`
+(real signer + in-process completion map), a token-or-URL, and returns a small
+status dict. Testing it directly avoids standing up the whole HTTP MCP server
+(which needs a public base URL to wire ``file_transfer`` at all).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from notebooklm.mcp._filelink import FileLinkSigner, FileTransferConfig  # noqa: E402
+from notebooklm.mcp.tools._fileupload import _await_upload, _extract_ul_token  # noqa: E402
+
+
+def _cfg() -> FileTransferConfig:
+    return FileTransferConfig(signer=FileLinkSigner(key=b"k" * 32), base_url="https://h.example")
+
+
+def _mint(cfg: FileTransferConfig) -> tuple[str, str]:
+    """Return ``(url, jti)`` for a fresh upload link."""
+    url = cfg.upload_url({"nb": "nb1"})
+    token = url.rsplit("/", 1)[1]
+    jti = cfg.signer.verify(token, op="ul")["jti"]
+    return url, jti
+
+
+def test_extract_token_from_url_or_bare() -> None:
+    assert _extract_ul_token("abc.def") == "abc.def"
+    assert _extract_ul_token("https://h.example/files/ul/abc.def") == "abc.def"
+    assert _extract_ul_token("https://h.example/files/ul/abc.def?filename=x#frag") == "abc.def"
+    assert _extract_ul_token("  https://h.example/files/ul/abc.def/  ") == "abc.def"
+
+
+async def test_received_when_result_already_recorded() -> None:
+    cfg = _cfg()
+    url, jti = _mint(cfg)
+    cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-1", "name": "r.pdf"})
+    # accepts the full URL...
+    out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "received"
+    assert out["source_id"] == "s-1"
+    assert out["file"] == {"source_id": "s-1", "name": "r.pdf"}
+    # ...and the bare token
+    out2 = await _await_upload(cfg, jti and url.rsplit("/", 1)[1], timeout_s=0, poll_interval_s=0)
+    assert out2["status"] == "received"
+
+
+async def test_pending_when_not_yet_uploaded() -> None:
+    cfg = _cfg()
+    url, _ = _mint(cfg)
+    out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "pending"
+    assert "re-invoke" in out["hint"]
+
+
+async def test_expired_or_invalid_token() -> None:
+    cfg = _cfg()
+    out = await _await_upload(cfg, "not-a-real.token", timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "expired_or_invalid"
+    assert "source_add" in out["hint"]
+
+
+async def test_poll_picks_up_a_later_same_process_commit() -> None:
+    # The whole point of the in-process map: a commit that lands WHILE await_upload is
+    # polling is seen on the next tick (no DB, same event loop).
+    cfg = _cfg()
+    url, jti = _mint(cfg)
+
+    async def _upload_lands() -> None:
+        await asyncio.sleep(0.02)
+        cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-late"})
+
+    lander = asyncio.create_task(_upload_lands())
+    out = await _await_upload(cfg, url, timeout_s=2.0, poll_interval_s=0.01)
+    await lander
+    assert out["status"] == "received"
+    assert out["source_id"] == "s-late"

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -15,6 +15,8 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+import notebooklm.mcp._filelink as filelink  # noqa: E402
+from notebooklm.exceptions import ValidationError  # noqa: E402
 from notebooklm.mcp._filelink import FileLinkSigner, FileTransferConfig  # noqa: E402
 from notebooklm.mcp.tools._fileupload import (  # noqa: E402
     _await_upload,
@@ -130,3 +132,36 @@ async def test_broker_returns_short_human_link_direct_agent_link_one_token() -> 
     got = await _await_upload(cfg, human, timeout_s=0, poll_interval_s=0)
     assert got["status"] == "received"
     assert got["source_id"] == "s-broker"
+
+
+async def test_non_finite_timeout_rejected() -> None:
+    # A NaN/inf timeout would make the poll deadline unsatisfiable (infinite loop). Reject it.
+    cfg = _cfg()
+    url, _ = _mint(cfg)
+    for bad in (float("inf"), float("nan"), float("-inf")):
+        with pytest.raises(ValidationError):
+            await _await_upload(cfg, url, timeout_s=bad)
+
+
+async def test_recovers_committed_result_after_token_expiry(monkeypatch) -> None:
+    # A large upload can commit its result just before the start-token expires; a later
+    # await_upload must still surface the source_id, not return expired_or_invalid.
+    cfg = _cfg()
+    url, jti = _mint(cfg)
+    exp = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
+    cfg.jti_store.commit(jti, exp, result={"source_id": "s-late-exp"})
+    # Freeze "now" past the token's expiry → normal verify fails, recovery path kicks in.
+    monkeypatch.setattr(filelink.time, "time", lambda: exp + 5)
+    out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "received"
+    assert out["source_id"] == "s-late-exp"
+
+
+async def test_expired_token_with_no_committed_result_stays_invalid(monkeypatch) -> None:
+    # Recovery is ONLY for committed uploads — an expired token with nothing committed is invalid.
+    cfg = _cfg()
+    url, _ = _mint(cfg)
+    exp = cfg.signer.verify(url.rsplit("/", 1)[1], op="ul")["exp"]
+    monkeypatch.setattr(filelink.time, "time", lambda: exp + 5)
+    out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "expired_or_invalid"

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -16,7 +16,11 @@ import pytest
 pytest.importorskip("fastmcp")
 
 from notebooklm.mcp._filelink import FileLinkSigner, FileTransferConfig  # noqa: E402
-from notebooklm.mcp.tools._fileupload import _await_upload, _extract_ul_token  # noqa: E402
+from notebooklm.mcp.tools._fileupload import (  # noqa: E402
+    _await_upload,
+    _broker_upload,
+    _extract_ul_token,
+)
 
 
 def _cfg() -> FileTransferConfig:
@@ -67,6 +71,26 @@ async def test_expired_or_invalid_token() -> None:
     assert "source_add" in out["hint"]
 
 
+async def test_received_via_short_link() -> None:
+    # await_upload must also accept the tap-friendly /u/<shortid> link (what the model now
+    # hands the user), resolving it to the real token via the in-process short-link store.
+    cfg = _cfg()
+    url = cfg.short_upload_url({"nb": "nb1"})  # https://h.example/u/<shortid>
+    shortid = url.rsplit("/", 1)[1]
+    token = cfg.short_links.get(shortid)
+    jti = cfg.signer.verify(token, op="ul")["jti"]
+    cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-short"})
+    out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "received"
+    assert out["source_id"] == "s-short"
+
+
+async def test_unknown_short_link_is_expired_or_invalid() -> None:
+    cfg = _cfg()
+    out = await _await_upload(cfg, "https://h.example/u/nope", timeout_s=0, poll_interval_s=0)
+    assert out["status"] == "expired_or_invalid"
+
+
 async def test_poll_picks_up_a_later_same_process_commit() -> None:
     # The whole point of the in-process map: a commit that lands WHILE await_upload is
     # polling is seen on the next tick (no DB, same event loop).
@@ -82,3 +106,27 @@ async def test_poll_picks_up_a_later_same_process_commit() -> None:
     await lander
     assert out["status"] == "received"
     assert out["source_id"] == "s-late"
+
+
+async def test_broker_returns_short_human_link_direct_agent_link_one_token() -> None:
+    # _broker_upload hands the human a tap-friendly /u/<shortid> and the agent the direct
+    # /files/ul POST target — both over ONE token (one jti). await_upload accepts the short one.
+    cfg = _cfg()
+    out = _broker_upload(cfg, "nb1", title=None, mime_type=None, path="report.pdf")
+    human = out["human_upload"]["url"]
+    agent = out["agent_upload"]["url"]
+    assert "/u/" in human and "/files/ul/" not in human  # short, tap-friendly
+    assert "/files/ul/" in agent  # direct raw-POST target
+
+    # both point at the SAME token (one jti, not two)
+    agent_token = agent.split("/files/ul/", 1)[1].split("?", 1)[0]
+    human_token = cfg.short_links.get(human.rsplit("/", 1)[1])
+    assert human_token == agent_token
+
+    # simulate the upload committing, then await via the SHORT link → received
+    jti = cfg.signer.verify(human_token, op="ul")["jti"]
+    exp = cfg.signer.verify(human_token, op="ul")["exp"]
+    cfg.jti_store.commit(jti, exp, result={"source_id": "s-broker"})
+    got = await _await_upload(cfg, human, timeout_s=0, poll_interval_s=0)
+    assert got["status"] == "received"
+    assert got["source_id"] == "s-broker"

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -147,9 +147,13 @@ async def test_source_add_file_with_config_returns_upload_url(mock_client, confi
     assert payload["title"] == "My Doc"
     assert payload["mime"] == "application/pdf"
     # Human/browser path is first-class (a named object, not prose) so an agent that
-    # can't upload the bytes itself reliably surfaces it to the user (#1801).
+    # can't upload the bytes itself reliably surfaces it to the user (#1801). It is now the
+    # SHORT tap-friendly /u/<shortid> link (a long opaque token gets mangled in mobile chat),
+    # NOT the deprecated top-level /files/ul url — and it resolves to the same signed token.
     human = sc["human_upload"]
-    assert human["url"] == sc["url"]
+    assert human["url"].startswith(f"{BASE}/u/")
+    assert human["url"] != sc["url"]
+    assert config.short_links.get(human["url"].rsplit("/", 1)[1]) == token
     assert "browser" in human["instructions"]
     # The mobile case is what makes the human path first-class — lock it in (#1801).
     assert "mobile" in human["instructions"]

--- a/tests/unit/mcp/test_filelink.py
+++ b/tests/unit/mcp/test_filelink.py
@@ -24,6 +24,7 @@ from notebooklm.mcp._filelink import (
     FileLinkError,
     FileLinkSigner,
     FileTransferConfig,
+    ShortLinkStore,
     _b64url_decode,
 )
 
@@ -282,6 +283,36 @@ def test_store_sweeps_expired_completion_results() -> None:
     store.commit("fresh", now + 60, result={"source_id": "s-fresh"})  # live → triggers sweep
     assert store.completed("old") is None
     assert store.completed("fresh") == {"source_id": "s-fresh"}
+
+
+def test_short_link_store_round_trips_token() -> None:
+    # Short-link indirection: mint a tap-friendly /u/<shortid> that resolves to the long
+    # signed token in-process (no DB), so the mobile URL survives a tap and model transcription.
+    store = ShortLinkStore()
+    exp = int(time.time()) + 60
+    sid = store.put("the.signed.token", exp)
+    assert sid and "/" not in sid  # URL-path-safe, non-empty
+    assert store.get(sid) == "the.signed.token"
+
+
+def test_short_link_store_unique_ids_per_put() -> None:
+    store = ShortLinkStore()
+    exp = int(time.time()) + 60
+    a = store.put("tok-a", exp)
+    b = store.put("tok-b", exp)
+    assert a != b
+    assert store.get(a) == "tok-a"
+    assert store.get(b) == "tok-b"
+
+
+def test_short_link_store_expired_id_returns_none() -> None:
+    store = ShortLinkStore()
+    sid = store.put("tok", int(time.time()) - 1)  # already expired
+    assert store.get(sid) is None  # not resolvable past its token's exp
+
+
+def test_short_link_store_unknown_id_returns_none() -> None:
+    assert ShortLinkStore().get("nope") is None
 
 
 def test_config_jti_store_excluded_from_equality_and_default_constructed() -> None:

--- a/tests/unit/mcp/test_filelink.py
+++ b/tests/unit/mcp/test_filelink.py
@@ -255,6 +255,35 @@ def test_store_recommit_same_jti_does_not_evict_at_cap(monkeypatch) -> None:
     assert store._seen["a"] == base + 9  # exp refreshed in place
 
 
+def test_store_commit_records_and_reads_back_completion_result() -> None:
+    # #Phase-1 await_upload: commit may carry the upload result so the in-process
+    # completion map lets a same-process poll surface {source_id, name, size, mime}.
+    store = ConsumedJtiStore()
+    exp = int(time.time()) + 60
+    assert store.completed("j1") is None  # nothing recorded yet
+    store.commit("j1", exp, result={"source_id": "s-1", "name": "report.pdf"})
+    assert store.completed("j1") == {"source_id": "s-1", "name": "report.pdf"}
+
+
+def test_store_commit_without_result_leaves_no_completion_record() -> None:
+    # A plain single-use burn (no result) records nothing readable — await_upload then
+    # stays "pending" rather than inventing an empty received payload.
+    store = ConsumedJtiStore()
+    store.commit("j1", int(time.time()) + 60)
+    assert store.completed("j1") is None
+
+
+def test_store_sweeps_expired_completion_results() -> None:
+    # The completion record is bounded to the token's life like _seen: once exp passes,
+    # a later commit sweeps it so the map cannot leak past TTL.
+    store = ConsumedJtiStore()
+    now = int(time.time())
+    store.commit("old", now - 10, result={"source_id": "s-old"})  # already expired
+    store.commit("fresh", now + 60, result={"source_id": "s-fresh"})  # live → triggers sweep
+    assert store.completed("old") is None
+    assert store.completed("fresh") == {"source_id": "s-fresh"}
+
+
 def test_config_jti_store_excluded_from_equality_and_default_constructed() -> None:
     # `compare=False` keeps the frozen config comparable by (signer, base_url) only —
     # the store is a mutable, dict-bearing object that must not drive __eq__/__hash__.

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -477,6 +477,42 @@ def test_upload_post_adds_source_with_title_and_mime_from_token(mock_client, con
     assert kwargs["title"] == "Signed Title"
 
 
+def test_upload_post_records_completion_result_for_await_upload(mock_client, config) -> None:
+    # Phase 1: a successful POST records {source_id, name, size, mime} in the in-process
+    # completion map keyed by jti, so a same-process await_upload poll surfaces the source.
+    add_file = AsyncMock(return_value=MagicMock(id="src-77"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB, "mime": "application/pdf"})
+    jti = config.signer.verify(url.rsplit("/", 1)[1], op="ul")["jti"]
+    assert config.jti_store.completed(jti) is None  # nothing before the upload
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(_path(url) + "?filename=paper.pdf", content=b"PDFDATA")
+    assert resp.status_code == 200
+    record = config.jti_store.completed(jti)
+    assert record == {
+        "source_id": "src-77",
+        "name": "paper.pdf",
+        "size": len(b"PDFDATA"),
+        "mime": "application/pdf",
+    }
+
+
+def test_upload_failed_add_records_no_completion_result(monkeypatch, mock_client, config) -> None:
+    # Success-only by design: a failed add rolls the jti back (retryable) and writes NO
+    # completion record, so await_upload stays "pending" rather than reporting a phantom add.
+    from notebooklm.exceptions import NotebookLMError
+
+    mock_client.sources.add_file = AsyncMock(side_effect=NotebookLMError("boom"))
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    jti = config.signer.verify(url.rsplit("/", 1)[1], op="ul")["jti"]
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(_path(url) + "?filename=x.pdf", content=b"DATA")
+    assert resp.status_code >= 400
+    assert config.jti_store.completed(jti) is None
+
+
 def test_upload_post_filename_is_sanitized_to_basename(mock_client, config) -> None:
     add_file = AsyncMock(return_value=MagicMock(id="src-1"))
     mock_client.sources.add_file = add_file

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -477,6 +477,30 @@ def test_upload_post_adds_source_with_title_and_mime_from_token(mock_client, con
     assert kwargs["title"] == "Signed Title"
 
 
+def test_short_link_redirects_to_canonical_upload_page(mock_client, config) -> None:
+    # /u/<shortid> is the tap-friendly link handed to mobile users; it 302-redirects to the
+    # real /files/ul/<token> page (single source of truth for the picker + POST).
+    app = _build(mock_client, config)
+    short = config.short_upload_url({"nb": NB})  # https://files.test/u/<shortid>
+    shortid = short.rsplit("/", 1)[1]
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get(f"/u/{shortid}", follow_redirects=False)
+        assert resp.status_code in (302, 307)
+        loc = resp.headers["location"]
+        assert "/files/ul/" in loc
+        # following it renders the real upload page
+        page = client.get(loc)
+    assert page.status_code == 200
+    assert "Upload a source to NotebookLM" in page.text
+
+
+def test_short_link_unknown_id_404(mock_client, config) -> None:
+    app = _build(mock_client, config)
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.get("/u/doesnotexist", follow_redirects=False)
+    assert resp.status_code == 404
+
+
 def test_upload_post_records_completion_result_for_await_upload(mock_client, config) -> None:
     # Phase 1: a successful POST records {source_id, name, size, mime} in the in-process
     # completion map keyed by jti, so a same-process await_upload poll surfaces the source.

--- a/tests/unit/mcp/test_manifest.py
+++ b/tests/unit/mcp/test_manifest.py
@@ -33,7 +33,7 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "notebook_describe",
         "notebook_rename",
         "notebook_delete",
-        # Sources (9)
+        # Sources (10)
         "source_list",
         "source_read",
         "source_rename",
@@ -43,6 +43,7 @@ EXPECTED_TOOLS: frozenset[str] = frozenset(
         "source_add_and_wait",
         "source_add_drive_file",
         "source_upload_bytes",
+        "await_upload",
         # Chat (3)
         "chat_ask",
         "chat_configure",
@@ -102,6 +103,7 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "notebook_describe",
         "source_list",
         "source_read",
+        "await_upload",
         "studio_list",
         "studio_status",
         "studio_get_prompt",

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -31,8 +31,15 @@ pytest.importorskip("fastmcp")
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
 SCHEMA_CHAR_BUDGET = (
-    41_700  # total serialized inputSchema + description chars (current 41_645; +55 slack)
+    42_450  # total serialized inputSchema + description chars (current 42_418; +32 slack)
 )
+# Phase 1 (remote MCP file upload) added await_upload — the completion signal for a
+# source_add(source_type="file") link, so the model learns the browser/mobile upload
+# landed without the user narrating it. A NEW discrete tool (+773 chars, 2 params:
+# upload_link, timeout), not growth of an existing one; per ADR-0025 the discrete verb
+# is preferred over widening source_add, and the docstring is kept lean. It reuses the
+# existing ADR-0024 signer + in-process jti store (no new state), so this is the whole
+# schema cost. Raised from 41_700.
 # #1884 added source_add_drive_file (auto-route add-from-Drive: download + upload the
 # upload-only Drive types NotebookLM's native import can't ingest) — a NEW discrete
 # tool (+1_144 chars, 4 params), not growth of an existing one. Per ADR-0025 the


### PR DESCRIPTION
## Mobile file upload: `await_upload` completion signal + short-link

Closes the "add a file from my phone" loop for the remote MCP server. The signed-URL upload page and broker already existed; this adds the two things that made it actually usable end-to-end — and both are **live-validated on a real Android device** (details below).

### What & why

**1. `await_upload` — the completion signal (Phase 1).**
Before: the browser upload worked, but nothing told the model *when* it landed — the user had to send a "done" message and the model diffed `source_list` to guess which source was new. Now the model presents the link and calls `await_upload` in the same turn; the instant the upload commits it returns `{"status":"received","source_id":…}` — the exact source, no user round-trip, no diffing.

Mechanically: the `/files/ul` POST records `{source_id,name,size,mime}` in an **in-process completion map** co-located on `ConsumedJtiStore`, and `await_upload` reads it in the same process. No DB, no new state — consistent with ADR-0024 (single-process / loopback / single-tenant). Success-only by design: a failed add records nothing, so `await_upload` stays `pending` and the model falls back to `source_list`. Short-poll ~45s then `pending` + re-invoke is the load-bearing completion path (the re-invoke loop, not a keepalive).

**2. Short-link indirection (`/u/<shortid>`).**
The ~250-char `/files/ul/<token>` URL is fragile through a mobile chat — the live test hit **three** corruption modes (tap-truncation → 404, the model re-typing the URL and dropping a UUID segment → 403, autocorrect `O`→`0` + injected spaces → 403), each breaking the HMAC. Fix: hand the user a short `/u/<shortid>` (~9 chars) that `302`-redirects to the canonical page server-side. `_broker_upload` now returns the short link for the human path and the direct `/files/ul` POST target for the agent path, over **one** token/jti; `await_upload` accepts `/u/…`, `/files/ul/…`, or a bare token.

### Live validation (Claude Android, separate account, prod untouched)
Full loop, twice:
```
source_add(file) → /u/<shortid> → 302 → GET /files/ul/<token> 200
  → resumable upload to NotebookLM 200 → POST /files/ul 200 (source added)
  → await_upload → {received, source_id} → source_wait READY
```
The short link worked on the **first** clean attempt where the long URL had failed three times — you only ever touch the 9-char link; the server expands it losslessly.

### Surface / guardrails
- New tool: `await_upload` (READ_ONLY). Registered from `server.register_all` so the at-cap `sources.py` (1020 lines) is untouched — the tool body lives in the `_fileupload` sibling.
- `SCHEMA_CHAR_BUDGET` → 42,450 (ADR-0025 discrete-verb justification in the test comment). `EXPECTED_TOOLS` / `READ_ONLY_TOOLS` / e2e `TOOL_COVERAGE` updated.
- Short-link adds no tools (a route + an in-process store).
- 869 MCP unit tests + guardrails green; mypy clean; ruff clean.

### Deferred (called out in code with `ponytail:` comments)
- `sha256` in the completion record — Phase 4 client/stream hashing.
- `ctx.report_progress` keepalive — only after a live claude.ai connector-timing test (the re-invoke loop covers it today).
- Phase 2b in-app widget probe / Phase 3 direct-PUT widget / Phase 5 SEP-2631 adapter — separate follow-ups.

### Follow-up (separate PR)
A tool-surface audit (multi-model) recommends a small ADR-0025 consolidation (36→34: fold `source_add_and_wait` and `source_upload_bytes` into `source_add`); tracked as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tap-friendly upload short links (`/u/<shortid>`) that redirect to the secure upload page.
  - Introduced upload completion tracking and the read-only `await_upload` tool (reports `received`, `pending`, or `expired_or_invalid`).
  - Upload completion results now include source ID, filename, total size, and MIME type.
- **Bug Fixes**
  - Fixed mobile URL corruption by switching from long signed URLs to short-link indirection.
- **Documentation**
  - Added a new mobile upload probing experiment write-up with results and next steps.
- **Tests**
  - Expanded unit/e2e coverage for short links, polling, recovery near expiry, redirects, and tool manifest/coverage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->