### PR TITLE
fix(download): audio overviews are .m4a/audio/mp4, not .mp3 (#2034) + REST spool-name honours output_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   > the default name when you pass no path, the per-file names under `--all`,
   > and the `filename` / `mime_type` the MCP and REST surfaces advertise.
   > Scripts that glob `*.mp3` in a download directory should glob `*.m4a`
-  > (or `*.m4a` and `*.mp3` during a transition).
+  > (or `*.m4a` and `*.mp3` during a transition). Note that re-running
+  > `download audio --all <dir>` after upgrading writes new `.m4a` files
+  > *alongside* any `.mp3` files a previous run left there — the names no
+  > longer collide, so nothing is overwritten or auto-renamed.
+
+- **REST `POST /v1/notebooks/{id}/artifacts/download` no longer mislabels a
+  non-default `output_format`.** The route named its spool file from the type's
+  *default* extension, then served that name as the download filename and
+  derived `Content-Type` from it — so a `pptx` slide deck arrived as
+  `artifact.pdf` / `application/pdf`, and a `markdown` quiz as `artifact.json`.
+  Same defect class as the audio fix above, on the format axis instead of the
+  type axis. The MCP `/files/dl` route already resolved both format-aware and
+  was unaffected
+  ([#2034](https://github.com/teng-lin/notebooklm-py/issues/2034)).
 
 ## [0.8.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audio overviews now download as `.m4a`, not `.mp3`.** The Audio Overview
+  bytes have always been AAC in an ISO-BMFF/MP4 container — the artifact
+  metadata itself advertises them as `audio/mp4` — so the `.mp3` name was a
+  mislabel that broke players, transcoders, and MIME-sniffing upload endpoints
+  in ways that were hard to trace back to the extension. Fixed on all three
+  surfaces (CLI `download audio`, MCP `studio_download`, REST
+  `POST /v1/notebooks/{id}/artifacts/download`), and the advertised MIME type is
+  now `audio/mp4` instead of `audio/mpeg`
+  ([#2034](https://github.com/teng-lin/notebooklm-py/issues/2034)).
+
+  > **⚠ Migration.** Only the *derived* filename changed — an explicit output
+  > path is still honoured verbatim, so `notebooklm download audio out.mp3`
+  > keeps writing `out.mp3` (with the same, still-AAC bytes). What changes is
+  > the default name when you pass no path, the per-file names under `--all`,
+  > and the `filename` / `mime_type` the MCP and REST surfaces advertise.
+  > Scripts that glob `*.mp3` in a download directory should glob `*.m4a`
+  > (or `*.m4a` and `*.mp3` during a transition).
+
 ## [0.8.0] - 2026-08-03
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ notebooklm generate mind-map                       # interactive studio map (def
 notebooklm generate data-table "compare key concepts"
 
 # 5. Download artifacts
-notebooklm download audio ./podcast.mp3
+notebooklm download audio ./podcast.m4a
 notebooklm download video ./overview.mp4
 notebooklm download cinematic-video ./documentary.mp4
 notebooklm download quiz --format markdown ./quiz.md
@@ -274,7 +274,7 @@ async def main():
         # Generate content (podcast, video, quiz, etc.)
         status = await client.artifacts.generate_audio(nb.id, instructions="make it fun")
         await client.artifacts.wait_for_completion(nb.id, status.task_id)
-        await client.artifacts.download_audio(nb.id, "podcast.mp3")
+        await client.artifacts.download_audio(nb.id, "podcast.m4a")
 
         # Generate quiz and download as JSON
         status = await client.artifacts.generate_quiz(nb.id)

--- a/SKILL.md
+++ b/SKILL.md
@@ -252,7 +252,7 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 | Check artifact status | `notebooklm artifact list` |
 | Wait for completion | `notebooklm artifact wait <artifact_id>` |
 | Delete artifact | `notebooklm artifact delete <artifact_id> --yes` |
-| Download audio | `notebooklm download audio ./output.mp3` |
+| Download audio | `notebooklm download audio ./output.m4a` |
 | Download video | `notebooklm download video ./output.mp4` |
 | Download cinematic video | `notebooklm download cinematic-video ./cinematic.mp4` (alias for `download video`) |
 | Download infographic | `notebooklm download infographic ./infographic.png` |
@@ -346,7 +346,7 @@ Common generate options vary by subcommand:
 
 | Type | Command | Options | Download |
 |------|---------|---------|----------|
-| Podcast | `generate audio` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]` | .mp3 |
+| Podcast | `generate audio` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]` | .m4a |
 | Video | `generate video` | `--format [explainer\|brief\|cinematic\|short]` (⁴), `--style [auto\|custom\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--style-prompt` with `--style custom` | .mp4 |
 | Slide Deck | `generate slide-deck` | `--format [detailed\|presenter]`, `--length [default\|short]` (²) | .pdf / .pptx |
 | Slide Revision | `generate revise-slide "prompt" --artifact <id> --slide N` | `--wait`, `--notebook` | *(re-downloads parent deck)* |
@@ -402,7 +402,7 @@ These capabilities are available via CLI but not in NotebookLM's web interface:
 4. `notebooklm generate audio "Focus on [specific angle]"` (confirm when asked) — *if rate limited: wait 5 min, retry once*
 5. Note the artifact ID returned
 6. Check `notebooklm artifact list` later for status
-7. `notebooklm download audio ./podcast.mp3` when complete (confirm when asked)
+7. `notebooklm download audio ./podcast.m4a` when complete (confirm when asked)
 
 ### Research to Podcast (Automated with Subagent)
 **Time:** 5-10 minutes, but continues in background
@@ -417,7 +417,7 @@ When user wants full automation (generate and download when ready):
    Task(
      prompt="Wait for artifact {task_id} in notebook {notebook_id} to complete, then download.
              Use: notebooklm artifact wait {task_id} -n {notebook_id} --timeout 1200
-             Then: notebooklm download audio ./podcast.mp3 -a {task_id} -n {notebook_id}",
+             Then: notebooklm download audio ./podcast.m4a -a {task_id} -n {notebook_id}",
      subagent_type="general-purpose"
    )
    ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1303,7 +1303,7 @@ notebooklm download <type> [OUTPUT_PATH] [OPTIONS]
 
 | Type | Default Extension | Description |
 |------|-------------------|-------------|
-| `audio` | `.mp3` | Audio overview (podcast) as MP3 |
+| `audio` | `.m4a` | Audio overview (podcast) — AAC audio in an MP4 container |
 | `video` | `.mp4` | Video overview |
 | `slide-deck` | `.pdf` or `.pptx` | Slide deck as PDF (default) or PowerPoint |
 | `infographic` | `.png` | Infographic image |
@@ -1326,7 +1326,7 @@ notebooklm download <type> [OUTPUT_PATH] [OPTIONS]
 **Examples:**
 ```bash
 # Download the latest podcast
-notebooklm download audio ./podcast.mp3
+notebooklm download audio ./podcast.m4a
 
 # Download all infographics
 notebooklm download infographic --all
@@ -1639,7 +1639,7 @@ notebooklm source add-research "climate change policy 2024" --mode deep --import
 notebooklm generate audio "Focus on policy solutions and future outlook" --format debate --wait
 
 # 5. Download the result
-notebooklm download audio ./climate-podcast.mp3
+notebooklm download audio ./climate-podcast.m4a
 ```
 
 ### Research → Podcast (Non-blocking with Subagent)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -442,7 +442,7 @@ curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
      -d '{"type":"quiz"}' $BASE/v1/notebooks/<id>/artifacts        # → {"task_id": ...}
 curl -H "Authorization: Bearer $TOKEN" $BASE/v1/notebooks/<id>/artifacts/<task_id>  # poll
 curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-     -d '{"type":"audio"}' $BASE/v1/notebooks/<id>/artifacts/download -o out.mp3     # download
+     -d '{"type":"audio"}' $BASE/v1/notebooks/<id>/artifacts/download -o out.m4a     # download
 # File upload is multipart (the original filename + content-type are preserved):
 curl -H "Authorization: Bearer $TOKEN" -F 'file=@./notes.pdf' \
      $BASE/v1/notebooks/<id>/sources/file

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -396,10 +396,10 @@ and the `_THIN_SOURCE_CHAR_THRESHOLD` boundary test).
 ```text
 task = studio_generate(notebook="Quantum Computing", artifact_type="audio")
 studio_status(notebook="Quantum Computing", task_id="<task_id from above>")   # poll until complete
-studio_download(notebook="Quantum Computing", artifact_type="audio", path="podcast.mp3")
+studio_download(notebook="Quantum Computing", artifact_type="audio", path="podcast.m4a")
 
 # Target a specific/older artifact instead of the latest-by-type (full ID or unique prefix):
-studio_download(notebook="Quantum Computing", artifact_type="audio", path="old_podcast.mp3", artifact_id="aaaaaaaa-aaaa")
+studio_download(notebook="Quantum Computing", artifact_type="audio", path="old_podcast.m4a", artifact_id="aaaaaaaa-aaaa")
 
 # Per-kind styling options are agent-settable, e.g. a custom-styled video:
 studio_generate(notebook="Quantum Computing", artifact_type="video",

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -36,7 +36,7 @@ async def main():
         # Generate a podcast
         status = await client.artifacts.generate_audio(nb.id)
         await client.artifacts.wait_for_completion(nb.id, status.task_id)
-        output_path = await client.artifacts.download_audio(nb.id, "podcast.mp3")
+        output_path = await client.artifacts.download_audio(nb.id, "podcast.m4a")
         print(f"Audio saved to: {output_path}")
 
 asyncio.run(main())
@@ -1393,7 +1393,7 @@ except ArtifactTimeoutError as exc:
     raise
 
 if final.is_complete:
-    path = await client.artifacts.download_audio(nb_id, "podcast.mp3")
+    path = await client.artifacts.download_audio(nb_id, "podcast.m4a")
     print(f"Saved to: {path}")
 else:
     print(f"Failed or timed out: {final.status}")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -58,7 +58,7 @@ async def main():
             print(f"  Complete! URL: {final.url}\n")
 
             # 5. Download (requires browser support)
-            # output_path = await client.artifacts.download_audio(nb.id, "./podcast.mp3")
+            # output_path = await client.artifacts.download_audio(nb.id, "./podcast.m4a")
             # print(f"  Downloaded to: {output_path}")
         else:
             print(f"  Generation status: {final.status}\n")

--- a/src/notebooklm/_app/download.py
+++ b/src/notebooklm/_app/download.py
@@ -53,6 +53,42 @@ FORMAT_EXTENSIONS: dict[str, str] = {
     "html": ".html",
 }
 
+#: The ONE file-extension → MIME-type table, keyed by the extensions the download
+#: specs resolve to. Lives here (next to :data:`FORMAT_EXTENSIONS`) rather than in
+#: any adapter so the MCP ``studio_download`` payload, the MCP ``/files/dl`` route,
+#: and the REST ``/download`` response all advertise the SAME Content-Type — and so
+#: none of them has to fall back to :mod:`mimetypes`, whose builtin table does not
+#: know ``.m4a`` (it resolves only when the host ships an ``/etc/mime.types``).
+#:
+#: ``.m4a`` → ``audio/mp4``: an Audio Overview is AAC in an ISO-BMFF/MP4 container,
+#: which is what the artifact row itself advertises (#2034). There is deliberately
+#: no ``.mp3`` row — no spec resolves to it.
+EXTENSION_MIME_TYPES: dict[str, str] = {
+    ".m4a": "audio/mp4",
+    ".mp4": "video/mp4",
+    ".pdf": "application/pdf",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".png": "image/png",
+    ".md": "text/markdown",
+    ".json": "application/json",
+    ".csv": "text/csv",
+    ".html": "text/html",
+}
+
+#: Fallback when an extension isn't in :data:`EXTENSION_MIME_TYPES` (unreachable for
+#: the registered specs — every spec extension is mapped — but keeps callers total).
+DEFAULT_MIME_TYPE = "application/octet-stream"
+
+
+def mime_type_for_extension(extension: str) -> str:
+    """The MIME type for ``extension`` (with leading dot), case-insensitively.
+
+    Falls back to :data:`DEFAULT_MIME_TYPE` for an unmapped extension rather than
+    guessing via :mod:`mimetypes`, whose result varies with the host's mime
+    database.
+    """
+    return EXTENSION_MIME_TYPES.get(extension.lower(), DEFAULT_MIME_TYPE)
+
 
 class ArtifactDict(TypedDict):
     """Artifact structure projected from the ``client.artifacts.list`` API."""

--- a/src/notebooklm/_app/download.py
+++ b/src/notebooklm/_app/download.py
@@ -12,9 +12,10 @@ vocabulary; the CLI adapter rebuilds its historical ``--json`` envelope in
 Public API: :class:`DownloadTypeSpec` (per-leaf metadata), :class:`DownloadPlan`
 (one validated invocation), :class:`DownloadResult` (the typed outcome),
 :func:`build_download_plan` (sync validation + assembly), :func:`execute_download`
-(the download coroutine), :data:`FORMAT_EXTENSIONS`, and the pure
-:func:`select_artifact` / :func:`artifact_title_to_filename` helpers re-exported
-by ``cli/download_helpers.py`` for its established import seam.
+(the download coroutine), the :data:`FORMAT_EXTENSIONS` and
+:data:`EXTENSION_MIME_TYPES` tables with :func:`mime_type_for_extension`, and the
+pure :func:`select_artifact` / :func:`artifact_title_to_filename` helpers
+re-exported by ``cli/download_helpers.py`` for its established import seam.
 
 The notebook-id and partial-artifact-id resolvers are **injected** as callables
 (``notebook_resolver`` / ``artifact_resolver``) so this module never imports the
@@ -54,11 +55,9 @@ FORMAT_EXTENSIONS: dict[str, str] = {
 }
 
 #: The ONE file-extension → MIME-type table, keyed by the extensions the download
-#: specs resolve to. Lives here (next to :data:`FORMAT_EXTENSIONS`) rather than in
-#: any adapter so the MCP ``studio_download`` payload, the MCP ``/files/dl`` route,
-#: and the REST ``/download`` response all advertise the SAME Content-Type — and so
-#: none of them has to fall back to :mod:`mimetypes`, whose builtin table does not
-#: know ``.m4a`` (it resolves only when the host ships an ``/etc/mime.types``).
+#: specs resolve to. Lives in this neutral core rather than in any adapter so the
+#: MCP ``studio_download`` payload, the MCP ``/files/dl`` route and the REST
+#: ``/download`` response all advertise the SAME Content-Type.
 #:
 #: ``.m4a`` → ``audio/mp4``: an Audio Overview is AAC in an ISO-BMFF/MP4 container,
 #: which is what the artifact row itself advertises (#2034). There is deliberately
@@ -83,9 +82,10 @@ DEFAULT_MIME_TYPE = "application/octet-stream"
 def mime_type_for_extension(extension: str) -> str:
     """The MIME type for ``extension`` (with leading dot), case-insensitively.
 
-    Falls back to :data:`DEFAULT_MIME_TYPE` for an unmapped extension rather than
-    guessing via :mod:`mimetypes`, whose result varies with the host's mime
-    database.
+    An unmapped extension falls back to :data:`DEFAULT_MIME_TYPE` rather than
+    being guessed via :mod:`mimetypes`, whose builtin table has no ``.m4a`` row
+    (it resolves only when the host ships an ``/etc/mime.types``) and otherwise
+    varies with the host's mime database.
     """
     return EXTENSION_MIME_TYPES.get(extension.lower(), DEFAULT_MIME_TYPE)
 
@@ -129,6 +129,25 @@ class DownloadTypeSpec:
     format_kwarg: str = ""
     format_param_name: str = "output_format"
     forward_format_only_if_set: bool = False
+
+
+def resolve_extension(spec: DownloadTypeSpec, output_format: str | None = None) -> str:
+    """The file extension a download of ``spec`` in ``output_format`` will carry.
+
+    ``output_format`` picks the extension for the format-bearing types (slide-deck
+    pdf/pptx; quiz/flashcards json/markdown/html) via the spec's
+    ``format_extension_map``; ``None`` — or a leaf with no format axis — yields the
+    spec's default ``extension`` (already the default format's extension).
+
+    An adapter that spools a download to a server-side temp file must name that
+    file with THIS extension rather than ``spec.extension``: a format-bearing type
+    writes a different representation than its default, so the default would label
+    a PPTX deck ``.pdf`` and a markdown quiz ``.json`` — and any Content-Type or
+    ``Content-Disposition`` derived from that name inherits the mislabel.
+    """
+    if output_format:
+        return spec.format_extension_map.get(output_format, spec.extension)
+    return spec.extension
 
 
 class _DownloadFacade(Protocol):
@@ -363,7 +382,7 @@ def artifact_title_to_filename(
 
     Args:
         title: Artifact title.
-        extension: File extension (with leading dot, e.g., ".mp3").
+        extension: File extension (with leading dot, e.g., ".m4a").
         existing_files: Set of filenames already used.
         max_length: Maximum filename length before extension.
 

--- a/src/notebooklm/cli/_download_specs.py
+++ b/src/notebooklm/cli/_download_specs.py
@@ -73,10 +73,8 @@ DOWNLOAD_SPECS: list[DownloadTypeSpec] = [
         name="audio",
         kind=ArtifactType.AUDIO,
         # ``.m4a``, NOT ``.mp3`` (#2034): the Audio Overview bytes are AAC in an
-        # ISO-BMFF/MP4 container. The artifact row itself advertises the media as
-        # ``audio/mp4`` — ``ArtifactRow.audio_url`` explicitly *prefers* that
-        # entry — so ``.mp3`` was always a mislabel that broke players,
-        # transcoders and MIME-sniffing upload endpoints.
+        # ISO-BMFF/MP4 container, which is what the artifact row itself advertises
+        # (``ArtifactRow.audio_url`` explicitly *prefers* the ``audio/mp4`` entry).
         extension=".m4a",
         default_dir="./audio",
         download_attr="download_audio",

--- a/src/notebooklm/cli/_download_specs.py
+++ b/src/notebooklm/cli/_download_specs.py
@@ -72,11 +72,16 @@ DOWNLOAD_SPECS: list[DownloadTypeSpec] = [
     DownloadTypeSpec(
         name="audio",
         kind=ArtifactType.AUDIO,
-        extension=".mp3",
+        # ``.m4a``, NOT ``.mp3`` (#2034): the Audio Overview bytes are AAC in an
+        # ISO-BMFF/MP4 container. The artifact row itself advertises the media as
+        # ``audio/mp4`` — ``ArtifactRow.audio_url`` explicitly *prefers* that
+        # entry — so ``.mp3`` was always a mislabel that broke players,
+        # transcoders and MIME-sniffing upload endpoints.
+        extension=".m4a",
         default_dir="./audio",
         download_attr="download_audio",
         help_summary="Download audio overview(s) to file.",
-        help_examples=_stock_examples("audio", ".mp3", "./audio"),
+        help_examples=_stock_examples("audio", ".m4a", "./audio"),
     ),
     DownloadTypeSpec(
         name="video",

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -55,6 +55,7 @@ from ._filelink import FileLinkError, FileTransferConfig
 from .tools._studio_download import (
     _DOWNLOAD_SPECS,
     _resolve_artifact_id,
+    download_extension,
     download_filename,
     download_mime_type,
 )
@@ -361,7 +362,14 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                     status_code=500,
                     headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"},
                 )
-            temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+            fmt = payload.get("fmt")
+            # Name the spool file for the extension the REQUESTED format resolves to.
+            # The served name + Content-Type below come from the format-aware
+            # ``download_filename`` / ``download_mime_type``, so this is invisible to
+            # the client either way — but keeping the on-disk name honest means the
+            # rule holds uniformly with the REST ``/download`` route, where the spool
+            # name IS what gets served (#2034).
+            temp_path = os.path.join(temp_dir, f"artifact{download_extension(spec, fmt)}")
             try:
                 args: dict[str, object] = {
                     "notebook_id": payload.get("nb"),
@@ -370,7 +378,6 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
                 }
                 if aid is not None:
                     args["artifact_id"] = aid
-                fmt = payload.get("fmt")
                 if fmt is not None:
                     args[spec.format_param_name] = fmt
                 plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -245,30 +245,16 @@ _KIND_TO_DOWNLOAD_KEY: dict[Any, DownloadType] = {
     spec.kind: cast(DownloadType, key) for key, spec in _DOWNLOAD_SPECS.items()
 }
 
-#: The extension → MIME-type table, re-exported from the neutral
-#: :mod:`notebooklm._app.download` core so the ``studio_download`` tool payload
-#: (:func:`_broker_download`), the ``/files/dl`` route, and the REST ``/download``
-#: response all advertise the SAME Content-Type. Aliased here (rather than
-#: inlined) to keep this module's historical name while leaving exactly one
-#: table to edit when a download type gains an extension.
-_EXTENSION_MIME_TYPES = download_core.EXTENSION_MIME_TYPES
-
-#: Fallback when an extension isn't in the table (unreachable for minted tokens —
-#: every spec extension is mapped — but keeps the helpers total).
-_DEFAULT_MIME = download_core.DEFAULT_MIME_TYPE
-
 
 def download_extension(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
     """The file extension a download of ``spec`` in ``output_format`` will carry.
 
-    ``output_format`` selects the extension for the format-bearing types
-    (slide-deck pdf/pptx; quiz/flashcards json/markdown/html) via the spec's
-    ``format_extension_map``; ``None`` (or a leaf with no format axis) yields the
-    spec's default ``extension`` (which is already the default format's extension).
+    Thin alias for :func:`~notebooklm._app.download.resolve_extension`, kept for
+    this module's established name (it is in ``__all__`` and read by
+    ``_fileroutes``); the rule itself lives in the neutral core so the REST
+    ``/download`` route resolves extensions identically.
     """
-    if output_format:
-        return spec.format_extension_map.get(output_format, spec.extension)
-    return spec.extension
+    return download_core.resolve_extension(spec, output_format)
 
 
 def download_filename(
@@ -286,7 +272,13 @@ def download_filename(
 
 
 def download_mime_type(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
-    """The MIME type for a download of ``spec`` in ``output_format`` (central table)."""
+    """The MIME type for a download of ``spec`` in ``output_format``.
+
+    Both the ``studio_download`` tool payload (:func:`_broker_download`) and the
+    ``/files/dl`` route derive their Content-Type from here, so they read the one
+    :data:`~notebooklm._app.download.EXTENSION_MIME_TYPES` table the REST
+    ``/download`` response uses and can never drift from it.
+    """
     return download_core.mime_type_for_extension(download_extension(spec, output_format))
 
 
@@ -408,7 +400,12 @@ async def _do_read_inline_artifact_text(
     # before the result is assigned, orphaning it past the ``finally`` cleanup.
     temp_dir = tempfile.mkdtemp(prefix="nblm-mcp-inline-")
     try:
-        temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+        # Format-resolved like every other spool site, so the invariant "a spooled
+        # download is named by ``resolve_extension``" holds everywhere and greps
+        # clean. Today's inline kinds (report / data-table) have no format axis, so
+        # this is identical to ``spec.extension`` — it is the future format-bearing
+        # text type that would otherwise reintroduce the #2034 mislabel here.
+        temp_path = os.path.join(temp_dir, f"artifact{download_extension(spec, output_format)}")
         args: dict[str, Any] = {
             "notebook_id": notebook_id,
             "output_path": temp_path,

--- a/src/notebooklm/mcp/tools/_studio_download.py
+++ b/src/notebooklm/mcp/tools/_studio_download.py
@@ -143,7 +143,9 @@ _DOWNLOAD_SPECS: dict[str, download_core.DownloadTypeSpec] = {
     "audio": download_core.DownloadTypeSpec(
         name="audio",
         kind=ArtifactType.AUDIO,
-        extension=".mp3",
+        # ``.m4a`` (AAC in an MP4 container), not ``.mp3`` — see the note on the
+        # CLI's matching row in ``cli/_download_specs.py`` (#2034).
+        extension=".m4a",
         default_dir="./audio",
         download_attr="download_audio",
         help_summary="",
@@ -243,27 +245,17 @@ _KIND_TO_DOWNLOAD_KEY: dict[Any, DownloadType] = {
     spec.kind: cast(DownloadType, key) for key, spec in _DOWNLOAD_SPECS.items()
 }
 
-#: The ONE file-extension → MIME-type table. Both the ``studio_download`` tool
-#: payload (:func:`_broker_download`) and the ``/files/dl`` route derive their
-#: Content-Type from this via :func:`download_mime_type`, so the advertised
-#: ``mime_type`` and the byte stream's ``Content-Type`` can never drift. Keyed by
-#: the extension the spec+format already resolve to, so a new download type only
-#: needs its extension mapped here.
-_EXTENSION_MIME_TYPES: dict[str, str] = {
-    ".mp3": "audio/mpeg",
-    ".mp4": "video/mp4",
-    ".pdf": "application/pdf",
-    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    ".png": "image/png",
-    ".md": "text/markdown",
-    ".json": "application/json",
-    ".csv": "text/csv",
-    ".html": "text/html",
-}
+#: The extension → MIME-type table, re-exported from the neutral
+#: :mod:`notebooklm._app.download` core so the ``studio_download`` tool payload
+#: (:func:`_broker_download`), the ``/files/dl`` route, and the REST ``/download``
+#: response all advertise the SAME Content-Type. Aliased here (rather than
+#: inlined) to keep this module's historical name while leaving exactly one
+#: table to edit when a download type gains an extension.
+_EXTENSION_MIME_TYPES = download_core.EXTENSION_MIME_TYPES
 
 #: Fallback when an extension isn't in the table (unreachable for minted tokens —
 #: every spec extension is mapped — but keeps the helpers total).
-_DEFAULT_MIME = "application/octet-stream"
+_DEFAULT_MIME = download_core.DEFAULT_MIME_TYPE
 
 
 def download_extension(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
@@ -295,7 +287,7 @@ def download_filename(
 
 def download_mime_type(spec: download_core.DownloadTypeSpec, output_format: str | None) -> str:
     """The MIME type for a download of ``spec`` in ``output_format`` (central table)."""
-    return _EXTENSION_MIME_TYPES.get(download_extension(spec, output_format), _DEFAULT_MIME)
+    return download_core.mime_type_for_extension(download_extension(spec, output_format))
 
 
 async def _passthrough_download_notebook(notebook_id: str) -> str:

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -593,17 +593,25 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
     # ``finally`` below.
     success = False
     try:
-        temp_path = os.path.join(temp_dir, f"artifact{spec.extension}")
+        if body.output_format is not None and not spec.format_choices:
+            raise ValidationError(f"type {body.type!r} does not support an output_format option")
+        # Name the spool file for the extension the REQUESTED format resolves to, not
+        # the spec default: this route serves ``os.path.basename(served)`` as the
+        # download name and derives Content-Type from its suffix, so ``spec.extension``
+        # would hand a ``--format pptx`` deck out as ``artifact.pdf`` /
+        # ``application/pdf`` and a markdown quiz as ``artifact.json``. (The MCP
+        # ``/files/dl`` route already resolves both format-aware; this brings the REST
+        # surface in line.)
+        temp_path = os.path.join(
+            temp_dir,
+            f"artifact{download_core.resolve_extension(spec, body.output_format)}",
+        )
         args: dict[str, Any] = {
             "notebook_id": notebook_id,
             "output_path": temp_path,
             "latest": True,
         }
         if body.output_format is not None:
-            if not spec.format_choices:
-                raise ValidationError(
-                    f"type {body.type!r} does not support an output_format option"
-                )
             args[spec.format_param_name] = body.output_format
         plan = download_core.build_download_plan(spec, args, cwd=Path.cwd())
         result = await download_core.execute_download(
@@ -629,12 +637,11 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
         served = result.output_path or temp_path
         if Path(temp_dir).resolve() not in Path(served).resolve().parents:
             raise ValidationError("Download produced an unexpected output path")
-        # Set ``media_type`` EXPLICITLY from the shared ``_app`` table rather than
-        # letting ``FileResponse`` guess via ``mimetypes``: the stdlib's builtin map
-        # has no ``.m4a`` row (it resolves only on hosts shipping ``/etc/mime.types``),
-        # so a guessed audio download would degrade to Starlette's ``text/plain``
-        # default on a slim container. Using the same table the MCP surfaces use also
-        # keeps the two servers' Content-Type in lockstep (#2034).
+        # ``media_type`` comes EXPLICITLY from the shared ``_app`` table — the same
+        # one the MCP surfaces read, so the two servers stay in lockstep. Left to
+        # guess, ``FileResponse`` would consult ``mimetypes``, which has no builtin
+        # ``.m4a`` row, and an audio download would degrade to Starlette's
+        # ``text/plain`` default on a slim container (#2034).
         response = _CleanupFileResponse(
             served,
             filename=os.path.basename(served),

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -639,9 +639,13 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
             raise ValidationError("Download produced an unexpected output path")
         # ``media_type`` comes EXPLICITLY from the shared ``_app`` table — the same
         # one the MCP surfaces read, so the two servers stay in lockstep. Left to
-        # guess, ``FileResponse`` would consult ``mimetypes``, which has no builtin
-        # ``.m4a`` row, and an audio download would degrade to Starlette's
-        # ``text/plain`` default on a slim container (#2034).
+        # guess, ``FileResponse`` falls back to
+        # ``guess_type(...)[0] or "application/octet-stream"``, and ``.m4a`` is NOT in
+        # ``mimetypes``' builtin table (``.mp3`` is) — it resolves only when the host
+        # ships a mime database such as ``/etc/mime.types``. So on a slim container an
+        # audio download would be served as ``application/octet-stream``, which defeats
+        # inline playback and any client that dispatches on MIME. Passing it explicitly
+        # also makes the header independent of the runner's mime database (#2034).
         response = _CleanupFileResponse(
             served,
             filename=os.path.basename(served),

--- a/src/notebooklm/server/routes/artifacts.py
+++ b/src/notebooklm/server/routes/artifacts.py
@@ -204,7 +204,9 @@ def _download_specs() -> dict[str, download_core.DownloadTypeSpec]:
         "audio": spec(
             name="audio",
             kind=ArtifactType.AUDIO,
-            extension=".mp3",
+            # ``.m4a`` (AAC in an MP4 container), not ``.mp3`` — see the note on
+            # the CLI's matching row in ``cli/_download_specs.py`` (#2034).
+            extension=".m4a",
             default_dir="./audio",
             download_attr="download_audio",
             help_summary="",
@@ -627,8 +629,17 @@ async def download(notebook_id: str, body: ArtifactDownload, client: ClientDep) 
         served = result.output_path or temp_path
         if Path(temp_dir).resolve() not in Path(served).resolve().parents:
             raise ValidationError("Download produced an unexpected output path")
+        # Set ``media_type`` EXPLICITLY from the shared ``_app`` table rather than
+        # letting ``FileResponse`` guess via ``mimetypes``: the stdlib's builtin map
+        # has no ``.m4a`` row (it resolves only on hosts shipping ``/etc/mime.types``),
+        # so a guessed audio download would degrade to Starlette's ``text/plain``
+        # default on a slim container. Using the same table the MCP surfaces use also
+        # keeps the two servers' Content-Type in lockstep (#2034).
         response = _CleanupFileResponse(
-            served, filename=os.path.basename(served), temp_dir=temp_dir
+            served,
+            filename=os.path.basename(served),
+            media_type=download_core.mime_type_for_extension(Path(served).suffix),
+            temp_dir=temp_dir,
         )
         success = True
         return response

--- a/tests/_guardrails/test_download_spec_parity.py
+++ b/tests/_guardrails/test_download_spec_parity.py
@@ -1,0 +1,138 @@
+"""The three ``DownloadTypeSpec`` registries must not drift apart.
+
+The CLI (``cli/_download_specs.py``), the MCP Studio tools
+(``mcp/tools/_studio_download.py``), and the REST server
+(``server/routes/artifacts.py``) each rebuild the SAME download-type table from
+the neutral ``_app.download`` types — deliberately, so neither adapter imports
+another's Click/FastMCP-coupled module. The cost of that deliberate duplication
+is that a per-type fix applied to one copy silently leaves the other two wrong.
+
+That is exactly how #2034 shipped: audio was registered as ``.mp3`` in all three
+tables while the artifact metadata advertises ``audio/mp4``, so every surface
+wrote AAC/MP4 bytes under an MP3 name. These tests pin the registries together
+on every field that decides what lands on disk, and pin every registered
+extension into the one shared MIME table, so a future one-surface edit fails
+loudly instead of shipping a partial fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notebooklm._app import download as download_core
+from notebooklm.cli._download_specs import DOWNLOAD_SPECS_BY_NAME
+
+pytest.importorskip("fastmcp", reason="MCP registry needs the 'mcp' extra")
+pytest.importorskip("fastapi", reason="REST registry needs the 'server' extra")
+
+from notebooklm.mcp.tools._studio_download import (  # noqa: E402 - after importorskip
+    _DOWNLOAD_SPECS as MCP_SPECS,
+)
+from notebooklm.server.routes.artifacts import DOWNLOAD_SPECS as SERVER_SPECS  # noqa: E402
+
+#: Spec fields that determine the bytes/filename a download produces.
+#:
+#: Deliberately excluded — these are adapter-local, not behavioural:
+#:
+#: * ``help_summary`` / ``help_examples`` — CLI ``--help`` prose; the neutral
+#:   registries leave them empty by design.
+#: * ``format_param_name`` — the name of the *adapter's own* kwarg carrying the
+#:   format choice. The CLI's slide-deck row keeps the legacy Click param name
+#:   ``slide_format`` while MCP/REST use the default ``output_format``; both
+#:   resolve to the same ``format_kwarg`` on the client call.
+_BEHAVIOURAL_FIELDS = (
+    "name",
+    "kind",
+    "extension",
+    "default_dir",
+    "download_attr",
+    "format_choices",
+    "format_default",
+    "format_extension_map",
+    "format_kwarg",
+    "forward_format_only_if_set",
+)
+
+
+def _behaviour(spec: download_core.DownloadTypeSpec) -> dict[str, Any]:
+    return {field: getattr(spec, field) for field in _BEHAVIOURAL_FIELDS}
+
+
+def test_registries_cover_the_same_download_types() -> None:
+    """All three tables register the same set of download-type keys."""
+    cli_names = set(DOWNLOAD_SPECS_BY_NAME)
+    assert set(MCP_SPECS) == cli_names, (
+        "mcp/tools/_studio_download.py::_DOWNLOAD_SPECS drifted from "
+        "cli/_download_specs.py::DOWNLOAD_SPECS: "
+        f"mcp-only={sorted(set(MCP_SPECS) - cli_names)} "
+        f"cli-only={sorted(cli_names - set(MCP_SPECS))}"
+    )
+    assert set(SERVER_SPECS) == cli_names, (
+        "server/routes/artifacts.py::DOWNLOAD_SPECS drifted from "
+        "cli/_download_specs.py::DOWNLOAD_SPECS: "
+        f"server-only={sorted(set(SERVER_SPECS) - cli_names)} "
+        f"cli-only={sorted(cli_names - set(SERVER_SPECS))}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(DOWNLOAD_SPECS_BY_NAME))
+def test_registries_agree_on_behavioural_fields(name: str) -> None:
+    """Each type's kind / extension / download binding / format axis match everywhere."""
+    cli_behaviour = _behaviour(DOWNLOAD_SPECS_BY_NAME[name])
+    for label, table in (
+        ("mcp/tools/_studio_download.py::_DOWNLOAD_SPECS", MCP_SPECS),
+        ("server/routes/artifacts.py::DOWNLOAD_SPECS", SERVER_SPECS),
+    ):
+        assert _behaviour(table[name]) == cli_behaviour, (
+            f"{label} row {name!r} disagrees with cli/_download_specs.py — a "
+            "per-type change must be applied to all three registries"
+        )
+
+
+def test_audio_downloads_are_labelled_m4a() -> None:
+    """Audio Overviews are AAC in an MP4 container, so ``.m4a`` / ``audio/mp4`` (#2034).
+
+    Pinned explicitly (not just cross-registry) because ``.mp3`` looks plausible
+    and passes every other test: the mislabel is only visible against the media
+    bytes, which no unit test downloads.
+    """
+    for label, spec in (
+        ("cli", DOWNLOAD_SPECS_BY_NAME["audio"]),
+        ("mcp", MCP_SPECS["audio"]),
+        ("server", SERVER_SPECS["audio"]),
+    ):
+        assert spec.extension == ".m4a", f"{label} audio spec regressed to {spec.extension!r}"
+    assert download_core.mime_type_for_extension(".m4a") == "audio/mp4"
+
+
+def test_every_registered_extension_has_a_mime_type() -> None:
+    """No spec can resolve to an extension the shared MIME table doesn't know.
+
+    An unmapped extension would silently degrade to ``application/octet-stream``
+    on the MCP link payload / ``/files/dl`` route and the REST ``/download``
+    response.
+    """
+    extensions = set()
+    for spec in DOWNLOAD_SPECS_BY_NAME.values():
+        extensions.add(spec.extension)
+        extensions.update(spec.format_extension_map.values())
+    unmapped = sorted(ext for ext in extensions if ext not in download_core.EXTENSION_MIME_TYPES)
+    assert unmapped == [], (
+        f"download extensions missing from _app.download.EXTENSION_MIME_TYPES: {unmapped}"
+    )
+
+
+def test_mime_table_has_no_unreachable_rows() -> None:
+    """The MIME table carries no extension no spec can produce.
+
+    A stale row is how a corrected mapping drifts back: ``.mp3 -> audio/mpeg``
+    survived in the MCP table long enough to be re-adopted.
+    """
+    reachable = set()
+    for spec in DOWNLOAD_SPECS_BY_NAME.values():
+        reachable.add(spec.extension)
+        reachable.update(spec.format_extension_map.values())
+    stale = sorted(ext for ext in download_core.EXTENSION_MIME_TYPES if ext not in reachable)
+    assert stale == [], f"unreachable rows in _app.download.EXTENSION_MIME_TYPES: {stale}"

--- a/tests/_guardrails/test_download_spec_parity.py
+++ b/tests/_guardrails/test_download_spec_parity.py
@@ -60,6 +60,15 @@ def _behaviour(spec: download_core.DownloadTypeSpec) -> dict[str, Any]:
     return {field: getattr(spec, field) for field in _BEHAVIOURAL_FIELDS}
 
 
+def _reachable_extensions() -> set[str]:
+    """Every extension a registered spec can resolve to — default and per-format."""
+    extensions: set[str] = set()
+    for spec in DOWNLOAD_SPECS_BY_NAME.values():
+        extensions.add(spec.extension)
+        extensions.update(spec.format_extension_map.values())
+    return extensions
+
+
 def test_registries_cover_the_same_download_types() -> None:
     """All three tables register the same set of download-type keys."""
     cli_names = set(DOWNLOAD_SPECS_BY_NAME)
@@ -114,11 +123,9 @@ def test_every_registered_extension_has_a_mime_type() -> None:
     on the MCP link payload / ``/files/dl`` route and the REST ``/download``
     response.
     """
-    extensions = set()
-    for spec in DOWNLOAD_SPECS_BY_NAME.values():
-        extensions.add(spec.extension)
-        extensions.update(spec.format_extension_map.values())
-    unmapped = sorted(ext for ext in extensions if ext not in download_core.EXTENSION_MIME_TYPES)
+    unmapped = sorted(
+        ext for ext in _reachable_extensions() if ext not in download_core.EXTENSION_MIME_TYPES
+    )
     assert unmapped == [], (
         f"download extensions missing from _app.download.EXTENSION_MIME_TYPES: {unmapped}"
     )
@@ -130,9 +137,6 @@ def test_mime_table_has_no_unreachable_rows() -> None:
     A stale row is how a corrected mapping drifts back: ``.mp3 -> audio/mpeg``
     survived in the MCP table long enough to be re-adopted.
     """
-    reachable = set()
-    for spec in DOWNLOAD_SPECS_BY_NAME.values():
-        reachable.add(spec.extension)
-        reachable.update(spec.format_extension_map.values())
+    reachable = _reachable_extensions()
     stale = sorted(ext for ext in download_core.EXTENSION_MIME_TYPES if ext not in reachable)
     assert stale == [], f"unreachable rows in _app.download.EXTENSION_MIME_TYPES: {stale}"

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -225,6 +225,31 @@ def test_download_with_output_format_streams(
     assert resp.content == fake_client.download_bytes
 
 
+def test_download_pptx_is_not_served_as_pdf(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """A ``--format pptx`` deck streams as ``.pptx``, not the spec-default ``.pdf``.
+
+    The route spools to ``artifact<ext>`` and then serves that basename as the
+    download name + derives Content-Type from its suffix. Naming the spool file
+    from ``spec.extension`` mislabelled every non-default format — a PPTX deck was
+    handed out as ``artifact.pdf`` / ``application/pdf``. Same defect class as the
+    ``.mp3``/AAC mislabel in #2034, on the format axis instead of the type axis.
+    """
+    fake_client.artifacts_store["nb-1"] = {"d1": make_artifact("d1", "slide-deck")}
+    resp = authed_client.post(
+        "/v1/notebooks/nb-1/artifacts/download",
+        json={"type": "slide-deck", "output_format": "pptx"},
+    )
+    assert resp.status_code == 200
+    assert ".pptx" in resp.headers["content-disposition"]
+    assert ".pdf" not in resp.headers["content-disposition"]
+    assert (
+        resp.headers["content-type"]
+        == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
+
+
 def test_download_unexpected_output_path_is_rejected(
     authed_client: TestClient, fake_client: FakeClient, tmp_path: object
 ) -> None:

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -101,6 +101,24 @@ def test_download_completed_artifact_streams_bytes(
     assert resp.content == fake_client.download_bytes
 
 
+def test_download_audio_advertises_m4a_and_audio_mp4(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """Audio streams as ``.m4a`` / ``audio/mp4``, never ``.mp3`` / ``audio/mpeg`` (#2034).
+
+    ``media_type`` is asserted because the route sets it EXPLICITLY from the shared
+    ``_app.download`` table: the stdlib ``mimetypes`` map that ``FileResponse``
+    would otherwise consult has no builtin ``.m4a`` row, so a guessed type would
+    degrade to ``text/plain`` on a host without ``/etc/mime.types``.
+    """
+    fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
+    resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/mp4"
+    assert ".m4a" in resp.headers["content-disposition"]
+    assert ".mp3" not in resp.headers["content-disposition"]
+
+
 def test_download_not_ready_is_409(authed_client: TestClient) -> None:
     # No artifacts exist → NO_ARTIFACTS → 409, not 500.
     resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})

--- a/tests/server/test_artifacts.py
+++ b/tests/server/test_artifacts.py
@@ -108,8 +108,11 @@ def test_download_audio_advertises_m4a_and_audio_mp4(
 
     ``media_type`` is asserted because the route sets it EXPLICITLY from the shared
     ``_app.download`` table: the stdlib ``mimetypes`` map that ``FileResponse``
-    would otherwise consult has no builtin ``.m4a`` row, so a guessed type would
-    degrade to ``text/plain`` on a host without ``/etc/mime.types``.
+    would otherwise consult has no builtin ``.m4a`` row (``.mp3`` it does have), so
+    a guessed type would degrade to ``FileResponse``'s
+    ``"application/octet-stream"`` fallback on a host without ``/etc/mime.types``.
+    Asserting the exact header therefore also pins this test to be independent of
+    whichever mime database the CI runner happens to ship (#2034).
     """
     fake_client.artifacts_store["nb-1"] = {"a1": make_artifact("a1", "audio")}
     resp = authed_client.post("/v1/notebooks/nb-1/artifacts/download", json={"type": "audio"})

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -634,7 +634,7 @@ class TestDownloadAll:
         assert result.exit_code == 0
         assert output_dir.exists()
         # Check that files were downloaded
-        downloaded_files = list(output_dir.glob("*.mp3"))
+        downloaded_files = list(output_dir.glob("*.m4a"))
         assert len(downloaded_files) == 2
 
     def test_download_all_dry_run(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
@@ -700,7 +700,7 @@ class TestDownloadAll:
         # is non-zero because at least one item failed.
         assert result.exit_code != 0
         # One file should be downloaded
-        downloaded_files = list(output_dir.glob("*.mp3"))
+        downloaded_files = list(output_dir.glob("*.m4a"))
         assert len(downloaded_files) == 1
         # The text-mode renderer must show the structured "Failed" section
         # listing the actual error, not just the boolean "Error: True" guard.
@@ -944,7 +944,7 @@ class TestDownloadAllNameFilter:
 
         assert result.exit_code == 0
         assert sorted(downloaded_ids) == ["audio_beta1", "audio_beta2"]
-        downloaded_files = list(output_dir.glob("*.mp3"))
+        downloaded_files = list(output_dir.glob("*.m4a"))
         assert len(downloaded_files) == 2
 
     def test_name_filter_dry_run_previews_only_matches(
@@ -1069,9 +1069,9 @@ class TestDownloadAllDryRunFilenameParity:
         # All three filenames must be distinct (the second and third get
         # auto-renamed via (2)/(3) suffixes — same as the execution path).
         assert len(set(filenames)) == 3
-        assert "Duplicate Title.mp3" in filenames
-        assert "Duplicate Title (2).mp3" in filenames
-        assert "Duplicate Title (3).mp3" in filenames
+        assert "Duplicate Title.m4a" in filenames
+        assert "Duplicate Title (2).m4a" in filenames
+        assert "Duplicate Title (3).m4a" in filenames
 
     def test_dry_run_matches_execution_filenames(
         self, runner, mock_auth, mock_fetch_tokens, tmp_path
@@ -1145,7 +1145,7 @@ class TestDownloadAllDryRunFilenameParity:
         output_dir = tmp_path / "downloads"
         output_dir.mkdir(parents=True)
         # Create existing file
-        (output_dir / "First Audio.mp3").write_bytes(b"existing")
+        (output_dir / "First Audio.m4a").write_bytes(b"existing")
 
         async def mock_download_audio(notebook_id, output_path, artifact_id=None, **kwargs):
             Path(output_path).write_bytes(b"new content")
@@ -1167,9 +1167,9 @@ class TestDownloadAllDryRunFilenameParity:
 
         assert result.exit_code == 0
         # First file should remain unchanged
-        assert (output_dir / "First Audio.mp3").read_bytes() == b"existing"
+        assert (output_dir / "First Audio.m4a").read_bytes() == b"existing"
         # Second file should be downloaded
-        assert (output_dir / "Second Audio.mp3").exists()
+        assert (output_dir / "Second Audio.m4a").exists()
 
 
 # =============================================================================

--- a/tests/unit/cli/test_download_characterization.py
+++ b/tests/unit/cli/test_download_characterization.py
@@ -74,7 +74,7 @@ class _CmdSpec:
 
 
 _LEAF_COMMANDS: list[_CmdSpec] = [
-    _CmdSpec("audio", 1, ".mp3", "download_audio"),
+    _CmdSpec("audio", 1, ".m4a", "download_audio"),  # AAC/MP4, not MP3 (#2034)
     _CmdSpec("video", 3, ".mp4", "download_video"),
     _CmdSpec("infographic", 7, ".png", "download_infographic"),
     _CmdSpec("slide-deck", 8, ".pdf", "download_slide_deck"),

--- a/tests/unit/mcp/test_file_tools.py
+++ b/tests/unit/mcp/test_file_tools.py
@@ -746,8 +746,8 @@ async def test_artifact_download_with_config_returns_resource_link(mock_client, 
     # Presentation metadata enriches the payload (#1826): a latest-by-type download
     # has no known title, so the filename falls back to the type name + extension,
     # the mime comes from the central table, and size is unknown up front.
-    assert sc["filename"] == "audio.mp3"
-    assert sc["mime_type"] == "audio/mpeg"
+    assert sc["filename"] == "audio.m4a"
+    assert sc["mime_type"] == "audio/mp4"
     assert sc["size_bytes"] is None
     # A clickable resource_link content item is included for claude.ai.
     assert any(getattr(block, "type", None) == "resource_link" for block in result.content)
@@ -924,8 +924,8 @@ async def test_artifact_download_remote_tool_encodes_aid(mock_client, config) ->
     assert sc["artifact_id"] == _AID_A
     # An explicit id resolves the artifact's title cheaply from the same list, so the
     # advertised filename is derived from it (not the type-name fallback) (#1826).
-    assert sc["filename"] == "Podcast.mp3"
-    assert sc["mime_type"] == "audio/mpeg"
+    assert sc["filename"] == "Podcast.m4a"
+    assert sc["mime_type"] == "audio/mp4"
     url = sc["url"]
     token = url.split("/")[-1]
     payload = config.signer.verify(token, op="dl")

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -97,8 +97,11 @@ def test_download_good_token_streams_bytes_no_bearer(monkeypatch, mock_client, c
     assert resp.status_code == 200
     assert resp.content == b"AUDIO"
     # The Content-Disposition uses the artifact title + the real extension, NOT
-    # the core's internal "artifact.mp3" (RFC 5987 percent-encodes the space).
-    assert "My%20Podcast.mp3" in resp.headers.get("content-disposition", "")
+    # the core's internal "artifact.m4a" (RFC 5987 percent-encodes the space).
+    # ``.m4a`` / ``audio/mp4``, not ``.mp3`` / ``audio/mpeg``: an Audio Overview is
+    # AAC in an MP4 container (#2034).
+    assert "My%20Podcast.m4a" in resp.headers.get("content-disposition", "")
+    assert "audio/mp4" in resp.headers["content-type"]
     assert resp.headers["cache-control"] == "no-store"
 
 

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -204,6 +204,18 @@ async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> 
     )
 
 
+def _audio_facade(download_audio: AsyncMock) -> SimpleNamespace:
+    """A facade serving one completed audio artifact, downloaded by ``download_audio``."""
+    audio = _artifact("a1", "Deep Dive", 1)
+    return SimpleNamespace(
+        artifacts=SimpleNamespace(
+            list=AsyncMock(return_value=[audio]),
+            _list_for_download=AsyncMock(return_value=([audio], [], [])),
+            download_audio=download_audio,
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_audio_derived_filename_is_m4a(tmp_path: Path) -> None:
     """With no ``--output`` path, an audio download derives a ``.m4a`` name (#2034).
@@ -213,15 +225,8 @@ async def test_audio_derived_filename_is_m4a(tmp_path: Path) -> None:
     download.
     """
     spec = DOWNLOAD_SPECS_BY_NAME["audio"]
-    audio = _artifact("a1", "Deep Dive", 1)
     download_audio = AsyncMock(return_value=None)
-    facade = SimpleNamespace(
-        artifacts=SimpleNamespace(
-            list=AsyncMock(return_value=[audio]),
-            _list_for_download=AsyncMock(return_value=([audio], [], [])),
-            download_audio=download_audio,
-        )
-    )
+    facade = _audio_facade(download_audio)
 
     plan = build_download_plan(spec, _args(latest=True), tmp_path)
     result = await execute_download(plan, facade)
@@ -239,16 +244,9 @@ async def test_explicit_output_path_extension_is_still_honoured(tmp_path: Path) 
     output path keeps working unchanged (the bytes were always AAC either way).
     """
     spec = DOWNLOAD_SPECS_BY_NAME["audio"]
-    audio = _artifact("a1", "Deep Dive", 1)
     chosen = str(tmp_path / "legacy-name.mp3")
     download_audio = AsyncMock(return_value=chosen)
-    facade = SimpleNamespace(
-        artifacts=SimpleNamespace(
-            list=AsyncMock(return_value=[audio]),
-            _list_for_download=AsyncMock(return_value=([audio], [], [])),
-            download_audio=download_audio,
-        )
-    )
+    facade = _audio_facade(download_audio)
 
     plan = build_download_plan(spec, _args(latest=True, output_path=chosen), tmp_path)
     result = await execute_download(plan, facade)

--- a/tests/unit/test_download_service.py
+++ b/tests/unit/test_download_service.py
@@ -127,8 +127,8 @@ async def test_execute_download_all_dry_run_applies_name_filter_and_duplicate_fi
         "count": 2,
         "output_dir": str(tmp_path / "downloads"),
         "artifacts": [
-            {"id": "a1", "title": "Episode", "filename": "Episode.mp3"},
-            {"id": "a2", "title": "Episode", "filename": "Episode (2).mp3"},
+            {"id": "a1", "title": "Episode", "filename": "Episode.m4a"},
+            {"id": "a2", "title": "Episode", "filename": "Episode (2).m4a"},
         ],
     }
     artifacts.download_audio.assert_not_called()
@@ -145,7 +145,7 @@ async def test_execute_download_all_reports_partial_failure_and_progress(tmp_pat
             ]
         ),
         download_audio=AsyncMock(
-            side_effect=[str(tmp_path / "Episode 1.mp3"), RuntimeError("boom")]
+            side_effect=[str(tmp_path / "Episode 1.m4a"), RuntimeError("boom")]
         ),
     )
     facade = SimpleNamespace(artifacts=artifacts)
@@ -202,3 +202,56 @@ async def test_execute_download_single_forwards_format_kwarg(tmp_path: Path) -> 
         artifact_id="quiz_1",
         output_format="markdown",
     )
+
+
+@pytest.mark.asyncio
+async def test_audio_derived_filename_is_m4a(tmp_path: Path) -> None:
+    """With no ``--output`` path, an audio download derives a ``.m4a`` name (#2034).
+
+    The Audio Overview bytes are AAC in an MP4 container (the artifact row itself
+    advertises ``audio/mp4``), so ``.mp3`` mislabelled every default-named
+    download.
+    """
+    spec = DOWNLOAD_SPECS_BY_NAME["audio"]
+    audio = _artifact("a1", "Deep Dive", 1)
+    download_audio = AsyncMock(return_value=None)
+    facade = SimpleNamespace(
+        artifacts=SimpleNamespace(
+            list=AsyncMock(return_value=[audio]),
+            _list_for_download=AsyncMock(return_value=([audio], [], [])),
+            download_audio=download_audio,
+        )
+    )
+
+    plan = build_download_plan(spec, _args(latest=True), tmp_path)
+    result = await execute_download(plan, facade)
+
+    assert result["status"] == "downloaded"
+    assert result["output_path"] == str(tmp_path / "Deep Dive.m4a")
+    assert download_audio.await_args.args[1] == str(tmp_path / "Deep Dive.m4a")
+
+
+@pytest.mark.asyncio
+async def test_explicit_output_path_extension_is_still_honoured(tmp_path: Path) -> None:
+    """An explicit ``.mp3`` path is written verbatim — the #2034 fix is not a rename.
+
+    Only the DERIVED filename changed, so a script that already passes its own
+    output path keeps working unchanged (the bytes were always AAC either way).
+    """
+    spec = DOWNLOAD_SPECS_BY_NAME["audio"]
+    audio = _artifact("a1", "Deep Dive", 1)
+    chosen = str(tmp_path / "legacy-name.mp3")
+    download_audio = AsyncMock(return_value=chosen)
+    facade = SimpleNamespace(
+        artifacts=SimpleNamespace(
+            list=AsyncMock(return_value=[audio]),
+            _list_for_download=AsyncMock(return_value=([audio], [], [])),
+            download_audio=download_audio,
+        )
+    )
+
+    plan = build_download_plan(spec, _args(latest=True, output_path=chosen), tmp_path)
+    result = await execute_download(plan, facade)
+
+    assert result["output_path"] == chosen
+    assert download_audio.await_args.args[1] == chosen


### PR DESCRIPTION
Fixes #2034

**Scope — this PR fixes two bugs of the same class, both in the diff:**

1. **#2034 (type axis):** `download audio` labelled AAC/MP4 bytes `.mp3`. Fixed to `.m4a` / `audio/mp4` on CLI, MCP and REST.
2. **Format axis (found while fixing the above):** the REST `/download` route named its spool file from the type's *default* extension regardless of `output_format`, then served that name and derived Content-Type from it — so `--format pptx` was served as `artifact.pdf` / `application/pdf`. Not scope creep: shipping the type-axis fix while leaving the format axis broken would be half a fix, and the same `resolve_extension` rule repairs both. Codex reached this one independently during review.

## The bug

`notebooklm download audio` wrote the audio-overview file with a `.mp3` extension, but the bytes are AAC in an ISO-BMFF/MP4 container. Anything that trusts the extension — players, transcoders, MIME-sniffing upload endpoints — mishandled the file, and because the extension is the *only* wrong part it is easy to lose hours on.

## The bytes were never MP3

Two independent lines of in-repo evidence, no live probe needed:

1. **Every audio artifact row on the wire advertises `audio/mp4`.** Across `tests/cassettes/*.yaml` there are **84 occurrences of `audio/mp4` and zero of `audio/mpeg`**. The rows carry `[url, code, mime]` media triples and the audio ones are uniformly `audio/mp4` — which is exactly the MIME type of `.m4a`.

2. **The codebase already knew.** `src/notebooklm/_row_adapters/artifacts.py:372` reads *"Audio Overview media URL, preferring the `audio/mp4` entry"* — the adapter explicitly selects the `audio/mp4` variant when picking the download URL, and then the spec labelled the result `.mp3`.

Both match the reporter's `ffprobe` (`codec_name=aac`, `format_name=mov,mp4,m4a,…`).

Video is unaffected (`video/mp4` → `.mp4`). Infographic/slide-deck rows carry no MIME at all, and report / mind-map / data-table / quiz / flashcards are formatted locally, so audio was the only type-axis mismatch.

## Why not derive the extension from `Content-Type`

The issue suggests deriving from the response header or sniffing magic bytes. Neither is structurally possible here:

- **The filename is chosen before the fetch.** `_app/download.py` resolves the output path in `build_download_plan` / `_execute_download_single`, and only then does `_artifact/downloads.py::download_url` issue the request. Header-derived naming would mean writing and then renaming, which breaks the "an explicit output path is honoured verbatim" contract.
- **The MCP broker never fetches at all.** `_broker_download` mints `filename` + `mime_type` into a *signed link* without touching the artifact — its own docstring says `size_bytes` is `None` because it "can't be known without eagerly fetching the artifact, which this must not do". There is no response to read a header from on that path.

So the extension stays a static spec field, corrected to `.m4a`. If per-artifact variance ever appears there is already a pre-fetch source of truth to switch to — the artifact row's own `audio/mp4` — but today it is invariant, so a constant is the honest encoding.

## Fixed on all three surfaces

The `DownloadTypeSpec` registry is deliberately rebuilt three times (layering forbids `server/` and `mcp/` from importing `cli/`), so the fix touches all three:

| Surface | File |
|---|---|
| CLI `download audio` | `cli/_download_specs.py` |
| MCP `studio_download` + `/files/dl` | `mcp/tools/_studio_download.py` |
| REST `POST .../artifacts/download` | `server/routes/artifacts.py` |

The extension→MIME table moves into the neutral `_app/download.py` (`EXTENSION_MIME_TYPES` / `mime_type_for_extension`) so all three advertise the same Content-Type from one place.

### Why the REST route now sets `media_type` explicitly

`.m4a` is **absent from Python's builtin `mimetypes` map**. Verified:

```python
>>> mimetypes.MimeTypes(filenames=(), strict=True).types_map[True].get('.m4a')
None      # builtin table — no .m4a row
>>> mimetypes.guess_type('x.m4a')
('audio/mp4', None)   # only because THIS host ships /etc/mime.types
```

Left to guess, `FileResponse` falls back to `guess_type(...)[0] or "application/octet-stream"` on any host without an `/etc/mime.types` — i.e. a slim deploy container. (**Correction to an earlier revision of this description**, which said `text/plain`: that is the base `Response` default, not `FileResponse`'s. `application/octet-stream` is still the wrong answer for audio — it defeats inline playback and any client dispatching on MIME — so the conclusion is unchanged, but the stated mechanism was wrong and is now verified against Starlette's source.) This is not hypothetical: inside the running `deploy-notebooklm-mcp-1` container `guess_type('x.m4a')` returns `(None, None)` (verified independently in that container; on this host it returns `('audio/mp4', None)` because this host ships a mime database). So the route passes `media_type` from the shared table instead of relying on the ambient mime database.

## Second bug, same class, found while fixing this

The REST route named its spool file `artifact{spec.extension}` — the type's **default** extension — regardless of `output_format`, then served that basename as the download filename and derived Content-Type from its suffix. So:

- `--format pptx` slide deck → served as `artifact.pdf` / `application/pdf`
- `--format markdown` quiz → served as `artifact.json` / `application/json`

Same defect as #2034 on the *format* axis instead of the *type* axis. The MCP `/files/dl` route already resolved both format-aware and was unaffected; this brings REST in line. The rule now lives in `_app/download.py::resolve_extension` and every spool site uses it, so the invariant greps clean.

`tests/server/test_artifacts.py::test_download_pptx_is_not_served_as_pdf` covers it — confirmed it fails without the fix with `attachment; filename="artifact.pdf"`.

## Guardrail

Nothing previously enforced that the three duplicated registries agree — `test_generation_kind_exhaustiveness.py` checks names/kinds/`download_attr` but never `extension`. That absence is exactly how a one-surface fix ships half-broken, so this adds `tests/_guardrails/test_download_spec_parity.py`: registries agree on every behavioural field, audio pinned to `.m4a`/`audio/mp4`, and the extension↔MIME table is total in both directions (no unmapped extension, no unreachable row — a stale `.mp3 → audio/mpeg` row is how a corrected mapping drifts back).

It immediately earned its keep by catching a real divergence: the CLI's slide-deck row keeps the legacy Click param name `format_param_name="slide_format"` while MCP/REST use `output_format`. That field is adapter-local, so it is excluded with a documented rationale rather than "fixed".

## ⚠ Migration

**Only *derived* filenames change.** An explicit output path is still honoured verbatim, so `notebooklm download audio out.mp3` keeps writing `out.mp3` (with the same, still-AAC bytes) — covered by a regression test.

What changes: the default name when you pass no path, the per-file names under `--all`, and the `filename` / `mime_type` the MCP and REST surfaces advertise.

- Scripts globbing `*.mp3` should glob `*.m4a` (or both during a transition).
- Re-running `download audio --all <dir>` after upgrading writes new `.m4a` files **alongside** any `.mp3` files a previous run left there — the names no longer collide, so nothing is overwritten or auto-renamed.

No deprecation runway: the file was never MP3, so there is no state in which the old name was correct. Per the repo's breaking-change policy, runways are for real contracts; a wrong file extension is a bug. CHANGELOG carries the migration note under `[Unreleased] → Fixed`.

## Verification

> **CI status.** The post-v0.8.0 allowlist prune landed in #2037, so `Code Quality` is green and the 15-job `Test` matrix (3 OS x 5 Python) is executing on this branch for the first time — rebased onto `27926aa4`. Per-leg results are reported in a comment below. The numbers in this block are the local run.

```
mypy src/notebooklm --ignore-missing-imports   Success: no issues found in 314 source files
pytest tests -q                                12459 passed, 64 skipped, 1 xfailed in 498.06s
ruff check . && ruff format --check .          All checks passed! / 951 files already formatted
```

Docs updated: `cli-reference` (the extension table now reads "AAC audio in an MP4 container"), `python-api`, `installation`, `mcp-guide`, `README`, `SKILL.md`, `examples/quickstart.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WddM9PnqkU8S3wmFYPorD5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio Overview downloads now use `.m4a` filenames and `audio/mp4` metadata across CLI, MCP, and REST.
  * REST artifact downloads now use the requested output format’s correct filename extension and MIME type, including non-default formats.
  * Explicit output paths remain unchanged.

* **Documentation**
  * Updated quick starts, guides, CLI references, and examples to show `.m4a` audio downloads and AAC audio in an MP4 container.

* **Tests**
  * Added coverage validating consistent download behavior and metadata across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

