### PR TITLE
docs(adr): ADR-0028 — rename plan for Google's "Gemini Notebook" rebrand

### DIFF
--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Proposed — v2, revised after a four-lens review (packaging, compatibility,
-surface coverage, strategy) of the 2026-08-03 original. The original decided a
-full rename including the import package; v2 reverses that (see Alternatives).
+Proposed — v3; the identity flip is consolidated into a single 0.9.0 release
+per maintainer review. v2 (same day) split it across 0.9/0.10 behind a
+brand-stability gate; v1 renamed the import package too. Both are recorded in
+Alternatives.
 
 ## Context
 
@@ -58,17 +59,18 @@ Constraints that shape the decision:
 ## Decision
 
 Rename the **distribution and the discoverability surfaces** to
-**`gemini-notebook-py`**; keep the **import package `notebooklm` and all
-operational plumbing permanently**. Dist-name ≠ import-name is an established
-Python pattern (`beautifulsoup4`/`bs4`, `scikit-learn`/`sklearn`,
-`pillow`/`PIL`), and every argument this ADR's Context makes against renaming
-the wire layer applies equally to the import package: churn with no functional
-gain, brand-stability risk, and — decisive — the plumbing writes its name into
-places we cannot patch after the fact.
+**`gemini-notebook-py`**, completing the flip in a **single 0.9.0 release**;
+keep the **import package `notebooklm` and all operational plumbing
+permanently**. Dist-name ≠ import-name is an established Python pattern
+(`beautifulsoup4`/`bs4`, `scikit-learn`/`sklearn`, `pillow`/`PIL`), and every
+argument this ADR's Context makes against renaming the wire layer applies
+equally to the import package: churn with no functional gain, brand-stability
+risk, and — decisive — the plumbing writes its name into places we cannot
+patch after the fact.
 
 | Surface | Disposition |
 |---|---|
-| PyPI dist `notebooklm-py` | → `gemini-notebook-py` canonical; old name becomes a permanent extras-forwarding shim |
+| PyPI dist `notebooklm-py` | → `gemini-notebook-py` canonical at 0.9.0; old name becomes a permanent extras-forwarding shim |
 | Bare `gemini-notebook` | registered as redirect metapackage (anti-squat) |
 | GitHub repo | → `teng-lin/gemini-notebook-py` (auto-redirects) |
 | CLI | `gemini-notebook`, `gemini-notebook-mcp`, `gemini-notebook-server` added; `notebooklm*` scripts kept **indefinitely** (they match the import name; no deprecation) |
@@ -89,7 +91,7 @@ frowns on) and we accept we may have to surrender it if challenged.
 
 - Register `gemini-notebook-py` and `gemini-notebook` on PyPI. Placeholders
   (`0.1.0`) **depend on `notebooklm-py`** so an early `pip install` works
-  rather than dead-ends; yank them once the real release ships. `publish.yml`'s
+  rather than dead-ends; yank them once 0.9.0 ships. `publish.yml`'s
   tag/version validation rejects out-of-band versions, so this is a one-off
   manual/TestPyPI-style upload using PyPI *pending publishers* registered for
   both names (plus keeping `notebooklm-py`'s publisher) — all against the
@@ -97,53 +99,27 @@ frowns on) and we accept we may have to surrender it if challenged.
 - README: replace the "keeps the name" note with the rename plan and its
   rationale; add `gemini`, `gemini-notebook` keywords (pyproject + manifest).
 
-### Phase 1a — 0.9.0, additive (fully reversible)
+### Phase 1 — 0.9.0: the rename release (single completion checklist)
 
-1. New console scripts `gemini-notebook{,-mcp,-server}` alongside the old
-   three. No startup hints — the old names are not deprecated. Every entry
-   point derives its displayed `prog` from the invoked name: the root Click
-   CLI (`notebooklm_cli.py:134` hardcodes `prog_name="NotebookLM CLI"`),
-   `mcp/__main__.py:181`, and `server/__main__.py:113` all pin the legacy
-   identity today, so the new commands would advertise the old names in
-   `--help`/`--version`.
-2. `GeminiNotebookClient = NotebookLMClient` exported from `notebooklm`
-   (static assignment: subclassing, `isinstance`, pickle, and mypy all keep
-   working; no `__getattr__` indirection).
-3. `__version__` resolution keyed to the distribution that actually supplied
-   the imported files, determined by matching `notebooklm.__file__` against
-   each candidate distribution's RECORD (`importlib.metadata.Distribution.files`).
-   `packages_distributions()` is **not** sufficient: in a dual install both
-   dists declare `notebooklm`, and the mapping says nothing about whose
-   files won the collision. A build-stamped version (extending the existing
-   `hatch_build.py` `_commit.py` bake) is an acceptable simpler alternative.
-   Name lookups (`gemini-notebook-py`, then `notebooklm-py`) remain only as
-   last-resort fallback. `src/notebooklm/__init__.py:40` is currently keyed
-   to the old dist only and would report `0.0.0.dev0` under the renamed
-   dist — and a plain name-ordered lookup is wrong too: with the Phase-0
-   placeholder plus a stale real `notebooklm-py` co-installed,
-   canonical-first would report the placeholder's version for files the old
-   dist supplied. Same fix in the skill version stamp (`_app/skill.py`).
-4. Docs/README lead with "Gemini Notebook"; old name mentioned once per page.
-5. Same-PR guardrail updates: `tests/_guardrails/test_public_surface.py`
-   (new export), CLI contract baseline regen (ADR-0022 machinery) for the new
-   scripts, `test_version_pyproject_sync.py`.
-
-Stopping forever after 1a is a fine outcome: nothing has flipped.
-
-### Phase 1b — 0.10.0, the identity flip (gated; see Guardrails for go/no-go)
-
-Ordered steps; the repo rename is its own verified step, **not** bundled with
-the first dual publish:
+One release completes the rename. Steps are ordered; the abort point is
+before step 1 (the repo rename) — from there everything ships together.
+The 0.9.0 acceptance matrix in Guardrails is the executable definition of
+done.
 
 1. **Repo rename first, quiet window**: rename to
    `teng-lin/gemini-notebook-py`; immediately re-point the Trusted-Publishing
    configs for all three dists at the new repo; verify with a TestPyPI publish
-   before any real release. Same-PR sweep of hardcoded repo strings:
-   `project.urls`, fancy-pypi-readme substitutions, badges, and every
-   `github.repository ==` guard (`publish-docker.yml`, `publish-mcpb.yml`,
-   `verify-package.yml:150,158` — string compares don't get redirects),
-   OCI source label, TestPyPI summary URL,
-   `tests/_guardrails/test_pypi_readme_substitutions.py`.
+   before the release. Same-PR sweep of hardcoded repo strings:
+   `project.urls`, fancy-pypi-readme substitutions, badges, the OCI source
+   label, the TestPyPI summary URL, and **every** `github.repository ==`
+   guard — `publish-docker.yml`, `publish-mcpb.yml`,
+   `verify-package.yml:150,158`, `nightly.yml`, `rpc-health.yml`, and
+   `verify-artifacts.yml` (string compares don't get redirects; after a
+   rename those jobs silently skip). A new repo-wide guardrail test fails CI
+   on any stale `github.repository` / `teng-lin/notebooklm-py` literal
+   outside historical records (CHANGELOG, ADRs), so no future guard can go
+   stale silently. `tests/_guardrails/test_pypi_readme_substitutions.py`
+   updates in the same PR.
 2. **Dist rename**: `project.name = "gemini-notebook-py"`; update the
    self-referential `all` extra and re-lock `uv.lock`. Hatch config is
    untouched (the import package doesn't move — ever).
@@ -152,69 +128,105 @@ the first dual publish:
    from one tag (versions asserted in lockstep), smoke-installs the shim with
    `--find-links dist/` (its pin isn't on PyPI yet), and uploads **canonical
    first**, shims after. Wheel globs/artifact names flip to
-   `gemini_notebook_py-*` here (dist-keyed, not import-keyed — `publish.yml:81`,
-   `testpypi-publish.yml`, artifact names).
-4. **Shim spec**: `notebooklm-py` shim ships zero Python files, zero console
-   scripts, and **mirrors every extra** (`[mcp]`, `[browser]`, … →
-   `gemini-notebook-py[<extra>]==<version>`) — the shipped desktop extension
-   hardcodes `notebooklm-py[mcp]` and must keep resolving. Pin `==`, released
-   in lockstep with every canonical release (automated by step 3), for as
-   long as dual publishing runs.
-5. **Dual-install hazard**: `gemini-notebook-py` still ships the `notebooklm`
-   package, so it collides file-for-file with a stale `notebooklm-py` ≤0.8
-   install. Mitigation — partial by construction: an import-time check
-   (`PackageNotFoundError`-guarded `importlib.metadata` lookup, PEP 440
-   comparison via `packaging.version`, never a string compare) that warns
-   loudly when any **pre-shim** `notebooklm-py` release is present alongside
-   `gemini-notebook-py` — every version below the first shim release
-   (0.10.0), which includes the Phase 1a 0.9.x releases, since those ship
-   real files too. `packaging` moves from the `dev` extra to the base
-   dependencies in the same PR (today it is dev-only, so the detector would
-   itself `ImportError` in exactly the environment it repairs). The warning
-   names the fix:
+   `gemini_notebook_py-*` here (dist-keyed — `publish.yml:81`,
+   `testpypi-publish.yml`, artifact names). `notebooklm-py` 0.9.0 is the
+   **first shim release**; no real (file-shipping) release ever carries a
+   version ≥ 0.9.0.
+4. **Shim spec and isolated-tool installs**: the `notebooklm-py` shim ships
+   zero Python files, zero console scripts, and **mirrors every extra**
+   (`[mcp]`, `[browser]`, … → `gemini-notebook-py[<extra>]==<version>`) —
+   the shipped desktop extension hardcodes `notebooklm-py[mcp]` and must
+   keep resolving. Pin `==`, released in lockstep with every canonical
+   release (automated by step 3). Zero scripts has a consequence for
+   isolated tool installers: `pipx install` and `uv tool install` expose
+   only the *requested* dist's entry points, so installing the shim that way
+   yields no commands. The contract, verified by CI flow tests: (a)
+   `uvx --from "notebooklm-py[mcp]" notebooklm-mcp` — the path baked into
+   shipped desktop extensions — keeps working, because `uvx` resolves
+   executables from the full environment; (b) `pipx install notebooklm-py`
+   requires `--include-deps` and the docs/tombstone README say so; (c) tool
+   installs are steered to `gemini-notebook-py` as the recommended form.
+   Shipping duplicate legacy scripts from the shim instead was rejected: two
+   dists owning the same `bin/` files recreates the uninstall-corruption
+   hazard of constraint 3 inside every dual-install venv.
+5. **New console scripts** `gemini-notebook{,-mcp,-server}` alongside the
+   old three (in the canonical dist). No startup hints — the old names are
+   not deprecated. Every entry point derives its displayed `prog` from the
+   invoked name: the root Click CLI (`notebooklm_cli.py:134` hardcodes
+   `prog_name="NotebookLM CLI"`), `mcp/__main__.py:181`, and
+   `server/__main__.py:113` all pin the legacy identity today, so the new
+   commands would advertise the old names in `--help`/`--version`.
+6. **Client alias**: `GeminiNotebookClient = NotebookLMClient` exported from
+   `notebooklm` (static assignment: subclassing, `isinstance`, pickle, and
+   mypy all keep working; no `__getattr__` indirection).
+7. **`__version__` provenance**: resolution keyed to the distribution that
+   actually supplied the imported files, by matching `notebooklm.__file__`
+   against each candidate distribution's RECORD
+   (`importlib.metadata.Distribution.files`). `packages_distributions()` is
+   **not** sufficient: in a dual install both dists declare `notebooklm`
+   without indicating whose files won. A build-stamped version (extending
+   the existing `hatch_build.py` `_commit.py` bake) is an acceptable simpler
+   alternative. Name lookups (`gemini-notebook-py`, then `notebooklm-py`)
+   remain only as last-resort fallback. `src/notebooklm/__init__.py:40` is
+   currently keyed to the old dist only and would report `0.0.0.dev0` under
+   the renamed dist. Same fix in the skill version stamp (`_app/skill.py`).
+8. **Dual-install hazard**: `gemini-notebook-py` ships the `notebooklm`
+   package, so it collides file-for-file with any pre-shim `notebooklm-py`
+   install. Detection uses an **explicit real-files marker**, not a version
+   threshold: warn when a co-installed `notebooklm-py` dist's RECORD lists
+   `notebooklm/` files (true for every pre-shim release — all < 0.9.0 under
+   this plan — and stays correct even if the boundary ever moves; a
+   `packaging.version` compare is the fallback when RECORD is unavailable,
+   with `PackageNotFoundError` guarded and `packaging` moved from the `dev`
+   extra to base dependencies in the same PR). The warning names the fix:
    `pip uninstall notebooklm-py && pip install --force-reinstall gemini-notebook-py` —
    `--force-reinstall` is required, not `-U`: uninstalling the stale dist
    deletes the shared `notebooklm` files listed in its RECORD, and a plain
    upgrade would consider the already-current canonical install satisfied
-   and never restore them.
-   The check only runs when the canonical files win the collision; a
-   stale-*last* install overwrites `__init__.py` and is undetectable at
-   runtime — that order is covered by docs/release notes only, and the ADR
-   claims no complete runtime mitigation. Test matrix: canonical-only,
-   stale-first, stale-last. Expect dependency-confusion-style scanner flags
-   when a long-lived dist turns shim; pre-empt in the release notes.
-6. **`verify-package.yml`**: replace the `--no-deps` old-name install steps
+   and never restore them. Mitigation is partial by construction: the check
+   only runs when the canonical files win the collision; a stale-*last*
+   install overwrites `__init__.py` and is undetectable at runtime — covered
+   by docs/release notes only. Test matrix covers **install and uninstall
+   orders**: canonical-only, stale-first, stale-last, uninstall-stale-after-
+   dual, uninstall-shim-after-dual. Expect dependency-confusion-style
+   scanner flags when a long-lived dist turns shim; pre-empt in the release
+   notes.
+9. **`verify-package.yml`**: replace the `--no-deps` old-name install steps
    (which break against an empty shim) with the dual-install smoke: shim +
    canonical in one venv, `import notebooklm` verified after installing each
    dist name (there is no second import path — the import package is
-   permanent), all **six** scripts.
-7. **`mcp install`**: `_app/mcp_install.py` writes
-   `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp` under the
-   **unchanged** server key `"notebooklm"` (no duplicate entries on
-   re-install, no orphaning); `desktop-extension/run_server.py` likewise.
-   Previously written configs keep working via the shim indefinitely.
-8. **`deploy/`**: compose/env.example/Makefile/tailscale move to the new
-   image name; all `NOTEBOOKLM_*` vars stay (permanent), so existing `.env`
-   files keep working. Docker pushed to both repositories;
-   `test_unit/test_deploy_compose_default.py` updated same PR.
-9. Same-PR guardrail updates: `test_install_docs.py` + SKILL.md/AGENTS.md
-   install commands (wheel-embedded agent instructions must not keep teaching
-   `pip install notebooklm-py`), the skill recovery hint in
-   `cli/skill_cmd.py` (`pip install --force-reinstall notebooklm-py` → new
-   dist), `test_skill_packaging.py`, `test_mcp_desktop_extension.py`,
-   mcp-install tests, CLI baselines.
+   permanent), all **six** scripts, plus the pipx/uv-tool/uvx flow tests
+   from step 4.
+10. **`mcp install`**: `_app/mcp_install.py` writes
+    `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp` under the
+    **unchanged** server key `"notebooklm"` (no duplicate entries on
+    re-install, no orphaning); `desktop-extension/run_server.py` likewise.
+    Previously written configs keep working via the shim indefinitely.
+11. **`deploy/`**: compose/env.example/Makefile/tailscale move to the new
+    image name; all `NOTEBOOKLM_*` vars stay (permanent), so existing `.env`
+    files keep working. Docker pushed to both repositories;
+    `tests/unit/test_deploy_compose_default.py` updated same PR.
+12. **Docs and guardrails**: README and primary docs lead with
+    "Gemini Notebook" (old name mentioned once per page);
+    `test_install_docs.py` + SKILL.md/AGENTS.md install commands
+    (wheel-embedded agent instructions must not keep teaching
+    `pip install notebooklm-py`), the skill recovery hint in
+    `cli/skill_cmd.py` (`pip install --force-reinstall notebooklm-py` → new
+    dist), `test_skill_packaging.py`, `test_mcp_desktop_extension.py`,
+    mcp-install tests, `tests/_guardrails/test_public_surface.py` (new
+    export), and CLI contract baseline regen (ADR-0022 machinery) for the
+    new scripts — all in the release PRs, not deferred.
 
-### Phase 2 — bake and docs sweep
+### Phase 2 — post-0.9.0 bake (optional)
 
-Dual publishing runs; docs (~1 900 refs), `examples/` prose, issue/PR
-templates, `SECURITY.md`, `CLAUDE.md`/`CONTRIBUTING.md` rewritten to lead with
-the new name. Watch signals: download split, shim bug reports, brand
-stability. `import notebooklm` examples are **correct forever** — no code
-sample churn.
+The long-tail docs sweep (~1 900 refs), `examples/` prose, issue/PR
+templates, `SECURITY.md`, `CLAUDE.md`/`CONTRIBUTING.md`. Watch signals:
+download split, shim bug reports, brand stability. `import notebooklm`
+examples are **correct forever** — no code sample churn.
 
-### Phase 3 — wind-down (no removal cliff)
+### Phase 3 — wind-down (gated; no removal cliff)
 
-When go/no-go criteria say so (Guardrails), dual asset publishing (Docker,
+When the wind-down gate says so (Guardrails), dual asset publishing (Docker,
 skill zip) ends. `notebooklm-py` gets a final shim pinned
 `gemini-notebook-py>=<current major>,<next major>` with a tombstone README —
 and because the import package never goes away, that terminal shim keeps
@@ -231,28 +243,40 @@ range must preserve all legacy extra names and console scripts — the
 shim-equivalence test below enforces this for as long as any published
 shim's range is open, so a future release cannot drop `[mcp]` out from
 under `notebooklm-py[mcp]` installs.
-There is no Phase-4 hard removal: old console scripts, env vars, and config
-home are permanent by decision, so no user ever hits a cliff.
 
 ### Guardrails
 
-- **Gate for 1b (go/no-go, recorded here so it isn't vibes later):** 0.8.0
-  final shipped; brand stable ≥3 months post-announcement (≥2026-10-16);
-  Trusted Publishing verified for all three dists via TestPyPI; the 1a
-  release out with no shim-related regressions.
-- **Gate for Phase 3:** ≥75 % of combined downloads on the new dist for 2
-  consecutive months, or 12 months after 1b, whichever first.
+- **0.9.0 acceptance matrix — the executable definition of done.** 0.9.0
+  does not ship until every row passes:
+  - *Publishing*: OIDC publishers verified for all three dists against the
+    renamed repo via a TestPyPI rehearsal; canonical + both shims built from
+    one tag with lockstep versions; upload order canonical-first exercised.
+  - *Install*: `pip install gemini-notebook-py` and
+    `pip install "notebooklm-py[mcp]"` both yield a working
+    `import notebooklm`; extras parity between shim and canonical; dual
+    install in one venv clean.
+  - *CLI*: all six console scripts run; each reports the invoked name in
+    `--help`/`--version`.
+  - *Version*: `notebooklm.__version__` correct under canonical-only and
+    under dual-install with mismatched versions (RECORD-provenance test).
+  - *Collision*: stale-install warning fires in the stale-first order,
+    remediation command verified to restore a working environment, and the
+    documented-only status of stale-last confirmed by test.
+  - *Tool installers*: `uvx --from "notebooklm-py[mcp]" notebooklm-mcp`
+    works; `pipx install --include-deps notebooklm-py` exposes the legacy
+    scripts; plain-shim pipx behavior documented.
+  - *Integrations*: `mcp install` writes the new uvx spec under the old
+    server key; desktop-extension launcher updated; `deploy/` compose/env
+    render with the new image and old env vars.
+  - *Guardrails/baselines*: public-surface, install-docs, CLI-contract,
+    deploy-compose, pypi-readme-substitution baselines regenerated; the new
+    repo-wide stale-`github.repository` literal guard green.
+- **Wind-down gate (Phase 3)**: ≥75 % of combined downloads on the new dist
+  for 2 consecutive months, or 12 months after 0.9.0, whichever first.
 - **Shim equivalence test** (in canonical repo CI): during dual publishing,
   shim metadata mirrors every canonical extra and pins the exact canonical
   version; after wind-down, every canonical release inside any published
   shim's open range must retain all legacy extra names and console scripts.
-- **Version-resolution test**: `notebooklm.__version__` correct when only
-  `gemini-notebook-py` is installed (the failure mode is a silent
-  `0.0.0.dev0`), and when the imported files come from one dist while a
-  different version is installed under the other name.
-- **Dual-install smoke** in `verify-package.yml` (Phase 1b step 6).
-- **Stale-install check** (Phase 1b step 5) has a unit test for both the
-  warn and the clean path.
 
 ## Consequences
 
@@ -264,14 +288,14 @@ home are permanent by decision, so no user ever hits a cliff.
   in every config file we've ever written to a user's machine.
 - Old-name users are never broken: the shim (with extras) resolves
   indefinitely, and its terminal pin still yields a working install.
-- Dual publishing is bounded by an explicit Phase-3 gate rather than open-ended
+- Consolidating the flip into 0.9.0 (a maintainer decision, replacing v2's
+  two-release phasing) trades the brand-stability bake window for a single
+  completion point with an executable acceptance matrix. The accepted risk:
+  if Google renames again, we carry one stale-brand dist name — the same
+  position we are in today, with the same playbook, and the plumbing
+  unaffected. The abort point is before the repo rename (Phase 1 step 1).
+- Dual publishing is bounded by the wind-down gate rather than open-ended
   maintainer toil; shim releases are automated in `publish.yml`, not manual.
-- The safe-stop points are explicit: after 1a nothing has flipped; the point
-  of no return is 1b step 1 (repo rename), which is why it is separately
-  gated and verified before the first dual publish.
-- If Google renames again after 1b, we are carrying one stale-brand dist name
-  — the same position we are in today, with the same playbook, and the
-  plumbing unaffected.
 - Risks accepted: a PEP 541 / trademark challenge on the `gemini-*` names
   (fallback: keep `notebooklm-py` canonical — everything still works);
   scanner noise when the old dist turns shim; `pynotebooklm` adjacency
@@ -292,7 +316,15 @@ home are permanent by decision, so no user ever hits a cliff.
   Click `envvar=` bypass no grep gate can see; and the 2.0 removal cliff
   strands every config `mcp install` ever wrote. Each had a known fix; the sum
   was a large, risky program buying nothing the dist rename doesn't.
-- **`GEMINI_NOTEBOOK_*` env-var twins** (subset of the above). Deferred
+- **Two-release phasing** (v2 of this ADR: additive-only 0.9, identity flip
+  at 0.10 behind a ≥3-month brand-stability gate). Rejected by maintainer
+  review: it left 0.9.0 with no executable definition of done, and shipping
+  a real (file-carrying) `notebooklm-py` 0.9.x before the first shim widened
+  the dual-install collision window to include users who followed the
+  planned rollout. The consolidated 0.9.0 accepts brand risk for a single
+  completion point; the technical verification steps (TestPyPI/OIDC
+  rehearsal before release) are retained.
+- **`GEMINI_NOTEBOOK_*` env-var twins** (subset of v1). Deferred
   indefinitely; any future attempt must solve, from v1's review: non-warning
   resolve path for the quiet gate and diagnostics, write-side dual-export plus
   twinned credential scrub, a custom `click.Option` for `envvar=`, an
@@ -304,8 +336,10 @@ home are permanent by decision, so no user ever hits a cliff.
   MCP config, and CI pipeline at once; contradicts ADR-0018.
 - **Never rename; keywords only.** Cheapest, and the old page's search rank is
   real — but it cedes the project's identity as "NotebookLM" disappears from
-  Google's own UI. Phase 0+1a alone approximate this alternative's cost while
-  leaving the flip optional, which is partly why 1b is gated rather than
-  scheduled.
+  Google's own UI.
+- **Shim ships duplicate legacy console scripts** (for pipx/uv-tool
+  ergonomics). Rejected in Phase 1 step 4: duplicate `bin/` ownership
+  recreates the uninstall-corruption hazard inside every dual-install venv;
+  documented `--include-deps` / canonical-dist guidance is the safer trade.
 - **`gnb` short CLI alias.** Dropped: PATH collision (srsRAN's `gnb`) and a
   brand-coupled acronym — exactly the churn constraint 1 warns about.

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -149,6 +149,12 @@ done.
    Shipping duplicate legacy scripts from the shim instead was rejected: two
    dists owning the same `bin/` files recreates the uninstall-corruption
    hazard of constraint 3 inside every dual-install venv.
+   The **`gemini-notebook` metapackage gets the identical shim contract**:
+   zero Python files, zero console scripts, every extra mirrored as
+   `gemini-notebook-py[<extra>]==<version>`, released in the same lockstep —
+   so `pip install "gemini-notebook[mcp]"` yields the same environment and a
+   working `import notebooklm`. It is a first-class row in the acceptance
+   matrix and the CI flow tests, not just an anti-squat placeholder.
 5. **New console scripts** `gemini-notebook{,-mcp,-server}` alongside the
    old three (in the canonical dist). No startup hints — the old names are
    not deprecated. Every entry point derives its displayed `prog` from the
@@ -160,16 +166,19 @@ done.
    `notebooklm` (static assignment: subclassing, `isinstance`, pickle, and
    mypy all keep working; no `__getattr__` indirection).
 7. **`__version__` provenance**: resolution keyed to the distribution that
-   actually supplied the imported files, by matching `notebooklm.__file__`
-   against each candidate distribution's RECORD
-   (`importlib.metadata.Distribution.files`). `packages_distributions()` is
-   **not** sufficient: in a dual install both dists declare `notebooklm`
-   without indicating whose files won. A build-stamped version (extending
-   the existing `hatch_build.py` `_commit.py` bake) is an acceptable simpler
-   alternative. Name lookups (`gemini-notebook-py`, then `notebooklm-py`)
-   remain only as last-resort fallback. `src/notebooklm/__init__.py:40` is
-   currently keyed to the old dist only and would report `0.0.0.dev0` under
-   the renamed dist. Same fix in the skill version stamp (`_app/skill.py`).
+   actually supplied the imported files — and ownership must be established
+   by **content, not path membership**: in a dual install *both* dists'
+   RECORDs list `notebooklm/__init__.py`, so `Distribution.files` path
+   matching (and `packages_distributions()`) can return two candidates. The
+   rule: hash the imported file's bytes and compare against each candidate
+   RECORD's recorded hash, accepting only a **unique** match; when the match
+   is ambiguous (identical hashes or missing RECORD hashes), fall back to
+   **build-stamped** provenance (extending the existing `hatch_build.py`
+   `_commit.py` bake to stamp the version), and never resolve ambiguity by
+   dist-name ordering — that is exactly the wrong-version failure mode.
+   `src/notebooklm/__init__.py:40` is currently keyed to the old dist only
+   and would report `0.0.0.dev0` under the renamed dist. Same fix in the
+   skill version stamp (`_app/skill.py`).
 8. **Dual-install hazard**: `gemini-notebook-py` ships the `notebooklm`
    package, so it collides file-for-file with any pre-shim `notebooklm-py`
    install. Detection uses an **explicit real-files marker**, not a version
@@ -251,14 +260,17 @@ under `notebooklm-py[mcp]` installs.
   - *Publishing*: OIDC publishers verified for all three dists against the
     renamed repo via a TestPyPI rehearsal; canonical + both shims built from
     one tag with lockstep versions; upload order canonical-first exercised.
-  - *Install*: `pip install gemini-notebook-py` and
-    `pip install "notebooklm-py[mcp]"` both yield a working
-    `import notebooklm`; extras parity between shim and canonical; dual
-    install in one venv clean.
+  - *Install*: `pip install gemini-notebook-py`,
+    `pip install "notebooklm-py[mcp]"`, and
+    `pip install "gemini-notebook[mcp]"` (the metapackage shim) all yield a
+    working `import notebooklm`; extras parity across both shims and the
+    canonical dist; dual install in one venv clean.
   - *CLI*: all six console scripts run; each reports the invoked name in
     `--help`/`--version`.
   - *Version*: `notebooklm.__version__` correct under canonical-only and
-    under dual-install with mismatched versions (RECORD-provenance test).
+    under dual-install with mismatched versions, tested in **both install
+    orders and with differing file contents** (hash-provenance unique-match
+    path and the ambiguous → build-stamp fallback both exercised).
   - *Collision*: stale-install warning fires in the stale-first order,
     remediation command verified to restore a working environment, and the
     documented-only status of stale-last confirmed by test.

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -100,23 +100,29 @@ frowns on) and we accept we may have to surrender it if challenged.
 ### Phase 1a — 0.9.0, additive (fully reversible)
 
 1. New console scripts `gemini-notebook{,-mcp,-server}` alongside the old
-   three. No startup hints — the old names are not deprecated. The `__main__`
-   entry points derive their displayed `prog` from the invoked name
-   (`mcp/__main__.py:181` and `server/__main__.py:113` currently hardcode the
-   legacy names, so the new commands would advertise the old ones in
-   `--help`).
+   three. No startup hints — the old names are not deprecated. Every entry
+   point derives its displayed `prog` from the invoked name: the root Click
+   CLI (`notebooklm_cli.py:134` hardcodes `prog_name="NotebookLM CLI"`),
+   `mcp/__main__.py:181`, and `server/__main__.py:113` all pin the legacy
+   identity today, so the new commands would advertise the old names in
+   `--help`/`--version`.
 2. `GeminiNotebookClient = NotebookLMClient` exported from `notebooklm`
    (static assignment: subclassing, `isinstance`, pickle, and mypy all keep
    working; no `__getattr__` indirection).
 3. `__version__` resolution keyed to the distribution that actually supplied
-   the imported files (`importlib.metadata.packages_distributions()`), with
-   name lookups (`gemini-notebook-py`, then `notebooklm-py`) only as
-   fallback. `src/notebooklm/__init__.py:40` is currently keyed to the old
-   dist only and would report `0.0.0.dev0` under the renamed dist — but a
-   plain name-ordered lookup is wrong too: with the Phase-0 placeholder plus
-   a stale real `notebooklm-py` co-installed, canonical-first would report
-   the placeholder's version for files the old dist supplied. Same fix in
-   the skill version stamp (`_app/skill.py`).
+   the imported files, determined by matching `notebooklm.__file__` against
+   each candidate distribution's RECORD (`importlib.metadata.Distribution.files`).
+   `packages_distributions()` is **not** sufficient: in a dual install both
+   dists declare `notebooklm`, and the mapping says nothing about whose
+   files won the collision. A build-stamped version (extending the existing
+   `hatch_build.py` `_commit.py` bake) is an acceptable simpler alternative.
+   Name lookups (`gemini-notebook-py`, then `notebooklm-py`) remain only as
+   last-resort fallback. `src/notebooklm/__init__.py:40` is currently keyed
+   to the old dist only and would report `0.0.0.dev0` under the renamed
+   dist — and a plain name-ordered lookup is wrong too: with the Phase-0
+   placeholder plus a stale real `notebooklm-py` co-installed,
+   canonical-first would report the placeholder's version for files the old
+   dist supplied. Same fix in the skill version stamp (`_app/skill.py`).
 4. Docs/README lead with "Gemini Notebook"; old name mentioned once per page.
 5. Same-PR guardrail updates: `tests/_guardrails/test_public_surface.py`
    (new export), CLI contract baseline regen (ADR-0022 machinery) for the new
@@ -159,9 +165,18 @@ the first dual publish:
    install. Mitigation — partial by construction: an import-time check
    (`PackageNotFoundError`-guarded `importlib.metadata` lookup, PEP 440
    comparison via `packaging.version`, never a string compare) that warns
-   loudly when a `notebooklm-py` dist < 0.9 is present alongside
-   `gemini-notebook-py`, naming the fix
-   (`pip uninstall notebooklm-py && pip install -U gemini-notebook-py`).
+   loudly when any **pre-shim** `notebooklm-py` release is present alongside
+   `gemini-notebook-py` — every version below the first shim release
+   (0.10.0), which includes the Phase 1a 0.9.x releases, since those ship
+   real files too. `packaging` moves from the `dev` extra to the base
+   dependencies in the same PR (today it is dev-only, so the detector would
+   itself `ImportError` in exactly the environment it repairs). The warning
+   names the fix:
+   `pip uninstall notebooklm-py && pip install --force-reinstall gemini-notebook-py` —
+   `--force-reinstall` is required, not `-U`: uninstalling the stale dist
+   deletes the shared `notebooklm` files listed in its RECORD, and a plain
+   upgrade would consider the already-current canonical install satisfied
+   and never restore them.
    The check only runs when the canonical files win the collision; a
    stale-*last* install overwrites `__init__.py` and is undetectable at
    runtime — that order is covered by docs/release notes only, and the ADR
@@ -204,12 +219,18 @@ skill zip) ends. `notebooklm-py` gets a final shim pinned
 `gemini-notebook-py>=<current major>,<next major>` with a tombstone README —
 and because the import package never goes away, that terminal shim keeps
 **working** (install + `import notebooklm`) rather than silently breaking.
-The open range (chosen over a frozen `==` so upgrades keep flowing to shim
-users) carries an obligation: every canonical release inside a
-shim-advertised range must preserve all legacy extra names and console
-scripts — the shim-equivalence test below enforces this for as long as any
-published shim's range is open, so a future release cannot drop `[mcp]` out
-from under `notebooklm-py[mcp]` installs.
+The open range is chosen over a frozen `==` because a stale exact pin would
+block an explicit `pip install -U gemini-notebook-py` in environments that
+still carry the shim — not because upgrades flow on their own: pip's default
+only-if-needed strategy never upgrades a dependency that still satisfies its
+range, and the terminal shim has no further releases, so canonical upgrades
+reach terminal-shim users only when they upgrade `gemini-notebook-py`
+directly (the tombstone README states exactly that). The range still
+carries an obligation: every canonical release inside a shim-advertised
+range must preserve all legacy extra names and console scripts — the
+shim-equivalence test below enforces this for as long as any published
+shim's range is open, so a future release cannot drop `[mcp]` out from
+under `notebooklm-py[mcp]` installs.
 There is no Phase-4 hard removal: old console scripts, env vars, and config
 home are permanent by decision, so no user ever hits a cliff.
 

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -100,14 +100,23 @@ frowns on) and we accept we may have to surrender it if challenged.
 ### Phase 1a — 0.9.0, additive (fully reversible)
 
 1. New console scripts `gemini-notebook{,-mcp,-server}` alongside the old
-   three. No startup hints — the old names are not deprecated.
+   three. No startup hints — the old names are not deprecated. The `__main__`
+   entry points derive their displayed `prog` from the invoked name
+   (`mcp/__main__.py:181` and `server/__main__.py:113` currently hardcode the
+   legacy names, so the new commands would advertise the old ones in
+   `--help`).
 2. `GeminiNotebookClient = NotebookLMClient` exported from `notebooklm`
    (static assignment: subclassing, `isinstance`, pickle, and mypy all keep
    working; no `__getattr__` indirection).
-3. `__version__` resolution tries `gemini-notebook-py` then `notebooklm-py`
-   (`src/notebooklm/__init__.py:40` is currently keyed to the old dist only
-   and would report `0.0.0.dev0` under the renamed dist). Same fix in the
-   skill version stamp (`_app/skill.py`).
+3. `__version__` resolution keyed to the distribution that actually supplied
+   the imported files (`importlib.metadata.packages_distributions()`), with
+   name lookups (`gemini-notebook-py`, then `notebooklm-py`) only as
+   fallback. `src/notebooklm/__init__.py:40` is currently keyed to the old
+   dist only and would report `0.0.0.dev0` under the renamed dist — but a
+   plain name-ordered lookup is wrong too: with the Phase-0 placeholder plus
+   a stale real `notebooklm-py` co-installed, canonical-first would report
+   the placeholder's version for files the old dist supplied. Same fix in
+   the skill version stamp (`_app/skill.py`).
 4. Docs/README lead with "Gemini Notebook"; old name mentioned once per page.
 5. Same-PR guardrail updates: `tests/_guardrails/test_public_surface.py`
    (new export), CLI contract baseline regen (ADR-0022 machinery) for the new
@@ -147,15 +156,23 @@ the first dual publish:
    long as dual publishing runs.
 5. **Dual-install hazard**: `gemini-notebook-py` still ships the `notebooklm`
    package, so it collides file-for-file with a stale `notebooklm-py` ≤0.8
-   install. Mitigation: an import-time check —
-   `importlib.metadata.version("notebooklm-py")` < 0.9 alongside
-   `gemini-notebook-py` ⇒ loud warning naming the fix
-   (`pip uninstall notebooklm-py && pip install -U gemini-notebook-py`) —
-   plus release notes. Expect dependency-confusion-style scanner flags when a
-   long-lived dist turns shim; pre-empt in the release notes.
+   install. Mitigation — partial by construction: an import-time check
+   (`PackageNotFoundError`-guarded `importlib.metadata` lookup, PEP 440
+   comparison via `packaging.version`, never a string compare) that warns
+   loudly when a `notebooklm-py` dist < 0.9 is present alongside
+   `gemini-notebook-py`, naming the fix
+   (`pip uninstall notebooklm-py && pip install -U gemini-notebook-py`).
+   The check only runs when the canonical files win the collision; a
+   stale-*last* install overwrites `__init__.py` and is undetectable at
+   runtime — that order is covered by docs/release notes only, and the ADR
+   claims no complete runtime mitigation. Test matrix: canonical-only,
+   stale-first, stale-last. Expect dependency-confusion-style scanner flags
+   when a long-lived dist turns shim; pre-empt in the release notes.
 6. **`verify-package.yml`**: replace the `--no-deps` old-name install steps
    (which break against an empty shim) with the dual-install smoke: shim +
-   canonical in one venv, both import paths, all **six** scripts.
+   canonical in one venv, `import notebooklm` verified after installing each
+   dist name (there is no second import path — the import package is
+   permanent), all **six** scripts.
 7. **`mcp install`**: `_app/mcp_install.py` writes
    `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp` under the
    **unchanged** server key `"notebooklm"` (no duplicate entries on
@@ -167,8 +184,10 @@ the first dual publish:
    `test_unit/test_deploy_compose_default.py` updated same PR.
 9. Same-PR guardrail updates: `test_install_docs.py` + SKILL.md/AGENTS.md
    install commands (wheel-embedded agent instructions must not keep teaching
-   `pip install notebooklm-py`), `test_skill_packaging.py`,
-   `test_mcp_desktop_extension.py`, mcp-install tests, CLI baselines.
+   `pip install notebooklm-py`), the skill recovery hint in
+   `cli/skill_cmd.py` (`pip install --force-reinstall notebooklm-py` → new
+   dist), `test_skill_packaging.py`, `test_mcp_desktop_extension.py`,
+   mcp-install tests, CLI baselines.
 
 ### Phase 2 — bake and docs sweep
 
@@ -185,6 +204,12 @@ skill zip) ends. `notebooklm-py` gets a final shim pinned
 `gemini-notebook-py>=<current major>,<next major>` with a tombstone README —
 and because the import package never goes away, that terminal shim keeps
 **working** (install + `import notebooklm`) rather than silently breaking.
+The open range (chosen over a frozen `==` so upgrades keep flowing to shim
+users) carries an obligation: every canonical release inside a
+shim-advertised range must preserve all legacy extra names and console
+scripts — the shim-equivalence test below enforces this for as long as any
+published shim's range is open, so a future release cannot drop `[mcp]` out
+from under `notebooklm-py[mcp]` installs.
 There is no Phase-4 hard removal: old console scripts, env vars, and config
 home are permanent by decision, so no user ever hits a cliff.
 
@@ -196,11 +221,14 @@ home are permanent by decision, so no user ever hits a cliff.
   release out with no shim-related regressions.
 - **Gate for Phase 3:** ≥75 % of combined downloads on the new dist for 2
   consecutive months, or 12 months after 1b, whichever first.
-- **Shim equivalence test** (in canonical repo CI): shim metadata mirrors
-  every canonical extra and pins the exact canonical version.
+- **Shim equivalence test** (in canonical repo CI): during dual publishing,
+  shim metadata mirrors every canonical extra and pins the exact canonical
+  version; after wind-down, every canonical release inside any published
+  shim's open range must retain all legacy extra names and console scripts.
 - **Version-resolution test**: `notebooklm.__version__` correct when only
   `gemini-notebook-py` is installed (the failure mode is a silent
-  `0.0.0.dev0`).
+  `0.0.0.dev0`), and when the imported files come from one dist while a
+  different version is installed under the other name.
 - **Dual-install smoke** in `verify-package.yml` (Phase 1b step 6).
 - **Stale-install check** (Phase 1b step 5) has a unit test for both the
   warn and the clean path.

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -1,0 +1,234 @@
+# ADR-0028: Renaming the package for Google's "Gemini Notebook" rebrand
+
+## Status
+
+Proposed (2026-08-03).
+
+## Context
+
+On 2026-07-16 Google renamed NotebookLM to **Gemini Notebook**
+([announcement](https://blog.google/innovation-and-ai/products/gemini-notebook/notebooklm-gemini-notebook/)).
+The product is unchanged for our purposes — same standalone app, same
+`batchexecute` wire protocol — but every user-facing name this project carries
+now points at a brand Google has retired. New users will search for
+"gemini notebook python", not "notebooklm python".
+
+The name is baked into far more than the PyPI listing. The public surface as
+of 0.8.0rc1:
+
+| Surface | Current name |
+|---|---|
+| PyPI distribution | `notebooklm-py` |
+| Import package | `notebooklm` (`src/notebooklm/`, ~2 000 in-tree references) |
+| Console scripts | `notebooklm`, `notebooklm-mcp`, `notebooklm-server` |
+| Environment variables | ~40 distinct `NOTEBOOKLM_*` names (`_env.py`, `paths.py`, `mcp/`, `server/`, …) |
+| Config home | `~/.notebooklm` (`NOTEBOOKLM_HOME` / `NOTEBOOKLM_PROFILE`, `paths.py`) |
+| Primary class | `NotebookLMClient` |
+| GitHub repo | `teng-lin/notebooklm-py` |
+| Desktop extension | `notebooklm-mcp.mcpb`, manifest `name: "notebooklm-mcp"` |
+| Docker image | `<namespace>/notebooklm-mcp` (`publish-docker.yml`) |
+| Skill archive | `notebooklm-skill.zip` (`publish-mcpb.yml`) |
+| CI artifacts / globs | `notebooklm-py-dist`, `dist/notebooklm_py-*.whl`, coverage/mypy/ruff config keyed on `notebooklm` |
+
+A hard cutover would strand every existing install, script, cron job, MCP
+config, and CI pipeline at once. Never renaming leaves the project invisible
+under the name users now search for. PyPI name availability was checked on
+2026-08-03: `gemini-notebook`, `gemini-notebook-py`, and
+`gemini-notebook-client` are all unregistered; PyPI has no reservation
+mechanism, so squatting is a live risk while we wait.
+
+Two standing constraints shape the plan:
+
+1. **Google renames products often.** The wire protocol still lives at
+   `notebooklm.google.com` and the internal RPC layer is keyed on obfuscated
+   method IDs, not names. Renaming the *internal* code buys nothing and risks
+   churn if the brand shifts again.
+2. **ADR-0018 already defines the deprecation machinery** —
+   `warn_deprecated(message, *, removal, stacklevel)` in `_deprecation.py`,
+   silenced by the quiet-deprecations gate. Every compatibility fallback in
+   this plan routes through it; no ad-hoc warnings.
+
+## Decision
+
+Adopt **`gemini-notebook-py`** as the new distribution name and
+**`gemini_notebook`** as the new import package, migrated in three phases so
+that no release breaks an existing user without a deprecation window, and the
+old names keep working (with warnings) until 2.0.
+
+The `-py` suffix is kept deliberately: it signals continuity with
+`notebooklm-py`, matches the existing convention, and — together with the
+"Unofficial" description — reduces the risk that a bare `gemini-*` name reads
+as an official Google package and draws a PyPI trademark complaint. We also
+register the bare `gemini-notebook` name as a redirect metapackage so it
+cannot be squatted.
+
+Name mapping (old → new):
+
+| Old | New | Old kept until |
+|---|---|---|
+| `notebooklm-py` (PyPI) | `gemini-notebook-py` | 2.0 (shim releases stop) |
+| `import notebooklm` | `import gemini_notebook` | 2.0 |
+| `notebooklm` CLI | `gemini-notebook` CLI (short alias `gnb`) | 2.0 |
+| `notebooklm-mcp` / `notebooklm-server` | `gemini-notebook-mcp` / `gemini-notebook-server` | 2.0 |
+| `NOTEBOOKLM_<X>` env vars | `GEMINI_NOTEBOOK_<X>` (1:1) | 2.0 |
+| `~/.notebooklm` | `~/.gemini-notebook` | indefinite read fallback |
+| `NotebookLMClient` | `GeminiNotebookClient` | 2.0 (alias) |
+| repo `teng-lin/notebooklm-py` | `teng-lin/gemini-notebook-py` | GitHub auto-redirects |
+
+What is explicitly **not** renamed: the `rpc/` layer's wire-level naming, the
+default base URL (`notebooklm.google.com` — Google's endpoint, not our brand),
+VCR cassette contents, and historical CHANGELOG/ADR text. Internal private
+modules are renamed only when the `src/` tree physically moves (Phase 3), as
+a mechanical consequence, not a goal.
+
+## The phases
+
+### Phase 0 — immediately, independent of any release
+
+- **Register the PyPI names.** Upload minimal placeholder sdists (version
+  `0.0.1`, README pointing at this repo) for `gemini-notebook-py` and
+  `gemini-notebook`. This is the only way PyPI lets you hold a name. Configure
+  Trusted Publishing for `gemini-notebook-py` mirroring the existing
+  `publish.yml` setup.
+- Add a "NotebookLM is now Gemini Notebook" note to `README.md` and
+  `docs/index`-level docs; add `gemini`, `gemini-notebook` to `keywords` in
+  `pyproject.toml` and `desktop-extension/manifest.json`. No behavior changes.
+
+### Phase 1 — 0.9.0, the compatibility release (additive only)
+
+Everything new is added; nothing old changes behavior. A user who upgrades
+and touches nothing sees at most a startup hint.
+
+1. **Env vars.** Introduce a single resolver (extend `_env.py`) used by every
+   env read: `GEMINI_NOTEBOOK_<X>` wins; `NOTEBOOKLM_<X>` still honored, with
+   a once-per-process `warn_deprecated(..., removal="2.0")` when only the old
+   name is set. All ~40 variables go through the resolver — no per-call-site
+   fallback logic (grep gate in CI, see Guardrails).
+2. **Console scripts.** Add `gemini-notebook`, `gnb`, `gemini-notebook-mcp`,
+   `gemini-notebook-server` entry points targeting the same mains. The old
+   three stay, and print a one-line deprecation hint on startup (stderr,
+   suppressed by the quiet gate).
+3. **Import alias.** Add a `gemini_notebook` package that re-exports
+   `notebooklm`'s public surface (`from notebooklm import *` plus explicit
+   `__all__`, `__version__`, submodule aliasing via `sys.modules` so
+   `gemini_notebook.types` etc. resolve). `notebooklm` remains the real code —
+   zero churn to the 2 000 internal references in this phase.
+4. **Class alias.** `GeminiNotebookClient = NotebookLMClient` exported from
+   both packages. No warning yet in either direction.
+5. **Config home.** `paths.py` precedence becomes:
+   `GEMINI_NOTEBOOK_HOME` > `NOTEBOOKLM_HOME` (deprecated) >
+   `~/.gemini-notebook` if it exists > `~/.notebooklm` if it exists >
+   `~/.gemini-notebook` (fresh default). No silent data copy — profile dirs
+   hold live auth state under `filelock`; a `notebooklm doctor` /
+   `gemini-notebook doctor` check offers an explicit one-shot migration
+   (rename the directory, leave a `~/.notebooklm` symlink for old scripts).
+6. **Dual publish begins.** `gemini-notebook-py 0.9.0` is the canonical dist
+   (full code). `notebooklm-py 0.9.0` becomes a **shim**: an empty
+   distribution whose only install requirement is
+   `gemini-notebook-py==0.9.0`, with a README explaining the rename. Shims
+   contain no Python files, so installing both never clobbers site-packages.
+   The bare `gemini-notebook` metapackage likewise depends on
+   `gemini-notebook-py`.
+7. **Repo rename.** Rename `teng-lin/notebooklm-py` →
+   `teng-lin/gemini-notebook-py` at 0.9.0 release time. GitHub redirects all
+   old URLs, remotes, and clones. Same-PR sweep: `project.urls`,
+   `hatch-fancy-pypi-readme` substitution URLs in `pyproject.toml`, badge
+   URLs, `publish-docker.yml`/`publish-mcpb.yml` `github.repository` guards,
+   `desktop-extension/manifest.json` links.
+8. **MCP / desktop extension.** Update `display_name` to
+   "Gemini Notebook (gemini-notebook-py)" and descriptions. Keep the manifest
+   `name: "notebooklm-mcp"` **unchanged** for now — the name is the extension's
+   identity in Claude Desktop, and changing it makes installed users' copies
+   orphaned rather than upgraded. Ship the identity change at 2.0 only,
+   release-noted. The launcher `run_server.py` switches to
+   `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp`.
+9. **Docker / release assets.** Push images to both `notebooklm-mcp` and
+   `gemini-notebook-mcp` repositories (second `DOCKERHUB_IMAGE`-style
+   variable); release both `notebooklm-skill.zip` and
+   `gemini-notebook-skill.zip` names.
+
+### Phase 2 — 0.9.x bake period
+
+At least one minor-release cycle (target: ~2 months) with both names live.
+Watch: PyPI download split between the two dists, bug reports against the
+alias package, and whether Google's brand holds. Docs are rewritten to lead
+with the new names during this window (mechanical `docs/` sweep, ~1 900
+references, old names mentioned once per page as "(formerly NotebookLM)").
+
+### Phase 3 — 1.0.0, the physical flip
+
+1. **Move the tree**: `git mv src/notebooklm src/gemini_notebook`, mechanical
+   rename of internal imports (the ~2 000 references). One dedicated PR, no
+   functional changes mixed in, so `git blame` damage is a single commit that
+   can be listed in `.git-blame-ignore-revs`.
+2. **Invert the shim**: `notebooklm` becomes the thin re-export package
+   (mirror of the Phase-1 `gemini_notebook` alias, now warning via
+   `warn_deprecated(..., removal="2.0")` on first import).
+3. **Rename-sensitive config** follows in the same PR: `tool.hatch.build`
+   `packages`/`force-include`, `tool.coverage.run` source,
+   `per_file_coverage_floors` keys, `tool.mypy` files + per-module overrides,
+   `ruff` `known-first-party`, `publish.yml` wheel glob
+   (`gemini_notebook_py-*.whl`) and artifact names, `verify-package` /
+   public-surface gates, `tests/` imports.
+4. `NotebookLMClient` remains exported as a deprecated alias of
+   `GeminiNotebookClient` (real subclass-free assignment, warning on
+   attribute-free construction is *not* attempted — the alias warns via
+   module `__getattr__` on first access).
+
+### Phase 4 — 2.0.0, removal
+
+Old console scripts, `NOTEBOOKLM_*` env fallbacks (except a hard error message
+naming the replacement), the `notebooklm` import shim, the `NotebookLMClient`
+alias, and `notebooklm-py` shim releases all end. `~/.notebooklm` read
+fallback stays (cheap, harmless). Final `notebooklm-py` upload is a shim
+pinned `gemini-notebook-py>=2,<3` with a tombstone README.
+
+## Guardrails
+
+- **One resolver rule** (mirrors ADR-0018's "one module, one switch"): CI
+  greps that no code outside `_env.py` reads `NOTEBOOKLM_` from `os.environ`
+  directly, so the fallback+warning behavior cannot fork.
+- **Shim equivalence test**: a unit test asserts
+  `dir(gemini_notebook)`-public == `dir(notebooklm)`-public and that
+  `gemini_notebook.__version__ is notebooklm.__version__`, so the alias can
+  never drift from the real package.
+- **Dual-install smoke** in `verify-package.yml`: install `notebooklm-py`
+  (shim) and `gemini-notebook-py` into one venv; both imports and all six
+  console scripts must work.
+- **Quiet gate parity**: the quiet-deprecations env var itself gains a
+  `GEMINI_NOTEBOOK_QUIET_DEPRECATIONS` twin via the same resolver — otherwise
+  silencing rename warnings would require the deprecated prefix.
+
+## Consequences
+
+- Existing users are never broken before 2.0; every old entry point keeps
+  working with a discoverable pointer to its replacement.
+- We carry dual publishing and alias surfaces for roughly two release phases —
+  accepted cost; the shim dists are near-empty and the alias package is ~50
+  lines.
+- The old PyPI page, GitHub stars/issues/links, and search ranking are
+  preserved (shim README + GitHub redirect) instead of reset.
+- If Google renames again before Phase 3, we stop at Phase 1/2: the additive
+  aliases are cheap to keep or retarget, and the expensive physical flip has
+  not happened. This is the main reason the flip is deferred to 1.0 rather
+  than done in 0.9.
+- Risk: a user with scripts on another machine sets only `NOTEBOOKLM_HOME`
+  pointing at shared state; the precedence order above keeps that working
+  indefinitely until 2.0, and `doctor` reports which home/profile source won
+  (extends the existing `home_source` diagnostic in `paths.py`).
+
+## Alternatives considered
+
+- **Bare `gemini-notebook` as the canonical dist name.** Cleaner, but loses
+  the visual continuity with `notebooklm-py` and looks more official-Google
+  than an unofficial client should. Registered as a redirect instead.
+- **Hard cutover at 0.9** (rename everything at once, publish only the new
+  name). Smallest total diff, but breaks every installed user, MCP config,
+  and CI pipeline simultaneously, and contradicts ADR-0018's windowed
+  deprecation policy.
+- **Never rename; add keywords only.** Preserves all names but cedes the
+  searchable identity of the project and confuses new users indefinitely as
+  "NotebookLM" disappears from Google's own UI.
+- **Physical flip in 0.9.** Rejected for the reason in Consequences: it
+  front-loads the most expensive, least reversible step while the new brand
+  is weeks old.

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -2,233 +2,261 @@
 
 ## Status
 
-Proposed (2026-08-03).
+Proposed — v2, revised after a four-lens review (packaging, compatibility,
+surface coverage, strategy) of the 2026-08-03 original. The original decided a
+full rename including the import package; v2 reverses that (see Alternatives).
 
 ## Context
 
 On 2026-07-16 Google renamed NotebookLM to **Gemini Notebook**
 ([announcement](https://blog.google/innovation-and-ai/products/gemini-notebook/notebooklm-gemini-notebook/)).
-The product is unchanged for our purposes — same standalone app, same
-`batchexecute` wire protocol — but every user-facing name this project carries
-now points at a brand Google has retired. New users will search for
-"gemini notebook python", not "notebooklm python".
+The product is unchanged for our purposes — same app, same `batchexecute` wire
+protocol at `notebooklm.google.com` — but the project's discoverable identity
+(PyPI listing, repo name, docs) now points at a retired brand. New users will
+search for "gemini notebook python". PyPI availability checked 2026-08-03:
+`gemini-notebook`, `gemini-notebook-py`, `gemini-notebook-client` are all
+unregistered; PyPI has no reservation mechanism, so squatting is a live risk.
 
-The name is baked into far more than the PyPI listing. The public surface as
-of 0.8.0rc1:
+The name is carried on two very different kinds of surface:
 
-| Surface | Current name |
-|---|---|
-| PyPI distribution | `notebooklm-py` |
-| Import package | `notebooklm` (`src/notebooklm/`, ~2 000 in-tree references) |
-| Console scripts | `notebooklm`, `notebooklm-mcp`, `notebooklm-server` |
-| Environment variables | ~40 distinct `NOTEBOOKLM_*` names (`_env.py`, `paths.py`, `mcp/`, `server/`, …) |
-| Config home | `~/.notebooklm` (`NOTEBOOKLM_HOME` / `NOTEBOOKLM_PROFILE`, `paths.py`) |
-| Primary class | `NotebookLMClient` |
-| GitHub repo | `teng-lin/notebooklm-py` |
-| Desktop extension | `notebooklm-mcp.mcpb`, manifest `name: "notebooklm-mcp"` |
-| Docker image | `<namespace>/notebooklm-mcp` (`publish-docker.yml`) |
-| Skill archive | `notebooklm-skill.zip` (`publish-mcpb.yml`) |
-| CI artifacts / globs | `notebooklm-py-dist`, `dist/notebooklm_py-*.whl`, coverage/mypy/ruff config keyed on `notebooklm` |
+- **Discoverability surfaces**: PyPI dist name, GitHub repo, README/docs
+  branding, MCP/desktop-extension display names, Docker image, skill archive.
+  These are what searchers and new users see.
+- **Operational plumbing**: the `notebooklm` import package (~2 000 in-tree
+  references), ~40 `NOTEBOOKLM_*` env vars (including write-side protocol vars
+  such as the credential scrub in `_auth/refresh.py` and compose-interpolation
+  vars in `deploy/`), `~/.notebooklm` config home, `logging.getLogger("notebooklm")`
+  namespaces (a documented API), `NotebookLMClient`, the MCP server identity
+  `"notebooklm"` written into users' client configs by `notebooklm mcp install`,
+  installed skill directories (`.claude/skills/notebooklm/`), and a dense
+  lattice of name-pinning guardrail tests and `scripts/` tooling.
 
-A hard cutover would strand every existing install, script, cron job, MCP
-config, and CI pipeline at once. Never renaming leaves the project invisible
-under the name users now search for. PyPI name availability was checked on
-2026-08-03: `gemini-notebook`, `gemini-notebook-py`, and
-`gemini-notebook-client` are all unregistered; PyPI has no reservation
-mechanism, so squatting is a live risk while we wait.
+Constraints that shape the decision:
 
-Two standing constraints shape the plan:
-
-1. **Google renames products often.** The wire protocol still lives at
-   `notebooklm.google.com` and the internal RPC layer is keyed on obfuscated
-   method IDs, not names. Renaming the *internal* code buys nothing and risks
-   churn if the brand shifts again.
-2. **ADR-0018 already defines the deprecation machinery** —
-   `warn_deprecated(message, *, removal, stacklevel)` in `_deprecation.py`,
-   silenced by the quiet-deprecations gate. Every compatibility fallback in
-   this plan routes through it; no ad-hoc warnings.
+1. **Google renames products often**; this brand is weeks old. Anything
+   expensive or irreversible keyed to the new name is a bet on brand stability.
+2. **Renaming plumbing strands users where we have no deprecation channel**:
+   configs `mcp install` already wrote to users' machines, self-host `.env` /
+   `docker-compose.yml` files attached to past releases, users' `logging`
+   configs, pickles of `notebooklm.*` classes, installed skill copies.
+3. **pip has no conflict mechanism.** Any two dists that both ship the
+   `notebooklm` package (an old `notebooklm-py` ≤0.8 install plus a renamed
+   canonical dist) silently clobber shared files, and uninstalling either
+   corrupts the survivor.
+4. **Publishing is OIDC Trusted-Publishing only** (`publish.yml`), keyed on
+   owner/repo + workflow. GitHub's redirect after a repo rename does **not**
+   apply to OIDC claims, so a repo rename breaks every configured publisher
+   until re-registered.
+5. **README currently promises the opposite** ("The package keeps the
+   `notebooklm-py` name", July 2026 note). This ADR reverses a published
+   commitment and must retract it explicitly, not silently.
+6. This is a single-maintainer project; every permanent dual surface is
+   permanent toil. A third-party `pynotebooklm` dist already crowds the
+   namespace. ADR-0018 provides the deprecation machinery for anything we do
+   deprecate.
 
 ## Decision
 
-Adopt **`gemini-notebook-py`** as the new distribution name and
-**`gemini_notebook`** as the new import package, migrated in three phases so
-that no release breaks an existing user without a deprecation window, and the
-old names keep working (with warnings) until 2.0.
+Rename the **distribution and the discoverability surfaces** to
+**`gemini-notebook-py`**; keep the **import package `notebooklm` and all
+operational plumbing permanently**. Dist-name ≠ import-name is an established
+Python pattern (`beautifulsoup4`/`bs4`, `scikit-learn`/`sklearn`,
+`pillow`/`PIL`), and every argument this ADR's Context makes against renaming
+the wire layer applies equally to the import package: churn with no functional
+gain, brand-stability risk, and — decisive — the plumbing writes its name into
+places we cannot patch after the fact.
 
-The `-py` suffix is kept deliberately: it signals continuity with
-`notebooklm-py`, matches the existing convention, and — together with the
-"Unofficial" description — reduces the risk that a bare `gemini-*` name reads
-as an official Google package and draws a PyPI trademark complaint. We also
-register the bare `gemini-notebook` name as a redirect metapackage so it
-cannot be squatted.
+| Surface | Disposition |
+|---|---|
+| PyPI dist `notebooklm-py` | → `gemini-notebook-py` canonical; old name becomes a permanent extras-forwarding shim |
+| Bare `gemini-notebook` | registered as redirect metapackage (anti-squat) |
+| GitHub repo | → `teng-lin/gemini-notebook-py` (auto-redirects) |
+| CLI | `gemini-notebook`, `gemini-notebook-mcp`, `gemini-notebook-server` added; `notebooklm*` scripts kept **indefinitely** (they match the import name; no deprecation) |
+| Docker image / skill zip / `.mcpb` display name | new names added, old kept during wind-down |
+| `import notebooklm`, `NOTEBOOKLM_*` env vars, `~/.notebooklm`, logger namespace, MCP identities (`SERVER_KEY`/`SERVER_NAME`/manifest `name`/skill dir), `[tool.notebooklm]` table | **permanent — never renamed** |
+| `NotebookLMClient` | kept; `GeminiNotebookClient` added as a permanent (non-deprecated) alias |
 
-Name mapping (old → new):
+No `gnb` short alias: a 3-letter binary is collision-prone (srsRAN ships a
+`gnb` executable) and the acronym dies with the next rebrand.
 
-| Old | New | Old kept until |
-|---|---|---|
-| `notebooklm-py` (PyPI) | `gemini-notebook-py` | 2.0 (shim releases stop) |
-| `import notebooklm` | `import gemini_notebook` | 2.0 |
-| `notebooklm` CLI | `gemini-notebook` CLI (short alias `gnb`) | 2.0 |
-| `notebooklm-mcp` / `notebooklm-server` | `gemini-notebook-mcp` / `gemini-notebook-server` | 2.0 |
-| `NOTEBOOKLM_<X>` env vars | `GEMINI_NOTEBOOK_<X>` (1:1) | 2.0 |
-| `~/.notebooklm` | `~/.gemini-notebook` | indefinite read fallback |
-| `NotebookLMClient` | `GeminiNotebookClient` | 2.0 (alias) |
-| repo `teng-lin/notebooklm-py` | `teng-lin/gemini-notebook-py` | GitHub auto-redirects |
+The `-py` suffix signals continuity and, with the "Unofficial" description,
+reduces the risk a bare `gemini-*` name reads as official Google. "Gemini" is
+a hotter, more actively defended mark than "NotebookLM"; the bare-name
+metapackage must carry a real dependency (not an empty squat, which PEP 541
+frowns on) and we accept we may have to surrender it if challenged.
 
-What is explicitly **not** renamed: the `rpc/` layer's wire-level naming, the
-default base URL (`notebooklm.google.com` — Google's endpoint, not our brand),
-VCR cassette contents, and historical CHANGELOG/ADR text. Internal private
-modules are renamed only when the `src/` tree physically moves (Phase 3), as
-a mechanical consequence, not a goal.
+### Phase 0 — immediately
 
-## The phases
+- Register `gemini-notebook-py` and `gemini-notebook` on PyPI. Placeholders
+  (`0.1.0`) **depend on `notebooklm-py`** so an early `pip install` works
+  rather than dead-ends; yank them once the real release ships. `publish.yml`'s
+  tag/version validation rejects out-of-band versions, so this is a one-off
+  manual/TestPyPI-style upload using PyPI *pending publishers* registered for
+  both names (plus keeping `notebooklm-py`'s publisher) — all against the
+  current repo name.
+- README: replace the "keeps the name" note with the rename plan and its
+  rationale; add `gemini`, `gemini-notebook` keywords (pyproject + manifest).
 
-### Phase 0 — immediately, independent of any release
+### Phase 1a — 0.9.0, additive (fully reversible)
 
-- **Register the PyPI names.** Upload minimal placeholder sdists (version
-  `0.0.1`, README pointing at this repo) for `gemini-notebook-py` and
-  `gemini-notebook`. This is the only way PyPI lets you hold a name. Configure
-  Trusted Publishing for `gemini-notebook-py` mirroring the existing
-  `publish.yml` setup.
-- Add a "NotebookLM is now Gemini Notebook" note to `README.md` and
-  `docs/index`-level docs; add `gemini`, `gemini-notebook` to `keywords` in
-  `pyproject.toml` and `desktop-extension/manifest.json`. No behavior changes.
+1. New console scripts `gemini-notebook{,-mcp,-server}` alongside the old
+   three. No startup hints — the old names are not deprecated.
+2. `GeminiNotebookClient = NotebookLMClient` exported from `notebooklm`
+   (static assignment: subclassing, `isinstance`, pickle, and mypy all keep
+   working; no `__getattr__` indirection).
+3. `__version__` resolution tries `gemini-notebook-py` then `notebooklm-py`
+   (`src/notebooklm/__init__.py:40` is currently keyed to the old dist only
+   and would report `0.0.0.dev0` under the renamed dist). Same fix in the
+   skill version stamp (`_app/skill.py`).
+4. Docs/README lead with "Gemini Notebook"; old name mentioned once per page.
+5. Same-PR guardrail updates: `tests/_guardrails/test_public_surface.py`
+   (new export), CLI contract baseline regen (ADR-0022 machinery) for the new
+   scripts, `test_version_pyproject_sync.py`.
 
-### Phase 1 — 0.9.0, the compatibility release (additive only)
+Stopping forever after 1a is a fine outcome: nothing has flipped.
 
-Everything new is added; nothing old changes behavior. A user who upgrades
-and touches nothing sees at most a startup hint.
+### Phase 1b — 0.10.0, the identity flip (gated; see Guardrails for go/no-go)
 
-1. **Env vars.** Introduce a single resolver (extend `_env.py`) used by every
-   env read: `GEMINI_NOTEBOOK_<X>` wins; `NOTEBOOKLM_<X>` still honored, with
-   a once-per-process `warn_deprecated(..., removal="2.0")` when only the old
-   name is set. All ~40 variables go through the resolver — no per-call-site
-   fallback logic (grep gate in CI, see Guardrails).
-2. **Console scripts.** Add `gemini-notebook`, `gnb`, `gemini-notebook-mcp`,
-   `gemini-notebook-server` entry points targeting the same mains. The old
-   three stay, and print a one-line deprecation hint on startup (stderr,
-   suppressed by the quiet gate).
-3. **Import alias.** Add a `gemini_notebook` package that re-exports
-   `notebooklm`'s public surface (`from notebooklm import *` plus explicit
-   `__all__`, `__version__`, submodule aliasing via `sys.modules` so
-   `gemini_notebook.types` etc. resolve). `notebooklm` remains the real code —
-   zero churn to the 2 000 internal references in this phase.
-4. **Class alias.** `GeminiNotebookClient = NotebookLMClient` exported from
-   both packages. No warning yet in either direction.
-5. **Config home.** `paths.py` precedence becomes:
-   `GEMINI_NOTEBOOK_HOME` > `NOTEBOOKLM_HOME` (deprecated) >
-   `~/.gemini-notebook` if it exists > `~/.notebooklm` if it exists >
-   `~/.gemini-notebook` (fresh default). No silent data copy — profile dirs
-   hold live auth state under `filelock`; a `notebooklm doctor` /
-   `gemini-notebook doctor` check offers an explicit one-shot migration
-   (rename the directory, leave a `~/.notebooklm` symlink for old scripts).
-6. **Dual publish begins.** `gemini-notebook-py 0.9.0` is the canonical dist
-   (full code). `notebooklm-py 0.9.0` becomes a **shim**: an empty
-   distribution whose only install requirement is
-   `gemini-notebook-py==0.9.0`, with a README explaining the rename. Shims
-   contain no Python files, so installing both never clobbers site-packages.
-   The bare `gemini-notebook` metapackage likewise depends on
-   `gemini-notebook-py`.
-7. **Repo rename.** Rename `teng-lin/notebooklm-py` →
-   `teng-lin/gemini-notebook-py` at 0.9.0 release time. GitHub redirects all
-   old URLs, remotes, and clones. Same-PR sweep: `project.urls`,
-   `hatch-fancy-pypi-readme` substitution URLs in `pyproject.toml`, badge
-   URLs, `publish-docker.yml`/`publish-mcpb.yml` `github.repository` guards,
-   `desktop-extension/manifest.json` links.
-8. **MCP / desktop extension.** Update `display_name` to
-   "Gemini Notebook (gemini-notebook-py)" and descriptions. Keep the manifest
-   `name: "notebooklm-mcp"` **unchanged** for now — the name is the extension's
-   identity in Claude Desktop, and changing it makes installed users' copies
-   orphaned rather than upgraded. Ship the identity change at 2.0 only,
-   release-noted. The launcher `run_server.py` switches to
-   `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp`.
-9. **Docker / release assets.** Push images to both `notebooklm-mcp` and
-   `gemini-notebook-mcp` repositories (second `DOCKERHUB_IMAGE`-style
-   variable); release both `notebooklm-skill.zip` and
-   `gemini-notebook-skill.zip` names.
+Ordered steps; the repo rename is its own verified step, **not** bundled with
+the first dual publish:
 
-### Phase 2 — 0.9.x bake period
+1. **Repo rename first, quiet window**: rename to
+   `teng-lin/gemini-notebook-py`; immediately re-point the Trusted-Publishing
+   configs for all three dists at the new repo; verify with a TestPyPI publish
+   before any real release. Same-PR sweep of hardcoded repo strings:
+   `project.urls`, fancy-pypi-readme substitutions, badges, and every
+   `github.repository ==` guard (`publish-docker.yml`, `publish-mcpb.yml`,
+   `verify-package.yml:150,158` — string compares don't get redirects),
+   OCI source label, TestPyPI summary URL,
+   `tests/_guardrails/test_pypi_readme_substitutions.py`.
+2. **Dist rename**: `project.name = "gemini-notebook-py"`; update the
+   self-referential `all` extra and re-lock `uv.lock`. Hatch config is
+   untouched (the import package doesn't move — ever).
+3. **Multi-dist publishing**: shim pyprojects live in `packaging/shims/
+   {notebooklm-py,gemini-notebook}/`; `publish.yml` builds canonical + shims
+   from one tag (versions asserted in lockstep), smoke-installs the shim with
+   `--find-links dist/` (its pin isn't on PyPI yet), and uploads **canonical
+   first**, shims after. Wheel globs/artifact names flip to
+   `gemini_notebook_py-*` here (dist-keyed, not import-keyed — `publish.yml:81`,
+   `testpypi-publish.yml`, artifact names).
+4. **Shim spec**: `notebooklm-py` shim ships zero Python files, zero console
+   scripts, and **mirrors every extra** (`[mcp]`, `[browser]`, … →
+   `gemini-notebook-py[<extra>]==<version>`) — the shipped desktop extension
+   hardcodes `notebooklm-py[mcp]` and must keep resolving. Pin `==`, released
+   in lockstep with every canonical release (automated by step 3), for as
+   long as dual publishing runs.
+5. **Dual-install hazard**: `gemini-notebook-py` still ships the `notebooklm`
+   package, so it collides file-for-file with a stale `notebooklm-py` ≤0.8
+   install. Mitigation: an import-time check —
+   `importlib.metadata.version("notebooklm-py")` < 0.9 alongside
+   `gemini-notebook-py` ⇒ loud warning naming the fix
+   (`pip uninstall notebooklm-py && pip install -U gemini-notebook-py`) —
+   plus release notes. Expect dependency-confusion-style scanner flags when a
+   long-lived dist turns shim; pre-empt in the release notes.
+6. **`verify-package.yml`**: replace the `--no-deps` old-name install steps
+   (which break against an empty shim) with the dual-install smoke: shim +
+   canonical in one venv, both import paths, all **six** scripts.
+7. **`mcp install`**: `_app/mcp_install.py` writes
+   `uvx --from "gemini-notebook-py[mcp]" gemini-notebook-mcp` under the
+   **unchanged** server key `"notebooklm"` (no duplicate entries on
+   re-install, no orphaning); `desktop-extension/run_server.py` likewise.
+   Previously written configs keep working via the shim indefinitely.
+8. **`deploy/`**: compose/env.example/Makefile/tailscale move to the new
+   image name; all `NOTEBOOKLM_*` vars stay (permanent), so existing `.env`
+   files keep working. Docker pushed to both repositories;
+   `test_unit/test_deploy_compose_default.py` updated same PR.
+9. Same-PR guardrail updates: `test_install_docs.py` + SKILL.md/AGENTS.md
+   install commands (wheel-embedded agent instructions must not keep teaching
+   `pip install notebooklm-py`), `test_skill_packaging.py`,
+   `test_mcp_desktop_extension.py`, mcp-install tests, CLI baselines.
 
-At least one minor-release cycle (target: ~2 months) with both names live.
-Watch: PyPI download split between the two dists, bug reports against the
-alias package, and whether Google's brand holds. Docs are rewritten to lead
-with the new names during this window (mechanical `docs/` sweep, ~1 900
-references, old names mentioned once per page as "(formerly NotebookLM)").
+### Phase 2 — bake and docs sweep
 
-### Phase 3 — 1.0.0, the physical flip
+Dual publishing runs; docs (~1 900 refs), `examples/` prose, issue/PR
+templates, `SECURITY.md`, `CLAUDE.md`/`CONTRIBUTING.md` rewritten to lead with
+the new name. Watch signals: download split, shim bug reports, brand
+stability. `import notebooklm` examples are **correct forever** — no code
+sample churn.
 
-1. **Move the tree**: `git mv src/notebooklm src/gemini_notebook`, mechanical
-   rename of internal imports (the ~2 000 references). One dedicated PR, no
-   functional changes mixed in, so `git blame` damage is a single commit that
-   can be listed in `.git-blame-ignore-revs`.
-2. **Invert the shim**: `notebooklm` becomes the thin re-export package
-   (mirror of the Phase-1 `gemini_notebook` alias, now warning via
-   `warn_deprecated(..., removal="2.0")` on first import).
-3. **Rename-sensitive config** follows in the same PR: `tool.hatch.build`
-   `packages`/`force-include`, `tool.coverage.run` source,
-   `per_file_coverage_floors` keys, `tool.mypy` files + per-module overrides,
-   `ruff` `known-first-party`, `publish.yml` wheel glob
-   (`gemini_notebook_py-*.whl`) and artifact names, `verify-package` /
-   public-surface gates, `tests/` imports.
-4. `NotebookLMClient` remains exported as a deprecated alias of
-   `GeminiNotebookClient` (real subclass-free assignment, warning on
-   attribute-free construction is *not* attempted — the alias warns via
-   module `__getattr__` on first access).
+### Phase 3 — wind-down (no removal cliff)
 
-### Phase 4 — 2.0.0, removal
+When go/no-go criteria say so (Guardrails), dual asset publishing (Docker,
+skill zip) ends. `notebooklm-py` gets a final shim pinned
+`gemini-notebook-py>=<current major>,<next major>` with a tombstone README —
+and because the import package never goes away, that terminal shim keeps
+**working** (install + `import notebooklm`) rather than silently breaking.
+There is no Phase-4 hard removal: old console scripts, env vars, and config
+home are permanent by decision, so no user ever hits a cliff.
 
-Old console scripts, `NOTEBOOKLM_*` env fallbacks (except a hard error message
-naming the replacement), the `notebooklm` import shim, the `NotebookLMClient`
-alias, and `notebooklm-py` shim releases all end. `~/.notebooklm` read
-fallback stays (cheap, harmless). Final `notebooklm-py` upload is a shim
-pinned `gemini-notebook-py>=2,<3` with a tombstone README.
+### Guardrails
 
-## Guardrails
-
-- **One resolver rule** (mirrors ADR-0018's "one module, one switch"): CI
-  greps that no code outside `_env.py` reads `NOTEBOOKLM_` from `os.environ`
-  directly, so the fallback+warning behavior cannot fork.
-- **Shim equivalence test**: a unit test asserts
-  `dir(gemini_notebook)`-public == `dir(notebooklm)`-public and that
-  `gemini_notebook.__version__ is notebooklm.__version__`, so the alias can
-  never drift from the real package.
-- **Dual-install smoke** in `verify-package.yml`: install `notebooklm-py`
-  (shim) and `gemini-notebook-py` into one venv; both imports and all six
-  console scripts must work.
-- **Quiet gate parity**: the quiet-deprecations env var itself gains a
-  `GEMINI_NOTEBOOK_QUIET_DEPRECATIONS` twin via the same resolver — otherwise
-  silencing rename warnings would require the deprecated prefix.
+- **Gate for 1b (go/no-go, recorded here so it isn't vibes later):** 0.8.0
+  final shipped; brand stable ≥3 months post-announcement (≥2026-10-16);
+  Trusted Publishing verified for all three dists via TestPyPI; the 1a
+  release out with no shim-related regressions.
+- **Gate for Phase 3:** ≥75 % of combined downloads on the new dist for 2
+  consecutive months, or 12 months after 1b, whichever first.
+- **Shim equivalence test** (in canonical repo CI): shim metadata mirrors
+  every canonical extra and pins the exact canonical version.
+- **Version-resolution test**: `notebooklm.__version__` correct when only
+  `gemini-notebook-py` is installed (the failure mode is a silent
+  `0.0.0.dev0`).
+- **Dual-install smoke** in `verify-package.yml` (Phase 1b step 6).
+- **Stale-install check** (Phase 1b step 5) has a unit test for both the
+  warn and the clean path.
 
 ## Consequences
 
-- Existing users are never broken before 2.0; every old entry point keeps
-  working with a discoverable pointer to its replacement.
-- We carry dual publishing and alias surfaces for roughly two release phases —
-  accepted cost; the shim dists are near-empty and the alias package is ~50
-  lines.
-- The old PyPI page, GitHub stars/issues/links, and search ranking are
-  preserved (shim README + GitHub redirect) instead of reset.
-- If Google renames again before Phase 3, we stop at Phase 1/2: the additive
-  aliases are cheap to keep or retarget, and the expensive physical flip has
-  not happened. This is the main reason the flip is deferred to 1.0 rather
-  than done in 0.9.
-- Risk: a user with scripts on another machine sets only `NOTEBOOKLM_HOME`
-  pointing at shared state; the precedence order above keeps that working
-  indefinitely until 2.0, and `doctor` reports which home/profile source won
-  (extends the existing `home_source` diagnostic in `paths.py`).
+- Permanent dist/import mismatch (`pip install gemini-notebook-py`,
+  `import notebooklm`) — well-precedented, documented in the README's first
+  screenful. In exchange: no 2 000-reference tree move, no logger-namespace
+  break, no pickle/mypy alias machinery, no `git blame` damage, no
+  `scripts/`+mypy+coverage+ruff config sweep, and the plumbing keeps working
+  in every config file we've ever written to a user's machine.
+- Old-name users are never broken: the shim (with extras) resolves
+  indefinitely, and its terminal pin still yields a working install.
+- Dual publishing is bounded by an explicit Phase-3 gate rather than open-ended
+  maintainer toil; shim releases are automated in `publish.yml`, not manual.
+- The safe-stop points are explicit: after 1a nothing has flipped; the point
+  of no return is 1b step 1 (repo rename), which is why it is separately
+  gated and verified before the first dual publish.
+- If Google renames again after 1b, we are carrying one stale-brand dist name
+  — the same position we are in today, with the same playbook, and the
+  plumbing unaffected.
+- Risks accepted: a PEP 541 / trademark challenge on the `gemini-*` names
+  (fallback: keep `notebooklm-py` canonical — everything still works);
+  scanner noise when the old dist turns shim; `pynotebooklm` adjacency
+  confusion (README disambiguates).
+- Reversed commitment: the README's July 2026 "keeps the name" note is
+  retracted in Phase 0 with rationale, not silently edited.
 
 ## Alternatives considered
 
-- **Bare `gemini-notebook` as the canonical dist name.** Cleaner, but loses
-  the visual continuity with `notebooklm-py` and looks more official-Google
-  than an unofficial client should. Registered as a redirect instead.
-- **Hard cutover at 0.9** (rename everything at once, publish only the new
-  name). Smallest total diff, but breaks every installed user, MCP config,
-  and CI pipeline simultaneously, and contradicts ADR-0018's windowed
-  deprecation policy.
-- **Never rename; add keywords only.** Preserves all names but cedes the
-  searchable identity of the project and confuses new users indefinitely as
-  "NotebookLM" disappears from Google's own UI.
-- **Physical flip in 0.9.** Rejected for the reason in Consequences: it
-  front-loads the most expensive, least reversible step while the new brand
-  is weeks old.
+- **Full rename including the import package** (v1 of this ADR: alias package
+  at 0.9, `git mv src/notebooklm src/gemini_notebook` at 1.0, removals at
+  2.0). Rejected on review: the flip forces a semver-unrelated 1.0; `sys.modules`
+  aliasing is invisible to mypy and breaks typed consumers; pickles of private
+  `notebooklm._types.*` paths break across the flip; the logger namespace (a
+  documented API) flips silently; env-var twinning requires write-side
+  duplication including a credential scrub (`_auth/refresh.py:361`) where a
+  missed twin is a security regression, a quiet-gate that self-recurses, and a
+  Click `envvar=` bypass no grep gate can see; and the 2.0 removal cliff
+  strands every config `mcp install` ever wrote. Each had a known fix; the sum
+  was a large, risky program buying nothing the dist rename doesn't.
+- **`GEMINI_NOTEBOOK_*` env-var twins** (subset of the above). Deferred
+  indefinitely; any future attempt must solve, from v1's review: non-warning
+  resolve path for the quiet gate and diagnostics, write-side dual-export plus
+  twinned credential scrub, a custom `click.Option` for `envvar=`, an
+  allowlist-based (not grep) CI gate, and the test-suite home-isolation
+  fixture (`tests/conftest.py:31-75`).
+- **Bare `gemini-notebook` as canonical.** Most official-looking name, highest
+  challenge risk; kept as a redirect instead.
+- **Hard cutover / publish only the new name.** Breaks every installed user,
+  MCP config, and CI pipeline at once; contradicts ADR-0018.
+- **Never rename; keywords only.** Cheapest, and the old page's search rank is
+  real — but it cedes the project's identity as "NotebookLM" disappears from
+  Google's own UI. Phase 0+1a alone approximate this alternative's cost while
+  leaving the flip optional, which is partly why 1b is gated rather than
+  scheduled.
+- **`gnb` short CLI alias.** Dropped: PATH collision (srsRAN's `gnb`) and a
+  brand-coupled acronym — exactly the churn constraint 1 warns about.

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -16,7 +16,10 @@ protocol at `notebooklm.google.com` — but the project's discoverable identity
 (PyPI listing, repo name, docs) now points at a retired brand. New users will
 search for "gemini notebook python". PyPI availability checked 2026-08-03:
 `gemini-notebook`, `gemini-notebook-py`, `gemini-notebook-client` are all
-unregistered; PyPI has no reservation mechanism, so squatting is a live risk.
+unregistered — and so is the bare `notebooklm` dist name, which the permanent
+dist/import mismatch this ADR adopts turns into a standing typosquat target
+(`pip install notebooklm` becomes the most likely wrong guess, forever). PyPI
+has no reservation mechanism, so squatting is a live risk on all of them.
 
 The name is carried on two very different kinds of surface:
 
@@ -72,6 +75,7 @@ patch after the fact.
 |---|---|
 | PyPI dist `notebooklm-py` | → `gemini-notebook-py` canonical at 0.9.0; old name becomes a permanent extras-forwarding shim |
 | Bare `gemini-notebook` | registered as redirect metapackage (anti-squat) |
+| Bare `notebooklm` (unregistered today) | registered as a defensive placeholder depending on the canonical dist — the mismatch makes it the permanent likely typo; the `bs4` precedent |
 | GitHub repo | → `teng-lin/gemini-notebook-py` (auto-redirects) |
 | CLI | `gemini-notebook`, `gemini-notebook-mcp`, `gemini-notebook-server` added; `notebooklm*` scripts kept **indefinitely** (they match the import name; no deprecation) |
 | Docker image / skill zip / `.mcpb` display name | new names added, old kept during wind-down |
@@ -91,7 +95,14 @@ frowns on) and we accept we may have to surrender it if challenged.
 
 - Register `gemini-notebook-py` and `gemini-notebook` on PyPI. Placeholders
   (`0.1.0`) **depend on `notebooklm-py`** so an early `pip install` works
-  rather than dead-ends; yank them once 0.9.0 ships. `publish.yml`'s
+  rather than dead-ends; yank them once 0.9.0 ships. Register the bare
+  **`notebooklm`** name in the same batch: with `import notebooklm` permanent,
+  `pip install notebooklm` is the most likely typo forever, and the name is
+  unregistered — exactly why the BeautifulSoup project registered `bs4`.
+  Same placeholder treatment (depends on the canonical dist of the day, README
+  redirects to `gemini-notebook-py`); unlike the two shims it is **not** part
+  of the lockstep matrix — its dependency floor is refreshed opportunistically
+  and it gets a one-time install smoke, not a per-release row. `publish.yml`'s
   tag/version validation rejects out-of-band versions, so this is a one-off
   manual/TestPyPI-style upload using PyPI *pending publishers* registered for
   both names (plus keeping `notebooklm-py`'s publisher) — all against the
@@ -314,6 +325,14 @@ under `notebooklm-py[mcp]` installs.
   confusion (README disambiguates).
 - Reversed commitment: the README's July 2026 "keeps the name" note is
   retracted in Phase 0 with rationale, not silently edited.
+- "Permanent" for the import package is a governance commitment, not physics:
+  it means unscheduled, with a named bar for reopening. A superseding ADR
+  requires either (a) the Gemini Notebook brand stable for 2+ years **and** a
+  1.0 major already planned on API-stability grounds (the only natural flip
+  point), or (b) sustained evidence of real user confusion (recurring issues,
+  measurable support burden). Another Google rename instead *confirms* this
+  decision — the import name that never chases brands is the only one that
+  cannot go stale twice.
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,11 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0021](0021-transport-neutral-app-layer.md) | Transport-neutral application layer (`_app/`) | Accepted |
 | [0022](0022-regenerable-baselines.md) | Regenerable test baselines (derive / store / compare / regen) | Accepted |
 | [0023](0023-master-token-headless-auth.md) | Master-token headless auth (Option A) | Accepted |
+| [0024](0024-mcp-remote-file-transfer.md) | MCP remote file transfer (signed-URL side-channel) | Proposed |
+| [0025](0025-mcp-tool-granularity.md) | MCP tool granularity — mega-tools vs. discrete verbs | Accepted |
+| [0026](0026-mcp-studio-surface.md) | MCP Studio surface — notes + artifacts unified | Accepted |
+| [0027](0027-mcp-app-upload-widget.md) | In-app MCP-App upload widget (opt-in) | Accepted (experimental / opt-in) |
+| [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,7 +62,7 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0025](0025-mcp-tool-granularity.md) | MCP tool granularity — mega-tools vs. discrete verbs | Accepted |
 | [0026](0026-mcp-studio-surface.md) | MCP Studio surface — notes + artifacts unified | Accepted |
 | [0027](0027-mcp-app-upload-widget.md) | In-app MCP-App upload widget (opt-in) | Accepted (experimental / opt-in) |
-| [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed |
+| [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed — v2 after multi-lens review |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,7 +62,7 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0025](0025-mcp-tool-granularity.md) | MCP tool granularity — mega-tools vs. discrete verbs | Accepted |
 | [0026](0026-mcp-studio-surface.md) | MCP Studio surface — notes + artifacts unified | Accepted |
 | [0027](0027-mcp-app-upload-widget.md) | In-app MCP-App upload widget (opt-in) | Accepted (experimental / opt-in) |
-| [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed — v2 after multi-lens review |
+| [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed — v3, single-release 0.9.0 flip |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 


### PR DESCRIPTION
## Summary

Google renamed NotebookLM to **Gemini Notebook** on 2026-07-16. This PR adds **ADR-0028**, the decision record for how this project responds: rename the **distribution and discoverability surfaces** to `gemini-notebook-py` in a **single 0.9.0 release**, while keeping **`import notebooklm` and all operational plumbing permanently** (the `beautifulsoup4`/`bs4` pattern — dist name ≠ import name).

The ADR went through four review rounds — a four-lens agent review (packaging, compatibility, surface coverage, strategy), three CodeRabbit passes, a Codex review, and the maintainer's multi-agent inline review — with 20+ findings all incorporated. The two headline outcomes: the original full-import-rename plan was rejected into *Alternatives considered* (mypy-invisible alias package, pickle breakage, logger-namespace break, credential-scrub twinning hazard, MCP-config stranding), and the two-release phasing was collapsed into one 0.9.0 completion checklist per maintainer review.

## Related Issue

None — decision record for the upstream rebrand.

## Changes

- **`docs/adr/0028-gemini-notebook-rename.md`** (new): the decision (v3) and its execution plan:
  - *Phase 0 — immediately*: register `gemini-notebook-py`, `gemini-notebook`, and the bare `notebooklm` name (defensive; the permanent dist/import mismatch makes `pip install notebooklm` the likely typo forever) via PyPI pending publishers; retract the README's July "keeps the name" note.
  - *Phase 1 — 0.9.0, the rename release*: one ordered 12-step checklist — repo rename first with OIDC Trusted-Publishing re-registration verified via TestPyPI (redirects don't cover OIDC claims), dist rename, multi-dist publishing from one tag, extras-forwarding lockstep shims (both `notebooklm-py` and `gemini-notebook`), content-hash `__version__` provenance with build-stamp fallback, marker-based stale-install detection with `--force-reinstall` remediation, isolated-tool-install contract (uvx/pipx), `mcp install`/desktop-extension/`deploy/` updates, and per-step guardrail-test updates. A **0.9.0 acceptance matrix** in Guardrails is the executable definition of done; the abort point is before the repo rename.
  - *Phase 2*: optional docs long-tail sweep. *Phase 3*: gated wind-down with **no removal cliff** — the terminal shim still yields a working `import notebooklm`, and canonical releases inside any open shim range must preserve legacy extras and console scripts (CI-enforced).
  - "Permanent" is defined with explicit reopen conditions (brand stable 2+ years plus a planned 1.0, or sustained confusion evidence). Rejected alternatives recorded: full import rename (v1), two-release phasing (v2), env-var twins, hard cutover, `gnb` alias, duplicate-script shim.
- **`docs/adr/README.md`**: index row for ADR-0028; backfilled missing index rows for ADRs 0024–0027.

## Test Plan

- [ ] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90`) — full CI matrix green on the head commit
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`) — Code Quality check green
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`) — runs in CI's Code Quality job
- [x] If this PR changes architectural shape, an ADR has been added or updated.

Docs-only change — no code paths touched; the checked items reflect CI results on the head commit.

## Notes

- The ADR is **Proposed**, not Accepted: merging this PR records the plan; executing Phase 0 (PyPI registrations, README retraction) is separate follow-up work.
- The decision deliberately reverses the README's published July 2026 commitment ("the package keeps the `notebooklm-py` name"); the ADR requires that retraction to be explicit, not silent.
- Prior versions are preserved in this branch's history: v1 (full import rename) at `937c8c7`, v2 (two-release phasing) at `e8b82ea`; both are summarized in *Alternatives considered* with the review findings that sank them, so the trade-offs aren't re-litigated later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LHh7EfTtni3Dkqsyw7bzp

---
_Generated by [Claude Code](https://claude.ai/code/session_015LHh7EfTtni3Dkqsyw7bzp)_


## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record proposing a single-release rename of distribution and discoverability surfaces to `gemini-notebook-py`.
  * Documented compatibility for existing imports, commands, deployments, and operational identifiers, including forwarding support for legacy package names.
  * Added rollout safeguards, versioning guidance, stale-install detection, and transition wind-down rules.
  * Updated the documentation index with recent decisions covering MCP transfers, tool granularity, MCP Studio, upload widgets, and package renaming.