### PR TITLE
chore: release v0.8.0rc1

### DIFF
--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "notebooklm-mcp",
   "display_name": "NotebookLM (notebooklm-py)",
-  "version": "0.8.0b5",
+  "version": "0.8.0rc1",
   "description": "Connect Claude to Google NotebookLM: manage notebooks and sources, chat over your notebooks, generate podcasts/videos/quizzes/mind maps, and run research.",
   "long_description": "This extension connects an MCP host (e.g. Claude Desktop) to Google NotebookLM via the Model Context Protocol, backed by the `notebooklm-py` Python client.\n\n**Prerequisites:**\n1. Install `uv` (the launcher runs `uvx`): `curl -LsSf https://astral.sh/uv/install.sh | sh`\n2. Authenticate once: `uvx --from \"notebooklm-py[mcp]\" notebooklm login` (or `notebooklm login` if installed), then select your Google profile.\n\nThe bundled `run_server.py` launcher locates `uvx` across common install paths and runs `uvx --from \"notebooklm-py[mcp]\" notebooklm-mcp`, so no global install is required.\n\n**Features:**\n- Create, list, describe, rename, and delete notebooks\n- Add sources (URL, YouTube, Google Drive, text, files) and read their content\n- Chat / ask questions over a notebook\n- Generate Audio Overviews (podcasts), videos, quizzes, flashcards, reports, and mind maps\n- Research topics via web or Drive and import the results",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.8.0b5"
+version = "0.8.0rc1"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.8.0b5"
+version = "0.8.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
First **release candidate** for 0.8.0 (after `b1`–`b5`). PEP 440 order: `0.8.0b5 < 0.8.0rc1 < 0.8.0`.

Bumps the version in the three source-of-truth files (`pyproject.toml`, `desktop-extension/manifest.json`, `uv.lock`) — no other changes. CHANGELOG folds post-tag per the established flow.

## Since 0.8.0b5
- **#1982** — MCP OAuth client registry is now **deployment-scoped** (keyed on the OAuth issuer `base_url`), so switching the served account no longer orphans registered clients (ChatGPT/claude.ai stay connected). Live-verified + migrated on the deploy.
- **#1987** (closes #1960) — `source_add` **honors an explicit `title`** for YouTube/Drive/web-page imports via a best-effort post-add rename; MCP flags a miss. Live-verified for URL + YouTube + Drive.

## After merge
- Tag `v0.8.0rc1` → triggers `publish.yml` (PyPI Trusted Publishing) + docker/mcpb publish.
- Post-tag: fold the Unreleased entries into `[0.8.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package version to 0.8.0rc1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->