### PR TITLE
feat(mcp): auto-confirm widget uploads without a second prompt (#1891) [needs live-rendering verification]

### DIFF
--- a/docs/adr/0027-mcp-app-upload-widget.md
+++ b/docs/adr/0027-mcp-app-upload-widget.md
@@ -52,9 +52,19 @@ tool-count / schema-char budgets) unless a deployment enables it.
 - The `ui.domain` gate is computed per-process from the public URL; a deployment behind a
   different URL than configured will not render (fails closed, silently — the link flow remains).
 - CORS on `/files/ul` is now permissive-origin; acceptable given token-only auth.
-- Follow-ups (not in the first cut): a progress bar, the fallback ladder
-  (`window.openai.uploadFile` → direct-PUT → link), and auto-wiring `await_upload` so the model
-  confirms the add without a second prompt.
+- **Auto-confirm without a second prompt (#1891).** The upload completes client-side, in a later
+  turn, *after* `source_add_widget` has already returned (the host renders the widget from the tool
+  result, so the tool cannot block-and-wait) — there is no active model turn when a file lands. So
+  the confirmation must be *triggered by the widget*, not the tool. `source_add_widget` returns a
+  machine-readable `confirm: {tool: "await_upload", arg: "upload_link", values: upload_urls}`
+  contract, and on each successful `/files/ul` POST the widget invokes it host-appropriately —
+  `window.openai.callTool` on ChatGPT, a `tools/call` postMessage on claude.ai — passing the link it
+  just uploaded to. The host runs `await_upload`, whose result flows to the model as confirmation.
+  Purely additive and best-effort: a host that does not run a widget-initiated call simply leaves
+  the model on the manual `await_upload` / `source_list` fallback. The exact claude.ai widget→host
+  invocation shape is host-specific and undocumented, so it is verified live, not headlessly.
+- Follow-ups still deferred: a progress bar and the fallback ladder
+  (`window.openai.uploadFile` → direct-PUT → link).
 - **Requires stateless HTTP.** An MCP-Apps host reads the `ui://` widget resource on a connection
   without the chat `Mcp-Session-Id`; a stateful FastMCP server rejects that ("Missing session ID"
   → "fail to fetch app content"). Enabling the widget therefore auto-enables

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -88,7 +88,19 @@ _WIDGET_HTML = """<!doctype html>
  const oai=window.openai;               // ChatGPT/Grok inject this; claude.ai does not
  const hasNative=!!(oai&&typeof oai.uploadFile==="function");  // OpenAI native upload (interop signal)
  let initialized=false, uploadUrls=null;  // a POOL of single-use tokens, one per file
+ let confirmSpec=null;  // {tool,arg,values}: the auto-confirm contract fired after a successful upload
  const geturls=o=>o&&((Array.isArray(o.upload_urls)&&o.upload_urls.length&&o.upload_urls)||(o.upload_url&&[o.upload_url]))||null;
+ // Auto-confirm (#1891): after a file lands, ask the host to run await_upload on the link we just
+ // used, so the model confirms the add with no second user prompt. Host-appropriate + best-effort:
+ // ChatGPT exposes window.openai.callTool; claude.ai/MCP-Apps takes a tools/call over postMessage.
+ // A host that ignores it just leaves the model on the manual await_upload/source_list path.
+ function confirmUpload(link){ if(!confirmSpec||!confirmSpec.tool||!link)return;
+   const args={}; args[confirmSpec.arg||"upload_link"]=link;
+   try{
+     if(oai&&typeof oai.callTool==="function"){oai.callTool(confirmSpec.tool,args);return;}
+     post({jsonrpc:"2.0",id:"cf"+Date.now(),method:"tools/call",params:{name:confirmSpec.tool,arguments:args}});
+   }catch(e){}
+ }
  function ready(h){if(initialized)return;initialized=true;
    sub.textContent=(h||(oai?"ChatGPT":"host"))+" · ready"+(hasNative?" · native upload available":"");
    post({jsonrpc:"2.0",method:"ui/notifications/initialized",params:{}});}  // claude.ai render gate
@@ -106,7 +118,7 @@ _WIDGET_HTML = """<!doctype html>
      try{const parsed=JSON.parse(c.text);if(geturls(parsed))d=parsed}catch(e){}}
    if(!geturls(d)&&geturls(p))d=p;
    const urls=geturls(d);
-   if(urls&&!uploadUrls){uploadUrls=urls;document.getElementById('f').disabled=false;
+   if(urls&&!uploadUrls){uploadUrls=urls;confirmSpec=d.confirm||null;document.getElementById('f').disabled=false;
      sub.textContent="pick file(s) to add"+(d.notebook?" to "+d.notebook:"");}
  }
  // claude.ai / Grok: tool result arrives via postMessage. We deliberately don't allowlist
@@ -147,7 +159,7 @@ _WIDGET_HTML = """<!doctype html>
          {method:"POST",headers:{"Accept":"application/json","Content-Type":file.type||"application/octet-stream"},body:file});
        const text=await res.text();
        log("["+res.status+"] "+file.name+": "+text.slice(0,160));
-       if(res.ok){ok++;uploadUrls[i]=null;}              // burn locally on success so a retry click skips it
+       if(res.ok){ok++;uploadUrls[i]=null;confirmUpload(tok);} // burn locally + auto-confirm the add (#1891)
        else failed++;                                    // non-2xx: token uncommitted → still valid for retry
      }catch(e){log("❌ "+file.name+": upload failed (CSP/CORS/network): "+e);failed++;} // transient → retryable
    }
@@ -200,10 +212,12 @@ def register_upload_widget(mcp: FastMCP, config: FileTransferConfig | None) -> N
     async def source_add_widget(ctx: Context, notebook: str) -> dict[str, Any]:
         """Open an in-app file picker to add one or more files to a notebook (experimental mobile
         upload widget). Renders inline in MCP-Apps hosts (e.g. claude.ai); the user picks file(s)
-        and the widget uploads each to its own token in ``upload_urls``. To confirm, call
-        ``await_upload`` on a specific ``upload_urls`` entry (``upload_url`` is just the first), or
-        ``source_list`` to verify the whole batch — the first file may be skipped while later ones
-        land, so don't rely on ``upload_url`` alone for a multi-file add."""
+        and the widget uploads each to its own token in ``upload_urls``. On a successful upload the
+        widget auto-invokes ``await_upload`` (per the ``confirm`` contract in the result) so the add
+        is confirmed WITHOUT a second prompt (#1891). If a host does not run that widget-initiated
+        call, fall back to calling ``await_upload`` on a specific ``upload_urls`` entry
+        (``upload_url`` is just the first), or ``source_list`` to verify the whole batch — the first
+        file may be skipped while later ones land, so don't rely on ``upload_url`` alone."""
         with mcp_errors():
             cfg = get_file_transfer(ctx)
             if cfg is None:
@@ -233,4 +247,12 @@ def register_upload_widget(mcp: FastMCP, config: FileTransferConfig | None) -> N
                 "upload_url": first,
                 "notebook_id": nb_id,
                 "notebook": notebook,
+                # Auto-confirm contract (#1891): after each successful /files/ul POST the widget
+                # invokes this tool host-appropriately (window.openai.callTool on ChatGPT; a
+                # tools/call postMessage on claude.ai), passing the link it just uploaded to as
+                # ``arg`` — so the model confirms the add with NO second user prompt. ``values``
+                # mirrors ``upload_urls`` (one link per file). Purely additive: a host that does not
+                # run the widget-initiated call just leaves the model on the manual await_upload /
+                # source_list path (the docstring's fallback).
+                "confirm": {"tool": "await_upload", "arg": "upload_link", "values": urls},
             }

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -89,16 +89,22 @@ _WIDGET_HTML = """<!doctype html>
  const hasNative=!!(oai&&typeof oai.uploadFile==="function");  // OpenAI native upload (interop signal)
  let initialized=false, uploadUrls=null;  // a POOL of single-use tokens, one per file
  let confirmSpec=null;  // {tool,arg,values}: the auto-confirm contract fired after a successful upload
+ let cfSeq=0;  // strictly-monotonic JSON-RPC id counter — unique per confirm even for same-ms completions
  const geturls=o=>o&&((Array.isArray(o.upload_urls)&&o.upload_urls.length&&o.upload_urls)||(o.upload_url&&[o.upload_url]))||null;
  // Auto-confirm (#1891): after a file lands, ask the host to run await_upload on the link we just
  // used, so the model confirms the add with no second user prompt. Host-appropriate + best-effort:
  // ChatGPT exposes window.openai.callTool; claude.ai/MCP-Apps takes a tools/call over postMessage.
  // A host that ignores it just leaves the model on the manual await_upload/source_list path.
- function confirmUpload(link){ if(!confirmSpec||!confirmSpec.tool||!link)return;
+ // SECURITY: confirmSpec arrives via the un-origin-checked postMessage handler below, so a spoofed
+ // message could set confirmSpec.tool to any name — HARD-ALLOWLIST the one tool the backend ever
+ // sends so a spoofed message can never redirect which tool we invoke (the link is always our own
+ // just-uploaded signed token, so the args aren't attacker-controlled either).
+ const CONFIRM_TOOL="await_upload";
+ function confirmUpload(link){ if(!confirmSpec||confirmSpec.tool!==CONFIRM_TOOL||!link)return;
    const args={}; args[confirmSpec.arg||"upload_link"]=link;
    try{
-     if(oai&&typeof oai.callTool==="function"){oai.callTool(confirmSpec.tool,args);return;}
-     post({jsonrpc:"2.0",id:"cf"+Date.now(),method:"tools/call",params:{name:confirmSpec.tool,arguments:args}});
+     if(oai&&typeof oai.callTool==="function"){oai.callTool(CONFIRM_TOOL,args).catch(()=>{});return;}
+     post({jsonrpc:"2.0",id:"cf"+(++cfSeq),method:"tools/call",params:{name:CONFIRM_TOOL,arguments:args}});
    }catch(e){}
  }
  function ready(h){if(initialized)return;initialized=true;
@@ -122,10 +128,13 @@ _WIDGET_HTML = """<!doctype html>
      sub.textContent="pick file(s) to add"+(d.notebook?" to "+d.notebook:"");}
  }
  // claude.ai / Grok: tool result arrives via postMessage. We deliberately don't allowlist
- // ev.origin (host origin differs per platform — claude.ai / chatgpt.com / Grok): the only thing
- // a message can influence is uploadUrl, and (a) the resource CSP connect-src pins uploads to
- // config.base_url and (b) /files/ul requires a server-signed single-use token, so a spoofed URL
- // can't exfiltrate or add anything. CSP + signed token are the guard, not the frame origin.
+ // ev.origin (host origin differs per platform — claude.ai / chatgpt.com / Grok). A spoofed
+ // message can influence two things: (1) uploadUrl — but the resource CSP connect-src pins uploads
+ // to config.base_url and /files/ul requires a server-signed single-use token, so a spoofed URL
+ // can't exfiltrate or add anything; and (2) confirmSpec (the #1891 auto-confirm contract) — but
+ // confirmUpload hard-allowlists the tool name (CONFIRM_TOOL) and only ever passes our own
+ // just-uploaded signed token, so a spoofed message can't redirect which tool runs or with what.
+ // CSP + signed token + the tool allowlist are the guard, not the frame origin.
  window.addEventListener("message",ev=>{let d=ev.data;if(d==null)return;
    if(typeof d==="string"){try{d=JSON.parse(d)}catch(e){return}}
    if(d.result&&!d.method){ready(d.result.hostInfo&&d.result.hostInfo.name);

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -394,7 +394,14 @@ def register_file_tools(mcp: Any) -> None:
     so the sources domain keeps a single manifest entry point while this module holds
     the file-specific overflow (ADR-0008 size budget)."""
 
-    @mcp.tool(annotations=READ_ONLY)
+    @mcp.tool(
+        annotations=READ_ONLY,
+        # ChatGPT (Apps SDK) gates component-initiated tool calls behind this opt-in
+        # (``openai/widgetAccessible`` defaults to false), so the upload widget's auto-confirm
+        # ``window.openai.callTool("await_upload", …)`` is rejected without it (#1891). Harmless
+        # on other hosts / when the widget is off — it's a read-only completion poll.
+        meta={"openai/widgetAccessible": True},
+    )
     async def await_upload(ctx: Context, upload_link: str, timeout: float = 45.0) -> dict[str, Any]:
         """Wait for a file uploaded via a ``source_add(source_type="file")`` link to land.
 

--- a/tests/unit/mcp/test_await_upload.py
+++ b/tests/unit/mcp/test_await_upload.py
@@ -208,6 +208,19 @@ async def test_progress_keepalive_errors_are_swallowed() -> None:
     assert out["source_id"] == "s-ok"
 
 
+async def test_await_upload_is_widget_accessible_for_chatgpt() -> None:
+    # #1891: ChatGPT (Apps SDK) gates component-initiated tool calls behind
+    # ``openai/widgetAccessible`` (defaults false), so the upload widget's auto-confirm
+    # ``callTool("await_upload", …)`` is rejected unless the tool descriptor opts in.
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[MagicMock]:
+        yield MagicMock()
+
+    server = create_server(client_factory=factory, file_transfer=_cfg())
+    tools = {t.name: t for t in await server._list_tools()}
+    assert (tools["await_upload"].meta or {}).get("openai/widgetAccessible") is True
+
+
 async def test_await_upload_tool_delivers_progress_over_the_protocol() -> None:
     # End-to-end over the REAL MCP protocol (in-memory Client with a progressToken-bearing
     # request): the await_upload tool's keepalive reaches the client as an actual progress

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -73,8 +73,28 @@ def test_widget_html_auto_confirms_only_on_success() -> None:
     # #1891: the auto-confirm fires from inside the res.ok branch (a committed upload), never on a
     # failed POST — a corrupted/failed upload must not tell the model a source was added.
     assert "uploadUrls[i]=null;confirmUpload(tok)" in _WIDGET_HTML
-    # It reads the confirm contract the tool returns, not a hard-coded tool name.
+    # It reads the confirm contract the tool returns for the arg/link...
     assert "confirmSpec=d.confirm" in _WIDGET_HTML
+
+
+def test_widget_html_hard_allowlists_the_confirm_tool() -> None:
+    # SECURITY: confirmSpec arrives via the un-origin-checked postMessage handler, so the tool name
+    # must be hard-allowlisted — a spoofed message must not be able to redirect which tool runs.
+    assert 'CONFIRM_TOOL="await_upload"' in _WIDGET_HTML
+    assert "confirmSpec.tool!==CONFIRM_TOOL" in _WIDGET_HTML  # gate before invoking
+    # The invocation uses the constant, never the message-supplied name.
+    assert "oai.callTool(CONFIRM_TOOL,args)" in _WIDGET_HTML
+    assert "name:CONFIRM_TOOL" in _WIDGET_HTML
+    # callTool rejection is swallowed (no unhandled promise rejection in the host console).
+    assert "oai.callTool(CONFIRM_TOOL,args).catch(" in _WIDGET_HTML
+
+
+def test_widget_confirm_uses_unique_monotonic_rpc_id() -> None:
+    # A multi-file batch fires confirmUpload once per file; two completions in the same millisecond
+    # must NOT collide on the JSON-RPC id, so the id is a strictly-monotonic counter, not Date.now().
+    assert 'id:"cf"+(++cfSeq)' in _WIDGET_HTML
+    assert "let cfSeq=0" in _WIDGET_HTML
+    assert 'id:"cf"+Date.now()' not in _WIDGET_HTML  # the collision-prone form must be gone
 
 
 def test_widget_domain_is_sha256_of_endpoint() -> None:

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -62,8 +62,19 @@ def test_widget_html_is_cross_host() -> None:
         'type="file" multiple',  # universal picker, multi-select
         "upload_urls",  # reads the token pool (one single-use token per file)
         "?filename=",  # direct-PUT to /files/ul
+        "confirmUpload",  # auto-confirm invoker (#1891)
+        "callTool",  # ChatGPT auto-confirm path (window.openai.callTool)
+        '"tools/call"',  # claude.ai auto-confirm path (postMessage tools/call)
     ):
         assert marker in _WIDGET_HTML, marker
+
+
+def test_widget_html_auto_confirms_only_on_success() -> None:
+    # #1891: the auto-confirm fires from inside the res.ok branch (a committed upload), never on a
+    # failed POST — a corrupted/failed upload must not tell the model a source was added.
+    assert "uploadUrls[i]=null;confirmUpload(tok)" in _WIDGET_HTML
+    # It reads the confirm contract the tool returns, not a hard-coded tool name.
+    assert "confirmSpec=d.confirm" in _WIDGET_HTML
 
 
 def test_widget_domain_is_sha256_of_endpoint() -> None:
@@ -140,6 +151,32 @@ async def test_widget_tool_returns_single_use_token_pool(monkeypatch) -> None:
     assert all("/files/ul/" in u for u in urls)
     assert result["upload_url"] == urls[0]  # await_upload back-compat
     assert result["notebook_id"] == "nb-123"
+
+
+async def test_widget_tool_returns_auto_confirm_contract(monkeypatch) -> None:
+    """#1891: source_add_widget returns a machine-readable ``confirm`` contract the widget fires
+    after a successful upload — await_upload on the link just used, so the model confirms the add
+    with no second prompt. ``values`` mirrors the token pool; back-compat fields are unchanged."""
+    monkeypatch.setenv("NOTEBOOKLM_MCP_UPLOAD_WIDGET", "1")
+    cfg = _cfg()
+    mcp = _server(cfg)
+    tool = {t.name: t for t in await mcp._list_tools()}["source_add_widget"]
+    monkeypatch.setattr(_uploadwidget, "resolve_notebook", AsyncMock(return_value="nb-123"))
+    ctx = SimpleNamespace(
+        request_context=SimpleNamespace(
+            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
+        )
+    )
+
+    result = await tool.fn(ctx, notebook="My Notebook")
+
+    assert result["confirm"] == {
+        "tool": "await_upload",
+        "arg": "upload_link",
+        "values": result["upload_urls"],
+    }
+    # Additive only — the pool/back-compat fields the widget already relies on are untouched.
+    assert result["upload_url"] == result["upload_urls"][0]
 
 
 async def test_widget_pool_tokens_carry_the_longer_widget_ttl(monkeypatch) -> None:


### PR DESCRIPTION
## Item 4 of #1938 — auto-confirm widget uploads without a second prompt (#1891)

> ⚠️ **HOLD — needs live-rendering verification by the maintainer before merge.** The widget JS can only be proven by rendering it live in claude.ai / ChatGPT against a running server; it can't be verified headlessly. CI green + bots addressed ≠ mergeable here. See "How to verify live" below.

### The problem this solves
After the user picks a file in the widget, the model needed a **second explicit prompt** to confirm the add (call `await_upload` / `source_list`). #1891 wants the add confirmed automatically.

### Why it can't be a tool-side wait
The upload completes **client-side, in a later turn, *after* `source_add_widget` has already returned** — the host renders the widget *from* the tool result, so the tool physically can't block-and-wait for an upload that only exists once the widget is rendered. There's no active model turn when a file lands. So the confirmation must be **triggered by the widget**, not the tool.

### Mechanism (backend contract + consuming JS ship together — nothing dormant)
- **Backend:** `source_add_widget` now returns `confirm: {tool: "await_upload", arg: "upload_link", values: upload_urls}`.
- **Widget JS:** on each **successful** `/files/ul` POST (the `res.ok` branch only — never a failed upload), it invokes the contract host-appropriately:
  - **ChatGPT:** `window.openai.callTool("await_upload", {upload_link: <link>})`
  - **claude.ai / MCP-Apps:** a `tools/call` postMessage `{method:"tools/call", params:{name, arguments}}`
  passing the exact link it uploaded to. The host runs `await_upload`, whose result reaches the model as confirmation.

### Safety / back-compat
- **Purely additive.** All existing fields (`upload_urls`, `upload_url`, `notebook_id`, `notebook`) are unchanged; a host that ignores a widget-initiated call just leaves the model on the manual `await_upload`/`source_list` fallback (docstring updated to say so).
- **Success-only.** Fires from inside `if(res.ok)`, so a corrupted/failed upload never tells the model a source was added.
- `await_upload`'s single-use/replay guarantees and the signed-token model are untouched.
- Opt-in widget (`NOTEBOOKLM_MCP_UPLOAD_WIDGET=1`), so it stays off the default tool surface / ADR-0025 budgets.

### What's NOT here (deferred to the sibling PR)
Progress bar + fallback ladder (`window.openai.uploadFile` → direct-PUT → link) — that's the "widget upload UX" PR, stacked on this branch.

### Tests (headless — cover the parts that can be)
- backend `confirm` contract shape + additive-only back-compat;
- widget JS contains the invoker, fires it **only** from the `res.ok` branch, and reads the contract (`confirmSpec=d.confirm`) rather than a hard-coded tool name;
- `test_widget_html_is_cross_host` extended with the `callTool` / `tools/call` markers.

`mypy`, `ruff` (whole tree), MCP unit suite, manifest/tool_eval, module-size (258/1000) and docs guardrails all green.

### How to verify live (maintainer)
1. Deploy with `NOTEBOOKLM_MCP_UPLOAD_WIDGET=1` + a public URL; connect from **claude.ai** (and/or **ChatGPT**).
2. Ask the model to add a file → the widget renders inline; pick a file → **Upload**.
3. **Expected:** on a successful upload, WITHOUT any further user prompt, the model reports the source was added (it received an `await_upload` result). The widget still shows its own "✅ added" line.
4. **The one uncertain bit:** the claude.ai widget→host `tools/call` postMessage shape is undocumented — if claude.ai doesn't run the tool, watch the iframe console and tell me the shape its bridge expects; I'll adjust. ChatGPT's `window.openai.callTool` is the more confident path. Either way the manual fallback still works, so nothing regresses.

Addresses part of #1938 (other items open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic upload confirmation immediately after successful uploads, when supported by the host.
  - Uses host-appropriate invocation paths (ChatGPT/Grok-style and claude.ai/MCP-style).
  - Falls back to the existing manual confirmation/verification flow when auto-confirmation isn’t available.

- **Documentation**
  - Updated the architecture document to describe the auto-confirmation contract, best-effort behavior, and fallback ladder.

- **Tests**
  - Expanded upload widget tests to cover auto-confirm triggers, allowlisting, and the confirmation contract.
  - Added coverage ensuring `await_upload` is marked as widget-accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---
### Live-verification detail from bot review (Codex P2 — the two host behaviors to confirm)
1. **Does the confirmation reach the *model*?** In MCP-Apps, a widget→host `tools/call` returns its result to the **view (widget)**, not the chat — so the model may not get a new tool result to confirm from. If live testing shows the model doesn't auto-confirm, the widget needs to additionally push the result via the host's model-context path (`ui/update-model-context` / a follow-up on claude.ai; the equivalent on ChatGPT). I've **not** speculatively implemented that surfacing (its exact shape is undocumented per host and would be guesswork) — it's the #1 thing to confirm live, and the manual `await_upload`/`source_list` fallback guarantees no regression meanwhile.
2. **ChatGPT opt-in (fixed in `1fff591e`):** `await_upload` now carries `openai/widgetAccessible: true` so ChatGPT permits the widget-initiated `callTool`. Confirm on ChatGPT that the call is no longer rejected.