### PR TITLE
feat(deploy): end-user quick start — default `:latest` + version-baked release compose

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -121,6 +121,32 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Stage the deploy assets (version-baked compose + env template)
+        # Bake THIS release's exact version into the compose default so a downloaded
+        # `docker compose up -d` resolves without depending on `:latest` (which only
+        # exists at a stable release). env.example is renamed non-hidden because
+        # actions/upload-artifact drops dotfiles by default (include-hidden-files=false).
+        env:
+          # TAG_NAME is step-scoped elsewhere in this job — declare it here too.
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          V="${TAG_NAME#v}"
+          sed "s#\${NOTEBOOKLM_MCP_VERSION:-latest}#\${NOTEBOOKLM_MCP_VERSION:-$V}#" \
+              deploy/docker-compose.yml > docker-compose.yml
+          grep -qF "\${NOTEBOOKLM_MCP_VERSION:-$V}" docker-compose.yml \
+              || { echo "::error::version bake did not apply (compose default drifted from :-latest)"; exit 1; }
+          cp deploy/.env.example env.example
+
+      - name: Upload the deploy assets as a workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # @ v7
+        with:
+          name: deploy-assets
+          path: |
+            docker-compose.yml
+            env.example
+          if-no-files-found: error
+          retention-days: 1
+
   attach:
     name: Attach the bundles to the release
     needs: build
@@ -136,10 +162,17 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # @ v8.0.1
         with:
           name: notebooklm-mcp-mcpb
+          merge-multiple: true
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # @ v8.0.1
         with:
           name: notebooklm-skill-zip
+          merge-multiple: true
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # @ v8.0.1
+        with:
+          name: deploy-assets
+          merge-multiple: true
 
       - name: Attach the bundles to the release
         env:
@@ -152,4 +185,4 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
         # `--clobber` makes re-runs idempotent (replaces an existing asset of
         # the same name instead of erroring).
-        run: gh release upload "$TAG_NAME" notebooklm-mcp.mcpb notebooklm-skill.zip --clobber
+        run: gh release upload "$TAG_NAME" notebooklm-mcp.mcpb notebooklm-skill.zip docker-compose.yml env.example --clobber

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,13 +3,48 @@
 Run the MCP server as a **remote connector** (Claude Code / claude.ai / Cursor)
 behind a tunnel: no public IP, no open ports, no TLS certificate to manage.
 Single-tenant, self-hosted. Pick **Cloudflare** (needs a domain) or **Tailscale
-Funnel** (no domain). `make up` pulls a **prebuilt image** — no source checkout.
+Funnel** (no domain). Both paths pull a **prebuilt image** (no build): download the release
+compose and run `docker compose up -d` (no repo — Cloudflare only), or `make up` from a `deploy/`
+checkout (either tunnel).
 
 > ⚠️ **Use a dedicated / throwaway Google account.** The mounted
 > `master_token.json` is a durable, full-account credential. Treat the mounted profile dir
 > and `.env` as secrets (both are gitignored).
 
-## Quick start (the easy path)
+## Quick start — end users (no repo, Cloudflare tunnel)
+
+No `git clone`, no `make` — just the two release assets + Docker. (Available from the **0.8.0
+stable** release; during pre-release use a specific tag URL, e.g. `…/download/v0.8.0b2/…`. This path
+is **Cloudflare only** — the Tailscale profile needs the `deploy/tailscale/` files from a checkout.)
+
+```bash
+# 1. One-time, on a machine with a browser — bootstrap the Google credential:
+pip install "notebooklm-py[browser,headless]"
+notebooklm login --master-token --account you@example.com
+#    → copy the profile dir it wrote (~/.notebooklm/profiles/<name>/, contains master_token.json)
+#      to your server. This is the one irreducible manual step.
+
+# 2. On the server, create the mount dir as YOUR uid (Docker would make it root:root otherwise):
+mkdir -p ~/.notebooklm/profiles/server      # place the bootstrapped master_token.json here
+
+# 3. Grab the release assets (use the tag you want; `latest` resolves at 0.8.0 stable):
+curl -LO https://github.com/teng-lin/notebooklm-py/releases/latest/download/docker-compose.yml
+curl -LO https://github.com/teng-lin/notebooklm-py/releases/latest/download/env.example
+cp env.example .env
+#    edit .env — the irreducible config:
+#      NOTEBOOKLM_MCP_TOKEN=<random> (or the OAuth vars for claude.ai — see §4)
+#      NOTEBOOKLM_PROFILE_DIR=<ABSOLUTE path to the dir from step 2; ~ is NOT expanded in .env>
+#      NOTEBOOKLM_UID / NOTEBOOKLM_GID = your `id -u` / `id -g` (make fills these; raw compose can't)
+#      CF_TUNNEL_TOKEN=<from Cloudflare> + a public hostname routed to http://notebooklm-mcp:9420 (§3)
+
+# 4. Start (the --profile flag is required — the tunnel is a compose profile):
+docker compose --profile cloudflare up -d
+
+# upgrade to a newer release: re-download its docker-compose.yml, then
+docker compose --profile cloudflare pull && docker compose --profile cloudflare up -d
+```
+
+## Quick start — from a `deploy/` checkout (`make`, either tunnel)
 ```bash
 # 1. bootstrap the master token once, on a machine with a browser (see §1):
 pip install "notebooklm-py[browser,headless]"
@@ -19,8 +54,8 @@ cd deploy && make setup
 # 3. finish the tunnel setup (§3 — the one irreducible manual part), then:
 make up
 ```
-`make up` pulls the published image and starts it. The rest of this doc is the
-detailed walk-through + the security model.
+`make up` pulls the published image (the checkout's version) and starts it. The rest of this doc is
+the detailed walk-through + the security model.
 
 ## Prerequisites
 - Docker + Docker Compose.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,13 +10,14 @@
 # tunnel, which terminates TLS at its edge (no CA cert for you to manage). See README.md.
 services:
   notebooklm-mcp:
-    # Pull the published image by default. `make up` / `make prod` require or
-    # inject a version; raw docker compose pull must set NOTEBOOKLM_MCP_VERSION.
-    # Override the namespace/tag via
-    # NOTEBOOKLM_MCP_IMAGE / NOTEBOOKLM_MCP_VERSION in .env. Contributors
-    # building from THIS checkout run `make dev`, which layers
-    # docker-compose.build.yml to add a `build:` section back (see that file).
-    image: ${NOTEBOOKLM_MCP_IMAGE:-tenglin/notebooklm-mcp}:${NOTEBOOKLM_MCP_VERSION:-set-version}
+    # Pull the published image. Default tag is `latest` = the latest STABLE release
+    # (pre-releases never move `:latest`), so a bare `docker compose up -d` works
+    # out of the box once a stable release exists. Pin a specific release with
+    # NOTEBOOKLM_MCP_VERSION=X.Y.Z in .env (release-download users get a compose with
+    # the exact version baked in). `make up`/`make prod` inject the checkout's version.
+    # Override the namespace via NOTEBOOKLM_MCP_IMAGE. Contributors building from THIS
+    # checkout run `make dev`, which layers docker-compose.build.yml (see that file).
+    image: ${NOTEBOOKLM_MCP_IMAGE:-tenglin/notebooklm-mcp}:${NOTEBOOKLM_MCP_VERSION:-latest}
     restart: unless-stopped
     # Run as YOUR uid:gid so the mounted profile's files (owned by you on the
     # host) are readable AND writable with NO chown — and your own `notebooklm`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -507,6 +507,10 @@ Wire it into an MCP client with either:
 - `notebooklm mcp install <client>` — auto-writes the server config for `claude-desktop`, `claude-code`, `cursor`, or `windsurf`; or
 - the one-click `.mcpb` desktop bundle — download it from the [latest release](https://github.com/teng-lin/notebooklm-py/releases/latest) (**Assets**) and use Claude Desktop's "Install Extension". Each stable release attaches a prebuilt, version-matched bundle; see [`desktop-extension/README.md`](../desktop-extension/README.md).
 
+For a **self-hosted remote connector** (claude.ai / mobile / ChatGPT over a tunnel), each release also
+attaches a version-baked `docker-compose.yml` + `env.example` — no repo clone: `curl` them, fill
+`.env`, `docker compose --profile cloudflare up -d`. See [`deploy/README.md`](../deploy/README.md#quick-start--end-users-no-repo-cloudflare-tunnel).
+
 Full usage walkthrough (auth, transports, the 34 tools, workflows, troubleshooting): **[mcp-guide.md](mcp-guide.md)**.
 
 ---

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -381,6 +381,15 @@ The `Publish to PyPI` step in `publish.yml` also opts into **PEP 740 attestation
 
 ### GitHub Release
 
+- [ ] **⏸️ Wait for the Docker image first.** Creating the release triggers `publish-mcpb.yml`, which
+  attaches a `docker-compose.yml` **version-baked** to this tag. That file pulls
+  `tenglin/notebooklm-mcp:<version>`, so the image must exist before the release publishes. The tag
+  push started `publish-docker.yml` in parallel with `publish.yml`; confirm it finished and the tag
+  is live before creating the release:
+  ```bash
+  gh run list --workflow=publish-docker.yml --branch "vX.Y.Z" --json status,conclusion
+  docker manifest inspect tenglin/notebooklm-mcp:X.Y.Z >/dev/null && echo "image present"
+  ```
 - [ ] Create release from tag:
   ```bash
   gh release create vX.Y.Z --title "vX.Y.Z" --notes "$(cat CHANGELOG.md | sed -n '/## \[X.Y.Z\]/,/## \[/p' | sed '$d')"
@@ -392,13 +401,12 @@ The `Publish to PyPI` step in `publish.yml` also opts into **PEP 740 attestation
   - Copy release notes from `CHANGELOG.md`
   - Publish release
 
-- [ ] Publishing a **stable** release fires `publish-mcpb.yml`, which builds
-  `notebooklm-mcp.mcpb` and attaches it to the release as an asset (it re-checks
-  that the manifest, tag, and `pyproject.toml` versions all agree). Confirm the
-  asset appears under the release once the workflow finishes — that is the
-  one-click Claude Desktop bundle users download. Pre-releases skip this step by
-  design (the thin launcher resolves the latest stable server, not the
-  pre-release), so a `vX.Y.ZaN` release carries no `.mcpb`.
+- [ ] Publishing a release (stable **and** pre-release) fires `publish-mcpb.yml`, which attaches
+  four assets: `notebooklm-mcp.mcpb` (the one-click Claude Desktop bundle — the launcher pins this
+  release's version), `notebooklm-skill.zip`, `docker-compose.yml`, and `env.example`. The compose
+  is **version-baked** to this exact release (so a downloaded `docker compose up -d` pulls
+  `tenglin/notebooklm-mcp:<this version>`, not `:latest`). It re-checks manifest/tag/pyproject
+  agreement. Confirm all four assets appear under the release once the workflow finishes.
 
 ### Prune the API-Compat Allowlist
 

--- a/tests/unit/test_deploy_compose_default.py
+++ b/tests/unit/test_deploy_compose_default.py
@@ -1,0 +1,33 @@
+"""Guard the deploy compose's default image tag.
+
+`deploy/docker-compose.yml` used to default the app image to a `set-version` sentinel that FAILS
+when unset (a deliberate fail-loud). It now defaults to `latest` so a bare `docker compose up -d`
+works for end users. This test pins that the default stays a *real, resolvable* tag shape (``latest``
+or a PEP 440 version) — a future edit can't silently reintroduce a non-resolving default, and the
+release workflow's version-bake (`sed` on ``${NOTEBOOKLM_MCP_VERSION:-latest}``) keeps matching.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    raise RuntimeError("could not locate repo root (no pyproject.toml above this file)")
+
+
+def test_deploy_compose_app_image_default_tag_is_resolvable() -> None:
+    compose = (_repo_root() / "deploy" / "docker-compose.yml").read_text(encoding="utf-8")
+    # The app service's image line: ...tenglin/notebooklm-mcp}:${NOTEBOOKLM_MCP_VERSION:-<default>}
+    m = re.search(r"notebooklm-mcp\}:\$\{NOTEBOOKLM_MCP_VERSION:-([^}]+)\}", compose)
+    assert m, "app image line not found / not in the expected ${NOTEBOOKLM_MCP_VERSION:-…} form"
+    default = m.group(1)
+    # Must be a real tag: `latest`, or a PEP 440-ish version (0.8.0 / 0.8.0b2 / 1.2.3rc1).
+    assert default == "latest" or re.fullmatch(r"\d+\.\d+\.\d+([abc]|rc)?\d*", default), (
+        f"deploy compose default tag {default!r} is not a resolvable tag "
+        f"(expected 'latest' or a PEP 440 version) — a bare `docker compose up` would fail to pull"
+    )

--- a/tests/unit/test_deploy_compose_default.py
+++ b/tests/unit/test_deploy_compose_default.py
@@ -26,8 +26,11 @@ def test_deploy_compose_app_image_default_tag_is_resolvable() -> None:
     m = re.search(r"notebooklm-mcp\}:\$\{NOTEBOOKLM_MCP_VERSION:-([^}]+)\}", compose)
     assert m, "app image line not found / not in the expected ${NOTEBOOKLM_MCP_VERSION:-…} form"
     default = m.group(1)
-    # Must be a real tag: `latest`, or a PEP 440-ish version (0.8.0 / 0.8.0b2 / 1.2.3rc1).
-    assert default == "latest" or re.fullmatch(r"\d+\.\d+\.\d+([abc]|rc)?\d*", default), (
+    # Must be a real tag: `latest`, or a PEP 440-ish version — release segment plus optional
+    # pre-release (a/b/rc/c), post-release (.postN), and/or dev-release (.devN):
+    # 0.8.0 / 0.8.0b2 / 1.2.3rc1 / 1.2.3.post1 / 1.2.3.dev0.
+    version_re = r"\d+\.\d+(\.\d+)?((a|b|c|rc)\d+)?(\.post\d+)?(\.dev\d+)?"
+    assert default == "latest" or re.fullmatch(version_re, default), (
         f"deploy compose default tag {default!r} is not a resolvable tag "
         f"(expected 'latest' or a PEP 440 version) — a bare `docker compose up` would fail to pull"
     )


### PR DESCRIPTION
## What
Give self-hosters the standard **download-compose → `docker compose up -d`** experience — no repo clone, no `make`, no version bookkeeping — while leaving the maintainer/`make` flow untouched. The user's ask: *"just run docker on a release image, minimal effort."*

Designed and **converged via a 3-model momus panel (Claude + Codex + agy)** — two rounds; round 1 unanimous REJECT, round 2 architecture agreed with precise fixes, all folded in.

## Changes
1. **`docker-compose.yml`** — default tag `set-version` (a failing sentinel) → `latest`. `:latest` == latest **stable** (pre-releases never move it), so a bare `docker compose up -d` works once stable ships. Pin via `NOTEBOOKLM_MCP_VERSION`; `make` unaffected (always injects the checkout's version — `_require-image-version` still guards `up/prod/dev/restart`).
2. **`publish-mcpb.yml`** — attach a **version-baked** `docker-compose.yml` + `env.example` to **every** release. The build job `sed`s the release's exact tag into the compose default (with a **fail-loud** `grep`), so a downloaded compose always resolves — no dependency on `:latest`/`/releases/latest` (which don't exist during the pre-release window). The checkout-less, minimal-`contents:write` attach split is preserved (files flow via artifacts; `env.example` staged non-hidden since `upload-artifact` drops dotfiles).
3. **`deploy/README.md`** — an **honest** no-repo quick start (Cloudflare-only; tailscale needs the checkout for `./tailscale/`): master-token bootstrap, host-dir `mkdir` + `UID/GID`, **absolute** `NOTEBOOKLM_PROFILE_DIR` (`~` isn't expanded in `.env`), CF token + route, and `--profile cloudflare` (a bare `up -d` starts only the app). The `make` block is reframed as "from a checkout"; the misleading "no source checkout" line fixed.
4. **`docs/installation.md`** — pointer to the no-repo quick start.
5. **`docs/releasing.md`** — **wait for `publish-docker.yml` + verify the Docker tag exists before creating the release** (else the baked compose is attached before its image exists → `up` fails); and fix the stale "pre-releases skip `.mcpb`" text to list all four attached assets.
6. **test** — `test_deploy_compose_default.py` guards the compose default stays a resolvable tag (`latest` or PEP 440), so no silent sentinel regression — restoring the fail-safe the old `set-version` provided.

## Why `:latest` is right for end users (not the anti-pattern)
`:latest` only ever tracks **stable**; restarts reuse the cached image (upgrades only on explicit `docker compose pull`); reproducibility is opt-in (`.env` pin, and the **downloaded release asset is version-baked**). Standard self-hosted convention.

## Verification
Bake verified (scoped — no collateral hit on cloudflared/tailscale `:latest`; fail-loud works); workflow YAML valid; 1105 tests + guardrails green (ruff/new test/install-docs/doc-module-refs). **Lands for end users at `0.8.0` stable** (first `:latest`); the version-baked, specific-tag download works from the next release this ships in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned Docker deployment assets (`docker-compose.yml` and `env.example`) to each GitHub Release.
  * Release assets are now tailored to the exact published version (not floating tags).
* **Documentation**
  * Updated installation and deployment guides for no-repo remote connector setup, including Cloudflare-only instructions and credential safety warnings.
  * Improved release checklist guidance for waiting on the versioned Docker image and verifying attached assets.
* **Bug Fixes**
  * Docker Compose now defaults to the resolvable `latest` image tag.
* **Tests**
  * Added unit coverage to validate the Docker image tag default behavior in `docker-compose.yml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->