### PR TITLE
fix(mcp): strip leading list marker from suggest prompts; drop redundant research_start ids (#1909)

### DIFF
--- a/src/notebooklm/_row_adapters/notebooks.py
+++ b/src/notebooklm/_row_adapters/notebooks.py
@@ -20,6 +20,7 @@ Position contract (pinned by ``tests/unit/test_notebooks_row_adapter.py``):
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -29,6 +30,30 @@ __all__ = [
     "PromptSuggestionRow",
     "unwrap_prompt_suggestions",
 ]
+
+# A single leading markdown list marker (bullet ``-``/``*``/``+`` or an ordered
+# ``1.`` / ``1)`` counter) plus its trailing space. The backend sometimes
+# formats a suggestion as a markdown list item, so a ``prompt`` / ``title`` leaf
+# can arrive as ``"\n- Ask X"``; an agent piping that straight into ``chat_ask``
+# would send a bullet-dash as the question. We strip one leading marker so both
+# the CLI and the MCP surface get a clean, ready-to-send string.
+_LEADING_LIST_MARKER = re.compile(r"(?:[-*+]|\d+[.)])\s+")
+
+
+def _strip_leading_list_marker(text: str) -> str:
+    """Return ``text`` with surrounding whitespace and one leading list marker removed.
+
+    Tight normalization for suggestion leaves (issue #1909): only leading
+    whitespace + a single leading bullet/counter marker + trailing whitespace
+    are removed. Interior newlines and content are left untouched, so a genuinely
+    multi-line prompt keeps its body — only the list-item framing is stripped.
+    """
+    stripped = text.strip()
+    marker = _LEADING_LIST_MARKER.match(stripped)
+    if marker:
+        stripped = stripped[marker.end() :].strip()
+    return stripped
+
 
 # ``GeneratePromptSuggestions`` (``otmP3b``) method id, threaded into
 # ``safe_index`` / drift diagnostics for the suggestion-list unwrap.
@@ -108,10 +133,19 @@ class PromptSuggestionRow:
 
     @property
     def title(self) -> str:
-        """Suggestion title — empty string when absent / non-string."""
-        return self._str_at(self._TITLE_POS)
+        """Suggestion title — empty string when absent / non-string.
+
+        A leading markdown list marker (e.g. ``"\\n- "``) is stripped so the
+        title is clean ready-to-display text (issue #1909).
+        """
+        return _strip_leading_list_marker(self._str_at(self._TITLE_POS))
 
     @property
     def prompt(self) -> str:
-        """Suggestion prompt — empty string when absent / non-string."""
-        return self._str_at(self._PROMPT_POS)
+        """Suggestion prompt — empty string when absent / non-string.
+
+        A leading markdown list marker (e.g. ``"\\n- "``) is stripped so the
+        prompt is a clean ready-to-send string — an agent can pipe it straight
+        into ``chat_ask`` without leaking a bullet-dash as the question (#1909).
+        """
+        return _strip_leading_list_marker(self._str_at(self._PROMPT_POS))

--- a/src/notebooklm/_row_adapters/notebooks.py
+++ b/src/notebooklm/_row_adapters/notebooks.py
@@ -31,28 +31,35 @@ __all__ = [
     "unwrap_prompt_suggestions",
 ]
 
-# A single leading markdown list marker (bullet ``-``/``*``/``+`` or an ordered
-# ``1.`` / ``1)`` counter) plus its trailing space. The backend sometimes
-# formats a suggestion as a markdown list item, so a ``prompt`` / ``title`` leaf
-# can arrive as ``"\n- Ask X"``; an agent piping that straight into ``chat_ask``
-# would send a bullet-dash as the question. We strip one leading marker so both
-# the CLI and the MCP surface get a clean, ready-to-send string.
-_LEADING_LIST_MARKER = re.compile(r"(?:[-*+]|\d+[.)])\s+")
+# A single leading markdown *bullet* marker (``-``/``*``/``+``) plus its trailing
+# space. The backend sometimes frames a suggestion as a markdown list item, so a
+# ``prompt`` / ``title`` leaf can arrive as ``"\n- Ask X"``; an agent piping that
+# straight into ``chat_ask`` would send a bullet-dash as the question. We strip
+# one leading bullet so both the CLI and the MCP surface get a clean, ready-to-send
+# string. Ordered-list counters (``1.`` / ``2026.``) are deliberately NOT matched:
+# the only observed framing is the bullet, and a numeric prefix is frequently
+# legitimate content (a year, a count) that must be preserved (#1912 review).
+_LEADING_LIST_MARKER = re.compile(r"[-*+]\s+")
 
 
 def _strip_leading_list_marker(text: str) -> str:
-    """Return ``text`` with surrounding whitespace and one leading list marker removed.
+    """Return ``text`` with surrounding whitespace and one leading bullet marker removed.
 
     Tight normalization for suggestion leaves (issue #1909): only leading
-    whitespace + a single leading bullet/counter marker + trailing whitespace
-    are removed. Interior newlines and content are left untouched, so a genuinely
-    multi-line prompt keeps its body — only the list-item framing is stripped.
+    whitespace + a single leading bullet marker + trailing whitespace are removed.
+    Interior newlines and content are left untouched, so a genuinely multi-line
+    prompt keeps its body — only the leading list-item framing is stripped.
+
+    ``lstrip`` runs before the match (not a full ``strip``) so a marker-only leaf
+    like ``"\\n-   "`` collapses cleanly to ``""`` rather than a bare ``"-"``
+    (#1912 review): the leading whitespace is removed first, the whole marker then
+    matches, and the empty remainder is returned.
     """
-    stripped = text.strip()
-    marker = _LEADING_LIST_MARKER.match(stripped)
+    lstripped = text.lstrip()
+    marker = _LEADING_LIST_MARKER.match(lstripped)
     if marker:
-        stripped = stripped[marker.end() :].strip()
-    return stripped
+        return lstripped[marker.end() :].strip()
+    return lstripped.rstrip()
 
 
 # ``GeneratePromptSuggestions`` (``otmP3b``) method id, threaded into

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -150,9 +150,16 @@ def register(mcp: Any) -> None:
                 poll_task_id = result.report_id
             else:
                 poll_task_id = result.task_id
-            # ``poll_task_id`` is placed AFTER the spread so a future
-            # ``ResearchStart`` field can never clobber it.
-            return {"notebook_id": nb_id, **to_jsonable(result), "poll_task_id": poll_task_id}
+            # Surface only ``poll_task_id`` as the id to carry forward (#1909).
+            # The raw ``task_id`` / ``report_id`` are mode-specific internals
+            # (deep's ``report_id`` / fast's ``task_id``) — leaking both plus
+            # ``poll_task_id`` gave three id fields for one concept, so we drop
+            # them from the wire shape. ``poll_task_id`` is placed AFTER the
+            # spread so a future ``ResearchStart`` field can never clobber it.
+            start_fields = to_jsonable(result)
+            start_fields.pop("task_id", None)
+            start_fields.pop("report_id", None)
+            return {"notebook_id": nb_id, **start_fields, "poll_task_id": poll_task_id}
 
     @mcp.tool(annotations=READ_ONLY)
     async def research_status(

--- a/tests/fixtures/rpc_golden/SUGGEST_PROMPTS.json
+++ b/tests/fixtures/rpc_golden/SUGGEST_PROMPTS.json
@@ -54,11 +54,11 @@
   "mapper_expected": [
     {
       "title": "Professional Briefing",
-      "prompt": "\n- Summarize the material for business professionals.\n- Focus on enterprise use cases."
+      "prompt": "Summarize the material for business professionals.\n- Focus on enterprise use cases."
     },
     {
       "title": "Process Timeline",
-      "prompt": "\n- Present the history of the product as a timeline.\n- Highlight major milestones."
+      "prompt": "Present the history of the product as a timeline.\n- Highlight major milestones."
     }
   ]
 }

--- a/tests/integration/mcp_vcr/test_research.py
+++ b/tests/integration/mcp_vcr/test_research.py
@@ -7,7 +7,8 @@ real ``NotebookLMClient`` → VCR-replayed RPC) for the three research tools:
   ``START_FAST_RESEARCH`` ``Ljjv0c`` POST) and ``research_start_deep.yaml``
   (single ``START_DEEP_RESEARCH`` ``QA9ei`` POST). Non-blocking: the tool returns
   the started task, so the assertions pin the ``ResearchStart`` wire shape
-  (``task_id`` / ``report_id`` / ``query`` / ``mode``) — no poll-to-completion.
+  (``poll_task_id`` / ``query`` / ``mode`` — the raw ``task_id`` / ``report_id``
+  are dropped as redundant, issue #1909) — no poll-to-completion.
 * ``research_status`` over ``research_poll.yaml`` (a single in-flight task →
   ``in_progress``) and ``research_poll_empty.yaml`` (no task → ``no_research``).
   ``research_status`` drives ``_app.research.poll_and_classify`` → one
@@ -71,8 +72,9 @@ async def test_mcp_research_start_fast_over_vcr() -> None:
 
     End-to-end: FastMCP ``Client`` → ``research_start`` tool →
     ``client.research.start`` → recorded ``START_FAST_RESEARCH`` (``Ljjv0c``) RPC.
-    Asserts the ``ResearchStart`` wire shape (``{notebook_id, task_id, report_id,
-    query, mode}``); the tool is non-blocking, so it never polls to completion.
+    Asserts the ``ResearchStart`` wire shape (``{notebook_id, poll_task_id,
+    query, mode}`` — raw ``task_id``/``report_id`` dropped, #1909); the tool is
+    non-blocking, so it never polls to completion.
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -88,13 +90,13 @@ async def test_mcp_research_start_fast_over_vcr() -> None:
     structured = result.structured_content
     assert isinstance(structured, dict)
     assert structured["notebook_id"] == RESEARCH_NOTEBOOK_ID
-    assert structured["task_id"], "expected a server-recorded research task id"
+    # Fast runs poll under the server-recorded task id, surfaced as ``poll_task_id``.
+    assert structured["poll_task_id"], "expected a server-recorded poll_task_id"
     assert structured["mode"] == "fast"
-    # ``report_id`` is None for fast research; ``query`` echoes the request.
-    assert structured["report_id"] is None
     assert structured["query"] == "Python programming best practices"
-    # Fast runs poll under ``task_id`` — ``poll_task_id`` mirrors it.
-    assert structured["poll_task_id"] == structured["task_id"]
+    # #1909: the raw internal ids are dropped — ``poll_task_id`` is the only id field.
+    assert "task_id" not in structured
+    assert "report_id" not in structured
 
 
 @pytest.mark.asyncio
@@ -104,7 +106,8 @@ async def test_mcp_research_start_deep_over_vcr() -> None:
 
     End-to-end: FastMCP ``Client`` → ``research_start`` tool →
     ``client.research.start`` → recorded ``START_DEEP_RESEARCH`` (``QA9ei``) RPC.
-    Deep research carries a ``report_id`` alongside the ``task_id``.
+    Deep research polls under its ``report_id`` (an unpollable sessionId
+    ``task_id`` is never surfaced) — ``poll_task_id`` carries that report id.
     """
     async with build_mcp_client() as mcp_client:
         result = await mcp_client.call_tool(
@@ -120,13 +123,12 @@ async def test_mcp_research_start_deep_over_vcr() -> None:
     structured = result.structured_content
     assert isinstance(structured, dict)
     assert structured["notebook_id"] == RESEARCH_NOTEBOOK_ID
-    assert structured["task_id"], "expected a server-recorded research task id"
     assert structured["mode"] == "deep"
-    # Deep runs poll under ``report_id`` — ``poll_task_id`` mirrors it, NOT the
-    # (unpollable sessionId) ``task_id``.
-    assert structured["poll_task_id"] == structured["report_id"]
-    # Deep research records a separate report id.
-    assert structured["report_id"], "expected a deep-research report id"
+    # Deep runs poll under the recorded report id, surfaced as ``poll_task_id``
+    # (the raw report_id/task_id are dropped as redundant, #1909).
+    assert structured["poll_task_id"], "expected a deep-research poll_task_id"
+    assert "task_id" not in structured
+    assert "report_id" not in structured
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_notebooks_suggest_prompts_vcr.py
+++ b/tests/integration/test_notebooks_suggest_prompts_vcr.py
@@ -95,9 +95,11 @@ class TestSuggestPromptsVCR:
         assert len(suggestions) == 3
         assert all(isinstance(s, PromptSuggestion) for s in suggestions)
         assert all(s.title and s.prompt for s in suggestions)
-        # Each prompt is a ready-to-send multi-line instruction (leading newline
-        # + bullet, matching the live wire shape).
-        assert suggestions[0].prompt.startswith("\n- ")
+        # The live wire frames each prompt as a markdown list item ("\n- …");
+        # the row adapter strips that leading marker (#1909) so the decoded prompt
+        # is a clean ready-to-send instruction, not a bullet line.
+        assert not suggestions[0].prompt.startswith(("\n", "- ", "* "))
+        assert suggestions[0].prompt == suggestions[0].prompt.strip()
 
     def test_cassette_carries_expected_wire_shape(self) -> None:
         """The recorded otmP3b body pins the six-slot request shape."""

--- a/tests/unit/mcp/test_research.py
+++ b/tests/unit/mcp/test_research.py
@@ -91,7 +91,7 @@ class FakeNotebook:
 async def test_research_start(mcp_call, mock_client) -> None:
     mock_client.research.start = AsyncMock(return_value=FakeResearchStart(task_id=TASK_ID))
     result = await mcp_call("research_start", {"notebook": NB_ID, "query": "quantum computing"})
-    assert result.structured_content["task_id"] == TASK_ID
+    assert result.structured_content["poll_task_id"] == TASK_ID
     mock_client.research.start.assert_awaited_once_with(NB_ID, "quantum computing", "web", "fast")
 
 
@@ -122,7 +122,7 @@ async def test_research_start_resolves_notebook_by_name(mcp_call, mock_client) -
     )
     mock_client.research.start = AsyncMock(return_value=FakeResearchStart(task_id=TASK_ID))
     result = await mcp_call("research_start", {"notebook": "My Notebook", "query": "q"})
-    assert result.structured_content["task_id"] == TASK_ID
+    assert result.structured_content["poll_task_id"] == TASK_ID
     mock_client.research.start.assert_awaited_once_with(NB_ID, "q", "web", "fast")
 
 
@@ -134,9 +134,9 @@ async def test_research_start_surfaces_poll_task_id_fast(mcp_call, mock_client) 
     result = await mcp_call("research_start", {"notebook": NB_ID, "query": "q"})
     sc = result.structured_content
     assert sc["poll_task_id"] == TASK_ID
-    # The raw start fields are still present (purely additive).
-    assert sc["task_id"] == TASK_ID
-    assert sc["report_id"] is None
+    # #1909: the raw internal ids are dropped — poll_task_id is the only id field.
+    assert "task_id" not in sc
+    assert "report_id" not in sc
 
 
 async def test_research_start_poll_task_id_prefers_report_id_deep(mcp_call, mock_client) -> None:
@@ -543,10 +543,10 @@ async def test_research_cancel_empty_poll_task_id_rejected(mcp_call, mock_client
 
 
 async def test_research_start_then_status_poll_shape(mcp_call, mock_client) -> None:
-    """start→status: start returns a task_id, status polls the notebook."""
+    """start→status: start returns poll_task_id, status polls the notebook."""
     mock_client.research.start = AsyncMock(return_value=FakeResearchStart(task_id=TASK_ID))
     started = await mcp_call("research_start", {"notebook": NB_ID, "query": "q"})
-    assert started.structured_content["task_id"] == TASK_ID
+    assert started.structured_content["poll_task_id"] == TASK_ID
 
     mock_client.research.poll = AsyncMock(
         return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED)

--- a/tests/unit/test_notebooks_row_adapter.py
+++ b/tests/unit/test_notebooks_row_adapter.py
@@ -60,7 +60,9 @@ class TestPromptSuggestionRow:
             PromptSuggestionRow(["t", "2026. Summarize the annual trends"]).prompt
             == "2026. Summarize the annual trends"
         )
-        assert PromptSuggestionRow(["t", "5) reasons to refactor"]).prompt == "5) reasons to refactor"
+        assert (
+            PromptSuggestionRow(["t", "5) reasons to refactor"]).prompt == "5) reasons to refactor"
+        )
 
     def test_clean_leaf_unchanged_apart_from_surrounding_whitespace(self) -> None:
         # A leaf with no leading marker keeps its content; only surrounding

--- a/tests/unit/test_notebooks_row_adapter.py
+++ b/tests/unit/test_notebooks_row_adapter.py
@@ -41,12 +41,26 @@ class TestPromptSuggestionRow:
         assert row.prompt == "Summarize."
 
     def test_leading_list_marker_stripped(self) -> None:
-        # Bullet ("- "/"* "/"+ ") and ordered ("1." / "1)") leading markers, with
-        # any surrounding whitespace, are stripped from both title and prompt.
+        # Bullet ("- "/"* "/"+ ") leading markers, with any surrounding
+        # whitespace, are stripped from both title and prompt.
         assert PromptSuggestionRow(["t", "\n- Ask X"]).prompt == "Ask X"
         assert PromptSuggestionRow(["t", "* Ask X"]).prompt == "Ask X"
-        assert PromptSuggestionRow(["t", "  1. Ask X"]).prompt == "Ask X"
+        assert PromptSuggestionRow(["t", "  + Ask X"]).prompt == "Ask X"
         assert PromptSuggestionRow(["\n- A title", "p"]).title == "A title"
+
+    def test_marker_only_leaf_collapses_to_empty(self) -> None:
+        # A leaf that is only a bullet + whitespace collapses to "" — not a bare
+        # "-" (the lstrip-before-match structure handles this, #1912 review).
+        assert PromptSuggestionRow(["t", "\n-   "]).prompt == ""
+
+    def test_numeric_prefix_preserved(self) -> None:
+        # Ordered-list counters are NOT stripped — a legit numeric prefix (a year,
+        # a count) is meaningful content, not list framing (#1912 review).
+        assert (
+            PromptSuggestionRow(["t", "2026. Summarize the annual trends"]).prompt
+            == "2026. Summarize the annual trends"
+        )
+        assert PromptSuggestionRow(["t", "5) reasons to refactor"]).prompt == "5) reasons to refactor"
 
     def test_clean_leaf_unchanged_apart_from_surrounding_whitespace(self) -> None:
         # A leaf with no leading marker keeps its content; only surrounding

--- a/tests/unit/test_notebooks_row_adapter.py
+++ b/tests/unit/test_notebooks_row_adapter.py
@@ -33,10 +33,26 @@ class TestPromptSuggestionRow:
     """Permissive position reads for one ``SUGGEST_PROMPTS`` suggestion row."""
 
     def test_well_formed_row(self) -> None:
+        # The backend formats the prompt as a markdown list item; the leading
+        # "\n- " marker is stripped so it is a clean ready-to-send string (#1909).
         row = PromptSuggestionRow(["Professional Briefing", "\n- Summarize."])
         assert row.is_well_formed
         assert row.title == "Professional Briefing"
-        assert row.prompt == "\n- Summarize."
+        assert row.prompt == "Summarize."
+
+    def test_leading_list_marker_stripped(self) -> None:
+        # Bullet ("- "/"* "/"+ ") and ordered ("1." / "1)") leading markers, with
+        # any surrounding whitespace, are stripped from both title and prompt.
+        assert PromptSuggestionRow(["t", "\n- Ask X"]).prompt == "Ask X"
+        assert PromptSuggestionRow(["t", "* Ask X"]).prompt == "Ask X"
+        assert PromptSuggestionRow(["t", "  1. Ask X"]).prompt == "Ask X"
+        assert PromptSuggestionRow(["\n- A title", "p"]).title == "A title"
+
+    def test_clean_leaf_unchanged_apart_from_surrounding_whitespace(self) -> None:
+        # A leaf with no leading marker keeps its content; only surrounding
+        # whitespace is trimmed, and interior newlines are preserved.
+        assert PromptSuggestionRow(["t", "Ask X"]).prompt == "Ask X"
+        assert PromptSuggestionRow(["t", "Line one\n- Line two"]).prompt == "Line one\n- Line two"
 
     def test_short_row_degrades_without_raise(self) -> None:
         # Missing the prompt slot (< _MIN_LEN): not well-formed; reads degrade to "".

--- a/tests/unit/test_notebooks_suggest_prompts.py
+++ b/tests/unit/test_notebooks_suggest_prompts.py
@@ -111,13 +111,16 @@ class TestSuggestPrompts:
     ) -> None:
         result = await api.suggest_prompts("nb_xyz", source_ids=["s1"], mode=4)
         assert result == [
+            # The backend frames each prompt as a markdown list item ("\n- …");
+            # the row adapter strips that leading marker (#1909), so the decoded
+            # ``prompt`` is the clean ready-to-send string.
             PromptSuggestion(
                 title="Professional Briefing",
-                prompt="\n- Summarize the material for business professionals.",
+                prompt="Summarize the material for business professionals.",
             ),
             PromptSuggestion(
                 title="Process Timeline",
-                prompt="\n- Present the history of the product as a timeline.",
+                prompt="Present the history of the product as a timeline.",
             ),
         ]
 
@@ -164,7 +167,8 @@ class TestSuggestPrompts:
         """A wrapped single-row envelope (``[[[t, p]]]``) decodes one suggestion."""
         mock_rpc.rpc_call.return_value = [[["Solo", "\n- One prompt."]]]
         result = await api.suggest_prompts("nb_xyz", source_ids=["s1"])
-        assert result == [PromptSuggestion(title="Solo", prompt="\n- One prompt.")]
+        # Leading "\n- " markdown-list marker stripped by the row adapter (#1909).
+        assert result == [PromptSuggestion(title="Solo", prompt="One prompt.")]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("payload", [None, [], [[]], "unexpected", [None]])


### PR DESCRIPTION
Fixes #1909. Two agent-navigability warts from the MCP stress test, both confirmed against the code.

## 1. `suggest_prompts` / `chat_ask(suggest_followups=true)` leaked a literal leading `\n- `
The backend frames each suggestion as a markdown list item, so a `prompt`/`title` leaf arrives as e.g. `"\n- Summarize …"`. An agent piping that straight into `chat_ask` sends a bullet-dash as the question. Fixed at the decode boundary — `PromptSuggestionRow.title`/`prompt` now strip surrounding whitespace + **one** leading bullet/counter marker (`-`/`*`/`+`/`1.`/`1)`), preserving interior newlines and content. Single fix covers CLI + MCP.

The golden/VCR fixtures pin real backend values that literally carry `"\n- "`, so this also confirms the wart is live traffic, not synthetic — those expectations were updated to the clean, ready-to-send form (interior bullets in a genuinely multi-line prompt are left intact; only the leading list-item framing is removed).

## 2. `research_start` returned three id fields for one concept
The response spread the start result (`task_id`, `report_id`) **and** added `poll_task_id`. The raw ids are mode-specific internals — deep's `task_id` is an unpollable sessionId; `report_id`/`task_id` equal `poll_task_id` in every case — so they're redundant/confusing at the tool surface. **Dropped** them; `poll_task_id` is the single id downstream tools (`research_status`/`import`/`cancel`) already accept. The `mcp_vcr` integration tests + wire-shape docstrings were updated to the `poll_task_id`-only shape (the unit test only was insufficient — the integration golden asserted the old shape).

## Verification
- `uv run pytest` — full suite green (12192 passed)
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaned suggestion-row titles and prompts by trimming leading whitespace and removing a leading markdown bullet marker (e.g., `-`/`*`/`+`), while preserving ordered-list numbering.
  * Updated `research_start` to standardize on a single carried-forward `poll_task_id`, omitting internal task/report identifiers from the response.
* **Tests**
  * Updated golden fixtures and integration/unit assertions to match the new prompt decoding and `research_start` response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->