### PR TITLE
feat(mcp): record a sha256 completion record for uploaded files (#1889)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -163,6 +163,13 @@ bearer-only deploy → the two file tools return a clear "not configured" error
   type and the streamed `Content-Type` can't drift), and `size_bytes` (`null` — the
   size isn't known without eagerly fetching the artifact, which the broker won't do;
   the route sets the real `Content-Length` when the link is opened).
+- **Confirm an upload landed:** `await_upload` (pass the `human_upload.url` or bare token)
+  polls the in-process completion record and returns `{source_id, file:{name, size, mime,
+  sha256}}` once the add commits — `sha256` is the digest of exactly the bytes the server
+  received, so a client that hashed its local copy can confirm byte-integrity. An agent
+  `PUT`ing to the upload URL may also append `?sha256=<hex>`: the route verifies the received
+  stream against it and rejects a corrupted transfer with a clean 400 (retryable) *before*
+  adding the source.
 - Links are HMAC-signed and short-lived (upload 15 min, download 30 min) and expire on
   a server restart. Google Drive (`source_add` with a Drive id) remains a no-browser
   alternative for adding files. stdio (local) installs are unchanged — they still read

--- a/src/notebooklm/mcp/_filelink.py
+++ b/src/notebooklm/mcp/_filelink.py
@@ -226,7 +226,7 @@ class ConsumedJtiStore:
     #: the concurrent request count and always released in the route's ``finally``, so
     #: it needs no sweep or size cap.
     _active: set[str] = field(default_factory=set)
-    #: jti -> upload result ({source_id, name, size, mime}), recorded on a successful
+    #: jti -> upload result ({source_id, name, size, mime, sha256}), recorded on a successful
     #: :meth:`commit` that carries one. This is the in-process **completion map**
     #: (Phase 1 ``await_upload``): the ``/files/ul`` POST route and the polling tool run
     #: in the same single process (ADR-0024), so a same-loop poll reads what the route

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -191,6 +191,22 @@ def _upstream_error_response(exc: NotebookLMError, *, note: str = "") -> PlainTe
 _safe_upload_name = add_core.safe_upload_name
 
 
+#: Lowercase hex chars a SHA-256 digest can contain — the exact alphabet a valid
+#: ``?sha256=`` claim must be drawn from (64 of them).
+_HEX_LOWER = frozenset("0123456789abcdef")
+
+
+def _is_sha256_hex(value: str) -> bool:
+    """True iff ``value`` is a well-formed lowercase SHA-256 hex digest (64 hex chars).
+
+    The client's ``?sha256=`` claim is validated with this BEFORE it reaches
+    :func:`hmac.compare_digest` — which raises ``TypeError`` on any non-ASCII string
+    (e.g. a ``?sha256=%C3%A9`` probe would otherwise 500). A malformed claim is a clean
+    400, never a crash.
+    """
+    return len(value) == 64 and all(c in _HEX_LOWER for c in value)
+
+
 def _cleanup(path: str) -> None:
     """Remove a temp directory tree, ignoring an already-removed path."""
     shutil.rmtree(path, ignore_errors=True)
@@ -531,12 +547,20 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 mime = raw_mime.split(";")[0].strip() if raw_mime else None
                 # Optional client-provided SHA-256 of the file bytes (?sha256=<hex>). When the
                 # client hashed the bytes it holds, we verify the stream we received matches
-                # (end-to-end transit-integrity, #1889 Phase 4). Normalize to lowercase hex; a
-                # non-hex / wrong-length claim simply won't match the computed digest → the same
-                # clean 400 as a corrupted transfer. Absent → no verification, we still record
-                # the server-computed digest below.
+                # (end-to-end transit-integrity, #1889 Phase 4). A blank / whitespace-only value
+                # means "no claim" (skip verification, uniformly with the param being absent). A
+                # present-but-malformed claim (wrong length, non-hex, or non-ASCII — the last
+                # would make ``compare_digest`` raise ``TypeError`` → 500) is rejected here as a
+                # clean 400, BEFORE spooling the body, so garbage never drives a 200 MiB write.
                 claimed_raw = request.query_params.get("sha256")
-                claimed_sha = claimed_raw.strip().lower() if claimed_raw else None
+                # Blank / whitespace-only → None (== absent); otherwise the normalized hex.
+                claimed_sha: str | None = (claimed_raw or "").strip().lower() or None
+                if claimed_sha is not None and not _is_sha256_hex(claimed_sha):
+                    return PlainTextResponse(
+                        "Malformed sha256 parameter (expected 64 hex chars).",
+                        status_code=400,
+                        headers=_CORS_ORIGIN,  # cross-origin widget reads the status
+                    )
 
                 try:
                     temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
@@ -578,13 +602,13 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                             hasher.update(chunk)  # incremental — no extra buffering
                             out.write(chunk)
                     sha256 = hasher.hexdigest()
-                    # Integrity gate (#1889): if the client sent its own hash, the bytes we
-                    # received must match — else the transfer corrupted them. Reject BEFORE the
-                    # add so a corrupted file never becomes a source; the outer ``finally`` rolls
-                    # the jti back (uncommitted), so a corrected retry on the same link works.
-                    # ``compare_digest`` is the idiomatic digest comparison; timing isn't
-                    # sensitive here (the checksum is a client-supplied integrity value, not a
-                    # secret), but it costs nothing and reads clearly.
+                    # Integrity gate (#1889): if the client sent a (well-formed, validated above)
+                    # hash, the bytes we received must match — else the transfer corrupted them.
+                    # Reject BEFORE the add so a corrupted file never becomes a source; the outer
+                    # ``finally`` rolls the jti back (uncommitted), so a corrected retry on the
+                    # same link works. ``compare_digest`` is the idiomatic digest comparison —
+                    # both operands are ASCII hex here (so it never raises), and timing isn't
+                    # sensitive (a client-supplied integrity value, not a secret).
                     if claimed_sha is not None and not hmac.compare_digest(sha256, claimed_sha):
                         return PlainTextResponse(
                             "Upload integrity check failed (sha256 mismatch); retry the upload.",

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -25,6 +25,8 @@ This module imports NOTHING from ``server/`` (which pulls ``fastapi`` — absent
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import html
 import os
 import shutil
@@ -527,6 +529,14 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 filename = _safe_upload_name(request.query_params.get("filename"))
                 raw_mime = payload.get("mime") or request.headers.get("content-type")
                 mime = raw_mime.split(";")[0].strip() if raw_mime else None
+                # Optional client-provided SHA-256 of the file bytes (?sha256=<hex>). When the
+                # client hashed the bytes it holds, we verify the stream we received matches
+                # (end-to-end transit-integrity, #1889 Phase 4). Normalize to lowercase hex; a
+                # non-hex / wrong-length claim simply won't match the computed digest → the same
+                # clean 400 as a corrupted transfer. Absent → no verification, we still record
+                # the server-computed digest below.
+                claimed_raw = request.query_params.get("sha256")
+                claimed_sha = claimed_raw.strip().lower() if claimed_raw else None
 
                 try:
                     temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ul-")  # mkdtemp is 0o700
@@ -553,6 +563,7 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 try:
                     fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
                     total = 0
+                    hasher = hashlib.sha256()  # digest of exactly the bytes that landed
                     with os.fdopen(fd, "wb") as out:
                         async for chunk in request.stream():
                             if not chunk:
@@ -564,7 +575,22 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                                     status_code=413,
                                     headers=_CORS_ORIGIN,  # cross-origin widget reads the status
                                 )
+                            hasher.update(chunk)  # incremental — no extra buffering
                             out.write(chunk)
+                    sha256 = hasher.hexdigest()
+                    # Integrity gate (#1889): if the client sent its own hash, the bytes we
+                    # received must match — else the transfer corrupted them. Reject BEFORE the
+                    # add so a corrupted file never becomes a source; the outer ``finally`` rolls
+                    # the jti back (uncommitted), so a corrected retry on the same link works.
+                    # ``compare_digest`` is the idiomatic digest comparison; timing isn't
+                    # sensitive here (the checksum is a client-supplied integrity value, not a
+                    # secret), but it costs nothing and reads clearly.
+                    if claimed_sha is not None and not hmac.compare_digest(sha256, claimed_sha):
+                        return PlainTextResponse(
+                            "Upload integrity check failed (sha256 mismatch); retry the upload.",
+                            status_code=400,
+                            headers=_CORS_ORIGIN,  # cross-origin widget reads the status
+                        )
                     plan = add_core.build_source_add_plan(
                         content=os.path.realpath(temp_path),
                         source_type="file",
@@ -590,8 +616,10 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                     # map so a same-process ``await_upload`` poll surfaces the added source
                     # (Phase 1); it is success-only by construction — a failed upload writes
                     # nothing, so ``await_upload`` stays "pending" and the model falls back
-                    # to ``source_list``. ``sha256`` is intentionally absent until the
-                    # deferred client/stream hashing (Phase 4) lands.
+                    # to ``source_list``. ``sha256`` is the digest of exactly the bytes that
+                    # landed, so ``await_upload`` can confirm byte-integrity of what was uploaded
+                    # (#1889 Phase 4) — already checked against the client's claim above when one
+                    # was sent.
                     config.jti_store.commit(
                         jti,
                         payload["exp"],
@@ -600,6 +628,7 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                             "name": filename,
                             "size": total,
                             "mime": mime,
+                            "sha256": sha256,
                         },
                     )
                     committed = True

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -583,6 +583,55 @@ def test_upload_post_mismatched_client_sha256_rejected_and_retryable(mock_client
     assert retried.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        "%C3%A9",  # non-ASCII (é) — would make hmac.compare_digest raise TypeError → 500
+        "deadbeef",  # too short
+        "z" * 64,  # right length, non-hex alphabet
+        "0" * 63,  # off-by-one length
+    ],
+)
+def test_upload_post_malformed_client_sha256_is_clean_400_not_500(
+    mock_client, config, bad_sha
+) -> None:
+    # A present-but-malformed ?sha256= (esp. non-ASCII) must be a clean 400 BEFORE any spool,
+    # never reach compare_digest (which raises TypeError on non-ASCII), and never add a source.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(app) as client:  # default raise_server_exceptions=True
+        resp = client.post(_path(url) + f"?filename=a.pdf&sha256={bad_sha}", content=b"PDFDATA")
+    assert resp.status_code == 400
+    assert "malformed sha256" in resp.text.lower()
+    assert resp.headers["access-control-allow-origin"] == "*"
+    add_file.assert_not_awaited()  # rejected before the add
+
+
+def test_upload_post_blank_client_sha256_skips_verification(mock_client, config) -> None:
+    # A blank / whitespace-only ?sha256= is "no claim" (uniform with the param being absent):
+    # verification is skipped and the add proceeds, but the server digest is still recorded.
+    add_file = AsyncMock(return_value=MagicMock(id="src-blank"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    jti = config.signer.verify(url.rsplit("/", 1)[1], op="ul")["jti"]
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(_path(url) + "?filename=a.pdf&sha256=%20%20", content=b"PDFDATA")
+    assert resp.status_code == 200
+    add_file.assert_awaited_once()
+    assert config.jti_store.completed(jti)["sha256"] == hashlib.sha256(b"PDFDATA").hexdigest()
+
+
+def test_is_sha256_hex_helper() -> None:
+    # Unit-level guard on the validator the route relies on to keep non-ASCII off compare_digest.
+    assert _fileroutes._is_sha256_hex(hashlib.sha256(b"x").hexdigest())
+    assert not _fileroutes._is_sha256_hex("é" * 64)  # non-ASCII
+    assert not _fileroutes._is_sha256_hex("A" * 64)  # uppercase (route lowercases first)
+    assert not _fileroutes._is_sha256_hex("abc")  # too short
+
+
 def test_upload_failed_add_records_no_completion_result(monkeypatch, mock_client, config) -> None:
     # Success-only by design: a failed add rolls the jti back (retryable) and writes NO
     # completion record, so await_upload stays "pending" rather than reporting a phantom add.

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -526,8 +526,9 @@ def test_upload_cors_preflight_and_allow_origin(mock_client, config) -> None:
 
 
 def test_upload_post_records_completion_result_for_await_upload(mock_client, config) -> None:
-    # Phase 1: a successful POST records {source_id, name, size, mime} in the in-process
-    # completion map keyed by jti, so a same-process await_upload poll surfaces the source.
+    # Phase 1/4: a successful POST records {source_id, name, size, mime, sha256} in the in-process
+    # completion map keyed by jti, so a same-process await_upload poll surfaces the source AND the
+    # byte-integrity digest of exactly what landed (#1889).
     add_file = AsyncMock(return_value=MagicMock(id="src-77"))
     mock_client.sources.add_file = add_file
     app = _build(mock_client, config)
@@ -543,7 +544,43 @@ def test_upload_post_records_completion_result_for_await_upload(mock_client, con
         "name": "paper.pdf",
         "size": len(b"PDFDATA"),
         "mime": "application/pdf",
+        "sha256": hashlib.sha256(b"PDFDATA").hexdigest(),  # digest of exactly the bytes received
     }
+
+
+def test_upload_post_verifies_matching_client_sha256(mock_client, config) -> None:
+    # #1889: a client that hashed the bytes it holds can pass ?sha256=<hex>; a MATCHING digest
+    # of the received stream lets the add proceed (end-to-end transit integrity confirmed).
+    add_file = AsyncMock(return_value=MagicMock(id="src-ok"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    digest = hashlib.sha256(b"PDFDATA").hexdigest()
+    with starlette_testclient.TestClient(app) as client:
+        resp = client.post(
+            _path(url) + f"?filename=paper.pdf&sha256={digest.upper()}", content=b"PDFDATA"
+        )
+    assert resp.status_code == 200  # case-insensitive hex accepted
+    add_file.assert_awaited_once()
+
+
+def test_upload_post_mismatched_client_sha256_rejected_and_retryable(mock_client, config) -> None:
+    # #1889: a WRONG ?sha256= means the bytes corrupted in transit → reject with a clean 400
+    # BEFORE the add (no source created), and the jti rolls back so a corrected retry works.
+    add_file = AsyncMock(return_value=MagicMock(id="src-1"))
+    mock_client.sources.add_file = add_file
+    app = _build(mock_client, config)
+    url = config.upload_url({"op": "ul", "nb": NB})
+    bad = "0" * 64  # valid-shaped hex that cannot match the real digest
+    with starlette_testclient.TestClient(app) as client:
+        rejected = client.post(_path(url) + f"?filename=a.pdf&sha256={bad}", content=b"PDFDATA")
+        # jti rolled back → the SAME link works on a corrected retry (no sha256 claim this time)
+        retried = client.post(_path(url) + "?filename=a.pdf", content=b"PDFDATA")
+    assert rejected.status_code == 400
+    assert "integrity check failed" in rejected.text.lower()
+    assert rejected.headers["access-control-allow-origin"] == "*"  # widget can read the reason
+    add_file.assert_awaited_once()  # only the retry added a source; the mismatch never did
+    assert retried.status_code == 200
 
 
 def test_upload_failed_add_records_no_completion_result(monkeypatch, mock_client, config) -> None:


### PR DESCRIPTION
## Item 2 of the #1938 backend upload follow-ups — sha256 completion record (#1889 Phase 4)

### What
The `/files/ul` upload route now computes the **SHA-256 of exactly the bytes it receives** (incrementally, chunk-by-chunk — no extra buffering, so a 200 MiB stream costs one hash context, not a second copy) and records it in the in-process completion map alongside `{source_id, name, size, mime}`. A same-process `await_upload` poll already returns the whole record as `file`, so it now surfaces `sha256` with **no change to `await_upload`** — the model/caller can confirm the byte-integrity of what landed.

### Optional end-to-end verification
A client that hashed its local copy may append `?sha256=<hex>` to the upload URL. The route compares its computed digest against the claim (case-insensitive hex, `hmac.compare_digest`) and, on mismatch, rejects the corrupted transfer with a clean **400 before adding the source** — the jti rolls back via the existing `finally`, so a corrected retry on the same link works. An absent claim simply skips verification while still recording the server-computed digest.

### Why this shape
- **Server-computed digest is authoritative** for "what was uploaded" — it's the hash of the exact bytes that reached the server, so `await_upload` always has an integrity value even for the browser/widget path that sends no hash.
- **The client claim is the transit-integrity check** — the only way to catch corruption between the client and the server, and it's opt-in so it never breaks an existing caller.
- The current widget JS is left untouched (it sends no hash): computing SHA-256 in the sandboxed iframe means reading the whole file into memory, which is memory-sensitive on mobile and belongs with the frontend agent's later JS work. The server-recorded digest already satisfies the completion-record requirement.

### Files
- `_fileroutes.py` — compute + record `sha256`; optional `?sha256=` verify gate.
- `_filelink.py` — completion-map shape doc updated to `{…, sha256}`.
- `docs/mcp-guide.md` — document the `await_upload` `sha256` field + the `?sha256=` integrity param.

### Tests (`test_fileroutes.py`)
- completion record now includes `sha256` = digest of the received bytes;
- a matching `?sha256=` (upper-case, to prove case-insensitivity) → 200, add proceeds;
- a mismatched `?sha256=` → 400 "integrity check failed", **no** source added, jti retryable, ACAO present.

`mypy`, `ruff check`/`format`, the MCP unit suite, and `tests/_guardrails` (module-size — `_fileroutes.py` at 699/1000 — + schema-char) all green.

Addresses part of #1938 (other items open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SHA-256 integrity verification for file uploads (via `?sha256=<hex>`) to help detect corrupted transfers.
  * Upload completion results now include the server-recorded SHA-256 alongside file metadata.
  * Integrity failures return a clear 400 response and do not create a source; corrected uploads can still be retried using the same link.

* **Documentation**
  * Updated the upload guide to describe the post-upload confirmation step and checksum options.

* **Tests**
  * Expanded unit coverage for matching, mismatching, malformed, and empty checksum inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->