### PR TITLE
test(mcp): restore schema-char ratchet above the real surface after #1911

### DIFF
--- a/tests/unit/mcp/test_tool_eval.py
+++ b/tests/unit/mcp/test_tool_eval.py
@@ -31,8 +31,15 @@ pytest.importorskip("fastmcp")
 #: to ~36.0k). Move these DOWN as the surface gets leaner; a rise means
 #: description/param bloat that must be justified, not rubber-stamped.
 SCHEMA_CHAR_BUDGET = (
-    39_400  # total serialized inputSchema + description chars (current 39_384; +16 slack)
+    39_480  # total serialized inputSchema + description chars (current 39_451; +29 slack)
 )
+# #1911 grew studio_download's description: on the remote (http) connector a text
+# artifact (report / data-table) now returns its body INLINE (bounded content +
+# char_count + truncated) for link-incapable hosts, since the server filesystem is
+# unreachable there. Justified feature growth (+67 chars over the prior +16 slack) —
+# three tool PRs (#1908/#1911/#1912) merged in quick succession with intermediate CI
+# runs cancelled, so the budget was not bumped in the race. This restores the ratchet
+# just above the real surface.
 # #1908 documented studio_generate's mind-map exception (mind-map renders
 # synchronously → NO pollable task_id; the rendered map is returned inline under
 # mind_map). Absorbed within the existing budget, partly by trimming the redundant


### PR DESCRIPTION
## Summary
`main` is currently **red** on `test_surface_schema_cost_within_budget` (`39451 > 39400`).

Root cause: three tool PRs (#1908/#1911/#1912) merged back-to-back tonight; the intermediate CI `Test` runs were **cancelled** (each superseded by the next push), so no run observed the combined surface, and the final `main` (`066f74b8`) landed **51 chars over budget**. The growth is legitimate — **#1911** added `studio_download`'s inline report/data-table body (bounded `content` + `char_count` + `truncated`) for the remote connector's link-incapable hosts.

Per ADR-0025 ("trim it **or justify raising** the budget"), this bumps the ceiling to `39_480` (current `39_451`, +29 slack) with the justification inline, restoring the ratchet just above the real surface. No source change.

## Test plan
- [x] `uv run pytest tests/unit/mcp/test_tool_eval.py` — green (was red on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the offline tool-schema validation threshold to reflect the current schema size.
  * Revised the related historical notes for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->