### PR TITLE
fix(sources): isolate per-URL SourceAddError in batch add (#1905)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -222,7 +222,8 @@ These conventions hold across every tool:
   `failed` tallies + per-item `results[].status` for partial outcomes.)
 - **Structured errors.** Failures arrive as `CODE: message (retriable=…)`, where `CODE` is one of
   `AUTH`, `RATE_LIMITED`, `NOT_FOUND`, `VALIDATION`, `TIMEOUT`, `NETWORK`, `SERVER`, `RPC`,
-  `CONFIG`, `NOTEBOOK_LIMIT`, `ARTIFACT_TIMEOUT`, `SOURCE_MUTATION`, `ERROR`, or `UNEXPECTED`. The
+  `CONFIG`, `NOTEBOOK_LIMIT`, `ARTIFACT_TIMEOUT`, `SOURCE_MUTATION`, `SOURCE_ADD`, `ERROR`, or
+  `UNEXPECTED`. The
   `retriable` flag tells an agent whether a retry could succeed (e.g. `RATE_LIMITED`, `TIMEOUT`,
   `NETWORK`). Many errors also carry an actionable `hint` (e.g. `AUTH → run notebooklm login`); a
   near-miss name lookup puts its `Did you mean: …` candidates (title + id) in that hint (see

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -26,6 +26,7 @@ The category set is deliberately granular enough that the CLI's
 ``SERVER``                  (5xx — CLI currently folds into ``NOTEBOOKLM_ERROR``)
 ``RPC``                     (other RPC failures -> ``NOTEBOOKLM_ERROR``)
 ``SOURCE_MUTATION``         (``SourceMutationError`` carries its own ``.code``)
+``SOURCE_ADD``              (``SourceAddError`` -> ``NOTEBOOKLM_ERROR``; non-fatal per-item)
 ``UNEXPECTED``              ``UNEXPECTED_ERROR`` (non-library exceptions)
 ==========================  ====================================
 
@@ -65,6 +66,7 @@ from ..exceptions import (
     RateLimitError,
     RPCError,
     ServerError,
+    SourceAddError,
     ValidationError,
     WaitTimeoutError,
 )
@@ -111,6 +113,14 @@ class ErrorCategory(Enum):
     #: catch-all so adapters can recover that carried code rather than folding
     #: it into the library default.
     SOURCE_MUTATION = "source_mutation"
+    #: A per-source ADD failure (``SourceAddError``) — NotebookLM rejected this
+    #: specific source input (invalid/inaccessible/paywalled/empty/unparseable
+    #: URL). Distinct from the generic :attr:`LIBRARY` catch-all so adapters
+    #: project it as a 4xx input error and, in a batch add, ISOLATE it as a
+    #: per-item error instead of aborting the whole batch. ``_source/add.py``
+    #: re-raises every infra signal (auth/rate-limit/server/network) UNWRAPPED,
+    #: so a ``SourceAddError`` is guaranteed to be a per-item input failure.
+    SOURCE_ADD = "source_add"
     #: A library error that fits none of the above (catch-all under
     #: ``NotebookLMError``).
     LIBRARY = "library"
@@ -142,6 +152,12 @@ CATEGORY_HINTS: dict[ErrorCategory, str | None] = {
     ErrorCategory.RPC: None,
     ErrorCategory.SOURCE_MUTATION: (
         "Resolve the source reference (it was missing, ambiguous, or needs confirmation)."
+    ),
+    ErrorCategory.SOURCE_ADD: (
+        "NotebookLM could not add this source (invalid/inaccessible URL, paywalled, empty, "
+        "or unparseable); fix the input and retry — a failed source stub may have been "
+        "created, so list the notebook's sources filtered to the error/failed status to "
+        "find and remove it."
     ),
     ErrorCategory.LIBRARY: None,
     ErrorCategory.UNEXPECTED: None,
@@ -284,6 +300,16 @@ def _category_for(exc: BaseException) -> ErrorCategory:
     # --- Remaining RPC failures (decoding, unknown-method, client 4xx, ...) ---
     if isinstance(exc, RPCError):
         return ErrorCategory.RPC
+
+    # --- Per-source ADD failure (SourceAddError). ----------------------------
+    # A SourceError -> NotebookLMError (NOT an RPCError), so it reaches here only
+    # after every RPC/infra branch missed. ``_source/add.py`` re-raises the infra
+    # signals (auth/rate-limit/server/network) UNWRAPPED and wraps ONLY a residual
+    # per-URL RPCError as SourceAddError, so this is guaranteed a per-item input
+    # failure — hence a NON-fatal category that isolates in a batch add. Must
+    # precede the LIBRARY catch-all to keep its distinct 4xx category.
+    if isinstance(exc, SourceAddError):
+        return ErrorCategory.SOURCE_ADD
 
     # --- CLI-input source-mutation error (carries its own .code taxonomy). ----
     # A direct NotebookLMError subclass, so it must precede the LIBRARY

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -156,7 +156,7 @@ CATEGORY_HINTS: dict[ErrorCategory, str | None] = {
     ErrorCategory.SOURCE_ADD: (
         "NotebookLM could not add this source (invalid/inaccessible URL, paywalled, empty, "
         "or unparseable); fix the input and retry — a failed source stub may have been "
-        "created, so list the notebook's sources filtered to the error/failed status to "
+        "created, so list the notebook's sources filtered to the error status to "
         "find and remove it."
     ),
     ErrorCategory.LIBRARY: None,
@@ -221,7 +221,7 @@ def is_retriable(category: ErrorCategory) -> bool:
     return category in _RETRIABLE_CATEGORIES
 
 
-def _normalized_rpc_code(exc: ClientError) -> int | None:
+def _normalized_rpc_code(exc: RPCError) -> int | None:
     """Return ``exc.rpc_code`` normalized to an ``int``, or ``None`` if absent/non-numeric.
 
     ``rpc_code`` is typed ``str | int | None``; a string ``"5"`` must compare
@@ -235,6 +235,22 @@ def _normalized_rpc_code(exc: ClientError) -> int | None:
         return int(code)
     except (TypeError, ValueError):
         return None
+
+
+#: rpc_codes that mean a *transient / server-side* failure (not specific to the one
+#: input): HTTP 5xx, plus the gRPC-status infra codes (4 DEADLINE_EXCEEDED, 8
+#: RESOURCE_EXHAUSTED, 13 INTERNAL, 14 UNAVAILABLE). Used to keep a SourceAddError
+#: whose bare-RPCError cause carries one of these FATAL in a batch add — the per-source
+#: rejection codes (e.g. 3 INVALID_ARGUMENT / 9 FAILED_PRECONDITION) fall through to
+#: the non-fatal SOURCE_ADD instead.
+_TRANSIENT_GRPC_CODES = frozenset({4, 8, 13, 14})
+
+
+def _is_transient_rpc_code(code: int | None) -> bool:
+    """Whether ``code`` denotes a transient/server-side failure worth a retry."""
+    if code is None:
+        return False
+    return 500 <= code < 600 or code in _TRANSIENT_GRPC_CODES
 
 
 def _category_for(exc: BaseException) -> ErrorCategory:
@@ -303,12 +319,19 @@ def _category_for(exc: BaseException) -> ErrorCategory:
 
     # --- Per-source ADD failure (SourceAddError). ----------------------------
     # A SourceError -> NotebookLMError (NOT an RPCError), so it reaches here only
-    # after every RPC/infra branch missed. ``_source/add.py`` re-raises the infra
-    # signals (auth/rate-limit/server/network) UNWRAPPED and wraps ONLY a residual
-    # per-URL RPCError as SourceAddError, so this is guaranteed a per-item input
-    # failure — hence a NON-fatal category that isolates in a batch add. Must
-    # precede the LIBRARY catch-all to keep its distinct 4xx category.
+    # after every RPC/infra branch missed. ``_source/add.py`` re-raises the TYPED
+    # infra signals (auth/rate-limit/server/network) UNWRAPPED and wraps only a
+    # residual RPCError as SourceAddError — usually a genuine per-source rejection
+    # (bad URL, FAILED_PRECONDITION, …), which isolates as the NON-fatal SOURCE_ADD.
+    # BUT a transient/server failure can still reach the wrap as a *bare* RPCError
+    # (the null-result-with-status path in ``rpc/decoder.py`` raises RPCError with an
+    # infra ``rpc_code`` rather than a typed ServerError). Keep those FATAL so a batch
+    # add aborts for retry/backoff instead of masking a rate-limit/5xx as a per-item
+    # error. Must precede the LIBRARY catch-all to keep its distinct 4xx category.
     if isinstance(exc, SourceAddError):
+        cause = getattr(exc, "cause", None)
+        if isinstance(cause, RPCError) and _is_transient_rpc_code(_normalized_rpc_code(cause)):
+            return ErrorCategory.SERVER
         return ErrorCategory.SOURCE_ADD
 
     # --- CLI-input source-mutation error (carries its own .code taxonomy). ----

--- a/src/notebooklm/mcp/_errors.py
+++ b/src/notebooklm/mcp/_errors.py
@@ -73,6 +73,7 @@ _CATEGORY_CODES: dict[ErrorCategory, str] = {
     ErrorCategory.SERVER: "SERVER",
     ErrorCategory.RPC: "RPC",
     ErrorCategory.SOURCE_MUTATION: "SOURCE_MUTATION",
+    ErrorCategory.SOURCE_ADD: "SOURCE_ADD",
     ErrorCategory.LIBRARY: "ERROR",
     ErrorCategory.UNEXPECTED: "UNEXPECTED",
 }

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -149,6 +149,7 @@ _FILE_ROUTE_STATUS: dict[ErrorCategory, int] = {
     ErrorCategory.SERVER: 502,
     ErrorCategory.RPC: 502,
     ErrorCategory.SOURCE_MUTATION: 422,
+    ErrorCategory.SOURCE_ADD: 422,
     ErrorCategory.LIBRARY: 502,
     ErrorCategory.UNEXPECTED: 500,
 }

--- a/src/notebooklm/server/_errors.py
+++ b/src/notebooklm/server/_errors.py
@@ -112,6 +112,7 @@ CATEGORY_STATUS: dict[ErrorCategory, int] = {
     ErrorCategory.SERVER: 502,
     ErrorCategory.RPC: 502,
     ErrorCategory.SOURCE_MUTATION: 422,
+    ErrorCategory.SOURCE_ADD: 422,
     ErrorCategory.LIBRARY: 500,
     ErrorCategory.UNEXPECTED: 500,
 }

--- a/tests/_guardrails/test_classify_error_handler_consistency.py
+++ b/tests/_guardrails/test_classify_error_handler_consistency.py
@@ -45,6 +45,7 @@ _CATEGORY_TO_CLI_CODE: dict[ErrorCategory, str] = {
     ErrorCategory.SERVER: "NOTEBOOKLM_ERROR",
     ErrorCategory.RPC: "NOTEBOOKLM_ERROR",
     ErrorCategory.SOURCE_MUTATION: "NOTEBOOKLM_ERROR",
+    ErrorCategory.SOURCE_ADD: "NOTEBOOKLM_ERROR",
     ErrorCategory.LIBRARY: "NOTEBOOKLM_ERROR",
     ErrorCategory.UNEXPECTED: "UNEXPECTED_ERROR",
 }
@@ -66,6 +67,7 @@ _EXEMPLARS: list[tuple[ErrorCategory, BaseException]] = [
     (ErrorCategory.SERVER, exc.ServerError("upstream 503")),
     (ErrorCategory.RPC, exc.RPCError("decode failed", method_id="abc123")),
     (ErrorCategory.SOURCE_MUTATION, SourceMutationError("ambiguous", "AMBIGUOUS_ID")),
+    (ErrorCategory.SOURCE_ADD, exc.SourceAddError("http://bad.example")),
     (ErrorCategory.LIBRARY, exc.NotebookLMError("some library error")),
     (ErrorCategory.UNEXPECTED, RuntimeError("boom")),
 ]

--- a/tests/_guardrails/test_mcp_classify_consistency.py
+++ b/tests/_guardrails/test_mcp_classify_consistency.py
@@ -58,6 +58,7 @@ _CATEGORY_TO_MCP_CODE: dict[ErrorCategory, str] = {
     ErrorCategory.SERVER: "SERVER",
     ErrorCategory.RPC: "RPC",
     ErrorCategory.SOURCE_MUTATION: "SOURCE_MUTATION",
+    ErrorCategory.SOURCE_ADD: "SOURCE_ADD",
     ErrorCategory.LIBRARY: "ERROR",
     ErrorCategory.UNEXPECTED: "UNEXPECTED",
 }
@@ -76,6 +77,7 @@ _EXEMPLARS: list[tuple[ErrorCategory, BaseException]] = [
     (ErrorCategory.SERVER, exc.ServerError("upstream 503")),
     (ErrorCategory.RPC, exc.RPCError("decode failed", method_id="abc123")),
     (ErrorCategory.SOURCE_MUTATION, SourceMutationError("ambiguous", "AMBIGUOUS_ID")),
+    (ErrorCategory.SOURCE_ADD, exc.SourceAddError("http://bad.example")),
     (ErrorCategory.LIBRARY, exc.NotebookLMError("some library error")),
     (ErrorCategory.UNEXPECTED, RuntimeError("boom")),
 ]

--- a/tests/_guardrails/test_server_classify_consistency.py
+++ b/tests/_guardrails/test_server_classify_consistency.py
@@ -47,6 +47,7 @@ _CATEGORY_TO_STATUS: dict[ErrorCategory, int] = {
     ErrorCategory.SERVER: 502,
     ErrorCategory.RPC: 502,
     ErrorCategory.SOURCE_MUTATION: 422,
+    ErrorCategory.SOURCE_ADD: 422,
     ErrorCategory.LIBRARY: 500,
     ErrorCategory.UNEXPECTED: 500,
 }
@@ -65,6 +66,7 @@ _EXEMPLARS: list[tuple[ErrorCategory, BaseException]] = [
     (ErrorCategory.SERVER, exc.ServerError("upstream 503")),
     (ErrorCategory.RPC, exc.RPCError("decode failed", method_id="abc123")),
     (ErrorCategory.SOURCE_MUTATION, SourceMutationError("ambiguous", "AMBIGUOUS_ID")),
+    (ErrorCategory.SOURCE_ADD, exc.SourceAddError("http://bad.example")),
     (ErrorCategory.LIBRARY, exc.NotebookLMError("some library error")),
     (ErrorCategory.UNEXPECTED, RuntimeError("boom")),
 ]

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -619,6 +619,50 @@ def test_add_batch_mid_item_rate_limit_is_top_level_429(
     assert "results" not in resp.json()
 
 
+def test_add_batch_mid_item_source_add_error_isolates_not_aborts(
+    authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
+) -> None:
+    # A per-URL SourceAddError (bad domain) is a 4xx INPUT failure specific to the
+    # one URL — it must isolate as a per-item source_add error (422 partition) while
+    # the rest of the batch proceeds, NOT abort with a misleading top-level 5xx
+    # (regression for #1905; the same shared classifier the MCP tool uses).
+    import pytest
+
+    from notebooklm.exceptions import SourceAddError
+
+    assert isinstance(monkeypatch, pytest.MonkeyPatch)
+    _seed_notebook(fake_client)
+
+    real_add_url = fake_client.sources.add_url
+
+    async def _maybe_bad(notebook_id: str, url: str) -> object:
+        if "bad-domain" in url:
+            raise SourceAddError(url)
+        return await real_add_url(notebook_id, url)
+
+    monkeypatch.setattr(fake_client.sources, "add_url", _maybe_bad)
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/sources/batch",
+        json={
+            "urls": [
+                "https://good-a.example.com",
+                "https://bad-domain.example.com",
+                "https://good-b.example.com",
+            ]
+        },
+    )
+    # Isolated, not aborted: a 201 batch envelope with per-item results.
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "added"
+    assert body["added"] == 2
+    assert body["failed"] == 1
+    assert [item["status"] for item in body["results"]] == ["added", "error", "added"]
+    err = body["results"][1]["error"]
+    assert err["category"] == "source_add"
+    assert err["retriable"] is False
+
+
 def test_add_batch_per_item_error_is_redacted(
     authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
 ) -> None:

--- a/tests/unit/app/test_app_errors.py
+++ b/tests/unit/app/test_app_errors.py
@@ -224,13 +224,35 @@ def test_source_add_error_is_its_own_non_library_category() -> None:
 
     This is what keeps a bad-URL item non-fatal in a batch add: ``LIBRARY`` is a
     fatal category (aborts the batch), whereas ``SOURCE_ADD`` isolates per item.
-    ``_source/add.py`` re-raises every infra signal unwrapped, so a
-    ``SourceAddError`` is guaranteed a per-item input failure — safe to isolate.
+    A bare rejection (no cause) and a per-source rejection code both isolate.
     """
-    result = classify(exc.SourceAddError("http://bad.example"))
-    assert result.category is ErrorCategory.SOURCE_ADD
-    assert result.category is not ErrorCategory.LIBRARY
-    assert result.retriable is False
+    for e in (
+        exc.SourceAddError("http://bad.example"),
+        exc.SourceAddError("http://bad.example", cause=exc.RPCError("boom", rpc_code=9)),
+    ):
+        result = classify(e)
+        assert result.category is ErrorCategory.SOURCE_ADD
+        assert result.category is not ErrorCategory.LIBRARY
+        assert result.retriable is False
+
+
+def test_source_add_error_with_transient_cause_stays_fatal() -> None:
+    """A ``SourceAddError`` wrapping a *transient/server* bare-RPCError cause stays FATAL.
+
+    ``rpc/decoder.py`` can raise a bare ``RPCError`` with an infra ``rpc_code`` (e.g. a
+    null-result-with-status INTERNAL 13, or an HTTP 5xx) that ``_source/add.py`` wraps as
+    ``SourceAddError``. Isolating that as a per-item error would mask a rate-limit/5xx and
+    let a batch add report partial success instead of aborting for retry/backoff (#1905
+    review). So it must NOT be SOURCE_ADD.
+    """
+    for code in (13, 14, 8, 4, 503):
+        e = exc.SourceAddError("http://x", cause=exc.RPCError("transient", rpc_code=code))
+        result = classify(e)
+        assert result.category is not ErrorCategory.SOURCE_ADD, f"code {code} should stay fatal"
+        assert result.category is ErrorCategory.SERVER
+        from notebooklm._app.source_batch import batch_item_is_fatal
+
+        assert batch_item_is_fatal(e) is True, f"code {code} must abort the batch"
 
 
 def test_source_mutation_error_keeps_cli_attributes() -> None:

--- a/tests/unit/app/test_app_errors.py
+++ b/tests/unit/app/test_app_errors.py
@@ -103,6 +103,14 @@ def test_every_library_exception_classifies_as_a_library_category(cls: type) -> 
             ErrorCategory.SOURCE_MUTATION,
             False,
         ),
+        # A per-URL ADD failure classifies as its own non-fatal category (#1905)
+        # so a bad URL isolates in a batch add instead of aborting it. Not
+        # retriable — the same input will not succeed unchanged.
+        (
+            exc.SourceAddError("http://bad.example"),
+            ErrorCategory.SOURCE_ADD,
+            False,
+        ),
         (ValueError("not ours"), ErrorCategory.UNEXPECTED, False),
         (RuntimeError("not ours"), ErrorCategory.UNEXPECTED, False),
     ],
@@ -209,6 +217,20 @@ def test_app_raised_errors_are_in_public_hierarchy_and_classify(
     result = classify(app_error)
     assert result.category is expected_category
     assert result.category is not ErrorCategory.UNEXPECTED
+
+
+def test_source_add_error_is_its_own_non_library_category() -> None:
+    """``SourceAddError`` classifies as ``SOURCE_ADD``, not the LIBRARY catch-all (#1905).
+
+    This is what keeps a bad-URL item non-fatal in a batch add: ``LIBRARY`` is a
+    fatal category (aborts the batch), whereas ``SOURCE_ADD`` isolates per item.
+    ``_source/add.py`` re-raises every infra signal unwrapped, so a
+    ``SourceAddError`` is guaranteed a per-item input failure — safe to isolate.
+    """
+    result = classify(exc.SourceAddError("http://bad.example"))
+    assert result.category is ErrorCategory.SOURCE_ADD
+    assert result.category is not ErrorCategory.LIBRARY
+    assert result.retriable is False
 
 
 def test_source_mutation_error_keeps_cli_attributes() -> None:

--- a/tests/unit/app/test_app_source_batch.py
+++ b/tests/unit/app/test_app_source_batch.py
@@ -30,6 +30,7 @@ _EXEMPLARS: list[tuple[ErrorCategory, BaseException]] = [
     (ErrorCategory.SERVER, exc.ServerError("upstream 503")),
     (ErrorCategory.RPC, exc.RPCError("decode failed", method_id="abc123")),
     (ErrorCategory.SOURCE_MUTATION, SourceMutationError("ambiguous", "AMBIGUOUS_ID")),
+    (ErrorCategory.SOURCE_ADD, exc.SourceAddError("http://bad.example")),
     (ErrorCategory.LIBRARY, exc.NotebookLMError("some library error")),
     (ErrorCategory.UNEXPECTED, RuntimeError("boom")),
 ]
@@ -50,6 +51,7 @@ _EXPECTED_FATAL: dict[ErrorCategory, bool] = {
     ErrorCategory.SERVER: True,  # 502
     ErrorCategory.RPC: True,  # 502
     ErrorCategory.SOURCE_MUTATION: False,  # 422
+    ErrorCategory.SOURCE_ADD: False,  # 422 — per-URL input failure isolates (#1905)
     ErrorCategory.LIBRARY: True,  # 500
     ErrorCategory.UNEXPECTED: True,  # 500
 }

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -51,6 +51,7 @@ _EXEMPLARS: list[tuple[ErrorCategory, BaseException]] = [
     (ErrorCategory.SERVER, exc.ServerError("upstream 503")),
     (ErrorCategory.RPC, exc.RPCError("decode failed", method_id="abc123")),
     (ErrorCategory.SOURCE_MUTATION, SourceMutationError("ambiguous", "AMBIGUOUS_ID")),
+    (ErrorCategory.SOURCE_ADD, exc.SourceAddError("http://bad.example")),
     (ErrorCategory.LIBRARY, exc.NotebookLMError("some library error")),
     (ErrorCategory.UNEXPECTED, RuntimeError("boom")),
 ]
@@ -76,6 +77,7 @@ _CATEGORY_TO_MCP_CODE: dict[ErrorCategory, str] = {
     ErrorCategory.SERVER: "SERVER",
     ErrorCategory.RPC: "RPC",
     ErrorCategory.SOURCE_MUTATION: "SOURCE_MUTATION",
+    ErrorCategory.SOURCE_ADD: "SOURCE_ADD",
     ErrorCategory.LIBRARY: "ERROR",
     ErrorCategory.UNEXPECTED: "UNEXPECTED",
 }

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -24,6 +24,7 @@ from notebooklm._types.sources import SourceType  # noqa: E402 - after importors
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     NetworkError,
     RPCError,
+    SourceAddError,
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
@@ -1710,6 +1711,64 @@ async def test_source_add_batch_isolates_non_fatal_input_error(mcp_call, mock_cl
     assert sc["results"][1]["source_id"] == SRC2_ID
     # Non-fatal → the batch continued and attempted the second URL.
     assert mock_client.sources.add_url.await_count == 2
+
+
+async def test_source_add_batch_isolates_source_add_error(mcp_call, mock_client) -> None:
+    """A per-URL ``SourceAddError`` (bad domain) isolates as a SOURCE_ADD error and
+    later URLs still process — regression for #1905.
+
+    Before the fix, ``SourceAddError`` classified as the fatal ``LIBRARY`` category,
+    so a single bad-domain URL aborted the whole batch (the 3rd + 4th entries were
+    never attempted). Now it is the non-fatal ``SOURCE_ADD`` category, so the batch
+    isolates it per item. ``[valid, bad-domain, valid, non-http]`` must yield 4 result
+    entries: 2 ``added``, 1 ``SOURCE_ADD`` error (the bad domain, wrapped by
+    ``_source/add.py`` from a residual ADD RPCError), 1 ``VALIDATION`` error (the
+    non-http entry, rejected by ``validate_url`` before any client call) — with no
+    abort.
+    """
+    mock_client.sources.add_url = AsyncMock(
+        side_effect=[
+            FakeSource(id=SRC_ID, title="A"),
+            SourceAddError("https://bad-domain.example.com"),
+            FakeSource(id=SRC2_ID, title="B"),
+        ]
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content="x" * 500, char_count=500)
+    )
+    result = await mcp_call(
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "urls": [
+                "https://valid-a.example.com",
+                "https://bad-domain.example.com",
+                "https://valid-b.example.com",
+                "ftp://not-http.example.com",
+            ],
+        },
+    )
+    sc = result.structured_content
+    # The whole call did NOT raise (isolated, not aborted).
+    assert sc["status"] == "added"
+    assert sc["added"] == 2
+    assert sc["failed"] == 2
+    assert [item["status"] for item in sc["results"]] == ["added", "error", "added", "error"]
+
+    assert sc["results"][0]["source_id"] == SRC_ID
+    # The bad domain is isolated as a per-item SOURCE_ADD error (non-fatal).
+    bad = sc["results"][1]
+    assert bad["input"] == "https://bad-domain.example.com"
+    assert bad["error"]["code"] == "SOURCE_ADD"
+    assert bad["error"]["retriable"] is False
+    # The URL AFTER the bad domain was still processed (not dropped by an abort).
+    assert sc["results"][2]["source_id"] == SRC2_ID
+    # The non-http entry is a VALIDATION error (rejected before any client call).
+    non_http = sc["results"][3]
+    assert non_http["input"] == "ftp://not-http.example.com"
+    assert non_http["error"]["code"] == "VALIDATION"
+    # add_url was attempted for the 3 http(s) entries; the non-http one never reached it.
+    assert mock_client.sources.add_url.await_count == 3
 
 
 async def test_source_add_batch_over_cap_rejected_before_any_add(mcp_call, mock_client) -> None:


### PR DESCRIPTION
## Problem

A batch `source_add` (MCP tool, and the REST `POST .../sources/batch` route) aborted the whole call when one URL failed with a bad domain, instead of isolating that URL as a per-item error and continuing.

Root cause: a per-URL add failure surfaces as `SourceAddError` (`_source/add.py` re-raises every infra signal — auth / rate-limit / server / network — **unwrapped**, and wraps *only* a residual per-URL `ADD_SOURCE` `RPCError` as `SourceAddError`, so a `SourceAddError` is **guaranteed** to be a per-item input failure). But `SourceAddError` is a `SourceError → NotebookLMError` (not an `RPCError`), so `_app.errors.classify` fell through to the `LIBRARY` catch-all. `LIBRARY ∈ _FATAL_CATEGORIES`, so `batch_item_is_fatal` returned `True` and the batch aborted.

## Fix

Add a new non-fatal `ErrorCategory.SOURCE_ADD`:

- `classify(SourceAddError)` now returns `SOURCE_ADD` (branch added before the `LIBRARY` catch-all).
- It is **not** in `_FATAL_CATEGORIES`, so a bad-URL item now **isolates** as a per-item error and later URLs still process — no abort.
- Adapters project it: MCP code `SOURCE_ADD`, REST HTTP **422**. This also corrects the REST batch behavior and fixes the previously misleading 5xx-style abort into a clean 422 per-item input error.

The ghost row (Google may create an errored source stub for a rejected URL) is surfaced via the per-item error hint (`source_list(status='error')` to find it). Fully auto-deleting the stub is out of scope — follow-up.

## Tests

- New MCP regression test: `[valid, bad-domain, valid, non-http]` → 4 result entries (2 `added`, 1 `SOURCE_ADD` error, 1 `VALIDATION` error), call does not raise, the URL after the bad domain is still processed.
- New REST regression test: mid-item `SourceAddError` isolates as a per-item `source_add` (422 partition) error while the rest of the batch proceeds.
- All classify-consistency guardrails (CLI / MCP / REST), the parity gate, the fatal-set gate, and the classify-exemplar coverage extended to the new category.

Fixes #1905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source-add failures are now isolated per URL in batch requests, without aborting the entire batch.
  * Failed source additions report a non-retriable `SOURCE_ADD` error and use HTTP status **422**.
  * Batch items keep correct retry/fatal behavior, including when the underlying cause is transient.

* **Documentation**
  * Updated structured MCP error documentation to include `SOURCE_ADD`.

* **Tests**
  * Added end-to-end and consistency test coverage for the new `SOURCE_ADD` category across server and MCP error projections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->