### PR TITLE
fix(mcp): flag bot-challenge / WAF interstitial pages in content-sanity

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1203,7 +1203,7 @@ src/notebooklm/
 │   ├── _paginate.py             # paginate(items, limit) — bounded page + {total, has_more} for the *_list tools (client-side slice; RPCs don't page); DEFAULT_LIMIT=50
 │   └── tools/                   # Per-domain tool modules; each exposes register(mcp) wired by server.register_all
 │       ├── __init__.py          # Tools package marker (no click/rich/cli)
-│       ├── _content_sanity.py   # _annotate_thin_warnings/_thin_content_warning — advisory thin/soft-404 web-page warning over _app.source_content (used by source_wait + source_add batch)
+│       ├── _content_sanity.py   # _annotate_thin_warnings/_thin_content_warning — advisory thin/soft-404/bot-challenge web-page warning over _app.source_content (used by source_wait + source_add batch)
 │       ├── _fileupload.py       # file-transfer slice of the source tools: _broker_upload (signed-URL upload_required) + _decode_upload_b64/_add_bytes (in-channel base64 byte upload for source_add(source_type="file", bytes_base64=…)) + the shared _add_one plan/execute seam (split from sources.py for the ADR-0008 size budget)
 │       ├── _passthrough.py      # Shared pass-through resolvers (passthrough_notebook_id/passthrough_child_id) for the CLI-shaped _app executors
 │       ├── _preview.py          # title_for_id() — shared id→title lookup for the delete tools' needs_confirmation previews

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -345,8 +345,8 @@ not found`, `whoops!`.
 The full bot-challenge phrase set (a Cloudflare "Just a moment…" or Akamai
 "Access Denied" page that serves HTTP 200 and indexes as ready): `just a moment`,
 `enable javascript and cookies`, `checking your browser`, `attention required`,
-`access denied`, `security verification`, `captcha`, `ray id`. The dead-link scan
-takes precedence when a body trips both.
+`access denied`, `security verification`, `captcha`, `cloudflare ray id`. The
+dead-link scan takes precedence when a body trips both.
 
 Each gate measures the source's **indexed text** length (`char_count` from a
 `source_read` with `detail="full"`), not the raw HTTP response — a large HTML

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -328,27 +328,35 @@ rejects**: the source stays READY, `ok` stays `true`, and any fetch failure
 (including a >5s slow `source_read`) degrades to no warning rather than breaking
 the wait.
 
-It fires on a **web-page source only** (`kind == "web_page"`) via two body-only
+It fires on a **web-page source only** (`kind == "web_page"`) via three body-only
 signals — the title is never scanned:
 
 | Signal | Threshold | Warning contains |
 |--------|-----------|------------------|
 | **char-thin** | indexed text shorter than **100 characters** | `"little/no text extracted (N chars) …"` |
-| **dead-link boilerplate** | **indexed text** shorter than **2000 characters** that (casefolded) contains any of the phrases below | `"ingested as ready (N chars) but the body matches a dead-link / error-page pattern …"` |
+| **dead-link boilerplate** | **indexed text** shorter than **2000 characters** that (casefolded) contains any of the dead-link phrases below | `"ingested as ready (N chars) but the body matches a dead-link / error-page pattern …"` |
+| **bot-challenge / WAF interstitial** | **indexed text** shorter than **5000 characters** that (casefolded) contains any of the challenge phrases below | `"ingested as ready (N chars) but the body matches a bot-challenge / WAF interstitial pattern …"` |
 
 The full dead-link phrase set (the complete list, so you can build a fixture that
 trips it): `broken link`, `page not found`, `page isn't available`, `page does
 not exist`, `page no longer available`, `no longer available`, `error 404`, `404
 not found`, `whoops!`.
 
-Both gates measure the source's **indexed text** length (`char_count` from a
+The full bot-challenge phrase set (a Cloudflare "Just a moment…" or Akamai
+"Access Denied" page that serves HTTP 200 and indexes as ready): `just a moment`,
+`enable javascript and cookies`, `checking your browser`, `attention required`,
+`access denied`, `security verification`, `captcha`, `ray id`. The dead-link scan
+takes precedence when a body trips both.
+
+Each gate measures the source's **indexed text** length (`char_count` from a
 `source_read` with `detail="full"`), not the raw HTTP response — a large HTML
-page that indexes to little text is still caught. The 2000-char gate is what
-keeps the weaker phrases safe: a page whose indexed text is 2000 chars or longer
-is never phrase-scanned (so `broken link` in a real article about broken links,
-or a shop's `no longer available`, does not false-positive), and the phrases are
-all multi-word / anchored — no bare `404` or `not found`. Every warning ends with
-`verify with source_read (detail="full").` (trailing period included).
+page that indexes to little text is still caught. The length gate is what keeps
+the phrases safe: a page whose indexed text is at/over its cap (2000 for
+dead-link, 5000 for bot-challenge) is never phrase-scanned (so `broken link` in a
+real article about broken links, or a passing mention of a WAF vendor, does not
+false-positive), and the phrases are all multi-word / anchored — no bare `404` or
+`not found`. Every warning ends with `verify with source_read (detail="full").`
+(trailing period included).
 
 **To exercise the warning branch** (the reason this is documented): note that a
 `text` source — even an empty one — is *never* flagged; only a `web_page` under
@@ -455,7 +463,7 @@ new chat may not render — call it again and it will (a ChatGPT-side quirk, not
 | Domain | Tools |
 |--------|-------|
 | **Notebooks** | `notebook_list(limit?, offset?)` · `notebook_create(title)` · `notebook_describe(notebook, include_metadata?)` (AI description; `include_metadata=true` adds a `metadata` block with notebook details + source list) · `notebook_rename(notebook, new_title)` · `notebook_delete(notebook, confirm)` |
-| **Sources** | `source_list(notebook, status?, label?, detail?, limit?, offset?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports; `detail=compact` returns a low-token roster of just `id`/`title`/`kind`/`status_label`/`created_at`) · `source_read(notebook, source, detail?, output_format?, max_chars?, offset?)` (`detail=full` (default) → metadata + a bounded slice of the indexed text: `max_chars` caps `content` (default 10k), `offset` pages, plus a `truncated` flag and the full `char_count`; `detail=summary` → low-token triage: AI summary **+ keywords**, not the body; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` (a READY web page with thin/empty text, or a short body matching a dead-link / soft-404 boilerplate pattern, carries a non-blocking `warning`) · `source_add(notebook, source_type, ..., bytes_base64?, filename?, wait?, timeout?, interval?, allow_internal?)` (single; echoes `kind`/`status_label`, flags a failed import inline with a `warning`. `bytes_base64`/`filename` add a small `file` in-channel (no signed URL). `wait=true` folds in `source_wait` → the aggregate plus a top-level `source_id`; single-source only, not a remote `file` upload) / `source_add(notebook, urls=[...], allow_internal?)` (batch → per-item `results`; a synchronously-ready web-page item may also carry the same content-sanity `warning`) |
+| **Sources** | `source_list(notebook, status?, label?, detail?, limit?, offset?)` (each source has string `kind`/`status_label`; `status` filters to one of ready\|processing\|error\|preparing — e.g. `status="error"` finds failed imports; `detail=compact` returns a low-token roster of just `id`/`title`/`kind`/`status_label`/`created_at`) · `source_read(notebook, source, detail?, output_format?, max_chars?, offset?)` (`detail=full` (default) → metadata + a bounded slice of the indexed text: `max_chars` caps `content` (default 10k), `offset` pages, plus a `truncated` flag and the full `char_count`; `detail=summary` → low-token triage: AI summary **+ keywords**, not the body; `output_format`: text\|markdown) · `source_rename(notebook, source, new_title)` · `source_delete(notebook, source, confirm)` · `source_wait(notebook, source?, timeout, interval)` (a READY web page with thin/empty text, or a short body matching a dead-link / soft-404 or bot-challenge / WAF interstitial pattern, carries a non-blocking `warning`) · `source_add(notebook, source_type, ..., bytes_base64?, filename?, wait?, timeout?, interval?, allow_internal?)` (single; echoes `kind`/`status_label`, flags a failed import inline with a `warning`. `bytes_base64`/`filename` add a small `file` in-channel (no signed URL). `wait=true` folds in `source_wait` → the aggregate plus a top-level `source_id`; single-source only, not a remote `file` upload) / `source_add(notebook, urls=[...], allow_internal?)` (batch → per-item `results`; a synchronously-ready web-page item may also carry the same content-sanity `warning`) |
 | **Chat** | `chat_ask(notebook, question?, conversation_id?, references?, source_ids?, history?, suggest_followups?)` (`references`: lite\|full; never returns the raw debug blob; `source_ids` scopes to specific sources — list, JSON-array string, or comma string; omit for all; `history`>0 also returns up to N prior `{question, answer}` pairs — omit `question` to recall only; `suggest_followups=true` also returns `suggested_prompts` (3 questions to ask — works question-less too)) · `chat_configure(notebook, chat_mode?, goal?, response_length?)` (`chat_mode`: default\|learning-guide\|concise\|detailed — a preset, mutually exclusive with `goal`/`response_length`; a **partial** custom call sets just `goal` or just `response_length` and **merges** with the current settings — the omitted field is preserved, not reset; only a bare call, no preset and neither field, is rejected) · `suggest_prompts(notebook, surface?, source_ids?, query?)` (READ_ONLY; `surface`: ask\|audio-deep-dive\|audio-brief\|audio-critique\|audio-debate\|video-explainer\|video-short\|quiz\|flashcards — returns `{title, prompt}` suggestions to steer that studio surface; `ask` (default) = chat questions) |
 | **Notes** | `note_save(notebook, note?, title?, content?)` (upsert: omit `note` to **create** — `title` AND `content` required; pass a `note` ref to **update** — `title` and/or `content`, title-only = rename). Reading and deleting notes fold into the Studio row below. |
 | **Studio** | `studio_list(notebook, item?, kind?, detail?, limit?, offset?)` (the unified Studio panel — **notes AND artifacts** merged into one `items` list; each item has `id`/`title`/`type` where `type` is `note` or a hyphenated artifact kind; artifacts add `status_label`/`url`; `detail=summary` (default) gives each note a bounded `content_preview` + full-body `char_count` to keep a discovery listing low-token, `detail=full` returns the whole note `content`, `detail=compact` collapses every item to `id`/`title`/`type`/`status_label`/`created_at`; `kind` filters to one `type`; `item` fetches one note-or-artifact by ref as a 1-element list, always with the note's full `content`) · `studio_generate(notebook, artifact_type, …)` · `studio_status(notebook, task_id)` · `studio_get_prompt(notebook, artifact)` (the free-text prompt an artifact was generated from; `null` if none) · `studio_download(notebook, artifact? \| artifact_type?, path?, output_format?, artifact_id?)` (target by `artifact` name-or-id ref **or** by `artifact_type` [+ `artifact_id` for a specific one, else latest]) · `studio_rename(notebook, item, new_title)` (cross-type: renames a note OR an artifact resolved from the merged list) · `studio_retry(notebook, artifact)` (re-run a failed artifact in place; task_id == artifact_id) · `studio_delete(notebook, item, confirm)` (cross-type: deletes a note OR an artifact resolved from the merged list) |

--- a/src/notebooklm/mcp/tools/_content_sanity.py
+++ b/src/notebooklm/mcp/tools/_content_sanity.py
@@ -88,7 +88,10 @@ _BOT_CHALLENGE_PHRASES = frozenset(
         "access denied",
         "security verification",
         "captcha",
-        "ray id",
+        # Vendor-anchored: bare ``ray id`` is a substring of ordinary text like
+        # "array id" / "array identifier"; require the Cloudflare prefix so a normal
+        # technical page can't trip a false WAF warning (#1923 review).
+        "cloudflare ray id",
     }
 )
 

--- a/src/notebooklm/mcp/tools/_content_sanity.py
+++ b/src/notebooklm/mcp/tools/_content_sanity.py
@@ -67,6 +67,31 @@ _SOFT_404_PHRASES = frozenset(
     }
 )
 
+#: A bot-challenge / WAF interstitial (Cloudflare "Just a moment…", Akamai "Access
+#: Denied") also serves HTTP 200 and ingests as a READY ``web_page``, but its body
+#: clears the char-thin gate and carries none of the dead-link vocabulary above, so
+#: #1709 missed it. Scanned (casefolded) up to :data:`_BOT_CHALLENGE_BODY_SCAN_LIMIT`
+#: — a wider cap than :data:`_SOFT_404_BODY_SCAN_LIMIT` because a challenge page
+#: carries more script/boilerplate than a soft-404 stub, so a real interstitial can
+#: land just over the tighter dead-link cap. Anchored to interstitial phrasing (no
+#: bare ``"cloudflare"`` / ``"cookies"``) so a real article that merely mentions a
+#: WAF vendor doesn't false-positive; advisory only, misses non-English pages. See
+#: :func:`_thin_content_warning`.
+_BOT_CHALLENGE_BODY_SCAN_LIMIT = 5000
+
+_BOT_CHALLENGE_PHRASES = frozenset(
+    {
+        "just a moment",
+        "enable javascript and cookies",
+        "checking your browser",
+        "attention required",
+        "access denied",
+        "security verification",
+        "captcha",
+        "ray id",
+    }
+)
+
 
 async def _annotate_thin_warnings(
     client: NotebookLMClient,
@@ -125,6 +150,11 @@ async def _thin_content_warning(
        :data:`_SOFT_404_PHRASES` marker (a full-bodied "Whoops! broken link" page
        that sails past the char-thin rule). The length gate runs BEFORE the body is
        casefolded, so a large healthy page is never lowercased + scanned.
+    3. **bot-challenge / WAF interstitial** — a body SHORTER than
+       :data:`_BOT_CHALLENGE_BODY_SCAN_LIMIT` chars (a wider cap than the dead-link
+       pass) that contains a :data:`_BOT_CHALLENGE_PHRASES` marker (a Cloudflare
+       "Just a moment…" or Akamai "Access Denied" page that ingests as ready but is
+       not the real content). Dead-link takes precedence when a body trips both.
 
     **web-page only** (short pasted text / transcripts are legitimate, never flagged;
     callers also pre-filter). **best-effort**: the body fetch reuses
@@ -152,18 +182,30 @@ async def _thin_content_warning(
                 "not-yet-indexed, a soft-404/dead link, blocked, or paywalled; "
                 'verify with source_read (detail="full").'
             )
-        # ponytail: a short multi-word phrase scan over a length-gated body — no
+        # ponytail: short multi-word phrase scans over a length-gated body — no
         # liveness probe, no classifier; misses non-English / long-bodied error pages.
-        if char_count < _SOFT_404_BODY_SCAN_LIMIT:
+        # The bot-challenge cap is the wider of the two, so it drives the outer gate;
+        # the dead-link pass keeps its own tighter cap. Dead-link takes precedence when
+        # a body somehow trips both.
+        if char_count < _BOT_CHALLENGE_BODY_SCAN_LIMIT:
             # ``content`` is typed ``str`` but guard against a backend that reports a
             # non-thin ``char_count`` yet a ``None`` body — make the intent explicit
             # rather than lean on the outer ``except`` silently swallowing it.
             body = (result.fulltext.content or "").casefold()
-            if any(phrase in body for phrase in _SOFT_404_PHRASES):
+            if char_count < _SOFT_404_BODY_SCAN_LIMIT and any(
+                phrase in body for phrase in _SOFT_404_PHRASES
+            ):
                 return (
                     f"ingested as ready ({char_count} chars) but the body matches a "
                     "dead-link / error-page pattern (e.g. 'broken link') — likely a "
                     'soft-404; verify with source_read (detail="full").'
+                )
+            if any(phrase in body for phrase in _BOT_CHALLENGE_PHRASES):
+                return (
+                    f"ingested as ready ({char_count} chars) but the body matches a "
+                    "bot-challenge / WAF interstitial pattern (e.g. 'Just a moment' / "
+                    "'access denied') — the real page was likely blocked "
+                    '(Cloudflare / Akamai); verify with source_read (detail="full").'
                 )
     except Exception:  # noqa: BLE001 - sanity check must never break a wait
         return None

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -31,6 +31,7 @@ from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
 )
 from notebooklm.mcp._errors import tool_error_payload  # noqa: E402 - after importorskip guard
 from notebooklm.mcp.tools._content_sanity import (  # noqa: E402 - after importorskip guard
+    _BOT_CHALLENGE_BODY_SCAN_LIMIT,
     _THIN_SOURCE_CHAR_THRESHOLD,
 )
 from notebooklm.rpc.types import SourceStatus  # noqa: E402 - after importorskip guard
@@ -1221,6 +1222,133 @@ async def test_source_wait_title_phrase_not_flagged(mcp_call, mock_client) -> No
         )
         result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
         assert result.structured_content["ready"][0].get("warning") is None
+
+
+# ---------------------------------------------------------------------------
+# source_wait — bot-challenge / WAF interstitial body scan (#1923): a READY
+# web_page whose (short) body is a Cloudflare "Just a moment" / Akamai "access
+# denied" challenge page is flagged with its own advisory. These sail past the
+# 100-char thin gate and carry no dead-link vocabulary, so #1709 missed them.
+# Body-only; never rejects; a wider scan cap than the dead-link pass.
+# ---------------------------------------------------------------------------
+
+
+async def test_source_wait_bot_challenge_cloudflare_warns(mcp_call, mock_client) -> None:
+    """The reported OECD case: a ~489-char Cloudflare "Just a moment… Enable
+    JavaScript and cookies" interstitial (above the 100-char thin gate, no dead-link
+    vocabulary) is flagged via the bot-challenge scan, distinct from the soft-404
+    message."""
+    prefix = (
+        "Just a moment... www.oecd.org needs to review the security of your "
+        "connection before proceeding. Enable JavaScript and cookies to continue. "
+    )
+    body = prefix + "x" * (489 - len(prefix))
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="OECD")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=489)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    sc = result.structured_content
+    assert sc["ok"] is True
+    row = sc["ready"][0]
+    assert "warning" in row
+    assert "489 chars" in row["warning"]
+    assert "bot-challenge" in row["warning"]
+    # Distinct from the dead-link advisory — never mislabels a WAF page as a soft-404.
+    assert "soft-404" not in row["warning"]
+    assert 'source_read (detail="full")' in row["warning"]
+
+
+async def test_source_wait_bot_challenge_akamai_access_denied_warns(mcp_call, mock_client) -> None:
+    """The reported CISA case: a ~248-char Akamai "Access Denied" block page is
+    flagged via the bot-challenge scan."""
+    prefix = "Access Denied. You don't have permission to access this resource. "
+    body = prefix + "Reference #18.abcd " + "x" * (248 - len(prefix) - len("Reference #18.abcd "))
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="CISA")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=248)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    row = result.structured_content["ready"][0]
+    assert "warning" in row
+    assert "248 chars" in row["warning"]
+    assert "bot-challenge" in row["warning"]
+
+
+async def test_source_wait_bot_challenge_above_dead_link_cap_still_warns(
+    mcp_call, mock_client
+) -> None:
+    """The wider scan cap earns its keep: a challenge body between the dead-link cap
+    (2000) and the bot-challenge cap is still scanned and flagged — a WAF page just
+    over 2000 chars would slip through the dead-link pass alone."""
+    body = "Attention Required! Checking your browser before accessing. " + "x" * 2500
+    char_count = len(body)
+    assert 2000 <= char_count < _BOT_CHALLENGE_BODY_SCAN_LIMIT
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Blocked")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=char_count)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    row = result.structured_content["ready"][0]
+    assert "warning" in row
+    assert "bot-challenge" in row["warning"]
+
+
+async def test_source_wait_bot_challenge_over_scan_cap_not_flagged(mcp_call, mock_client) -> None:
+    """Boundary: a body of EXACTLY _BOT_CHALLENGE_BODY_SCAN_LIMIT chars is NOT scanned
+    (gate is ``< limit``) even though it carries a challenge phrase — keeps a large
+    healthy page from being lowercased + scanned."""
+    prefix = "Just a moment... enable javascript and cookies. "
+    body = prefix + "x" * (_BOT_CHALLENGE_BODY_SCAN_LIMIT - len(prefix))
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Big")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=_BOT_CHALLENGE_BODY_SCAN_LIMIT)
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    assert result.structured_content["ready"][0].get("warning") is None
+
+
+async def test_source_wait_bot_challenge_title_not_scanned(mcp_call, mock_client) -> None:
+    """No-title-scan holds for the challenge pass too: a page TITLED like a WAF page
+    ("Just a moment…") with a clean, phrase-free body is NOT flagged. Body is sub-cap
+    so the scan path is active — a regression that folded the title in would fire."""
+    body = (
+        "A genuine, thorough article about web performance, edge caching strategies, "
+        "and how to structure a fast static site for real readers over the long term."
+    )
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="Just a moment... | Cloudflare")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=len(body))
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    assert result.structured_content["ready"][0].get("warning") is None
+
+
+async def test_source_wait_bot_challenge_healthy_body_not_flagged(mcp_call, mock_client) -> None:
+    """A short healthy body that merely mentions a challenge topic in passing but
+    carries no anchored interstitial phrase is not flagged."""
+    body = (
+        "Our comprehensive guide to configuring a CDN covers performance tuning, cache "
+        "invalidation, and origin shielding in depth for teams running at real scale."
+    )
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="CDN guide")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=len(body))
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    assert result.structured_content["ready"][0].get("warning") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1313,7 +1313,7 @@ async def test_source_wait_bot_challenge_over_scan_cap_not_flagged(mcp_call, moc
         return_value=FakeFulltext(content=body, char_count=_BOT_CHALLENGE_BODY_SCAN_LIMIT)
     )
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
-    assert result.structured_content["ready"][0].get("warning") is None
+    assert "warning" not in result.structured_content["ready"][0]
 
 
 async def test_source_wait_bot_challenge_title_not_scanned(mcp_call, mock_client) -> None:
@@ -1331,7 +1331,7 @@ async def test_source_wait_bot_challenge_title_not_scanned(mcp_call, mock_client
         return_value=FakeFulltext(content=body, char_count=len(body))
     )
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
-    assert result.structured_content["ready"][0].get("warning") is None
+    assert "warning" not in result.structured_content["ready"][0]
 
 
 async def test_source_wait_bot_challenge_healthy_body_not_flagged(mcp_call, mock_client) -> None:
@@ -1348,7 +1348,25 @@ async def test_source_wait_bot_challenge_healthy_body_not_flagged(mcp_call, mock
         return_value=FakeFulltext(content=body, char_count=len(body))
     )
     result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
-    assert result.structured_content["ready"][0].get("warning") is None
+    assert "warning" not in result.structured_content["ready"][0]
+
+
+async def test_source_wait_bot_challenge_array_id_not_false_positive(mcp_call, mock_client) -> None:
+    """The Cloudflare Ray-ID marker is vendor-anchored, not a bare ``ray id`` substring:
+    ordinary technical prose containing 'array id' / 'array identifier' must NOT trip
+    the WAF warning (#1923 review). Only 'cloudflare ray id' matches."""
+    body = (
+        "Each record in the response carries an array id and an array identifier so "
+        "clients can reconcile the returned rows against the request they submitted."
+    )
+    mock_client.sources.wait_until_ready = AsyncMock(
+        return_value=FakeSource(id=SRC_ID, title="API reference")
+    )
+    mock_client.sources.get_fulltext = AsyncMock(
+        return_value=FakeFulltext(content=body, char_count=len(body))
+    )
+    result = await mcp_call("source_wait", {"notebook": NB_ID, "source": SRC_ID})
+    assert "warning" not in result.structured_content["ready"][0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1923.

## Problem
The thin-content sanity warning (shipped for web pages in #1709) misses **bot-challenge / WAF interstitial pages**. They serve HTTP 200, ingest as a **READY** source, clear the 100-char thin gate, and carry none of the dead-link/404 vocabulary — so they were marked ready with **no warning**. A Codex MCP stress-test (v0.8.0b2) surfaced two:
- a CISA page that was an Akamai **"Access Denied"** (~248 chars)
- an OECD page that was a Cloudflare **"Just a moment… Enable JavaScript and cookies"** interstitial (~489 chars)

## Fix — `src/notebooklm/mcp/tools/_content_sanity.py`
- Add a sibling `_BOT_CHALLENGE_PHRASES` set (`just a moment`, `enable javascript and cookies`, `checking your browser`, `attention required`, `access denied`, `security verification`, `captcha`, `ray id`) with its **own** advisory message, distinct from the dead-link one.
- Scan over a **wider** `_BOT_CHALLENGE_BODY_SCAN_LIMIT = 5000` cap than the 2000-char dead-link cap — a challenge page carries more script/boilerplate than a soft-404 stub, so a real interstitial can land just over the tighter cap. The wider cap now drives the outer length gate; the dead-link pass keeps its own tighter cap and **precedence** when a body trips both.
- Phrases are anchored to interstitial phrasing (no bare `cloudflare`/`cookies`) so a real article that merely mentions a WAF vendor doesn't false-positive.
- **Advisory only** — never rejects, same UX as the existing thin-content warning; any fetch failure still degrades to no warning.

## Tests (TDD)
Added unit tests in `tests/unit/mcp/test_sources.py`: the Cloudflare and Akamai reported bodies produce the bot-challenge warning; a body between the dead-link cap (2000) and the bot-challenge cap still warns; the scan-cap boundary is not flagged; the title is never scanned; and a healthy short body mentioning a challenge topic in passing is not flagged.

## Docs
Updated `docs/mcp-guide.md` (third signal row + full challenge phrase set) and the `docs/architecture.md` file index.

## Gate
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check . && ruff format --check .` — clean
- `uv run pytest` — 11886 passed, 80 skipped, 1 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added advisory warnings when ready web pages contain bot-protection or WAF interstitials, such as Cloudflare or Akamai challenge pages.
  - Warnings distinguish bot challenges from soft-404 pages and report the scanned content size.

- **Bug Fixes**
  - Improved detection of bot-challenge pages that were previously missed by content checks.

- **Documentation**
  - Expanded guidance for content-sanity warnings, detection signals, thresholds, and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->