### PR TITLE
fix(sources): classify upstream upload HTTP errors instead of leaking httpx (#1892)

### DIFF
--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -355,13 +355,20 @@ def _raise_from_upload_http_status(exc: httpx.HTTPStatusError, filename: str) ->
     turned it into an opaque 500; the CLI/REST ``add_file`` path leaked it too).
 
     The status classes mirror the RPC executor's contract (429 →
-    :class:`RateLimitError`, 401/403 → :class:`AuthError`, 5xx →
+    :class:`RateLimitError`, 401/403 and **3xx** → :class:`AuthError`, 5xx →
     :class:`ServerError`) with one deliberate deviation: a generic **4xx** is
     raised as :class:`ValidationError`, not ``ClientError``. The endpoint returns
     **400** when it rejects the file *type/content* (e.g. a ``.pub`` that slips
     past the local :func:`_validate_upload_file_supported` allowlist), which is the
     same bad-input outcome as that local check — so it surfaces as a clean,
     redacted 4xx through the MCP/REST adapters instead of a gateway 5xx/500.
+
+    ``httpx.raise_for_status`` raises for **any** non-2xx (the upload clients do
+    not follow redirects), so an unfollowed **3xx** reaches here too. A redirect
+    during upload means the request was bounced (typically an expired/invalid
+    Google session redirected to a login page) rather than accepted, so it is
+    classified as auth — NOT swept into the ``ValidationError`` "unsupported file"
+    catch-all, which would mislabel a dead session as a bad file.
     """
     status = exc.response.status_code
     reason = exc.response.reason_phrase
@@ -373,14 +380,20 @@ def _raise_from_upload_http_status(exc: httpx.HTTPStatusError, filename: str) ->
         raise RateLimitError(msg, retry_after=retry_after) from exc
     if status in (401, 403):
         raise AuthError(f"Authentication failed uploading {filename!r} (HTTP {status})") from exc
+    if 300 <= status < 400:
+        raise AuthError(
+            f"Upload of {filename!r} was redirected (HTTP {status}); the Google session "
+            "may have expired — re-run `notebooklm login`."
+        ) from exc
     if status >= 500:
         raise ServerError(
             f"NotebookLM upload endpoint returned {status} for {filename!r}: {reason}",
             status_code=status,
         ) from exc
-    # Any other 4xx (raise_for_status only fires for >=400, so this is exhaustive):
-    # the request/file was rejected. Treat it as invalid input — same category as
-    # the local unsupported-type check — so it becomes a clean 4xx, not an opaque 500.
+    # Remaining case: a 4xx client rejection (raise_for_status fired, and 3xx/5xx
+    # are handled above). The request/file was rejected — treat it as invalid
+    # input, same category as the local unsupported-type check, so it becomes a
+    # clean 4xx rather than an opaque 500.
     raise ValidationError(
         f"NotebookLM rejected the upload of {filename!r} (HTTP {status}: {reason}). "
         "The file type or content may be unsupported."

--- a/src/notebooklm/_source/_upload_decode.py
+++ b/src/notebooklm/_source/_upload_decode.py
@@ -11,11 +11,15 @@ from __future__ import annotations
 
 import mimetypes
 import re
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 from urllib.parse import SplitResult, parse_qsl, urlsplit
 
-from ..exceptions import ValidationError
+import httpx
+
+from .._transport_errors import parse_retry_after
+from ..exceptions import AuthError, RateLimitError, ServerError, ValidationError
 from ..rpc import get_upload_url
 
 _SOURCE_ID_UUID_PATTERN = re.compile(
@@ -338,3 +342,114 @@ def _validate_upload_file_supported(file_path: Path, content_type: str) -> None:
             "HTML file uploads are not supported by NotebookLM's upload endpoint: "
             f"{file_path.name}. Convert the page to .txt, .md, or .pdf first, then retry."
         )
+
+
+def _raise_from_upload_http_status(exc: httpx.HTTPStatusError, filename: str) -> NoReturn:
+    """Convert a raw ``httpx.HTTPStatusError`` from the file-upload endpoint into a
+    classified :class:`~notebooklm.exceptions.NotebookLMError` (issue #1892).
+
+    NotebookLM's resumable-upload endpoint (``/upload/_/``) answers with an HTTP
+    status, not a batchexecute envelope, so it never passes through the RPC
+    executor's status mapper — the client layer must map it here or a raw
+    ``httpx.HTTPStatusError`` leaks to every caller (the MCP ``/files/ul`` route
+    turned it into an opaque 500; the CLI/REST ``add_file`` path leaked it too).
+
+    The status classes mirror the RPC executor's contract (429 →
+    :class:`RateLimitError`, 401/403 → :class:`AuthError`, 5xx →
+    :class:`ServerError`) with one deliberate deviation: a generic **4xx** is
+    raised as :class:`ValidationError`, not ``ClientError``. The endpoint returns
+    **400** when it rejects the file *type/content* (e.g. a ``.pub`` that slips
+    past the local :func:`_validate_upload_file_supported` allowlist), which is the
+    same bad-input outcome as that local check — so it surfaces as a clean,
+    redacted 4xx through the MCP/REST adapters instead of a gateway 5xx/500.
+    """
+    status = exc.response.status_code
+    reason = exc.response.reason_phrase
+    if status == 429:
+        retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
+        msg = f"Upload of {filename!r} was rate limited"
+        if retry_after:
+            msg += f"; retry after {retry_after} seconds"
+        raise RateLimitError(msg, retry_after=retry_after) from exc
+    if status in (401, 403):
+        raise AuthError(f"Authentication failed uploading {filename!r} (HTTP {status})") from exc
+    if status >= 500:
+        raise ServerError(
+            f"NotebookLM upload endpoint returned {status} for {filename!r}: {reason}",
+            status_code=status,
+        ) from exc
+    # Any other 4xx (raise_for_status only fires for >=400, so this is exhaustive):
+    # the request/file was rejected. Treat it as invalid input — same category as
+    # the local unsupported-type check — so it becomes a clean 4xx, not an opaque 500.
+    raise ValidationError(
+        f"NotebookLM rejected the upload of {filename!r} (HTTP {status}: {reason}). "
+        "The file type or content may be unsupported."
+    ) from exc
+
+
+def raise_for_upload_status(response: httpx.Response, filename: str) -> None:
+    """``response.raise_for_status()`` that classifies a failure via
+    :func:`_raise_from_upload_http_status` instead of leaking the raw
+    ``httpx.HTTPStatusError`` to callers (issue #1892)."""
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        _raise_from_upload_http_status(exc, filename)
+
+
+GetSourceLimit = Callable[[], Awaitable[int | None]]
+
+_SOURCE_LIMIT_HINT_FLOOR = 50
+_TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
+
+
+async def _build_invalid_argument_source_limit_hint(
+    *,
+    source_count: int | None,
+    get_source_limit: GetSourceLimit | None,
+    logger: Any,
+) -> str:
+    """Build a best-effort hint for ADD_SOURCE_FILE status code 3 failures."""
+    source_limit: int | None = None
+    if get_source_limit is not None:
+        try:
+            source_limit = await get_source_limit()
+        except Exception:  # noqa: BLE001 - hint lookup must not mask the upload error.
+            logger.debug(
+                "register_file_source: source-limit lookup failed; continuing without limit hint",
+                exc_info=True,
+            )
+
+    if source_limit is not None and source_limit <= 0:
+        source_limit = None
+
+    if source_count is not None and source_limit is not None:
+        if source_count >= source_limit:
+            return (
+                f" Notebook currently has {source_count}/{source_limit} sources, "
+                "so this likely means the notebook has reached its tier-specific "
+                "per-notebook source limit. Delete sources or try a fresh notebook, "
+                "then retry."
+            )
+        return (
+            f" Notebook currently has {source_count}/{source_limit} sources, below "
+            "the advertised account limit. If the file is valid, try the same add "
+            "in a fresh notebook to distinguish file rejection from notebook state."
+        )
+
+    if source_count is not None and source_count >= _SOURCE_LIMIT_HINT_FLOOR:
+        return (
+            f" Notebook currently has {source_count} sources; status code 3 can "
+            "indicate the notebook is at or near the tier-specific per-notebook "
+            f"source limit ({_TIER_SOURCE_LIMITS_SUMMARY}). Delete sources or "
+            "try a fresh notebook, then retry."
+        )
+
+    if source_limit is not None:
+        return (
+            f" Advertised source limit for this tier is {source_limit}; compare "
+            "it with this notebook's source count. Status code 3 can indicate a "
+            "per-notebook source-limit rejection."
+        )
+
+    return ""

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -53,8 +53,12 @@ from ._upload_decode import (  # noqa: F401
     _SOURCE_ID_ENVELOPE_MAX_DEPTH,
     _SOURCE_ID_FIELD_NAMES,
     _SOURCE_ID_UUID_PATTERN,
+    _SOURCE_LIMIT_HINT_FLOOR,
     _SOURCE_NAME_FIELD_NAMES,
     _STRICT_TRANSIENT_ERROR_TYPES,
+    _TIER_SOURCE_LIMITS_SUMMARY,
+    GetSourceLimit,
+    _build_invalid_argument_source_limit_hint,
     _coerce_filename_candidate,
     _coerce_source_id_candidate,
     _default_port_for_scheme,
@@ -75,6 +79,7 @@ from ._upload_decode import (  # noqa: F401
     _unwrap_singleton_envelope,
     _validate_resumable_upload_url,
     _validate_upload_file_supported,
+    raise_for_upload_status,
 )
 from .listing import SourceLister
 from .polling import SourcePoller
@@ -127,67 +132,10 @@ class RpcCallback(Protocol):
     ) -> Any: ...
 
 
-GetSourceLimit = Callable[[], Awaitable[int | None]]
-
-
 _INVALID_ARGUMENT_RPC_CODE = 3
-_SOURCE_LIMIT_HINT_FLOOR = 50
-_TIER_SOURCE_LIMITS_SUMMARY = "50/100/300/600"
 # Preserve the historical ``notebooklm._sources`` log channel after moving
 # upload choreography into this module.
 module_logger = logging.getLogger("notebooklm").getChild("_sources")
-
-
-async def _build_invalid_argument_source_limit_hint(
-    *,
-    source_count: int | None,
-    get_source_limit: GetSourceLimit | None,
-    logger: Any,
-) -> str:
-    """Build a best-effort hint for ADD_SOURCE_FILE status code 3 failures."""
-    source_limit: int | None = None
-    if get_source_limit is not None:
-        try:
-            source_limit = await get_source_limit()
-        except Exception:  # noqa: BLE001 - hint lookup must not mask the upload error.
-            logger.debug(
-                "register_file_source: source-limit lookup failed; continuing without limit hint",
-                exc_info=True,
-            )
-
-    if source_limit is not None and source_limit <= 0:
-        source_limit = None
-
-    if source_count is not None and source_limit is not None:
-        if source_count >= source_limit:
-            return (
-                f" Notebook currently has {source_count}/{source_limit} sources, "
-                "so this likely means the notebook has reached its tier-specific "
-                "per-notebook source limit. Delete sources or try a fresh notebook, "
-                "then retry."
-            )
-        return (
-            f" Notebook currently has {source_count}/{source_limit} sources, below "
-            "the advertised account limit. If the file is valid, try the same add "
-            "in a fresh notebook to distinguish file rejection from notebook state."
-        )
-
-    if source_count is not None and source_count >= _SOURCE_LIMIT_HINT_FLOOR:
-        return (
-            f" Notebook currently has {source_count} sources; status code 3 can "
-            "indicate the notebook is at or near the tier-specific per-notebook "
-            f"source limit ({_TIER_SOURCE_LIMITS_SUMMARY}). Delete sources or "
-            "try a fresh notebook, then retry."
-        )
-
-    if source_limit is not None:
-        return (
-            f" Advertised source limit for this tier is {source_limit}; compare "
-            "it with this notebook's source count. Status code 3 can indicate a "
-            "per-notebook source-limit rejection."
-        )
-
-    return ""
 
 
 class AsyncClientFactory(Protocol):
@@ -812,7 +760,9 @@ class SourceUploadPipeline(LoopBoundPrimitive):
                 headers=request.headers,
                 content=request.body,
             )
-            response.raise_for_status()
+            # Classify a rejection (e.g. an unsupported ``.pub`` → HTTP 400) instead of
+            # leaking a raw ``httpx.HTTPStatusError`` to callers (#1892).
+            raise_for_upload_status(response, filename)
 
             upload_url = response.headers.get("x-goog-upload-url")
             if not upload_url:
@@ -913,7 +863,9 @@ class SourceUploadPipeline(LoopBoundPrimitive):
                         response = await client.post(
                             upload_url, headers=headers, content=file_stream()
                         )
-                    response.raise_for_status()
+                    # The finalize POST can also be rejected upstream (propagates via
+                    # ``asyncio.shield`` below); classify it too (#1892).
+                    raise_for_upload_status(response, diag_name)
 
             def _on_finalize_done(t: asyncio.Task[None]) -> None:
                 if path_fallback is None:

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -561,6 +561,38 @@ def test_upload_failed_add_records_no_completion_result(monkeypatch, mock_client
     assert config.jti_store.completed(jti) is None
 
 
+def test_upload_upstream_rejection_surfaces_clean_redacted_4xx(mock_client, config) -> None:
+    # Regression (#1892): an unsupported file type (.pub) is rejected upstream with an
+    # HTTP 400 inside add_file → start_resumable_upload. The client layer now classifies
+    # that as a ValidationError (not a raw httpx.HTTPStatusError), so the route returns a
+    # clean, redacted 4xx — NOT an opaque 500. The message is scrubbed and the response
+    # still carries the ACAO header so the cross-origin widget can read the real error.
+    from notebooklm.exceptions import ValidationError
+
+    mock_client.sources.add_file = AsyncMock(
+        side_effect=ValidationError(
+            "NotebookLM rejected the upload of 'x.pub' (HTTP 400: Bad Request). "
+            "The file type or content may be unsupported. f.sid=SUPERSECRETVALUE12345"
+        )
+    )
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(
+            _path(url) + "?filename=x.pub",
+            content=b"PUBDATA",
+            headers={"Origin": "https://example.test"},
+        )
+    assert resp.status_code == 400  # a clean 4xx, not a 500
+    assert "SUPERSECRETVALUE12345" not in resp.text  # secret scrubbed by redact()
+    # The load-bearing assertion: without ACAO the browser blocks the cross-origin
+    # response as a CORS failure and the widget shows only "TypeError: Failed to
+    # fetch". With it, the user sees the real, readable reason in the body.
+    assert resp.headers["access-control-allow-origin"] == "*"
+    assert "unsupported" in resp.text.lower()
+    assert resp.headers["cache-control"] == "no-store"
+
+
 def test_upload_post_filename_is_sanitized_to_basename(mock_client, config) -> None:
     add_file = AsyncMock(return_value=MagicMock(id="src-1"))
     mock_client.sources.add_file = add_file

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -785,6 +785,8 @@ async def test_start_resumable_upload_rejects_untrusted_upload_header_url() -> N
     [
         (400, ValidationError),  # unsupported file type (.pub) → clean 4xx
         (415, ValidationError),  # unsupported media type → clean 4xx
+        (401, AuthError),  # session/credentials rejected → auth
+        (403, AuthError),  # forbidden → auth
         (302, AuthError),  # session bounced to login → auth, NOT "unsupported file"
         (503, ServerError),  # transient upstream failure stays a (retriable) server error
         (429, RateLimitError),  # rate limit stays a rate-limit error

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -19,6 +19,7 @@ from notebooklm._source.upload import (
     _validate_resumable_upload_url,
 )
 from notebooklm.exceptions import (
+    AuthError,
     NetworkError,
     RateLimitError,
     ServerError,
@@ -784,6 +785,7 @@ async def test_start_resumable_upload_rejects_untrusted_upload_header_url() -> N
     [
         (400, ValidationError),  # unsupported file type (.pub) → clean 4xx
         (415, ValidationError),  # unsupported media type → clean 4xx
+        (302, AuthError),  # session bounced to login → auth, NOT "unsupported file"
         (503, ServerError),  # transient upstream failure stays a (retriable) server error
         (429, RateLimitError),  # rate limit stays a rate-limit error
     ],

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -18,7 +18,12 @@ from notebooklm._source.upload import (
     _transient_error_types_for_upload,
     _validate_resumable_upload_url,
 )
-from notebooklm.exceptions import NetworkError, ValidationError
+from notebooklm.exceptions import (
+    NetworkError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
 from notebooklm.rpc import RPCError, RPCMethod
 from notebooklm.types import Source, SourceAddError
 
@@ -772,6 +777,48 @@ async def test_start_resumable_upload_rejects_untrusted_upload_header_url() -> N
             "src_123",
             "application/pdf",
         )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exc"),
+    [
+        (400, ValidationError),  # unsupported file type (.pub) → clean 4xx
+        (415, ValidationError),  # unsupported media type → clean 4xx
+        (503, ServerError),  # transient upstream failure stays a (retriable) server error
+        (429, RateLimitError),  # rate limit stays a rate-limit error
+    ],
+)
+@pytest.mark.asyncio
+async def test_start_resumable_upload_maps_upstream_status_to_notebooklm_error(
+    status: int, expected_exc: type[Exception]
+) -> None:
+    # NotebookLM's /upload endpoint answers with a raw HTTP status (not a
+    # batchexecute envelope), so the client layer must classify it — a raw
+    # ``httpx.HTTPStatusError`` must never leak to callers (#1892). A 4xx
+    # request/file rejection surfaces as ``ValidationError`` (the same bad-input
+    # category as the local unsupported-type check) so the MCP/REST adapters
+    # render a clean, redacted 4xx instead of an opaque 500.
+    req = httpx.Request("POST", "https://notebooklm.google.com/upload/_/")
+    response = httpx.Response(status, request=req, text="upstream rejected the upload")
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client
+    client_factory = MagicMock(return_value=client_cm)
+    runtime = HttpRuntime()
+    service = make_pipeline(kernel=runtime, auth=runtime, async_client_factory=client_factory)
+
+    with pytest.raises(expected_exc) as exc_info:
+        await service.start_resumable_upload(
+            "nb_123",
+            "newsletter.pub",
+            12,
+            "src_123",
+            "application/vnd.ms-publisher",
+        )
+    # The filename rides in the classified message; the raw httpx error is chained.
+    assert "newsletter.pub" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem (#1892)

Uploading an unsupported file type (observed with `.pub`, also `.sig`) through the remote MCP `/files/ul` route returned an **unclassified HTTP 500** instead of a clean, redacted 4xx. In the browser upload **widget** this is worse than ugly: the framework 500 bypasses our response handlers and carries **no `Access-Control-Allow-Origin` header**, so the browser blocks it as a CORS failure and the user sees only `TypeError: Failed to fetch` — never the real reason.

### Root cause

NotebookLM's resumable-upload endpoint (`notebooklm.google.com/upload/_/`) answers with a raw HTTP status, **not** a batchexecute envelope, so it never flows through the RPC executor's status mapper. When it rejects a file type, `start_resumable_upload` (`src/notebooklm/_source/upload.py`) called `response.raise_for_status()`, which raised a bare `httpx.HTTPStatusError`. That is **not** a `NotebookLMError`, so `upload_route`'s `except NotebookLMError` arm (which routes through `_upstream_error_response` → classified + redacted) never caught it, and it escaped to a raw Starlette 500. The REST/CLI `add_file` path leaked the same raw error too.

## Fix — at the client layer (preferred)

I wrapped the raw `httpx.HTTPStatusError` **in the client layer**, not the route, because the client layer should never leak raw httpx errors and this fixes **all** callers at once (REST `add_file` and CLI, not just MCP `/files/ul`).

A shared `raise_for_upload_status(response, filename)` helper (in the `_source/_upload_decode.py` sibling) classifies the failure, **mirroring the RPC executor's existing `raise_rpc_error_from_http_status` contract**:

| upstream status | raised | `classify()` | `/files/*` HTTP |
|---|---|---|---|
| 429 | `RateLimitError` | RATE_LIMITED | 429 |
| 401 / 403 | `AuthError` | AUTH | 502 (gateway) |
| 5xx | `ServerError` | SERVER | 502 (gateway) |
| other 4xx (incl. 400) | **`ValidationError`** | VALIDATION | **400** |

The one deliberate deviation from the executor's mapper (which uses `ClientError` for a generic 4xx) is that an upstream **4xx** becomes a `ValidationError`. That is the **same category as the local `_validate_upload_file_supported` unsupported-type check** — a `.pub` that slips past the local allowlist and is rejected server-side is the same bad-input outcome — so it surfaces as a clean, redacted **400** rather than a gateway 5xx. `ClientError` would classify to RPC → 502, which is not the 4xx the issue calls for.

Both the resumable-upload **START** and the **finalize/streaming** POST now go through the classifier.

### CORS / widget readability

The wrapped `ValidationError` is caught by `upload_route`'s existing `except ValidationError` arm → clean redacted **400** `PlainTextResponse`, and the route's CORS middleware stamps `access-control-allow-origin: *` on the response (same as the existing 403-rejection ACAO behavior). That header is the load-bearing part: it turns the widget's `Failed to fetch` into a readable "unsupported file type" message.

### Module-size ratchet (ADR-0008)

`_source/upload.py` sat exactly at the 1000-line ceiling and was already drained off the allowlist (a one-way ratchet — re-allowlisting is disallowed). So the new classifier **plus** the pre-existing pure `_build_invalid_argument_source_limit_hint` helper were moved to the `_upload_decode.py` sibling (its designated home for pure upload helpers) and re-exported. `upload.py` drops to 952 lines; no allowlist change.

## Tests

- **Client layer** (`test_source_upload_pipeline.py`): `start_resumable_upload` maps 400/415 → `ValidationError`, 503 → `ServerError`, 429 → `RateLimitError`, with the raw `httpx.HTTPStatusError` chained as `__cause__`.
- **MCP route** (`test_fileroutes.py`): an upstream 4xx surfaces as a clean **400** (not 500) with a scrubbed body, a readable "unsupported" reason, **and** `access-control-allow-origin: *`.

Full default suite green (12175 passed) except one pre-existing, unrelated `test_version_matches_pyproject` failure (worktree `__init__` 0.8.0a3 vs pyproject 0.8.0a4 — files not touched here).

Closes #1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload failures are now classified into application-specific errors for authentication issues, rate limits, validation failures, and server errors.
  * Resumable uploads surface clearer, filename-specific error context and no longer leak raw HTTP status errors.
  * Upload guidance improves when source limits are likely exceeded.
  * File upload routes now return clean, redacted 4xx responses with correct CORS and `no-store` caching behavior.

* **Tests**
  * Added unit coverage for upstream upload rejections and HTTP-to-error classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->