### PR TITLE
fix(mcp): render the upload widget on ChatGPT's first call

### DIFF
--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -91,10 +91,11 @@ _WIDGET_HTML = """<!doctype html>
  setTimeout(()=>ready(oai?"ChatGPT":null),500);
  function size(){post({jsonrpc:"2.0",method:"ui/notifications/size-changed",
    params:{height:document.documentElement.scrollHeight,width:document.documentElement.scrollWidth}});}
- function consider(p){ // tool result: {structuredContent:{upload_url}} | content[].text | raw obj (window.openai.toolOutput)
-   let d=p&&p.structuredContent;
-   if(!d&&p&&p.content)for(const c of p.content)if(c&&c.type==="text"){try{d=JSON.parse(c.text)}catch(e){}}
-   if(!d&&p&&p.upload_url)d=p;
+ function consider(p){ // tool result: {structuredContent:{upload_url}} | {toolResult:…} | content[].text | raw obj
+   if(!p)return; if(p.toolResult)p=p.toolResult; // unwrap the ui/notifications/tool-result envelope
+   let d=p.structuredContent;
+   if(!d&&p.content)for(const c of p.content)if(c&&c.type==="text"){try{d=JSON.parse(c.text)}catch(e){}}
+   if(!d&&p.upload_url)d=p;
    if(d&&d.upload_url&&!uploadUrl){uploadUrl=d.upload_url;document.getElementById('f').disabled=false;
      sub.textContent="pick a file to add"+(d.notebook?" to "+d.notebook:"");}
  }
@@ -112,7 +113,11 @@ _WIDGET_HTML = """<!doctype html>
  // ChatGPT: tool result arrives on window.openai.toolOutput (set at/after load)
  function pullOai(){if(oai&&oai.toolOutput)consider(oai.toolOutput);}
  window.addEventListener("openai:set_globals",pullOai);
- [100,600,1500].forEach(t=>setTimeout(pullOai,t));
+ // ChatGPT fetches the template lazily on the FIRST call, so the iframe can attach AFTER the
+ // one-shot ui/notifications/tool-result fires — toolOutput is the durable fallback. Poll it until
+ // the upload_url lands (first render often sets it late) instead of a few fixed tries, else the
+ // first widget of a chat renders but stays stuck with no upload target.
+ let _pt=0;const _pi=setInterval(()=>{pullOai();if(uploadUrl||++_pt>66)clearInterval(_pi);},300);
  const fi=document.getElementById('f'),btn=document.getElementById('up');
  fi.addEventListener('change',()=>{btn.disabled=!(fi.files&&fi.files[0]);});
  btn.addEventListener('click',async()=>{

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -94,7 +94,7 @@ _WIDGET_HTML = """<!doctype html>
  function consider(p){ // tool result: {structuredContent:{upload_url}} | {toolResult:…} | content[].text | raw obj
    if(!p)return; if(p.toolResult)p=p.toolResult; // unwrap the ui/notifications/tool-result envelope
    let d=p.structuredContent;
-   if(!d&&p.content)for(const c of p.content)if(c&&c.type==="text"){try{d=JSON.parse(c.text)}catch(e){}}
+   if(!d&&Array.isArray(p.content))for(const c of p.content)if(c&&c.type==="text"){try{d=JSON.parse(c.text)}catch(e){}}
    if(!d&&p.upload_url)d=p;
    if(d&&d.upload_url&&!uploadUrl){uploadUrl=d.upload_url;document.getElementById('f').disabled=false;
      sub.textContent="pick a file to add"+(d.notebook?" to "+d.notebook:"");}

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -94,8 +94,11 @@ _WIDGET_HTML = """<!doctype html>
  function consider(p){ // tool result: {structuredContent:{upload_url}} | {toolResult:…} | content[].text | raw obj
    if(!p)return; if(p.toolResult)p=p.toolResult; // unwrap the ui/notifications/tool-result envelope
    let d=p.structuredContent;
-   if(!d&&Array.isArray(p.content))for(const c of p.content)if(c&&c.type==="text"){try{d=JSON.parse(c.text)}catch(e){}}
-   if(!d&&p.upload_url)d=p;
+   // Gate fallbacks on upload_url, not truthiness: a structuredContent without upload_url must not
+   // block the content[]/raw fallbacks, and a later text fragment must not overwrite a good result.
+   if(!d?.upload_url&&Array.isArray(p.content))for(const c of p.content)if(c&&c.type==="text"){
+     try{const parsed=JSON.parse(c.text);if(parsed?.upload_url)d=parsed}catch(e){}}
+   if(!d?.upload_url&&p.upload_url)d=p;
    if(d&&d.upload_url&&!uploadUrl){uploadUrl=d.upload_url;document.getElementById('f').disabled=false;
      sub.textContent="pick a file to add"+(d.notebook?" to "+d.notebook:"");}
  }

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -44,6 +44,8 @@ def test_widget_html_is_cross_host() -> None:
         'method:"ui/notifications/initialized"',  # claude.ai render gate
         "window.openai",  # ChatGPT bridge
         "oai.toolOutput",  # ChatGPT tool-result path
+        "setInterval",  # persistent toolOutput poll — survives ChatGPT's late first-call template fetch
+        "p.toolResult",  # unwrap the ui/notifications/tool-result envelope
         'addEventListener("message"',  # claude.ai/Grok tool-result path
         'type="file"',  # universal picker
         "?filename=",  # direct-PUT to /files/ul


### PR DESCRIPTION
## Problem

The Phase 3 upload widget (#1891) rendered on ChatGPT's **second** `source_add_widget` call in a new chat but not the **first**.

## Root cause (confirmed in deploy logs)

ChatGPT fetches the `ui://` widget template **lazily, ~1s after the first `CallToolRequest`** (the `ReadResourceRequest` trails the call on a cold conversation). So the iframe attaches *after* ChatGPT has already fired the one-shot `ui/notifications/tool-result` postMessage, and the widget misses it. The widget then polled `window.openai.toolOutput` only 3× (≤1.5s) before giving up — so the first widget rendered but stayed stuck with no `upload_url`. The second call (template now cached) worked.

## Fix

- Poll `window.openai.toolOutput` **until the `upload_url` arrives** (~20s cap) instead of a few fixed tries — it's the durable fallback per [OpenAI's Apps SDK docs](https://developers.openai.com/apps-sdk/build/chatgpt-ui).
- Unwrap the `ui/notifications/tool-result` `toolResult` envelope in `consider()`.

claude.ai is unaffected (no `window.openai`; the poll finds nothing and clears). **Live-validated on ChatGPT: first-call render now works.**

Follow-up to #1891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the in-iframe MCP upload widget’s upload URL extraction to handle additional tool-result envelope variations and better fall back to available content text when structured data doesn’t include an upload URL.
  * Updated ChatGPT interop logic to use recurring polling until the upload URL appears (or a timeout is reached), reducing missed uploads.
* **Tests**
  * Extended unit tests to assert the new polling mechanism and tool-result unwrapping markers in the widget HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->