### PR TITLE
chore: prepare v0.8.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -473,6 +473,14 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
 
 ### Fixed
 
+- **A blank `FASTMCP_STATELESS_HTTP` no longer crash-loops the remote MCP server.**
+  The deploy compose passed the variable through as `${FASTMCP_STATELESS_HTTP:-}`,
+  which injects an **empty string** when unset — and FastMCP's settings bool-parse
+  it at import and raise, so a docker deploy that didn't set the var crash-looped.
+  The compose passthrough is removed (the upload widget auto-enables stateless in
+  code; a non-widget deploy stays stateful), and an import-time guard treats an
+  empty/whitespace-only value as unset so a blank value from any source can't crash
+  the server. ([#1898](https://github.com/teng-lin/notebooklm-py/issues/1898))
 - **Upstream upload errors surface as a clean, redacted 4xx — not an opaque 500.**
   An unsupported file type (or other upstream rejection) during a remote
   `/files/ul` upload used to leak a raw `httpx.HTTPStatusError` as an unclassified

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0b1",
+  "version": "0.8.0b2",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0b1"
+version = "0.8.0b2"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0b1"
+version = "0.8.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Second beta of the 0.8.0 cycle. Prep only — tag/publish follows separately with the confirm-gates.

## Version
`0.8.0b1 → 0.8.0b2` (pyproject + `desktop-extension/manifest.json` + `uv.lock`; `uv lock --check` clean).

## What changed since b1
The **only** delta is [#1898](https://github.com/teng-lin/notebooklm-py/issues/1898) — a blank `FASTMCP_STATELESS_HTTP` no longer crash-loops the remote MCP server (compose passthrough removed + an import-time env guard). Added to `[0.8.0]` Fixed.

## E2E scope (deliberate)
b2 touches **no RPC/API code** (`rpc/` and every live call path are identical to b1, which already passed full E2E + RPC health hands-on). So the standalone step-8 E2E/RPC-health dispatches are **skipped as redundant** — but **Verify Package still runs unit+integration+E2E against the published wheel** (not skippable), so the packaged artifact is E2E-verified regardless.

## Gates (local)
- ✅ Public-API compat audit (0 unapproved breaks) · ruff (945 files) · mypy (312) · desktop-extension version-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented remote MCP servers from repeatedly crashing when `FASTMCP_STATELESS_HTTP` is provided as an empty or whitespace-only value.
  * Empty configuration values are now handled as unset for more reliable server startup.

* **Chores**
  * Updated the application and desktop extension version to 0.8.0b2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->