### PR TITLE
fix(deploy): bake git commit into from-source image so server_info reports provenance

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -77,6 +77,9 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "Publishing: ${TAGS}"
 
+      - id: commit
+        run: echo "short=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # @ v4.2.0
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # @ v4.2.0
 
@@ -93,3 +96,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: org.opencontainers.image.source=https://github.com/teng-lin/notebooklm-py
+          # .dockerignore strips .git, so the in-container build can't discover
+          # the commit — pass it so the PUBLISHED image's server_info reports it
+          # too (not just from-source `make dev`). Short-8 to match the CLI.
+          build-args: |
+            GIT_COMMIT=${{ steps.commit.outputs.short }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -28,7 +28,8 @@ COPY . /src
 RUN if [ -n "$NOTEBOOKLM_SPEC" ]; then \
         pip install --no-cache-dir "$NOTEBOOKLM_SPEC"; \
     else \
-        if [ -n "$GIT_COMMIT" ]; then printf 'COMMIT = "%s"\n' "$GIT_COMMIT" > /src/src/notebooklm/_commit.py; fi; \
+        if [ -n "$GIT_COMMIT" ]; then printf 'COMMIT = "%s"\n' "$GIT_COMMIT" > /src/src/notebooklm/_commit.py; \
+        else rm -f /src/src/notebooklm/_commit.py; fi; \
         pip install --no-cache-dir "/src[mcp,headless]"; \
     fi
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,15 +13,22 @@
 FROM python:3.12-slim
 
 ARG NOTEBOOKLM_SPEC=""
+# Short git commit of the build source. .dockerignore strips .git, so the
+# in-container hatch build can't discover it — the host passes it in (Makefile
+# → compose build arg) and we bake _commit.py so server_info reports the commit.
+ARG GIT_COMMIT=""
 
 # Copy the repo source (build context = repo root; see .dockerignore for excludes).
 COPY . /src
 
 # Empty NOTEBOOKLM_SPEC → install the copied source (dev). Non-empty → install
-# that spec from PyPI (production) and ignore the copied source.
+# that spec from PyPI (production) and ignore the copied source. PyPI wheels
+# already carry _commit.py (baked by CI where .git existed), so only the
+# from-source path needs the hand-off.
 RUN if [ -n "$NOTEBOOKLM_SPEC" ]; then \
         pip install --no-cache-dir "$NOTEBOOKLM_SPEC"; \
     else \
+        if [ -n "$GIT_COMMIT" ]; then printf 'COMMIT = "%s"\n' "$GIT_COMMIT" > /src/src/notebooklm/_commit.py; fi; \
         pip install --no-cache-dir "/src[mcp,headless]"; \
     fi
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -50,6 +50,9 @@ DC_BUILD = $(DC) -f docker-compose.yml -f docker-compose.build.yml
 # Run the container as YOUR uid/gid so the mounted profile needs no chown.
 export NOTEBOOKLM_UID ?= $(shell id -u)
 export NOTEBOOKLM_GID ?= $(shell id -g)
+# Short commit of the checkout, handed to the from-source build so the image's
+# server_info reports it (.dockerignore strips .git). Empty outside a checkout.
+export GIT_COMMIT ?= $(shell git -C .. rev-parse --short=8 HEAD 2>/dev/null)
 # NOTE: do NOT set/export NOTEBOOKLM_PROFILE_DIR here. make does not read .env, so a
 # `?=` default would resolve to "default" and `export` would push it into compose's
 # env, where it OUTRANKS the .env value (shell env > .env) — silently ignoring the

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -52,7 +52,9 @@ export NOTEBOOKLM_UID ?= $(shell id -u)
 export NOTEBOOKLM_GID ?= $(shell id -g)
 # Short commit of the checkout, handed to the from-source build so the image's
 # server_info reports it (.dockerignore strips .git). Empty outside a checkout.
-export GIT_COMMIT ?= $(shell git -C .. rev-parse --short=8 HEAD 2>/dev/null)
+# Guard on ../.git first (matches hatch_build.py) so an *enclosing* repo can't
+# leak its unrelated hash when `..` is not itself a checkout.
+export GIT_COMMIT ?= $(shell [ -e ../.git ] && git -C .. rev-parse --short=8 HEAD 2>/dev/null)
 # NOTE: do NOT set/export NOTEBOOKLM_PROFILE_DIR here. make does not read .env, so a
 # `?=` default would resolve to "default" and `export` would push it into compose's
 # env, where it OUTRANKS the .env value (shell env > .env) — silently ignoring the

--- a/deploy/docker-compose.build.yml
+++ b/deploy/docker-compose.build.yml
@@ -9,6 +9,9 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile
+      args:
+        # Baked into _commit.py so server_info reports the source commit (the
+        # Makefile exports GIT_COMMIT; empty when not a git checkout).
+        GIT_COMMIT: ${GIT_COMMIT:-}
       # To build from a published PyPI release instead of this checkout:
-      # args:
       #   NOTEBOOKLM_SPEC: "notebooklm-py[mcp,headless]==<version>"


### PR DESCRIPTION
## Problem

Calling `server_info` on the deployed MCP server returns a **bare** version with no commit:

```json
{"server":"notebooklm","version":"0.8.0b5", ...}
```

…whereas the CLI run from a checkout reports the commit: `NotebookLM CLI, version 0.8.0b5 (5719c122)`. All three surfaces (CLI, REST, MCP) already share `version_string()`, so the code is fine — the gap is in the **from-source Docker build**.

## Root cause

The from-source image (`make dev` / `make restart`) runs `pip install /src[...]`, building the wheel **in-container**. But `.dockerignore:3` strips `.git`, so `hatch_build._git_commit()` finds no repo → no `_commit.py` baked → `version_string()` falls back to the bare version.

PyPI-mode builds are unaffected: those wheels bake `_commit.py` in CI where `.git` exists.

## Fix

Hand the host's commit into the build instead of un-ignoring `.git` (which would bloat the context):

- **`deploy/Makefile`** — `export GIT_COMMIT ?= $(shell git -C .. rev-parse --short=8 HEAD ...)`
- **`deploy/docker-compose.build.yml`** — forwards it as a `GIT_COMMIT` build arg
- **`deploy/Dockerfile`** — writes `_commit.py` in the **source path only**; empty commit → no file, no build failure

## Verification

- Makefile resolves `GIT_COMMIT` via `git rev-parse` ✅
- `docker compose config` interpolates `GIT_COMMIT: 5719c122` into build args ✅
- Dockerfile shell branch dry-run: empty → skips file; set → writes `COMMIT = "5719c122"` ✅
- Not run: a full `docker build` (pulls chromium via the `headless` extra). After merge, `make restart` + re-call `server_info` to confirm `0.8.0b5 (<hash>)` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server metadata can now include a short source commit identifier for images built from source.
  * Build pipelines and compose builds automatically pass commit information into the image when available.
* **Bug Fixes**
  * Improved alignment of build/version identification between source-based and packaged installation paths.
* **Chores**
  * When commit data isn’t available (e.g., not in a Git checkout), builds proceed normally without commit metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->