### PR TITLE
feat(mcp): upload progress bar in the widget (#1938) [needs live-rendering verification]

### DIFF
--- a/docs/adr/0027-mcp-app-upload-widget.md
+++ b/docs/adr/0027-mcp-app-upload-widget.md
@@ -63,8 +63,14 @@ tool-count / schema-char budgets) unless a deployment enables it.
   Purely additive and best-effort: a host that does not run a widget-initiated call simply leaves
   the model on the manual `await_upload` / `source_list` fallback. The exact claude.ai widget→host
   invocation shape is host-specific and undocumented, so it is verified live, not headlessly.
-- Follow-ups still deferred: a progress bar and the fallback ladder
-  (`window.openai.uploadFile` → direct-PUT → link).
+- **Upload progress bar.** The widget uploads each file via `XMLHttpRequest` (not `fetch`, which
+  can't report upload progress) so `xhr.upload.onprogress` drives an inline `<progress>` bar — useful
+  feedback for large files on a slow mobile link. The cross-origin POST, headers, and direct raw-body
+  transfer are unchanged; the existing `/files/ul` CORS (preflight + ACAO) already covers XHR.
+- Follow-up still deferred — the **`window.openai.uploadFile` fallback rung**: `uploadFile`'s
+  behavior for a *custom* (non-OpenAI-storage) upload endpoint is unclear, so building the
+  `uploadFile → direct-PUT → link` ladder around it needs live clarification first (direct-PUT
+  remains the working default; the signed link is the durable fallback).
 - **Requires stateless HTTP.** An MCP-Apps host reads the `ui://` widget resource on a connection
   without the chat `Mcp-Session-Id`; a stateful FastMCP server rejects that ("Missing session ID"
   → "fail to fetch app content"). Enabling the widget therefore auto-enables

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -180,7 +180,7 @@ _WIDGET_HTML = """<!doctype html>
      if(!tok){skipped++;log("• "+file.name+": already added");continue;} // token consumed on a prior click
      if(file.size>200*1024*1024){log("❌ "+file.name+": exceeds 200 MB — skipped");failed++;continue;} // mirrors MAX_UPLOAD_BYTES
      log("uploading "+file.name+" ("+file.size+" B)…");
-     pg.style.display="block"; pg.value=0;  // show the progress bar for this file
+     pg.style.display="block"; pg.value=0; size();  // show the bar + tell the host the iframe grew
      try{
        const res=await putFile(tok+"?filename="+encodeURIComponent(file.name), file, (loaded,total)=>{
          const pct=total?Math.round(loaded/total*100):0; pg.value=pct;
@@ -191,7 +191,7 @@ _WIDGET_HTML = """<!doctype html>
        else failed++;                                    // non-2xx: token uncommitted → still valid for retry
      }catch(e){log("❌ "+file.name+": upload failed (CSP/CORS/network): "+e);failed++;} // transient → retryable
    }
-   pg.style.display="none";  // batch done — hide the bar; the summary line below reports the outcome
+   pg.style.display="none"; size();  // batch done — hide the bar + tell the host the iframe shrank
    sub.textContent = failed ? ("✅ "+ok+" added · "+failed+" to retry — fix and click Upload again")
      : ok ? ("✅ "+ok+" added — you can close this and continue in chat")
      : "nothing to upload — already added";           // all files were skipped (tokens consumed): no misleading "0 added"

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -79,11 +79,28 @@ _WIDGET_HTML = """<!doctype html>
  <div id="sub" style="font-size:12px;color:#6b7a6e;margin-top:3px">starting…</div>
  <input id="f" type="file" multiple disabled>
  <button id="up" disabled>Upload</button>
+ <progress id="pg" max="100" value="0" style="display:none;width:100%;margin-top:10px"></progress>
  <div id="out"></div>
 </div>
 <script type="module">
- const sub=document.getElementById('sub'),out=document.getElementById('out');
+ const sub=document.getElementById('sub'),out=document.getElementById('out'),pg=document.getElementById('pg');
  const log=m=>{out.textContent+=(out.textContent?"\\n":"")+m;size();};
+ // Upload one file via XHR (not fetch) so xhr.upload.onprogress can drive the <progress> bar —
+ // fetch can't report upload progress. Same cross-origin POST + headers as before; the /files/ul
+ // CORS (preflight + ACAO) already covers it, and onprogress works cross-origin given the ACAO.
+ // Resolves {status,ok,text} like a fetch Response would; rejects on a network/abort error so the
+ // caller's existing catch handles it. Direct-PUT/POST of the raw body is unchanged.
+ function putFile(url,file,onprog){ return new Promise((resolve,reject)=>{
+   const xhr=new XMLHttpRequest();
+   xhr.open("POST",url);
+   xhr.setRequestHeader("Accept","application/json");
+   xhr.setRequestHeader("Content-Type",file.type||"application/octet-stream");
+   if(xhr.upload)xhr.upload.onprogress=e=>{if(e.lengthComputable&&onprog)onprog(e.loaded,e.total);};
+   xhr.onload=()=>resolve({status:xhr.status,ok:xhr.status>=200&&xhr.status<300,text:xhr.responseText||""});
+   xhr.onerror=()=>reject(new Error("network"));
+   xhr.onabort=()=>reject(new Error("abort"));
+   xhr.send(file);
+ });}
  const post=m=>{try{window.parent.postMessage(m,"*")}catch(e){}};
  const oai=window.openai;               // ChatGPT/Grok inject this; claude.ai does not
  const hasNative=!!(oai&&typeof oai.uploadFile==="function");  // OpenAI native upload (interop signal)
@@ -163,15 +180,18 @@ _WIDGET_HTML = """<!doctype html>
      if(!tok){skipped++;log("• "+file.name+": already added");continue;} // token consumed on a prior click
      if(file.size>200*1024*1024){log("❌ "+file.name+": exceeds 200 MB — skipped");failed++;continue;} // mirrors MAX_UPLOAD_BYTES
      log("uploading "+file.name+" ("+file.size+" B)…");
+     pg.style.display="block"; pg.value=0;  // show the progress bar for this file
      try{
-       const res=await fetch(tok+"?filename="+encodeURIComponent(file.name),
-         {method:"POST",headers:{"Accept":"application/json","Content-Type":file.type||"application/octet-stream"},body:file});
-       const text=await res.text();
+       const res=await putFile(tok+"?filename="+encodeURIComponent(file.name), file, (loaded,total)=>{
+         const pct=total?Math.round(loaded/total*100):0; pg.value=pct;
+         sub.textContent="uploading "+file.name+" — "+pct+"%"+(n>1?" ("+(i+1)+"/"+n+")":"");});
+       const text=res.text;
        log("["+res.status+"] "+file.name+": "+text.slice(0,160));
        if(res.ok){ok++;uploadUrls[i]=null;confirmUpload(tok);} // burn locally + auto-confirm the add (#1891)
        else failed++;                                    // non-2xx: token uncommitted → still valid for retry
      }catch(e){log("❌ "+file.name+": upload failed (CSP/CORS/network): "+e);failed++;} // transient → retryable
    }
+   pg.style.display="none";  // batch done — hide the bar; the summary line below reports the outcome
    sub.textContent = failed ? ("✅ "+ok+" added · "+failed+" to retry — fix and click Upload again")
      : ok ? ("✅ "+ok+" added — you can close this and continue in chat")
      : "nothing to upload — already added";           // all files were skipped (tokens consumed): no misleading "0 added"

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -65,8 +65,25 @@ def test_widget_html_is_cross_host() -> None:
         "confirmUpload",  # auto-confirm invoker (#1891)
         "callTool",  # ChatGPT auto-confirm path (window.openai.callTool)
         '"tools/call"',  # claude.ai auto-confirm path (postMessage tools/call)
+        'id="pg"',  # upload progress bar element
+        "xhr.upload.onprogress",  # progress driven by XHR upload events
     ):
         assert marker in _WIDGET_HTML, marker
+
+
+def test_widget_html_uploads_via_xhr_with_progress() -> None:
+    # Upload UX: files go through XHR (not fetch) so the <progress> bar can be driven by
+    # xhr.upload.onprogress — fetch can't report upload progress.
+    assert "new XMLHttpRequest()" in _WIDGET_HTML
+    assert "function putFile(" in _WIDGET_HTML
+    assert "await putFile(" in _WIDGET_HTML  # the loop uses the XHR helper, not fetch
+    assert "await fetch(" not in _WIDGET_HTML  # the old fetch upload is gone
+    # The bar is shown per file and hidden when the batch finishes.
+    assert 'pg.style.display="block"' in _WIDGET_HTML
+    assert 'pg.style.display="none"' in _WIDGET_HTML
+    # Same raw-body cross-origin POST + headers as before (direct-PUT unchanged).
+    assert 'xhr.open("POST",url)' in _WIDGET_HTML
+    assert 'xhr.setRequestHeader("Content-Type"' in _WIDGET_HTML
 
 
 def test_widget_html_auto_confirms_only_on_success() -> None:

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -78,9 +78,11 @@ def test_widget_html_uploads_via_xhr_with_progress() -> None:
     assert "function putFile(" in _WIDGET_HTML
     assert "await putFile(" in _WIDGET_HTML  # the loop uses the XHR helper, not fetch
     assert "await fetch(" not in _WIDGET_HTML  # the old fetch upload is gone
-    # The bar is shown per file and hidden when the batch finishes.
-    assert 'pg.style.display="block"' in _WIDGET_HTML
-    assert 'pg.style.display="none"' in _WIDGET_HTML
+    # The bar is shown per file and hidden when the batch finishes — and each show/hide notifies
+    # the host of the new iframe height (ui/notifications/size-changed via size()), else the host
+    # sizes the iframe stale and clips the bar / leaves dead space.
+    assert 'pg.style.display="block"; pg.value=0; size();' in _WIDGET_HTML
+    assert 'pg.style.display="none"; size();' in _WIDGET_HTML
     # Same raw-body cross-origin POST + headers as before (direct-PUT unchanged).
     assert 'xhr.open("POST",url)' in _WIDGET_HTML
     assert 'xhr.setRequestHeader("Content-Type"' in _WIDGET_HTML


### PR DESCRIPTION
## #1938 widget upload UX — progress bar (stacked on #1948)

> ⚠️ **HOLD — needs live-rendering verification by the maintainer before merge.** Widget UI; only proves out rendered live. **Stacked on #1948** (auto-confirm) — base is that branch so this diff shows only the progress-bar change; retarget to `main` when #1948 merges.

### What
The widget now uploads each file via `XMLHttpRequest` instead of `fetch`, so `xhr.upload.onprogress` can drive an inline `<progress>` bar (with a per-file "uploading name — NN% (i/n)" status). `fetch` can't report upload progress; XHR can. Useful feedback for a large file on a slow mobile link.

### Unchanged
- Same cross-origin **raw-body POST** + headers (`Accept`, `Content-Type`) — direct-PUT transfer is identical; the existing `/files/ul` CORS (preflight + ACAO) already covers XHR.
- `putFile()` resolves `{status, ok, text}` like a `fetch` Response and rejects on network/abort, so the loop's existing `try/catch`, retry-on-failure, single-use-token, and **auto-confirm (#1891, res.ok only)** logic all behave exactly as before.

### Deferred (per review discipline — same principle as #1948's Codex P2b)
The **`window.openai.uploadFile` fallback rung** is intentionally NOT built: `uploadFile`'s behavior for a *custom* (non-OpenAI-storage) upload endpoint is unclear, so a `uploadFile → direct-PUT → link` ladder around it would be speculative, unverifiable code. Direct-PUT stays the working default; the signed link is the durable fallback. Tracked under #1938 for live clarification first.

### Tests (headless)
`test_widget_html_uploads_via_xhr_with_progress` — asserts XHR + `putFile` are used, `await fetch(` is gone, the bar shows/hides, and the raw-body POST headers are unchanged; `test_widget_html_is_cross_host` extended with the `pg` / `xhr.upload.onprogress` markers. mypy/ruff/docs guardrails green; `_uploadwidget.py` 287/1000 lines.

### How to verify live (maintainer)
1. Deploy with `NOTEBOOKLM_MCP_UPLOAD_WIDGET=1` + public URL; open the widget in claude.ai / ChatGPT.
2. Add a **large** file → **Upload**. **Expected:** the `<progress>` bar fills as the bytes transfer and the sub-line shows a live percentage; on completion the bar hides and the "✅ added" summary + auto-confirm (#1948) still fire.
3. Confirm small-file uploads and the retry path still work (the bar just fills instantly).

Addresses part of #1938 (other items open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC