### PR TITLE
docs: 'Unknown tool' after upgrade — remove & re-add connector (not reconnect)

### DIFF
--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -543,11 +543,12 @@ gate the destructive ones.
   searches common install dirs beyond `PATH`.
 - **Client doesn't see the tools.** Confirm the config was written (`notebooklm mcp install <client>`)
   and **restart the client** — most hosts only read MCP config at startup.
-- **`Unknown tool: '<name>'` after upgrading the server.** The claude.ai connector caches the tool
-  list from when it connected, so a version upgrade that **renamed or folded** a tool leaves the old
-  name callable-but-failing until you **reconnect the connector** (disconnect + reconnect, or toggle it
-  off/on). Newly-added *optional* parameters on existing tools forward through the stale schema and keep
-  working without a reconnect. See [troubleshooting.md](troubleshooting.md#unknown-tool-from-the-claudeai-connector-after-upgrading-the-server).
+- **`Unknown tool: '<name>'` after upgrading the server.** The MCP host (claude.ai, ChatGPT, …) caches
+  the tool list from when it connected, so a version upgrade that **renamed or folded** a tool leaves the
+  old name callable-but-failing. **Remove and re-add the connector** to refresh it — a reconnect / re-auth
+  is often *not* enough (some hosts, notably ChatGPT, keep the cached manifest across reconnects). The
+  server's live manifest is correct; only *removed/renamed tools* ghost — newly-added *optional* parameters
+  on existing tools forward through the stale schema and keep working. See [troubleshooting.md](troubleshooting.md#unknown-tool-from-an-mcp-host-claudeai-chatgpt--after-upgrading-the-server).
 - **Wrong account.** The server binds one profile per process. Start it with `--profile <name>`, or set
   `NOTEBOOKLM_PROFILE`. See [configuration.md](configuration.md#multiple-accounts).
 - **`RATE_LIMITED`.** NotebookLM enforces per-account quotas; the error is `retriable=true` — back off

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -825,18 +825,25 @@ the features:
 - **`curl_cffi` transport**: `NOTEBOOKLM_TRANSPORT=curl_cffi` requires the
   `curl_cffi` package; see the region / anti-abuse gate section above.
 
-### "Unknown tool" from the claude.ai connector after upgrading the server
+### "Unknown tool" from an MCP host (claude.ai, ChatGPT, …) after upgrading the server
 
-**Cause:** The claude.ai connector fetches the server's tool list (`tools/list`)
-when it connects and caches it. After you upgrade a deployed server to a version
-that **renamed or folded** a tool, the connector keeps advertising the *old*
-manifest, so a call to a since-removed tool reaches the server and fails cleanly
-with `Unknown tool: '<name>'`. This is expected MCP-host caching, not a server
-bug: a server can't notify a client that isn't connected, and
-`notifications/tools/list_changed` only reaches a *live* session.
+**Cause:** The MCP host fetches the server's tool list (`tools/list`) when it first
+connects and **caches it against the connector**. After you upgrade a deployed
+server to a version that **renamed or folded** a tool, the host keeps advertising
+the *old* manifest, so a call to a since-removed tool reaches the server and fails
+cleanly with `Unknown tool: '<name>'`. This is expected MCP-host caching, **not a
+server bug** — the server's live manifest is correct (you can confirm with
+`await Client(create_server()).list_tools()`). A server can't notify a host that
+isn't connected, and `notifications/tools/list_changed` only reaches a *live*
+session.
 
-**Solution:** Reconnect the connector in claude.ai — disconnect and reconnect, or
-toggle it off and back on — to refresh the manifest.
+**Solution: remove and re-add the connector** in the host's connector settings.
+A *reconnect* / re-auth / off-and-on toggle is often **not enough** — several
+hosts (notably ChatGPT) re-authenticate but keep the cached tool list and do not
+re-call `tools/list`, so the ghost tool persists across reconnects. Fully deleting
+the connector and adding it again forces a fresh `tools/list`. (Newly-added
+*optional parameters* on existing tools forward through the stale schema and keep
+working without any refresh — only *removed/renamed tools* ghost.)
 
 **Only removed or renamed _tools_ ghost this way — new _optional_ parameters
 forward through the stale schema.** For example, when `source_upload_bytes` was folded


### PR DESCRIPTION
Corrects the #1956/#1957 troubleshooting note. Verified empirically: the deployed b5 server's live manifest is **correct** (queried the container directly — 33 tools, no `studio_get_prompt`/`source_upload_bytes`/`source_add_and_wait`). The ghost tool is **host-side manifest caching**, not a server bug.

But the previous advice ("reconnect / toggle off-on to refresh") is **insufficient** — some hosts (notably **ChatGPT**) re-authenticate on reconnect but keep the cached tool list and don't re-call `tools/list`, so the removed tool persists across reconnects. **Fix: fully remove and re-add the connector.** Also broadens "claude.ai connector" → "MCP host (claude.ai, ChatGPT, …)" since the caching affects multiple hosts.

Docs-only; doc-link/drift checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XmN63FN4Kz2nkmC4eX99jC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting guidance for “Unknown tool” errors across MCP hosts, including claude.ai and ChatGPT.
  * Clarified that hosts may cache outdated tool lists after server upgrades.
  * Updated the recommended fix: remove and re-add the connector to refresh available tools.
  * Documented how renamed or removed tools may continue to appear temporarily, while new optional parameters remain usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->