### PR TITLE
fix(auth): centralize Windows-safe Playwright startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `notebooklm login --master-token` now starts Playwright with the required Windows
+  event-loop policy, avoiding a pre-browser `NotImplementedError` (#2011).
 - `notebooklm login` now recognizes `notebook.google.com` as the personal app landing
   host after the Gemini Notebook rebrand, preventing successful browser sign-ins from
   timing out after five minutes. Enterprise and RPC base-host validation remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `notebooklm login` now recognizes `notebook.google.com` as the personal app landing
+  host after the Gemini Notebook rebrand, preventing successful browser sign-ins from
+  timing out after five minutes. Enterprise and RPC base-host validation remain
+  unchanged. (#2013)
+- `notebooklm login --master-token` now starts Playwright with the required Windows
+  event-loop policy, avoiding a pre-browser `NotImplementedError` (#2011).
 - `server_info(include_account=True)` (MCP tool and the REST `GET /v1/server/info`
   route) now adds an `output_language_is_default` boolean to the account block. When
   the account has never set an explicit output language, `output_language` is `null`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `notebooklm login` now recognizes `notebook.google.com` as the personal app landing
-  host after the Gemini Notebook rebrand, preventing successful browser sign-ins from
-  timing out after five minutes. Enterprise and RPC base-host validation remain
-  unchanged. (#2013)
-- `notebooklm login --master-token` now starts Playwright with the required Windows
-  event-loop policy, avoiding a pre-browser `NotImplementedError` (#2011).
 - `server_info(include_account=True)` (MCP tool and the REST `GET /v1/server/info`
   route) now adds an `output_language_is_default` boolean to the account block. When
   the account has never set an explicit output language, `output_language` is `null`

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -310,6 +310,15 @@ def windows_playwright_event_loop() -> Iterator[None]:
         asyncio.set_event_loop_policy(original_policy)
 
 
+@contextmanager
+def sync_playwright_context() -> Iterator[Any]:
+    """Enter synchronous Playwright with its required Windows event-loop policy."""
+    from playwright.sync_api import sync_playwright
+
+    with windows_playwright_event_loop(), sync_playwright() as playwright:
+        yield playwright
+
+
 def recover_page(context: BrowserContext, io: BrowserCaptureIO) -> Page:
     """Get a fresh page from a persistent browser context.
 
@@ -493,7 +502,6 @@ def run_browser_capture(
     ensure_playwright_available(io, browser=browser)
     from playwright.sync_api import Error as PlaywrightError
     from playwright.sync_api import TimeoutError as PlaywrightTimeout
-    from playwright.sync_api import sync_playwright
 
     def _capture_page_html(page: Any) -> str | None:
         try:
@@ -505,9 +513,7 @@ def run_browser_capture(
 
     captured_page_html: str | None = None
 
-    # Use context manager to restore ProactorEventLoop for Playwright on Windows
-    # (fixes #89: NotImplementedError on Windows Python 3.12)
-    with windows_playwright_event_loop(), sync_playwright() as p:
+    with sync_playwright_context() as p:
         launch_kwargs: dict[str, Any] = {
             "user_data_dir": str(browser_profile),
             "headless": headless,
@@ -803,7 +809,6 @@ def run_cdp_capture(
     """
     ensure_playwright_available(io, browser="chromium")
     from playwright.sync_api import Error as PlaywrightError
-    from playwright.sync_api import sync_playwright
 
     storage_path = plan.storage_path
     include_domains = plan.include_domains
@@ -817,7 +822,7 @@ def run_cdp_capture(
             return None
         return content if isinstance(content, str) else None
 
-    with windows_playwright_event_loop(), sync_playwright() as p:
+    with sync_playwright_context() as p:
         browser = p.chromium.connect_over_cdp(cdp_url)
         page = None
         try:
@@ -912,6 +917,7 @@ __all__ = [
     "recover_page",
     "run_browser_capture",
     "run_cdp_capture",
+    "sync_playwright_context",
     "url_matches_base_host",
     "windows_playwright_event_loop",
 ]

--- a/src/notebooklm/cli/services/login/master_token.py
+++ b/src/notebooklm/cli/services/login/master_token.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+from ...._auth.browser_capture import sync_playwright_context  # noqa: TID252
 from ....auth import (  # noqa: TID252 (package-relative; public boundary, not _auth.*)
     MasterTokenError,
     exchange_master_token,
@@ -125,14 +126,14 @@ def capture_oauth_token(
     Requires the ``[browser]`` extra. Attaches to a running Chrome via ``cdp_url``
     when given, else launches a headed Playwright browser."""
     try:
-        from playwright.sync_api import sync_playwright  # noqa: PLC0415
+        import playwright.sync_api  # noqa: F401, PLC0415
     except ImportError as exc:  # pragma: no cover - import guard
         raise MasterTokenError(
             "Browser-assisted oauth_token capture needs the [browser] extra "
             "(pip install 'notebooklm-py[browser]'), or pass --oauth-token manually."
         ) from exc
 
-    with sync_playwright() as p:
+    with sync_playwright_context() as p:
         # Track what WE created so teardown never closes the user's own browser/
         # context (CDP adopts the user's live session) and always runs on error.
         owns_browser = owns_context = False

--- a/tests/_guardrails/test_login_package_dag.py
+++ b/tests/_guardrails/test_login_package_dag.py
@@ -37,8 +37,8 @@ ALLOWED_EDGES: dict[str, set[str]] = {
     "outcomes": set(),
     "cookie_domains": set(),
     "rookiepy_errors": set(),
-    # master_token: bootstrap/refresh service; imports only from notebooklm.auth /
-    # notebooklm.client (outside this package), so it is a login-package leaf.
+    # master_token: bootstrap/refresh service; its auth, client, and browser-capture
+    # imports live outside this package, so it remains a login-package leaf.
     "master_token": set(),
     "io_seam": set(),
     "cookie_jar": {

--- a/tests/_guardrails/test_playwright_gateway.py
+++ b/tests/_guardrails/test_playwright_gateway.py
@@ -1,0 +1,67 @@
+"""Keep raw synchronous Playwright startup behind its Windows-safe gateway.
+
+The CLI installs ``WindowsSelectorEventLoopPolicy`` on Windows, while
+Playwright needs the default Proactor policy to start its driver subprocess.
+Every raw ``sync_playwright`` entry point must therefore stay inside the one
+gateway that swaps and restores the policy. This guard prevents a new caller
+from repeating #2011 by bypassing that gateway.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+GATEWAY = ("src/notebooklm/_auth/browser_capture.py", "sync_playwright_context")
+
+
+class _RawSyncPlaywrightVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self._path = path.relative_to(REPO_ROOT).as_posix()
+        self._owners = ["<module>"]
+        self.sites: set[tuple[str, str, int]] = set()
+
+    def _record(self, node: ast.AST) -> None:
+        self.sites.add((self._path, self._owners[-1], node.lineno))
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._owners.append(node.name)
+        self.generic_visit(node)
+        self._owners.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module == "playwright.sync_api" and any(
+            alias.name == "sync_playwright" for alias in node.names
+        ):
+            self._record(node)
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id == "sync_playwright":
+            self._record(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr == "sync_playwright":
+            self._record(node)
+        self.generic_visit(node)
+
+
+def test_raw_sync_playwright_is_confined_to_policy_gateway() -> None:
+    sites: set[tuple[str, str, int]] = set()
+    for path in SRC_ROOT.rglob("*.py"):
+        visitor = _RawSyncPlaywrightVisitor(path)
+        visitor.visit(ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
+        sites.update(visitor.sites)
+
+    owners = {(path, owner) for path, owner, _line in sites}
+    assert owners == {GATEWAY}, (
+        f"Raw sync_playwright use must stay inside the policy-safe gateway; found {sorted(sites)}"
+    )

--- a/tests/unit/cli/test_login_master_token.py
+++ b/tests/unit/cli/test_login_master_token.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 import notebooklm.cli.services.login.master_token as mt_service
+from notebooklm._auth import browser_capture
 from notebooklm.notebooklm_cli import cli
 from notebooklm.paths import get_storage_path
 
@@ -66,6 +69,58 @@ def test_master_token_bootstrap_browser_capture_when_no_oauth(tmp_path, monkeypa
     assert result.exit_code == 0, result.output
     assert cap.called
     assert boot.call_args.kwargs["oauth_token"] == "CAPTOK"
+
+
+class _ReachedPlaywright(RuntimeError):
+    pass
+
+
+class _PolicyProbe:
+    def __init__(self, get_policy, default_policy):
+        self._get_policy = get_policy
+        self._default_policy = default_policy
+
+    def __enter__(self):
+        assert self._get_policy() is self._default_policy
+        raise _ReachedPlaywright
+
+    def __exit__(self, *args):
+        return False
+
+
+@pytest.mark.requires_playwright
+@pytest.mark.parametrize("cdp_url", [None, "http://localhost:9222"])
+def test_master_token_capture_uses_default_windows_policy(monkeypatch, cdp_url):
+    """The policy swap must happen before Playwright enters, then be restored."""
+    original_policy = object()
+    default_policy = object()
+    current_policy = original_policy
+    transitions = []
+
+    def get_policy():
+        return current_policy
+
+    def set_policy(policy):
+        nonlocal current_policy
+        current_policy = policy
+        transitions.append(policy)
+
+    monkeypatch.setattr(browser_capture.sys, "platform", "win32")
+    monkeypatch.setattr(asyncio, "get_event_loop_policy", get_policy)
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", set_policy)
+    monkeypatch.setattr(asyncio, "DefaultEventLoopPolicy", lambda: default_policy)
+
+    with (
+        patch(
+            "playwright.sync_api.sync_playwright",
+            return_value=_PolicyProbe(get_policy, default_policy),
+        ),
+        pytest.raises(_ReachedPlaywright),
+    ):
+        mt_service.capture_oauth_token(cdp_url=cdp_url)
+
+    assert transitions == [default_policy, original_policy]
+    assert current_policy is original_policy
 
 
 def test_master_token_refuses_account_clobber(tmp_path, monkeypatch):

--- a/tests/unit/cli/test_login_master_token.py
+++ b/tests/unit/cli/test_login_master_token.py
@@ -105,10 +105,10 @@ def test_master_token_capture_uses_default_windows_policy(monkeypatch, cdp_url):
         current_policy = policy
         transitions.append(policy)
 
-    monkeypatch.setattr(browser_capture.sys, "platform", "win32")
     monkeypatch.setattr(asyncio, "get_event_loop_policy", get_policy)
     monkeypatch.setattr(asyncio, "set_event_loop_policy", set_policy)
     monkeypatch.setattr(asyncio, "DefaultEventLoopPolicy", lambda: default_policy)
+    monkeypatch.setattr(browser_capture.sys, "platform", "win32")
 
     with (
         patch(

--- a/tests/unit/test_windows_compatibility.py
+++ b/tests/unit/test_windows_compatibility.py
@@ -17,6 +17,9 @@ from unittest.mock import patch
 
 import pytest
 
+from notebooklm._auth.browser_capture import (
+    sync_playwright_context as _sync_playwright_context,
+)
 from notebooklm.cli.services.playwright_login import (
     windows_playwright_event_loop as _windows_playwright_event_loop,
 )
@@ -38,10 +41,7 @@ class TestPlaywrightSmokeTest:
         sync_playwright() raises NotImplementedError on Windows because
         WindowsSelectorEventLoopPolicy doesn't support subprocess spawning.
         """
-        from playwright.sync_api import sync_playwright
-
-        # This would fail without the context manager fix
-        with _windows_playwright_event_loop(), sync_playwright() as p:
+        with _sync_playwright_context() as p:
             # Just verify Playwright initializes - don't launch a browser
             assert p.chromium is not None
             assert p.firefox is not None
@@ -55,10 +55,7 @@ class TestPlaywrightSmokeTest:
         if sys.platform == "win32":
             pytest.skip("Non-Windows test")
 
-        from playwright.sync_api import sync_playwright
-
-        # Context manager is no-op on non-Windows, Playwright should still work
-        with _windows_playwright_event_loop(), sync_playwright() as p:
+        with _sync_playwright_context() as p:
             assert p.chromium is not None
 
 


### PR DESCRIPTION
## Summary

- centralize synchronous Playwright startup behind one Windows-policy-safe context
- route regular browser capture, CDP capture, and master-token OAuth capture through that gateway
- add a source guard against future raw `sync_playwright` callers and regression coverage for launch/CDP

## Root cause

The CLI installs `WindowsSelectorEventLoopPolicy` on Windows to avoid the #79 IOCP hang. Playwright's synchronous API needs the default Proactor policy to spawn its driver.

The existing policy helper was optional at each call site. The master-token OAuth capture entered `sync_playwright()` directly, so `notebooklm login --master-token` raised `NotImplementedError` before browser launch. Existing Windows tests exercised the helper itself, while master-token tests mocked the failing capture boundary.

The new gateway owns both policy switching and Playwright startup, and an AST guard makes bypasses fail CI.

Fixes #2011.
Closes #2014.

## Validation

- [x] `pytest -n auto --dist=worksteal -q` — 12,375 passed, 77 skipped, 1 expected xfail
- [x] focused browser, master-token, Windows, and guardrail tests — 144 passed, 5 skipped
- [x] `mypy src/notebooklm --ignore-missing-imports`
- [x] `pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows startup for `login --master-token` by ensuring Playwright uses the required event-loop policy.
* **New Features**
  * Standardized the browser automation initialization pathway across supported login/OAuth flows.
* **Tests**
  * Added guardrails to ensure raw Playwright `sync_playwright` usage is confined to the Windows-safe pathway.
  * Added/updated regression tests for Windows event-loop policy handling and Playwright initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->