### PR TITLE
fix(mcp-oauth): key OAuth state on base_url, not the served profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Self-hosted MCP OAuth: switching the served account no longer resets the client
+  registry.** OAuth-registered clients + issued tokens (`oauth_state.json`) were stored
+  under the *served account's profile dir*, so pointing the server at a different profile
+  silently orphaned every connected client (ChatGPT / claude.ai → "Client ID not found").
+  The OAuth state is now **deployment-scoped**, keyed on `NOTEBOOKLM_MCP_OAUTH_BASE_URL`
+  (the OAuth issuer) at `<home>/oauth/<slug>.json` — independent of the served profile,
+  and distinct per issuer so two servers on one host stay isolated. New
+  `NOTEBOOKLM_MCP_OAUTH_STATE_PATH` overrides the path; the Docker deploy mounts a
+  dedicated `/data/oauth` volume (`NOTEBOOKLM_OAUTH_STATE_DIR`). Existing installs are
+  migrated once on startup (the legacy profile-dir `oauth_state.json` is copied over, then
+  renamed `.migrated` so it is never re-read). This deliberately reverses the profile-dir
+  coupling introduced in #1765, and applies the deployment-vs-data separation that the
+  proposed multi-profile server
+  ([#1901](https://github.com/teng-lin/notebooklm-py/issues/1901)) builds on — without
+  implementing it.
+
 ## [0.8.0]
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -27,10 +27,15 @@ NOTEBOOKLM_MCP_TOKEN=
 # NOTE: Cloudflare's edge sees this password in transit (it terminates TLS) — use a
 # throwaway Google account. Rotating the password swaps the in-memory check but does
 # NOT revoke already-issued OAuth tokens (they're long-lived and persisted): real
-# revocation = delete the profile's oauth_state.json and restart. Both vars required
-# together (partial → refuses to start).
+# revocation = delete the OAuth state file (path logged at startup; default
+# /data/oauth/<slug>.json on the mount below) and restart. Both vars required together
+# (partial → refuses to start).
 # NOTEBOOKLM_MCP_OAUTH_PASSWORD=
 # NOTEBOOKLM_MCP_OAUTH_BASE_URL=https://your-host.example.com
+# Where the OAuth client registry + tokens persist. Unset → /data/oauth/<slug>.json
+# (keyed on the base_url, deployment-scoped — INDEPENDENT of NOTEBOOKLM_PROFILE_DIR, so
+# switching the served profile no longer orphans registered clients). Set to override.
+# NOTEBOOKLM_MCP_OAUTH_STATE_PATH=/data/oauth/oauth_state.json
 # Cloudflare ONLY: trust the tunnel's CF-Connecting-IP header so the login throttle keys
 # per-IP instead of globally. Leave unset unless a trusted proxy sets that header (an
 # exposed-directly origin could forge it to dodge the throttle). Tailscale Funnel does not
@@ -59,6 +64,13 @@ CF_TUNNEL_TOKEN=
 # Defaults to your local "default" profile. Point at a dedicated/throwaway
 # profile here (recommended — master_token.json is a full-account credential).
 # NOTEBOOKLM_PROFILE_DIR=/home/you/.notebooklm/profiles/throwaway
+
+# Host dir bind-mounted to /data/oauth for the OAuth client registry (+ tokens), kept
+# SEPARATE from the profile dir so it survives a profile switch. Defaults to
+# deploy/oauth-state (the `make` targets pre-create it 0700; direct `docker compose up`
+# users must `mkdir -p ./oauth-state && chmod 700 ./oauth-state` first so it isn't
+# root-created). Full-account secret; only used when OAuth is enabled.
+# NOTEBOOKLM_OAUTH_STATE_DIR=./oauth-state
 
 # The container runs as this uid:gid so the mounted profile needs NO chown (your
 # own CLI keeps owning the files). `make` fills these from `id` automatically;

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,3 +1,4 @@
 # Never commit deployment secrets.
 .env
 profile/
+oauth-state/

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -19,7 +19,10 @@ TUNNEL ?= $(if $(_TUNNEL_DOTENV),$(_TUNNEL_DOTENV),cloudflare)
 # CLI/env override wins; else deploy/.env; else ./oauth-state (matches the compose
 # default). make-only, so `_ensure-state-dir` can pre-create it (user-owned) before `up`.
 _OAUTH_STATE_DOTENV := $(shell [ -f .env ] && sed -n 's/^NOTEBOOKLM_OAUTH_STATE_DIR=//p' .env | tr -d '\r' | head -1)
-OAUTH_STATE_DIR ?= $(if $(_OAUTH_STATE_DOTENV),$(_OAUTH_STATE_DOTENV),./oauth-state)
+# Match Compose's own interpolation precedence: an exported NOTEBOOKLM_OAUTH_STATE_DIR
+# (which Compose reads directly) wins, then deploy/.env, then the default. Otherwise
+# `NOTEBOOKLM_OAUTH_STATE_DIR=/x make up` would mount /x but pre-create ./oauth-state.
+OAUTH_STATE_DIR ?= $(or $(NOTEBOOKLM_OAUTH_STATE_DIR),$(_OAUTH_STATE_DOTENV),./oauth-state)
 
 # Pin a published image tag with `make prod VERSION=x.y.z`. Otherwise, keep the
 # override order: shell/CLI env, deploy/.env, this checkout's pyproject version,

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -15,6 +15,12 @@ COMPOSE ?= docker compose
 _TUNNEL_DOTENV := $(shell [ -f .env ] && sed -n 's/^TUNNEL=//p' .env | tr -d '\r' | head -1)
 TUNNEL ?= $(if $(_TUNNEL_DOTENV),$(_TUNNEL_DOTENV),cloudflare)
 
+# OAUTH_STATE_DIR: host dir bind-mounted to /data/oauth for the OAuth client registry.
+# CLI/env override wins; else deploy/.env; else ./oauth-state (matches the compose
+# default). make-only, so `_ensure-state-dir` can pre-create it (user-owned) before `up`.
+_OAUTH_STATE_DOTENV := $(shell [ -f .env ] && sed -n 's/^NOTEBOOKLM_OAUTH_STATE_DIR=//p' .env | tr -d '\r' | head -1)
+OAUTH_STATE_DIR ?= $(if $(_OAUTH_STATE_DOTENV),$(_OAUTH_STATE_DOTENV),./oauth-state)
+
 # Pin a published image tag with `make prod VERSION=x.y.z`. Otherwise, keep the
 # override order: shell/CLI env, deploy/.env, this checkout's pyproject version,
 # then Make's missing-version guard.
@@ -75,19 +81,26 @@ _require-tunnel-token:
 			|| { echo "✗ TUNNEL=tailscale needs TS_AUTHKEY — set it in deploy/.env"; exit 1; }; \
 	else echo "✗ Unknown TUNNEL=$(TUNNEL) (use cloudflare or tailscale)"; exit 1; fi
 
+# Pre-create the OAuth-state mount dir as the invoking user, so Docker never
+# root-creates it (which the uid-mapped container then couldn't write). chmod 700
+# because it holds a full-account secret and shell `mkdir` honors umask (0755 under the
+# common 022). Harmless when OAuth is off — just an empty dir the server ignores.
+_ensure-state-dir:
+	@mkdir -p "$(OAUTH_STATE_DIR)" && chmod 700 "$(OAUTH_STATE_DIR)"
+
 setup: ## Interactive first run: pick a tunnel + generate secrets → writes .env
 	@sh setup.sh
 
 up: prod ## Pull the published image and start (the easy path)
 
-prod: _require-image-version _require-tunnel-token ## Pull a published version and start (VERSION=x.y.z, or pin NOTEBOOKLM_MCP_VERSION in .env)
+prod: _require-image-version _require-tunnel-token _ensure-state-dir ## Pull a published version and start (VERSION=x.y.z, or pin NOTEBOOKLM_MCP_VERSION in .env)
 	$(DC) pull
 	$(DC) up -d
 
-dev: _require-image-version _require-tunnel-token ## Build THIS checkout and start (contributors; TUNNEL=cloudflare|tailscale)
+dev: _require-image-version _require-tunnel-token _ensure-state-dir ## Build THIS checkout and start (contributors; TUNNEL=cloudflare|tailscale)
 	$(DC_BUILD) up -d --build
 
-restart: _require-image-version _require-tunnel-token ## Rebuild THIS checkout + recreate after a source/config change
+restart: _require-image-version _require-tunnel-token _ensure-state-dir ## Rebuild THIS checkout + recreate after a source/config change
 	$(DC_BUILD) up -d --build
 
 logs: ## Tail the server logs

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -253,14 +253,19 @@ unaffected); when set, the bearer and OAuth work side by side on the same `/mcp`
 
 > **What it does NOT need vs an IdP:** no dashboard, no JWT template, no audience/email
 > config — the password is the whole identity. Registered clients + tokens **persist**
-> across restarts in `oauth_state.json` under the mounted profile, so a redeploy doesn't
-> force re-login. **Treat `oauth_state.json` as a full-account secret** (it holds
-> long-lived OAuth tokens — same tier as `master_token.json`).
+> across restarts in a **deployment-scoped** state file keyed on the base_url — by
+> default `/data/oauth/<slug>.json` on the dedicated `oauth-state` mount, **not** the
+> profile dir — so switching the served account no longer orphans registered clients
+> (path is logged at startup; override with `NOTEBOOKLM_MCP_OAUTH_STATE_PATH`). **Treat
+> that file as a full-account secret** (it holds long-lived OAuth tokens — same tier as
+> `master_token.json`); the `oauth-state` host dir is created `0700`.
 > **Honest trade:** because the login page is served through your tunnel, **Cloudflare's
 > edge sees the password in transit** (it terminates TLS) — use a throwaway Google
 > account. Note: rotating the password does **not** revoke already-issued OAuth tokens
-> (they're long-lived + persisted); **real revocation = delete `oauth_state.json` and
-> restart**. (To remove Cloudflare from the path, self-host TLS instead.)
+> (they're long-lived + persisted); **real revocation = delete the live OAuth state file
+> (the `/data/oauth/<slug>.json` logged at startup) and restart** — a once-migrated legacy
+> `oauth_state.json` is renamed `.migrated` and never re-read, so it can't resurrect them.
+> (To remove Cloudflare from the path, self-host TLS instead.)
 
 ## 7. (Optional) Connect from ChatGPT — same OAuth, Developer Mode required
 ChatGPT's custom MCP connectors speak the **same self-hosted OAuth** as claude.ai — there's

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,12 @@
 #   docker compose --profile tailscale  up -d   # Tailscale Funnel (no domain; *.ts.net)
 #   # (the Makefile wraps this: `make dev` / `make dev TUNNEL=tailscale`)
 #
+# OAuth users invoking `docker compose up` DIRECTLY (not via `make`) must first create
+# the OAuth-state mount dir as yourself: `mkdir -p ./oauth-state && chmod 700 ./oauth-state`.
+# Otherwise Docker auto-creates it root-owned and the (uid 1000) container cannot write it;
+# the chmod keeps this full-account-secret dir private (shell mkdir honors umask). `make`
+# targets do this for you.
+#
 # The notebooklm-mcp service runs under either profile; exactly one tunnel sidecar
 # is selected. No host ports are published — the ONLY way in is through the chosen
 # tunnel, which terminates TLS at its edge (no CA cert for you to manage). See README.md.
@@ -34,9 +40,15 @@ services:
       NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND: "1"
       # Optional self-hosted OAuth (for claude.ai). Unset → bearer-only; set both
       # together (partial → refuses to start). See .env.example. The OAuth state
-      # (registered clients + tokens) persists under the mounted profile volume.
+      # (registered clients + tokens) persists under the dedicated /data/oauth mount
+      # below — keyed on the base_url, INDEPENDENT of the served profile, so switching
+      # NOTEBOOKLM_PROFILE_DIR no longer orphans registered clients.
       NOTEBOOKLM_MCP_OAUTH_PASSWORD: ${NOTEBOOKLM_MCP_OAUTH_PASSWORD:-}
       NOTEBOOKLM_MCP_OAUTH_BASE_URL: ${NOTEBOOKLM_MCP_OAUTH_BASE_URL:-}
+      # Optional explicit OAuth-state path. Unset → derived default
+      # /data/oauth/<slug>.json on the mount below. Must be listed here to reach the
+      # container (compose `.env` is interpolation-source only, not container env).
+      NOTEBOOKLM_MCP_OAUTH_STATE_PATH: ${NOTEBOOKLM_MCP_OAUTH_STATE_PATH:-}
       # Optional (Cloudflare profile only): trust the tunnel's CF-Connecting-IP header as
       # the per-IP login-throttle key. Default off → throttle keys on the socket peer (the
       # tunnel egress), i.e. one global bucket. Tailscale Funnel does not set this header.
@@ -65,6 +77,11 @@ services:
       # in .env to point at a different profile dir (e.g. a dedicated/throwaway one).
       # Treat the dir as a secret — master_token.json is a full-account credential.
       - "${NOTEBOOKLM_PROFILE_DIR:-${HOME}/.notebooklm/profiles/default}:/data/profiles/server:rw"
+      # READ-WRITE, deployment-scoped: the OAuth client registry + issued tokens live
+      # here (/data/oauth/<slug>.json), NOT in the profile dir — so switching the served
+      # profile keeps registered clients. Pre-create the host dir as yourself (the `make`
+      # targets do; direct `docker compose up` users: `mkdir -p ./oauth-state && chmod 700 ./oauth-state`).
+      - "${NOTEBOOKLM_OAUTH_STATE_DIR:-./oauth-state}:/data/oauth:rw"
     # No `ports:` — not reachable except via the tunnel.
 
   # --- Tunnel option A: Cloudflare (needs a domain in your Cloudflare account) ----

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -73,6 +73,12 @@ umask 077
   fi
 } > .env
 
+# Pre-create the OAuth-state mount dir (host ./oauth-state → /data/oauth) as the invoking
+# user, so Docker never root-creates it and the uid-mapped container can write it. chmod
+# 700 — it holds a full-account secret and shell `mkdir` honors umask. The `make` targets
+# also do this via `_ensure-state-dir`; harmless to repeat.
+[ -n "$OAUTH" ] && { mkdir -p ./oauth-state && chmod 700 ./oauth-state; }
+
 echo
 echo "✓ Wrote deploy/.env — TUNNEL=$TUNNEL, bearer token generated${OAUTH:+, OAuth password generated}."
 echo "Next:"

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -125,6 +125,22 @@ before you start: the auth model and remote file transfer.
 Use a **dedicated/throwaway Google account** — the mounted `master_token.json` is a durable
 full-account credential. Multi-tenant hosting is out of scope for this single-tenant setup.
 
+**Where OAuth state lives.** The registered clients + issued tokens persist to a
+deployment-scoped file keyed on `NOTEBOOKLM_MCP_OAUTH_BASE_URL` (the OAuth issuer), **not**
+the served account profile: `<home>/oauth/<slug>.json` by default (the Docker deploy mounts
+this at `/data/oauth` — the `make` targets pre-create the host dir `0700`; direct `docker
+compose up` users must `mkdir -p ./oauth-state && chmod 700 ./oauth-state` first), or set
+`NOTEBOOKLM_MCP_OAUTH_STATE_PATH` to override. Because it's keyed on the base_url, **switching the served profile/account no longer
+orphans your registered clients** (ChatGPT/claude.ai stay connected), and two servers with
+different origins on one host keep separate registries. On first startup after upgrading, a
+legacy `oauth_state.json` in the **active profile dir** is migrated once (then renamed
+`.migrated`, so it's never re-read); if you keep OAuth state elsewhere or had already switched
+profiles, copy it across manually first — `cp <old-profile-dir>/oauth_state.json <new-path>`
+(Docker: into your `./oauth-state` mount). Treat the file as a full-account secret. Keying
+on the issuer also isolates two servers reachable via different origins (a token minted for
+one base_url is never routed through another), but it requires a **stable** hostname — an
+ephemeral tunnel URL that changes on restart shifts the slug and re-orphans clients.
+
 ### File upload & download (remote)
 
 The MCP/JSON-RPC channel can't carry large binaries, so over a remote connector

--- a/src/notebooklm/mcp/_oauth.py
+++ b/src/notebooklm/mcp/_oauth.py
@@ -168,7 +168,9 @@ def _slug_for_base_url(base_url: str) -> str:
     host charset nor the port, so the prefix alone is not unique.
     """
     norm = base_url.strip().rstrip("/").lower()
-    readable = re.sub(r"[^a-z0-9._-]", "_", urlsplit(base_url).netloc.lower()) or "origin"
+    # Cap the readable prefix so a pathologically long hostname can't push the filename
+    # past the 255-byte limit; the hash (over the FULL origin) still disambiguates.
+    readable = (re.sub(r"[^a-z0-9._-]", "_", urlsplit(base_url).netloc.lower()) or "origin")[:64]
     digest = hashlib.sha256(norm.encode()).hexdigest()[:16]
     return f"{readable}.{digest}"
 
@@ -201,21 +203,22 @@ def _migrate_legacy_state(state_path: Path, legacy_path: Path | None) -> None:
     if legacy_path == state_path or (state_path.exists() and legacy_path.samefile(state_path)):
         return
     migrated = legacy_path.with_name(legacy_path.name + ".migrated")
-    # Already migrated on a prior run, but a legacy file lingers (an earlier rename
-    # failed/crashed). Retire it so it can never be re-migrated after a revocation.
-    if state_path.exists():
-        try:
+    # Migration already happened for this deployment — either the ``.migrated`` marker
+    # exists (a reappeared oauth_state.json is a backup restore or leftover, and importing
+    # it could resurrect revoked tokens) or the live state file is present (a prior rename
+    # failed/crashed). Retire the reappeared/lingering legacy so it is never re-migrated,
+    # and never overwrite the authoritative live state.
+    if migrated.exists() or state_path.exists():
+        with contextlib.suppress(OSError):
             os.replace(legacy_path, migrated)
-        except OSError as exc:
-            logger.warning("Could not retire lingering legacy OAuth state %s: %s", legacy_path, exc)
         return
     try:
-        raw = legacy_path.read_text(encoding="utf-8")
+        raw = legacy_path.read_bytes()
     except OSError as exc:  # transient read error — leave in place, retry next startup
         logger.warning("Could not read legacy OAuth state %s (will retry): %s", legacy_path, exc)
         return
     try:
-        data = json.loads(raw)
+        data = json.loads(raw)  # bytes: invalid UTF-8 or bad JSON → ValueError family
     except ValueError:
         data = None
     if not isinstance(data, dict):

--- a/src/notebooklm/mcp/_oauth.py
+++ b/src/notebooklm/mcp/_oauth.py
@@ -39,26 +39,32 @@ exposes the co-located full-account ``master_token.json``):
   owner's authorize from being *rejected*, but a sustained pre-auth flood can still
   evict the owner's idle in-flight ``sid`` BEFORE they submit the password ("login link
   expired"); the owner simply retries. Availability-only; bounded by the 300s TTL.
-* persisted tokens — refresh tokens are long-lived and written (0600) to
-  ``oauth_state.json``; treat that file as a FULL-ACCOUNT secret (same tier as
-  ``master_token.json``). Real revocation = delete ``oauth_state.json`` + restart;
-  rotating ``NOTEBOOKLM_MCP_OAUTH_PASSWORD`` does NOT revoke already-issued tokens.
+* persisted tokens — refresh tokens are long-lived and written (0600) to the OAuth
+  state file (path logged at startup; default ``<home>/oauth/<slug>.json`` keyed on the
+  base_url — see :func:`get_oauth_config`); treat it as a FULL-ACCOUNT secret (same tier
+  as ``master_token.json``). Real revocation = delete THAT file + restart; a legacy
+  profile-dir ``oauth_state.json`` migrated once is renamed ``.migrated`` and never
+  re-read, so deleting the live file does not resurrect its tokens. Rotating
+  ``NOTEBOOKLM_MCP_OAUTH_PASSWORD`` does NOT revoke already-issued tokens.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import html
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, NamedTuple
+from urllib.parse import urlsplit
 
 import anyio
 from fastmcp.server.auth import AuthProvider
@@ -77,8 +83,8 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, Response
 from starlette.routing import Route
 
-from notebooklm._atomic_io import atomic_write_json
-from notebooklm.paths import get_profile_dir
+from notebooklm._atomic_io import atomic_update_json, atomic_write_json
+from notebooklm.paths import get_home_dir, get_profile_dir
 
 from ._urlcheck import _validate_bare_https_origin
 
@@ -87,6 +93,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "OAUTH_BASE_URL_ENV",
     "OAUTH_PASSWORD_ENV",
+    "OAUTH_STATE_PATH_ENV",
     "TRUST_PROXY_ENV",
     "OAuthConfig",
     "SelfHostedOAuthProvider",
@@ -98,6 +105,12 @@ __all__ = [
 #: enable OAuth; unset → bearer-only (Phase A unchanged).
 OAUTH_PASSWORD_ENV = "NOTEBOOKLM_MCP_OAUTH_PASSWORD"
 OAUTH_BASE_URL_ENV = "NOTEBOOKLM_MCP_OAUTH_BASE_URL"
+#: Optional override for where the OAuth client registry + issued tokens persist. When
+#: set (non-empty) it wins over the derived default; used verbatim as a path
+#: (operator-supplied, so no traversal guard). Unset → ``<home>/oauth/<slug>.json`` keyed
+#: on the base_url (the AS issuer) — deployment-scoped, NOT tied to the served account
+#: profile, so switching profiles no longer orphans registered clients.
+OAUTH_STATE_PATH_ENV = "NOTEBOOKLM_MCP_OAUTH_STATE_PATH"
 #: Opt-in: trust the proxy-set ``CF-Connecting-IP`` header as the login-throttle key
 #: (``"1"`` to enable). Default off → key on the socket peer. Only set this when a trusted
 #: proxy (e.g. the Cloudflare tunnel) authoritatively sets the header; if the origin is
@@ -138,9 +151,107 @@ class OAuthConfig:
     password: str = field(repr=False)
     base_url: str = field(repr=True)
     state_path: Path | None = field(default=None)  # persist target; None → no persistence
+    # One-time migration source: the pre-#1765-reversal profile-dir oauth_state.json.
+    # Read ONCE at startup if ``state_path`` does not exist yet, then renamed ``.migrated``.
+    legacy_state_path: Path | None = field(default=None)
     # Trust the proxy-set CF-Connecting-IP header for throttle keying (default off — the
     # socket peer is used unless an operator asserts a trusted proxy sets the header).
     trust_proxy: bool = field(default=False)
+
+
+def _slug_for_base_url(base_url: str) -> str:
+    """Filesystem-safe, collision-resistant filename stem for an OAuth issuer.
+
+    A readable ``netloc`` prefix (cosmetic) plus a 64-bit hash of the normalized origin
+    (the disambiguator). Distinct origins → distinct hash → distinct file, even when the
+    sanitized prefix collides — :func:`_validate_bare_https_origin` restricts neither the
+    host charset nor the port, so the prefix alone is not unique.
+    """
+    norm = base_url.strip().rstrip("/").lower()
+    readable = re.sub(r"[^a-z0-9._-]", "_", urlsplit(base_url).netloc.lower()) or "origin"
+    digest = hashlib.sha256(norm.encode()).hexdigest()[:16]
+    return f"{readable}.{digest}"
+
+
+def _derived_state_path(base_url: str) -> Path:
+    """Default OAuth-state path ``<home>/oauth/<slug(base_url)>.json``.
+
+    Keyed on the base_url (the AS issuer), so it is deployment-scoped: two servers with
+    different issuers get different files; one server keeps its file across a
+    served-account switch (the base_url is unchanged)."""
+    return get_home_dir() / "oauth" / f"{_slug_for_base_url(base_url)}.json"
+
+
+def _migrate_legacy_state(state_path: Path, legacy_path: Path | None) -> None:
+    """One-time, non-destructive migration of a legacy profile-dir ``oauth_state.json``.
+
+    Best-effort and never fatal: any failure is logged and startup continues. The
+    ``.migrated`` rename is the durable "already handled" marker — it is independent of
+    ``state_path`` (so it survives a revocation that deletes the live file), and it is
+    committed by renaming the legacy file BEFORE the migrated state is exposed at
+    ``state_path``. That ordering is what makes revocation safe even if the write fails:
+    a failed write rolls the rename back for a clean retry, and there is never a window
+    where a live ``state_path`` coexists with a still-migratable legacy file. Concurrent
+    startups are safe — only one wins the atomic rename; the loser sees the legacy gone.
+    """
+    if legacy_path is None or not legacy_path.exists():
+        return
+    # If an explicit override points the live state AT the legacy file itself, there is
+    # nothing to migrate — and retiring it would delete the very file the provider loads.
+    if legacy_path == state_path or (state_path.exists() and legacy_path.samefile(state_path)):
+        return
+    migrated = legacy_path.with_name(legacy_path.name + ".migrated")
+    # Already migrated on a prior run, but a legacy file lingers (an earlier rename
+    # failed/crashed). Retire it so it can never be re-migrated after a revocation.
+    if state_path.exists():
+        try:
+            os.replace(legacy_path, migrated)
+        except OSError as exc:
+            logger.warning("Could not retire lingering legacy OAuth state %s: %s", legacy_path, exc)
+        return
+    try:
+        raw = legacy_path.read_text(encoding="utf-8")
+    except OSError as exc:  # transient read error — leave in place, retry next startup
+        logger.warning("Could not read legacy OAuth state %s (will retry): %s", legacy_path, exc)
+        return
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        data = None
+    if not isinstance(data, dict):
+        # Corrupt or non-object payload: retire it (so it isn't re-parsed every startup)
+        # WITHOUT writing it as state.
+        logger.warning("Legacy OAuth state %s is unusable; retiring without migrating", legacy_path)
+        with contextlib.suppress(OSError):
+            os.replace(legacy_path, migrated)
+        return
+    try:
+        if os.name == "posix":
+            state_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        else:
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+        # Commit the marker FIRST (os.replace is atomic + cross-platform, unlike
+        # Path.rename which raises on Windows if the dest exists): retire the legacy
+        # source before exposing migrated state, so no failure past this point can leave
+        # a resurrectable legacy file beside a live state_path.
+        os.replace(legacy_path, migrated)
+    except OSError as exc:
+        logger.warning(
+            "Skipped legacy OAuth-state migration (retiring %s failed): %s", legacy_path, exc
+        )
+        return
+    try:
+        # Locked (atomic_update_json wraps a filelock) + race-safe: keep a concurrent
+        # startup's fresh state rather than clobbering it with the legacy copy.
+        atomic_update_json(state_path, lambda cur: cur if cur else data, mode=0o600)
+    except (OSError, ValueError) as exc:
+        # Write failed after the marker committed — roll the rename back so the next
+        # startup retries cleanly instead of stranding the data in ``.migrated``.
+        with contextlib.suppress(OSError):
+            os.replace(migrated, legacy_path)
+        logger.warning("Legacy OAuth-state migration write failed (rolled back): %s", exc)
+        return
+    logger.info("Migrated legacy OAuth state %s → %s", legacy_path, state_path)
 
 
 def get_oauth_config(profile: str | None = None) -> OAuthConfig | None:
@@ -151,19 +262,21 @@ def get_oauth_config(profile: str | None = None) -> OAuthConfig | None:
     URL must be https (the MCP SDK rejects non-HTTPS non-localhost issuers anyway).
 
     ``state_path`` (where issued tokens + registered clients persist, 0600) is
-    resolved through the SAME canonical profile resolver the client runtime uses
-    (:func:`notebooklm.paths.get_profile_dir`), so it always tracks the profile the
-    server actually drives — the ``--profile`` flag, ``NOTEBOOKLM_PROFILE``, the
-    ``notebooklm use``-set active profile, or the ``~/.notebooklm`` home default
-    (#1765). Pass ``profile`` to bind an explicit one; ``None`` resolves the active
-    profile.
+    **deployment-scoped**, keyed on the ``base_url`` (the OAuth issuer): the
+    ``NOTEBOOKLM_MCP_OAUTH_STATE_PATH`` override wins, else ``<home>/oauth/<slug>.json``
+    (:func:`_derived_state_path`). This intentionally REVERSES #1765's profile-dir
+    coupling — the client registry is a property of the server, not the served account,
+    so switching profiles no longer orphans registered clients. ``legacy_state_path``
+    (the old profile-dir ``oauth_state.json``, resolved best-effort via ``profile`` —
+    ``None`` if the profile is malformed) is migrated once at startup, see
+    :func:`_migrate_legacy_state`.
 
     Args:
-        profile: Explicit auth profile to persist OAuth state under. ``None``
-            resolves the active profile via the standard precedence.
+        profile: Auth profile whose legacy ``oauth_state.json`` is the one-time
+            migration source. ``None`` resolves the active profile.
 
     Raises:
-        SystemExit: partial/invalid config, or a malformed ``profile`` name.
+        SystemExit: partial/invalid OAuth config (missing var, weak password, bad URL).
     """
     password = os.environ.get(OAUTH_PASSWORD_ENV) or ""
     base_url = (os.environ.get(OAUTH_BASE_URL_ENV) or "").strip()
@@ -188,22 +301,29 @@ def get_oauth_config(profile: str | None = None) -> OAuthConfig | None:
     # fine.) The same check guards the file-transfer base URL — shared helper.
     _validate_bare_https_origin(base_url, OAUTH_BASE_URL_ENV)
 
-    # Persist OAuth state under the SAME profile dir the client runtime drives —
-    # not a separate raw-env derivation that silently diverged (#1765). Honors the
-    # --profile flag / NOTEBOOKLM_PROFILE / active profile / ~/.notebooklm default.
+    # Deployment-scoped OAuth-state path, keyed on the base_url (the AS issuer), NOT the
+    # served profile (#1765 reversal — see the docstring). An explicit override wins.
+    override = os.environ.get(OAUTH_STATE_PATH_ENV)
+    state_path: Path = Path(override).expanduser() if override else _derived_state_path(base_url)
+    # One-time migration source: the old profile-dir oauth_state.json. Best-effort — a
+    # malformed profile name (get_profile_dir raises ValueError) just means "no legacy to
+    # migrate", NOT a startup failure (the profile guard still fires where the client
+    # runtime actually uses it for storage).
     try:
-        state_path: Path = get_profile_dir(profile) / "oauth_state.json"
-    except ValueError as exc:
-        # Malformed profile name (e.g. path traversal). Fail clean on the http
-        # startup path instead of leaking a traceback.
-        raise SystemExit(str(exc)) from exc
+        legacy_state_path: Path | None = get_profile_dir(profile) / "oauth_state.json"
+    except ValueError:
+        legacy_state_path = None
 
     # Opt-in trusted-proxy: only reached once OAuth is fully configured, so it never
     # fires on the OAuth-off path. Default off keeps the throttle keyed on the socket peer.
     trust_proxy = os.environ.get(TRUST_PROXY_ENV) == "1"
 
     return OAuthConfig(
-        password=password, base_url=base_url, state_path=state_path, trust_proxy=trust_proxy
+        password=password,
+        base_url=base_url,
+        state_path=state_path,
+        legacy_state_path=legacy_state_path,
+        trust_proxy=trust_proxy,
     )
 
 
@@ -569,9 +689,15 @@ class SelfHostedOAuthProvider(InMemoryOAuthProvider):
 def build_oauth_provider(config: OAuthConfig) -> AuthProvider:
     """Build the self-hosted OAuth provider from validated config.
 
-    Runs once at HTTP-server startup. ``config.state_path`` is resolved by
-    :func:`get_oauth_config` under the active profile dir, so issued tokens +
-    registered clients persist (0600) across restarts by default (#1765)."""
+    Runs once at HTTP-server startup. ``config.state_path`` is the deployment-scoped,
+    base_url-keyed path resolved by :func:`get_oauth_config`, so issued tokens +
+    registered clients persist (0600) across restarts and survive a served-account
+    switch. Before constructing the provider we migrate a legacy profile-dir
+    ``oauth_state.json`` once (:func:`_migrate_legacy_state`) so existing deployments
+    keep their registered clients across the #1765 reversal."""
+    if config.state_path is not None:
+        _migrate_legacy_state(config.state_path, config.legacy_state_path)
+        logger.info("OAuth client registry + tokens persist at %s", config.state_path)
     return SelfHostedOAuthProvider(
         password=config.password,
         base_url=config.base_url,

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -313,6 +313,36 @@ def test_migrate_legacy_state_noop_when_override_equals_legacy(tmp_path: Path) -
     assert json.loads(same.read_text()) == {"clients": {"c1": {}}}
 
 
+def test_migrate_legacy_state_retires_invalid_utf8(tmp_path: Path) -> None:
+    """A legacy file with invalid UTF-8 bytes is unusable → retired (not a startup crash;
+    UnicodeDecodeError ⊂ ValueError is caught), never written as state."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_bytes(b"\xff\xfe not utf-8 at all")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    _migrate_legacy_state(new, legacy)  # must not raise
+
+    assert not new.exists()
+    assert not legacy.exists()
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+
+
+def test_migrate_legacy_state_ignores_reappeared_backup_when_marker_exists(tmp_path: Path) -> None:
+    """After a one-time migration (``.migrated`` marker present) and a revocation (live
+    state deleted), a restored/leftover oauth_state.json must NOT be re-imported — it is
+    retired, not migrated, so revoked tokens can't be resurrected from a backup."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {"revoked": {}}}), encoding="utf-8")
+    (tmp_path / "oauth_state.json.migrated").write_text("{}", encoding="utf-8")  # prior marker
+    new = tmp_path / "oauth" / "host.abcd.json"  # revoked → live state absent
+
+    _migrate_legacy_state(new, legacy)
+
+    assert not new.exists()  # NOT re-imported
+    assert not legacy.exists()  # retired (folded into the marker)
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+
+
 # --------------------------------------------------------------------------- routes / DCR
 def test_provider_routes_include_login_and_register() -> None:
     p = _provider()

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
+import os
 import re
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,11 +34,15 @@ from notebooklm.mcp._oauth import (  # noqa: E402
     MAX_LOGIN_ATTEMPTS,
     OAUTH_BASE_URL_ENV,
     OAUTH_PASSWORD_ENV,
+    OAUTH_STATE_PATH_ENV,
     THROTTLE_MAX_FAILURES,
     TRUST_PROXY_ENV,
     OAuthConfig,
     SelfHostedOAuthProvider,
     _client_ip,
+    _derived_state_path,
+    _migrate_legacy_state,
+    _slug_for_base_url,
     build_oauth_provider,
     get_oauth_config,
 )
@@ -117,40 +124,193 @@ def test_config_fail_closed(
     assert needle in str(e.value)
 
 
-def test_config_ok_with_state_path(_clear_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_config_state_path_is_base_url_keyed_derived_default(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default state_path is deployment-scoped: <home>/oauth/<slug(base_url)>.json,
+    NOT the served profile dir (#1765 reversal). legacy_state_path still points at the
+    old profile-dir file so an existing install can be migrated once."""
     monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
     monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
-    monkeypatch.setenv("NOTEBOOKLM_HOME", "/data")
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     monkeypatch.setenv("NOTEBOOKLM_PROFILE", "server")
     cfg = get_oauth_config()
     assert cfg is not None and cfg.state_path is not None
-    # Path.parts is OS-agnostic (Windows uses backslash separators, so a string suffix
-    # check on forward slashes would spuriously fail on the Windows CI matrix).
-    assert cfg.state_path.parts[-3:] == ("profiles", "server", "oauth_state.json")
+    assert cfg.state_path == _derived_state_path("https://host.example.com")
+    assert cfg.state_path.parent == tmp_path / "oauth"
+    assert cfg.state_path.name.startswith("host.example.com.")
+    # legacy migration source still tracks the served profile
+    assert cfg.legacy_state_path is not None
+    assert cfg.legacy_state_path.parts[-3:] == ("profiles", "server", "oauth_state.json")
 
 
-def test_config_state_path_honors_profile_without_env(
-    _clear_env: None, monkeypatch: pytest.MonkeyPatch
+def test_config_state_path_env_override_wins(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """#1765: state_path resolves through the canonical profile resolver. An explicit
-    profile (the --profile flag) is honored even when NOTEBOOKLM_PROFILE is unset (the
-    old code read env only and ignored it), and with NOTEBOOKLM_HOME also unset it still
-    resolves to a real path under the default home instead of silently going None."""
+    """NOTEBOOKLM_MCP_OAUTH_STATE_PATH is used verbatim and wins over the derived default;
+    an empty value is treated as unset (falls back to derived)."""
     monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
     monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
-    cfg = get_oauth_config(profile="work")  # no HOME/PROFILE env set
-    assert cfg is not None and cfg.state_path is not None
-    assert cfg.state_path.parts[-3:] == ("profiles", "work", "oauth_state.json")
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    custom = tmp_path / "custom" / "oauth.json"
+    monkeypatch.setenv(OAUTH_STATE_PATH_ENV, str(custom))
+    cfg = get_oauth_config()
+    assert cfg is not None and cfg.state_path == custom
+    # empty string → treated as unset → derived default
+    monkeypatch.setenv(OAUTH_STATE_PATH_ENV, "")
+    cfg2 = get_oauth_config()
+    assert cfg2 is not None and cfg2.state_path == _derived_state_path("https://host.example.com")
 
 
-def test_config_rejects_malformed_profile(
-    _clear_env: None, monkeypatch: pytest.MonkeyPatch
+def test_config_malformed_profile_yields_no_legacy_not_systemexit(
+    _clear_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A path-traversal profile name fails clean (SystemExit), not a raw traceback."""
+    """A path-traversal profile name no longer aborts OAuth startup: the derived
+    (base_url-keyed) state_path is unaffected, and legacy_state_path degrades to None
+    (nothing to migrate) rather than raising SystemExit."""
     monkeypatch.setenv(OAUTH_PASSWORD_ENV, _PW)
     monkeypatch.setenv(OAUTH_BASE_URL_ENV, "https://host.example.com")
-    with pytest.raises(SystemExit):
-        get_oauth_config(profile="../escape")
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    cfg = get_oauth_config(profile="../escape")
+    assert cfg is not None
+    assert cfg.state_path == _derived_state_path("https://host.example.com")
+    assert cfg.legacy_state_path is None
+
+
+def test_slug_is_collision_resistant() -> None:
+    """Distinct origins → distinct slug even when the sanitized readable prefix collides
+    (the 64-bit hash of the normalized origin disambiguates); same origin differing only
+    by case/trailing-slash → same slug."""
+    # readable-prefix collisions that MUST still differ (hash disambiguates)
+    for a, b in [
+        ("https://bücher.example", "https://b_cher.example"),
+        ("https://host:1", "https://host_1"),
+        ("https://[::1]", "https://__1"),
+    ]:
+        assert _slug_for_base_url(a) != _slug_for_base_url(b), (a, b)
+    # case- and trailing-slash-insensitive (same server)
+    assert _slug_for_base_url("https://Host.Example.com") == _slug_for_base_url(
+        "https://host.example.com/"
+    )
+    # output is filesystem-safe (single path component, no separators/traversal)
+    slug = _slug_for_base_url("https://host.example.com")
+    assert "/" not in slug and "\\" not in slug and slug not in (".", "..")
+
+
+def test_derived_state_path_distinct_per_origin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    a = _derived_state_path("https://a.example.com")
+    b = _derived_state_path("https://b.example.com")
+    assert a != b
+    assert a.parent == b.parent == tmp_path / "oauth"
+
+
+def test_migrate_legacy_state_copies_renames_and_is_revocation_safe(tmp_path: Path) -> None:
+    """Legacy oauth_state.json is migrated once into the new path (0600), the legacy file
+    is renamed .migrated, re-runs are no-ops, and after a revocation (rm the new file) it
+    is NOT re-created — the legacy source no longer exists as a fallback."""
+    legacy = tmp_path / "profiles" / "server" / "oauth_state.json"
+    legacy.parent.mkdir(parents=True)
+    payload = {"clients": {"c1": {"redirect_uris": ["https://claude.ai/cb"]}}, "access_tokens": {}}
+    legacy.write_text(json.dumps(payload), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    _migrate_legacy_state(new, legacy)
+
+    assert json.loads(new.read_text()) == payload
+    assert not legacy.exists()
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+    if os.name == "posix":
+        assert (new.stat().st_mode & 0o777) == 0o600
+    # idempotent: a second run (new exists) is a no-op
+    _migrate_legacy_state(new, legacy)
+    # revocation-safe: delete the live state file → no legacy source remains to re-migrate
+    new.unlink()
+    _migrate_legacy_state(new, legacy)
+    assert not new.exists()
+
+
+def test_migrate_legacy_state_skips_malformed_and_missing(tmp_path: Path) -> None:
+    """Corrupt legacy JSON is skipped without crashing; a None/missing legacy is a no-op."""
+    new = tmp_path / "oauth" / "host.abcd.json"
+    bad = tmp_path / "oauth_state.json"
+    bad.write_text("not json at all", encoding="utf-8")
+    _migrate_legacy_state(new, bad)  # must not raise
+    assert not new.exists()
+    _migrate_legacy_state(new, None)  # no-op
+    _migrate_legacy_state(new, tmp_path / "does-not-exist.json")  # no-op
+    assert not new.exists()
+
+
+def test_migrate_legacy_state_rolls_back_on_write_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the state write fails after the legacy file is retired, the rename is rolled
+    back so the next startup retries cleanly — no live state_path is left to trap a later
+    revocation, and the data isn't stranded in .migrated."""
+    import notebooklm.mcp._oauth as oauth_mod
+
+    legacy = tmp_path / "profiles" / "server" / "oauth_state.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(json.dumps({"clients": {}}), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(oauth_mod, "atomic_update_json", _boom)
+    _migrate_legacy_state(new, legacy)  # must not raise
+
+    assert legacy.exists()  # rolled back — legacy restored for a clean retry
+    assert not legacy.with_name("oauth_state.json.migrated").exists()
+    assert not new.exists()
+
+
+def test_migrate_legacy_state_retires_lingering_legacy_when_state_exists(tmp_path: Path) -> None:
+    """Defensive cleanup: state_path already exists but a legacy file lingers (an earlier
+    rename failed) — retire the legacy so it can't be re-migrated after a revocation,
+    without touching the authoritative live state."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {"old": {}}}), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+    new.parent.mkdir(parents=True)
+    new.write_text(json.dumps({"clients": {"live": {}}}), encoding="utf-8")
+
+    _migrate_legacy_state(new, legacy)
+
+    assert not legacy.exists()
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+    assert json.loads(new.read_text()) == {"clients": {"live": {}}}  # live state untouched
+
+
+def test_migrate_legacy_state_retires_non_dict_payload(tmp_path: Path) -> None:
+    """A valid-JSON-but-non-object legacy file is retired (not re-parsed every startup)
+    and never written as state."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text("[1, 2, 3]", encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    _migrate_legacy_state(new, legacy)
+
+    assert not new.exists()
+    assert not legacy.exists()
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+
+
+def test_migrate_legacy_state_noop_when_override_equals_legacy(tmp_path: Path) -> None:
+    """If NOTEBOOKLM_MCP_OAUTH_STATE_PATH points the live state AT the legacy file itself,
+    migration is a no-op — the file must NOT be retired out from under the provider that
+    then loads it (which would orphan every registered client)."""
+    same = tmp_path / "oauth_state.json"
+    same.write_text(json.dumps({"clients": {"c1": {}}}), encoding="utf-8")
+
+    _migrate_legacy_state(same, same)
+
+    assert same.exists()  # untouched — not renamed to .migrated
+    assert not same.with_name("oauth_state.json.migrated").exists()
+    assert json.loads(same.read_text()) == {"clients": {"c1": {}}}
 
 
 # --------------------------------------------------------------------------- routes / DCR
@@ -654,9 +814,9 @@ def test_throttle_separates_buckets_by_cf_header_when_trusted() -> None:
 def test_build_oauth_provider_wires_state_without_warning(
     tmp_path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """#1765: state_path now always resolves (get_oauth_config binds it to the active
-    profile dir), so build_oauth_provider just wires it through — the old "state not
-    persisted" startup warning was removed and must not fire."""
+    """state_path always resolves (get_oauth_config derives a base_url-keyed path), so
+    build_oauth_provider wires it through — the old "state not persisted" startup warning
+    was removed and must not fire. With no legacy_state_path set, migration is a no-op."""
     cfg = OAuthConfig(
         password=_PW, base_url="https://h.example.com", state_path=tmp_path / "oauth_state.json"
     )


### PR DESCRIPTION
## Summary
The self-hosted MCP OAuth **client registry + issued tokens** (`oauth_state.json`) were stored under the *served account's profile dir*, so switching the served profile silently orphaned every registered client — ChatGPT / claude.ai got **"Client ID not found"** (hit live this session).

This makes the OAuth state **deployment-scoped, keyed on the `base_url`** (the OAuth issuer):
- Default `<home>/oauth/<slug>.json` (slug = sanitized netloc + 64-bit sha256 of the normalized origin); override with **`NOTEBOOKLM_MCP_OAUTH_STATE_PATH`**.
- A served-profile switch keeps the **same** file (base_url unchanged) → clients stay connected. Distinct issuers → distinct files → two servers on one host stay isolated.
- One-time, **race- and revocation-safe** migration of the legacy profile-dir `oauth_state.json`: the `.migrated` rename is committed **before** the migrated state is exposed, so a failed write rolls back and a later revocation (`rm` the live file) can never resurrect its tokens.
- Docker mounts a dedicated **`/data/oauth`** volume (`NOTEBOOKLM_OAUTH_STATE_DIR`), pre-created `0700` by the `make` targets / `setup.sh`.

## ⚠ Deliberate #1765 reversal (please weigh in)
#1765 intentionally coupled OAuth state to the served profile dir. This **reverses** that: the client registry is a property of the *server deployment*, not the *served account*, and the coupling is exactly what caused the orphaning. The profile is still validated where the client runtime actually uses it for storage; OAuth no longer reads it for the state path. Called out explicitly for maintainer review.

Independently corroborated by a NotebookLM OAuth-best-practices review: keying persisted OAuth state on the issuer `base_url` "aligns with OAuth best practices" (RFC 8414) and **prevents mix-up attacks** across tunnels.

## Design review
Went through two `/momus` rounds (claude + codex + agy) on the plan, then a full `/polish` pass (code-simplifier + claude/codex/agy triple review + ultrathink) on the code. Fixes folded in: retire-first+rollback migration ordering, `0700` on the shell-created host dir, `expanduser()` on the override, startup log of the resolved path, non-dict-legacy retirement, and a guard for the degenerate case where the override points *at* the legacy file.

## Test plan
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run pytest` (full suite) — **12355 passed**, 77 skipped, 1 xfailed
- [x] OAuth module: 54 tests — env override / derived / empty / two-origins / case-insensitive / collision pairs / migration copy+rename+revocation / write-failure rollback / cleanup-on-exists / non-dict retire / override==legacy no-op

## Deferred / follow-ups
- Malformed `--profile` now surfaces downstream instead of a clean early `SystemExit` (polish Optional; the profile is still validated loudly where the client runtime uses it).
- Separate hardening the notebook flagged (out of scope here) → tracking issues after merge: restrict/replace open DCR, refresh-token rotation, RFC 8707 resource indicators, exact redirect-URI matching / `offline_access` / IP-allowlisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Self-hosted MCP OAuth state (client registrations and tokens) now persists deployment-wide, not per active profile.
  - Multiple servers remain isolated by issuer URL.
  - Legacy OAuth state is migrated automatically on first startup after upgrading.

- **Configuration**
  - Added `NOTEBOOKLM_MCP_OAUTH_STATE_PATH` to override where OAuth state is stored.
  - Added `NOTEBOOKLM_OAUTH_STATE_DIR` support and updated setup to pre-create and permission the dedicated state directory.
  - “Revocation” now corresponds to deleting the live OAuth state file.

- **Documentation**
  - Updated deployment and MCP guidance for new persistence paths, migration behavior, permissions, and restart/revocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->