### PR TITLE
chore(deploy): expose MCP origin on loopback

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -12,6 +12,9 @@ TUNNEL=cloudflare
 # NOTEBOOKLM_MCP_IMAGE=tenglin/notebooklm-mcp
 # NOTEBOOKLM_MCP_VERSION=<version>
 
+# Loopback-only host port used by a consolidated host-networked tunnel connector.
+# NOTEBOOKLM_MCP_HOST_PORT=9420
+
 # Bearer token clients must present to use the MCP endpoint. Generate a strong
 # random value, e.g.:  python -c "import secrets; print(secrets.token_urlsafe(32))"
 # Works with Claude Code / Desktop (which send an Authorization header).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -97,8 +97,9 @@ cp deploy/.env.example deploy/.env
 
 ## 3. Choose a tunnel
 The stack ships two tunnel sidecars as Compose **profiles** — pick one (the server
-runs under either). Both terminate TLS at their edge, so there's no cert to manage and
-no host ports are published.
+runs under either). Both terminate TLS at their edge, so there's no cert to manage.
+The origin publishes only `127.0.0.1:9420`, which is unreachable off-host and also lets
+a consolidated host-networked tunnel route `http://notebooklm-mcp:9420` to it.
 
 > **Only using Claude Code / Cursor / Desktop (not claude.ai)? You may not need a public
 > tunnel at all** — those clients send a bearer, so they need *reachability*, not a public
@@ -133,6 +134,10 @@ Feb 2026; the old Zero Trust dashboard now redirects here):
    `https://` in the field's placeholder. Cloudflare auto-creates the DNS record + serves TLS.
    Leave **Path** empty so the **whole host** (`/`) is routed — not a `/mcp`-scoped path — so
    the root OAuth routes are reachable. (Profile: `cloudflare`, the default.)
+
+For a consolidated host tunnel, do not enable the `cloudflare` profile. Start only
+`notebooklm-mcp`, map `notebooklm-mcp` to `127.0.0.1` in the shared connector, and keep
+the same public-hostname service URL.
 > Optional: set `NOTEBOOKLM_MCP_TRUST_PROXY=1` in `.env` to key the per-IP login
 > throttle on the tunnel's `CF-Connecting-IP` header. Default off keys on the socket
 > peer (the tunnel egress) — one global throttle bucket. Only enable it behind a trusted

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,8 +12,8 @@
 # targets do this for you.
 #
 # The notebooklm-mcp service runs under either profile; exactly one tunnel sidecar
-# is selected. No host ports are published — the ONLY way in is through the chosen
-# tunnel, which terminates TLS at its edge (no CA cert for you to manage). See README.md.
+# is selected. The loopback-only host port also lets a host-networked shared tunnel
+# reach it without exposing the origin publicly.
 services:
   notebooklm-mcp:
     # Pull the published image. Default tag is `latest` = the latest STABLE release
@@ -82,7 +82,8 @@ services:
       # profile keeps registered clients. Pre-create the host dir as yourself (the `make`
       # targets do; direct `docker compose up` users: `mkdir -p ./oauth-state && chmod 700 ./oauth-state`).
       - "${NOTEBOOKLM_OAUTH_STATE_DIR:-./oauth-state}:/data/oauth:rw"
-    # No `ports:` — not reachable except via the tunnel.
+    ports:
+      - "127.0.0.1:${NOTEBOOKLM_MCP_HOST_PORT:-9420}:9420"
 
   # --- Tunnel option A: Cloudflare (needs a domain in your Cloudflare account) ----
   cloudflared:


### PR DESCRIPTION
## What changed

- Publish the NotebookLM MCP origin on a configurable host-loopback port (default `9420`).
- Document running the app without its per-stack Cloudflare sidecar when a consolidated host-networked connector is used.
- Keep the origin unreachable off-host while allowing the shared connector to route `notebooklm-mcp:9420`.

## Why

NotebookLM now shares one application tunnel with the other MCP services instead of starting its own Cloudflare container.

## Validation

- Core imports, pre-commit, mypy, workflow permission/secret/pinning checks passed
- Documentation and public API compatibility audits passed
- RPC coverage and cassette/fixture secret scans passed
- 12,417 tests passed; 64 skipped; 1 expected xfail
- Coverage: 96.52%; all five per-file floors passed
- Deployment Compose config validated
- Live public `/mcp` returned the expected HTTP 405 for an unauthenticated GET through the consolidated tunnel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration guidance for the loopback-only tunnel connector port, defaulting to `9420`.
  * Enabled the service to be accessed by a consolidated tunnel through a loopback-bound port without publicly exposing the origin.

* **Documentation**
  * Updated deployment and Cloudflare setup instructions to describe the consolidated tunnel configuration and service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->