### PR TITLE
fix(mcp): seed bytes-upload filename from title+mime so it isn't extensionless (#1955)

### DIFF
--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -217,8 +217,17 @@ def _seed_upload_filename(
     if filename:
         return filename
     stem = (title or "").strip()
-    ext = mimetypes.guess_extension(mime_type) if mime_type else None
+    # guess_extension does an exact (lower-cased) dict lookup, so a parameterized
+    # Content-Type like ``text/plain; charset=utf-8`` — a standard value an HTTP-facing
+    # connector passes — would miss and reproduce #1955. Strip params to the bare type
+    # first, the same normalization the sibling ``/files/ul`` route applies.
+    bare_mime = mime_type.split(";", 1)[0].strip() if mime_type else None
+    ext = mimetypes.guess_extension(bare_mime) if bare_mime else None
     if ext:
+        # Only skips doubling on an exact match, so a title carrying a DIFFERENT
+        # extension than the mime implies (``report.doc`` + ``application/pdf`` →
+        # ``report.doc.pdf``) still gets one appended — a known simplification: the
+        # upload succeeds either way since a real extension is present.
         if stem and os.path.splitext(stem)[1].lower() == ext.lower():
             return stem
         return (stem or "upload") + ext

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -191,6 +191,15 @@ def _broker_upload(
     }
 
 
+#: MIME types too generic to seed a useful extension. ``application/octet-stream`` is
+#: "unknown binary"; ``guess_extension`` maps it to a platform-dependent suffix
+#: (``.bin`` / ``.so`` / ``.obj`` / …), none better than the extensionless-equivalent
+#: NotebookLM already rejects — and all of which would wrongly clobber a real extension
+#: the title carries (``notes.txt`` → ``notes.txt.bin``, #1955 review). Treat them as
+#: "no extension signal" so a title's own extension wins instead.
+_GENERIC_MIMES = frozenset({"application/octet-stream", "binary/octet-stream"})
+
+
 def _seed_upload_filename(
     filename: str | None, title: str | None, mime_type: str | None
 ) -> str | None:
@@ -203,10 +212,13 @@ def _seed_upload_filename(
 
     * an explicit ``filename`` wins verbatim (unchanged behavior);
     * otherwise seed the stem from ``title`` (default ``"upload"``) and the extension
-      from ``mime_type`` via :func:`mimetypes.guess_extension` (``text/plain`` →
-      ``.txt``, ``application/pdf`` → ``.pdf``), not doubling one the title already
-      spells (``report.pdf`` + ``.pdf`` → ``report.pdf``);
-    * with no mime-derived extension, a title that already carries one seeds the name;
+      from a *specific* ``mime_type`` via :func:`mimetypes.guess_extension`
+      (``text/plain`` → ``.txt``, ``application/pdf`` → ``.pdf``), not doubling one the
+      title already spells (``report.pdf`` + ``.pdf`` → ``report.pdf``);
+    * a generic ``application/octet-stream`` carries no real extension signal
+      (:data:`_GENERIC_MIMES`), so it never overrides an extension the title already
+      has (``notes.txt`` stays ``notes.txt``, not ``notes.txt.bin``);
+    * with no usable mime extension, a title that already carries one seeds the name;
     * failing all of that, return ``None`` so :func:`safe_upload_name` applies its
       extensioned ``upload.bin`` fallback rather than a bare extensionless name.
 
@@ -221,12 +233,16 @@ def _seed_upload_filename(
     # Content-Type like ``text/plain; charset=utf-8`` — a standard value an HTTP-facing
     # connector passes — would miss and reproduce #1955. Strip params to the bare type
     # first, the same normalization the sibling ``/files/ul`` route applies.
-    bare_mime = mime_type.split(";", 1)[0].strip() if mime_type else None
-    ext = mimetypes.guess_extension(bare_mime) if bare_mime else None
+    bare_mime = mime_type.split(";", 1)[0].strip().lower() if mime_type else ""
+    ext = (
+        mimetypes.guess_extension(bare_mime)
+        if bare_mime and bare_mime not in _GENERIC_MIMES
+        else None
+    )
     if ext:
         # Only skips doubling on an exact match, so a title carrying a DIFFERENT
-        # extension than the mime implies (``report.doc`` + ``application/pdf`` →
-        # ``report.doc.pdf``) still gets one appended — a known simplification: the
+        # extension than a specific mime implies (``report.doc`` + ``application/pdf``
+        # → ``report.doc.pdf``) still gets one appended — a known simplification: the
         # upload succeeds either way since a real extension is present.
         if stem and os.path.splitext(stem)[1].lower() == ext.lower():
             return stem

--- a/src/notebooklm/mcp/tools/_fileupload.py
+++ b/src/notebooklm/mcp/tools/_fileupload.py
@@ -15,6 +15,7 @@ import asyncio
 import base64
 import binascii
 import math
+import mimetypes
 import os
 import shutil
 import tempfile
@@ -190,6 +191,42 @@ def _broker_upload(
     }
 
 
+def _seed_upload_filename(
+    filename: str | None, title: str | None, mime_type: str | None
+) -> str | None:
+    """Pick the spool basename for a bytes upload so a real extension survives to disk.
+
+    NotebookLM 400s an extensionless upload (#1955), yet the folded ``source_add``
+    bytes path let ``title`` / ``mime_type`` ride along without either seeding the
+    basename — a caller passing ``bytes_base64 + title`` (no ``filename``) landed on
+    ``upload.bin`` and hit the 400 even for plain text. Priority:
+
+    * an explicit ``filename`` wins verbatim (unchanged behavior);
+    * otherwise seed the stem from ``title`` (default ``"upload"``) and the extension
+      from ``mime_type`` via :func:`mimetypes.guess_extension` (``text/plain`` →
+      ``.txt``, ``application/pdf`` → ``.pdf``), not doubling one the title already
+      spells (``report.pdf`` + ``.pdf`` → ``report.pdf``);
+    * with no mime-derived extension, a title that already carries one seeds the name;
+    * failing all of that, return ``None`` so :func:`safe_upload_name` applies its
+      extensioned ``upload.bin`` fallback rather than a bare extensionless name.
+
+    The result is ALWAYS passed through :func:`safe_upload_name` for the security pass
+    (path-traversal / control-char / byte-length defenses) — this only chooses a better
+    *candidate*, never bypasses sanitization.
+    """
+    if filename:
+        return filename
+    stem = (title or "").strip()
+    ext = mimetypes.guess_extension(mime_type) if mime_type else None
+    if ext:
+        if stem and os.path.splitext(stem)[1].lower() == ext.lower():
+            return stem
+        return (stem or "upload") + ext
+    if stem and os.path.splitext(stem)[1]:
+        return stem
+    return None
+
+
 async def _add_bytes(
     client: NotebookLMClient,
     notebook_id: str,
@@ -206,12 +243,15 @@ async def _add_bytes(
     to a ``0600`` file under a ``0700`` ``mkdtemp`` dir — the same spool-then-add
     shape the ``/files/ul`` upload route uses, minus the signed-token / single-use /
     concurrency machinery that guards that PUBLIC internet-facing route (this path is
-    already authenticated by the MCP session, so none of it applies). ``filename`` is
-    sanitized to a safe basename (traversal / control-char / empty defenses shared
-    with the upload route via ``safe_upload_name``). The temp tree is always removed —
-    on success, a rejected add, or an error.
+    already authenticated by the MCP session, so none of it applies). The basename is
+    seeded from ``filename`` — or, when it is absent, from ``title`` + a
+    ``mime_type``-inferred extension (:func:`_seed_upload_filename`, #1955) so a
+    caller who passes only ``bytes_base64 + title`` doesn't 400 on an extensionless
+    ``upload.bin`` — and then sanitized to a safe basename (traversal / control-char /
+    empty defenses shared with the upload route via ``safe_upload_name``). The temp
+    tree is always removed — on success, a rejected add, or an error.
     """
-    safe = add_core.safe_upload_name(filename)
+    safe = add_core.safe_upload_name(_seed_upload_filename(filename, title, mime_type))
     temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-ulb-")
     try:
         temp_path = os.path.join(temp_dir, safe)

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import mimetypes
 import os
 import textwrap
 from collections.abc import AsyncIterator
@@ -316,13 +317,22 @@ async def test_source_add_bytes_default_filename_and_no_mime(mock_client) -> Non
 # real extension (NotebookLM 400s an extensionless upload) by seeding it from the
 # title + mime, and must NEVER regress the extensioned `upload.bin` fallback nor
 # bypass the shared safe_upload_name security pass.
+#
+# ``application/pdf`` is a single, stable mime→ext mapping, so ``.pdf`` is asserted
+# literally. ``text/plain`` maps to many extensions whose order (hence
+# ``guess_extension``'s pick) depends on the platform's mime.types, so those rows
+# compute the expected extension from ``mimetypes`` rather than hardcoding it —
+# what the fix guarantees is "an extension is seeded", not which one.
+_TXT_EXT = mimetypes.guess_extension("text/plain")
+
+
 @pytest.mark.parametrize(
     ("filename", "title", "mime_type", "expected"),
     [
         # Explicit filename always wins verbatim — title/mime don't touch it.
         ("report.pdf", "My Title", "text/plain", "report.pdf"),
         # title + mime → stem from title, extension from mime.
-        (None, "b3-stress-bytes", "text/plain", "b3-stress-bytes.txt"),
+        (None, "b3-stress-bytes", "text/plain", f"b3-stress-bytes{_TXT_EXT}"),
         # mime only (no title) → the default "upload" stem + mime extension.
         (None, None, "application/pdf", "upload.pdf"),
         (None, "", "application/pdf", "upload.pdf"),
@@ -340,6 +350,14 @@ async def test_source_add_bytes_default_filename_and_no_mime(mock_client) -> Non
 )
 def test_seed_upload_filename(filename, title, mime_type, expected) -> None:
     assert fileupload_mod._seed_upload_filename(filename, title, mime_type) == expected
+
+
+def test_text_plain_resolves_to_an_extension() -> None:
+    # Guards the assumption the #1955 fix rests on: a text/plain bytes upload can be
+    # given a real extension. If a platform's mimetypes can't map text/plain, the seed
+    # would fall back to upload.bin — surface that here rather than in a confusing
+    # basename mismatch elsewhere.
+    assert _TXT_EXT and _TXT_EXT.startswith(".")
 
 
 async def test_source_add_bytes_title_and_mime_seed_extension(mock_client) -> None:
@@ -367,7 +385,7 @@ async def test_source_add_bytes_title_and_mime_seed_extension(mock_client) -> No
         },
     )
     assert result.structured_content["status"] == "added"
-    assert os.path.basename(seen["path"]) == "b3-stress-bytes.txt"
+    assert os.path.basename(seen["path"]) == f"b3-stress-bytes{_TXT_EXT}"
     # The title still rides through as the source label, independent of the basename.
     assert seen["title"] == "b3-stress-bytes"
     assert seen["mime"] == "text/plain"
@@ -446,7 +464,7 @@ async def test_source_add_bytes_seeded_name_still_sanitized(mock_client) -> None
         },
     )
     # basename strips the traversal; the mime extension is appended to the safe leaf.
-    assert os.path.basename(seen["path"]) == "passwd.txt"
+    assert os.path.basename(seen["path"]) == f"passwd{_TXT_EXT}"
     assert "/etc/passwd" not in seen["path"]
 
 

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -333,6 +333,9 @@ _TXT_EXT = mimetypes.guess_extension("text/plain")
         ("report.pdf", "My Title", "text/plain", "report.pdf"),
         # title + mime → stem from title, extension from mime.
         (None, "b3-stress-bytes", "text/plain", f"b3-stress-bytes{_TXT_EXT}"),
+        # A parameterized Content-Type (charset param) is normalized to the bare type
+        # before the extension lookup — otherwise it'd miss and reproduce #1955.
+        (None, "b3-stress-bytes", "text/plain; charset=utf-8", f"b3-stress-bytes{_TXT_EXT}"),
         # mime only (no title) → the default "upload" stem + mime extension.
         (None, None, "application/pdf", "upload.pdf"),
         (None, "", "application/pdf", "upload.pdf"),

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -343,6 +343,13 @@ _TXT_EXT = mimetypes.guess_extension("text/plain")
         (None, "report.pdf", "application/pdf", "report.pdf"),
         # No mime, but the title carries its own extension → seed from the title.
         (None, "notes.txt", None, "notes.txt"),
+        # A generic octet-stream mime carries no real extension → don't let its ".bin"
+        # guess clobber the title's own extension (notes.txt, NOT notes.txt.bin).
+        (None, "notes.txt", "application/octet-stream", "notes.txt"),
+        (None, "notes.txt", "binary/octet-stream", "notes.txt"),
+        # Generic octet-stream with no title extension → no signal → None (upload.bin).
+        (None, "data", "application/octet-stream", None),
+        (None, None, "application/octet-stream", None),
         # No usable extension signal at all → None (→ safe_upload_name's upload.bin).
         (None, "notes", None, None),
         (None, None, None, None),

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -312,6 +312,144 @@ async def test_source_add_bytes_default_filename_and_no_mime(mock_client) -> Non
     assert seen["mime"] is None
 
 
+# _seed_upload_filename (#1955): a bytes upload with no `filename` must still land a
+# real extension (NotebookLM 400s an extensionless upload) by seeding it from the
+# title + mime, and must NEVER regress the extensioned `upload.bin` fallback nor
+# bypass the shared safe_upload_name security pass.
+@pytest.mark.parametrize(
+    ("filename", "title", "mime_type", "expected"),
+    [
+        # Explicit filename always wins verbatim — title/mime don't touch it.
+        ("report.pdf", "My Title", "text/plain", "report.pdf"),
+        # title + mime → stem from title, extension from mime.
+        (None, "b3-stress-bytes", "text/plain", "b3-stress-bytes.txt"),
+        # mime only (no title) → the default "upload" stem + mime extension.
+        (None, None, "application/pdf", "upload.pdf"),
+        (None, "", "application/pdf", "upload.pdf"),
+        # Title already spells the mime extension → don't double it.
+        (None, "report.pdf", "application/pdf", "report.pdf"),
+        # No mime, but the title carries its own extension → seed from the title.
+        (None, "notes.txt", None, "notes.txt"),
+        # No usable extension signal at all → None (→ safe_upload_name's upload.bin).
+        (None, "notes", None, None),
+        (None, None, None, None),
+        (None, "   ", None, None),
+        # Unknown mime yields no extension → fall back like the no-signal case.
+        (None, "blob", "application/x-not-a-real-mime", None),
+    ],
+)
+def test_seed_upload_filename(filename, title, mime_type, expected) -> None:
+    assert fileupload_mod._seed_upload_filename(filename, title, mime_type) == expected
+
+
+async def test_source_add_bytes_title_and_mime_seed_extension(mock_client) -> None:
+    # The #1955 trap: bytes + title (no filename) with a known mime must reach disk
+    # under a real extension (…​.txt), not the extensionless upload.bin that 400s.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        seen["mime"] = mime
+        seen["title"] = title
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    result = await _call(
+        mock_client,
+        None,
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "source_type": "file",
+            "bytes_base64": base64.b64encode(b"Hello. Grounded RAG rocks.\n").decode(),
+            "title": "b3-stress-bytes",
+            "mime_type": "text/plain",
+        },
+    )
+    assert result.structured_content["status"] == "added"
+    assert os.path.basename(seen["path"]) == "b3-stress-bytes.txt"
+    # The title still rides through as the source label, independent of the basename.
+    assert seen["title"] == "b3-stress-bytes"
+    assert seen["mime"] == "text/plain"
+
+
+async def test_source_add_bytes_mime_only_seeds_extension(mock_client) -> None:
+    # No filename, no title — just a mime. The default "upload" stem gets the
+    # mime-inferred extension so the spooled file isn't extensionless.
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "source_type": "file",
+            "bytes_base64": base64.b64encode(b"%PDF-1.4 hi").decode(),
+            "mime_type": "application/pdf",
+        },
+    )
+    assert os.path.basename(seen["path"]) == "upload.pdf"
+
+
+async def test_source_add_bytes_unknown_mime_keeps_upload_bin(mock_client) -> None:
+    # An unknown mime yields no extension → the extensioned upload.bin fallback holds
+    # (never a bare extensionless name that would 400).
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "source_type": "file",
+            "bytes_base64": base64.b64encode(b"data").decode(),
+            "title": "just-a-label",
+            "mime_type": "application/x-not-a-real-mime",
+        },
+    )
+    assert os.path.basename(seen["path"]) == "upload.bin"
+
+
+async def test_source_add_bytes_seeded_name_still_sanitized(mock_client) -> None:
+    # The seeded candidate is NOT trusted — it still flows through safe_upload_name,
+    # so a traversal-shaped title can't escape the temp dir (#1955 must not weaken the
+    # security pass shared with the /files/ul route).
+    seen: dict[str, Any] = {}
+
+    async def _capture(nb_id, path, mime, *, title=None):
+        seen["path"] = path
+        return FakeReadyPdf(id="s")
+
+    mock_client.sources.add_file = AsyncMock(side_effect=_capture)
+    await _call(
+        mock_client,
+        None,
+        "source_add",
+        {
+            "notebook": NB_ID,
+            "source_type": "file",
+            "bytes_base64": base64.b64encode(b"x").decode(),
+            "title": "../../etc/passwd",
+            "mime_type": "text/plain",
+        },
+    )
+    # basename strips the traversal; the mime extension is appended to the safe leaf.
+    assert os.path.basename(seen["path"]) == "passwd.txt"
+    assert "/etc/passwd" not in seen["path"]
+
+
 async def test_source_add_bytes_sanitizes_traversal_filename(mock_client) -> None:
     seen: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
`source_add(source_type="file", bytes_base64=..., title="x")` **without** a `filename` spooled the file as `upload.bin`, and NotebookLM rejects the extensionless `.bin` with **HTTP 400** even for plain-text content. Neither `title` nor `mime_type` seeded the extension — a natural first-call trap for agents using the consolidated bytes path (found in a live b3 connector stress test).

## Root cause
`mcp/tools/_fileupload.py::_add_bytes` received `title` and `mime_type` but only passed `filename` to `add_core.safe_upload_name`; the shared sanitizer returns `upload.bin` for an empty/None input (by design — "never extensionless").

## Fix
New private helper `_seed_upload_filename(filename, title, mime_type)` in the **bytes path only** (localized — the shared `safe_upload_name` is untouched, as it is also used by the public `/files/ul` route where the name comes from the URL query, not `title`/`mime`):

- explicit `filename` wins verbatim (unchanged);
- otherwise seed the stem from `title` (default `"upload"`) and the extension from `mime_type` via `mimetypes.guess_extension` (`text/plain` → `.txt`, `application/pdf` → `.pdf`), not doubling one the title already spells (`report.pdf` + `.pdf` → `report.pdf`);
- with no mime-derived extension, a title that already carries one seeds the name;
- failing all that, return `None` so `safe_upload_name` applies its extensioned `upload.bin` fallback — never a bare extensionless name.

The derived candidate is **always** run through `safe_upload_name`, so the security-critical sanitization (path-traversal / control-char / NUL / UTF-8 byte-length truncation) shared with the `/files/ul` route still applies — a traversal-shaped `title` is basenamed before the extension is appended.

## Tests
Added to `tests/unit/mcp/test_file_tools.py`:
- a parametrized pure-function table for `_seed_upload_filename` (filename-wins, title+mime, mime-only, extension-doubling, title-with-extension, unknown mime, no-signal → `None`);
- integration through `source_add`: `title + mime` → `b3-stress-bytes.txt`; `mime` only → `upload.pdf`; unknown mime → still `upload.bin`; a traversal-shaped title → sanitized to `passwd.txt`.

## Verification
- `mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check .` + `ruff format --check .` — clean
- full `pytest` — 12313 passed, 77 skipped, 1 xfailed

Closes #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC