### PR TITLE
fix(deploy): empty FASTMCP_STATELESS_HTTP crash-loops the MCP server

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -69,11 +69,10 @@ CF_TUNNEL_TOKEN=
 # Experimental: expose the in-app MCP-App upload widget (renders inline in MCP-Apps hosts
 # like claude.ai; a mobile user picks + uploads a file without leaving the chat). Off by
 # default. Requires the http transport + a public URL. Enabling it auto-enables stateless
-# HTTP (below), which the widget needs to render. See docs/mcp-guide.md.
+# HTTP in-code (the widget needs it to render) — no separate flag required. See docs/mcp-guide.md.
 #NOTEBOOKLM_MCP_UPLOAD_WIDGET=1
 
-# Stateless MCP HTTP: serve each POST /mcp independently (no server-side session). REQUIRED for
-# the upload widget — MCP-Apps hosts read the ui:// widget resource on a connection without the
-# chat session id, which a stateful server rejects ("fail to fetch app content"). Auto-enabled
-# when NOTEBOOKLM_MCP_UPLOAD_WIDGET=1; set explicitly to override. Harmless for normal tool use.
-#FASTMCP_STATELESS_HTTP=true
+# Stateless MCP HTTP is auto-enabled in code when NOTEBOOKLM_MCP_UPLOAD_WIDGET=1 (a non-widget
+# deploy stays stateful). It is intentionally NOT a compose passthrough: an empty value crashes
+# FastMCP's settings at import. To force it without the widget, set FASTMCP_STATELESS_HTTP to a real
+# bool (true/false, never blank) directly in the container's process env — not via this file.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -44,12 +44,11 @@ services:
       # upload widget (renders inline in MCP-Apps hosts like claude.ai). Off by default;
       # requires this http transport + a public URL. See docs/mcp-guide.md.
       NOTEBOOKLM_MCP_UPLOAD_WIDGET: ${NOTEBOOKLM_MCP_UPLOAD_WIDGET:-}
-      # Stateless MCP HTTP (FastMCP): serve each POST /mcp independently, no server-side
-      # session. Required for MCP-Apps hosts (claude.ai) whose app-content fetcher reads the
-      # ui:// widget resource on a connection without the chat Mcp-Session-Id — a stateful
-      # server rejects that as "Missing session ID" and the widget shows "fail to fetch app
-      # content". Recommended on when the upload widget is enabled.
-      FASTMCP_STATELESS_HTTP: ${FASTMCP_STATELESS_HTTP:-}
+      # NOTE: FastMCP stateless HTTP is deliberately NOT passed through here. A compose
+      # `${FASTMCP_STATELESS_HTTP:-}` injects an EMPTY string when unset, and FastMCP's pydantic
+      # Settings() bool-parses it at import and crash-loops the server. Enabling the upload widget
+      # auto-enables stateless in code; a non-widget deploy stays stateful. To force it without the
+      # widget, set FASTMCP_STATELESS_HTTP to a real bool in the process env (never a blank value).
       # Point the app at the mounted profile, independent of the (arbitrary) uid's
       # home. The host dir is always mounted as the profile literally named
       # "server"; NOTEBOOKLM_HOME/profiles/server is where the app reads+writes.

--- a/src/notebooklm/mcp/__init__.py
+++ b/src/notebooklm/mcp/__init__.py
@@ -19,7 +19,8 @@ import os as _os
 # docker-compose `${FASTMCP_STATELESS_HTTP:-}` passthrough injects when the operator hasn't set it.
 # Treat an empty value as unset so a blank env var can't crash-loop the server before it even
 # reaches argv/flag handling (the widget-driven stateless default is applied later, in __main__).
-if _os.environ.get("FASTMCP_STATELESS_HTTP") == "":
+_stateless = _os.environ.get("FASTMCP_STATELESS_HTTP")
+if _stateless is not None and _stateless.strip() == "":  # "" or whitespace-only → treat as unset
     del _os.environ["FASTMCP_STATELESS_HTTP"]
 
 from .server import SERVER_INSTRUCTIONS, SERVER_NAME, create_server  # noqa: E402 — guard runs first

--- a/src/notebooklm/mcp/__init__.py
+++ b/src/notebooklm/mcp/__init__.py
@@ -12,6 +12,16 @@ This package imports NO ``click`` / ``rich`` / ``cli`` — it is built on the
 
 from __future__ import annotations
 
-from .server import SERVER_INSTRUCTIONS, SERVER_NAME, create_server
+import os as _os
+
+# FastMCP's Settings() (pulled in transitively by the .server import below) bool-parses
+# FASTMCP_STATELESS_HTTP at import time and RAISES on an empty string — exactly what a
+# docker-compose `${FASTMCP_STATELESS_HTTP:-}` passthrough injects when the operator hasn't set it.
+# Treat an empty value as unset so a blank env var can't crash-loop the server before it even
+# reaches argv/flag handling (the widget-driven stateless default is applied later, in __main__).
+if _os.environ.get("FASTMCP_STATELESS_HTTP") == "":
+    del _os.environ["FASTMCP_STATELESS_HTTP"]
+
+from .server import SERVER_INSTRUCTIONS, SERVER_NAME, create_server  # noqa: E402 — guard runs first
 
 __all__ = ["SERVER_INSTRUCTIONS", "SERVER_NAME", "create_server"]

--- a/tests/unit/mcp/test_stateless_env_guard.py
+++ b/tests/unit/mcp/test_stateless_env_guard.py
@@ -1,0 +1,49 @@
+"""Guard: an empty ``FASTMCP_STATELESS_HTTP`` must not crash the MCP server at import.
+
+A docker-compose ``${FASTMCP_STATELESS_HTTP:-}`` passthrough injects an empty string when the
+operator hasn't set the var, and FastMCP's pydantic ``Settings()`` bool-parses it at import time
+and raises on ``''`` — crash-looping the container. ``notebooklm.mcp.__init__`` treats an empty
+value as unset before the FastMCP import runs; this pins that behavior against a real subprocess
+import (the in-process module is already cached, so the crash only reproduces in a fresh process).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+
+def test_empty_stateless_env_does_not_crash_mcp_import() -> None:
+    env = {**os.environ, "FASTMCP_STATELESS_HTTP": ""}
+    result = subprocess.run(
+        [sys.executable, "-c", "import notebooklm.mcp; print('imported-ok')"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import notebooklm.mcp crashed with FASTMCP_STATELESS_HTTP='':\n{result.stderr}"
+    )
+    assert "imported-ok" in result.stdout
+
+
+def test_valid_stateless_env_is_left_untouched() -> None:
+    # A real bool value must survive the guard (only the empty string is treated as unset).
+    env = {**os.environ, "FASTMCP_STATELESS_HTTP": "true"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import notebooklm.mcp, os; print(os.environ.get('FASTMCP_STATELESS_HTTP'))",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "true"

--- a/tests/unit/mcp/test_stateless_env_guard.py
+++ b/tests/unit/mcp/test_stateless_env_guard.py
@@ -19,7 +19,11 @@ pytest.importorskip("fastmcp")
 
 
 def test_empty_stateless_env_does_not_crash_mcp_import() -> None:
-    env = {**os.environ, "FASTMCP_STATELESS_HTTP": ""}
+    env = {
+        **os.environ,
+        "FASTMCP_STATELESS_HTTP": "",
+        "PYTHONPATH": os.pathsep.join(p for p in sys.path if p),  # subprocess resolves notebooklm
+    }
     result = subprocess.run(
         [sys.executable, "-c", "import notebooklm.mcp; print('imported-ok')"],
         env=env,
@@ -34,7 +38,11 @@ def test_empty_stateless_env_does_not_crash_mcp_import() -> None:
 
 def test_valid_stateless_env_is_left_untouched() -> None:
     # A real bool value must survive the guard (only the empty string is treated as unset).
-    env = {**os.environ, "FASTMCP_STATELESS_HTTP": "true"}
+    env = {
+        **os.environ,
+        "FASTMCP_STATELESS_HTTP": "true",
+        "PYTHONPATH": os.pathsep.join(p for p in sys.path if p),  # subprocess resolves notebooklm
+    }
     result = subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Bug (hit live on 0.8.0b1)

The deploy compose passed `FASTMCP_STATELESS_HTTP: ${FASTMCP_STATELESS_HTTP:-}`. When an operator hasn't set the var, compose injects an **empty string**, and FastMCP's pydantic `Settings()` **bool-parses it at import and raises** — so **any docker deploy that doesn't set `FASTMCP_STATELESS_HTTP` crash-loops**:

```
pydantic_core.ValidationError: 1 validation error for Settings
stateless_http
  Input should be a valid boolean, unable to interpret input [input_value='']
```

Found while pointing a live prod connector at `0.8.0b1` (the pre-sync compose lacked the line, so a4 ran; the first b1 `make up` crash-looped). The **image is fine** — this is the deploy config.

## Fix (two layers)

1. **Remove the compose passthrough** (repo-only; fixes the default `git clone → make up` path immediately). The upload widget already **auto-enables stateless in code**; a non-widget deploy stays stateful; nothing injects a blank value. `deploy/.env.example` updated — setting it via `.env` is no longer a passthrough (an empty value is the footgun; force it via the process env only, never blank).
2. **Guard in `mcp/__init__.py`** (runs *before* the transitive FastMCP import): treat an empty `FASTMCP_STATELESS_HTTP` as unset, so a blank value from **any** source can't crash the server at import. This ships in the next image.

The empty string also defeated the widget stateless auto-enable (an empty value counts as "set") — both issues resolved.

## Tests
Subprocess regression test: `import notebooklm.mcp` with `FASTMCP_STATELESS_HTTP=''` must not crash, and a real bool value is left untouched. ruff/mypy/entrypoint green.

Follow-up to the 0.8.0b1 deploy config; a candidate to fold into a corrected `0.8.0b2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when the stateless HTTP environment variable is set but left blank during MCP import/startup.
  * Ensured non-blank stateless HTTP values are respected as provided.
* **Documentation**
  * Updated the example environment guidance and docker-compose notes for enabling the MCP upload widget and stateless HTTP behavior.
* **Tests**
  * Added unit coverage to verify MCP imports cleanly with a blank value and preserves valid values correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->