### PR TITLE
fix(cli): detect missing Chromium via executable_path, not --dry-run text (#2031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cookie-*scoping* failure that surfaced as a generic "authentication expired"
   line, leaving the nightly log with nothing to diagnose it from
   ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019)).
+- **`notebooklm login` now actually auto-installs Chromium**
+  ([#2031](https://github.com/teng-lin/notebooklm-py/issues/2031)). The
+  pre-flight in `cli/services/playwright_login.py` scraped
+  `playwright install --dry-run chromium` for a `"will download"` marker no
+  Playwright release emits, so it always returned early and the user hit a raw
+  `Executable doesn't exist` error at launch. `--dry-run` cannot answer the
+  question in either direction — it prints the same `Install location:` block
+  whether or not the browser is on disk — so the probe now resolves
+  Playwright's own `chromium.executable_path` (in an isolated, timeout-bounded
+  interpreter) and tests that path.
 
 ## [0.8.0] - 2026-08-03
 

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -206,35 +206,77 @@ def repair_playwright_account_metadata(
 # Chromium install pre-flight (CLI-install concern; stays in the adapter)
 # ---------------------------------------------------------------------------
 
+CHROMIUM_PRESENT_MARKER = "notebooklm-chromium-present"
+CHROMIUM_MISSING_MARKER = "notebooklm-chromium-missing"
+
+# Detection source for the pre-flight, run in an isolated interpreter.
+#
+# It asks Playwright itself where the bundled Chromium build lives
+# (``BrowserType.executable_path``, a stable public API) and tests that path
+# on disk, printing one of the markers above.
+#
+# It deliberately does NOT parse ``playwright install --dry-run`` output
+# (#2031): that command prints the same ``browser:`` / ``Install location:`` /
+# ``Download url:`` block whether or not the browser is on disk — it reports
+# where a build *would* go, not whether it is there — so it cannot answer this
+# question in either direction. Its human-readable text is also not a stable
+# interface (the historical ``"will download"`` marker this pre-flight matched
+# on is emitted by no shipping Playwright release).
+#
+# Running it out-of-process keeps the check timeout-bounded (an in-process
+# ``sync_playwright()`` start cannot be interrupted), starts the driver with a
+# clean default event-loop policy on Windows, and leaves no Playwright state in
+# the CLI process before the real launch.
+CHROMIUM_PROBE_SOURCE = f"""\
+import os
+import sys
+
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as playwright:
+    path = playwright.chromium.executable_path
+sys.stdout.write(
+    "{CHROMIUM_PRESENT_MARKER}" if path and os.path.exists(path) else "{CHROMIUM_MISSING_MARKER}"
+)
+"""
+
 
 def ensure_chromium_installed(io: LoginIO) -> None:
     """Check if Chromium is installed and install if needed.
 
-    Runs ``playwright install --dry-run chromium`` to detect a missing browser,
-    then auto-installs. Silently proceeds on any error so Playwright handles it
-    during launch. Both subprocess calls are timeout-bounded (30 s dry-run,
-    300 s install) so a network-stalled CLI cannot hang ``notebooklm login``;
-    ``TimeoutExpired`` is a pre-flight failure — the warning surfaces and login
-    continues. ``io`` carries the presentation / exit sink (an install failure
-    exits 1 via ``io.fail``; the ``except SystemExit: raise`` re-raise keeps
-    that terminal path intact).
+    Resolves Playwright's bundled-Chromium executable path in an isolated
+    interpreter (:data:`CHROMIUM_PROBE_SOURCE`) and auto-installs when that
+    path is absent. Silently proceeds on any error — including an unreadable
+    probe answer — so Playwright handles it during launch. Both subprocess
+    calls are timeout-bounded (30 s probe, 300 s install) so a network-stalled
+    CLI cannot hang ``notebooklm login``; ``TimeoutExpired`` is a pre-flight
+    failure — the warning surfaces and login continues. ``io`` carries the
+    presentation / exit sink (an install failure exits 1 via ``io.fail``; the
+    ``except SystemExit: raise`` re-raise keeps that terminal path intact).
     """
     try:
         result = subprocess.run(
-            [sys.executable, "-m", "playwright", "install", "--dry-run", "chromium"],
+            [sys.executable, "-c", CHROMIUM_PROBE_SOURCE],
             capture_output=True,
             text=True,
             timeout=30,
         )
-        stdout_lower = result.stdout.lower()
-        if "chromium" not in stdout_lower or "will download" not in stdout_lower:
-            # The dry-run probe succeeded but didn't see a "will download"
-            # marker; nothing to do. If the probe printed an unexpected
-            # diagnostic to stderr, surface a sanitised version at debug
-            # level so operators can investigate without leaking env values.
+        saw_present = CHROMIUM_PRESENT_MARKER in result.stdout
+        saw_missing = CHROMIUM_MISSING_MARKER in result.stdout
+        # Install only on an unambiguous "missing" answer. Anything else —
+        # the browser is on disk, or the probe returned an answer we cannot
+        # read (crashed, printed neither marker, or printed both) — means
+        # "nothing to do": installing on a guess would re-download on every
+        # login, and a genuinely missing browser still raises an actionable
+        # Playwright error at launch.
+        chromium_missing = saw_missing and not saw_present
+        if not chromium_missing:
+            # If the probe printed an unexpected diagnostic to stderr, surface
+            # a sanitised version at debug level so operators can investigate
+            # without leaking env values.
             if result.stderr:
                 logger.debug(
-                    "playwright install --dry-run stderr: %s",
+                    "chromium pre-flight probe stderr: %s",
                     redact_subprocess_output(result.stderr),
                 )
             return
@@ -283,8 +325,9 @@ def ensure_chromium_installed(io: LoginIO) -> None:
             f"{exc.timeout}s. Proceeding anyway.[/dim]"
         )
     except Exception as e:
-        # FileNotFoundError: playwright CLI not found but sync_playwright imported
-        # Other exceptions: dry-run check failed — let Playwright handle it during launch.
+        # FileNotFoundError: the interpreter that runs the probe is gone.
+        # Other exceptions: the probe could not run — let Playwright handle it
+        # during launch.
         io.emit(f"[dim]Warning: Chromium pre-flight check failed: {e}. Proceeding anyway.[/dim]")
 
 

--- a/src/notebooklm/cli/services/playwright_login.py
+++ b/src/notebooklm/cli/services/playwright_login.py
@@ -263,13 +263,13 @@ def ensure_chromium_installed(io: LoginIO) -> None:
         )
         saw_present = CHROMIUM_PRESENT_MARKER in result.stdout
         saw_missing = CHROMIUM_MISSING_MARKER in result.stdout
-        # Install only on an unambiguous "missing" answer. Anything else —
-        # the browser is on disk, or the probe returned an answer we cannot
-        # read (crashed, printed neither marker, or printed both) — means
-        # "nothing to do": installing on a guess would re-download on every
-        # login, and a genuinely missing browser still raises an actionable
-        # Playwright error at launch.
-        chromium_missing = saw_missing and not saw_present
+        # Install only on an unambiguous "missing" answer from a probe that
+        # ran to completion. Anything else — the browser is on disk, the probe
+        # exited non-zero, or it returned an answer we cannot read (printed
+        # neither marker, or printed both) — means "nothing to do": installing
+        # on a guess would re-download on every login, and a genuinely missing
+        # browser still raises an actionable Playwright error at launch.
+        chromium_missing = result.returncode == 0 and saw_missing and not saw_present
         if not chromium_missing:
             # If the probe printed an unexpected diagnostic to stderr, surface
             # a sanitised version at debug level so operators can investigate

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -193,7 +193,9 @@ def test_windows_event_loop_noop_off_win32(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 # ensure_chromium_installed — detection contract (#2031)
 # ---------------------------------------------------------------------------
-def _record_subprocess(monkeypatch, probe_stdout: str) -> list[list[str]]:
+def _record_subprocess(
+    monkeypatch, probe_stdout: str, probe_returncode: int = 0
+) -> list[list[str]]:
     """Stub ``subprocess.run``: probe returns ``probe_stdout``, install succeeds."""
     calls: list[list[str]] = []
 
@@ -201,7 +203,7 @@ def _record_subprocess(monkeypatch, probe_stdout: str) -> list[list[str]]:
         calls.append(cmd)
         if "install" in cmd:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
-        return SimpleNamespace(stdout=probe_stdout, stderr="", returncode=0)
+        return SimpleNamespace(stdout=probe_stdout, stderr="", returncode=probe_returncode)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     return calls
@@ -267,6 +269,19 @@ def test_missing_marker_runs_the_install(monkeypatch, capsys) -> None:
 def test_unreadable_probe_answer_does_not_install(monkeypatch, capsys, probe_stdout) -> None:
     """An ambiguous answer must not install — guessing re-downloads every login."""
     calls = _record_subprocess(monkeypatch, probe_stdout)
+    ensure_chromium_installed(make_login_io())
+
+    assert len(calls) == 1  # probe only, no install
+    assert capsys.readouterr().out == ""
+
+
+def test_missing_marker_from_failed_probe_does_not_install(monkeypatch, capsys) -> None:
+    """A non-zero probe exit is unreadable even when the marker reached stdout.
+
+    A probe that dies after writing the marker (or a wrapper that echoes it)
+    must not be trusted to start a download.
+    """
+    calls = _record_subprocess(monkeypatch, CHROMIUM_MISSING_MARKER, probe_returncode=1)
     ensure_chromium_installed(make_login_io())
 
     assert len(calls) == 1  # probe only, no install

--- a/tests/unit/cli/test_playwright_login_coverage.py
+++ b/tests/unit/cli/test_playwright_login_coverage.py
@@ -4,7 +4,8 @@ These tests target branches not exercised by the existing
 * :func:`_select_playwright_account` ambiguity-reason branches.
 * :func:`repair_playwright_account_metadata` clear-metadata-failure path.
 * :func:`windows_playwright_event_loop` win32 policy swap.
-* :func:`ensure_chromium_installed` timeout + generic-exception pre-flight
+* :func:`ensure_chromium_installed` detection contract (present / missing /
+  unreadable probe answer) plus its timeout + generic-exception pre-flight
   failures.
 * :func:`recover_page` TargetClosed + non-TargetClosed PlaywrightError paths.
 * :func:`validate_login_flag_conflicts` remaining mutual-exclusion gates.
@@ -18,6 +19,7 @@ with stub/mocked collaborators so no real browser / network is required.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -29,6 +31,9 @@ import notebooklm.auth as auth_module
 from notebooklm.cli.playwright_login_io import make_login_io
 from notebooklm.cli.services import playwright_login
 from notebooklm.cli.services.playwright_login import (
+    CHROMIUM_MISSING_MARKER,
+    CHROMIUM_PRESENT_MARKER,
+    CHROMIUM_PROBE_SOURCE,
     Conflict,
     PathError,
     PreparedPaths,
@@ -183,6 +188,129 @@ def test_windows_event_loop_noop_off_win32(monkeypatch) -> None:
     monkeypatch.setattr(playwright_login.sys, "platform", "linux")
     with windows_playwright_event_loop():
         pass  # no exception, nothing swapped
+
+
+# ---------------------------------------------------------------------------
+# ensure_chromium_installed — detection contract (#2031)
+# ---------------------------------------------------------------------------
+def _record_subprocess(monkeypatch, probe_stdout: str) -> list[list[str]]:
+    """Stub ``subprocess.run``: probe returns ``probe_stdout``, install succeeds."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_):
+        calls.append(cmd)
+        if "install" in cmd:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(stdout=probe_stdout, stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return calls
+
+
+def test_probe_is_programmatic_not_dry_run_output_scraping(monkeypatch) -> None:
+    """The probe runs :data:`CHROMIUM_PROBE_SOURCE`, never ``install --dry-run``.
+
+    ``playwright install --dry-run`` prints the same block whether or not the
+    browser is on disk, so its output can never answer this question (#2031).
+    """
+    calls = _record_subprocess(monkeypatch, CHROMIUM_PRESENT_MARKER)
+    ensure_chromium_installed(make_login_io())
+
+    assert calls == [[sys.executable, "-c", CHROMIUM_PROBE_SOURCE]]
+    assert "--dry-run" not in calls[0]
+
+
+def test_both_subprocess_calls_stay_timeout_bounded(monkeypatch) -> None:
+    """30 s probe / 300 s install: an unbounded call could hang ``notebooklm login``."""
+    timeouts: list[Any] = []
+
+    def fake_run(cmd, **kwargs):
+        timeouts.append(kwargs.get("timeout"))
+        if "install" in cmd:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        return SimpleNamespace(stdout=CHROMIUM_MISSING_MARKER, stderr="", returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ensure_chromium_installed(make_login_io())
+
+    assert timeouts == [30, 300]
+
+
+def test_present_marker_skips_install(monkeypatch, capsys) -> None:
+    """A present answer installs nothing and prints nothing."""
+    calls = _record_subprocess(monkeypatch, CHROMIUM_PRESENT_MARKER)
+    ensure_chromium_installed(make_login_io())
+
+    assert len(calls) == 1  # probe only
+    assert capsys.readouterr().out == ""
+
+
+def test_missing_marker_runs_the_install(monkeypatch, capsys) -> None:
+    """A missing answer triggers ``playwright install chromium`` (the #2031 bug)."""
+    calls = _record_subprocess(monkeypatch, f"{CHROMIUM_MISSING_MARKER}\n")
+    ensure_chromium_installed(make_login_io())
+
+    assert calls[1] == [sys.executable, "-m", "playwright", "install", "chromium"]
+    out = capsys.readouterr().out
+    assert "Chromium browser not installed" in out
+    assert "installed successfully" in out
+
+
+@pytest.mark.parametrize(
+    "probe_stdout",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("Traceback (most recent call last): ...", id="crashed"),
+        pytest.param(f"{CHROMIUM_PRESENT_MARKER}{CHROMIUM_MISSING_MARKER}", id="both-markers"),
+    ],
+)
+def test_unreadable_probe_answer_does_not_install(monkeypatch, capsys, probe_stdout) -> None:
+    """An ambiguous answer must not install — guessing re-downloads every login."""
+    calls = _record_subprocess(monkeypatch, probe_stdout)
+    ensure_chromium_installed(make_login_io())
+
+    assert len(calls) == 1  # probe only, no install
+    assert capsys.readouterr().out == ""
+
+
+@pytest.mark.requires_playwright
+def test_probe_source_detects_both_states_against_real_playwright(tmp_path, monkeypatch) -> None:
+    """The probe answers correctly against a REAL Playwright install (#2031).
+
+    Regression guard for the class of bug this replaced: the previous
+    pre-flight scraped ``playwright install --dry-run chromium`` for a
+    ``"will download"`` marker no Playwright release emits, and every unit test
+    fed ``subprocess.run`` fabricated output — so the probe was never once
+    checked against the real tool. This test runs the actual probe source.
+    """
+    browsers_dir = tmp_path / "browsers"
+    browsers_dir.mkdir()
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(browsers_dir))
+
+    def run_source(source: str) -> str:
+        result = subprocess.run(
+            [sys.executable, "-c", source], capture_output=True, text=True, timeout=120
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    # Empty browsers dir → the bundled build is genuinely absent.
+    assert run_source(CHROMIUM_PROBE_SOURCE) == CHROMIUM_MISSING_MARKER
+
+    # Materialise the exact executable Playwright resolves → detected present.
+    resolved = Path(
+        run_source(
+            "import sys\n"
+            "from playwright.sync_api import sync_playwright\n"
+            "with sync_playwright() as playwright:\n"
+            "    sys.stdout.write(playwright.chromium.executable_path)\n"
+        )
+    )
+    assert browsers_dir in resolved.parents
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.touch()
+
+    assert run_source(CHROMIUM_PROBE_SOURCE) == CHROMIUM_PRESENT_MARKER
 
 
 # ---------------------------------------------------------------------------
@@ -597,28 +725,6 @@ def test_redact_subprocess_output_skips_non_string_env_value() -> None:
     out = playwright_login.redact_subprocess_output("leak supersecretvalue here", env=env)
     assert "<redacted>" in out
     assert "supersecretvalue" not in out
-
-
-# ---------------------------------------------------------------------------
-# ensure_chromium_installed — install success path
-# ---------------------------------------------------------------------------
-def test_ensure_chromium_install_success(monkeypatch, capsys) -> None:
-    """When the dry-run reports a missing browser and install succeeds, the
-    success banner is printed ."""
-    calls: list[list[str]] = []
-
-    def fake_run(cmd, **_):
-        calls.append(cmd)
-        if "--dry-run" in cmd:
-            return SimpleNamespace(stdout="chromium will download to ...", stderr="", returncode=0)
-        # The real install call.
-        return SimpleNamespace(stdout="", stderr="", returncode=0)
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    ensure_chromium_installed(make_login_io())
-    out = capsys.readouterr().out
-    assert "installed successfully" in out
-    assert len(calls) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_playwright_login_render_contract.py
+++ b/tests/unit/cli/test_playwright_login_render_contract.py
@@ -394,17 +394,17 @@ class TestPreflightPrepareFresh:
 # Reached through the real ``login`` command's chromium pre-flight by patching
 # ``subprocess.run`` rather than stubbing out the helper.
 # ---------------------------------------------------------------------------
-def _dry_run_says_missing(stdout="chromium will download to ...") -> SimpleNamespace:
-    return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+def _probe_says_missing() -> SimpleNamespace:
+    return SimpleNamespace(stdout=_pl.CHROMIUM_MISSING_MARKER, stderr="", returncode=0)
 
 
 class TestEnsureChromiumInstalled:
     @pytest.mark.requires_playwright
     def test_install_success_banner_then_login(self, runner):
         def fake_run(cmd, **_):
-            if "--dry-run" in cmd:
-                return _dry_run_says_missing()
-            return SimpleNamespace(stdout="", stderr="", returncode=0)
+            if "install" in cmd:
+                return SimpleNamespace(stdout="", stderr="", returncode=0)
+            return _probe_says_missing()
 
         result, _ = _drive_login(runner, subprocess_run=fake_run, patch_ensure=False)
         assert result.exit_code == 0
@@ -429,9 +429,9 @@ class TestEnsureChromiumInstalled:
         """
 
         def fake_run(cmd, **_):
-            if "--dry-run" in cmd:
-                return _dry_run_says_missing()
-            return SimpleNamespace(stdout="", stderr="install boom [err]", returncode=1)
+            if "install" in cmd:
+                return SimpleNamespace(stdout="", stderr="install boom [err]", returncode=1)
+            return _probe_says_missing()
 
         result, _ = _drive_login(
             runner, subprocess_run=fake_run, patch_ensure=False, python_executable="/py"

--- a/tests/unit/cli/test_playwright_login_stderr.py
+++ b/tests/unit/cli/test_playwright_login_stderr.py
@@ -30,6 +30,8 @@ import pytest
 
 from notebooklm.cli.playwright_login_io import make_login_io
 from notebooklm.cli.services.playwright_login import (
+    CHROMIUM_MISSING_MARKER,
+    CHROMIUM_PRESENT_MARKER,
     ensure_chromium_installed,
     redact_subprocess_output,
 )
@@ -290,8 +292,8 @@ def test_install_failure_prints_sanitised_stderr(
     secret = "install_path_secret_value_xyz"
     monkeypatch.setenv("REDACT_INSTALL_TEST", secret)
 
-    dry_run = _StubCompletedProcess(
-        stdout="chromium will download to /tmp/...",
+    probe = _StubCompletedProcess(
+        stdout=CHROMIUM_MISSING_MARKER,
         stderr="",
         returncode=0,
     )
@@ -307,9 +309,9 @@ def test_install_failure_prints_sanitised_stderr(
 
     def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
         call_log.append(cmd)
-        if "--dry-run" in cmd:
-            return dry_run
-        return install_fail
+        if "install" in cmd:
+            return install_fail
+        return probe
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -318,7 +320,7 @@ def test_install_failure_prints_sanitised_stderr(
         ensure_chromium_installed(make_login_io())
 
     assert exc_info.value.code == 1
-    assert len(call_log) == 2  # dry-run probe + install attempt
+    assert len(call_log) == 2  # executable-path probe + install attempt
 
     captured = capsys.readouterr().out
     # Secret env value must NOT appear in cleartext.
@@ -341,8 +343,8 @@ def test_install_failure_falls_back_to_stdout_when_stderr_is_only_whitespace(
     so a stderr that contained only ANSI progress noise would shadow a
     stdout line carrying the actual failure message.
     """
-    dry_run = _StubCompletedProcess(
-        stdout="chromium will download to /tmp/...",
+    probe = _StubCompletedProcess(
+        stdout=CHROMIUM_MISSING_MARKER,
         stderr="",
         returncode=0,
     )
@@ -354,9 +356,9 @@ def test_install_failure_falls_back_to_stdout_when_stderr_is_only_whitespace(
     )
 
     def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
-        if "--dry-run" in cmd:
-            return dry_run
-        return install_fail
+        if "install" in cmd:
+            return install_fail
+        return probe
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -368,24 +370,24 @@ def test_install_failure_falls_back_to_stdout_when_stderr_is_only_whitespace(
     assert "Subprocess output (sanitised)" in captured
 
 
-def test_dry_run_unexpected_stderr_routed_through_redactor(
+def test_probe_unexpected_stderr_routed_through_redactor(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Dry-run stderr (debug log path) also goes through the redactor."""
+    """Probe stderr (debug log path) also goes through the redactor."""
     import logging as _logging
 
-    secret = "dry_run_secret_value_abc"
-    monkeypatch.setenv("REDACT_DRY_RUN_TEST", secret)
+    secret = "probe_secret_value_abc"
+    monkeypatch.setenv("REDACT_PROBE_TEST", secret)
 
-    dry_run = _StubCompletedProcess(
-        # "will download" marker absent → take the early-return branch.
-        stdout="chromium is already installed",
+    probe = _StubCompletedProcess(
+        # Browser present → take the early-return branch.
+        stdout=CHROMIUM_PRESENT_MARKER,
         stderr=f"warning: TOKEN={secret}\n",
         returncode=0,
     )
 
     def fake_run(cmd: list[str], **_: Any) -> _StubCompletedProcess:
-        return dry_run
+        return probe
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -396,8 +398,8 @@ def test_dry_run_unexpected_stderr_routed_through_redactor(
     matching = [
         record.getMessage()
         for record in caplog.records
-        if "playwright install --dry-run stderr" in record.getMessage()
+        if "chromium pre-flight probe stderr" in record.getMessage()
     ]
-    assert matching, "expected a debug log line for dry-run stderr"
+    assert matching, "expected a debug log line for probe stderr"
     assert all(secret not in msg for msg in matching)
     assert any("<redacted>" in msg for msg in matching)


### PR DESCRIPTION
Fixes #2031.

## The bug

`ensure_chromium_installed()` decided whether to auto-install Chromium by grepping `playwright install --dry-run chromium` stdout for `"will download"`:

```python
if "chromium" not in stdout_lower or "will download" not in stdout_lower:
    return
```

**No shipping Playwright release emits that string.** The dry-run printer (`playwright/driver/package/lib/cli/program.js`) only ever prints `browser:`, `Install location:`, `Download url:` and `Download fallback N:`. The guard therefore always early-returned, the auto-install never fired once, and users hit a raw error at launch instead:

```
playwright._impl._errors.Error: BrowserType.launch_persistent_context: Executable doesn't exist at ...
```

`git log -S "will download"` puts the marker in the guard's original commit `ac518653` (#38) — it was **introduced already broken** and has never worked in any release.

Real output on the current pin (Playwright 1.57.0):

```
browser: chromium version 143.0.7499.4
  Install location:    /home/…/.cache/ms-playwright/chromium-1200
  Download url:        https://cdn.playwright.dev/…/chromium-linux.zip
  Download fallback 1: …
  Download fallback 2: …
```

Applying the **original guard condition verbatim** to that real output:

```
installed    'chromium' in stdout=True  'will download' in stdout=False  -> OLD GUARD EARLY-RETURNS=True
empty-cache  'chromium' in stdout=True  'will download' in stdout=False  -> OLD GUARD EARLY-RETURNS=True
```

## Why a one-line string fix would have been worse

`--dry-run` reports where a build *would* go, not whether it is there. With `PLAYWRIGHT_BROWSERS_PATH` pointed at an empty directory the output is byte-identical modulo the echoed path — same four blocks, same order, no "already installed" marker — because the driver builds the list from `registry.resolveBrowsers()` and never consults disk.

So the probe cannot answer the question in **either** direction. Had the string matched, the pre-flight would have re-downloaded Chromium on **every login**.

## The fix

Ask Playwright itself instead of scraping its human-readable output: resolve `chromium.executable_path` (stable public API) and test that path on disk, in a small script run in an isolated interpreter.

| state | probe result | time |
|---|---|---|
| browsers installed | `notebooklm-chromium-present` | 0.44 s |
| `PLAYWRIGHT_BROWSERS_PATH` = empty dir | `notebooklm-chromium-missing` | 0.46 s |

(the broken `--dry-run` subprocess it replaces costs 0.42 s — no regression.)

Out-of-process rather than an in-process `sync_playwright()` because it keeps the check **timeout-bounded** (an in-process driver start cannot be interrupted), gets a clean default event-loop policy on Windows instead of depending on the CLI's global `WindowsSelectorEventLoopPolicy` swap (#2016), and leaves no Playwright state in the CLI process before the real launch.

Alternatives considered and rejected: parsing `Install location:` and stat-ing it (fixes the string, keeps the fragile interface that caused this bug); `playwright install --list` (does reflect real state, but exits 1 with `ENOENT … /.links` on an empty registry, and is still output scraping); unconditional idempotent `playwright install chromium` (correct, 0.58 s, but loses the ability to warn *before* a possible 150 MB download — the CLI would look hung); reimplementing the registry from `driver/package/browsers.json` (reimplements Playwright internals).

### Contracts preserved

30 s probe / 300 s install timeouts (now pinned by a test), `TimeoutExpired` → warn and continue, `except SystemExit: raise`, "silently proceed on any error so Playwright handles it at launch", stderr through `redact_subprocess_output`. Stays a CLI-adapter concern per ADR-0021 — `_auth/browser_capture.py` is untouched.

New, deliberate: an **unreadable** probe answer (crashed, neither marker, both markers) is treated as "nothing to do" rather than "install", so no failure mode can re-download on every login.

## Why the existing tests did not catch it

They asserted the broken behaviour. Five call sites fabricated `stdout="chromium will download to ..."` — output no Playwright emits — and one test's comment reads, verbatim:

```python
# "will download" marker absent → take the early-return branch.
```

i.e. the always-taken path was being asserted as if it were the browser-installed case. Every test mocked `subprocess.run`, so **no test ever ran the real command**, and 100 % branch coverage coexisted with a probe that could not fire.

All of them now pin the marker contract, and `test_probe_source_detects_both_states_against_real_playwright` runs the **actual probe source against a real Playwright**: asserts `missing` under an empty `PLAYWRIGHT_BROWSERS_PATH`, then materialises the exact path Playwright resolves and asserts `present`. It needs no downloaded browser, so it is CI-safe.

## Verification

```
ruff check . && ruff format --check .            All checks passed! / 950 files already formatted
mypy src/notebooklm --ignore-missing-imports     Success: no issues found in 314 source files
pytest (full suite)                              12448 passed, 64 skipped, 1 xfailed
```

## Known overlap with #2005

PR #2005 ("Closes #2004") edits two of the same files — `cli/services/playwright_login.py` and `tests/unit/cli/test_playwright_login_render_contract.py` — but the changes are disjoint in intent: #2005 adds Windows launch-failure and cookie-decryption *hints* (it wraps the `run_browser_capture` call in `run_playwright_login` and adds a test under `TestLoginErrorRender`), while this PR replaces the *chromium pre-flight probe* in `ensure_chromium_installed` and updates tests under `TestEnsureChromiumInstalled`. #2005 does not touch `ensure_chromium_installed` at all.

A trial merge of the two heads (`git merge-tree --write-tree`) is **clean** — both shared files auto-merge with no conflict. Whichever lands second rebases; no coordination should be needed either way.

## Deliberately out of scope

In `_auth/browser_capture.py` the friendly "Executable doesn't exist" handling is gated on `browser in CHANNEL_BROWSERS`, so a missing **bundled** chromium still surfaces as `Unexpected error: …` + exit 2. That is a separate follow-up owned by another PR in flight; this change does not touch that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WddM9PnqkU8S3wmFYPorD5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `notebooklm login` so it correctly detects whether Chromium is available and automatically installs it when needed.
  * Improved login reliability when browser detection encounters unexpected output, errors, or timeouts.
  * Preserved safe failure handling and sanitized diagnostics during browser setup.

* **Documentation**
  * Added an Unreleased changelog entry describing the Chromium installation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->