### PR TITLE
docs(changelog): dedup the #1921/#1931 RPC-error-leak entry (same fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,7 +563,8 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   (or `The server returned an empty result …` when no status is attached); the
   method id, status code, and found-id list remain on the exception attributes
   (`method_id` / `rpc_code` / `found_ids`) for logging and debugging.
-  ([#1921](https://github.com/teng-lin/notebooklm-py/issues/1921))
+  ([#1921](https://github.com/teng-lin/notebooklm-py/issues/1921),
+  [#1931](https://github.com/teng-lin/notebooklm-py/issues/1931))
 - **A blank `FASTMCP_STATELESS_HTTP` no longer crash-loops the remote MCP server.**
   The deploy compose passed the variable through as `${FASTMCP_STATELESS_HTTP:-}`,
   which injects an **empty string** when unset — and FastMCP's settings bool-parse
@@ -1002,9 +1003,6 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   `ALLOW_EXTERNAL_BIND` flag alone (e.g. set while `--host` stays at loopback) no
   longer disables it, closing a rebinding gap on an unauthenticated local server
   ([#1935](https://github.com/teng-lin/notebooklm-py/issues/1935)).
-- **Client-facing RPC errors no longer leak the obfuscated internal method id or
-  the raw upstream status code**, trimming information disclosure in error
-  messages ([#1931](https://github.com/teng-lin/notebooklm-py/issues/1931)).
 
 ### Breaking
 


### PR DESCRIPTION
`#1931` is the PR that fixes issue `#1921` (its body: "Fixes #1921") — the same RPC error-leak fix. Folding the post-b3 `[Unreleased]` entries into `[0.8.0]` surfaced that the aggregate now documented it twice:

- the detailed `### Fixed` entry citing `#1921` (with the example, the stabilized message, and the preserved `method_id`/`rpc_code`/`found_ids` exception attributes), and
- a terser `### Security` restatement citing `#1931`.

This keeps the detailed Fixed entry and cites both numbers on it, and removes the redundant Security bullet. The `#1935` host-guard Security entry is untouched. Pure changelog edit; the v0.8.0b3 GitHub release notes were generated from the `[Unreleased]` delta and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.8.0 changelog to consolidate RPC error security fixes and related issue references.
  * Removed a duplicate entry describing the prevention of sensitive information in client-facing RPC errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->