### PR TITLE
fix(mcp): warn when the upload widget is enabled but stateless HTTP is disabled (#1915)

### DIFF
--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -111,6 +111,49 @@ def _check_http_auth_required(host: str, token: str | None, oauth: OAuthConfig |
         )
 
 
+#: Values of ``FASTMCP_STATELESS_HTTP`` that FastMCP reads as False. An explicit one of
+#: these (paired with the upload widget) is the footgun this warning guards (#1915).
+_FALSEY_STATELESS_VALUES = frozenset({"false", "0", "no", "off"})
+
+
+def _resolve_stateless_http() -> bool | None:
+    """Resolve the ``stateless_http`` value for the http transport, warning on a footgun.
+
+    * Widget on + ``FASTMCP_STATELESS_HTTP`` unset → return ``True`` (auto-enable stateless,
+      which the MCP-Apps upload widget needs to render) and log it.
+    * Widget on + ``FASTMCP_STATELESS_HTTP`` explicitly **falsey** → warn: the widget cannot
+      render (an MCP-Apps host fetches the ``ui://`` resource without a session id, which a
+      stateful server rejects), then return ``None`` (honor the operator's explicit choice).
+    * Otherwise → return ``None`` (FastMCP reads ``FASTMCP_STATELESS_HTTP`` itself).
+
+    An empty ``FASTMCP_STATELESS_HTTP`` is already stripped to *unset* by ``notebooklm.mcp``
+    at import (#1898), so a present value here is a real, non-empty one.
+    """
+    from ._uploadwidget import _WIDGET_FLAG
+
+    widget_on = os.environ.get(_WIDGET_FLAG) == "1"
+    stateless_env = os.environ.get("FASTMCP_STATELESS_HTTP")
+    log = logging.getLogger(__name__)
+    if stateless_env is None:
+        if widget_on:
+            log.info(
+                "%s=1 → enabling stateless HTTP (required for MCP-Apps widget rendering)",
+                _WIDGET_FLAG,
+            )
+            return True
+        return None
+    if widget_on and stateless_env.strip().lower() in _FALSEY_STATELESS_VALUES:
+        log.warning(
+            "%s=1 but FASTMCP_STATELESS_HTTP=%s — the in-app upload widget CANNOT render: an "
+            "MCP-Apps host fetches the ui:// resource without a chat session id, which a stateful "
+            "server rejects. Unset FASTMCP_STATELESS_HTTP (the widget auto-enables stateless) or "
+            "set it to a true value.",
+            _WIDGET_FLAG,
+            stateless_env,
+        )
+    return None
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="notebooklm-mcp",
@@ -246,19 +289,13 @@ def main(argv: list[str] | None = None) -> None:
         from starlette.middleware import Middleware
 
         from ._host_guard import LoopbackHostGuardMiddleware
-        from ._uploadwidget import _WIDGET_FLAG
 
         # The MCP-App upload widget needs stateless HTTP: an MCP-Apps host (claude.ai) fetches the
         # ui:// widget resource on a connection WITHOUT the chat Mcp-Session-Id, which a stateful
-        # server rejects as "Missing session ID" ("fail to fetch app content"). So enabling the
-        # widget implies stateless unless the operator set FASTMCP_STATELESS_HTTP explicitly.
-        stateless_http: bool | None = None  # None → FastMCP reads FASTMCP_STATELESS_HTTP
-        if "FASTMCP_STATELESS_HTTP" not in os.environ and os.environ.get(_WIDGET_FLAG) == "1":
-            stateless_http = True
-            logging.getLogger(__name__).info(
-                "%s=1 → enabling stateless HTTP (required for MCP-Apps widget rendering)",
-                _WIDGET_FLAG,
-            )
+        # server rejects as "Missing session ID" ("fail to fetch app content"). Enabling the widget
+        # implies stateless unless the operator set FASTMCP_STATELESS_HTTP explicitly — and an
+        # explicit falsey value is warned about (it silently breaks the widget). See #1915.
+        stateless_http = _resolve_stateless_http()  # None → FastMCP reads FASTMCP_STATELESS_HTTP
 
         server.run(
             transport="http",

--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -111,9 +111,10 @@ def _check_http_auth_required(host: str, token: str | None, oauth: OAuthConfig |
         )
 
 
-#: Values of ``FASTMCP_STATELESS_HTTP`` that FastMCP reads as False. An explicit one of
-#: these (paired with the upload widget) is the footgun this warning guards (#1915).
-_FALSEY_STATELESS_VALUES = frozenset({"false", "0", "no", "off"})
+#: Values of ``FASTMCP_STATELESS_HTTP`` that FastMCP (pydantic-settings) reads as False.
+#: An explicit one of these (paired with the upload widget) is the footgun this warning
+#: guards (#1915). Kept in sync with pydantic's bool-false set (case-insensitive).
+_FALSEY_STATELESS_VALUES = frozenset({"0", "false", "f", "no", "n", "off"})
 
 
 def _resolve_stateless_http() -> bool | None:
@@ -131,18 +132,21 @@ def _resolve_stateless_http() -> bool | None:
     """
     from ._uploadwidget import _WIDGET_FLAG
 
-    widget_on = os.environ.get(_WIDGET_FLAG) == "1"
+    if os.environ.get(_WIDGET_FLAG) != "1":
+        return None  # Widget off → nothing to resolve; FastMCP reads the env itself.
+
     stateless_env = os.environ.get("FASTMCP_STATELESS_HTTP")
     log = logging.getLogger(__name__)
     if stateless_env is None:
-        if widget_on:
-            log.info(
-                "%s=1 → enabling stateless HTTP (required for MCP-Apps widget rendering)",
-                _WIDGET_FLAG,
-            )
-            return True
-        return None
-    if widget_on and stateless_env.strip().lower() in _FALSEY_STATELESS_VALUES:
+        log.info(
+            "%s=1 → enabling stateless HTTP (required for MCP-Apps widget rendering)",
+            _WIDGET_FLAG,
+        )
+        return True
+    # No .strip(): pydantic-settings does not strip, so a whitespace-padded value is
+    # rejected at FastMCP import (a loud crash, not a silent non-render) — this warning
+    # targets exactly the values FastMCP reads as False, matching pydantic's set.
+    if stateless_env.lower() in _FALSEY_STATELESS_VALUES:
         log.warning(
             "%s=1 but FASTMCP_STATELESS_HTTP=%s — the in-app upload widget CANNOT render: an "
             "MCP-Apps host fetches the ui:// resource without a chat session id, which a stateful "

--- a/tests/unit/mcp/test_widget_stateless_warn.py
+++ b/tests/unit/mcp/test_widget_stateless_warn.py
@@ -19,7 +19,7 @@ _WIDGET = "NOTEBOOKLM_MCP_UPLOAD_WIDGET"
 _STATELESS = "FASTMCP_STATELESS_HTTP"
 
 
-@pytest.mark.parametrize("falsey", ["false", "False", "0", "no", "off", " OFF "])
+@pytest.mark.parametrize("falsey", ["false", "False", "0", "f", "no", "n", "off", "OFF"])
 def test_widget_with_explicit_falsey_stateless_warns(monkeypatch, caplog, falsey: str) -> None:
     monkeypatch.setenv(_WIDGET, "1")
     monkeypatch.setenv(_STATELESS, falsey)
@@ -35,9 +35,22 @@ def test_widget_with_explicit_falsey_stateless_warns(monkeypatch, caplog, falsey
 def test_widget_with_stateless_unset_auto_enables(monkeypatch, caplog) -> None:
     monkeypatch.setenv(_WIDGET, "1")
     monkeypatch.delenv(_STATELESS, raising=False)
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO, logger="notebooklm.mcp.__main__"):
         result = _resolve_stateless_http()
     assert result is True  # auto-enabled for the widget
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert infos and "stateless" in infos[0].getMessage().lower()
+
+
+def test_widget_with_unparseable_stateless_stays_quiet(monkeypatch, caplog) -> None:
+    # A non-falsey/non-true value is neither auto-enabled nor warned — FastMCP itself
+    # rejects it at import. The helper just falls through to None.
+    monkeypatch.setenv(_WIDGET, "1")
+    monkeypatch.setenv(_STATELESS, "maybe")
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stateless_http()
+    assert result is None
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 

--- a/tests/unit/mcp/test_widget_stateless_warn.py
+++ b/tests/unit/mcp/test_widget_stateless_warn.py
@@ -1,0 +1,59 @@
+"""The upload widget warns (not silently breaks) when stateless HTTP is disabled (#1915).
+
+``FASTMCP_STATELESS_HTTP`` set explicitly falsey while the widget is on suppresses the
+auto-enable, so the widget registers but cannot render. ``_resolve_stateless_http`` must
+warn loudly in that case, auto-enable when the var is unset, and stay quiet otherwise.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from notebooklm.mcp.__main__ import _resolve_stateless_http  # noqa: E402
+
+_WIDGET = "NOTEBOOKLM_MCP_UPLOAD_WIDGET"
+_STATELESS = "FASTMCP_STATELESS_HTTP"
+
+
+@pytest.mark.parametrize("falsey", ["false", "False", "0", "no", "off", " OFF "])
+def test_widget_with_explicit_falsey_stateless_warns(monkeypatch, caplog, falsey: str) -> None:
+    monkeypatch.setenv(_WIDGET, "1")
+    monkeypatch.setenv(_STATELESS, falsey)
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stateless_http()
+    # Honor the operator's explicit choice (do not force-enable) — just warn.
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, f"expected a warning for {_STATELESS}={falsey!r}"
+    assert "cannot render" in warnings[0].getMessage().lower()
+
+
+def test_widget_with_stateless_unset_auto_enables(monkeypatch, caplog) -> None:
+    monkeypatch.setenv(_WIDGET, "1")
+    monkeypatch.delenv(_STATELESS, raising=False)
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stateless_http()
+    assert result is True  # auto-enabled for the widget
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_widget_with_stateless_true_is_quiet(monkeypatch, caplog) -> None:
+    monkeypatch.setenv(_WIDGET, "1")
+    monkeypatch.setenv(_STATELESS, "true")
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stateless_http()
+    assert result is None  # FastMCP reads the (true) value itself
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_no_widget_never_warns(monkeypatch, caplog) -> None:
+    monkeypatch.delenv(_WIDGET, raising=False)
+    monkeypatch.setenv(_STATELESS, "false")
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stateless_http()
+    assert result is None
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]


### PR DESCRIPTION
## Summary
`NOTEBOOKLM_MCP_UPLOAD_WIDGET=1` with an explicit **falsey** `FASTMCP_STATELESS_HTTP` silently produces a **non-rendering** upload widget: the tool/`ui://` resource register, but an MCP-Apps host fetches the `ui://` resource without a chat session id, which a **stateful** server rejects ("fail to fetch app content"). The auto-enable is gated on the var being *absent*, so an explicit `false` suppresses it with no signal.

This extracts the stateless resolution into a testable `_resolve_stateless_http()` that logs a prominent **WARNING** in that case (unset the var to auto-enable stateless, or set it true). No change to the auto-enable gating — the explicit-override escape hatch is intentional.

- `_FALSEY_STATELESS_VALUES` matches pydantic-settings' full bool-false set (`{0,false,f,no,n,off}`, case-insensitive) — verified against pydantic 2.13.4 by both reviewers.
- No `.strip()`: pydantic rejects whitespace-padded bools at import (loud crash, not a silent non-render), so the warning targets exactly the values FastMCP reads as False.

## Test plan
- [x] `uv run pytest tests/unit/mcp/` (916 passed) incl. the new `test_widget_stateless_warn.py`
- [x] ruff + mypy clean; `/polish` (code-simplifier + Claude/Codex review) — 0 critical/important

Fixes #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upload widgets when stateless HTTP is disabled or not configured.
  * Upload widgets now automatically enable stateless HTTP when appropriate.
  * Added clearer warnings when widget rendering is unavailable due to an explicit configuration.

* **Tests**
  * Added coverage for widget and stateless HTTP configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->