### PR TITLE
feat(mcp): emit report_progress keepalives during await_upload's poll (#1889)

### DIFF
--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -419,9 +419,8 @@ def register_file_tools(mcp: Any) -> None:
             # watching for a stalled call sees liveness across the ~45s wait — the re-invoke
             # loop stays the load-bearing completion path. ``progress`` climbs a plain tick
             # counter (an honest liveness ping, not an upload %-done — this polls, it doesn't
-            # transfer the bytes). ``report_progress`` no-ops when the client sent no
-            # progressToken, and ``_await_upload`` swallows any error, so this never fails the
-            # tool.
+            # transfer the bytes). It's best-effort by ``_await_upload``'s contract (swallowed
+            # on error; a no-op when the client sent no progressToken).
             ticks = 0
 
             async def _keepalive() -> None:

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -325,9 +325,20 @@ async def _await_upload(
     - ``{"status": "expired_or_invalid", "hint": ...}`` — the link failed signature/
       expiry/op checks; mint a fresh one via ``source_add(source_type="file")``.
 
-    ``progress`` (best-effort) is awaited at t=0 and each tick as a keepalive; the design
-    does not depend on it.
+    ``progress`` (best-effort) is awaited at t=0 and each poll tick as a keepalive; the
+    design does not depend on it, so its exceptions are swallowed (a missing client
+    progressToken or a transient notify error must never abort the wait — the re-invoke
+    loop, not the keepalive, is the load-bearing completion path).
     """
+
+    async def _emit_progress() -> None:
+        if progress is None:
+            return
+        try:
+            await progress()
+        except Exception:  # noqa: BLE001 - best-effort keepalive, never abort the poll
+            pass
+
     invalid = {
         "status": "expired_or_invalid",
         "hint": "this upload link is invalid or expired — call "
@@ -360,8 +371,7 @@ async def _await_upload(
         return invalid
     jti = str(payload.get("jti") or "")
     deadline = time.monotonic() + timeout_s
-    if progress is not None:
-        await progress()
+    await _emit_progress()
     while True:
         result = cfg.jti_store.completed(jti)
         if result is not None:
@@ -374,8 +384,7 @@ async def _await_upload(
         # Never sleep past the deadline — cap the tick to the time remaining so a small
         # custom timeout returns ``pending`` on time instead of overshooting by an interval.
         await asyncio.sleep(min(poll_interval_s, max(0.0, deadline - time.monotonic())))
-        if progress is not None:
-            await progress()
+        await _emit_progress()
 
 
 def register_file_tools(mcp: Any) -> None:
@@ -405,7 +414,19 @@ def register_file_tools(mcp: Any) -> None:
                     "await_upload needs the remote signed-URL transport; set "
                     "NOTEBOOKLM_MCP_PUBLIC_URL on the server to enable it"
                 )
-            # ponytail: no ctx.report_progress keepalive yet — the re-invoke loop is the
-            # load-bearing completion path; add one only if a live claude.ai timing test
-            # shows the ~45s poll needs it (ADR-0024 / Phase 1 plan).
-            return await _await_upload(cfg, upload_link, timeout_s=timeout)
+
+            # Emit a progress notification each poll tick (t=0 + every ~2s) so an MCP host
+            # watching for a stalled call sees liveness across the ~45s wait — the re-invoke
+            # loop stays the load-bearing completion path. ``progress`` climbs a plain tick
+            # counter (an honest liveness ping, not an upload %-done — this polls, it doesn't
+            # transfer the bytes). ``report_progress`` no-ops when the client sent no
+            # progressToken, and ``_await_upload`` swallows any error, so this never fails the
+            # tool.
+            ticks = 0
+
+            async def _keepalive() -> None:
+                nonlocal ticks
+                ticks += 1
+                await ctx.report_progress(progress=ticks, message="waiting for the upload to land…")
+
+            return await _await_upload(cfg, upload_link, timeout_s=timeout, progress=_keepalive)

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -9,7 +9,11 @@ status dict. Testing it directly avoids standing up the whole HTTP MCP server
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,6 +22,7 @@ pytest.importorskip("fastmcp")
 import notebooklm.mcp._filelink as filelink  # noqa: E402
 from notebooklm.exceptions import ValidationError  # noqa: E402
 from notebooklm.mcp._filelink import FileLinkSigner, FileTransferConfig  # noqa: E402
+from notebooklm.mcp.server import create_server  # noqa: E402
 from notebooklm.mcp.tools._fileupload import (  # noqa: E402
     _await_upload,
     _broker_upload,
@@ -165,3 +170,66 @@ async def test_expired_token_with_no_committed_result_stays_invalid(monkeypatch)
     monkeypatch.setattr(filelink.time, "time", lambda: exp + 5)
     out = await _await_upload(cfg, url, timeout_s=0, poll_interval_s=0)
     assert out["status"] == "expired_or_invalid"
+
+
+# --------------------------------------------------------------------------- #
+# Progress keepalive (Item 3 / #1889) — the host sees liveness across the ~45s poll
+# --------------------------------------------------------------------------- #
+async def test_progress_keepalive_invoked_at_t0_and_each_tick() -> None:
+    # The progress hook fires at t=0 AND on every poll tick, so an MCP host watching for a
+    # stalled call sees liveness across the whole wait (not just once).
+    cfg = _cfg()
+    url, _ = _mint(cfg)
+    calls = 0
+
+    async def _progress() -> None:
+        nonlocal calls
+        calls += 1
+
+    # Nothing committed → polls until the timeout; expect the t=0 emit plus ≥1 tick emit.
+    out = await _await_upload(cfg, url, timeout_s=0.05, poll_interval_s=0.01, progress=_progress)
+    assert out["status"] == "pending"
+    assert calls >= 2
+
+
+async def test_progress_keepalive_errors_are_swallowed() -> None:
+    # Best-effort by contract: a keepalive that raises (no client progressToken / transient
+    # notify failure) must NOT abort the poll or surface as an error.
+    cfg = _cfg()
+    url, jti = _mint(cfg)
+    cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-ok"})
+
+    async def _boom() -> None:
+        raise RuntimeError("notify channel closed")
+
+    out = await _await_upload(cfg, url, timeout_s=0.05, poll_interval_s=0.01, progress=_boom)
+    assert out["status"] == "received"  # the raising keepalive did not break the wait
+    assert out["source_id"] == "s-ok"
+
+
+async def test_await_upload_tool_emits_report_progress() -> None:
+    # End-to-end wiring: the await_upload TOOL passes a ctx.report_progress keepalive down to
+    # the poll, so a real host receives progress notifications during the wait.
+    cfg = _cfg()
+    url, jti = _mint(cfg)
+    cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-ok"})
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    mcp = create_server(client_factory=factory, file_transfer=cfg)
+    tool = {t.name: t for t in await mcp._list_tools()}["await_upload"]
+    report = AsyncMock()
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
+        ),
+        report_progress=report,
+    )
+
+    out = await tool.fn(ctx, upload_link=url, timeout=0.0)
+    assert out["status"] == "received"
+    report.assert_awaited()  # the keepalive fired (at least the t=0 emit)
+    # It carries a human-readable status message (an honest liveness ping).
+    assert any(call.kwargs.get("message") for call in report.await_args_list)

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -12,12 +12,13 @@ import asyncio
 import contextlib
 import time
 from collections.abc import AsyncIterator
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 pytest.importorskip("fastmcp")
+
+from fastmcp import Client  # noqa: E402
 
 import notebooklm.mcp._filelink as filelink  # noqa: E402
 from notebooklm.exceptions import ValidationError  # noqa: E402
@@ -207,9 +208,10 @@ async def test_progress_keepalive_errors_are_swallowed() -> None:
     assert out["source_id"] == "s-ok"
 
 
-async def test_await_upload_tool_emits_report_progress() -> None:
-    # End-to-end wiring: the await_upload TOOL passes a ctx.report_progress keepalive down to
-    # the poll, so a real host receives progress notifications during the wait.
+async def test_await_upload_tool_delivers_progress_over_the_protocol() -> None:
+    # End-to-end over the REAL MCP protocol (in-memory Client with a progressToken-bearing
+    # request): the await_upload tool's keepalive reaches the client as an actual progress
+    # notification — not merely that ctx.report_progress was called.
     cfg = _cfg()
     url, jti = _mint(cfg)
     cfg.jti_store.commit(jti, int(time.time()) + 60, result={"source_id": "s-ok"})
@@ -218,18 +220,18 @@ async def test_await_upload_tool_emits_report_progress() -> None:
     async def factory() -> AsyncIterator[MagicMock]:
         yield MagicMock()
 
-    mcp = create_server(client_factory=factory, file_transfer=cfg)
-    tool = {t.name: t for t in await mcp._list_tools()}["await_upload"]
-    report = AsyncMock()
-    ctx = SimpleNamespace(
-        request_context=SimpleNamespace(
-            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
-        ),
-        report_progress=report,
-    )
+    server = create_server(client_factory=factory, file_transfer=cfg)
+    updates: list[tuple[float, str | None]] = []
 
-    out = await tool.fn(ctx, upload_link=url, timeout=0.0)
-    assert out["status"] == "received"
-    report.assert_awaited()  # the keepalive fired (at least the t=0 emit)
+    async def on_progress(progress: float, total: float | None, message: str | None) -> None:
+        updates.append((progress, message))
+
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "await_upload", {"upload_link": url, "timeout": 0.0}, progress_handler=on_progress
+        )
+
+    assert result.data["status"] == "received"
+    assert updates, "the keepalive must reach the client as a real progress notification"
     # It carries a human-readable status message (an honest liveness ping).
-    assert any(call.kwargs.get("message") for call in report.await_args_list)
+    assert any(msg for _progress, msg in updates)


### PR DESCRIPTION
## Item 3 of the #1938 backend upload follow-ups — report_progress keepalive (#1889)

### What & why
`await_upload` polls the in-process completion map for up to ~45 s (bounded just under claude.ai's ~60 s connector watchdog). On a slow upload, an MCP host watching for a stalled call could consider that single poll window dead. This wires `ctx.report_progress` into the `await_upload` tool so it emits a progress notification at **t=0 and each ~2 s tick**, giving the host visible liveness across the wait.

The re-invoke loop stays the **load-bearing** completion path — the keepalive is purely a "still alive" signal, so `progress` climbs a plain tick counter with a status message rather than pretending to be an upload %-done (the tool polls; it does not transfer the bytes).

### Scope note (coordinated with the lead)
The brief listed `_fileroutes.py` for this item, but `/files/ul` is a raw Starlette HTTP route (the browser→server byte transfer) with **no MCP `ctx`** — there is no progress channel there. The MCP call a host can consider stalled is the `await_upload` **tool**, which already had an unused best-effort `progress` hook in `_await_upload` (`tools/_fileupload.py`) and a ponytail TODO for exactly this. So the change lands there. It does **not** overlap `fix/consolidate-source-add-1890` (whose `_fileupload.py` edits are top-of-file docstring renames, far from `await_upload`).

### Best-effort by contract
- `report_progress` no-ops when the client sent no `progressToken`.
- `_await_upload` now **centrally swallows** any progress-callback error (`_emit_progress`), enforcing the "the design does not depend on it" contract that was previously only documented — a notify failure can never abort the wait.

### Tool surface unchanged
`await_upload(ctx, upload_link, timeout=45.0)` signature/docstring are untouched → no ADR-0025 schema-char / tool-count impact (verified: `test_tool_eval`, `test_manifest` green). `_fileupload.py` at 432/1000 lines.

### Tests (`test_await_upload.py`)
- keepalive fires at t=0 **and** each poll tick (≥2 calls over a short poll);
- a **raising** keepalive is swallowed → the poll still returns `received`;
- end-to-end: the `await_upload` **tool** (built via `create_server`) awaits `ctx.report_progress` with a status message.

`mypy`, `ruff`, MCP unit suite, and the touched guardrails all green.

Addresses part of #1938 (other items open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional MCP progress notifications during file upload waiting, including an initial update and periodic keepalive-style updates.
  * Progress updates now include human-readable status messages and are delivered as real protocol notifications.
* **Bug Fixes**
  * Progress/keepalive reporting failures are now handled best-effort, so errors in progress callbacks no longer interrupt or fail the upload-wait flow.
* **Tests**
  * Expanded unit and end-to-end MCP coverage for keepalive/progress behavior and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->