### PR TITLE
chore: release v0.8.0b4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP `source_add` bytes upload no longer defaults to an extensionless
+  `upload.bin`.** Passing `bytes_base64` without an explicit `filename` used to
+  spool the file as `upload.bin`, which NotebookLM rejected with an HTTP 400
+  ("file type unsupported") even for plain text. The filename/extension is now
+  seeded from the `title` and/or `mime_type` (falling back to `upload.bin` only
+  when neither yields one), so a bytes upload succeeds without a caller-supplied
+  filename ([#1955](https://github.com/teng-lin/notebooklm-py/issues/1955)).
 - **Research import is now idempotent.** Re-importing a completed research task
   no longer duplicates its sources: `import_sources_with_verification` (and the
   MCP `research_import` tool that drives it) pre-filters requested sources whose

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0b3",
+  "version": "0.8.0b4",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0b3"
+version = "0.8.0b4"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0b3"
+version = "0.8.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release **v0.8.0b4** (beta serial bump; 0.8.0b3 → 0.8.0b4).

Fixes since 0.8.0b3 — see CHANGELOG.md `[Unreleased]`:

- **#1961** — `research_import` is now idempotent (URL pre-filter on every attempt; `newly_imported`/`already_present`; `allow_duplicate` opt-out honored even on the timeout-reconcile path; task-provenance validated before the filter). The top autonomous-safety item from the stress-test rounds.
- **#1965** — `chat_ask` reports `is_follow_up=true` when a null ask resumes an existing conversation.
- **#1959** — missing optional-dependency errors (e.g. `markdownify`) get a dedicated `DEPENDENCY` category + install-command hint instead of the wrong "check auth/storage" hint.
- **#1955** — `source_add` bytes upload seeds the filename/extension from `title`/`mime_type` instead of an extensionless `upload.bin` (which NotebookLM 400'd).

Gates green locally: public-API audit (allowlisted-only, `--check-stale` clean), ruff + mypy + doc-drift, full suite (10901 passed / 84 skipped / 1 xfailed). `fastmcp` stays pinned at `==3.4.2` (the dependabot 3.4.4 bump is held pending a connector-handshake check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plain-text byte uploads without an explicit filename so their file type is inferred from the title or MIME type, preventing upload rejections.
  * Retained `upload.bin` as a fallback when no extension information is available.

* **Chores**
  * Updated the application and extension version to 0.8.0b4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->