### PR TITLE
fix(auth): recognize Gemini Notebook login host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `notebooklm login` now recognizes `notebook.google.com` as the personal app landing
+  host after the Gemini Notebook rebrand, preventing successful browser sign-ins from
+  timing out after five minutes. Enterprise and RPC base-host validation remain
+  unchanged. (#2013)
 - `server_info(include_account=True)` (MCP tool and the REST `GET /v1/server/info`
   route) now adds an `output_language_is_default` boolean to the account block. When
   the account has never set an explicit output language, `output_language` is `null`

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -50,7 +50,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 from urllib.parse import urlparse
 
 from .._atomic_io import atomic_write_json
-from ..config import get_base_host, get_base_url
+from ..config import PERSONAL_BASE_HOST, get_base_host, get_base_url
 from ..exceptions import HeadlessLoginRequiredError
 from .cookie_policy import build_cookie_domain_allowlist
 
@@ -340,9 +340,12 @@ def is_navigation_interrupted_error(error: str | Exception) -> bool:
 
 
 def url_matches_base_host(url: str) -> bool:
-    """Return True when ``url`` is on the configured NotebookLM host."""
+    """Return True when ``url`` is on the configured NotebookLM host or personal-app alias."""
     current_host = (urlparse(url).hostname or "").lower()
-    return current_host == get_base_host().lower()
+    base_host = get_base_host().lower()
+    return current_host == base_host or (
+        base_host == PERSONAL_BASE_HOST and current_host == "notebook.google.com"
+    )
 
 
 def connection_error_help() -> str:
@@ -621,7 +624,7 @@ def run_browser_capture(
                     # host. Cookies are read later at storage_state() (after the
                     # cookie-forcing round-trips), so resolving early is safe;
                     # page.content() at capture time is best-effort/None-tolerant.
-                    page.wait_for_url(f"{get_base_url()}/**", wait_until="commit", timeout=300_000)
+                    page.wait_for_url(url_matches_base_host, wait_until="commit", timeout=300_000)
                 except PlaywrightTimeout:
                     io.emit(
                         "[red]Login not detected within 5 minutes.[/red]\n"

--- a/tests/unit/cli/test_login.py
+++ b/tests/unit/cli/test_login.py
@@ -67,6 +67,7 @@ class TestLoginUrlValidation:
         )
 
         assert _url_matches_base_host("https://notebooklm.google.com/notebook/abc")
+        assert _url_matches_base_host("https://notebook.google.com/notebook/abc")
         assert not _url_matches_base_host(
             "https://example.com/path?next=https://notebooklm.google.com/"
         )
@@ -80,6 +81,7 @@ class TestLoginUrlValidation:
 
         assert _url_matches_base_host("https://notebooklm.cloud.google.com/notebook/abc")
         assert not _url_matches_base_host("https://notebooklm.google.com/notebook/abc")
+        assert not _url_matches_base_host("https://notebook.google.com/notebook/abc")
 
     def test_connection_error_help_uses_enterprise_base_host(self, monkeypatch):
         monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
@@ -410,13 +412,13 @@ class TestLoginCommand:
     ):
         """When the initial page is on accounts.google.com, wait_for_url is called."""
         mock_page = mock_login_browser_with_storage
-        # Initial URL is on Google login, then wait_for_url "succeeds" and the
-        # next reads of mock_page.url return the NotebookLM host for the
-        # subsequent cookie-forcing navigation.
+        # Initial URL is on Google login, then wait_for_url reaches the personal
+        # app alias used by the Gemini Notebook rebrand.
         mock_page.url = "https://accounts.google.com/signin"
 
-        def succeed(url, **kwargs):
-            mock_page.url = "https://notebooklm.google.com/"
+        def succeed(predicate, **kwargs):
+            assert predicate("https://notebook.google.com/")
+            mock_page.url = "https://notebook.google.com/"
 
         mock_page.wait_for_url.side_effect = succeed
 


### PR DESCRIPTION
## Summary
- accept `notebook.google.com` as the personal browser-login landing alias
- reuse the shared host predicate for Playwright login detection while keeping enterprise and RPC host validation strict
- add regression coverage and an Unreleased changelog entry

## Task
Fixes #2013

## Test plan
- [x] `uv run pytest` — 10,915 passed, 84 skipped, 1 expected xfail
- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Deferred polish findings
- Keep the one-use alias local until another consumer exists.
- Preserve the existing browser-URL contract instead of adding raw-host or scheme behavior.
- Avoid duplicating shared-helper coverage in each headless and CDP arm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `notebooklm login` timing out after browser sign-in when redirected to `notebook.google.com`.
  * Personal NotebookLM sign-ins now recognize the updated Google Notebook landing host while preserving existing enterprise sign-in validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->