### PR TITLE
fix(cli): isolate browser profiles for custom storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `notebooklm login --storage <path>` now gives each custom storage file an
+  isolated persistent browser profile, with login, logout, `status --paths`, and
+  L3 headless re-auth resolving the same storage-specific path. Existing
+  custom-storage browser sessions are not auto-migrated because the old shared
+  profile cannot be safely attributed to a storage file or account. (#2026)
 - `notebooklm login --master-token` now starts Playwright with the required Windows
   event-loop policy, avoiding a pre-browser `NotImplementedError` (#2011).
 - `notebooklm login` now recognizes `notebook.google.com` as the personal app landing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `notebooklm login --storage <path>` now gives each custom storage file an
-  isolated persistent browser profile, with login, logout, `status --paths`, and
-  L3 headless re-auth resolving the same storage-specific path. Existing
-  custom-storage browser sessions are not auto-migrated because the old shared
-  profile cannot be safely attributed to a storage file or account. (#2026)
+  isolated persistent browser profile, with login, logout, `status --paths`,
+  doctor's L3 readiness row, and L3 headless re-auth resolving the same
+  storage-specific path. New explicit-storage browser directories carry an
+  ownership marker: `login --fresh` refuses to recursively delete unowned
+  sidecars and logout leaves them intact (and reports the preserved path).
+  Canonical legacy and named-profile layouts remain managed even when selected
+  through `--storage`. Very long storage filenames use a stable canonical-path hash to
+  stay within filesystem component limits. Existing custom-storage browser
+  sessions are not auto-migrated because the old shared profile cannot be safely
+  attributed to a storage file or account. (#2026)
 - `notebooklm login --master-token` now starts Playwright with the required Windows
   event-loop policy, avoiding a pre-browser `NotImplementedError` (#2011).
 - `notebooklm login` now recognizes `notebook.google.com` as the personal app landing

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -499,10 +499,14 @@ fully dead and neither L1 nor L2 can help. `refresh_auth(allow_headless=True)` (
 `NOTEBOOKLM_HEADLESS_REAUTH=1` for automatic mid-RPC opt-in) drives an unattended
 headless browser against the **persisted profile that is a sibling of this client's
 storage file** — `browser_profile/` beside a conventional `storage_state.json`,
-or `<storage_path>.browser_profile/` for any other filename — never the ambient
-profile. This lets two custom storage files in the same directory retain separate
-Google sessions. L3 silently re-mints cookies, reloads them, and retries the homepage
-GET once. Set `NOTEBOOKLM_HEADLESS_REAUTH_CDP_URL=http://127.0.0.1:9222` to attach
+or `<storage_path>.browser_profile/` for a normal-length custom filename; names
+that would exceed the filesystem component limit use a stable hash of the
+canonical storage path — never the ambient profile. This lets two custom storage
+files in the same directory retain separate Google sessions. The ownership marker
+written during path preparation is ignored when deciding whether the directory
+contains reusable Chrome state. L3 silently re-mints cookies, reloads them, and
+retries the homepage GET once. Set
+`NOTEBOOKLM_HEADLESS_REAUTH_CDP_URL=http://127.0.0.1:9222` to attach
 to an already-running local Chrome instead; non-loopback hosts are refused because
 a CDP endpoint is account-equivalent. If the profile is missing, Playwright is
 unavailable, env-var auth has no writeable file, or the browser session is also

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -498,8 +498,10 @@ When the homepage GET 302s to the Google login page, the first-party cookies are
 fully dead and neither L1 nor L2 can help. `refresh_auth(allow_headless=True)` (or
 `NOTEBOOKLM_HEADLESS_REAUTH=1` for automatic mid-RPC opt-in) drives an unattended
 headless browser against the **persisted profile that is a sibling of this client's
-`storage_state.json`** (`<storage_path>/../browser_profile`) — never the ambient
-profile — to silently re-mint cookies, then reloads them and retries the homepage
+storage file** — `browser_profile/` beside a conventional `storage_state.json`,
+or `<storage_path>.browser_profile/` for any other filename — never the ambient
+profile. This lets two custom storage files in the same directory retain separate
+Google sessions. L3 silently re-mints cookies, reloads them, and retries the homepage
 GET once. Set `NOTEBOOKLM_HEADLESS_REAUTH_CDP_URL=http://127.0.0.1:9222` to attach
 to an already-running local Chrome instead; non-loopback hosts are refused because
 a CDP endpoint is account-equivalent. If the profile is missing, Playwright is

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -411,7 +411,7 @@ By default, opens a Chromium browser with a persistent profile. Complete the Goo
 - `--account EMAIL` - Pick a signed-in Google account by email when several are present in the browser. Saves to the active profile by default; use `--profile-name` for a separate named profile or `--storage` for an exact path. Only valid with `--browser-cookies`.
 - `--all-accounts` - Extract every Google account signed in to the browser into separate profiles named from each account email. Only valid with `--browser-cookies`.
 - `--profile-name NAME` - Write a targeted `--account` import to this named profile instead of the active profile. Only valid with `--browser-cookies`.
-- `--fresh` - Start with a clean browser session (deletes the cached browser profile). Use to switch Google accounts. Has no effect with `--browser-cookies`.
+- `--fresh` - Start with a clean browser session (deletes the cached browser profile). Use to switch Google accounts. With explicit `--storage`, a pre-existing browser sidecar is deleted only when it carries NotebookLM's ownership marker or is the canonical legacy/named-profile layout; arbitrary unowned directories are refused. Has no effect with `--browser-cookies`.
 - `--include-domains LABEL[,LABEL...]` - Opt in to extracting sibling-product cookies (default: required Google auth/Drive cookies only). Supported labels: `youtube`, `docs`, `myaccount`, `mail`, `all`. Pass labels comma-separated or repeat the flag.
 
 **Master-token (headless) options** — mint/refresh web cookies from a durable Google master token, no per-session browser. Requires `pip install "notebooklm-py[headless]"`. Full guide: [installation.md#d-headless-server-or-ci](installation.md#d-headless-server-or-ci).
@@ -814,7 +814,7 @@ notebooklm auth inspect --browser firefox --json
 
 ### Authentication: `auth logout`
 
-Log out by clearing saved authentication. Removes both the saved cookie file (`storage_state.json`) and the cached browser profile. After logout, run `notebooklm login` to authenticate with a different Google account.
+Log out by clearing saved authentication. Removes both the saved cookie file (`storage_state.json`) and the cached browser profile. With explicit `--storage`, an arbitrary unowned browser sidecar is left intact; canonical managed profile layouts are still removed. After logout, run `notebooklm login` to authenticate with a different Google account.
 
 ```bash
 notebooklm auth logout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,8 +121,20 @@ A persistent Chromium user data directory used during `notebooklm login`.
 
 With `--storage <path>`, the browser profile is isolated with that storage file.
 The conventional `storage_state.json` uses a `browser_profile/` directory beside
-it; any other filename uses `<path>.browser_profile`. For example, `A.json` and
-`B.json` use `A.json.browser_profile/` and `B.json.browser_profile/` respectively.
+it; any normal-length custom filename uses `<path>.browser_profile`. For example,
+`A.json` and `B.json` use `A.json.browser_profile/` and
+`B.json.browser_profile/` respectively. If that filename would exceed the
+255-byte component limit, the canonical storage path maps to a short stable
+`storage-<hash>.browser_profile/` name; relative and absolute aliases map to the
+same directory.
+
+Browser directories newly created for explicit storage contain a
+`.notebooklm-owned` marker. `login --fresh` refuses to recursively delete an
+unowned sidecar, and `auth logout` skips it and reports the preserved path.
+Canonical named-profile and legacy browser directories remain managed even when
+their `storage_state.json` is selected explicitly with `--storage`; an arbitrary
+same-named directory outside `NOTEBOOKLM_HOME` remains unowned. A marker-only
+directory does not count as a reusable L3 browser session.
 
 > **Upgrading:** Existing custom-storage browser sessions are not migrated. You
 > may need one interactive sign-in per storage file. Do not copy or delete the
@@ -568,8 +580,11 @@ they are NOT the same file:
   secrets bound to the same Google account route as the original profile.
 - **Persistent browser state** lives beside the selected storage file. A path
   named `storage_state.json` uses `browser_profile/`; other filenames append
-  `.browser_profile` to the full filename. Login, headless re-auth,
-  `status --paths`, and logout all resolve the same storage-specific directory.
+  `.browser_profile` to the full filename when it fits, or use a stable
+  canonical-path hash when it does not. Login, headless re-auth, doctor's L3
+  readiness row, `status --paths`, and logout all resolve the same
+  storage-specific directory. Recursive deletion by `login --fresh` or logout
+  requires either the ownership marker or a canonical managed profile layout.
 
 Run `notebooklm --storage <path> status --paths` to see exactly which
 storage, context, and browser-profile paths are in use.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,15 @@ A persistent Chromium user data directory used during `notebooklm login`.
 
 **To reset:** Delete the `browser_profile/` directory and run `notebooklm login` again.
 
+With `--storage <path>`, the browser profile is isolated with that storage file.
+The conventional `storage_state.json` uses a `browser_profile/` directory beside
+it; any other filename uses `<path>.browser_profile`. For example, `A.json` and
+`B.json` use `A.json.browser_profile/` and `B.json.browser_profile/` respectively.
+
+> **Upgrading:** Existing custom-storage browser sessions are not migrated. You
+> may need one interactive sign-in per storage file. Do not copy or delete the
+> old shared browser profile unless its account/profile ownership is known.
+
 ### Master Token (`master_token.json`)
 
 Written only by `notebooklm login --master-token` (the `[headless]` extra). Holds
@@ -557,9 +566,13 @@ they are NOT the same file:
   index and optional `email`) lives in-band inside the selected
   `storage_state.json`. This keeps copied files and `NOTEBOOKLM_AUTH_JSON`
   secrets bound to the same Google account route as the original profile.
+- **Persistent browser state** lives beside the selected storage file. A path
+  named `storage_state.json` uses `browser_profile/`; other filenames append
+  `.browser_profile` to the full filename. Login, headless re-auth,
+  `status --paths`, and logout all resolve the same storage-specific directory.
 
 Run `notebooklm --storage <path> status --paths` to see exactly which
-context file is being used for notebook selection.
+storage, context, and browser-profile paths are in use.
 
 ## CI/CD Configuration
 

--- a/src/notebooklm/_app/session.py
+++ b/src/notebooklm/_app/session.py
@@ -269,11 +269,14 @@ class LogoutOutcome:
             this logout (file-based artifacts removed but the env var survives).
         failure: ``None`` on success; a :class:`LogoutFailure` when one of the
             three filesystem steps raised :class:`OSError`.
+        browser_profile_preserved: Existing unowned browser directory skipped
+            by policy, or ``None`` when no browser directory was preserved.
     """
 
     removed_any: bool
     env_auth_remains: bool
     failure: LogoutFailure | None = None
+    browser_profile_preserved: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -301,6 +304,8 @@ class LogoutInputs:
             storage/browser teardown runs.
         env_auth_remains: ``True`` when env-supplied auth survives this logout.
         rmtree: Recursive directory remover (the CLI passes ``shutil.rmtree``).
+        remove_browser_profile: Whether the resolved browser directory is safe
+            to remove. Explicit-storage adapters set this only for owned dirs.
     """
 
     storage_path: Path
@@ -309,18 +314,20 @@ class LogoutInputs:
     context_path: Callable[[], Path]
     env_auth_remains: bool
     rmtree: Callable[[Path], Any]
+    remove_browser_profile: bool = True
 
 
 def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
     """Execute ``auth logout`` end-to-end as a pure-typed-outcome operation.
 
-    Removes the resolved storage file, the cached browser profile, and the
-    per-context cache file. Returns a :class:`LogoutOutcome` carrying whichever
-    step (if any) raised an :class:`OSError`; the adapter owns all presentation
-    and exit-code policy. The order matches the legacy implementation:
+    Removes the resolved storage file, the cached browser profile when the
+    adapter marks it safe to remove, and the per-context cache file. Returns a
+    :class:`LogoutOutcome` carrying whichever step (if any) raised an
+    :class:`OSError`; the adapter owns all presentation and exit-code policy.
+    The order matches the legacy implementation:
 
     1. Storage file (the credential itself).
-    2. Browser profile (the persistent SSO cache).
+    2. Browser profile (the persistent SSO cache), when enabled.
     3. Context cache (notebook + account routing).
 
     Each step is independent — a failure short-circuits the rest of the pipeline
@@ -335,6 +342,11 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
     line on stderr requires.
     """
     removed_any = False
+    browser_profile_preserved = (
+        inputs.browser_profile_dir
+        if not inputs.remove_browser_profile and inputs.browser_profile_dir.exists()
+        else None
+    )
 
     if inputs.storage_path.exists():
         try:
@@ -347,6 +359,7 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
             return LogoutOutcome(
                 removed_any=removed_any,
                 env_auth_remains=inputs.env_auth_remains,
+                browser_profile_preserved=browser_profile_preserved,
                 failure=LogoutFailure(
                     kind="storage",
                     path=inputs.storage_path,
@@ -354,7 +367,7 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
                 ),
             )
 
-    if inputs.browser_profile_dir.exists():
+    if inputs.remove_browser_profile and inputs.browser_profile_dir.exists():
         try:
             inputs.rmtree(inputs.browser_profile_dir)
             removed_any = True
@@ -367,6 +380,7 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
             return LogoutOutcome(
                 removed_any=removed_any,
                 env_auth_remains=inputs.env_auth_remains,
+                browser_profile_preserved=browser_profile_preserved,
                 failure=LogoutFailure(
                     kind="browser_profile",
                     path=inputs.browser_profile_dir,
@@ -395,6 +409,7 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
         return LogoutOutcome(
             removed_any=removed_any,
             env_auth_remains=inputs.env_auth_remains,
+            browser_profile_preserved=browser_profile_preserved,
             failure=LogoutFailure(
                 kind="context",
                 path=context_path,
@@ -405,6 +420,7 @@ def execute_logout(inputs: LogoutInputs) -> LogoutOutcome:
     return LogoutOutcome(
         removed_any=removed_any,
         env_auth_remains=inputs.env_auth_remains,
+        browser_profile_preserved=browser_profile_preserved,
         failure=None,
     )
 

--- a/src/notebooklm/_auth/headless_reauth.py
+++ b/src/notebooklm/_auth/headless_reauth.py
@@ -327,11 +327,14 @@ def _resolve_reusable_profile(
     # session. An absent or non-directory path has no session to harvest.
     if not candidate.is_dir():
         return None
-    # An empty dir (e.g. created by a path-prep step but never logged into) has
-    # no Chrome session state. ``next(iterdir)`` is cheap and avoids treating a
-    # freshly-mkdir'd profile as reusable.
+    # An empty or ownership-marker-only dir (created by path prep but never
+    # logged into) has no Chrome session state.
+    from ..paths import BROWSER_PROFILE_OWNERSHIP_MARKER
+
     try:
-        next(candidate.iterdir())
+        next(
+            entry for entry in candidate.iterdir() if entry.name != BROWSER_PROFILE_OWNERSHIP_MARKER
+        )
     except StopIteration:
         return None
     except OSError as exc:  # unreadable dir — treat as no reusable profile

--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -147,8 +147,8 @@ async def _try_headless_reauth(
     :func:`notebooklm._auth.psidts_recovery._resolve_recovery_path`.
 
     Profile binding (CRITICAL): the headless browser is driven against the
-    persistent profile that is a sibling of THIS client's ``storage_state.json``
-    (``<storage_path>/../browser_profile``), NOT the ambient/default profile.
+    storage-specific persistent profile for THIS client's auth file, NOT the
+    ambient/default profile.
     A ``from_storage(profile="work")`` or ``--storage <path>`` client therefore
     re-mints from and into ITS OWN profile, never silently harvesting another
     account's session or overwriting the wrong storage file. When no such
@@ -172,17 +172,11 @@ async def _try_headless_reauth(
         logger.debug("Headless re-auth skipped: env-var auth has no writeable storage path.")
         return False
 
+    from ..paths import get_browser_profile_dir
     from .cookies import _replace_cookie_jar, build_httpx_cookies_from_storage
     from .headless_reauth import HeadlessReauthStatus, attempt_headless_reauth
 
-    # Bind the browser profile to the SAME profile as this storage file: the
-    # persistent profile dir is the ``browser_profile`` sibling of
-    # ``storage_state.json`` (see ``notebooklm.paths`` layout). Resolving it
-    # explicitly here — rather than letting ``attempt_headless_reauth`` fall
-    # back to the active/default profile — keeps a non-default client (custom
-    # ``--storage`` or ``profile="work"``) from re-minting against the wrong
-    # account's session.
-    browser_profile = storage_path.parent / "browser_profile"
+    browser_profile = get_browser_profile_dir(storage_path=storage_path)
 
     result = await asyncio.to_thread(
         attempt_headless_reauth,

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -162,7 +162,15 @@ def _render_logout_outcome(outcome: LogoutOutcome, *, json_output: bool = False)
             json_error_response(
                 f"logout_{failure.kind}_failed",
                 failure.error_message,
-                {"path": str(failure.path), "env_auth_remains": outcome.env_auth_remains},
+                {
+                    "path": str(failure.path),
+                    "env_auth_remains": outcome.env_auth_remains,
+                    "browser_profile_preserved": (
+                        str(outcome.browser_profile_preserved)
+                        if outcome.browser_profile_preserved is not None
+                        else None
+                    ),
+                },
             )
         else:
             json_output_response(
@@ -170,6 +178,11 @@ def _render_logout_outcome(outcome: LogoutOutcome, *, json_output: bool = False)
                     "status": "logged_out" if outcome.removed_any else "already_logged_out",
                     "removed": outcome.removed_any,
                     "env_auth_remains": outcome.env_auth_remains,
+                    "browser_profile_preserved": (
+                        str(outcome.browser_profile_preserved)
+                        if outcome.browser_profile_preserved is not None
+                        else None
+                    ),
                 }
             )
         return
@@ -178,6 +191,12 @@ def _render_logout_outcome(outcome: LogoutOutcome, *, json_output: bool = False)
         console.print(
             f"[yellow]Note: {AUTH_JSON_ENV_NAME} is set — env-based auth will "
             "remain active after logout. Unset it to fully log out.[/yellow]"
+        )
+
+    if outcome.browser_profile_preserved is not None:
+        console.print(
+            "[yellow]Note: Unowned browser profile preserved:[/yellow]\n"
+            f"{outcome.browser_profile_preserved}"
         )
 
     failure = outcome.failure

--- a/src/notebooklm/cli/doctor_cmd.py
+++ b/src/notebooklm/cli/doctor_cmd.py
@@ -25,6 +25,7 @@ from ..paths import (
 )
 from .error_handler import exit_with_code, handle_errors
 from .rendering import console, json_output_response
+from .services.auth_source import AuthSource
 
 
 def _doctor_paths() -> DoctorPaths:
@@ -33,11 +34,19 @@ def _doctor_paths() -> DoctorPaths:
     Each callable is resolved off the module global at call time so a
     ``patch("notebooklm.cli.doctor_cmd.<helper>", ...)`` test seam lands.
     """
+    auth = AuthSource.from_click_context(click.get_current_context(silent=True))
     return DoctorPaths(
-        get_path_info=get_path_info,
+        get_path_info=lambda: get_path_info(
+            profile=auth.profile,
+            storage_path=auth.storage_override,
+        ),
         get_home_dir=get_home_dir,
         get_profile_dir=get_profile_dir,
-        get_storage_path=get_storage_path,
+        get_storage_path=lambda: (
+            auth.storage_override
+            if auth.storage_override is not None
+            else get_storage_path(profile=auth.profile)
+        ),
         get_config_path=get_config_path,
         headless_reauth_check=_headless_reauth_check,
     )
@@ -58,17 +67,26 @@ def _headless_reauth_check() -> dict[str, str]:
     forces a ``playwright`` import on the common path.
 
     ``doctor`` is a read-only diagnostic, so resolving the browser-profile dir
-    is wrapped: ``get_browser_profile_dir`` can raise ``ValueError`` (malformed
-    profile config) or ``OSError`` (permission / filesystem issues), and the
-    readiness probe stats the dir. Either is degraded to a ``warn`` row rather
-    than crashing the whole command — consistent with the other doctor checks,
-    which all map malformed inputs to a status instead of raising.
+    is wrapped: path resolution can raise ``ValueError`` / ``OSError``, and the
+    readiness probe can also raise ``RuntimeError`` while checking browser
+    availability. Each is degraded to a ``warn`` row rather than crashing the
+    whole command — consistent with the other doctor checks, which all map
+    malformed inputs to a status instead of raising.
+
+    This L3 row reads the live :class:`AuthSource` independently of the other
+    doctor paths so root ``--storage`` and ``--profile`` select the same browser
+    directory as runtime re-auth.
     """
     from .._auth.headless_reauth import headless_reauth_readiness
 
     try:
-        readiness = headless_reauth_readiness(browser_profile=get_browser_profile_dir())
-    except (ValueError, OSError) as exc:
+        auth = AuthSource.from_click_context(click.get_current_context(silent=True))
+        browser_profile = get_browser_profile_dir(
+            profile=auth.profile,
+            storage_path=auth.storage_override,
+        )
+        readiness = headless_reauth_readiness(browser_profile=browser_profile)
+    except (ValueError, OSError, RuntimeError) as exc:
         return {
             "status": "warn",
             "detail": f"unavailable: could not resolve the browser profile ({type(exc).__name__})",

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -60,7 +60,12 @@ from ..._auth.browser_capture import (
     url_matches_base_host,
     windows_playwright_event_loop,
 )
-from ...paths import get_browser_profile_dir, get_storage_path
+from ...paths import (
+    BROWSER_PROFILE_OWNERSHIP_MARKER,
+    browser_profile_is_owned,
+    get_browser_profile_dir,
+    get_storage_path,
+)
 from .playwright_redaction import redact_subprocess_output
 
 logger = logging.getLogger(__name__)
@@ -355,7 +360,9 @@ def prepare_login_paths(
 
     Clears the cached browser profile on ``--fresh`` (returning
     :class:`PathError` on OSError so the command layer exits 1), then creates
-    both parent dirs with platform-aware permissions. Returns
+    both parent dirs with platform-aware permissions. Explicit-storage browser
+    dirs created here receive an ownership marker; ``--fresh`` refuses to
+    delete an existing unowned sidecar. Returns
     :class:`PreparedPaths` on success (``fresh_cleared`` flags whether the
     wipe ran, so the wrapper emits the cleared-session line).
     """
@@ -371,6 +378,13 @@ def prepare_login_paths(
 
     fresh_cleared = False
     if fresh and browser_profile.exists():
+        if storage and not browser_profile_is_owned(storage_path, browser_profile):
+            return PathError(
+                "[red]Refusing to delete an unowned browser profile.[/red]\n"
+                "The directory is not recognized as NotebookLM-managed:\n"
+                f"{browser_profile}\n"
+                "Move it aside, or remove it manually only if you know it is safe."
+            )
         try:
             shutil.rmtree(browser_profile)
             fresh_cleared = True
@@ -382,6 +396,7 @@ def prepare_login_paths(
                 f"If the problem persists, manually delete: {browser_profile}"
             )
 
+    browser_profile_existed = browser_profile.exists()
     if sys.platform == "win32":
         # On Windows < Python 3.13, mode= is ignored by mkdir(). On
         # Python 3.13+, mode= applies Windows ACLs that can be overly
@@ -394,6 +409,9 @@ def prepare_login_paths(
         storage_path.parent.chmod(0o700)
         browser_profile.mkdir(parents=True, exist_ok=True, mode=0o700)
         browser_profile.chmod(0o700)
+
+    if storage and not browser_profile_existed:
+        (browser_profile / BROWSER_PROFILE_OWNERSHIP_MARKER).touch()
 
     return PreparedPaths(
         storage_path=storage_path,

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -361,11 +361,13 @@ def prepare_login_paths(
     """
     if storage:
         storage_path = Path(storage)
+        browser_profile = get_browser_profile_dir(storage_path=storage_path)
     elif profile:
         storage_path = get_storage_path(profile=profile)
+        browser_profile = get_browser_profile_dir(profile=profile)
     else:
         storage_path = get_storage_path()
-    browser_profile = get_browser_profile_dir()
+        browser_profile = get_browser_profile_dir()
 
     fresh_cleared = False
     if fresh and browser_profile.exists():

--- a/src/notebooklm/cli/services/session_context.py
+++ b/src/notebooklm/cli/services/session_context.py
@@ -194,15 +194,18 @@ def execute_logout(ctx: click.Context | None) -> LogoutOutcome:
     and the OSError→:class:`LogoutFailure` mapping; the caller owns presentation
     and exit-code policy.
     """
+    auth = AuthSource.from_click_context(ctx)
 
     def _context_path() -> Path:
-        storage_override = AuthSource.from_click_context(ctx).storage_override
-        return get_context_path(storage_path=storage_override)
+        return get_context_path(storage_path=auth.storage_override)
 
     return _execute_logout_core(
         LogoutInputs(
             storage_path=resolve_logout_storage_path(ctx),
-            browser_profile_dir=get_browser_profile_dir(),
+            browser_profile_dir=get_browser_profile_dir(
+                profile=auth.profile,
+                storage_path=auth.storage_override,
+            ),
             clear_context=lambda: clear_context(clear_account=True),
             context_path=_context_path,
             env_auth_remains=warn_env_auth_remains_after_logout(),

--- a/src/notebooklm/cli/services/session_context.py
+++ b/src/notebooklm/cli/services/session_context.py
@@ -47,6 +47,7 @@ from ..._app.session import verify_and_set_notebook as _verify_and_set_notebook_
 # injected-bundle builders below read them through the module globals at call
 # time, never close over them at import.
 from ...paths import (
+    browser_profile_is_owned,
     get_browser_profile_dir,
     get_context_path,
     get_path_info,
@@ -195,20 +196,26 @@ def execute_logout(ctx: click.Context | None) -> LogoutOutcome:
     and exit-code policy.
     """
     auth = AuthSource.from_click_context(ctx)
+    browser_profile = get_browser_profile_dir(
+        profile=auth.profile,
+        storage_path=auth.storage_override,
+    )
+    storage_path = resolve_logout_storage_path(ctx)
+    remove_browser_profile = auth.storage_override is None or browser_profile_is_owned(
+        storage_path, browser_profile
+    )
 
     def _context_path() -> Path:
         return get_context_path(storage_path=auth.storage_override)
 
     return _execute_logout_core(
         LogoutInputs(
-            storage_path=resolve_logout_storage_path(ctx),
-            browser_profile_dir=get_browser_profile_dir(
-                profile=auth.profile,
-                storage_path=auth.storage_override,
-            ),
+            storage_path=storage_path,
+            browser_profile_dir=browser_profile,
             clear_context=lambda: clear_context(clear_account=True),
             context_path=_context_path,
             env_auth_remains=warn_env_auth_remains_after_logout(),
             rmtree=shutil.rmtree,
+            remove_browser_profile=remove_browser_profile,
         )
     )

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -35,6 +35,7 @@ Usage:
     set_active_profile("work")
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -42,6 +43,11 @@ import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Explicit-storage browser dirs created by login carry this marker. Profile and
+# legacy layouts are owned by their enclosing profile and do not need it.
+BROWSER_PROFILE_OWNERSHIP_MARKER = ".notebooklm-owned"
+_MAX_PATH_COMPONENT_BYTES = 255
 
 # Public surface (ADR-0012). Underscore-prefixed helpers like
 # ``_read_default_profile`` and ``_reset_config_cache`` remain importable for
@@ -358,8 +364,10 @@ def get_browser_profile_dir(
     An explicit storage path gets its own sibling browser profile. The
     conventional ``storage_state.json`` name keeps the existing
     ``browser_profile`` sibling name; other filenames preserve their full
-    name and append ``.browser_profile``. Without an explicit storage path,
-    this falls back to the existing profile and legacy-path behavior.
+    name and append ``.browser_profile``. If that component would exceed 255
+    bytes, a stable hash of the canonical storage path keeps it filesystem-safe
+    and makes relative/absolute aliases converge. Without an explicit storage
+    path, this falls back to the existing profile and legacy-path behavior.
     Keeping the conventional name preserves the established profile layout;
     suffixing custom names prevents same-directory storage files from sharing
     a browser session.
@@ -375,10 +383,52 @@ def get_browser_profile_dir(
     if storage_path is not None:
         if storage_path.name == "storage_state.json":
             return storage_path.parent / "browser_profile"
-        return storage_path.with_suffix(storage_path.suffix + ".browser_profile")
+        candidate = storage_path.with_suffix(storage_path.suffix + ".browser_profile")
+        if len(os.fsencode(candidate.name)) <= _MAX_PATH_COMPONENT_BYTES:
+            return candidate
+        canonical_storage = storage_path.expanduser().resolve()
+        digest = hashlib.sha256(os.fsencode(canonical_storage)).hexdigest()[:16]
+        return canonical_storage.parent / f"storage-{digest}.browser_profile"
     resolved = resolve_profile(profile)
     profile_path = get_profile_dir(resolved) / "browser_profile"
     return _legacy_fallback(profile_path, "browser_profile", resolved)
+
+
+def browser_profile_is_owned(storage_path: Path, browser_profile: Path) -> bool:
+    """Return whether a browser-profile directory is safe for NotebookLM to remove.
+
+    A marker explicitly owns any storage-specific sidecar created by NotebookLM.
+    Unmarked directories are owned only when their canonical paths match the
+    legacy layout or one direct child of ``NOTEBOOKLM_HOME/profiles``. Resolving
+    paths before comparison prevents a symlinked profile entry from claiming a
+    directory outside the NotebookLM home.
+    """
+    if (browser_profile / BROWSER_PROFILE_OWNERSHIP_MARKER).is_file():
+        return True
+
+    try:
+        home = get_home_dir().resolve()
+        canonical_storage = storage_path.expanduser().resolve()
+        canonical_browser = browser_profile.expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+    if (
+        canonical_storage == home / "storage_state.json"
+        and canonical_browser == home / "browser_profile"
+    ):
+        return True
+
+    profiles_dir = home / "profiles"
+    try:
+        relative_storage = canonical_storage.relative_to(profiles_dir)
+    except ValueError:
+        return False
+    return (
+        len(relative_storage.parts) == 2
+        and relative_storage.name == "storage_state.json"
+        and canonical_browser == canonical_storage.parent / "browser_profile"
+    )
 
 
 def get_config_path() -> Path:

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -348,18 +348,34 @@ def get_context_path(
     return _legacy_fallback(profile_path, "context.json", resolved)
 
 
-def get_browser_profile_dir(profile: str | None = None) -> Path:
-    """Get browser profile directory for a profile.
+def get_browser_profile_dir(
+    profile: str | None = None,
+    *,
+    storage_path: Path | None = None,
+) -> Path:
+    """Get browser profile directory for a profile or storage file.
 
-    Falls back to legacy home-root path for the "default" profile if the
-    profile-based path doesn't exist (pre-migration compatibility).
+    An explicit storage path gets its own sibling browser profile. The
+    conventional ``storage_state.json`` name keeps the existing
+    ``browser_profile`` sibling name; other filenames preserve their full
+    name and append ``.browser_profile``. Without an explicit storage path,
+    this falls back to the existing profile and legacy-path behavior.
+    Keeping the conventional name preserves the established profile layout;
+    suffixing custom names prevents same-directory storage files from sharing
+    a browser session.
 
     Args:
         profile: Profile name. If None, uses the active profile.
+        storage_path: Explicit storage path from ``--storage``. When set, it
+            takes precedence over profile resolution.
 
     Returns:
         Path to browser_profile/ directory.
     """
+    if storage_path is not None:
+        if storage_path.name == "storage_state.json":
+            return storage_path.parent / "browser_profile"
+        return storage_path.with_suffix(storage_path.suffix + ".browser_profile")
     resolved = resolve_profile(profile)
     profile_path = get_profile_dir(resolved) / "browser_profile"
     return _legacy_fallback(profile_path, "browser_profile", resolved)
@@ -385,9 +401,10 @@ def get_path_info(
 
     Args:
         profile: Profile name. If None, uses the active profile.
-        storage_path: Explicit ``--storage`` override. When set, ``storage_path``
-            and ``context_path`` in the result reflect the sibling-context
-            layout rather than the profile path.
+        storage_path: Explicit ``--storage`` override. When set, the
+            ``storage_path``, ``context_path``, and ``browser_profile_dir`` in
+            the result reflect the storage-specific sibling layout rather than
+            profile paths.
 
     Returns:
         Dict with path information and sources.
@@ -395,11 +412,8 @@ def get_path_info(
     home_from_env = os.environ.get("NOTEBOOKLM_HOME")
     resolved = resolve_profile(profile)
 
-    # Determine profile source. When --storage is set, profile resolution is
-    # effectively bypassed for the auth + context paths — but we still resolve
-    # ``profile`` because consumers may want to know what profile *would* be
-    # active otherwise. Make the override clear in the label so ``status
-    # --paths`` doesn't claim "CLI flag (--storage)" set the profile.
+    # --storage bypasses the profile for auth, context, and browser paths. Resolve
+    # it anyway so diagnostics can show which profile would otherwise be active.
     other_profile_set = (
         profile
         or _active_profile
@@ -435,5 +449,5 @@ def get_path_info(
         "storage_path": resolved_storage,
         "context_path": resolved_context,
         "config_path": str(get_config_path()),
-        "browser_profile_dir": str(get_browser_profile_dir(resolved)),
+        "browser_profile_dir": str(get_browser_profile_dir(resolved, storage_path=storage_path)),
     }

--- a/tests/unit/app/test_app_session.py
+++ b/tests/unit/app/test_app_session.py
@@ -247,6 +247,7 @@ def _logout_inputs(
     context_path: Callable[[], Path],
     env_auth_remains: bool = False,
     rmtree: Callable[[Path], Any],
+    remove_browser_profile: bool = True,
 ) -> LogoutInputs:
     return LogoutInputs(
         storage_path=storage_path,
@@ -255,6 +256,7 @@ def _logout_inputs(
         context_path=context_path,
         env_auth_remains=env_auth_remains,
         rmtree=rmtree,
+        remove_browser_profile=remove_browser_profile,
     )
 
 
@@ -314,6 +316,27 @@ def test_logout_no_artifacts_removed_any_false(tmp_path: Path) -> None:
     assert outcome.env_auth_remains is True
     # rmtree never runs when the browser dir is absent.
     inputs.rmtree.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_logout_reports_existing_browser_profile_preserved_by_policy(tmp_path: Path) -> None:
+    """A skipped unowned browser dir is carried through the typed outcome."""
+    browser_dir = tmp_path / "browser"
+    browser_dir.mkdir()
+    rmtree = MagicMock()
+    inputs = _logout_inputs(
+        storage_path=tmp_path / "missing_storage.json",
+        browser_profile_dir=browser_dir,
+        clear_context=lambda: False,
+        context_path=lambda: tmp_path / "ctx.json",
+        rmtree=rmtree,
+        remove_browser_profile=False,
+    )
+
+    outcome = execute_logout(inputs)
+
+    assert outcome.browser_profile_preserved == browser_dir
+    assert outcome.removed_any is False
+    rmtree.assert_not_called()
 
 
 def test_logout_storage_unlink_oserror_short_circuits(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1602,6 +1602,36 @@ class TestLoginBrowserCookies:
 
 
 class TestAuthLogoutCommand:
+    def test_auth_logout_storage_override_removes_only_matching_state(self, runner, tmp_path):
+        """Custom-storage logout leaves other and ambient browser profiles intact."""
+        storage_a = tmp_path / "A.json"
+        storage_a.write_text('{"cookies": []}')
+        context_a = tmp_path / "A.json.context.json"
+        context_a.write_text('{"notebook_id": "A"}')
+        browser_a = tmp_path / "A.json.browser_profile"
+        browser_a.mkdir()
+
+        storage_b = tmp_path / "B.json"
+        storage_b.write_text('{"cookies": []}')
+        context_b = tmp_path / "B.json.context.json"
+        context_b.write_text('{"notebook_id": "B"}')
+        browser_b = tmp_path / "B.json.browser_profile"
+        browser_b.mkdir()
+
+        ambient_browser = _sc.get_browser_profile_dir()
+        ambient_browser.mkdir(parents=True)
+
+        result = runner.invoke(cli, ["--storage", str(storage_a), "auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert not storage_a.exists()
+        assert not context_a.exists()
+        assert not browser_a.exists()
+        assert storage_b.exists()
+        assert context_b.exists()
+        assert browser_b.exists()
+        assert ambient_browser.exists()
+
     def test_auth_logout_deletes_storage_and_browser_profile(
         self, runner, tmp_path, mock_context_file, monkeypatch
     ):

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1654,7 +1654,7 @@ class TestAuthLogoutCommand:
         assert not context.exists()
         assert payload.read_text() == "external"
         assert "preserved" in result.output.lower()
-        assert str(browser_profile) in result.output
+        assert browser_profile.name in result.output
 
     def test_auth_logout_json_reports_preserved_unowned_browser_profile(self, runner, tmp_path):
         storage = tmp_path / "A.json"

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1610,6 +1610,7 @@ class TestAuthLogoutCommand:
         context_a.write_text('{"notebook_id": "A"}')
         browser_a = tmp_path / "A.json.browser_profile"
         browser_a.mkdir()
+        (browser_a / ".notebooklm-owned").touch()
 
         storage_b = tmp_path / "B.json"
         storage_b.write_text('{"cookies": []}')
@@ -1617,6 +1618,7 @@ class TestAuthLogoutCommand:
         context_b.write_text('{"notebook_id": "B"}')
         browser_b = tmp_path / "B.json.browser_profile"
         browser_b.mkdir()
+        (browser_b / ".notebooklm-owned").touch()
 
         ambient_browser = _sc.get_browser_profile_dir()
         ambient_browser.mkdir(parents=True)
@@ -1631,6 +1633,63 @@ class TestAuthLogoutCommand:
         assert context_b.exists()
         assert browser_b.exists()
         assert ambient_browser.exists()
+
+    def test_auth_logout_storage_override_preserves_unmarked_browser_profile(
+        self, runner, tmp_path
+    ):
+        """Custom-storage logout never deletes a pre-existing unowned sidecar."""
+        storage = tmp_path / "A.json"
+        storage.write_text('{"cookies": []}')
+        context = tmp_path / "A.json.context.json"
+        context.write_text('{"notebook_id": "A"}')
+        browser_profile = tmp_path / "A.json.browser_profile"
+        browser_profile.mkdir()
+        payload = browser_profile / "keep-me"
+        payload.write_text("external")
+
+        result = runner.invoke(cli, ["--storage", str(storage), "auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert not storage.exists()
+        assert not context.exists()
+        assert payload.read_text() == "external"
+        assert "preserved" in result.output.lower()
+        assert str(browser_profile) in result.output
+
+    def test_auth_logout_json_reports_preserved_unowned_browser_profile(self, runner, tmp_path):
+        storage = tmp_path / "A.json"
+        storage.write_text('{"cookies": []}')
+        browser_profile = tmp_path / "A.json.browser_profile"
+        browser_profile.mkdir()
+
+        result = runner.invoke(
+            cli,
+            ["--storage", str(storage), "auth", "logout", "--json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["browser_profile_preserved"] == str(browser_profile)
+        assert browser_profile.is_dir()
+
+    def test_auth_logout_explicit_named_profile_removes_unmarked_browser_profile(
+        self, runner, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(home))
+        profile_dir = home / "profiles" / "work"
+        profile_dir.mkdir(parents=True)
+        storage = profile_dir / "storage_state.json"
+        storage.write_text('{"cookies": []}')
+        browser_profile = profile_dir / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "session").write_text("managed")
+
+        result = runner.invoke(cli, ["--storage", str(storage), "auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert not browser_profile.exists()
+        assert "preserved" not in result.output.lower()
 
     def test_auth_logout_deletes_storage_and_browser_profile(
         self, runner, tmp_path, mock_context_file, monkeypatch

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -78,6 +78,26 @@ def test_doctor_reports_clean_profile_layout(runner, isolated_notebooklm_home):
         assert data["checks"]["profile_dir"] == {"status": "pass", "detail": str(profile_dir)}
 
 
+def test_doctor_explicit_storage_drives_path_info_and_auth(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    profile_dir = _make_profile(home, "work")
+    _write_json(profile_dir / "storage_state.json", _storage([]))
+    storage = home / "custom.json"
+    _write_json(
+        storage,
+        _storage([{"name": "SID", "value": "x"}, {"name": "__Secure-1PSIDTS", "value": "y"}]),
+    )
+
+    data = _invoke_json(runner, ["--profile", "work", "--storage", str(storage)])
+
+    assert data["profile"] == "work"
+    assert data["profile_source"] == "CLI flag (--storage, profile ignored)"
+    assert data["checks"]["auth"] == {
+        "status": "pass",
+        "detail": "local auth cookies present (2 cookies)",
+    }
+
+
 def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated_notebooklm_home):
     home = isolated_notebooklm_home
     _write_json(
@@ -85,7 +105,7 @@ def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated
         _storage([{"name": "SID", "value": "x"}, {"name": "__Secure-1PSIDTS", "value": "y"}]),
     )
 
-    data = _invoke_json(runner, ["--storage", str(home / "unused.json")], exit_code=1)
+    data = _invoke_json(runner, ["--storage", str(home / "storage_state.json")], exit_code=1)
 
     assert data["checks"]["migration"] == {
         "status": "fail",
@@ -247,7 +267,7 @@ def test_doctor_fix_migrates_legacy_layout(runner, isolated_notebooklm_home):
 
     result = runner.invoke(
         cli,
-        ["--storage", str(home / "unused.json"), "doctor", "--fix", "--json"],
+        ["--storage", str(home / "storage_state.json"), "doctor", "--fix", "--json"],
     )
 
     assert result.exit_code == 0, result.output
@@ -304,14 +324,15 @@ def test_doctor_json_wraps_unexpected_filesystem_error(runner, isolated_notebook
     assert result.stderr == ""
 
 
+@pytest.mark.parametrize("error_type", [ValueError, OSError, RuntimeError])
 def test_doctor_headless_reauth_degrades_to_warn_on_profile_resolution_error(
-    runner, isolated_notebooklm_home, monkeypatch
+    runner, isolated_notebooklm_home, monkeypatch, error_type
 ):
     """A read-only diagnostic must not crash if the profile dir cannot resolve.
 
-    ``get_browser_profile_dir`` can raise ``ValueError`` (malformed profile
-    config) / ``OSError`` (permissions); the headless-reauth check degrades to
-    a ``warn`` row instead of bubbling up. ``monkeypatch.setattr`` on the public
+    Path resolution can raise ``ValueError`` / ``OSError`` and readiness probes
+    can raise ``RuntimeError``; the headless-reauth check degrades each to a
+    ``warn`` row instead of bubbling up. ``monkeypatch.setattr`` on the public
     helper avoids growing the string-patch ratchet for this file.
     """
     from notebooklm.cli import doctor_cmd
@@ -323,7 +344,7 @@ def test_doctor_headless_reauth_degrades_to_warn_on_profile_resolution_error(
     )
 
     def _boom(*_a, **_k):
-        raise ValueError("malformed profile name")
+        raise error_type("malformed profile name")
 
     monkeypatch.setattr(doctor_cmd, "get_browser_profile_dir", _boom)
 
@@ -332,7 +353,31 @@ def test_doctor_headless_reauth_degrades_to_warn_on_profile_resolution_error(
     assert data["checks"]["headless_reauth"]["status"] == "warn"
     assert "could not resolve the browser profile" in data["checks"]["headless_reauth"]["detail"]
     # The error type is surfaced, never a raw path / value.
-    assert "ValueError" in data["checks"]["headless_reauth"]["detail"]
+    assert error_type.__name__ in data["checks"]["headless_reauth"]["detail"]
+
+
+def test_doctor_headless_reauth_uses_live_storage_and_profile(runner, isolated_notebooklm_home):
+    """The L3 readiness row resolves the root command's auth identity."""
+    browser_profile = isolated_notebooklm_home / "custom-browser"
+    (browser_profile / "Default").mkdir(parents=True)
+    storage = isolated_notebooklm_home / "custom.json"
+
+    with patch.object(
+        doctor_cmd_module,
+        "get_browser_profile_dir",
+        return_value=browser_profile,
+    ) as resolve_browser_profile:
+        data = _invoke_json(
+            runner,
+            ["--profile", "work", "--storage", str(storage)],
+            exit_code=1,
+        )
+
+    resolve_browser_profile.assert_called_once_with(
+        profile="work",
+        storage_path=storage.resolve(),
+    )
+    assert data["checks"]["headless_reauth"]["status"] in {"pass", "warn"}
 
 
 def test_doctor_text_mode_exits_nonzero_on_failure(runner, isolated_notebooklm_home):
@@ -383,7 +428,11 @@ def test_doctor_warn_only_keeps_exit_zero(runner, isolated_notebooklm_home):
     # otherwise sweep this file into the profile before the checks run.
     _write_json(home / "context.json", {"current_notebook": "nb_123"})
 
-    data = _invoke_json(runner, ["--storage", str(home / "unused.json")], exit_code=0)
+    data = _invoke_json(
+        runner,
+        ["--storage", str(profile_dir / "storage_state.json")],
+        exit_code=0,
+    )
 
     assert data["checks"]["migration"]["status"] == "warn"
     assert not any(c["status"] == "fail" for c in data["checks"].values())

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -349,13 +349,94 @@ def test_prepare_login_paths_isolates_custom_storage_profiles(tmp_path) -> None:
     assert outcome_b.browser_profile == tmp_path / "B.json.browser_profile"
 
 
+def test_prepare_login_paths_marks_new_custom_profile_as_owned(tmp_path) -> None:
+    """A browser directory created for explicit storage carries an ownership marker."""
+    outcome = prepare_login_paths(
+        profile=None,
+        storage=str(tmp_path / "A.json"),
+        fresh=False,
+    )
+
+    assert isinstance(outcome, PreparedPaths)
+    assert (outcome.browser_profile / ".notebooklm-owned").is_file()
+
+
+def test_prepare_login_paths_fresh_refuses_unmarked_custom_profile(tmp_path) -> None:
+    """--fresh never recursively deletes a pre-existing unowned sidecar."""
+    browser_profile = tmp_path / "A.json.browser_profile"
+    browser_profile.mkdir()
+    payload = browser_profile / "keep-me"
+    payload.write_text("external")
+
+    outcome = prepare_login_paths(
+        profile=None,
+        storage=str(tmp_path / "A.json"),
+        fresh=True,
+    )
+
+    assert isinstance(outcome, PathError)
+    assert "Refusing to delete" in outcome.message
+    assert payload.read_text() == "external"
+
+
+def test_prepare_login_paths_fresh_refuses_arbitrary_conventional_profile(
+    tmp_path, monkeypatch
+) -> None:
+    """A conventional filename outside NOTEBOOKLM_HOME is still unowned."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "home"))
+    external = tmp_path / "external"
+    external.mkdir()
+    browser_profile = external / "browser_profile"
+    browser_profile.mkdir()
+    payload = browser_profile / "keep-me"
+    payload.write_text("external")
+
+    outcome = prepare_login_paths(
+        profile=None,
+        storage=str(external / "storage_state.json"),
+        fresh=True,
+    )
+
+    assert isinstance(outcome, PathError)
+    assert payload.read_text() == "external"
+
+
+def test_prepare_login_paths_fresh_accepts_explicit_named_profile_without_marker(
+    tmp_path, monkeypatch
+) -> None:
+    """An explicit path to a managed profile has the same ownership as ``-p``."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(home))
+    profile_dir = home / "profiles" / "work"
+    profile_dir.mkdir(parents=True)
+    storage = profile_dir / "storage_state.json"
+    storage.write_text("{}")
+    browser_profile = profile_dir / "browser_profile"
+    browser_profile.mkdir()
+    payload = browser_profile / "stale"
+    payload.write_text("session")
+
+    outcome = prepare_login_paths(
+        profile=None,
+        storage=str(storage),
+        fresh=True,
+    )
+
+    assert isinstance(outcome, PreparedPaths)
+    assert outcome.fresh_cleared is True
+    assert not payload.exists()
+
+
 def test_prepare_login_paths_fresh_clears_only_matching_custom_profile(tmp_path) -> None:
     """--fresh resets only the browser profile bound to the selected storage file."""
     browser_a = tmp_path / "A.json.browser_profile"
     browser_b = tmp_path / "B.json.browser_profile"
     browser_a.mkdir()
     browser_b.mkdir()
-    (browser_a / "marker").write_text("A")
+    ownership_a = browser_a / ".notebooklm-owned"
+    ownership_a.touch()
+    payload_a = browser_a / "payload"
+    payload_a.write_text("A")
     marker_b = browser_b / "marker"
     marker_b.write_text("B")
 
@@ -368,7 +449,8 @@ def test_prepare_login_paths_fresh_clears_only_matching_custom_profile(tmp_path)
     assert isinstance(outcome, PreparedPaths)
     assert outcome.fresh_cleared is True
     assert browser_a.is_dir()
-    assert not any(browser_a.iterdir())
+    assert ownership_a.is_file()
+    assert not payload_a.exists()
     assert marker_b.read_text() == "B"
 
 

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -332,7 +332,44 @@ def test_prepare_login_paths_explicit_storage(tmp_path, monkeypatch) -> None:
     assert outcome.fresh_cleared is False
     # Explicit ``--storage`` short-circuits the path resolver entirely.
     fake_storage_path.assert_not_called()
-    fake_browser_profile_dir.assert_called_once_with()
+    fake_browser_profile_dir.assert_called_once_with(storage_path=tmp_path / "explicit.json")
+
+
+def test_prepare_login_paths_isolates_custom_storage_profiles(tmp_path) -> None:
+    """Different custom storage files use different persistent browser profiles."""
+    storage_a = tmp_path / "A.json"
+    storage_b = tmp_path / "B.json"
+
+    outcome_a = prepare_login_paths(profile="work", storage=str(storage_a), fresh=False)
+    outcome_b = prepare_login_paths(profile="work", storage=str(storage_b), fresh=False)
+
+    assert isinstance(outcome_a, PreparedPaths)
+    assert isinstance(outcome_b, PreparedPaths)
+    assert outcome_a.browser_profile == tmp_path / "A.json.browser_profile"
+    assert outcome_b.browser_profile == tmp_path / "B.json.browser_profile"
+
+
+def test_prepare_login_paths_fresh_clears_only_matching_custom_profile(tmp_path) -> None:
+    """--fresh resets only the browser profile bound to the selected storage file."""
+    browser_a = tmp_path / "A.json.browser_profile"
+    browser_b = tmp_path / "B.json.browser_profile"
+    browser_a.mkdir()
+    browser_b.mkdir()
+    (browser_a / "marker").write_text("A")
+    marker_b = browser_b / "marker"
+    marker_b.write_text("B")
+
+    outcome = prepare_login_paths(
+        profile=None,
+        storage=str(tmp_path / "A.json"),
+        fresh=True,
+    )
+
+    assert isinstance(outcome, PreparedPaths)
+    assert outcome.fresh_cleared is True
+    assert browser_a.is_dir()
+    assert not any(browser_a.iterdir())
+    assert marker_b.read_text() == "B"
 
 
 def test_prepare_login_paths_with_profile(tmp_path, monkeypatch) -> None:
@@ -351,7 +388,7 @@ def test_prepare_login_paths_with_profile(tmp_path, monkeypatch) -> None:
     assert outcome.browser_profile == browser_profile
     # The profile branch forwards the profile name to the storage resolver.
     fake_storage_path.assert_called_once_with(profile="work")
-    fake_browser_profile_dir.assert_called_once_with()
+    fake_browser_profile_dir.assert_called_once_with(profile="work")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_storage_context_isolation.py
+++ b/tests/unit/cli/test_storage_context_isolation.py
@@ -92,6 +92,7 @@ class TestGetPathInfoStorageOverride:
         info = get_path_info(storage_path=storage)
         assert info["storage_path"] == str(storage)
         assert info["context_path"] == str(tmp_path / "explicit.json.context.json")
+        assert info["browser_profile_dir"] == str(tmp_path / "explicit.json.browser_profile")
         assert info["profile_source"] == "CLI flag (--storage)"
 
     def test_no_override_unchanged(self, isolated_home):
@@ -197,6 +198,7 @@ class TestStatusPathsReflectsStorageOverride:
         paths = data["paths"]
         assert paths["storage_path"] == str(storage_a)
         assert paths["context_path"] == str(tmp_path / "A.json.context.json")
+        assert paths["browser_profile_dir"] == str(tmp_path / "A.json.browser_profile")
         assert paths["profile_source"] == "CLI flag (--storage)"
 
 

--- a/tests/unit/test_auth_headless_reauth.py
+++ b/tests/unit/test_auth_headless_reauth.py
@@ -120,6 +120,17 @@ def test_optin_on_empty_profile_dir_is_unavailable(tmp_path: Path, monkeypatch) 
     assert result.status is HeadlessReauthStatus.UNAVAILABLE
 
 
+def test_ownership_marker_only_profile_is_not_reusable(tmp_path: Path) -> None:
+    """A freshly prepared marker-only directory holds no reusable Google session."""
+    profile = tmp_path / "A.json.browser_profile"
+    profile.mkdir()
+    (profile / ".notebooklm-owned").touch()
+
+    readiness = hr.headless_reauth_readiness(browser_profile=profile)
+
+    assert readiness.profile_present is False
+
+
 # ---------------------------------------------------------------------------
 # Decision matrix: opt-in ON + profile present → drives the browser
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_auth_session_headless_reauth.py
+++ b/tests/unit/test_auth_session_headless_reauth.py
@@ -150,6 +150,40 @@ async def test_dead_cookies_optin_but_unavailable_raises(monkeypatch, tmp_path: 
             await refresh_auth_session(allow_headless=True, **b)
 
 
+@pytest.mark.asyncio
+async def test_headless_reauth_uses_storage_specific_browser_profile(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Custom storage files do not share an ambient L3 browser profile."""
+    import notebooklm._auth.headless_reauth as hr
+    import notebooklm._auth.session as session_mod
+
+    browser_profiles: list[Path] = []
+
+    def _record_attempt(**kwargs):
+        browser_profiles.append(kwargs["browser_profile"])
+        return HeadlessReauthResult(HeadlessReauthStatus.UNAVAILABLE, "no profile")
+
+    monkeypatch.setattr(hr, "attempt_headless_reauth", _record_attempt)
+
+    for storage_path in (
+        tmp_path / "A.json",
+        tmp_path / "B.json",
+        tmp_path / "work" / "storage_state.json",
+    ):
+        await session_mod._try_headless_reauth(
+            auth=_auth(storage_path=storage_path),
+            kernel=object(),
+            allow_headless=True,
+        )
+
+    assert browser_profiles == [
+        tmp_path / "A.json.browser_profile",
+        tmp_path / "B.json.browser_profile",
+        tmp_path / "work" / "browser_profile",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Opt-in success: re-mint heals, retry yields fresh tokens
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -328,6 +328,32 @@ class TestGetContextPath:
 
 
 class TestGetBrowserProfileDir:
+    def test_custom_storage_files_get_distinct_sibling_profiles(self, tmp_path):
+        """Custom storage filenames retain their full name for isolation."""
+        storage_a = tmp_path / "A.json"
+        storage_b = tmp_path / "B.json"
+
+        assert get_browser_profile_dir(storage_path=storage_a) == (
+            tmp_path / "A.json.browser_profile"
+        )
+        assert get_browser_profile_dir(storage_path=storage_b) == (
+            tmp_path / "B.json.browser_profile"
+        )
+
+    def test_conventional_storage_filename_uses_browser_profile_sibling(self, tmp_path):
+        """The standard storage filename preserves the established directory name."""
+        storage = tmp_path / "storage_state.json"
+
+        assert get_browser_profile_dir(storage_path=storage) == tmp_path / "browser_profile"
+
+    def test_storage_path_takes_precedence_over_profile(self, tmp_path):
+        """An explicit storage path wins over profile resolution."""
+        storage = tmp_path / "account.json"
+
+        assert get_browser_profile_dir(profile="work", storage_path=storage) == (
+            tmp_path / "account.json.browser_profile"
+        )
+
     def test_profile_based_path(self, tmp_path):
         """Returns profile-based browser_profile path."""
         home = tmp_path / "home"

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -9,8 +9,10 @@ from unittest.mock import patch
 import pytest
 
 from notebooklm.paths import (
+    BROWSER_PROFILE_OWNERSHIP_MARKER,
     _read_default_profile,
     _reset_config_cache,
+    browser_profile_is_owned,
     get_browser_profile_dir,
     get_context_path,
     get_home_dir,
@@ -354,6 +356,23 @@ class TestGetBrowserProfileDir:
             tmp_path / "account.json.browser_profile"
         )
 
+    def test_long_custom_storage_name_uses_stable_canonical_hash(self, tmp_path, monkeypatch):
+        """Long relative and absolute aliases resolve to one safe short component."""
+        accounts = tmp_path / "accounts"
+        accounts.mkdir()
+        monkeypatch.chdir(tmp_path)
+        relative_storage = Path("accounts") / ("x" * 240 + ".json")
+        canonical_storage = relative_storage.resolve()
+
+        relative_result = get_browser_profile_dir(storage_path=relative_storage)
+        canonical_result = get_browser_profile_dir(storage_path=canonical_storage)
+
+        assert relative_result == canonical_result
+        assert relative_result.parent == accounts.resolve()
+        assert relative_result.name.endswith(".browser_profile")
+        assert len(os.fsencode(relative_result.name)) <= 255
+        assert relative_result.name != relative_storage.name + ".browser_profile"
+
     def test_profile_based_path(self, tmp_path):
         """Returns profile-based browser_profile path."""
         home = tmp_path / "home"
@@ -382,6 +401,55 @@ class TestGetBrowserProfileDir:
             result = get_browser_profile_dir()
             assert "browser_profile" in str(result)
             assert str(custom_path.resolve()) in str(result)
+
+
+class TestBrowserProfileIsOwned:
+    def test_marker_owns_arbitrary_browser_profile(self, tmp_path):
+        browser_profile = tmp_path / "external" / "browser_profile"
+        browser_profile.mkdir(parents=True)
+        (browser_profile / BROWSER_PROFILE_OWNERSHIP_MARKER).touch()
+
+        assert browser_profile_is_owned(tmp_path / "external" / "storage.json", browser_profile)
+
+    def test_recognizes_legacy_and_named_profile_layouts(self, tmp_path):
+        home = tmp_path / "home"
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(home)}, clear=True):
+            assert browser_profile_is_owned(
+                home / "storage_state.json",
+                home / "browser_profile",
+            )
+            assert browser_profile_is_owned(
+                home / "profiles" / "work" / "storage_state.json",
+                home / "profiles" / "work" / "browser_profile",
+            )
+
+    def test_rejects_arbitrary_conventional_layout(self, tmp_path):
+        home = tmp_path / "home"
+        external = tmp_path / "external"
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(home)}, clear=True):
+            assert not browser_profile_is_owned(
+                external / "storage_state.json",
+                external / "browser_profile",
+            )
+
+    def test_rejects_named_profile_symlink_that_escapes_home(self, tmp_path):
+        home = tmp_path / "home"
+        profiles = home / "profiles"
+        profiles.mkdir(parents=True)
+        external = tmp_path / "external"
+        external.mkdir()
+        try:
+            (profiles / "work").symlink_to(external, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"directory symlinks unavailable: {exc}")
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(home)}, clear=True):
+            assert not browser_profile_is_owned(
+                profiles / "work" / "storage_state.json",
+                profiles / "work" / "browser_profile",
+            )
 
 
 class TestListProfiles:


### PR DESCRIPTION
## Summary

- derive the persistent Chromium profile from an explicit storage path
- use the same storage-specific path for login, fresh cleanup, status, logout, and L3 headless re-auth
- guard destructive cleanup with explicit ownership, including preserved-path reporting
- preserve the existing profile/legacy layout and bound overlong sidecar names with a stable hash

## Root cause

`prepare_login_paths()` honored `--storage` for the auth file but resolved the persistent browser profile from the ambient active profile. Custom storage files therefore shared one Chromium profile and could collide across Google accounts.

## Test plan

- `uv run pytest` (10,943 passed, 84 skipped, 1 expected failure)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

Closes #2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom storage files now use isolated, persistent browser profiles with independent sessions.
  * Login, logout, status, headless re-authentication, and readiness checks consistently use the matching profile.
  * Path diagnostics report the associated browser-profile location.
  * Logout preserves externally managed profiles and reports their location.
  * Fresh login safely avoids deleting unowned profiles; long paths receive stable profile locations.
* **Documentation**
  * Added guidance on profile paths, independent sessions, safe cleanup, and custom-storage behavior.
  * Noted that existing custom-storage sessions may require signing in again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
