### PR TITLE
feat(mcp): return report/data-table body inline on remote studio_download

### DIFF
--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -410,7 +410,11 @@ async def _do_read_inline_artifact_text(
 ) -> _InlineText | None:
     """Spool + read one inline artifact (the body of :func:`_read_inline_artifact_text`,
     split out so the concurrency-counter increment/decrement wraps it cleanly)."""
-    temp_dir = await asyncio.to_thread(tempfile.mkdtemp, prefix="nblm-mcp-inline-")
+    # mkdtemp runs synchronously (it is a quick syscall, and this is how _fileroutes
+    # spools) so the dir handle is bound to ``temp_dir`` in the SAME step it is created:
+    # an ``await asyncio.to_thread(mkdtemp)`` could be cancelled after the dir exists but
+    # before the result is assigned, orphaning it past the ``finally`` cleanup.
+    temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-inline-")
     try:
         temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
         args: dict[str, Any] = {
@@ -440,7 +444,14 @@ async def _do_read_inline_artifact_text(
             # broker still hands out the link (which will surface the same state).
             return None
         served = result.output_path or temp_path
-        content, char_count, truncated = await asyncio.to_thread(_read_bounded_text, served)
+        try:
+            content, char_count, truncated = await asyncio.to_thread(_read_bounded_text, served)
+        except (OSError, ValueError):
+            # Best-effort: a local read/decode failure (I/O error, or a malformed file
+            # that isn't valid UTF-8 → UnicodeError ⊂ ValueError) degrades to link-only,
+            # same as the soft download failures above — it must NOT sink the whole
+            # studio_download call and its guaranteed resource_link.
+            return None
     finally:
         await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
 

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -21,7 +21,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools.tool import ToolResult
@@ -69,6 +69,58 @@ INLINE_TEXT_MAX_CHARS = 10_000
 #: Appended to the inline TEXT block (not the structured ``content`` prefix) when the
 #: body was truncated, pointing the reader at the link for the complete file.
 _INLINE_TRUNCATION_MARKER = "\n\n[… truncated — open the download link above for the full file …]"
+
+#: Chunk size (chars) for streaming past the inline prefix to count the remaining
+#: length without materializing the whole file in memory.
+_INLINE_READ_CHUNK = 65536
+
+#: Cap concurrent inline reads. Each spools an artifact to a private temp dir and
+#: fetches it from Google before reading it back, so many parallel report/data-table
+#: ``studio_download`` calls could otherwise drive unbounded temp disk + upstream
+#: fetch fan-out (mirrors ``_fileroutes._MAX_CONCURRENT_DOWNLOADS``). Because inline
+#: text is best-effort, exceeding the cap simply SKIPS the inline body (the tool still
+#: returns the link) rather than erroring. A plain counter (mutated only between
+#: ``await`` points in this single-process async server) suffices — no lock, and no
+#: asyncio primitive that would bind to one event loop.
+_MAX_CONCURRENT_INLINE_READS = 4
+_inflight_inline_reads = 0
+
+
+class _InlineText(NamedTuple):
+    """The bounded inline body of a text artifact plus the artifact it came from.
+
+    ``artifact_id`` / ``title`` are the CONCRETE artifact ``execute_download`` selected
+    (even on the "latest" path where the caller passed no id), so the broker can PIN the
+    signed link to the exact artifact whose body was inlined — otherwise a "latest" link
+    could resolve to a newer artifact than the inline text if one completes in between.
+    """
+
+    content: str
+    char_count: int
+    truncated: bool
+    artifact_id: str | None
+    title: str | None
+
+
+def _read_bounded_text(path: str) -> tuple[str, int, bool]:
+    """Read the first :data:`INLINE_TEXT_MAX_CHARS` chars of ``path`` as the inline
+    ``content`` and stream the rest only to COUNT it — returning
+    ``(content, char_count, truncated)`` without ever holding more than the prefix plus
+    one chunk in memory (so a large data-table/report can't OOM the tool call).
+
+    ``char_count`` is the FULL post-decode length (mirroring ``source_read``); read with
+    ``utf-8-sig`` so a data-table CSV's BOM is stripped (a report is plain ``utf-8``).
+    """
+    with open(path, encoding="utf-8-sig") as fh:
+        content = fh.read(INLINE_TEXT_MAX_CHARS)
+        remainder = 0
+        while True:
+            chunk = fh.read(_INLINE_READ_CHUNK)
+            if not chunk:
+                break
+            remainder += len(chunk)
+    return content, len(content) + remainder, remainder > 0
+
 
 #: The downloadable artifact-type keys (the ``artifact_type`` param's enum).
 DownloadType = Literal[
@@ -306,9 +358,9 @@ async def _read_inline_artifact_text(
     spec: download_core.DownloadTypeSpec,
     output_format: str | None,
     artifact_id: str | None,
-) -> tuple[str, int, bool] | None:
-    """Download a TEXT artifact server-side and return ``(content, char_count,
-    truncated)`` bounded to :data:`INLINE_TEXT_MAX_CHARS`, or ``None`` when no
+) -> _InlineText | None:
+    """Download a TEXT artifact server-side and return its bounded inline body plus the
+    concrete artifact it was read from (:class:`_InlineText`), or ``None`` when no
     completed artifact of the type is available.
 
     Used by :func:`_broker_download` to inline a report / data-table body so a
@@ -316,6 +368,13 @@ async def _read_inline_artifact_text(
     :func:`~notebooklm._app.download.execute_download` path the ``/files/dl`` route
     serves — spooling to a private temp file and reading it back — so the inline
     text is byte-identical to the file the signed link hands out.
+
+    On the "latest" path (``artifact_id is None``) ``execute_download`` still selects a
+    CONCRETE artifact; its id + title ride back in the result so the broker can pin the
+    signed link to the same artifact (see :class:`_InlineText`). The body is read with a
+    bounded/streaming reader (:func:`_read_bounded_text`) so a large export can't OOM the
+    call — only the ``INLINE_TEXT_MAX_CHARS`` prefix is held; the tail is counted, not
+    materialized.
 
     Inline text is strictly **best-effort**: a missing/incomplete artifact, a soft
     download error, OR an upstream list/RPC failure all yield ``None`` so the broker
@@ -325,10 +384,32 @@ async def _read_inline_artifact_text(
     refs are already validated before this runs, so a swallowed error here can only be
     an infra/transient failure, never a bad-id miss.
 
-    ``content`` is the clean first-``INLINE_TEXT_MAX_CHARS``-chars prefix; ``char_count``
-    is the FULL length; ``truncated`` says whether the prefix omits any tail. Read with
-    ``utf-8-sig`` so a data-table CSV's BOM is stripped (a report is plain ``utf-8``).
+    Bounded by :data:`_MAX_CONCURRENT_INLINE_READS`: when too many inline reads are
+    already in flight this returns ``None`` (link-only) WITHOUT spooling — so a burst of
+    concurrent report/data-table downloads can't exhaust temp disk / upstream fetch
+    fan-out (the best-effort contract makes skipping safe).
     """
+    global _inflight_inline_reads
+    if _inflight_inline_reads >= _MAX_CONCURRENT_INLINE_READS:
+        return None
+    _inflight_inline_reads += 1
+    try:
+        return await _do_read_inline_artifact_text(
+            client, notebook_id, spec, output_format, artifact_id
+        )
+    finally:
+        _inflight_inline_reads -= 1
+
+
+async def _do_read_inline_artifact_text(
+    client: NotebookLMClient,
+    notebook_id: str,
+    spec: download_core.DownloadTypeSpec,
+    output_format: str | None,
+    artifact_id: str | None,
+) -> _InlineText | None:
+    """Spool + read one inline artifact (the body of :func:`_read_inline_artifact_text`,
+    split out so the concurrency-counter increment/decrement wraps it cleanly)."""
     temp_dir = await asyncio.to_thread(tempfile.mkdtemp, prefix="nblm-mcp-inline-")
     try:
         temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
@@ -359,13 +440,14 @@ async def _read_inline_artifact_text(
             # broker still hands out the link (which will surface the same state).
             return None
         served = result.output_path or temp_path
-        text = await asyncio.to_thread(Path(served).read_text, encoding="utf-8-sig")
+        content, char_count, truncated = await asyncio.to_thread(_read_bounded_text, served)
     finally:
         await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
 
-    char_count = len(text)
-    truncated = char_count > INLINE_TEXT_MAX_CHARS
-    return text[:INLINE_TEXT_MAX_CHARS], char_count, truncated
+    # The concrete artifact execute_download selected — id + title — so the broker can
+    # PIN the link to it (the "latest" path passed no id but resolved one here).
+    selected = result.artifact or {}
+    return _InlineText(content, char_count, truncated, selected.get("id"), selected.get("title"))
 
 
 def _broker_download(

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -15,12 +15,17 @@ from ``cli/_download_specs.py``.
 
 from __future__ import annotations
 
+import asyncio
+import os
+import shutil
+import tempfile
 import time
-from typing import Any, Literal, cast
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.tools.tool import ToolResult
-from mcp.types import ResourceLink
+from mcp.types import ResourceLink, TextContent
 from pydantic import AnyUrl
 
 from ..._app import download as download_core
@@ -29,18 +34,41 @@ from ...exceptions import ValidationError
 from ...types import ArtifactType
 from .._filelink import DOWNLOAD_TTL, FileTransferConfig
 
+if TYPE_CHECKING:
+    from ...client import NotebookLMClient
+
 __all__ = [
+    "INLINE_TEXT_MAX_CHARS",
     "DownloadType",
     "_DOWNLOAD_SPECS",
+    "_INLINE_TEXT_TYPES",
     "_KIND_TO_DOWNLOAD_KEY",
     "_broker_download",
     "_is_http_transport",
     "_passthrough_download_notebook",
+    "_read_inline_artifact_text",
     "_resolve_artifact_id",
     "download_extension",
     "download_filename",
     "download_mime_type",
 ]
+
+#: Download-type keys whose file is UTF-8 text safe to ALSO return inline in the
+#: ``studio_download`` tool result (alongside the ``resource_link``), so a host that
+#: cannot open a ``resource_link`` — e.g. the claude.ai remote connector — can still
+#: read the body. Every other kind is binary (audio/video/pdf/png) or structured
+#: JSON best consumed as a file. #1907.
+_INLINE_TEXT_TYPES: frozenset[str] = frozenset({"report", "data-table"})
+
+#: Max chars of inline artifact text returned alongside the download link, mirroring
+#: ``source_read``'s 10k content cap (ADR-0025). A longer body is truncated (the tool
+#: marks ``truncated`` and appends a marker to the inline block); the full file stays
+#: reachable via the ``resource_link`` / signed URL.
+INLINE_TEXT_MAX_CHARS = 10_000
+
+#: Appended to the inline TEXT block (not the structured ``content`` prefix) when the
+#: body was truncated, pointing the reader at the link for the complete file.
+_INLINE_TRUNCATION_MARKER = "\n\n[… truncated — open the download link above for the full file …]"
 
 #: The downloadable artifact-type keys (the ``artifact_type`` param's enum).
 DownloadType = Literal[
@@ -272,6 +300,62 @@ def _is_http_transport() -> bool:
     return True
 
 
+async def _read_inline_artifact_text(
+    client: NotebookLMClient,
+    notebook_id: str,
+    spec: download_core.DownloadTypeSpec,
+    output_format: str | None,
+    artifact_id: str | None,
+) -> tuple[str, int, bool] | None:
+    """Download a TEXT artifact server-side and return ``(content, char_count,
+    truncated)`` bounded to :data:`INLINE_TEXT_MAX_CHARS`, or ``None`` when no
+    completed artifact of the type is available.
+
+    Used by :func:`_broker_download` to inline a report / data-table body so a
+    resource-link-incapable host can read it (#1907). Reuses the SAME
+    :func:`~notebooklm._app.download.execute_download` path the ``/files/dl`` route
+    serves — spooling to a private temp file and reading it back — so the inline
+    text is byte-identical to the file the signed link hands out. A missing artifact
+    or a soft download error yields ``None`` (the link still stands); an upstream RPC
+    failure propagates (the link would fail identically).
+
+    ``content`` is the clean first-``INLINE_TEXT_MAX_CHARS``-chars prefix; ``char_count``
+    is the FULL length; ``truncated`` says whether the prefix omits any tail. Read with
+    ``utf-8-sig`` so a data-table CSV's BOM is stripped (a report is plain ``utf-8``).
+    """
+    temp_dir = await asyncio.to_thread(tempfile.mkdtemp, prefix="nblm-mcp-inline-")
+    try:
+        temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+        args: dict[str, Any] = {
+            "notebook_id": notebook_id,
+            "output_path": temp_path,
+            "latest": artifact_id is None,
+        }
+        if artifact_id is not None:
+            args["artifact_id"] = artifact_id
+        if output_format is not None:
+            args[spec.format_param_name] = output_format
+        plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
+        result = await download_core.execute_download(
+            plan,
+            client,
+            notebook_resolver=_passthrough_download_notebook,
+            artifact_resolver=_resolve_artifact_id,
+        )
+        if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
+            # No completed artifact / soft download error — return nothing so the
+            # broker still hands out the link (which will surface the same state).
+            return None
+        served = result.output_path or temp_path
+        text = await asyncio.to_thread(Path(served).read_text, encoding="utf-8-sig")
+    finally:
+        await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
+
+    char_count = len(text)
+    truncated = char_count > INLINE_TEXT_MAX_CHARS
+    return text[:INLINE_TEXT_MAX_CHARS], char_count, truncated
+
+
 def _broker_download(
     cfg: FileTransferConfig,
     notebook_id: str,
@@ -280,6 +364,7 @@ def _broker_download(
     artifact_id: str | None = None,
     *,
     title: str | None = None,
+    inline: tuple[str, int, bool] | None = None,
 ) -> ToolResult:
     """Mint a signed download URL + a clickable ``resource_link`` for a remote
     ``studio_download``.
@@ -295,6 +380,13 @@ def _broker_download(
     helpers the ``/files/dl`` route serves with, so the advertised metadata and the
     streamed bytes can't drift. ``size_bytes`` is ``None``: it can't be known
     without eagerly fetching the artifact, which this must not do.
+
+    ``inline`` (``(content, char_count, truncated)``, from
+    :func:`_read_inline_artifact_text` for text kinds — report / data-table) adds the
+    bounded body to the payload AND as a ``TextContent`` block, so a host that cannot
+    open the ``resource_link`` can still read it (#1907). ``content`` is the bounded
+    prefix, ``char_count`` the full length, ``truncated`` whether the prefix omits a
+    tail; the inline block appends a truncation marker when truncated.
     """
     spec = _DOWNLOAD_SPECS[artifact_type]
     payload: dict[str, Any] = {
@@ -335,4 +427,12 @@ def _broker_download(
         uri=AnyUrl(url),
         description=desc,
     )
-    return ToolResult(content=[link], structured_content=structured)
+    content: list[Any] = [link]
+    if inline is not None:
+        inline_content, char_count, truncated = inline
+        structured["content"] = inline_content
+        structured["char_count"] = char_count
+        structured["truncated"] = truncated
+        block = inline_content + _INLINE_TRUNCATION_MARKER if truncated else inline_content
+        content.append(TextContent(type="text", text=block))
+    return ToolResult(content=content, structured_content=structured)

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -30,7 +30,7 @@ from pydantic import AnyUrl
 
 from ..._app import download as download_core
 from ..._app.resolve import resolve_ref
-from ...exceptions import ValidationError
+from ...exceptions import NotebookLMError, ValidationError
 from ...types import ArtifactType
 from .._filelink import DOWNLOAD_TTL, FileTransferConfig
 
@@ -315,9 +315,15 @@ async def _read_inline_artifact_text(
     resource-link-incapable host can read it (#1907). Reuses the SAME
     :func:`~notebooklm._app.download.execute_download` path the ``/files/dl`` route
     serves — spooling to a private temp file and reading it back — so the inline
-    text is byte-identical to the file the signed link hands out. A missing artifact
-    or a soft download error yields ``None`` (the link still stands); an upstream RPC
-    failure propagates (the link would fail identically).
+    text is byte-identical to the file the signed link hands out.
+
+    Inline text is strictly **best-effort**: a missing/incomplete artifact, a soft
+    download error, OR an upstream list/RPC failure all yield ``None`` so the broker
+    still hands out the ``resource_link`` (the guaranteed deliverable — the link needs
+    no RPC to mint on the "latest" path, and opening it later re-runs this fetch, so a
+    transient hiccup must not fail the whole ``studio_download`` call). Explicit-id
+    refs are already validated before this runs, so a swallowed error here can only be
+    an infra/transient failure, never a bad-id miss.
 
     ``content`` is the clean first-``INLINE_TEXT_MAX_CHARS``-chars prefix; ``char_count``
     is the FULL length; ``truncated`` says whether the prefix omits any tail. Read with
@@ -336,12 +342,18 @@ async def _read_inline_artifact_text(
         if output_format is not None:
             args[spec.format_param_name] = output_format
         plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
-        result = await download_core.execute_download(
-            plan,
-            client,
-            notebook_resolver=_passthrough_download_notebook,
-            artifact_resolver=_resolve_artifact_id,
-        )
+        try:
+            result = await download_core.execute_download(
+                plan,
+                client,
+                notebook_resolver=_passthrough_download_notebook,
+                artifact_resolver=_resolve_artifact_id,
+            )
+        except NotebookLMError:
+            # Upstream list/RPC failure (execute_download does not wrap its own list
+            # call). Inline text is best-effort, so degrade to link-only rather than
+            # failing the whole download.
+            return None
         if result.outcome != download_core.DownloadOutcome.SINGLE_DOWNLOADED:
             # No completed artifact / soft download error — return nothing so the
             # broker still hands out the link (which will surface the same state).

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -50,11 +50,13 @@ from .._resolve import (
 from ._passthrough import passthrough_child_id, passthrough_notebook_id
 from ._studio_download import (
     _DOWNLOAD_SPECS,
+    _INLINE_TEXT_TYPES,
     _KIND_TO_DOWNLOAD_KEY,
     DownloadType,
     _broker_download,
     _is_http_transport,
     _passthrough_download_notebook,
+    _read_inline_artifact_text,
     _resolve_artifact_id,
 )
 from ._studio_items import (
@@ -221,11 +223,11 @@ def register(mcp: Any) -> None:
         also carry ``status_label`` / ``url``. Bounded page of ``limit`` (default 50)
         from ``offset``, with ``total`` / ``offset`` / ``has_more``.
 
-        * ``detail`` ladder: ``summary`` (default) gives each note a bounded
-          ``content_preview`` + ``char_count`` (artifacts unaffected); ``full`` returns
-          the whole ``content``; ``compact`` collapses every item to ``id`` / ``title``
-          / ``type`` / ``status_label`` / ``created_at`` (no body/``url``) — a low-token
-          roster.
+        * ``detail`` ladder (NOTE bodies only; read a report/data-table body via
+          ``studio_download``): ``summary`` (default) gives each note a bounded
+          ``content_preview`` + ``char_count``; ``full`` returns the whole ``content``;
+          ``compact`` collapses every item to ``id`` / ``title`` / ``type`` /
+          ``status_label`` / ``created_at`` (no body/``url``) — a low-token roster.
         * ``kind`` filters to one ``type``.
         * ``item`` (name or id) fetches just that item as a 1-element list with the
           note's FULL ``content``; no match is NOT_FOUND. ``limit`` / ``offset`` /
@@ -526,9 +528,8 @@ def register(mcp: Any) -> None:
         """Download a generated artifact. Accepts a notebook name or ID.
 
         Target the artifact in ONE of two ways (exactly one):
-        * ``artifact`` — a name-or-id ref (title / id / unique-id-prefix), the same
-          form the other ``artifact_*`` tools take. The tool resolves it to the
-          artifact's type + id for you.
+        * ``artifact`` — a name-or-id ref (title / id / unique-id-prefix), the form the
+          other ``artifact_*`` tools take; resolves to its type + id.
         * ``artifact_type`` — one of audio|video|slide-deck|infographic|report|
           mind-map|data-table|quiz|flashcards, optionally with ``artifact_id``
           (full or unique-prefix) for a specific one; omit ``artifact_id`` to get
@@ -537,14 +538,14 @@ def register(mcp: Any) -> None:
         ``output_format`` overrides the default file format where supported:
         slide-deck → pdf|pptx; quiz/flashcards → json|markdown|html.
 
-        Over **stdio** the artifact is written to ``path`` (the output file on the
-        server host; required). Over the **remote (http) connector** the server's
-        filesystem is unreachable, so the tool instead returns a clickable
-        ``resource_link`` plus ``{"status": "download_ready", "url": …}`` — a
-        short-lived signed URL; ``path`` is ignored. On the remote connector an
-        explicit ``artifact_id`` (and ``output_format``) is validated up front at the
-        tool call — an unknown/ambiguous id fails immediately, not as a browser-side
-        400 when the link is opened.
+        Over **stdio** the artifact is written to ``path`` (required). Over the
+        **remote (http) connector** the server filesystem is unreachable, so the tool
+        returns a clickable ``resource_link`` plus ``{"status": "download_ready", "url":
+        …}`` — a short-lived signed URL; ``path`` is ignored. A text kind
+        (report/data-table) also returns the body inline (bounded ``content`` +
+        ``char_count`` + ``truncated``) for link-incapable hosts. On the remote
+        connector an explicit ``artifact_id`` (and ``output_format``) is validated up
+        front — an unknown/ambiguous id fails immediately, not as a 400 when opened.
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -674,8 +675,25 @@ def register(mcp: Any) -> None:
                                 f"(status: {incomplete.status_str}); wait for it to complete."
                             ) from None
                         raise
+                # For text kinds (report / data-table) also fetch the body and return
+                # it INLINE alongside the link, so a host that can't open a
+                # resource_link still gets the content (#1907). Bounded to
+                # INLINE_TEXT_MAX_CHARS; the link remains the full file.
+                inline = (
+                    await _read_inline_artifact_text(
+                        client, nb_id, spec, output_format, artifact_id
+                    )
+                    if artifact_type in _INLINE_TEXT_TYPES
+                    else None
+                )
                 return _broker_download(
-                    cfg, nb_id, artifact_type, output_format, artifact_id, title=resolved_title
+                    cfg,
+                    nb_id,
+                    artifact_type,
+                    output_format,
+                    artifact_id,
+                    title=resolved_title,
+                    inline=inline,
                 )
             # No file-transfer config. On the remote (http) connector the server
             # filesystem is unreachable REGARDLESS of `path`, so fail clearly here —

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -679,13 +679,21 @@ def register(mcp: Any) -> None:
                 # it INLINE alongside the link, so a host that can't open a
                 # resource_link still gets the content (#1907). Bounded to
                 # INLINE_TEXT_MAX_CHARS; the link remains the full file.
-                inline = (
-                    await _read_inline_artifact_text(
+                inline: tuple[str, int, bool] | None = None
+                if artifact_type in _INLINE_TEXT_TYPES:
+                    read = await _read_inline_artifact_text(
                         client, nb_id, spec, output_format, artifact_id
                     )
-                    if artifact_type in _INLINE_TEXT_TYPES
-                    else None
-                )
+                    if read is not None:
+                        inline = (read.content, read.char_count, read.truncated)
+                        # Pin the signed link to the SAME artifact whose body we inlined
+                        # — on the "latest" path (artifact_id was None) this stops the
+                        # link from drifting to a newer artifact if one completes before
+                        # the link is opened. Also adopt its title for the filename.
+                        if read.artifact_id is not None:
+                            artifact_id = read.artifact_id
+                        if resolved_title is None:
+                            resolved_title = read.title
                 return _broker_download(
                     cfg,
                     nb_id,

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -913,3 +913,144 @@ async def test_artifact_download_remote_ref_path_not_double_validated(mock_clien
     assert result.structured_content["artifact_id"] == _AID_A
     # No list call carried the pre-validation's distinctive type-scoped positional.
     assert all(len(call.args) < 2 for call in mock_client.artifacts.list.await_args_list)
+
+
+async def test_artifact_download_remote_audio_has_no_inline_content(mock_client, config) -> None:
+    # A binary/non-text kind (audio) must NOT gain the inline body fields — the link
+    # remains the only affordance, and no extra download RPC is issued for it (#1907).
+    mock_client.artifacts.list = AsyncMock(return_value=[_audio_artifact(_AID_A)])
+    mock_client.artifacts.download_audio = AsyncMock()
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "audio", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert "content" not in sc and "char_count" not in sc and "truncated" not in sc
+    assert not any(getattr(block, "type", None) == "text" for block in result.content)
+    mock_client.artifacts.download_audio.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# studio_download — inline text for report / data-table (#1907)
+# --------------------------------------------------------------------------- #
+def _report_artifact(art_id: str, title: str = "Q3 Report", *, completed: bool = True) -> Artifact:
+    return Artifact(
+        id=art_id,
+        title=title,
+        _artifact_type=ArtifactTypeCode.REPORT.value,
+        status=int(ArtifactStatus.COMPLETED if completed else ArtifactStatus.PROCESSING),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _data_table_artifact(art_id: str, title: str = "Table") -> Artifact:
+    return Artifact(
+        id=art_id,
+        title=title,
+        _artifact_type=ArtifactTypeCode.DATA_TABLE.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _writing_download(body: str, *, encoding: str = "utf-8") -> AsyncMock:
+    """An ``AsyncMock`` for a ``download_<x>`` that writes ``body`` to the given path
+    (mirroring the real download methods) so ``execute_download`` yields a real file
+    for the inline reader to read back."""
+
+    async def _dl(notebook_id: str, output_path: str, artifact_id: str | None = None, **_: Any):
+        with open(output_path, "w", encoding=encoding) as fh:
+            fh.write(body)
+        return output_path
+
+    return AsyncMock(side_effect=_dl)
+
+
+async def test_artifact_download_remote_report_returns_inline_text(mock_client, config) -> None:
+    # The reporter's exact failure (#1907): a completed report over the remote connector
+    # must return the body INLINE alongside the resource_link, so a link-incapable host
+    # can still read it.
+    body = "# Q3 Report\n\nThe numbers are up."
+    mock_client.artifacts.list = AsyncMock(return_value=[_report_artifact(_AID_A)])
+    mock_client.artifacts.download_report = _writing_download(body)
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    # The link is still present (full file for link-capable hosts)...
+    assert any(getattr(b, "type", None) == "resource_link" for b in result.content)
+    # ...and the body rides inline, bounded, with the full char_count + truncated flag.
+    assert sc["content"] == body
+    assert sc["char_count"] == len(body)
+    assert sc["truncated"] is False
+    # A TextContent block carries the body for a host that renders content, not links.
+    text_blocks = [b for b in result.content if getattr(b, "type", None) == "text"]
+    assert len(text_blocks) == 1
+    assert text_blocks[0].text == body
+
+
+async def test_artifact_download_remote_report_truncates_long_body(mock_client, config) -> None:
+    # A body over the cap is truncated: content is the bounded prefix, char_count stays
+    # the FULL length, truncated is True, and the inline block ends with a marker that
+    # points at the link for the full file.
+    body = "x" * (art_mod.INLINE_TEXT_MAX_CHARS + 500)
+    mock_client.artifacts.list = AsyncMock(return_value=[_report_artifact(_AID_A)])
+    mock_client.artifacts.download_report = _writing_download(body)
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert sc["content"] == body[: art_mod.INLINE_TEXT_MAX_CHARS]
+    assert len(sc["content"]) == art_mod.INLINE_TEXT_MAX_CHARS
+    assert sc["char_count"] == len(body)
+    assert sc["truncated"] is True
+    block = next(b for b in result.content if getattr(b, "type", None) == "text")
+    assert block.text.startswith(body[: art_mod.INLINE_TEXT_MAX_CHARS])
+    assert "truncated" in block.text.lower()
+
+
+async def test_artifact_download_remote_report_no_artifact_is_link_only(
+    mock_client, config
+) -> None:
+    # The latest path with no completed report: the inline read yields nothing (the
+    # execute_download returns NO_ARTIFACTS), so the result is link-only — no inline
+    # fields — and the link still stands (opening it surfaces the same state).
+    mock_client.artifacts.list = AsyncMock(return_value=[])
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report"},
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    assert "content" not in sc
+    assert not any(getattr(b, "type", None) == "text" for b in result.content)
+
+
+async def test_artifact_download_remote_data_table_inline_strips_bom(mock_client, config) -> None:
+    # A data-table is inlined too; the real writer uses utf-8-sig (BOM), so the inline
+    # reader must strip the BOM — the returned content is clean CSV without a leading
+    # BOM (newlines are normalized to \n on read; the link keeps the file's CRLF).
+    csv_body = "col_a,col_b\r\n1,2\r\n"
+    mock_client.artifacts.list = AsyncMock(return_value=[_data_table_artifact(_AID_A)])
+    mock_client.artifacts.download_data_table = _writing_download(csv_body, encoding="utf-8-sig")
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "data-table", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert sc["content"] == "col_a,col_b\n1,2\n"
+    assert not sc["content"].startswith("﻿")  # BOM stripped by utf-8-sig read
+    assert sc["truncated"] is False

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -1021,6 +1021,32 @@ async def test_artifact_download_remote_report_truncates_long_body(mock_client, 
     assert "truncated" in block.text.lower()
 
 
+async def test_artifact_download_remote_report_latest_pins_link_to_selected_id(
+    mock_client, config
+) -> None:
+    # The "latest" path (no artifact_id) inlines the concrete latest report AND pins the
+    # signed link to that same artifact's id — so the inline body and the file the link
+    # serves can't drift to different artifacts if a newer one completes in between.
+    body = "# Latest\n\nbody"
+    mock_client.artifacts.list = AsyncMock(return_value=[_report_artifact(_AID_A, "Latest")])
+    mock_client.artifacts.download_report = _writing_download(body)
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report"},  # no artifact_id → latest
+    )
+    sc = result.structured_content
+    assert sc["content"] == body
+    # The link is pinned: structured payload echoes the resolved id and the token
+    # carries it as `aid` (not a moving latest link).
+    assert sc["artifact_id"] == _AID_A
+    token = sc["url"].rsplit("/", 1)[1]
+    assert config.signer.verify(token, op="dl")["aid"] == _AID_A
+    # Filename adopts the resolved artifact's title.
+    assert sc["filename"] == "Latest.md"
+
+
 async def test_artifact_download_remote_report_no_artifact_is_link_only(
     mock_client, config
 ) -> None:
@@ -1060,6 +1086,27 @@ async def test_artifact_download_remote_report_inline_failure_is_link_only(
     assert "content" not in sc
     assert any(getattr(b, "type", None) == "resource_link" for b in result.content)
     assert not any(getattr(b, "type", None) == "text" for b in result.content)
+
+
+async def test_artifact_download_remote_inline_skipped_when_cap_exceeded(
+    mock_client, config, monkeypatch
+) -> None:
+    # When too many inline reads are already in flight, the (best-effort) inline body is
+    # skipped WITHOUT spooling — the tool still returns the link, and no download RPC is
+    # issued for the body. Simulated by setting the cap to 0.
+    monkeypatch.setattr(art_mod, "_MAX_CONCURRENT_INLINE_READS", 0)
+    mock_client.artifacts.list = AsyncMock(return_value=[_report_artifact(_AID_A)])
+    mock_client.artifacts.download_report = _writing_download("# Body")
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    assert "content" not in sc
+    mock_client.artifacts.download_report.assert_not_called()
 
 
 async def test_artifact_download_remote_data_table_inline_strips_bom(mock_client, config) -> None:

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -1109,6 +1109,31 @@ async def test_artifact_download_remote_inline_skipped_when_cap_exceeded(
     mock_client.artifacts.download_report.assert_not_called()
 
 
+async def test_artifact_download_remote_report_read_error_is_link_only(
+    mock_client, config, monkeypatch
+) -> None:
+    # A local read/decode failure of the spooled file must stay within the best-effort
+    # contract: degrade to link-only rather than failing the whole download (the
+    # guaranteed resource_link is still returned).
+    mock_client.artifacts.list = AsyncMock(return_value=[_report_artifact(_AID_A)])
+    mock_client.artifacts.download_report = _writing_download("# Body")
+
+    def _boom(_path: str):
+        raise UnicodeDecodeError("utf-8", b"", 0, 1, "bad byte")
+
+    monkeypatch.setattr(art_mod, "_read_bounded_text", _boom)
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report", "artifact_id": _AID_A},
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    assert "content" not in sc
+    assert any(getattr(b, "type", None) == "resource_link" for b in result.content)
+
+
 async def test_artifact_download_remote_data_table_inline_strips_bom(mock_client, config) -> None:
     # A data-table is inlined too; the real writer uses utf-8-sig (BOM), so the inline
     # reader must strip the BOM — the returned content is clean CSV without a leading

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -961,7 +961,10 @@ def _writing_download(body: str, *, encoding: str = "utf-8") -> AsyncMock:
     for the inline reader to read back."""
 
     async def _dl(notebook_id: str, output_path: str, artifact_id: str | None = None, **_: Any):
-        with open(output_path, "w", encoding=encoding) as fh:
+        # newline="" disables platform newline translation so the on-disk bytes are
+        # identical on POSIX and Windows (a text-mode write would turn "\r\n" into
+        # "\r\r\n" on Windows and break the reader assertions).
+        with open(output_path, "w", encoding=encoding, newline="") as fh:
             fh.write(body)
         return output_path
 
@@ -1034,6 +1037,28 @@ async def test_artifact_download_remote_report_no_artifact_is_link_only(
     sc = result.structured_content
     assert sc["status"] == "download_ready"
     assert "content" not in sc
+    assert not any(getattr(b, "type", None) == "text" for b in result.content)
+
+
+async def test_artifact_download_remote_report_inline_failure_is_link_only(
+    mock_client, config
+) -> None:
+    # Inline text is best-effort: an upstream listing/RPC failure during the inline read
+    # must NOT fail the whole download — the link (the guaranteed deliverable) is still
+    # returned, just without the inline body.
+    from notebooklm.exceptions import ServerError
+
+    mock_client.artifacts.list = AsyncMock(side_effect=ServerError("upstream 500"))
+    result = await _call(
+        mock_client,
+        config,
+        "studio_download",
+        {"notebook": NB_ID, "artifact_type": "report"},
+    )
+    sc = result.structured_content
+    assert sc["status"] == "download_ready"
+    assert "content" not in sc
+    assert any(getattr(b, "type", None) == "resource_link" for b in result.content)
     assert not any(getattr(b, "type", None) == "text" for b in result.content)
 
 


### PR DESCRIPTION
Fixes #1907.

## Problem
A generated **report** artifact's body was strictly unreachable inline from an MCP host that can't render a `resource_link` (the claude.ai remote connector). Notes round-trip fully; reports didn't:
- `studio_list` never carries artifact content (only notes get a body/preview) — so a report's text isn't there at any `detail`.
- `studio_status` on a completed report has no media URL, so url/metadata come back null.
- On the remote (http) connector, `studio_download` returned only a signed-URL `resource_link` — which a resource-link-incapable host can't open.

Net: on such a host the report body was unreachable through MCP, even though the server has the markdown in hand.

## Decision — approach B (localized), report + data-table
I chose **(B)**: have the remote `studio_download` return the **extracted text inline** (in `structured_content` + a `TextContent` block) **in addition to** the `resource_link`, for the text kinds (`report`, `data-table`). A link-incapable host then gets the body; link-capable hosts keep the link for the full file.

Why not (A) (surface text in `studio_list`): fetching each report's body is a per-artifact download, so doing it for a whole list is expensive. (B) unblocks the reporter's exact failure with **no per-list cost** and is fully localized to the download path.

**Token bound:** the inline body is bounded to **10,000 chars** (`INLINE_TEXT_MAX_CHARS`, mirroring `source_read`'s content cap / ADR-0025). `content` is the clean prefix, `char_count` is the FULL length, `truncated` is a bool, and the inline `TextContent` block appends a clear truncation marker pointing at the link for the full file.

## How it works
The inline text is produced by the **same `execute_download` path** the `/files/dl` route serves — spool to a private temp dir, read back with `utf-8-sig` (strips a data-table CSV BOM; a report reads unchanged), clean up. This guarantees the inline body is **byte-identical** to the file the signed link hands out and adds **zero new client-runtime surface** (no `_artifacts`/downloads-service changes → no api-compat / module-size risk). A missing artifact or soft download error yields `None` → the link still stands.

Binary/JSON kinds (audio/video/slide-deck/infographic/mind-map/quiz/flashcards) are unchanged — link only, no extra download RPC.

## Also
- Fixes the `studio_list` `full`-rung docstring, which promised artifacts' "whole content" it never returns (true for **notes** only) and now points at `studio_download` for a report/data-table body — done regardless of A/B.
- Trimmed both touched docstrings to stay under the ADR-0025 schema-char budget (verified: total 39,4xx ≤ 39,400).

## Tests
Full suite green (11850 passed). New unit tests in `tests/unit/mcp/test_file_tools.py`:
- remote report returns inline `content` + `resource_link` + `char_count` + `truncated`, and a `TextContent` block;
- long body → `content` is the 10k prefix, `char_count` full, `truncated=True`, block ends with the marker (the truncation bound);
- data-table inline strips the CSV BOM;
- no completed artifact → link-only (no inline fields);
- audio (non-text) broker unchanged — no inline fields, no extra download RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote downloads for text-based report and data-table artifacts now include bounded inline text alongside the signed link.
  * Inline content provides total character count plus a truncation indicator/marker when exceeding the maximum length.
  * Inline text decoding applies BOM stripping and normalizes line endings for consistent rendering.

* **Bug Fixes**
  * Binary artifacts (e.g., audio) remain link-only.
  * When no completed artifact is available, or inline retrieval fails (including inline-read cap reached), results correctly fall back to link-only output.

* **Tests**
  * Added unit coverage for inline, truncation, “latest” resolution, BOM/newline handling, and cap/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->