### PR TITLE
chore: release v0.8.0b5

### DIFF
--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0b4",
+  "version": "0.8.0b5",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0b4"
+version = "0.8.0b5"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0b4"
+version = "0.8.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release **v0.8.0b5** (beta serial bump; 0.8.0b4 → 0.8.0b5).

Fix since 0.8.0b4 — see CHANGELOG.md `[Unreleased]`:

- **#1973** — `chat_ask` no longer reports `is_follow_up=true` on the **first** question to a notebook (a regression from the b4 #1965 fix). Fixed by external contributor @loulanyue in #1974: the null-conversation path now always runs a **pre-POST raw `get_conversation_turns(limit=1)` existence probe** (server-authoritative, no cache fast-path — cross-client safe; probe errors propagate rather than defaulting the flag). `turn_number` reliability tracked separately in #1976.

Gates green locally: public-API audit (allowlisted-only, `--check-stale` clean), ruff + mypy + doc-drift, full suite (10905 passed / 84 skipped / 1 xfailed). `fastmcp` stays pinned at `==3.4.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop extension and package release version to 0.8.0b5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->