### PR TITLE
docs(rpc): mark DELETE_NOTEBOOK + DELETE_ARTIFACT as single-only (verified)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -656,11 +656,7 @@ class ArtifactsAPI:
             no longer enters its block.
         """
         logger.debug("Deleting artifact %s from notebook %s", artifact_id, notebook_id)
-        # Single-id only. Despite delete-of-missing being a no-op, live probing
-        # confirmed no batch shape works: [[2], id1, id2, id3] deletes only the
-        # first, and [[2], [id1, id2, id3]] deletes none. (Contrast the plural
-        # DELETE_SOURCE / ADD_SOURCE / DELETE_NOTE, which ARE batch-capable.)
-        params = [[2], artifact_id]
+        params = [[2], artifact_id]  # Single-id only; live batch-shape probes failed.
         await self._rpc.rpc_call(
             RPCMethod.DELETE_ARTIFACT,
             params,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -656,6 +656,10 @@ class ArtifactsAPI:
             no longer enters its block.
         """
         logger.debug("Deleting artifact %s from notebook %s", artifact_id, notebook_id)
+        # Single-id only. Despite delete-of-missing being a no-op, live probing
+        # confirmed no batch shape works: [[2], id1, id2, id3] deletes only the
+        # first, and [[2], [id1, id2, id3]] deletes none. (Contrast the plural
+        # DELETE_SOURCE / ADD_SOURCE / DELETE_NOTE, which ARE batch-capable.)
         params = [[2], artifact_id]
         await self._rpc.rpc_call(
             RPCMethod.DELETE_ARTIFACT,

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -758,8 +758,12 @@ class NotebooksAPI:
             no longer enters its block.
         """
         logger.debug("Deleting notebook: %s", notebook_id)
-        # DELETE_NOTEBOOK is the live ``DeleteProjects`` (batch-capable: the
-        # leading slot is a list of ids); we delete a single notebook per call.
+        # DELETE_NOTEBOOK is the live ``DeleteProjects``. Despite the plural
+        # name, it is single-id here: the leading slot takes exactly one id.
+        # Live-probed batch variants — [[id1,id2,id3],[2]], [ids,[2,2,2]],
+        # [[[id],[2]]…], [[[id1],[id2],[id3]],[2]] — all return rpc_code=3
+        # (invalid argument). Delete one notebook per call. (Contrast
+        # DELETE_SOURCE / ADD_SOURCE / DELETE_NOTE, which ARE batch-capable.)
         params = [[notebook_id], [2]]
         await self._rpc.rpc_call(RPCMethod.DELETE_NOTEBOOK, params)
 

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -75,7 +75,7 @@ class RPCMethod(str, Enum):
     CREATE_NOTEBOOK = "CCqFvf"  # -> CreateProject
     GET_NOTEBOOK = "rLM1Ne"  # -> GetProject
     RENAME_NOTEBOOK = "s0tc2d"  # -> MutateProject (generic notebook mutator; see note below)
-    DELETE_NOTEBOOK = "WWINqb"  # -> DeleteProjects (batch-capable; we send a single id)
+    DELETE_NOTEBOOK = "WWINqb"  # -> DeleteProjects (single id; batch shapes probed & rejected, see _notebooks.delete)
 
     # Source operations
     ADD_SOURCE = "izAoDd"  # -> AddSources (batch-capable; we send a single source)

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -107,7 +107,7 @@ class RPCMethod(str, Enum):
     # -> CreateArtifact. Generate any artifact (audio, video, report, quiz, etc.)
     CREATE_ARTIFACT = "R7cb6c"
     LIST_ARTIFACTS = "gArtLc"  # -> ListArtifacts. List all artifacts in a notebook
-    DELETE_ARTIFACT = "V5N4be"  # -> DeleteArtifact
+    DELETE_ARTIFACT = "V5N4be"  # -> DeleteArtifact (single id; batch shapes probed & rejected)
     # -> UpdateArtifact (generic artifact updater; we only set the title)
     RENAME_ARTIFACT = "rc3d8d"
     # -> ExportToDrive (Google Drive only; Docs/Sheets are Drive destinations)


### PR DESCRIPTION
## What

Corrects/clarifies the batch-capability comments on the two delete RPCs that are **not** batch-capable, based on live probing (scratch notebooks/artifacts on a test account, all torn down).

### `DELETE_NOTEBOOK` (`DeleteProjects`) — comment was **wrong**
Claimed "batch-capable: the leading slot is a list of ids." Every obvious batch shape returns `rpc_code=3` (invalid argument), deleting 0/3: `[[id1,id2,id3],[2]]`, `[ids,[2,2,2]]`, `[[[id1],[id2],[id3]],[2]]`, `[[[id],[2]]…]`. Only single `[[id],[2]]` works.

### `DELETE_ARTIFACT` (`DeleteArtifact`) — added a **verified** note
Tested with 3 real report artifacts: `[[2], id1, id2, id3]` deletes only the first (1/3); `[[2], [id1,id2,id3]]` deletes none. Single-id only.

## Why

These `# batch-capable` annotations are reverse-engineering guesses, not verified truth. This audit checked all of them: `DELETE_SOURCE` / `ADD_SOURCE` / `DELETE_NOTE` **are** genuinely batch-capable (verified — #1995 / #1998 / #1999); `DELETE_NOTEBOOK` and `DELETE_ARTIFACT` are **not**. Recording the negative results so nobody builds a `delete_many` on a false premise or re-probes what's settled. Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deletion documentation for notebooks and artifacts to reflect single-id delete operations.
  * Clarified that batch-style deletion requests are not supported and may be rejected as invalid (e.g., `rpc_code=3`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->