### PR TITLE
docs(sources): correct "native import can't ingest PDF" framing in 3 siblings (#1938)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -958,7 +958,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact/polling.py` | Poll coordination service for artifact generation tasks |
 | `_source/add.py` | Core service layer for adding text, URL, or Google Drive sources |
-| `_source/drive_import.py` | Auto-route add-from-Drive (#1884): download + upload the upload-only Drive types (epub/docx/txt/…) NotebookLM's native import can't ingest; header-first cookie-authed streaming fetch behind injected seams |
+| `_source/drive_import.py` | Auto-route add-from-Drive (#1884): download + upload the upload-only Drive types (epub/docx/txt/…); native import (`add_drive`) instead takes Docs/Slides/Sheets + PDF by reference; header-first cookie-authed streaming fetch behind injected seams |
 | `_source/content.py` | Core service layer for fetching source HTML/markdown content |
 | `_source/listing.py` | Core service layer for listing notebook sources |
 | `_source/polling.py` | Poll coordination service for active source conversions |

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -589,8 +589,8 @@ class SourcesAPI:
     ) -> Source:
         """Auto-route an upload-only Google Drive file: download it, then upload (#1884).
 
-        Covers the Drive file types NotebookLM's native import (:meth:`add_drive`)
-        can't ingest (epub/docx/txt/md/rtf/odt/csv/tsv/pdf): fetches the file
+        Covers the upload-only Drive file types (epub/docx/txt/md/rtf/odt/csv/tsv/pdf);
+        a Drive PDF can also go by reference via :meth:`add_drive`. Fetches the file
         SERVER-SIDE using the same live ``.google.com`` cookie jar the upload leg
         uses (so it works in stdio AND remote MCP mode with no ``upload_required``
         detour), then streams it through :meth:`add_file`. Native Docs/Slides/

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -526,9 +526,9 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, json_output, c
 def source_add_drive_file(ctx, document_id, notebook_id, title, wait, json_output, client_auth):
     """Add an upload-only Google Drive file (epub/docx/txt/md/rtf/odt/csv/tsv/pdf).
 
-    Downloads the file from Drive (server-side, using your session) and uploads it
-    — for the types NotebookLM's native Drive import can't ingest. DOCUMENT_ID is a
-    raw file id or share URL; use `source add-drive` for native Docs/Slides/Sheets.
+    Downloads the file from Drive (server-side, using your session) and uploads it.
+    A Drive PDF can also go by reference via `source add-drive` (which takes native
+    Docs/Slides/Sheets + PDF). DOCUMENT_ID is a raw file id or share URL.
     """
     nb_id = require_notebook(notebook_id)
 


### PR DESCRIPTION
## Summary

PR #1947 corrected an inaccurate *"native import can't ingest (…pdf)"* framing in the MCP `source_add_drive_file` tool docstring — a Drive PDF **can** be added by reference (native `add_drive` / `source add-drive` takes Google Docs/Slides/Sheets **+ PDF**), and `add_drive_file` merely offers the server-side download+upload path (PDF is genuinely dual-path).

The same inaccurate framing still lived in three sibling surfaces. This makes them consistent with the corrected #1947 wording:

- `src/notebooklm/_sources.py` — `add_drive_file` client-method docstring
- `src/notebooklm/cli/source_cmd.py` — `source add-drive-file` CLI command help
- `docs/architecture.md` — the `_source/drive_import.py` per-file index row

## Net-zero constraint (ADR-0008 1000-line ceiling)

`_sources.py` and `cli/source_cmd.py` are at exactly the 1000-line ceiling (full-suite `test_module_size_ratchet`). Edits are **reworded in place** — net-zero (2/2 and 3/3 lines); both files remain at exactly 1000. `docs/architecture.md` has no such limit.

## Test plan

Docs-only reword (6 insertions / 6 deletions), no behavior change.

- [x] `mypy src/notebooklm --ignore-missing-imports` — clean (313 files)
- [x] `ruff check . && ruff format --check .` — clean (whole tree)
- [x] `wc -l` both capped files — exactly **1000** each (net-zero)
- [x] Full `pytest -q` — 12298 passed / 77 skipped; module-size ratchet green (the lone `test_version_matches_pyproject` failure is a stale editable-install metadata artifact, unrelated to this docs change)
- [x] Polish triple review (claude + codex + agy): accuracy verified against `_source/drive_import.py`'s dual-path set, consistency with the #1947 canonical confirmed, no residual "can't ingest" framing

Addresses part of #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which Google Drive file types require download-and-upload handling.
  * Documented that Drive PDFs can also be added by reference.
  * Refined guidance for accepted document ID formats and Drive import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->