### PR TITLE
test(e2e): stop interactive mind-map leak on post-create rate-limit skip (#1937)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -70,12 +70,14 @@ _COVERAGE_FLOOR_MARKERS = {
 # fails if an unregistered generate_/revise_/retry_ method appears on a covered class.
 #
 # Note: wrapping a whole method means a RateLimitError from a *post-create* RPC (e.g.
-# mind_maps.generate(wait=True) polling after the artifact id exists) would also skip
-# before its caller can clean up. The #1819 create-time case raises before any artifact
-# exists (no leak). To avoid the post-create-throttle leak, callers that need cleanup
-# create with wait=False (id captured, cleanup guard armed) and poll for completion
-# inside the guard — see tests/e2e/test_interactive_mind_map.py (#1937). The wrapper is
-# still whole-method: it covers the create-time skip; the guarded poll owns its own.
+# mind_maps.generate(wait=True) polling, or its settling _find_interactive LIST, after
+# CREATE_ARTIFACT already made the artifact) also skips — before generate returns the id
+# to its caller, so the caller can't clean up and the artifact leaks. The #1819
+# create-time case raises before any artifact exists (no leak). Splitting create from
+# poll does NOT close this: even generate(wait=False) issues a post-create LIST. Callers
+# that need cleanup therefore guard with an unconditional teardown sweep of the created
+# artifact type (id capture is unreliable across the skip) — see
+# tests/e2e/test_interactive_mind_map.py's swept_interactive_mind_maps fixture (#1937).
 _GENERATION_SKIP_TARGETS = {
     # ``retry_failed`` re-runs generation and raises RateLimitError on quota, same
     # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -70,10 +70,12 @@ _COVERAGE_FLOOR_MARKERS = {
 # fails if an unregistered generate_/revise_/retry_ method appears on a covered class.
 #
 # Note: wrapping a whole method means a RateLimitError from a *post-create* RPC (e.g.
-# mind_maps.generate(wait=True) polling after the artifact id exists) also skips. The
-# #1819 create-time case raises before any artifact exists (no leak); the rarer
-# post-create-throttle path may leave one artifact in the test notebook uncleaned —
-# an accepted trade-off for keeping the create-time skip simple (codex).
+# mind_maps.generate(wait=True) polling after the artifact id exists) would also skip
+# before its caller can clean up. The #1819 create-time case raises before any artifact
+# exists (no leak). To avoid the post-create-throttle leak, callers that need cleanup
+# create with wait=False (id captured, cleanup guard armed) and poll for completion
+# inside the guard — see tests/e2e/test_interactive_mind_map.py (#1937). The wrapper is
+# still whole-method: it covers the create-time skip; the guarded poll owns its own.
 _GENERATION_SKIP_TARGETS = {
     # ``retry_failed`` re-runs generation and raises RateLimitError on quota, same
     # as generate_*/revise_* — cover it too so a future e2e test doesn't hard-fail.

--- a/tests/e2e/test_interactive_mind_map.py
+++ b/tests/e2e/test_interactive_mind_map.py
@@ -12,9 +12,10 @@ Run: ``uv run pytest tests/e2e/test_interactive_mind_map.py -m e2e``
 
 from __future__ import annotations
 
+import contextlib
+
 import pytest
 
-from notebooklm.exceptions import RateLimitError
 from notebooklm.types import MindMapKind
 
 # Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
@@ -23,40 +24,58 @@ from notebooklm.types import MindMapKind
 pytestmark = pytest.mark.live_generation
 
 
+@pytest.fixture
+async def swept_interactive_mind_maps(client, generation_notebook_id):
+    """Guarantee no interactive mind map is orphaned in the live notebook.
+
+    ``_install_generation_rate_limit_skip`` (conftest, #1819) wraps the WHOLE
+    ``client.mind_maps.generate`` method, turning a quota ``RateLimitError``
+    into ``pytest.skip``. That skip can fire on *any* RPC inside ``generate``
+    that runs after ``CREATE_ARTIFACT`` has already created the artifact — the
+    completion poll (``wait=True``) OR the settling ``_find_interactive``
+    ``LIST_ARTIFACTS`` — before ``generate`` returns the id to the test. When
+    it does, the test never binds ``mind_map`` and its own ``finally`` delete
+    is skipped, orphaning the artifact (#1937).
+
+    This teardown runs regardless of test outcome (pass / fail / skip) and
+    deletes every interactive mind map left in the generation notebook, so no
+    post-create skip location can leak one. A create-time skip raises before
+    any artifact exists, so the sweep simply finds nothing. Best-effort: a
+    throttled sweep can't clean up, but the next session's pre-test
+    ``_cleanup_generation_notebook`` deletes all artifacts anyway.
+    """
+    yield
+    with contextlib.suppress(Exception):
+        for m in await client.mind_maps.list(generation_notebook_id):
+            if m.kind == MindMapKind.INTERACTIVE:
+                with contextlib.suppress(Exception):
+                    await client.mind_maps.delete(
+                        generation_notebook_id, m.id, kind=MindMapKind.INTERACTIVE
+                    )
+
+
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_interactive_mind_map_full_lifecycle(client, generation_notebook_id):
+async def test_interactive_mind_map_full_lifecycle(
+    client, generation_notebook_id, swept_interactive_mind_maps
+):
     nb_id = generation_notebook_id
     source_ids = await client.notebooks.get_source_ids(nb_id)
     assert source_ids, "generation notebook must have at least one source"
 
-    # --- generate (CREATE_ARTIFACT, type 4 / variant 4), NO wait ---
-    # Split the create from the completion-poll deliberately: ``wait=False``
-    # returns as soon as the artifact id exists, so the id is captured and the
-    # cleanup ``finally`` below is armed BEFORE any polling that can raise. A
-    # create-time quota rejection still raises RateLimitError here (inside the
-    # conftest generation skip wrapper, #1819) before any artifact exists, so
-    # it skips with nothing to leak. A *post-create* throttle, by contrast, now
-    # surfaces during the guarded poll — where the finally always deletes the
-    # already-created artifact instead of orphaning it in the live notebook
-    # (#1937).
+    # --- generate (CREATE_ARTIFACT, type 4 / variant 4) + poll to completion ---
+    # A quota RateLimitError from anywhere inside generate (create, the
+    # completion poll, or the settling _find_interactive list) is turned into
+    # pytest.skip by the conftest wrapper (#1819) — potentially before this
+    # returns and binds mind_map. The swept_interactive_mind_maps fixture is
+    # the leak guard for that case; the try/finally below cleans up promptly on
+    # the normal path and on an assertion failure (#1937).
     mind_map = await client.mind_maps.generate(
-        nb_id, source_ids, kind=MindMapKind.INTERACTIVE, wait=False
+        nb_id, source_ids, kind=MindMapKind.INTERACTIVE, wait=True
     )
     try:
         assert mind_map.kind == MindMapKind.INTERACTIVE
         assert mind_map.id, "generate() must return a non-empty interactive artifact id"
-
-        # --- poll to completion INSIDE the cleanup guard ---
-        # ``mind_maps.generate(wait=False)`` skips this poll, so it lives here
-        # rather than in the wrapped generate call. A post-create quota
-        # rejection is server-side throttling, not a client defect, so mirror
-        # the create-time skip (conftest #1819) — the ``finally`` still runs
-        # first and deletes the artifact, so the skip never leaks it.
-        try:
-            await client.artifacts.wait_for_completion(nb_id, mind_map.id)
-        except RateLimitError as e:
-            pytest.skip(f"Rate limit: {e}")
 
         # --- recognition (Phase 1) ---
         listed = {m.id: m for m in await client.mind_maps.list(nb_id)}

--- a/tests/e2e/test_interactive_mind_map.py
+++ b/tests/e2e/test_interactive_mind_map.py
@@ -43,15 +43,21 @@ async def swept_interactive_mind_maps(client, generation_notebook_id):
     any artifact exists, so the sweep simply finds nothing. Best-effort: a
     throttled sweep can't clean up, but the next session's pre-test
     ``_cleanup_generation_notebook`` deletes all artifacts anyway.
+
+    Enumerates via the *unfiltered* ``client.artifacts.list`` and matches
+    ``is_interactive_mind_map`` OR ``is_unclassified_type4`` — mirroring
+    ``_find_interactive(allow_unclassified=True)``. The strict
+    ``client.mind_maps.list`` filter would exclude a still-settling type-4 row
+    whose ``variant`` slot has not populated (``variant=None``), which is
+    exactly the state a throttled settling ``_find_interactive`` LIST leaves
+    behind — so the sweep must tolerate it too, or that narrowest window leaks.
     """
     yield
     with contextlib.suppress(Exception):
-        for m in await client.mind_maps.list(generation_notebook_id):
-            if m.kind == MindMapKind.INTERACTIVE:
+        for art in await client.artifacts.list(generation_notebook_id):
+            if art.is_interactive_mind_map or art.is_unclassified_type4:
                 with contextlib.suppress(Exception):
-                    await client.mind_maps.delete(
-                        generation_notebook_id, m.id, kind=MindMapKind.INTERACTIVE
-                    )
+                    await client.artifacts.delete(generation_notebook_id, art.id)
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_interactive_mind_map.py
+++ b/tests/e2e/test_interactive_mind_map.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 
+from notebooklm.exceptions import RateLimitError
 from notebooklm.types import MindMapKind
 
 # Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
@@ -29,15 +30,33 @@ async def test_interactive_mind_map_full_lifecycle(client, generation_notebook_i
     source_ids = await client.notebooks.get_source_ids(nb_id)
     assert source_ids, "generation notebook must have at least one source"
 
-    # --- generate (CREATE_ARTIFACT, type 4 / variant 4) + poll to completion ---
+    # --- generate (CREATE_ARTIFACT, type 4 / variant 4), NO wait ---
+    # Split the create from the completion-poll deliberately: ``wait=False``
+    # returns as soon as the artifact id exists, so the id is captured and the
+    # cleanup ``finally`` below is armed BEFORE any polling that can raise. A
+    # create-time quota rejection still raises RateLimitError here (inside the
+    # conftest generation skip wrapper, #1819) before any artifact exists, so
+    # it skips with nothing to leak. A *post-create* throttle, by contrast, now
+    # surfaces during the guarded poll — where the finally always deletes the
+    # already-created artifact instead of orphaning it in the live notebook
+    # (#1937).
     mind_map = await client.mind_maps.generate(
-        nb_id, source_ids, kind=MindMapKind.INTERACTIVE, wait=True
+        nb_id, source_ids, kind=MindMapKind.INTERACTIVE, wait=False
     )
-    # Enter the cleanup guard immediately after create so a failed assertion
-    # below never leaks the real interactive artifact in the live notebook.
     try:
         assert mind_map.kind == MindMapKind.INTERACTIVE
         assert mind_map.id, "generate() must return a non-empty interactive artifact id"
+
+        # --- poll to completion INSIDE the cleanup guard ---
+        # ``mind_maps.generate(wait=False)`` skips this poll, so it lives here
+        # rather than in the wrapped generate call. A post-create quota
+        # rejection is server-side throttling, not a client defect, so mirror
+        # the create-time skip (conftest #1819) — the ``finally`` still runs
+        # first and deletes the artifact, so the skip never leaks it.
+        try:
+            await client.artifacts.wait_for_completion(nb_id, mind_map.id)
+        except RateLimitError as e:
+            pytest.skip(f"Rate limit: {e}")
 
         # --- recognition (Phase 1) ---
         listed = {m.id: m for m in await client.mind_maps.list(nb_id)}


### PR DESCRIPTION
## Summary

- Fixes an e2e artifact leak: `tests/e2e/test_interactive_mind_map.py` ran create+poll via `mind_maps.generate(wait=True)` **outside** the `try/finally`. The conftest `_install_generation_rate_limit_skip` wraps the **whole** `generate` method (including its post-create `wait=True` poll), so a throttle during that poll raised `RateLimitError` → `pytest.skip` **before** `mind_map` was assigned — the cleanup `finally` never ran and the already-created interactive artifact was orphaned in the live notebook.
- **Fix:** split create from poll. `generate(wait=False)` captures the artifact id and arms the cleanup `finally` **before** any polling; then poll to completion via `client.artifacts.wait_for_completion(nb_id, mind_map.id)` **inside** the guard (identical call + defaults to what `generate(wait=True)` made internally — behavior-preserving). A post-create `RateLimitError` is converted to `pytest.skip` locally, so the `finally` deletes the artifact first and the skip never leaks it. Create-time throttling still skips via the whole-method wrapper (no artifact exists yet → no leak).
- Updates the conftest #1819 note: the post-create-throttle leak is no longer an accepted trade-off.

## Task

Closes #1937

## Test plan

This is an e2e test file (needs live auth, not run in CI). Verified without live run:
- [x] `ruff check .` + `ruff format --check .` — clean (whole tree)
- [x] `mypy src/notebooklm --ignore-missing-imports` — clean (313 files)
- [x] `pytest tests/e2e/test_interactive_mind_map.py --collect-only -q` — collects
- [x] Full non-e2e suite — 12287 passed / 77 skipped (lone `test_version_matches_pyproject` failure is a stale editable-install metadata artifact, unrelated to this test-only change)
- [x] Reasoned correctness (polish triple review: claude + codex + agy): `finally` runs on skip/raise, `wait=False` always returns a populated id, create-time skip preserved, no double-skip, all original assertions intact, poll parity with old internal `wait=True` path

## Deferred polish findings

- `finally` delete could itself raise and mask the `pytest.skip` (agy). **Deferred**: swallowing the delete exception prevents no leak (the artifact leaks iff delete fails, regardless), only flips a double-throttle test outcome from error→skip, and would introduce a silent-failure anti-pattern that hides genuinely broken cleanup. Pre-existing and unchanged by this diff; ranked non-blocking by 2 of 3 reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the interactive mind map end-to-end lifecycle test to use a best-effort cleanup fixture that removes orphaned interactive mind maps from the generation notebook, including cases where generation is skipped after an artifact is created but before the test can bind it.
  * Adjusted lifecycle/cleanup expectations to account for throttling-related skips that can occur during completion polling and settling.

* **Documentation**
  * Clarified how “wait” behavior can still skip during post-create polling/settling, and advised using an unconditional teardown sweep when cleanup reliability is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->