### PR TITLE
fix(mcp): distinguish cancelled research + surface raw status code (#1922)

### DIFF
--- a/src/notebooklm/_app/research.py
+++ b/src/notebooklm/_app/research.py
@@ -68,6 +68,11 @@ class ResearchStatusResult:
     report: str
     public_dict: dict[str, Any]
     task_id: str = ""
+    # Raw backend status code carried through from ``ResearchTask.status_code``
+    # (issue #1922, F10). ``None`` when the poll had no code (empty / not-found).
+    # The MCP ``research_status`` tool surfaces it so an agent can distinguish
+    # failure sub-codes the coarse ``status`` flattens into ``failed``.
+    status_code: int | None = None
 
 
 def _classify_status_kind(status_val: str) -> ResearchStatusKind:
@@ -108,6 +113,7 @@ async def poll_and_classify(
         report=status.report,
         public_dict=status.to_public_dict(),
         task_id=status.task_id,
+        status_code=status.status_code,
     )
 
 

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -278,6 +278,10 @@ def parse_research_task_models(result: Any) -> list[ResearchTask]:
                 sources=tuple(parsed_sources),
                 summary=summary_opt or "",
                 report=report,
+                # Preserve the raw ``task_info[4]`` integer alongside the coarsened
+                # ``status`` enum (issue #1922, F10) so a caller can distinguish
+                # failure sub-codes the enum flattens into ``FAILED``.
+                status_code=status_code,
             )
         )
 

--- a/src/notebooklm/_types/research.py
+++ b/src/notebooklm/_types/research.py
@@ -141,6 +141,15 @@ class ResearchTask:
     summary: str = ""
     report: str = ""
     tasks: tuple[ResearchTask, ...] = ()
+    # Raw backend status code (``task_info[4]``) preserved verbatim (issue
+    # #1922, F10). ``status`` coarsens this into the lifecycle enum and cannot
+    # tell a "no matches" failure sub-code from a genuine error; keeping the raw
+    # integer lets a caller distinguish failure sub-codes. ``None`` when the poll
+    # carried no code (empty / not-found placeholders, or a malformed row). It is
+    # deliberately absent from :meth:`to_public_dict` / :meth:`_to_task_dict` so
+    # the CLI ``--json`` shape stays byte-stable — the MCP ``research_status``
+    # tool surfaces it directly from the attribute.
+    status_code: int | None = None
 
     @classmethod
     def empty(cls) -> ResearchTask:

--- a/src/notebooklm/mcp/_context.py
+++ b/src/notebooklm/mcp/_context.py
@@ -11,6 +11,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
@@ -24,11 +25,56 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AppState",
+    "CancelledResearchTracker",
     "get_cancelled_research",
     "get_client",
     "get_client_from_app",
     "get_file_transfer",
 ]
+
+# Hard ceiling on retained cancel intents (issue #1922, F9). Cancels are rare
+# and user-driven, so this is generous; it only guards against a pathological
+# long-lived server that cancels many runs which are never polled to a terminal
+# state (the usual eviction path). Oldest intents are dropped first (FIFO).
+_CANCEL_INTENT_CAP = 1024
+
+
+class CancelledResearchTracker:
+    """Bounded, insertion-ordered set of cancelled ``(notebook_id, task_id)`` runs.
+
+    Backs the client-side cancel-intent tracking for issue #1922 (F9):
+    ``research_cancel`` records a run here so a later ``research_status`` poll
+    can annotate the resulting generic ``failed`` as ``cancelled`` (the backend
+    surfaces a user-cancelled run as ``FAILED`` with no distinct wire code).
+
+    Bounded two ways so a long-running MCP server cannot leak memory:
+    ``research_status`` evicts an intent (:meth:`discard`) once its run reaches a
+    terminal poll, and a hard FIFO cap (:data:`_CANCEL_INTENT_CAP`) drops the
+    oldest intents even if a cancelled run is never polled to a terminal state.
+    """
+
+    def __init__(self, cap: int = _CANCEL_INTENT_CAP) -> None:
+        self._cap = cap
+        # ``OrderedDict`` as an ordered set (values unused) — preserves insertion
+        # order for FIFO eviction and gives O(1) membership / discard.
+        self._items: OrderedDict[tuple[str, str], None] = OrderedDict()
+
+    def record(self, key: tuple[str, str]) -> None:
+        """Record a cancel intent, evicting the oldest entries past the cap."""
+        self._items.pop(key, None)
+        self._items[key] = None
+        while len(self._items) > self._cap:
+            self._items.popitem(last=False)
+
+    def discard(self, key: tuple[str, str]) -> None:
+        """Drop a cancel intent if present (no-op otherwise)."""
+        self._items.pop(key, None)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._items
+
+    def __len__(self) -> int:
+        return len(self._items)
 
 
 @dataclass
@@ -39,19 +85,14 @@ class AppState:
     validated public base URL); ``None`` on stdio and on an http deployment
     without a public URL (ADR-0024).
 
-    ``cancelled_research`` records the cancel intent tracked client-side for
-    issue #1922 (F9): after a successful ``research_cancel`` the
-    ``(notebook_id, poll_task_id)`` pair is added here so a later
-    ``research_status`` poll can annotate the resulting ``failed`` state as
-    ``cancelled`` (the backend surfaces a user-cancelled run as a generic
-    ``FAILED`` with no distinct wire code). It is process-scoped in-memory state
-    (no persistence, consistent with the loop-bound lifespan client) and small —
-    one tuple per cancelled run — so it is left uncapped.
+    ``cancelled_research`` is the bounded cancel-intent tracker for issue #1922
+    (F9) — see :class:`CancelledResearchTracker`. Process-scoped in-memory state
+    (no persistence, consistent with the loop-bound lifespan client).
     """
 
     client: NotebookLMClient
     file_transfer: FileTransferConfig | None = None
-    cancelled_research: set[tuple[str, str]] = field(default_factory=set)
+    cancelled_research: CancelledResearchTracker = field(default_factory=CancelledResearchTracker)
 
 
 def _app_state(ctx: Context) -> AppState:
@@ -77,13 +118,14 @@ def get_client(ctx: Context) -> NotebookLMClient:
     return _app_state(ctx).client
 
 
-def get_cancelled_research(ctx: Context) -> set[tuple[str, str]]:
-    """Return the process-scoped set of cancelled ``(notebook_id, task_id)`` runs.
+def get_cancelled_research(ctx: Context) -> CancelledResearchTracker:
+    """Return the bounded cancel-intent tracker for the current tool call.
 
-    The mutable set backing the client-side cancel-intent tracking (issue #1922,
-    F9): ``research_cancel`` adds an entry on a successful cancel and
-    ``research_status`` reads it to annotate a later ``failed`` poll as
-    ``cancelled``. Returns the live set so callers mutate it in place. Mirrors
+    The live :class:`CancelledResearchTracker` backing the client-side
+    cancel-intent tracking (issue #1922, F9): ``research_cancel`` records an
+    entry on a successful cancel and ``research_status`` reads it to annotate a
+    later ``failed`` poll as ``cancelled`` (evicting it on the terminal poll).
+    Returns the live tracker so callers mutate it in place. Mirrors
     :func:`get_client`.
     """
     return _app_state(ctx).cancelled_research

--- a/src/notebooklm/mcp/_context.py
+++ b/src/notebooklm/mcp/_context.py
@@ -11,7 +11,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from fastmcp import Context
@@ -22,7 +22,13 @@ if TYPE_CHECKING:
     from ..client import NotebookLMClient
     from ._filelink import FileTransferConfig
 
-__all__ = ["AppState", "get_client", "get_client_from_app", "get_file_transfer"]
+__all__ = [
+    "AppState",
+    "get_cancelled_research",
+    "get_client",
+    "get_client_from_app",
+    "get_file_transfer",
+]
 
 
 @dataclass
@@ -32,10 +38,20 @@ class AppState:
     ``file_transfer`` is the optional remote file-transfer config (signer +
     validated public base URL); ``None`` on stdio and on an http deployment
     without a public URL (ADR-0024).
+
+    ``cancelled_research`` records the cancel intent tracked client-side for
+    issue #1922 (F9): after a successful ``research_cancel`` the
+    ``(notebook_id, poll_task_id)`` pair is added here so a later
+    ``research_status`` poll can annotate the resulting ``failed`` state as
+    ``cancelled`` (the backend surfaces a user-cancelled run as a generic
+    ``FAILED`` with no distinct wire code). It is process-scoped in-memory state
+    (no persistence, consistent with the loop-bound lifespan client) and small —
+    one tuple per cancelled run — so it is left uncapped.
     """
 
     client: NotebookLMClient
     file_transfer: FileTransferConfig | None = None
+    cancelled_research: set[tuple[str, str]] = field(default_factory=set)
 
 
 def _app_state(ctx: Context) -> AppState:
@@ -59,6 +75,18 @@ def get_client(ctx: Context) -> NotebookLMClient:
             lifespan binding is always present during a real tool invocation).
     """
     return _app_state(ctx).client
+
+
+def get_cancelled_research(ctx: Context) -> set[tuple[str, str]]:
+    """Return the process-scoped set of cancelled ``(notebook_id, task_id)`` runs.
+
+    The mutable set backing the client-side cancel-intent tracking (issue #1922,
+    F9): ``research_cancel`` adds an entry on a successful cancel and
+    ``research_status`` reads it to annotate a later ``failed`` poll as
+    ``cancelled``. Returns the live set so callers mutate it in place. Mirrors
+    :func:`get_client`.
+    """
+    return _app_state(ctx).cancelled_research
 
 
 def get_file_transfer(ctx: Context) -> FileTransferConfig | None:

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -46,7 +46,7 @@ from ..._app.serialize import to_jsonable
 from ..._deprecation import warn_deprecated
 from ...exceptions import ValidationError
 from .._confirm import READ_ONLY
-from .._context import get_client
+from .._context import get_cancelled_research, get_client
 from .._errors import mcp_errors
 from .._resolve import resolve_notebook
 
@@ -217,6 +217,18 @@ def register(mcp: Any) -> None:
             nb_id = await resolve_notebook(client, notebook)
             result = await research_core.poll_and_classify(client, nb_id, poll_task_id)
 
+            # F9 (#1922): a user-cancelled run surfaces as a generic ``failed``
+            # with no distinct wire code, so consult the client-side cancel-intent
+            # set recorded by ``research_cancel``. Match on the pinned id AND the
+            # polled task_id (an unfiltered poll resolves the id only in the
+            # result), keyed by notebook so ids never cross notebooks.
+            cancelled = False
+            if result.status == "failed":
+                intents = get_cancelled_research(ctx)
+                cancelled = (nb_id, result.task_id) in intents or (
+                    poll_task_id is not None and (nb_id, poll_task_id) in intents
+                )
+
             # Report content lives in TWO places — the top-level ``report`` AND
             # each source's ``report_markdown`` — so BOTH are gated by
             # ``include_report`` or a deep report leaks through the source rows.
@@ -246,6 +258,10 @@ def register(mcp: Any) -> None:
                 "poll_task_id": result.task_id,
                 "kind": result.kind,
                 "status": result.status,
+                # Raw backend status code preserved from the poll (F10, #1922);
+                # ``None`` when the poll carried no code. Lets an agent tell a
+                # "no matches" failure sub-code from a genuine error.
+                "status_code": result.status_code,
                 "query": result.query,
                 "sources": windowed,
                 "sources_total": sources_total,
@@ -256,6 +272,11 @@ def register(mcp: Any) -> None:
                 "report_char_count": report_char_count,
                 "report_truncated": report_truncated,
             }
+            # Only annotate a failure known to be user-cancelled (F9, #1922);
+            # absence means "not a tracked cancel", so a genuine failure stays
+            # un-annotated.
+            if cancelled:
+                payload["cancelled"] = True
             if deprecation is not None:
                 payload["deprecation"] = deprecation
             return payload
@@ -321,6 +342,11 @@ def register(mcp: Any) -> None:
             # preflight actually observed so a caller can tell a confirmed-running
             # cancel from an unconfirmed (lag-or-unknown) one.
             await client.research.cancel(nb_id, poll_task_id)
+            # Record the cancel intent (F9, #1922) so a later ``research_status``
+            # poll can annotate the resulting generic ``failed`` as ``cancelled``
+            # (the backend surfaces a cancelled run as FAILED with no distinct
+            # wire code). Keyed by notebook so ids never cross notebooks.
+            get_cancelled_research(ctx).add((nb_id, poll_task_id))
             result = {
                 "status": "cancel_requested",
                 "notebook_id": nb_id,

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -219,15 +219,23 @@ def register(mcp: Any) -> None:
 
             # F9 (#1922): a user-cancelled run surfaces as a generic ``failed``
             # with no distinct wire code, so consult the client-side cancel-intent
-            # set recorded by ``research_cancel``. Match on the pinned id AND the
-            # polled task_id (an unfiltered poll resolves the id only in the
-            # result), keyed by notebook so ids never cross notebooks.
+            # tracker recorded by ``research_cancel``. Match on the pinned id AND
+            # the polled task_id (an unfiltered poll resolves the id only in the
+            # result), keyed by notebook so ids never cross notebooks. On ANY
+            # terminal poll (failed / completed) evict the intent so the
+            # process-scoped tracker cannot grow without bound — a later poll of
+            # the same terminal run won't be re-annotated, which is acceptable
+            # (the agent already saw ``cancelled`` on the first terminal poll).
             cancelled = False
-            if result.status == "failed":
+            if result.status in ("failed", "completed"):
                 intents = get_cancelled_research(ctx)
-                cancelled = (nb_id, result.task_id) in intents or (
-                    poll_task_id is not None and (nb_id, poll_task_id) in intents
-                )
+                candidates = [(nb_id, result.task_id)]
+                if poll_task_id is not None and poll_task_id != result.task_id:
+                    candidates.append((nb_id, poll_task_id))
+                hit = any(key in intents for key in candidates)
+                cancelled = hit and result.status == "failed"
+                for key in candidates:
+                    intents.discard(key)
 
             # Report content lives in TWO places — the top-level ``report`` AND
             # each source's ``report_markdown`` — so BOTH are gated by
@@ -345,8 +353,9 @@ def register(mcp: Any) -> None:
             # Record the cancel intent (F9, #1922) so a later ``research_status``
             # poll can annotate the resulting generic ``failed`` as ``cancelled``
             # (the backend surfaces a cancelled run as FAILED with no distinct
-            # wire code). Keyed by notebook so ids never cross notebooks.
-            get_cancelled_research(ctx).add((nb_id, poll_task_id))
+            # wire code). Keyed by notebook so ids never cross notebooks; the
+            # tracker is bounded (evict-on-terminal + hard FIFO cap).
+            get_cancelled_research(ctx).record((nb_id, poll_task_id))
             result = {
                 "status": "cancel_requested",
                 "notebook_id": nb_id,

--- a/tests/unit/mcp/test_research.py
+++ b/tests/unit/mcp/test_research.py
@@ -620,6 +620,31 @@ async def test_research_cancel_then_failed_status_annotated_unfiltered_poll(
     assert result.structured_content["cancelled"] is True
 
 
+async def test_research_cancel_intent_evicted_on_terminal_poll(server_factory, mock_client) -> None:
+    """The cancel intent is evicted once the run reaches a terminal poll, so the
+    tracker cannot grow without bound: the FIRST failed poll is annotated, a
+    SECOND poll of the same terminal run is no longer annotated (#1922, F9)."""
+    server = server_factory()
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    async with Client(server) as client:
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+        )
+        await client.call_tool("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, task_id=TASK_ID)
+        )
+        first = await client.call_tool(
+            "research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID}
+        )
+        second = await client.call_tool(
+            "research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID}
+        )
+    assert first.structured_content["cancelled"] is True
+    assert "cancelled" not in second.structured_content
+
+
 async def test_research_status_failed_without_cancel_not_annotated(mcp_call, mock_client) -> None:
     """A genuine failure (never cancelled) is NOT annotated — absence of the
     ``cancelled`` key means "not a tracked cancel"."""

--- a/tests/unit/mcp/test_research.py
+++ b/tests/unit/mcp/test_research.py
@@ -18,6 +18,7 @@ import pytest
 # Skip cleanly when the `mcp` extra (fastmcp) is absent; see conftest.py.
 pytest.importorskip("fastmcp")
 
+from fastmcp import Client  # noqa: E402 - after importorskip guard
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
 from notebooklm import ResearchStartUnavailableError  # noqa: E402 - after importorskip guard
@@ -68,6 +69,7 @@ class FakeResearchTask:
     summary: str = ""
     report: str = ""
     task_id: str = TASK_ID
+    status_code: int | None = None
 
     def to_public_dict(self) -> dict[str, Any]:
         return {
@@ -540,6 +542,137 @@ async def test_research_cancel_empty_poll_task_id_rejected(mcp_call, mock_client
     assert "VALIDATION" in str(excinfo.value)
     mock_client.research.poll.assert_not_called()
     mock_client.research.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# F10 (#1922): research_status surfaces the raw backend status code
+# ---------------------------------------------------------------------------
+
+
+async def test_research_status_surfaces_status_code(mcp_call, mock_client) -> None:
+    """The raw ``task_info[4]`` code is surfaced so an agent can tell a
+    "no matches" failure sub-code from a genuine error (the coarse ``status``
+    flattens both to ``failed``)."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, status_code=7)
+    )
+    result = await mcp_call("research_status", {"notebook": NB_ID})
+    assert result.structured_content["status"] == "failed"
+    assert result.structured_content["status_code"] == 7
+
+
+async def test_research_status_status_code_none_when_absent(mcp_call, mock_client) -> None:
+    """A poll carrying no code surfaces ``status_code: None`` (not omitted)."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS)
+    )
+    result = await mcp_call("research_status", {"notebook": NB_ID})
+    assert result.structured_content["status_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# F9 (#1922): a cancelled run's later ``failed`` poll is annotated ``cancelled``
+# ---------------------------------------------------------------------------
+
+
+async def test_research_cancel_then_failed_status_is_annotated_cancelled(
+    server_factory, mock_client
+) -> None:
+    """After a successful cancel, a later ``failed`` poll for that run is flagged
+    ``cancelled: true`` (cancel intent is tracked client-side; the backend
+    surfaces a cancelled run as a generic FAILED). Both tool calls share one
+    open client so they hit the same lifespan ``AppState``."""
+    server = server_factory()
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    async with Client(server) as client:
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+        )
+        await client.call_tool("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, task_id=TASK_ID)
+        )
+        result = await client.call_tool(
+            "research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID}
+        )
+    assert result.structured_content["status"] == "failed"
+    assert result.structured_content["cancelled"] is True
+
+
+async def test_research_cancel_then_failed_status_annotated_unfiltered_poll(
+    server_factory, mock_client
+) -> None:
+    """The annotation keys off the polled ``task_id`` too, so an unfiltered
+    ``research_status`` (no pin) after a cancel is still flagged."""
+    server = server_factory()
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    async with Client(server) as client:
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+        )
+        await client.call_tool("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, task_id=TASK_ID)
+        )
+        result = await client.call_tool("research_status", {"notebook": NB_ID})
+    assert result.structured_content["cancelled"] is True
+
+
+async def test_research_status_failed_without_cancel_not_annotated(mcp_call, mock_client) -> None:
+    """A genuine failure (never cancelled) is NOT annotated — absence of the
+    ``cancelled`` key means "not a tracked cancel"."""
+    mock_client.research.poll = AsyncMock(
+        return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, task_id=TASK_ID)
+    )
+    result = await mcp_call("research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+    assert result.structured_content["status"] == "failed"
+    assert "cancelled" not in result.structured_content
+
+
+async def test_research_cancel_does_not_annotate_different_task(
+    server_factory, mock_client
+) -> None:
+    """Cancel intent for one run does not leak onto a DIFFERENT failed run."""
+    other = "research-task-2"
+    server = server_factory()
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    async with Client(server) as client:
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+        )
+        await client.call_tool("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.FAILED, task_id=other)
+        )
+        result = await client.call_tool(
+            "research_status", {"notebook": NB_ID, "poll_task_id": other}
+        )
+    assert "cancelled" not in result.structured_content
+
+
+async def test_research_cancel_then_completed_status_not_annotated(
+    server_factory, mock_client
+) -> None:
+    """``cancelled`` only annotates a ``failed`` outcome — a cancel that lost the
+    race and the run completed anyway is not mislabelled."""
+    server = server_factory()
+    mock_client.research.cancel = AsyncMock(return_value=None)
+    async with Client(server) as client:
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.IN_PROGRESS, task_id=TASK_ID)
+        )
+        await client.call_tool("research_cancel", {"notebook": NB_ID, "poll_task_id": TASK_ID})
+
+        mock_client.research.poll = AsyncMock(
+            return_value=FakeResearchTask(status=FakeResearchStatus.COMPLETED, task_id=TASK_ID)
+        )
+        result = await client.call_tool(
+            "research_status", {"notebook": NB_ID, "poll_task_id": TASK_ID}
+        )
+    assert "cancelled" not in result.structured_content
 
 
 async def test_research_start_then_status_poll_shape(mcp_call, mock_client) -> None:

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -16,6 +16,7 @@ from fastmcp import Client, FastMCP  # noqa: E402 - after importorskip guard
 from notebooklm.mcp import __main__ as entry  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._context import (  # noqa: E402 - after importorskip guard
     AppState,
+    get_cancelled_research,
     get_client,
 )
 from notebooklm.mcp.server import (  # noqa: E402 - after importorskip guard
@@ -65,6 +66,21 @@ def test_get_client_reads_appstate() -> None:
     ctx = MagicMock()
     ctx.request_context.lifespan_context = state
     assert get_client(ctx) is sentinel
+
+
+def test_get_cancelled_research_returns_live_appstate_set() -> None:
+    """get_cancelled_research returns the mutable set on the bound AppState so
+    research_cancel/research_status share cancel intent (issue #1922, F9)."""
+    state = AppState(client=MagicMock())
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = state
+
+    intents = get_cancelled_research(ctx)
+    assert intents == set()
+    intents.add(("nb", "task"))
+    # The same live set is returned on the next call (process-scoped state).
+    assert get_cancelled_research(ctx) == {("nb", "task")}
+    assert state.cancelled_research == {("nb", "task")}
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -16,6 +16,7 @@ from fastmcp import Client, FastMCP  # noqa: E402 - after importorskip guard
 from notebooklm.mcp import __main__ as entry  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._context import (  # noqa: E402 - after importorskip guard
     AppState,
+    CancelledResearchTracker,
     get_cancelled_research,
     get_client,
 )
@@ -68,19 +69,38 @@ def test_get_client_reads_appstate() -> None:
     assert get_client(ctx) is sentinel
 
 
-def test_get_cancelled_research_returns_live_appstate_set() -> None:
-    """get_cancelled_research returns the mutable set on the bound AppState so
+def test_get_cancelled_research_returns_live_appstate_tracker() -> None:
+    """get_cancelled_research returns the live tracker on the bound AppState so
     research_cancel/research_status share cancel intent (issue #1922, F9)."""
     state = AppState(client=MagicMock())
     ctx = MagicMock()
     ctx.request_context.lifespan_context = state
 
     intents = get_cancelled_research(ctx)
-    assert intents == set()
-    intents.add(("nb", "task"))
-    # The same live set is returned on the next call (process-scoped state).
-    assert get_cancelled_research(ctx) == {("nb", "task")}
-    assert state.cancelled_research == {("nb", "task")}
+    assert len(intents) == 0
+    intents.record(("nb", "task"))
+    # The same live tracker is returned on the next call (process-scoped state).
+    assert ("nb", "task") in get_cancelled_research(ctx)
+    assert state.cancelled_research is intents
+
+
+def test_cancelled_research_tracker_discard_and_cap() -> None:
+    """The tracker discards spent intents and enforces a hard FIFO cap so it
+    cannot grow without bound (issue #1922, F9)."""
+    tracker = CancelledResearchTracker(cap=3)
+    tracker.record(("nb", "a"))
+    assert ("nb", "a") in tracker
+    tracker.discard(("nb", "a"))
+    assert ("nb", "a") not in tracker
+    # discard is a no-op on an absent key.
+    tracker.discard(("nb", "missing"))
+
+    # Recording past the cap evicts the OLDEST entries (FIFO).
+    for i in range(5):
+        tracker.record(("nb", str(i)))
+    assert len(tracker) == 3
+    assert ("nb", "0") not in tracker and ("nb", "1") not in tracker
+    assert all(("nb", str(i)) in tracker for i in (2, 3, 4))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -255,6 +255,28 @@ class TestParseResearchTasks:
         # ``tasks`` key); the model's ``_to_task_dict`` is the matching builder.
         assert tasks[0]._to_task_dict() == parse_research_tasks([[["task_123", task_info]]])[0]
 
+    def test_parse_preserves_raw_status_code(self):
+        """The raw ``task_info[4]`` code is kept on the model verbatim (#1922, F10),
+        even when the coarse ``status`` enum flattens it (an unknown code → FAILED)."""
+        # An unknown terminal code coarsens to FAILED but the raw int survives.
+        task_info = [None, ["query"], None, [[], None], 99]
+        tasks = parse_research_task_models([[["task_fail", task_info]]])
+        assert tasks[0].status == "failed"
+        assert tasks[0].status_code == 99
+
+        # A completed run keeps its raw code too.
+        task_info_ok = [None, ["query"], None, [[], None], 2]
+        ok = parse_research_task_models([[["task_ok", task_info_ok]]])
+        assert ok[0].status == "completed"
+        assert ok[0].status_code == 2
+
+    def test_parse_status_code_none_when_non_int(self):
+        """A non-int ``task_info[4]`` yields ``status_code=None`` (→ in_progress)."""
+        task_info = [None, ["query"], None, [[], None], "weird"]
+        tasks = parse_research_task_models([[["task_x", task_info]]])
+        assert tasks[0].status == "in_progress"
+        assert tasks[0].status_code is None
+
     def test_research_source_public_dict_preserves_unknown_result_type(self):
         source = ResearchSource(
             url="https://example.com/video",


### PR DESCRIPTION
Fixes #1922.

## Problem
`research_status` could not tell a **user-cancelled** run from a genuine **failure** (both surface as `failed`), and it **discarded the raw backend status code**, so an agent could not distinguish a "no matches" failure sub-code from an error.

## F9 — cancelled reported as generic `failed`
The backend surfaces a cancelled run as a generic `FAILED` with no confirmed distinct wire code, so instead of trusting an unconfirmed code we track cancel intent **client-side**:

- `research_cancel` records the `(notebook_id, poll_task_id)` pair on the process-scoped lifespan `AppState` (new `cancelled_research` set + `get_cancelled_research` accessor).
- A later `failed` `research_status` poll for that run is annotated `cancelled: true`. The match keys on the pinned id **and** the polled `task_id` (so an unfiltered poll after a cancel is still flagged), scoped by notebook so ids never cross notebooks.
- A genuine failure (never cancelled) is left un-annotated; the annotation only ever fires on `failed`.

No `CANCELLED` enum member is added (the code comment confirms cancel surfaces as `FAILED`; there is no confirmed distinct wire signal).

## F10 — failed research drops the raw diagnostic code
The parser now preserves `task_info[4]` verbatim on `ResearchTask.status_code` (alongside the coarse `status` enum), threaded through `ResearchStatusResult` and surfaced as `research_status`'s `status_code`. It is deliberately **absent** from `to_public_dict` / `_to_task_dict`, so the CLI `--json` shape stays byte-stable. No `no_results` state is invented (undocumented/volatile codes, out of scope).

## Budget
Both are additive **response** fields — no new input params — so the MCP `SCHEMA_CHAR_BUDGET` is unchanged (docstrings untouched; the fields self-describe in the JSON output).

## Tests
- `tests/unit/mcp/test_research.py`: cancel→failed annotated `cancelled: true` (pinned and unfiltered polls); un-cancelled failure not annotated; cancel intent does not leak onto a different run; a cancel that lost the race and completed is not mislabelled; `status_code` surfaced (and `None` when absent).
- `tests/unit/test_research_task_parser.py`: parser preserves the raw code (incl. an unknown code that coarsens to `failed`), `None` on a non-int code.
- `tests/unit/mcp/test_server.py`: `get_cancelled_research` returns the live `AppState` set.

Full gate green: mypy clean, ruff check + format clean, `uv run pytest` — 11890 passed, 80 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Research status responses now expose backend-specific `status_code` when available.
  * User-initiated research cancellations are now surfaced as `cancelled: true`, even when the backend returns a failed state.
* **Bug Fixes**
  * Cancellation labeling now applies only to the intended notebook/task and is not reused across repeated terminal polls.
* **Tests**
  * Added unit and end-to-end coverage for backend status-code reporting, cancellation tracking (including FIFO eviction), and parsing of raw terminal status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->