### PR TITLE
docs(mcp): note stale connector manifest after server upgrade (#1956)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -543,6 +543,11 @@ gate the destructive ones.
   searches common install dirs beyond `PATH`.
 - **Client doesn't see the tools.** Confirm the config was written (`notebooklm mcp install <client>`)
   and **restart the client** — most hosts only read MCP config at startup.
+- **`Unknown tool: '<name>'` after upgrading the server.** The claude.ai connector caches the tool
+  list from when it connected, so a version upgrade that **renamed or folded** a tool leaves the old
+  name callable-but-failing until you **reconnect the connector** (disconnect + reconnect, or toggle it
+  off/on). Newly-added *optional* parameters on existing tools forward through the stale schema and keep
+  working without a reconnect. See [troubleshooting.md](troubleshooting.md#unknown-tool-from-the-claudeai-connector-after-upgrading-the-server).
 - **Wrong account.** The server binds one profile per process. Start it with `--profile <name>`, or set
   `NOTEBOOKLM_PROFILE`. See [configuration.md](configuration.md#multiple-accounts).
 - **`RATE_LIMITED`.** NotebookLM enforces per-account quotas; the error is `retriable=true` — back off

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting
 
 **Status:** Active
-**Last Updated:** 2026-07-04
+**Last Updated:** 2026-07-16
 
 Common issues, known limitations, and workarounds for `notebooklm-py`.
 
@@ -824,6 +824,26 @@ the features:
   otherwise). See [installation.md#rest-api-server](installation.md#rest-api-server).
 - **`curl_cffi` transport**: `NOTEBOOKLM_TRANSPORT=curl_cffi` requires the
   `curl_cffi` package; see the region / anti-abuse gate section above.
+
+### "Unknown tool" from the claude.ai connector after upgrading the server
+
+**Cause:** The claude.ai connector fetches the server's tool list (`tools/list`)
+when it connects and caches it. After you upgrade a deployed server to a version
+that **renamed or folded** a tool, the connector keeps advertising the *old*
+manifest, so a call to a since-removed tool reaches the server and fails cleanly
+with `Unknown tool: '<name>'`. This is expected MCP-host caching, not a server
+bug: a server can't notify a client that isn't connected, and
+`notifications/tools/list_changed` only reaches a *live* session.
+
+**Solution:** Reconnect the connector in claude.ai — disconnect and reconnect, or
+toggle it off and back on — to refresh the manifest.
+
+**Only removed or renamed _tools_ ghost this way — new _optional_ parameters
+forward through the stale schema.** For example, when `source_upload_bytes` was folded
+into `source_add(bytes_base64=…)` (and `studio_get_prompt` into
+`studio_list(item=…)`), the removed tool names failed with `Unknown tool`, but
+`source_add` with the new `bytes_base64` argument reached the upgraded server and
+worked without a reconnect.
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

Documents the surprising-but-expected MCP-host caching behavior found in a live connector stress test (#1956): after a deployed server is upgraded to a version that **renamed or folded** a tool, the claude.ai connector keeps serving its cached `tools/list` manifest until it reconnects, so calling a since-removed tool reaches the server and fails cleanly as `Unknown tool: '<name>'`.

- **`docs/troubleshooting.md`** — new subsection under *Adapter-specific issues (MCP server, REST server)*: Cause / Solution (reconnect the connector) / the nuance that only removed-or-renamed **tools** ghost, while newly-added **optional** parameters on existing tools forward through the stale schema (e.g. `source_add(bytes_base64=…)` reaches the upgraded server without a reconnect). Bumped **Last Updated** to 2026-07-16.
- **`docs/mcp-guide.md`** — one cross-linked bullet in the `## Troubleshooting` list, next to the sibling "restart the client" entry.

Out of scope (separate follow-up per the issue): emitting `notifications/tools/list_changed` on live sessions — it wouldn't fix the cross-restart case anyway (client disconnected).

## Task

Closes #1956

## Test plan

- [x] `python scripts/check_docs_module_refs.py` — OK
- [x] `python scripts/check_claude_md_freshness.py` — OK
- [x] `ruff format --check .` / `ruff check .` — clean
- [x] doc guardrail suite (`pytest -k "docs or changelog or markdown"`) — 120 passed
- [x] Cross-doc anchor `#unknown-tool-from-the-claudeai-connector-after-upgrading-the-server` verified byte-exact + unique (GitHub slug rules)

## Deferred polish findings

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC