### PR TITLE
fix(chat): classify empty conversations as fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh conversations are no longer reported as follow-ups.** A null-conversation
+  ask now checks whether the server-assigned current conversation has any turns
+  before setting `AskResult.is_follow_up` ([#1973](https://github.com/teng-lin/notebooklm-py/issues/1973)).
+
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -439,10 +439,33 @@ class ChatAPI(LoopBoundPrimitive):
                     # conversation for the null POST, so drop the override and
                     # recover the real id post-POST, not the deleted one (#1875).
                     override = None if current_id in self._deleted_conversations else current_id
-                    # Resuming a live current conversation is a genuine
-                    # follow-up; a deleted one makes the server start fresh, so
-                    # it is not (override is None ⇒ new conversation) (#1965).
-                    is_follow_up = override is not None
+                    # A current id can refer to an auto-created, zero-turn
+                    # conversation. Only classify it as a follow-up when it has
+                    # local or server-side history (#1973).
+                    is_follow_up = False
+                    if override is not None:
+                        cached_turns = self._cache.get_cached_conversation(override)
+                        if cached_turns:
+                            is_follow_up = True
+                        else:
+                            try:
+                                turns_data = await self.get_conversation_turns(
+                                    notebook_id, override, limit=1
+                                )
+                                is_follow_up = bool(
+                                    unwrap_conversation_turns(
+                                        turns_data, source="_chat.ask.follow_up_probe"
+                                    )
+                                )
+                            except Exception as e:  # noqa: BLE001 - metadata probe is best-effort
+                                # Preserve ask availability when the metadata probe
+                                # fails; an existing id remains the safest fallback.
+                                logger.warning(
+                                    "Failed to inspect current conversation %s before ask: %s",
+                                    override,
+                                    e,
+                                )
+                                is_follow_up = True
                     posted = await perform_request(
                         conversation_history=None,
                         active_conversation_id=None,

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -440,22 +440,18 @@ class ChatAPI(LoopBoundPrimitive):
                     # recover the real id post-POST, not the deleted one (#1875).
                     override = None if current_id in self._deleted_conversations else current_id
                     # A current id can refer to an auto-created, zero-turn
-                    # conversation. Only classify it as a follow-up when it has
-                    # local or server-side history (#1973).
+                    # conversation. Query the server even when local turns are
+                    # cached because another client may have deleted them (#1973).
                     is_follow_up = False
                     if override is not None:
-                        cached_turns = self._cache.get_cached_conversation(override)
-                        if cached_turns:
-                            is_follow_up = True
-                        else:
-                            turns_data = await self.get_conversation_turns(
-                                notebook_id, override, limit=1
+                        turns_data = await self.get_conversation_turns(
+                            notebook_id, override, limit=1
+                        )
+                        is_follow_up = bool(
+                            unwrap_conversation_turns(
+                                turns_data, source="_chat.ask.follow_up_probe"
                             )
-                            is_follow_up = bool(
-                                unwrap_conversation_turns(
-                                    turns_data, source="_chat.ask.follow_up_probe"
-                                )
-                            )
+                        )
                     posted = await perform_request(
                         conversation_history=None,
                         active_conversation_id=None,

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -448,24 +448,14 @@ class ChatAPI(LoopBoundPrimitive):
                         if cached_turns:
                             is_follow_up = True
                         else:
-                            try:
-                                turns_data = await self.get_conversation_turns(
-                                    notebook_id, override, limit=1
+                            turns_data = await self.get_conversation_turns(
+                                notebook_id, override, limit=1
+                            )
+                            is_follow_up = bool(
+                                unwrap_conversation_turns(
+                                    turns_data, source="_chat.ask.follow_up_probe"
                                 )
-                                is_follow_up = bool(
-                                    unwrap_conversation_turns(
-                                        turns_data, source="_chat.ask.follow_up_probe"
-                                    )
-                                )
-                            except (ChatError, NetworkError, UnknownRPCMethodError) as e:
-                                # Preserve ask availability when the metadata probe
-                                # fails; an existing id remains the safest fallback.
-                                logger.warning(
-                                    "Failed to inspect current conversation %s before ask: %s",
-                                    override,
-                                    e,
-                                )
-                                is_follow_up = True
+                            )
                     posted = await perform_request(
                         conversation_history=None,
                         active_conversation_id=None,

--- a/src/notebooklm/_chat/api.py
+++ b/src/notebooklm/_chat/api.py
@@ -457,7 +457,7 @@ class ChatAPI(LoopBoundPrimitive):
                                         turns_data, source="_chat.ask.follow_up_probe"
                                     )
                                 )
-                            except Exception as e:  # noqa: BLE001 - metadata probe is best-effort
+                            except (ChatError, NetworkError, UnknownRPCMethodError) as e:
                                 # Preserve ask availability when the metadata probe
                                 # fails; an existing id remains the safest fallback.
                                 logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,6 +441,27 @@ def mock_get_conversation_id(httpx_mock, build_rpc_response):
 
 
 @pytest.fixture
+def legacy_vcr_follow_up_probe(monkeypatch):
+    """Supply the pre-existing turn omitted from chat cassettes recorded before #1973.
+
+    The old recordings contain the current-conversation lookup and chat POST,
+    but not the new pre-POST ``khqZz`` probe. Keep those recordings immutable;
+    dedicated characterization tests exercise the real probe request and its
+    empty, non-empty, and failure branches.
+    """
+    from notebooklm._chat import ChatAPI
+
+    original = ChatAPI.get_conversation_turns
+
+    async def _get_conversation_turns(self, notebook_id, conversation_id=None, limit=100):
+        if limit == 1:
+            return [[[None, None, 1, "Existing cassette conversation turn"]]]
+        return await original(self, notebook_id, conversation_id, limit)
+
+    monkeypatch.setattr(ChatAPI, "get_conversation_turns", _get_conversation_turns)
+
+
+@pytest.fixture
 def auth_tokens():
     """Canonical mock ``AuthTokens`` for unit tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,7 +388,7 @@ def build_rpc_response():
 
 @pytest.fixture
 def mock_get_conversation_id(httpx_mock, build_rpc_response):
-    """Register a batchexecute response for ``ChatAPI.get_conversation_id``.
+    """Register batchexecute responses for an existing conversation.
 
     After issue #659, ``ChatAPI.ask`` calls ``get_conversation_id``
     (wire-level ``hPTbtc``) post-ask for new conversations to recover the
@@ -396,7 +396,8 @@ def mock_get_conversation_id(httpx_mock, build_rpc_response):
     chat response. Any test that exercises the new-conversation path
     through ``client.chat.ask(...)`` without a ``conversation_id``
     argument must register a response, or the SDK will time out retrying
-    the unmocked call.
+    the unmocked call. The optional ``khqZz`` response gives that id one
+    existing turn when ``ask`` probes implicit follow-up state (#1973).
 
     Usage::
 
@@ -422,6 +423,17 @@ def mock_get_conversation_id(httpx_mock, build_rpc_response):
             content=response.encode(),
             method="POST",
             is_reusable=reusable,
+        )
+        turns_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [[[None, None, 1, "Existing question?"]]],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=khqZz.*"),
+            content=turns_response.encode(),
+            method="POST",
+            is_optional=True,
+            is_reusable=True,
         )
         return conv_id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,7 +453,8 @@ def legacy_vcr_follow_up_probe(monkeypatch):
 
     original = ChatAPI.get_conversation_turns
 
-    async def _get_conversation_turns(self, notebook_id, conversation_id=None, limit=100):
+    async def _get_conversation_turns(self, notebook_id: str, conversation_id: str, limit: int = 2):
+        """Replay legacy chat cassettes without changing the production signature."""
         if limit == 1:
             return [[[None, None, 1, "Existing cassette conversation turn"]]]
         return await original(self, notebook_id, conversation_id, limit)

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -73,6 +73,13 @@ def _build_get_conversation_id_response_body(conversation_id: str) -> str:
     return f")]}}'\n{len(chunk)}\n{chunk}\n"
 
 
+def _build_get_conversation_turns_response_body() -> str:
+    """Build a minimal ``khqZz`` response containing one existing turn."""
+    inner = json.dumps([[[None, None, 1, "Existing question?"]]])
+    chunk = json.dumps(["wrb.fr", RPCMethod.GET_CONVERSATION_TURNS.value, inner, None, None])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
 def _parse_chat_params(request: httpx.Request) -> list:
     """Decode the params list out of a chat POST body.
 
@@ -156,6 +163,13 @@ class _SerializingChatTransport(httpx.AsyncBaseTransport):
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         if "batchexecute" in str(request.url):
             notebook_id = _extract_source_path_notebook_id(request)
+            if "rpcids=khqZz" in str(request.url):
+                self._events.append(("khqzz", notebook_id, None))
+                return httpx.Response(
+                    200,
+                    text=_build_get_conversation_turns_response_body(),
+                    request=request,
+                )
             self._events.append(("hptbtc", notebook_id, None))
             conversation_id = self._conversation_ids_by_notebook.get(
                 notebook_id,

--- a/tests/integration/mcp_vcr/test_chat.py
+++ b/tests/integration/mcp_vcr/test_chat.py
@@ -60,7 +60,7 @@ CONFIGURE_NOTEBOOK_ID = "2bba3730-4547-48c7-b5f5-e631eb5332ca"
 
 @pytest.mark.asyncio
 @notebooklm_vcr.use_cassette("chat_ask.yaml")
-async def test_mcp_chat_ask_with_references_over_vcr() -> None:
+async def test_mcp_chat_ask_with_references_over_vcr(legacy_vcr_follow_up_probe) -> None:
     """``chat_ask`` returns the recorded answer + citations through the real client.
 
     End-to-end: FastMCP ``Client`` → ``chat_ask`` tool → ``client.chat.ask`` →

--- a/tests/integration/test_chat_multi_source_vcr.py
+++ b/tests/integration/test_chat_multi_source_vcr.py
@@ -286,7 +286,7 @@ class TestChatMultiSource:
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
-    async def test_ask_with_five_explicit_sources(self) -> None:
+    async def test_ask_with_five_explicit_sources(self, legacy_vcr_follow_up_probe) -> None:
         """A chat ask against five explicit sources round-trips successfully.
 
         Recording-mode behavior: create scratch notebook + five sources

--- a/tests/integration/test_chat_oversized_rejection_vcr.py
+++ b/tests/integration/test_chat_oversized_rejection_vcr.py
@@ -117,7 +117,9 @@ def _recorded_notebook_id() -> str:
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_oversized_question_raises_chat_error_not_parse_error() -> None:
+async def test_oversized_question_raises_chat_error_not_parse_error(
+    legacy_vcr_follow_up_probe,
+) -> None:
     """An over-long question surfaces a ``ChatError`` rejection, not a parse error.
 
     The assertion is the regression: pre-fix this raised

--- a/tests/integration/test_golden_decoded_vcr.py
+++ b/tests/integration/test_golden_decoded_vcr.py
@@ -104,7 +104,7 @@ class TestChatGoldenDecoded:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("chat_ask.yaml", match_on=_CHAT_MATCH_ON)
-    async def test_ask_decoded_golden(self):
+    async def test_ask_decoded_golden(self, legacy_vcr_follow_up_probe):
         """``chat.ask`` decodes the recorded answer / conversation / references."""
         async with vcr_client() as client:
             result = await client.chat.ask(
@@ -160,7 +160,7 @@ class TestChatGoldenDecoded:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("chat_ask_with_references.yaml", match_on=_CHAT_MATCH_ON)
-    async def test_ask_with_references_decoded_golden(self):
+    async def test_ask_with_references_decoded_golden(self, legacy_vcr_follow_up_probe):
         """``chat.ask`` decodes per-reference offsets AND server relevance scores.
 
         This cassette additionally exercises the ``score`` slot (server-side

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -628,7 +628,7 @@ class TestChatAPI:
         # because most endpoints do not send ``f.req``.
         match_on=["method", "scheme", "host", "port", "path", "freq"],
     )
-    async def test_ask(self):
+    async def test_ask(self, legacy_vcr_follow_up_probe):
         """Ask a question."""
         async with vcr_client() as client:
             result = await client.chat.ask(
@@ -648,7 +648,7 @@ class TestChatAPI:
         # by replay-order. See ``test_ask`` above for the full rationale.
         match_on=["method", "scheme", "host", "port", "path", "freq"],
     )
-    async def test_ask_with_references(self):
+    async def test_ask_with_references(self, legacy_vcr_follow_up_probe):
         """Ask a question that generates references."""
         async with vcr_client() as client:
             result = await client.chat.ask(

--- a/tests/integration/test_workflow_tracer_vcr.py
+++ b/tests/integration/test_workflow_tracer_vcr.py
@@ -110,7 +110,9 @@ class TestWorkflowTracerBullet:
         # here keeps the per-cassette ``match_on`` self-contained.
         match_on=["method", "scheme", "host", "port", "path", "rpcids", "freq"],
     )
-    async def test_full_workflow(self, tmp_path: Path, fast_sleep: None) -> None:
+    async def test_full_workflow(
+        self, tmp_path: Path, fast_sleep: None, legacy_vcr_follow_up_probe
+    ) -> None:
         """End-to-end user journey produces a downloadable report.
 
         Asserts each phase's intermediate output:

--- a/tests/server/test_integration_real_client.py
+++ b/tests/server/test_integration_real_client.py
@@ -158,7 +158,7 @@ class TestSources:
 
 class TestChatAndArtifacts:
     @notebooklm_vcr.use_cassette("chat_ask.yaml", allow_playback_repeats=True)
-    def test_chat_ask(self, real_authed_client: TestClient) -> None:
+    def test_chat_ask(self, real_authed_client: TestClient, legacy_vcr_follow_up_probe) -> None:
         resp = real_authed_client.post(
             f"/v1/notebooks/{_NB}/chat", json={"question": "What is this notebook about?"}
         )

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -568,8 +568,9 @@ class TestChatNewConversationLocks:
                 return result
 
             async def get_conversation_turns(
-                self, notebook_id: str, conversation_id: str | None = None, limit: int = 100
+                self, notebook_id: str, conversation_id: str, limit: int = 2
             ) -> list[Any]:
+                """Return existing history through the production method contract."""
                 return [[[None, None, 1, "Existing question?"]]]
 
         async def fake_perform_authed_post(*args: Any, **kwargs: Any) -> httpx.Response:

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -372,10 +372,15 @@ class TestChatRefreshRetry:
                 # through this fake_post. Identify it by URL and return a
                 # minimal RPC response that decodes to a valid conv_id.
                 if "batchexecute" in str(url):
-                    rpc_body = (
-                        ")]}'\n"
-                        '63\n[["wrb.fr","hPTbtc","[[[\\"real-conv-id-from-hptbtc\\"]]]",null,null]]'
+                    rpc_id = "khqZz" if "rpcids=khqZz" in str(url) else "hPTbtc"
+                    data = (
+                        [[[None, None, 1, "Existing question?"]]]
+                        if rpc_id == "khqZz"
+                        else [[["real-conv-id-from-hptbtc"]]]
                     )
+                    inner = json.dumps(data)
+                    chunk = json.dumps(["wrb.fr", rpc_id, inner, None, None])
+                    rpc_body = f")]}}'\n{len(chunk)}\n{chunk}\n"
                     return httpx.Response(
                         200,
                         request=httpx.Request("POST", url),
@@ -561,6 +566,11 @@ class TestChatNewConversationLocks:
                 if isinstance(result, ChatError):
                     raise result
                 return result
+
+            async def get_conversation_turns(
+                self, notebook_id: str, conversation_id: str | None = None, limit: int = 100
+            ) -> list[Any]:
+                return [[[None, None, 1, "Existing question?"]]]
 
         async def fake_perform_authed_post(*args: Any, **kwargs: Any) -> httpx.Response:
             return httpx.Response(

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1126,6 +1126,49 @@ class TestAskServerAssignedConversationId:
         assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
 
     @pytest.mark.asyncio
+    async def test_server_probe_overrides_stale_cached_turns(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A warm cache cannot override an externally emptied conversation."""
+        import json
+        import re
+
+        current_id = "externally-emptied-conversation"
+        inner_json = json.dumps(
+            [["Fresh answer.", None, ["stream-id", 12345], None, [[], None, None, [], 1]]]
+        )
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=f")]}}'\n{len(chunk_json)}\n{chunk_json}\n".encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=hPTbtc.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_LAST_CONVERSATION_ID, [[[current_id]]]
+            ).encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=khqZz.*"),
+            content=build_rpc_response(RPCMethod.GET_CONVERSATION_TURNS, [[]]).encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            client.chat._cache.cache_conversation_turn(
+                current_id, "Cached question?", "Cached answer.", turn_number=1
+            )
+            result = await client.chat.ask("nb_123", "Fresh question?", source_ids=["src_001"])
+
+        assert result.is_follow_up is False
+        assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
+
+    @pytest.mark.asyncio
     async def test_conversation_probe_failure_raises_before_chat_post(
         self,
         auth_tokens,

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1039,6 +1039,48 @@ class TestAskServerAssignedConversationId:
         )
 
     @pytest.mark.asyncio
+    async def test_empty_current_conversation_is_not_a_follow_up(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """An auto-created current conversation with no turns is still fresh (#1973)."""
+        import json
+        import re
+
+        current_id = "empty-current-conversation"
+        inner_json = json.dumps(
+            [["First answer.", None, ["stream-id", 12345], None, [[], None, None, [], 1]]]
+        )
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=f")]}}'\n{len(chunk_json)}\n{chunk_json}\n".encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=hPTbtc.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_LAST_CONVERSATION_ID, [[[current_id]]]
+            ).encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=khqZz.*"),
+            content=build_rpc_response(RPCMethod.GET_CONVERSATION_TURNS, [[]]).encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.ask("nb_123", "First question?", source_ids=["src_001"])
+
+        assert result.conversation_id == current_id
+        assert result.turn_number == 1
+        assert result.is_follow_up is False
+        assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
+
+    @pytest.mark.asyncio
     async def test_new_conversation_raises_when_hptbtc_returns_no_conversation(
         self,
         auth_tokens,

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1081,6 +1081,49 @@ class TestAskServerAssignedConversationId:
         assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
 
     @pytest.mark.asyncio
+    async def test_conversation_probe_failure_preserves_follow_up_fallback(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A failed history probe must not prevent asking in an existing conversation."""
+        import json
+        import re
+
+        from notebooklm.exceptions import NetworkError
+
+        current_id = "unavailable-current-conversation"
+        inner_json = json.dumps(
+            [["Fallback answer.", None, ["stream-id", 12345], None, [[], None, None, [], 1]]]
+        )
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=f")]}}'\n{len(chunk_json)}\n{chunk_json}\n".encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=hPTbtc.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_LAST_CONVERSATION_ID, [[[current_id]]]
+            ).encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.chat,
+                "get_conversation_turns",
+                new=AsyncMock(side_effect=NetworkError("history unavailable")),
+            ):
+                result = await client.chat.ask("nb_123", "Continue?", source_ids=["src_001"])
+
+        assert result.conversation_id == current_id
+        assert result.turn_number == 1
+        assert result.is_follow_up is True
+
+    @pytest.mark.asyncio
     async def test_new_conversation_raises_when_hptbtc_returns_no_conversation(
         self,
         auth_tokens,

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1081,21 +1081,19 @@ class TestAskServerAssignedConversationId:
         assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
 
     @pytest.mark.asyncio
-    async def test_conversation_probe_failure_preserves_follow_up_fallback(
+    async def test_current_conversation_with_turns_is_a_follow_up(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
-        """A failed history probe must not prevent asking in an existing conversation."""
+        """A cold cache still detects prior server-side conversation turns."""
         import json
         import re
 
-        from notebooklm.exceptions import NetworkError
-
-        current_id = "unavailable-current-conversation"
+        current_id = "existing-current-conversation"
         inner_json = json.dumps(
-            [["Fallback answer.", None, ["stream-id", 12345], None, [[], None, None, [], 1]]]
+            [["Next answer.", None, ["stream-id", 12345], None, [[], None, None, [], 1]]]
         )
         chunk_json = json.dumps([["wrb.fr", None, inner_json]])
         httpx_mock.add_response(
@@ -1110,18 +1108,56 @@ class TestAskServerAssignedConversationId:
             ).encode(),
             method="POST",
         )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=khqZz.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_CONVERSATION_TURNS,
+                [[[None, None, 1, "Earlier question?"]]],
+            ).encode(),
+            method="POST",
+        )
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch.object(
-                client.chat,
-                "get_conversation_turns",
-                new=AsyncMock(side_effect=NetworkError("history unavailable")),
-            ):
-                result = await client.chat.ask("nb_123", "Continue?", source_ids=["src_001"])
+            result = await client.chat.ask("nb_123", "Continue?", source_ids=["src_001"])
 
         assert result.conversation_id == current_id
         assert result.turn_number == 1
         assert result.is_follow_up is True
+        assert any("rpcids=khqZz" in str(r.url) for r in httpx_mock.get_requests())
+
+    @pytest.mark.asyncio
+    async def test_conversation_probe_failure_raises_before_chat_post(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A failed history probe aborts before generating an answer."""
+        import re
+
+        from notebooklm.exceptions import ServerError
+
+        current_id = "unavailable-current-conversation"
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=hPTbtc.*"),
+            content=build_rpc_response(
+                RPCMethod.GET_LAST_CONVERSATION_ID, [[[current_id]]]
+            ).encode(),
+            method="POST",
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*rpcids=khqZz.*"),
+            status_code=500,
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
+            with pytest.raises(ServerError, match="500"):
+                await client.chat.ask("nb_123", "Continue?", source_ids=["src_001"])
+
+        assert not any(
+            "GenerateFreeFormStreamed" in str(request.url) for request in httpx_mock.get_requests()
+        )
 
     @pytest.mark.asyncio
     async def test_new_conversation_raises_when_hptbtc_returns_no_conversation(

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -75,6 +75,8 @@ def mock_core():
     async def _rpc_call_dispatch(method, params, **kwargs):
         if method == _RPC.GET_LAST_CONVERSATION_ID:
             return [[["mock-core-conv-id"]]]
+        if method == _RPC.GET_CONVERSATION_TURNS:
+            return [[[None, None, 1, "Existing question?"]]]
         return rpc_call.return_value
 
     rpc_call.side_effect = _rpc_call_dispatch


### PR DESCRIPTION
## Summary

Treat an auto-created current conversation with zero server-side turns as a fresh conversation, so the first `chat_ask` reports `is_follow_up=false`.

## Related Issue

Closes #1973

## Changes

- reuse locally cached turns when available to avoid an extra metadata request
- otherwise query at most one server-side turn before classifying an implicit continuation
- keep the history probe best-effort so metadata failures do not block the chat request
- add a regression test for a non-null current conversation ID with an empty turn list

## Test Plan

- [x] I tested these changes locally
- [x] Full test and coverage suite passes (`uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90`): 12,387 passed, 64 skipped, 1 xfailed; 96.45% coverage
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] No architectural shape change; an ADR is not required

## Notes

The additional `khqZz` lookup only runs when the current conversation has no locally cached turns. If that best-effort lookup fails, the existing-ID behavior is retained and the ask proceeds.

This contribution was developed with AI assistance. I reviewed the resulting diff and ran the test, coverage, lint, formatting, and type-check commands listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected follow-up detection for chat requests by deriving follow-up status from detected prior turn history for the server-assigned current conversation.
  * Prevented fresh conversations from being incorrectly marked as follow-ups when no prior turns exist.
  * Ensured history-probe failures raise an error and stop subsequent chat submission.

* **Tests**
  * Added unit regression coverage for empty vs. non-empty history and probe-failure behavior.
  * Extended test fixtures/mocks and updated VCR-based integration tests to support the added follow-up probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->