### PR TITLE
docs(adr-0027): correct multi-replica upload guidance (per-process signing key) (#1936)

### DIFF
--- a/docs/adr/0027-mcp-app-upload-widget.md
+++ b/docs/adr/0027-mcp-app-upload-widget.md
@@ -60,17 +60,21 @@ tool-count / schema-char budgets) unless a deployment enables it.
   → "fail to fetch app content"). Enabling the widget therefore auto-enables
   `FASTMCP_STATELESS_HTTP` (overridable). Stateless is safe for the **single-process** connector —
   every tool is request/response — but two consequences are worth recording:
-  - **Single-process invariant (the real constraint — not stateless per se).** `await_upload`
-    reads an in-process completion map that the *session-less* `/files/ul` POST writes, and
-    `ConsumedJtiStore` (the single-use/replay guard) is likewise per-process. Because the file
-    routes carry no session id, a load balancer can't co-locate the POST and the poll even in
+  - **Single-process invariant (the real constraint — not stateless per se).** The `/files/ul`
+    signing key (`FileLinkSigner`) is minted per-process, and `FileLinkSigner.verify` MACs each
+    upload against *that* process's key; the in-process completion map that `await_upload` reads
+    and `ConsumedJtiStore` (the single-use/replay guard) are likewise per-process. Because the file
+    routes carry no session id, a load balancer can't co-locate the mint and the POST even in
     *stateful* mode — the hazard is **>1 replica**, which stateless only makes tempting. Under
-    multi-replica: (a) `await_upload` false-negatives — the upload still lands, and `source_list`
-    (an RPC to Google, works on any replica) is the source-of-truth backstop, so **no data loss**;
-    (b) the single-use guard degrades to per-replica, so a leaked token is replayable ~once per
-    replica within its TTL (low harm: a duplicate source, or re-downloading an artifact the
-    URL-holder could already fetch). To scale out, back both stores with a shared store (e.g.
-    Redis) or pin `/files/*` + `await_upload` to one replica.
+    multi-replica: (a) a `/files/ul` POST minted by one process but landing on another **fails
+    signature verification (403) — the source is never added**, not merely an `await_upload`
+    confirmation miss; (b) even with a shared signing key, `await_upload` would false-negative
+    across processes (`source_list`, an RPC to Google that works on any replica, is the
+    source-of-truth backstop) and the single-use guard degrades to per-process, so a leaked token
+    is replayable ~once per process within its TTL (low harm: a duplicate source, or re-downloading
+    an artifact the URL-holder could already fetch). To scale out, back the signing key **and** the
+    JTI / completion stores with a shared store (e.g. Redis) or pin `/files/*` + `await_upload` to
+    one replica.
   - **Forecloses server→client MCP features.** Stateless rules out sampling, elicitation, and
     subscriptions / out-of-band notifications (single-request progress notifications still work).
     Each is already covered otherwise — NotebookLM answers with its own grounded model, not the

--- a/docs/adr/0027-mcp-app-upload-widget.md
+++ b/docs/adr/0027-mcp-app-upload-widget.md
@@ -61,20 +61,20 @@ tool-count / schema-char budgets) unless a deployment enables it.
   `FASTMCP_STATELESS_HTTP` (overridable). Stateless is safe for the **single-process** connector —
   every tool is request/response — but two consequences are worth recording:
   - **Single-process invariant (the real constraint — not stateless per se).** The `/files/ul`
-    signing key (`FileLinkSigner`) is minted per-process, and `FileLinkSigner.verify` MACs each
-    upload against *that* process's key; the in-process completion map that `await_upload` reads
-    and `ConsumedJtiStore` (the single-use/replay guard) are likewise per-process. Because the file
-    routes carry no session id, a load balancer can't co-locate the mint and the POST even in
-    *stateful* mode — the hazard is **>1 replica**, which stateless only makes tempting. Under
+    signing key (`FileLinkSigner`) is minted per-process, and `FileLinkSigner.verify` checks each
+    upload token's signature against *that* process's key; the in-process completion map that
+    `await_upload` reads and `ConsumedJtiStore` (the single-use/replay guard) are likewise
+    per-process. Because the file routes carry no session id, a load balancer can't co-locate the
+    mint and the POST via MCP session affinity even in *stateful* mode (explicit cookie/IP affinity
+    still could) — the hazard is **>1 replica**, which stateless only makes tempting. Under
     multi-replica: (a) a `/files/ul` POST minted by one process but landing on another **fails
     signature verification (403) — the source is never added**, not merely an `await_upload`
     confirmation miss; (b) even with a shared signing key, `await_upload` would false-negative
     across processes (`source_list`, an RPC to Google that works on any replica, is the
-    source-of-truth backstop) and the single-use guard degrades to per-process, so a leaked token
-    is replayable ~once per process within its TTL (low harm: a duplicate source, or re-downloading
-    an artifact the URL-holder could already fetch). To scale out, back the signing key **and** the
-    JTI / completion stores with a shared store (e.g. Redis) or pin `/files/*` + `await_upload` to
-    one replica.
+    source-of-truth backstop) and the single-use guard (upload tokens only) degrades to per-process,
+    so a leaked upload token is replayable ~once per process within its TTL (low harm: a duplicate
+    source). To scale out, back the signing key **and** the JTI / completion stores with a shared
+    store (e.g. Redis) or pin token minting + `/files/*` + `await_upload` to one replica.
   - **Forecloses server→client MCP features.** Stateless rules out sampling, elicitation, and
     subscriptions / out-of-band notifications (single-request progress notifications still work).
     Each is already covered otherwise — NotebookLM answers with its own grounded model, not the

--- a/docs/adr/0027-mcp-app-upload-widget.md
+++ b/docs/adr/0027-mcp-app-upload-widget.md
@@ -66,15 +66,17 @@ tool-count / schema-char budgets) unless a deployment enables it.
     `await_upload` reads and `ConsumedJtiStore` (the single-use/replay guard) are likewise
     per-process. Because the file routes carry no session id, a load balancer can't co-locate the
     mint and the POST via MCP session affinity even in *stateful* mode (explicit cookie/IP affinity
-    still could) — the hazard is **>1 replica**, which stateless only makes tempting. Under
-    multi-replica: (a) a `/files/ul` POST minted by one process but landing on another **fails
-    signature verification (403) — the source is never added**, not merely an `await_upload`
-    confirmation miss; (b) even with a shared signing key, `await_upload` would false-negative
-    across processes (`source_list`, an RPC to Google that works on any replica, is the
-    source-of-truth backstop) and the single-use guard (upload tokens only) degrades to per-process,
-    so a leaked upload token is replayable ~once per process within its TTL (low harm: a duplicate
-    source). To scale out, back the signing key **and** the JTI / completion stores with a shared
-    store (e.g. Redis) or pin token minting + `/files/*` + `await_upload` to one replica.
+    still could) — the hazard is **>1 process** (multiple replicas, or a single replica running
+    multiple workers), which stateless only makes tempting. Under multi-process: (a) a `/files/ul`
+    POST minted by one process but landing on another **fails signature verification (403) — the
+    source is never added**, not merely an `await_upload` confirmation miss; (b) even with a shared
+    signing key, `await_upload` would false-negative across processes (`source_list`, an RPC to
+    Google that works on any replica, is the source-of-truth backstop) and the single-use guard
+    (upload tokens only) degrades to per-process, so a leaked upload token — a content-agnostic
+    write primitive — is replayable ~once per process within its TTL, each replay adding one more
+    attacker-chosen source (bounded by process count and TTL; a deployment wanting a hard cap needs
+    quota controls). To scale out, back the signing key **and** the JTI / completion stores with a
+    shared store (e.g. Redis) or pin token minting + `/files/*` + `await_upload` to one replica.
   - **Forecloses server→client MCP features.** Stateless rules out sampling, elicitation, and
     subscriptions / out-of-band notifications (single-request progress notifications still work).
     Each is already covered otherwise — NotebookLM answers with its own grounded model, not the


### PR DESCRIPTION
## What

Corrects the ADR-0027 "Consequences → single-process invariant" bullet, which described the wrong multi-replica hazard and mislabeled the invariant's scope.

## Correction

- **Real multi-replica hazard.** The `/files/ul` signing key (`FileLinkSigner`) is minted **per-process** (`src/notebooklm/mcp/__main__.py:175`) and `FileLinkSigner.verify` MACs every upload against *that* process's key (`src/notebooklm/mcp/_filelink.py:125` → flat 403). So under multi-replica, a `/files/ul` POST minted by one process but landing on another **fails signature verification (403) — the source is never added**, not merely an `await_upload` confirmation miss. Dropped the incorrect "the upload still lands … no data loss" wording; scaling out now correctly requires a **shared signing key** in addition to shared JTI/completion state.
- **Per-process, not per-replica.** The invariant is in-**process** (signing key + JTI store + completion map) — a single replica with multiple worker processes already breaks it. Replaced "per-replica" with "per-process".

Docs-only; no code or other sections changed. `scripts/check_docs_module_refs.py` passes.

Fixes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified multi-replica deployment risks for the in-app upload flow.
  * Explained how cross-process upload requests can fail verification and stop uploads from completing.
  * Updated scaling guidance to share upload verification/completion storage or ensure uploads are handled by a single replica.
  * Clarified token replay behavior across instances (effectively repeatable per process within TTL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->