### PR TITLE
fix(sources): align notebook_describe source count and dedup enumeration (#1919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP `notebook_describe(include_metadata=true)` no longer reports a source
+  count that disagrees with its own `sources` list.** The exposed
+  `metadata.notebook.sources_count` is now re-projected to the enumerated
+  (id-bearing, deduped) source count instead of the raw unfiltered
+  `GET_NOTEBOOK` row count, which could inflate it (e.g. 168 vs 50) and mislead
+  autonomous agents on quota / completeness. Source enumeration
+  (`source_list` / `metadata.sources`) also dedups duplicate id-bearing rows
+  (research re-imports, ghost/probe echoes), keeping the first occurrence
+  ([#1919](https://github.com/teng-lin/notebooklm-py/issues/1919)).
+
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/src/notebooklm/_source/listing.py
+++ b/src/notebooklm/_source/listing.py
@@ -52,7 +52,24 @@ class SourceLister:
         if sources_list is None:
             return []
 
-        return [source for src in sources_list if (source := self._parse_source(src)) is not None]
+        # Dedup by resolved id, keeping the FIRST occurrence (#1919). The
+        # backend can surface the same id-bearing source in ``nb_info[1]`` more
+        # than once — research imports re-emit a URL, and ghost/probe rows can
+        # echo an existing id — which would otherwise over-count both
+        # ``source_list`` and ``metadata.sources``. A collision is a benign
+        # backend artifact, so it logs at DEBUG rather than WARNING.
+        seen_ids: set[str] = set()
+        sources: builtins.list[Source] = []
+        for src in sources_list:
+            source = self._parse_source(src)
+            if source is None:
+                continue
+            if source.id in seen_ids:
+                logger.debug("SourcesAPI.list: Skipping duplicate source id %s", source.id)
+                continue
+            seen_ids.add(source.id)
+            sources.append(source)
+        return sources
 
     async def get(
         self,

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -121,9 +121,9 @@ def register(mcp: Any) -> None:
                 # mislead an agent on quota / completeness. Scoped to this
                 # projection: the shared ``Notebook.sources_count`` semantics stay
                 # untouched elsewhere (e.g. ``notebook_list`` list rows).
-                notebook_record = metadata_block.get("notebook")
-                if isinstance(notebook_record, dict):
-                    notebook_record["sources_count"] = len(meta_result.metadata.sources)
+                # ``NotebookMetadata.notebook`` is a non-optional ``Notebook``
+                # dataclass, so ``to_jsonable`` always emits it as a dict here.
+                metadata_block["notebook"]["sources_count"] = len(meta_result.metadata.sources)
                 output["metadata"] = metadata_block
                 return output
             result = await core.execute_notebook_describe(

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -111,7 +111,20 @@ def register(mcp: Any) -> None:
                     await asyncio.gather(*tasks, return_exceptions=True)
                     raise
                 output = to_jsonable(result)
-                output["metadata"] = to_jsonable(meta_result.metadata)
+                metadata_block = to_jsonable(meta_result.metadata)
+                # Re-project the exposed ``sources_count`` to the enumerated
+                # (id-bearing, deduped) source count so the metadata block is
+                # internally consistent (#1919). The raw ``Notebook.sources_count``
+                # is an unfiltered ``len(nb_info[1])`` row count that includes
+                # id-less placeholder / ghost rows the ``sources`` list drops, so
+                # the two can disagree wildly (168 vs 50) inside one response and
+                # mislead an agent on quota / completeness. Scoped to this
+                # projection: the shared ``Notebook.sources_count`` semantics stay
+                # untouched elsewhere (e.g. ``notebook_list`` list rows).
+                notebook_record = metadata_block.get("notebook")
+                if isinstance(notebook_record, dict):
+                    notebook_record["sources_count"] = len(meta_result.metadata.sources)
+                output["metadata"] = metadata_block
                 return output
             result = await core.execute_notebook_describe(
                 client, nb_id, resolve_notebook_id=passthrough_notebook_id

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -198,12 +198,14 @@ async def test_notebook_describe_include_metadata_adds_block(mcp_call, mock_clie
     assert content["notebook_id"] == NB_ID
     assert content["description"] == {"summary": "A summary"}
     # ... and the metadata block carries the notebook details + source list.
+    # ``sources_count`` is re-projected to the enumerated length (1), not the
+    # raw ``Notebook.sources_count`` scalar (#1919).
     assert content["metadata"] == {
         "notebook": {
             "id": NB_ID,
             "title": "Research",
             "created_at": None,
-            "sources_count": 0,
+            "sources_count": 1,
             "is_owner": True,
             "modified_at": None,
         },
@@ -211,6 +213,32 @@ async def test_notebook_describe_include_metadata_adds_block(mcp_call, mock_clie
     }
     mock_client.notebooks.get_description.assert_awaited_once_with(NB_ID)
     mock_client.notebooks.get_metadata.assert_awaited_once_with(NB_ID)
+
+
+async def test_notebook_describe_metadata_source_count_matches_enumeration(
+    mcp_call, mock_client
+) -> None:
+    """#1919: the exposed ``metadata.notebook.sources_count`` agrees with the
+    enumerated ``sources`` length, even when the raw ``Notebook.sources_count``
+    scalar is a larger unfiltered row count (id-less placeholder / ghost rows).
+    """
+    mock_client.notebooks.get_description = AsyncMock(
+        return_value=FakeDescription(summary="A summary")
+    )
+    mock_client.notebooks.get_metadata = AsyncMock(
+        return_value=NotebookMetadata(
+            # Raw scalar (168) intentionally disagrees with the filtered list (2).
+            notebook=Notebook(id=NB_ID, title="Research", sources_count=168),
+            sources=[
+                SourceSummary(kind=SourceType.PDF, title="A", url=None),
+                SourceSummary(kind=SourceType.PDF, title="B", url=None),
+            ],
+        )
+    )
+    result = await mcp_call("notebook_describe", {"notebook": NB_ID, "include_metadata": True})
+    metadata = result.structured_content["metadata"]
+    assert metadata["notebook"]["sources_count"] == 2
+    assert metadata["notebook"]["sources_count"] == len(metadata["sources"])
 
 
 async def test_notebook_describe_cancels_sibling_on_error(mcp_call, mock_client) -> None:

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -321,6 +321,38 @@ async def test_malformed_source_id_shape_logs_and_skips(
 
 
 @pytest.mark.asyncio
+async def test_list_dedups_duplicate_ids_keeping_first(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # #1919: research imports (and ghost/probe rows) can leave the same
+    # id-bearing source in ``nb_info[1]`` more than once. The enumeration must
+    # dedup by resolved id, keeping the first occurrence, so ``source_list`` /
+    # ``metadata.sources`` never over-count.
+    lister = SourceLister(
+        RecordingRpc(
+            [
+                [
+                    "Notebook",
+                    [
+                        source_entry("src_dup", title="First"),
+                        source_entry("src_unique", title="Unique"),
+                        source_entry("src_dup", title="Second"),
+                    ],
+                ]
+            ]
+        )
+    )
+    caplog.set_level("DEBUG", logger="notebooklm._sources")
+
+    sources = await lister.list("nb_123")
+
+    assert [source.id for source in sources] == ["src_dup", "src_unique"]
+    # The FIRST occurrence wins (later duplicate dropped).
+    assert sources[0].title == "First"
+    assert "duplicate source id" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_created_at_uses_shared_timestamp_parser() -> None:
     lister = SourceLister(
         RecordingRpc(


### PR DESCRIPTION
Fixes #1919.

## Problem
`notebook_describe(include_metadata=true)` surfaced two materially different source counts **inside one response**: the raw `Notebook.sources_count` (an unfiltered `len(nb_info[1])` row count — 168 in the stress-test report) sat beside a filtered `metadata.sources` list (50). An autonomous agent could not tell how many sources were actually enumerable.

Root cause (per the issue, confirmed against `main`):
- `metadata.notebook.sources_count` came from `_extract_notebook_sources_count` = raw `len(data[1])`. The CLI's `NotebookMetadata.to_dict()` deliberately omits it, but the MCP path serializes via `to_jsonable` dataclass reflection, re-exposing the raw scalar.
- `source_list` / `metadata.sources` enumerate the same `nb_info[1]` but drop id-less rows — and had **no dedup**, so duplicate id-bearing rows (research re-imports, ghost/probe echoes) survived.

## Fix (scoped to count alignment + dedup only)
1. **Align the scalar** — in the MCP `notebook_describe` metadata projection, re-project `notebook.sources_count` to `len(metadata.sources)` so the block is internally consistent. The shared `Notebook.from_api_response` / `_extract_notebook_sources_count` extractor is **untouched** (still used by `notebook_list` list rows, where `data[1]` may be an abbreviated preview array).
2. **Dedup enumeration** — `SourceLister.list` now dedups by resolved id, keeping the first occurrence (collisions logged at DEBUG as a benign backend artifact).

The richer active/processing/failed/placeholder taxonomy is out of scope (capture-gated, tracked in #1925).

## Tests (TDD)
- `test_notebook_describe_metadata_source_count_matches_enumeration` — exposed count equals enumerated `sources` length even when the raw scalar (168) disagrees.
- Updated `test_notebook_describe_include_metadata_adds_block` — pins re-projected count.
- `test_list_dedups_duplicate_ids_keeping_first` — a wire array with a duplicate id-bearing row yields one source (first wins).

## Gate
`mypy` clean · `ruff check` + `ruff format --check` clean (whole tree) · full `pytest` green (12229 passed, 77 skipped, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate notebook sources by `source.id`, keeping the first occurrence.
  * Corrected `notebook_describe(include_metadata=true)` metadata so `sources_count` reflects the returned (deduplicated) sources list.

* **Tests**
  * Added regression coverage for deduplication behavior (including logging) when duplicate source IDs are present.
  * Updated and extended MCP metadata tests to verify `sources_count` always matches `len(sources)`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->