### PR TITLE
fix(mcp): don't bypass the Host guard on a tokenless loopback bind (#1935)

### DIFF
--- a/src/notebooklm/mcp/__main__.py
+++ b/src/notebooklm/mcp/__main__.py
@@ -111,6 +111,24 @@ def _check_http_auth_required(host: str, token: str | None, oauth: OAuthConfig |
         )
 
 
+def _host_guard_bypass_allowed(
+    *, allow_external: bool, token: str | None, oauth: OAuthConfig | None
+) -> bool:
+    """Whether the loopback ``Host``-header (DNS-rebinding) guard may be bypassed.
+
+    The guard is safe to skip only when the operator opted into an external bind
+    (``ALLOW_EXTERNAL_BIND``) **and** auth is configured — a bearer/OAuth server can't
+    be DNS-rebound because the attacker's page can't present the credential. The env
+    flag ALONE is NOT sufficient (#1935): with the flag set but ``--host`` left at the
+    loopback default, :func:`_check_http_auth_required` does not require auth (a loopback
+    bind), so a flag-keyed bypass would leave a *tokenless* local server open to
+    DNS-rebinding — the exact hole #1876 set out to close. Keying on auth also keeps the
+    guard active for the default no-flag Claude Code bind (defense-in-depth) while still
+    letting an authed external/tunnel deployment accept its public-origin ``Host``.
+    """
+    return allow_external and (token is not None or oauth is not None)
+
+
 #: Values of ``FASTMCP_STATELESS_HTTP`` that FastMCP (pydantic-settings) reads as False.
 #: An explicit one of these (paired with the upload widget) is the footgun this warning
 #: guards (#1915). Kept in sync with pydantic's bool-false set (case-insensitive).
@@ -286,13 +304,19 @@ def main(argv: list[str] | None = None) -> None:
         # ourselves via NOTEBOOKLM_MCP_TRUST_PROXY (CF-Connecting-IP only), so keep the ASGI
         # peer the true socket peer. Nothing here derives security from the forwarded scheme
         # (OAuth endpoints + signed links use the explicitly-configured base URL).
-        # DNS-rebinding guard: a loopback bind skips bearer auth, so reject any
-        # request whose Host header isn't a loopback literal (mirrors the REST
-        # server; #1869). Skipped when an external bind is explicitly allowed —
-        # that path already mandates bearer/OAuth auth via _check_http_auth_required.
+        # DNS-rebinding guard: a loopback bind that isn't otherwise authenticated must
+        # reject any request whose Host header isn't a loopback literal (mirrors the REST
+        # server; #1869). The guard is bypassed ONLY when the operator opted into an
+        # external bind AND auth is configured (a credential the rebinding page can't
+        # present); the ALLOW_EXTERNAL_BIND flag alone is not enough, since with the flag
+        # set but --host left at loopback the auth-required check is skipped (#1935).
         from starlette.middleware import Middleware
 
         from ._host_guard import LoopbackHostGuardMiddleware
+
+        host_guard_bypass = _host_guard_bypass_allowed(
+            allow_external=allow_external, token=token, oauth=oauth_config
+        )
 
         # The MCP-App upload widget needs stateless HTTP: an MCP-Apps host (claude.ai) fetches the
         # ui:// widget resource on a connection WITHOUT the chat Mcp-Session-Id, which a stateful
@@ -307,7 +331,7 @@ def main(argv: list[str] | None = None) -> None:
             port=_resolve_port(args.port),
             stateless_http=stateless_http,
             uvicorn_config={"proxy_headers": False},
-            middleware=[Middleware(LoopbackHostGuardMiddleware, allow_external=allow_external)],
+            middleware=[Middleware(LoopbackHostGuardMiddleware, allow_external=host_guard_bypass)],
         )
     else:
         # show_banner=False keeps FastMCP's startup banner out of the host's logs

--- a/tests/unit/mcp/test_entrypoint.py
+++ b/tests/unit/mcp/test_entrypoint.py
@@ -125,6 +125,42 @@ def test_explicit_http_transport_binds_loopback(monkeypatch: pytest.MonkeyPatch)
     assert fake_server.run.call_args.kwargs["stateless_http"] is None
 
 
+def test_flagged_loopback_without_auth_keeps_host_guard_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1935 regression guard (entrypoint wiring): ALLOW_EXTERNAL_BIND=1 + default loopback
+    host + no auth must NOT bypass the Host guard. Auth is only *required* on a non-loopback
+    bind, so a flag-keyed bypass would leave a tokenless local server open to DNS-rebinding.
+    Catches a revert of the middleware wiring back to the raw flag (the direct
+    ``_host_guard_bypass_allowed`` unit test would not)."""
+    # OAuth env is cleared by the autouse _clear_oauth_env fixture; no token below → no auth.
+    fake_server = MagicMock()
+    monkeypatch.setattr(entry, "create_server", lambda **_: fake_server)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+
+    entry.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8123"])
+
+    _assert_http_run(fake_server, host="127.0.0.1", port=8123, allow_external=False)
+
+
+def test_flagged_loopback_with_oauth_bypasses_host_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flagged loopback bind WITH OAuth (a tunnel deployment) bypasses the Host guard so the
+    tunnel's public-origin Host isn't rejected — OAuth authenticates every request, so a
+    DNS-rebinding page can't present a credential."""
+    fake_server = MagicMock()
+    monkeypatch.setattr(entry, "create_server", lambda **_: fake_server)
+    monkeypatch.setenv("NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND", "1")
+    monkeypatch.delenv("NOTEBOOKLM_MCP_TOKEN", raising=False)
+    _set_oauth_env(monkeypatch)
+
+    entry.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8123"])
+
+    _assert_http_run(fake_server, host="127.0.0.1", port=8123, allow_external=True)
+
+
 def _run_http(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     fake_server = MagicMock()
     monkeypatch.setattr(entry, "create_server", lambda **_: fake_server)

--- a/tests/unit/mcp/test_host_guard.py
+++ b/tests/unit/mcp/test_host_guard.py
@@ -6,8 +6,14 @@ from typing import Any, cast
 
 import pytest
 
-from notebooklm.mcp.__main__ import _host_guard_bypass_allowed
-from notebooklm.mcp._host_guard import LoopbackHostGuardMiddleware
+pytest.importorskip("fastmcp")  # __main__ pulls in fastmcp via _auth
+
+from notebooklm.mcp.__main__ import (
+    _host_guard_bypass_allowed,  # noqa: E402 - after importorskip guard
+)
+from notebooklm.mcp._host_guard import (
+    LoopbackHostGuardMiddleware,  # noqa: E402 - after importorskip guard
+)
 
 
 class _Recorder:

--- a/tests/unit/mcp/test_host_guard.py
+++ b/tests/unit/mcp/test_host_guard.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
+from notebooklm.mcp.__main__ import _host_guard_bypass_allowed
 from notebooklm.mcp._host_guard import LoopbackHostGuardMiddleware
 
 
@@ -86,3 +89,33 @@ async def test_non_http_scope_passes_through() -> None:
         {"type": "lifespan"}, receive, send
     )
     assert app.reached is True
+
+
+# --- who may bypass the guard (the #1935 fix: flag alone is NOT enough) ---------
+@pytest.mark.parametrize(
+    ("allow_external", "token", "has_oauth", "expected_bypass"),
+    [
+        # default loopback dev — guard active
+        (False, None, False, False),
+        # loopback + bearer, no flag — guard stays active (defense-in-depth)
+        (False, "tok", False, False),
+        # OAuth but no flag — guard stays active (flag is necessary even with auth)
+        (False, None, True, False),
+        # flag set but NO auth (loopback default host) — guard MUST stay active (#1935)
+        (True, None, False, False),
+        # flag + bearer — authed external/tunnel bypasses
+        (True, "tok", False, True),
+        # flag + OAuth — authed external bypasses
+        (True, None, True, True),
+        # flag + both auth kinds — bypasses
+        (True, "tok", True, True),
+    ],
+)
+def test_host_guard_bypass_requires_flag_and_auth(
+    allow_external: bool, token: str | None, has_oauth: bool, expected_bypass: bool
+) -> None:
+    oauth = cast(Any, object()) if has_oauth else None
+    assert (
+        _host_guard_bypass_allowed(allow_external=allow_external, token=token, oauth=oauth)
+        is expected_bypass
+    )


### PR DESCRIPTION
## Summary
The loopback `Host`-header guard (DNS-rebinding protection, #1876) is disabled whenever `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1`, but auth is only *required* on a non-loopback effective bind. So **`flag=1` + `--host` left at the default `127.0.0.1` + no token/OAuth** = a **tokenless loopback server with the guard OFF** — a page resolving `evil.example → 127.0.0.1` can hit it with `Host: evil.example`.

Fix: the guard is bypassed only when the operator opted into an external bind **AND** auth is configured (`_host_guard_bypass_allowed = allow_external and (token is not None or oauth is not None)`) — a credential a DNS-rebinding page can't present. The env flag alone is no longer enough.

| flag | host | auth | guard |
|------|------|------|-------|
| off | loopback | any | **active** (defense-in-depth) |
| on | loopback | none | **active** ← the #1935 fix |
| on | loopback | token/oauth | bypassed (tunnel; auth blocks rebinding) |
| on | non-loopback | token/oauth | bypassed (external; auth required) |
| * | non-loopback | none | refused at startup |

FastMCP's `RequireAuthMiddleware` runs `verify_token` on **every** request (not interface-conditional), so the authed-bypass rows are safe.

## Test plan
- [x] `uv run pytest tests/unit/mcp/` (965 passed): truth table over `_host_guard_bypass_allowed` + **entrypoint-level** guards asserting the wired middleware kwarg (verified they fail if the wiring reverts to the raw flag)
- [x] ruff + mypy clean; `/polish` (code-simplifier + Claude + Codex security review) — 0 critical/important

Fixes #1935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened HTTP host-header protection when enabling external binding.
  * External binding no longer disables loopback Host-header protection unless authentication (bearer token and/or OAuth) is configured.
  * Added unit and entry-point regression tests to validate the Host guard bypass behavior across authenticated vs. unauthenticated configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->