### PR TITLE
docs(changelog): dedup the #1921/#1931 RPC-error-leak entry (same fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,7 +563,8 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   (or `The server returned an empty result …` when no status is attached); the
   method id, status code, and found-id list remain on the exception attributes
   (`method_id` / `rpc_code` / `found_ids`) for logging and debugging.
-  ([#1921](https://github.com/teng-lin/notebooklm-py/issues/1921))
+  ([#1921](https://github.com/teng-lin/notebooklm-py/issues/1921),
+  [#1931](https://github.com/teng-lin/notebooklm-py/issues/1931))
 - **A blank `FASTMCP_STATELESS_HTTP` no longer crash-loops the remote MCP server.**
   The deploy compose passed the variable through as `${FASTMCP_STATELESS_HTTP:-}`,
   which injects an **empty string** when unset — and FastMCP's settings bool-parse
@@ -1002,9 +1003,6 @@ get-returns-None / kwarg-alias deprecation machinery — has been **removed**
   `ALLOW_EXTERNAL_BIND` flag alone (e.g. set while `--host` stays at loopback) no
   longer disables it, closing a rebinding gap on an unauthenticated local server
   ([#1935](https://github.com/teng-lin/notebooklm-py/issues/1935)).
-- **Client-facing RPC errors no longer leak the obfuscated internal method id or
-  the raw upstream status code**, trimming information disclosure in error
-  messages ([#1931](https://github.com/teng-lin/notebooklm-py/issues/1931)).
 
 ### Breaking
 


### PR DESCRIPTION
## Summary

#1931 is the PR that fixes issue #1921 (its body says "Fixes #1921") — the **same** RPC error-leak fix was documented **twice** in the in-progress `## [0.8.0]` notes: once under `### Fixed` (#1921) and once under `### Security` (#1931). The b3 release notes are unaffected (those came from the `[Unreleased]` delta), but the aggregate would double-list it in the eventual final 0.8.0 notes.

This dedups it:
- **Keep** the canonical, detailed `### Fixed` entry (it has the example, the stable message, and the preserved-exception-attributes detail) and cite **both** issues on it: `([#1921](…), [#1931](…))`.
- **Remove** the redundant `### Security` bullet ("Client-facing RPC errors no longer leak…").
- The #1935 host-guard entry stays as the sole `## [0.8.0] ### Security` item.

Net 2-line change (2 insertions, 4 deletions). No wording of the kept entry changed beyond appending the second issue link. No behavior change.

## Verification

- `#1931` now appears exactly once (on the Fixed entry); `#1935` remains the only Security entry.
- `python scripts/audit_public_api_compat.py --check-stale` → `OK` (exit 0) — a CHANGELOG edit can't touch the API surface.
- Changelog guardrail (`pytest -k changelog`) green; `ruff` clean.

## Test plan

- [x] audit `--check-stale` clean · changelog guardrail green · ruff clean
- [x] CI runs the full suite (docs-only; no Python touched)

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated release notes to clarify that client-facing RPC errors no longer expose obfuscated internal method IDs or raw upstream status codes.
- **Documentation**
  - Consolidated duplicate security-related changelog entries and updated the associated issue references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->