### PR TITLE
chore: prepare v0.8.0b1 (first beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,6 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Added
 
-- **`source_add` gains in-channel bytes and an inline wait.**
-  `source_add(source_type="file", bytes_base64=…, filename=…)` adds a small
-  file's bytes directly (no signed-URL round-trip), and `source_add(…, wait=True,
-  timeout=…, interval=…)` returns the `source_wait` aggregate once processing
-  settles. These fold the separate `source_add_and_wait` / `source_upload_bytes`
-  tools that shipped in the 0.8.0 alphas into a single `source_add` verb (ADR-0025
-  param-over-verb; MCP tool surface 36 → 34, schema-char budget ratcheted down).
-  ([#1890](https://github.com/teng-lin/notebooklm-py/issues/1890))
 - **`await_upload` — confirm a brokered file upload landed.** A new MCP tool that
   waits for a source created via the remote signed-URL upload flow to finish,
   returning the added source (`source_id` / name / size / mime) as soon as the
@@ -107,7 +99,8 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   `source_add(..., wait=True, timeout=…, interval=…)` composes the add with
   `source_wait` for single-source adds — returning the `source_wait` aggregate plus a
   top-level `source_id`. This keeps the MCP surface leaner (ADR-0025): one `source_add`
-  verb with input modes, not three near-duplicate add tools.
+  verb with input modes, not three near-duplicate add tools (MCP tool surface 36 → 34,
+  schema-char budget ratcheted down).
 
 - **Compact roster mode for `source_list` and `studio_list`**
   ([#1806](https://github.com/teng-lin/notebooklm-py/issues/1806)) — a terser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,31 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Added
 
+- **`source_add` gains in-channel bytes and an inline wait.**
+  `source_add(source_type="file", bytes_base64=…, filename=…)` adds a small
+  file's bytes directly (no signed-URL round-trip), and `source_add(…, wait=True,
+  timeout=…, interval=…)` returns the `source_wait` aggregate once processing
+  settles. These fold the separate `source_add_and_wait` / `source_upload_bytes`
+  tools that shipped in the 0.8.0 alphas into a single `source_add` verb (ADR-0025
+  param-over-verb; MCP tool surface 36 → 34, schema-char budget ratcheted down).
+  ([#1890](https://github.com/teng-lin/notebooklm-py/issues/1890))
+- **`await_upload` — confirm a brokered file upload landed.** A new MCP tool that
+  waits for a source created via the remote signed-URL upload flow to finish,
+  returning the added source (`source_id` / name / size / mime) as soon as the
+  browser POST completes — so an agent that brokered an upload can confirm the add
+  without polling `source_list`. Accepts the upload URL, the `/u/<shortid>`
+  short-link, or the bare token.
+  ([#1889](https://github.com/teng-lin/notebooklm-py/issues/1889))
+- **Experimental in-app upload widget (opt-in).** With
+  `NOTEBOOKLM_MCP_UPLOAD_WIDGET=1` on a remote HTTP deployment, `source_add_widget`
+  renders a file picker *inline* in MCP-Apps hosts (claude.ai, ChatGPT) so a mobile
+  user can pick and upload **one or more files** (up to 10) without leaving the
+  chat — no browser round-trip. Enabling it auto-enables stateless HTTP (which
+  MCP-Apps hosts require to fetch the `ui://` widget resource). It stays off the
+  default tool surface / budgets unless enabled; the portable signed-link flow
+  remains the fallback. See [ADR-0027](docs/adr/0027-mcp-app-upload-widget.md).
+  ([#1891](https://github.com/teng-lin/notebooklm-py/issues/1891),
+  [#1894](https://github.com/teng-lin/notebooklm-py/issues/1894))
 - **`studio_download` `download_ready` now carries `filename` / `mime` /
   `size_bytes`.** The MCP download-ready payload previously returned only the
   local path, so an agent had to stat the file to learn what it got; the
@@ -455,6 +480,15 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Fixed
 
+- **Upstream upload errors surface as a clean, redacted 4xx — not an opaque 500.**
+  An unsupported file type (or other upstream rejection) during a remote
+  `/files/ul` upload used to leak a raw `httpx.HTTPStatusError` as an unclassified
+  500 with no CORS header — which a browser upload widget could only report as
+  "Failed to fetch". Upload HTTP errors are now classified at the client layer
+  (429 → rate-limit, 5xx → server, 401/403/3xx → auth, other 4xx → validation)
+  into a redacted, CORS-carrying response, so the user sees the real reason. Fixes
+  the REST/CLI `add_file` path too.
+  ([#1892](https://github.com/teng-lin/notebooklm-py/issues/1892))
 - **Upload-only Drive file types auto-route to the file-upload path.** Adding a
   Drive file whose type NotebookLM only accepts as an upload (not an add-by-URL)
   used to fail at the RPC; the add-from-Drive path now detects those types and

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0a4",
+  "version": "0.8.0b1",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -507,7 +507,7 @@ Wire it into an MCP client with either:
 - `notebooklm mcp install <client>` — auto-writes the server config for `claude-desktop`, `claude-code`, `cursor`, or `windsurf`; or
 - the one-click `.mcpb` desktop bundle — download it from the [latest release](https://github.com/teng-lin/notebooklm-py/releases/latest) (**Assets**) and use Claude Desktop's "Install Extension". Each stable release attaches a prebuilt, version-matched bundle; see [`desktop-extension/README.md`](../desktop-extension/README.md).
 
-Full usage walkthrough (auth, transports, the 35 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
+Full usage walkthrough (auth, transports, the 34 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
 
 ---
 

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -6,7 +6,7 @@
 > server and its dependencies only arrive with the `mcp` extra.
 
 The MCP server exposes NotebookLM to any [Model Context Protocol](https://modelcontextprotocol.io)
-client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **32 tools** — manage
+client (Claude Desktop, Claude Code, Cursor, Windsurf, …) as a set of **34 tools** — manage
 notebooks and sources, chat over a notebook's sources, generate and download studio artifacts,
 and run deep research. It is a thin adapter over the same business logic the CLI uses, so it
 behaves identically to `notebooklm <command>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0a4"
+version = "0.8.0b1"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0a4"
+version = "0.8.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
First **beta** of the 0.8.0 cycle. Prep only — no functional change; the tag/publish steps follow separately per `docs/releasing.md` (with the confirm-gates).

## Version
`0.8.0a4 → 0.8.0b1` in `pyproject.toml`, `desktop-extension/manifest.json`, and `uv.lock` (canonical PEP 440; `uv lock --check` clean). Serial progression a4 → b1 (no patch bump); the beta carries the same surface as a1–a4 with this cycle's file-work.

## CHANGELOG ([0.8.0], accumulating per pre-release policy)
- **Added:** `source_add(bytes_base64=…, filename=…)` + `source_add(wait=…, timeout=…, interval=…)` — folds the alpha-only `source_add_and_wait` / `source_upload_bytes` tools into one verb (MCP surface **36→34**, #1890); `await_upload` (#1889); experimental in-app upload widget (#1891, #1894).
- **Fixed:** upstream upload HTTP errors now classify into a redacted, CORS-carrying **4xx** instead of an opaque 500 (#1892).

## Docs
- Tool-count prose corrected to the tested `EXPECTED_TOOLS = 34` (`mcp-guide.md`, `installation.md`).

## Gates (local)
- ✅ **Public-API compat audit** — compatible with v0.7.0 baseline; 150 reviewed breaks allowlisted, **0 unapproved** (the MCP tool removal isn't in the Python public API).
- ✅ ruff (944 files) · mypy (312 files) · desktop-extension version-match test · mcp + guardrail suites (1990 passed; the only local reds are the stale-shared-venv version-sync test — passes in CI's fresh install — and untracked `docs/notes`/`docs/plans` working files not in this PR).

## Not in this PR (feature-freeze call is yours)
Nothing new — this freezes the current 0.8.0 surface. The experimental MCP widget stays opt-in. SEP-2631 (#1656) remains parked `do-not-implement-yet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inline upload data with an optional wait-for-completion flow.
  * Introduced a tool to confirm completion of brokered remote signed-URL uploads.
  * Added an opt-in in-app upload widget for compatible MCP-Apps hosts.
* **Bug Fixes**
  * Improved reporting of upstream remote upload failures by returning clean, redacted, CORS-friendly 4xx errors instead of opaque 500s (including REST/CLI add-file flows).
* **Documentation**
  * Updated MCP tool counts in installation and MCP guide (35→34; 32→34).
* **Chores**
  * Bumped app and package version to 0.8.0b1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->