### PR TITLE
docs(readme): note the NotebookLM → Gemini Notebook rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **A Comprehensive NotebookLM Skill & Unofficial Python API.** Full programmatic access to NotebookLM's features—including capabilities the web UI doesn't expose—via Python, CLI, and AI agents like Claude Code, Codex, and OpenClaw.
 
+> **Note (July 2026):** Google rebranded **NotebookLM** to **[Gemini Notebook](https://blog.google/innovation-and-ai/products/gemini-notebook/notebooklm-gemini-notebook/)**. It remains the same standalone product (now also reachable inside the Gemini app), existing links redirect automatically, and this library drives the same underlying service and works unchanged. The package keeps the `notebooklm-py` name.
+
 [![PyPI version](https://img.shields.io/pypi/v/notebooklm-py.svg)](https://pypi.org/project/notebooklm-py/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/notebooklm-py/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Google rebranded **NotebookLM → Gemini Notebook** on 2026-07-16 ([blog](https://blog.google/innovation-and-ai/products/gemini-notebook/notebooklm-gemini-notebook/)). It remains the same standalone product, existing links redirect automatically, and there's **no announced API/backend change** — the client works unchanged (verified live post-rebrand).

Adds a one-line note to the README intro for accuracy + discoverability (users now search "Gemini Notebook"). The package keeps the `notebooklm-py` name.

Related: #1977 (migration watch — monitor-only, no code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a July 2026 note explaining Google’s rebranding of NotebookLM to “Gemini Notebook.”
  * Clarified that the product remains standalone and that existing links redirect automatically.
  * Confirmed that the library continues to use the `notebooklm-py` package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->