### PR TITLE
fix(studio): media_ready flag, download size_bytes, actionable retry error (#1924)

### DIFF
--- a/src/notebooklm/_app/artifacts.py
+++ b/src/notebooklm/_app/artifacts.py
@@ -266,6 +266,14 @@ class ArtifactStatusView:
     error_code: str | None
     metadata: dict[str, Any] | None
     is_complete: bool
+    #: Whether the artifact's media is fully ready. ``poll_status`` extracts
+    #: ``url`` unconditionally (even for a still-pending row), so a non-null
+    #: ``url`` alone does NOT mean it is safe to use. This mirrors the poll
+    #: adapter's ``is_media_ready`` gate (it downgrades a COMPLETED-but-not-yet-
+    #: populated media row back to in-progress), so it is ``True`` exactly when
+    #: generation has completed — when ``False`` any ``url`` present is
+    #: provisional/expiring and should not be fetched yet (#1924 F13).
+    media_ready: bool
 
 
 def status_view(status: GenerationStatus) -> ArtifactStatusView:
@@ -284,6 +292,11 @@ def status_view(status: GenerationStatus) -> ArtifactStatusView:
         error_code=getattr(status, "error_code", None),
         metadata=getattr(status, "metadata", None),
         is_complete=status.is_complete,
+        # ``poll_status`` only reports ``is_complete`` once the media URL is
+        # populated (it downgrades a COMPLETED-but-empty media row to in-progress
+        # via ``is_media_ready``), so ``is_complete`` is the media-ready signal:
+        # a non-null ``url`` on a not-yet-complete row is provisional (#1924 F13).
+        media_ready=status.is_complete,
     )
 
 

--- a/src/notebooklm/_app/download.py
+++ b/src/notebooklm/_app/download.py
@@ -27,6 +27,7 @@ This module is transport-neutral — no ``click`` / ``rich`` / ``cli`` /
 
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -223,6 +224,11 @@ class DownloadResult:
     suggestion: str | None = None
     artifact: dict[str, Any] | None = None
     output_path: str | None = None
+    #: On-disk size of a single downloaded file, in bytes. Populated only for a
+    #: ``SINGLE_DOWNLOADED`` outcome (``os.path.getsize`` of the written file);
+    #: ``None`` otherwise, or when the size cannot be read (#1924 F14). Mirrors the
+    #: remote broker's ``size_bytes`` key so the stdio and remote wire shapes agree.
+    size_bytes: int | None = None
     output_dir: str | None = None
     count: int | None = None
     total: int | None = None
@@ -755,6 +761,19 @@ async def _execute_download_all(
     )
 
 
+def _file_size_or_none(path: str) -> int | None:
+    """Return ``os.path.getsize(path)``, or ``None`` when it cannot be read.
+
+    Used to stamp a ``SINGLE_DOWNLOADED`` result's ``size_bytes`` (#1924 F14). A
+    missing/unreadable file (e.g. a mocked ``download_fn`` returning a path without
+    writing) yields ``None`` rather than propagating an ``OSError``.
+    """
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return None
+
+
 async def _execute_download_single(
     plan: DownloadPlan,
     facade: _DownloadFacade,
@@ -826,10 +845,16 @@ async def _execute_download_single(
         result_path = await download_fn(
             nb_id_resolved, str(final_path), artifact_id=str(selected["id"])
         )
+        written_path = result_path or str(final_path)
         return DownloadResult(
             outcome=DownloadOutcome.SINGLE_DOWNLOADED,
             artifact=selected_envelope,
-            output_path=result_path or str(final_path),
+            output_path=written_path,
+            # ``os.path.getsize`` of the just-written file is free — the download
+            # already wrote it to disk (#1924 F14). Tolerate a missing file (e.g. a
+            # mocked ``download_fn`` that returns a path without writing) by leaving
+            # ``size_bytes`` at ``None`` rather than raising.
+            size_bytes=_file_size_or_none(written_path),
         )
     except Exception as e:
         return DownloadResult(outcome=DownloadOutcome.ERROR, error=str(e), artifact=dict(selected))

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .._row_adapters.artifacts import ArtifactRow
 from .._row_adapters.notes import NoteRow
+from ..exceptions import UnknownRPCMethodError
 from ..rpc.types import (
     FLASHCARDS_VARIANT,
     INTERACTIVE_MIND_MAP_VARIANT,
@@ -174,6 +175,12 @@ class Artifact:
     _variant: int | None = field(
         default=None, repr=False
     )  # For type 4: 1=flashcards, 2=quiz, 4=interactive_mind_map
+    #: The free-text prompt this artifact was generated from, or ``None`` (e.g. a
+    #: note-backed mind map, or a type whose prompt slot is absent). Decoded from
+    #: the listing row so a listing surfaces it without a per-artifact fetch
+    #: (#1925). ``None`` on prompt-position drift — the read is guarded so a
+    #: reshaped payload never breaks ``artifacts.list``.
+    generation_prompt: str | None = None
 
     @property
     def kind(self) -> ArtifactType:
@@ -207,6 +214,14 @@ class Artifact:
         # guard is needed here.
         url = row.artifact_url(artifact_type, suppress_drift=True)
 
+        # The generation prompt is a nice-to-have listing field, not core to an
+        # artifact's identity — guard its (type-specific) nested read so a prompt-
+        # position drift degrades to ``None`` rather than breaking every listing.
+        try:
+            generation_prompt = row.generation_prompt
+        except UnknownRPCMethodError:
+            generation_prompt = None
+
         return cls(
             id=row.id,
             title=row.title,
@@ -215,6 +230,7 @@ class Artifact:
             created_at=row.created_at,
             url=url,
             _variant=row.variant,
+            generation_prompt=generation_prompt,
         )
 
     @classmethod

--- a/src/notebooklm/mcp/tools/_studio_items.py
+++ b/src/notebooklm/mcp/tools/_studio_items.py
@@ -100,7 +100,11 @@ class StudioResolvedItem:
 
 
 async def studio_items(
-    client: NotebookLMClient, nb_id: str, *, include_created_at: bool = False
+    client: NotebookLMClient,
+    nb_id: str,
+    *,
+    include_created_at: bool = False,
+    include_artifact_meta: bool = False,
 ) -> list[dict[str, Any]]:
     """Fetch + merge a notebook's text notes and studio artifacts into one list.
 
@@ -116,6 +120,12 @@ async def studio_items(
     key (ISO string or ``None``) read from the already-fetched note/artifact row — used
     by ``studio_list(detail="compact")``. It defaults off so the by-ref resolver and the
     default list paths stay byte-identical.
+
+    When ``include_artifact_meta`` is set, each ARTIFACT item additionally carries
+    ``created_at`` and ``generation_prompt`` (both already decoded on the ``Artifact``)
+    — used by ``studio_list(detail="summary")`` to give artifacts the same richer
+    projection notes get. Notes are untouched by this flag. It defaults off so the
+    by-ref resolver and the default list paths stay byte-identical.
 
     Items are keyed by id (notes first) so a hypothetical future note∩artifact
     overlap can't double-list — this never fires today (``notes.list`` excludes
@@ -148,11 +158,16 @@ async def studio_items(
             "status_label": getattr(art, "status_str", None),
             "url": getattr(art, "url", None),
         }
-        if include_created_at:
+        if include_created_at or include_artifact_meta:
             # Direct attribute access — ``created_at`` is an unconditional field on the
             # typed ``Artifact`` (``status_str`` / ``url`` above keep ``getattr`` because
             # minimal fakes/rows can lack them).
             art_item["created_at"] = to_jsonable(art.created_at)
+        if include_artifact_meta:
+            # ``generation_prompt`` is an unconditional field on the typed ``Artifact``
+            # (``getattr`` guards a minimal fake that predates it); ``None`` for a
+            # note-backed mind map or a prompt-less type (#1925).
+            art_item["generation_prompt"] = getattr(art, "generation_prompt", None)
         items[art_id] = art_item
     return list(items.values())
 

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -35,7 +35,7 @@ from ..._app import notes as note_core
 from ..._app.language import is_supported_language
 from ..._app.resolve import FULL_ID_PATTERN
 from ..._app.serialize import to_jsonable
-from ...exceptions import NotFoundError, ValidationError
+from ...exceptions import ArtifactFeatureUnavailableError, NotFoundError, ValidationError
 from .._coerce import coerce_list
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -225,9 +225,9 @@ def register(mcp: Any) -> None:
 
         * ``detail`` ladder (NOTE bodies only; read a report/data-table body via
           ``studio_download``): ``summary`` (default) gives each note a bounded
-          ``content_preview`` + ``char_count``; ``full`` returns the whole ``content``;
-          ``compact`` collapses every item to ``id`` / ``title`` / ``type`` /
-          ``status_label`` / ``created_at`` (no body/``url``) — a low-token roster.
+          ``content_preview`` + ``char_count`` (artifacts add ``created_at`` +
+          ``generation_prompt``); ``full`` = whole ``content``; ``compact`` = a
+          ``id``/``title``/``type``/``status_label``/``created_at`` roster.
         * ``kind`` filters to one ``type``.
         * ``item`` (name or id) fetches just that item as a 1-element list with the
           note's FULL ``content``; no match is NOT_FOUND. ``limit`` / ``offset`` /
@@ -258,8 +258,15 @@ def register(mcp: Any) -> None:
                     "has_more": False,
                 }
             # ``compact`` needs each row's ``created_at`` (dropped by the default
-            # projection); fetch it only for that mode so the other paths are unchanged.
-            items = await studio_items(client, nb_id, include_created_at=(detail == "compact"))
+            # projection); ``summary`` additionally surfaces each artifact's
+            # ``created_at`` + ``generation_prompt`` (#1925). Fetch each only for its
+            # mode so the by-ref/``full`` paths stay unchanged.
+            items = await studio_items(
+                client,
+                nb_id,
+                include_created_at=(detail == "compact"),
+                include_artifact_meta=(detail == "summary"),
+            )
             if kind is not None:
                 items = [it for it in items if it["type"] == kind]
             page, meta = paginate(items, limit, offset)
@@ -489,9 +496,9 @@ def register(mcp: Any) -> None:
     async def studio_status(ctx: Context, notebook: str, task_id: str) -> dict[str, Any]:
         """Poll a generation task's status. Accepts a notebook name or ID.
 
-        Stateless: pass the ``task_id`` returned by ``studio_generate``. Returns
-        ``status`` / ``url`` / ``error`` / ``is_complete``; call repeatedly until
-        ``is_complete`` is true.
+        Stateless: pass the ``task_id`` from ``studio_generate``. Returns ``status`` /
+        ``url`` / ``error`` / ``is_complete`` / ``media_ready``; poll until done. A
+        pending ``url`` is provisional — trust it only if ``media_ready``.
         """
         client = get_client(ctx)
         with mcp_errors():
@@ -817,7 +824,23 @@ def register(mcp: Any) -> None:
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             art_id = await resolve_artifact(client, nb_id, artifact)
-            result = await artifact_core.retry_artifact(client, nb_id, art_id)
+            try:
+                result = await artifact_core.retry_artifact(client, nb_id, art_id)
+            except ArtifactFeatureUnavailableError:
+                # Retry refused (null result). The most common cause is retrying an
+                # artifact that is not FAILED (retry only re-runs a failed one). Turn
+                # the generic "Retry generation is unavailable" into an actionable
+                # message naming the current state — but only on the refusal path, so
+                # the happy path stays free of the extra ``get_or_none`` list (#1924
+                # F15). Re-raise the generic error when the state doesn't explain it
+                # (already-failed artifact, or it vanished between resolve and here).
+                art = await client.artifacts.get_or_none(nb_id, art_id)
+                if art is not None and not art.is_failed:
+                    raise ValidationError(
+                        f"artifact is not failed (status: {art.status_str}); retry only "
+                        "re-runs a failed artifact — use studio_generate for a new one."
+                    ) from None
+                raise
             return {
                 "notebook_id": nb_id,
                 "artifact_id": art_id,

--- a/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
+++ b/tests/fixtures/rpc_golden/LIST_ARTIFACTS.json
@@ -64,7 +64,8 @@
       "status": 3,
       "created_at": null,
       "url": null,
-      "_variant": null
+      "_variant": null,
+      "generation_prompt": null
     },
     {
       "id": "SCRUBBED_ARTIFACT_002",
@@ -73,7 +74,8 @@
       "status": 3,
       "created_at": null,
       "url": null,
-      "_variant": null
+      "_variant": null,
+      "generation_prompt": null
     }
   ]
 }

--- a/tests/unit/app/test_app_artifacts.py
+++ b/tests/unit/app/test_app_artifacts.py
@@ -301,7 +301,23 @@ def test_status_view_projects_full_generation_status() -> None:
         error_code="CODE",
         metadata={"k": "v"},
         is_complete=status.is_complete,
+        media_ready=status.is_complete,
     )
+
+
+def test_status_view_pending_url_is_not_media_ready() -> None:
+    """A pending row that already exposes a url is flagged ``media_ready=False``
+    so a caller knows the url is provisional (#1924 F13)."""
+    status = GenerationStatus(
+        task_id="t",
+        status="pending",
+        url="https://provisional",
+    )
+    view = status_view(status)
+    assert view.is_complete is False
+    assert view.media_ready is False
+    # The url still passes through — flagged, not dropped.
+    assert view.url == "https://provisional"
 
 
 def test_status_view_tolerates_duck_typed_source_without_optional_attrs() -> None:

--- a/tests/unit/mcp/test_studio.py
+++ b/tests/unit/mcp/test_studio.py
@@ -28,6 +28,7 @@ from notebooklm._types.artifacts import (  # noqa: E402
 )
 from notebooklm._types.mind_maps import MindMapKind  # noqa: E402
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
     NotebookNotFoundError,
     RateLimitError,
@@ -326,16 +327,21 @@ async def test_studio_list_item_single_fetch_returns_full_body(mcp_call, mock_cl
     assert "content_preview" not in note
 
 
-async def test_studio_list_summary_leaves_artifacts_untouched(mcp_call, mock_client) -> None:
-    """An artifact item (no body) is identical in summary vs full — no preview/char_count."""
+async def test_studio_list_summary_enriches_artifacts_with_meta(mcp_call, mock_client) -> None:
+    """An artifact item gets no note-style preview/char_count, but summary DOES add
+    ``created_at`` + ``generation_prompt`` (the #1925 sliver) — so it differs from full,
+    which leaves the projection untouched."""
     mock_client.notes.list = AsyncMock(return_value=[])
     mock_client.artifacts.list = AsyncMock(return_value=[_completed_artifact("art1", "My Podcast")])
     summary = await mcp_call("studio_list", {"notebook": NB_ID})
     full = await mcp_call("studio_list", {"notebook": NB_ID, "detail": "full"})
-    assert summary.structured_content["items"] == full.structured_content["items"]
     art = summary.structured_content["items"][0]
+    # No note-body projection leaks onto an artifact.
     assert "content_preview" not in art
     assert "char_count" not in art
+    # Summary surfaces the artifact metadata; full does not (scoped enrichment).
+    assert "created_at" in art and "generation_prompt" in art
+    assert "generation_prompt" not in full.structured_content["items"][0]
 
 
 async def test_studio_list_rejects_bad_detail(mcp_call, mock_client) -> None:
@@ -444,6 +450,71 @@ async def test_studio_items_created_at_opt_in() -> None:
     assert "created_at" not in default[0]
     enriched = await studio_items(client, NB_ID, include_created_at=True)
     assert enriched[0]["created_at"] == "2024-01-02T00:00:00+00:00"
+
+
+async def test_studio_items_artifact_meta_opt_in() -> None:
+    """``include_artifact_meta`` adds ``created_at`` + ``generation_prompt`` to ARTIFACT
+    items only; notes are untouched and the default output is unchanged (#1925)."""
+    from notebooklm.mcp.tools._studio_items import studio_items
+
+    art = Artifact(
+        id="art1",
+        title="Pod",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        generation_prompt="Summarize the intro",
+    )
+    client = MagicMock()
+    client.notes.list = AsyncMock(return_value=[FakeNote(id=_NOTE_ID, title="N", content="b")])
+    client.artifacts.list = AsyncMock(return_value=[art])
+
+    default = await studio_items(client, NB_ID)
+    art_row = next(it for it in default if it["type"] == "audio")
+    assert "generation_prompt" not in art_row
+    assert "created_at" not in art_row
+
+    enriched = await studio_items(client, NB_ID, include_artifact_meta=True)
+    art_row = next(it for it in enriched if it["type"] == "audio")
+    assert art_row["generation_prompt"] == "Summarize the intro"
+    assert art_row["created_at"] == "2024-01-01T00:00:00+00:00"
+    # Notes are unaffected by the artifact-only flag.
+    note_row = next(it for it in enriched if it["type"] == "note")
+    assert "generation_prompt" not in note_row
+    assert "created_at" not in note_row
+
+
+async def test_studio_list_summary_artifact_carries_created_at_and_prompt(
+    mcp_call, mock_client
+) -> None:
+    """Sliver of #1925: summary-mode (default) artifact rows surface ``created_at`` +
+    ``generation_prompt`` (already decoded on the row), matching how notes get a
+    preview + char_count."""
+    art = Artifact(
+        id="art1",
+        title="My Podcast",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        generation_prompt="Summarize the intro",
+    )
+    mock_client.notes.list = AsyncMock(return_value=[])
+    mock_client.artifacts.list = AsyncMock(return_value=[art])
+    result = await mcp_call("studio_list", {"notebook": NB_ID})
+    row = result.structured_content["items"][0]
+    assert row["created_at"] == "2024-01-01T00:00:00+00:00"
+    assert row["generation_prompt"] == "Summarize the intro"
+
+
+async def test_studio_list_full_artifact_omits_prompt(mcp_call, mock_client) -> None:
+    """``detail="full"`` leaves the artifact projection untouched — no ``generation_prompt``
+    (the enrichment is scoped to summary mode)."""
+    art = _completed_artifact("art1", "My Podcast")
+    mock_client.notes.list = AsyncMock(return_value=[])
+    mock_client.artifacts.list = AsyncMock(return_value=[art])
+    result = await mcp_call("studio_list", {"notebook": NB_ID, "detail": "full"})
+    row = result.structured_content["items"][0]
+    assert "generation_prompt" not in row
 
 
 # ---------------------------------------------------------------------------
@@ -1048,6 +1119,33 @@ async def test_artifact_generate_then_status_poll_shape(mcp_call, mock_client) -
     assert polled.structured_content["is_complete"] is True
 
 
+async def test_artifact_status_pending_url_is_provisional(mcp_call, mock_client) -> None:
+    """F13: a still-pending artifact that already exposes a media url reports
+    ``media_ready: false`` so an agent knows the url is provisional, not final."""
+    mock_client.artifacts.poll_status = AsyncMock(
+        return_value=FakeStatus(
+            task_id=TASK_ID,
+            status=GenerationState.PENDING,
+            url="https://example.com/provisional.mp3",
+        )
+    )
+    result = await mcp_call("studio_status", {"notebook": NB_ID, "task_id": TASK_ID})
+    sc = result.structured_content
+    assert sc["is_complete"] is False
+    assert sc["media_ready"] is False
+    # The url is flagged provisional, not dropped — callers already reading it keep it.
+    assert sc["url"] == "https://example.com/provisional.mp3"
+
+
+async def test_artifact_status_complete_is_media_ready(mcp_call, mock_client) -> None:
+    """F13: a completed artifact reports ``media_ready: true``."""
+    mock_client.artifacts.poll_status = AsyncMock(
+        return_value=FakeStatus(task_id=TASK_ID, status=GenerationState.COMPLETED)
+    )
+    result = await mcp_call("studio_status", {"notebook": NB_ID, "task_id": TASK_ID})
+    assert result.structured_content["media_ready"] is True
+
+
 # ---------------------------------------------------------------------------
 # studio_get_prompt
 # ---------------------------------------------------------------------------
@@ -1126,6 +1224,23 @@ async def test_artifact_download_audio(mcp_call, mock_client, tmp_path) -> None:
     assert result.structured_content["outcome"] == "single_downloaded"
     assert result.structured_content["output_path"] == out
     mock_client.artifacts.download_audio.assert_awaited_once()
+
+
+async def test_artifact_download_reports_size_bytes(mcp_call, mock_client, tmp_path) -> None:
+    """F14: a stdio download echoes the on-disk ``size_bytes`` (the file was just
+    written; ``os.path.getsize`` is free and previously thrown away)."""
+    out = tmp_path / "out.mp3"
+
+    async def _write(*_a: Any, **_k: Any) -> str:
+        out.write_bytes(b"hello world")  # 11 bytes
+        return str(out)
+
+    mock_client.artifacts.list = AsyncMock(return_value=[_AUDIO_ARTIFACT])
+    mock_client.artifacts.download_audio = AsyncMock(side_effect=_write)
+    result = await mcp_call(
+        "studio_download", {"notebook": NB_ID, "artifact_type": "audio", "path": str(out)}
+    )
+    assert result.structured_content["size_bytes"] == 11
 
 
 async def test_artifact_download_by_artifact_ref_infers_type(
@@ -1719,6 +1834,59 @@ async def test_artifact_retry_refusal_projects_tool_error(mcp_call, mock_client)
     mock_client.artifacts.retry_failed = AsyncMock(side_effect=_raise)
     with pytest.raises(ToolError):
         await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+
+
+async def test_artifact_retry_completed_gives_actionable_error(mcp_call, mock_client) -> None:
+    """F15: retrying a completed (non-failed) artifact turns the generic
+    'Retry generation is unavailable' refusal into an actionable error naming the
+    current status and pointing at studio_generate."""
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.retry_failed = AsyncMock(
+        side_effect=ArtifactFeatureUnavailableError("retry")
+    )
+    mock_client.artifacts.get_or_none = AsyncMock(return_value=art)
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+    msg = str(excinfo.value)
+    assert "completed" in msg  # names the current status
+    assert "studio_generate" in msg  # actionable next step
+    assert "Retry generation is unavailable" not in msg  # not the generic text
+
+
+async def test_artifact_retry_refusal_on_failed_reraises_generic(mcp_call, mock_client) -> None:
+    """F15 guard: when the artifact IS failed (or vanished) the refusal doesn't fit the
+    'not failed' story, so the original generic error is re-raised unchanged."""
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.FAILED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.retry_failed = AsyncMock(
+        side_effect=ArtifactFeatureUnavailableError("retry")
+    )
+    mock_client.artifacts.get_or_none = AsyncMock(return_value=art)
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+    assert "Retry generation is unavailable" in str(excinfo.value)
+
+
+async def test_artifact_retry_happy_path_skips_state_check(mcp_call, mock_client) -> None:
+    """F15: the happy path must NOT pay for the extra ``get_or_none`` state read."""
+    mock_client.artifacts.retry_failed = AsyncMock(
+        return_value=FakeStatus(task_id=_ART_FULL, status=GenerationState.IN_PROGRESS, url=None)
+    )
+    mock_client.artifacts.get_or_none = AsyncMock()
+    result = await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+    assert result.structured_content["status"] == "in_progress"
+    mock_client.artifacts.get_or_none.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1924. Also part of #1925 (the cheap listing sliver).

Three MCP Studio-tool response-quality gaps from a Codex stress-test (all confirmed against code), plus one cheap sliver from #1925.

## F13 — provisional media URL while pending
`poll_status` extracts `url` unconditionally regardless of status, so a still-pending artifact could report a non-null (provisional/expiring) media `url` with `is_complete: false` and no way for an agent to tell it apart from a final URL.

**Fix:** add a `media_ready` bool to `ArtifactStatusView`, fed by the poll adapter's existing `is_media_ready` gate (it downgrades a COMPLETED-but-not-yet-populated media row to in-progress, so `is_complete` is the media-ready signal). Surfaced in `studio_status`. The `url` is flagged, not dropped — callers already reading it keep it.

## F14 — download `size_bytes: null`
The stdio `DownloadResult` had **no** `size_bytes` field, even though `_execute_download_single` writes the file to disk and holds the path.

**Fix:** add `size_bytes: int | None` to `DownloadResult`, populated from `os.path.getsize` on a `SINGLE_DOWNLOADED` outcome (tolerating a missing file → `None`). Unifies the stdio wire shape with the remote broker's existing `size_bytes` key. The broker only mints a signed URL without fetching, so it stays `None` there (the `/files/dl` route already sets a real Content-Length when opened) — left as-is per the issue.

## F15 — vague retry error
Retrying a **completed** (non-failed) artifact returned the generic `"Retry generation is unavailable"`.

**Fix:** `studio_retry` catches the `ArtifactFeatureUnavailableError` refusal and — only on that path, so the happy path stays free of the extra call — reads the artifact state via `get_or_none`. If it isn't failed, it raises an actionable `ValidationError` naming the current status and pointing at `studio_generate`; otherwise it re-raises the generic error unchanged.

## Sliver of #1925
`created_at` + `generation_prompt` are already decoded on the artifact row but weren't surfaced in `studio_list`. Added to the summary-mode artifact projection (notes already get preview/char_count). This adds `generation_prompt` to the typed `Artifact` (guarded read so a prompt-position drift degrades to `None` rather than breaking `artifacts.list`) and an `include_artifact_meta` opt-in on `studio_items`. Duration / counts / generator-version stay capture-gated — #1925 remains open for them.

## Notes
- Behavior/response-shape fixes, not new input params. Net MCP schema-char cost kept under the ADR-0025 budget.
- Touches `studio_status` / `studio_retry` / `studio_list` — disjoint from #1914's `_generation_payload` (mind-map) edit in the same file.

## Tests
- `studio_status` pending row with a non-null url reports `media_ready: false`; completed reports `true`; `status_view` unit coverage.
- stdio download result carries `size_bytes` = the on-disk file size.
- `studio_retry` on a completed artifact returns an actionable error naming the status (not the generic text); re-raises generic when the artifact is failed; happy path skips the state check.
- `studio_list` summary artifact rows carry `created_at` + `generation_prompt`; `full` leaves them off; `studio_items` `include_artifact_meta` opt-in.
- Full suite green (mypy, ruff, `pytest`); LIST_ARTIFACTS golden fixture updated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTdQA3fnD98jve4fB6Aocf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Artifact status now clearly indicates whether media is ready, even when a temporary URL is available.
  - Artifact summaries include creation time and generation prompt metadata.
  - Single-file downloads report the downloaded file size in bytes.

- **Bug Fixes**
  - Retry errors now explain when an artifact cannot be retried and direct users to generate it again.
  - Preserved clearer status and URL information for pending artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->