### PR TITLE
fix(mcp): trim studio_generate docstring back under SCHEMA_CHAR_BUDGET (main skew)

### DIFF
--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -373,14 +373,13 @@ def register(mcp: Any) -> None:
           briefing-doc|study-guide|blog-post|custom).
 
         Each per-kind option is valid ONLY for the kind(s) listed above; passing one
-        to a different ``artifact_type`` (e.g. ``orientation`` to ``quiz``) is a
-        validation error rather than a silent no-op. Options default to the standard
-        choice when omitted.
+        to a different ``artifact_type`` is a validation error, not a silent no-op.
+        Options default to the standard choice when omitted.
 
         ``source_ids`` (optional) scopes generation to specific sources; omit it
         to use every source. It accepts a real list, a JSON-array string, or a
-        comma-separated string (the comma form cannot carry a source title that
-        itself contains a comma — use a JSON array or a real list for those).
+        comma-separated string (a source title containing a comma needs the
+        JSON-array or list form).
         ``instructions`` is free-text guidance for kinds that accept it
         (including ``mind-map``). ``language`` (optional) is a language code,
         e.g. ``en``/``ja``/``zh_Hans``.

--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -31,8 +31,13 @@ pytest.importorskip("fastmcp")
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
 SCHEMA_CHAR_BUDGET = (
-    39_400  # total serialized inputSchema + description chars (current 39_384; +16 slack)
+    39_400  # total serialized inputSchema + description chars (current 39_361; +39 slack)
 )
+# Budget skew (#1912 + #1913): #1909's warts trim and #1908's mind-map note each
+# merged individually-green, but were measured against a main WITHOUT the other, so
+# their COMBINED total (39_451) breached this cap. Fixed by trimming redundant prose
+# from studio_generate's docstring (the per-kind validation example and the comma
+# source-title aside) — cap held at 39_400, no behavior change.
 # #1908 documented studio_generate's mind-map exception (mind-map renders
 # synchronously → NO pollable task_id; the rendered map is returned inline under
 # mind_map). Absorbed within the existing budget, partly by trimming the redundant


### PR DESCRIPTION
**Fixes red main** (Test run on 066f74b8 — `test_surface_schema_cost_within_budget` failing on every OS/Python).

## Cause: budget skew
PRs #1912 (#1909 warts) and #1913 (#1908 mind-map) each added MCP tool-schema/docstring chars. Each PR's CI measured the schema-char total against a main that did **not** yet contain the other change (#1912's branch predated #1913's merge), so both merged individually green. Their **combined** total is 39_451, which exceeds the 39_400 `SCHEMA_CHAR_BUDGET` — the ratchet only tripped once both were on main. Not a logic bug.

## Fix
Trim redundant prose from `studio_generate`'s docstring — the per-kind validation example (`e.g. orientation to quiz`) and the verbose comma-source-title aside — bringing the total to **39_361** (+39 slack). Cap held at 39_400 per ADR-0025 (trim, don't raise the budget). No behavior change; params/Literals untouched.

## Verification
- `uv run pytest` — full suite green (11868 passed)
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified accepted `source_ids` input formats, including handling titles that contain commas.
  * Updated schema budget documentation to accurately describe size calculations and available slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->