### PR TITLE
docs(mcp): sharpen the source_add_drive_file tool docstring (#1896)

### DIFF
--- a/src/notebooklm/mcp/tools/sources_drive.py
+++ b/src/notebooklm/mcp/tools/sources_drive.py
@@ -39,20 +39,20 @@ def register(mcp: Any) -> None:
         title: str | None = None,
         wait: bool = False,
     ) -> dict[str, Any]:
-        """Add an upload-only Google Drive file (epub/docx/txt/md/rtf/odt/csv/tsv/pdf).
+        """Add a Google Drive file by downloading it server-side and uploading it (supports
+        epub/docx/txt/md/rtf/odt/csv/tsv/pdf).
 
-        Use this for the Drive file types NotebookLM's native Drive import can't
-        ingest: the file is downloaded from Drive on the server and uploaded. For
-        a Google-native Doc/Slides/Sheet (imported by reference), use
-        ``source_add(source_type='drive', mime_type=…)`` instead — this tool
-        returns a pointer error for those, since they aren't downloadable.
+        Probes the Drive file and routes: a downloadable type is fetched server-side and
+        uploaded; a Google-native Doc/Slides/Sheet isn't downloadable and returns a pointer
+        error → use ``source_add(source_type='drive', mime_type=…)`` for those (or for a
+        Drive PDF you'd rather add by reference). Use ``source_add(source_type='file')`` when
+        you hold the bytes locally.
 
-        Accepts a notebook name or ID, and a raw Drive file id or a Drive share
-        URL (``/d/<id>``, ``/file/d/<id>/…``, or ``?id=<id>``). The fetch runs
-        server-side with the profile's session, so it works over the remote (http)
-        connector too — no ``upload_required`` step. The import is processed
-        ASYNCHRONOUSLY; pass ``wait=true`` to block until it is READY (or confirm
-        later with ``source_wait`` / ``source_list(status="error")``).
+        Accepts a notebook name or ID and a Drive file id or share URL (``/d/<id>``,
+        ``/file/d/<id>/…``, ``?id=<id>``). The fetch runs server-side with the profile's
+        session, so it works on the remote (http) connector too — no ``upload_required``
+        step. Processed ASYNCHRONOUSLY; pass ``wait=true`` to block until READY (else
+        confirm via ``source_wait`` / ``source_list(status="error")``).
         """
         client = get_client(ctx)
         with mcp_errors():


### PR DESCRIPTION
## Summary

Sharpens the agent-facing docstring (schema description) of the `source_add_drive_file` MCP tool so it accurately states **when to use each Drive/upload path**. Docstring-only — no behavior change.

The tool probes a Drive file and routes: a downloadable type is fetched server-side and uploaded; a Google-native Doc/Slides/Sheet is not downloadable and returns a pointer error to `source_add(source_type='drive', mime_type=…)` (#1884/#1885/#1887).

The rewritten docstring:
- frames the **probe/route** behavior instead of a bare "auto-route";
- gives the **three-way decision** — this tool (download a Drive file) vs `source_add(source_type='drive')` (Google-native Docs/Slides/Sheets, or a Drive PDF *by reference*) vs `source_add(source_type='file')` (local bytes);
- drops the inaccurate "the ones NotebookLM's native Drive import can't ingest" framing — a Drive **PDF** is ingestible by-reference too, so it can go either way (this was flagged in review).

## Budget

Stays within `SCHEMA_CHAR_BUDGET`: full surface total **39,030 ≤ 39,050** cap (no ratchet change).

## Task

Addresses part of #1938 (#1896 ADR-0025 folds). Does not close #1938.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run pytest tests/unit/mcp/test_sources_drive.py tests/unit/mcp/test_tool_eval.py tests/unit/mcp/test_manifest.py` — pass; full suite green except the pre-existing `test_version_matches_pyproject` (stale-venv metadata artifact, unrelated).

## Deferred polish findings

None. (Codex's two Important accuracy findings — the PDF-ingest framing and the over-broad "in Drive" guidance — were applied before opening this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified supported Google Drive file handling for the “add by file” workflow, including which downloadable formats are routed through download→upload.
  * Explained how Google-native Docs/Slides/Sheets and selected PDFs may require adding by reference instead.
  * Updated the “wait” guidance to confirm readiness and check error status during asynchronous processing.
  * Refreshed the CLI command help text to match the documented Drive support behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->