### PR TITLE
fix(scripts): preserve cookie domains in the RPC-health / bundle-drift auth path (#2019)

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -235,8 +235,12 @@ jobs:
     # so a drift hit files an issue rather than red-failing the canary outright.
     - name: Run bundle drift monitor
       id: bundle
-      # Reads auth from the profile materialized above (load_auth_from_storage
-      # falls back to the storage_state.json file when the env var is absent).
+      # Reads auth from the profile materialized above
+      # (build_httpx_cookies_from_storage falls back to the storage_state.json
+      # file when the env var is absent). It must stay the DOMAIN-PRESERVING
+      # loader: a flat name->value mapping handed to httpx.get(cookies=...)
+      # carries no domain, so every cookie is sent to every host in the
+      # redirect chain regardless of which auth source fed it — issue #2019.
       continue-on-error: true
       shell: bash
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type axis. The MCP `/files/dl` route already resolved both format-aware and
   was unaffected
   ([#2034](https://github.com/teng-lin/notebooklm-py/issues/2034)).
+- **Nightly RPC-health and bundle-drift checks no longer report "Authentication
+  expired" against valid credentials.** `scripts/check_rpc_health.py` and
+  `scripts/capture_rpc_registry.py` loaded auth through the flat
+  `load_auth_from_storage()` mapping, which drops every cookie's domain. Under
+  `NOTEBOOKLM_AUTH_JSON` there is no storage file to recover them from, so
+  host-scoped cookies (`OSID` on the NotebookLM host, `LSID` on
+  `accounts.google.com`) were broadcast to every `*.google.com` host. Once
+  Google's `notebook.google.com` cutover landed, the stale broadcast `OSID`
+  collided with the freshly minted host cookie and dead-ended the sign-in chain
+  on `accounts.google.com/CookieMismatch`. Both scripts now use the
+  domain-preserving loaders the CLI already used
+  (`AuthTokens.from_storage()` / `build_httpx_cookies_from_storage()`), and a
+  unit guardrail pins that the jar mirrors the `storage_state` domains
+  ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019),
+  [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018)).
 
 ## [0.8.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on `accounts.google.com/CookieMismatch`. Both scripts now use the
   domain-preserving loaders the CLI already used
   (`AuthTokens.from_storage()` / `build_httpx_cookies_from_storage()`), and a
-  unit guardrail pins that the jar mirrors the `storage_state` domains
+  unit guardrail pins that the jar mirrors the `storage_state` domains and that
+  a host-scoped cookie value never reaches a host it was not scoped to
   ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019),
   [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018)).
+
+### Changed
+
+- **`scripts/check_rpc_health.py` reports what it authenticated with.** The
+  report now names the auth source (`NOTEBOOKLM_AUTH_JSON` vs the resolved
+  profile path), the base host, the account route, and the cookie jar's
+  `name@domain` scopes — names and domains only, never values. #2019 was a
+  cookie-*scoping* failure that surfaced as a generic "authentication expired"
+  line, leaving the nightly log with nothing to diagnose it from
+  ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019)).
 
 ## [0.8.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,17 +42,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Nightly RPC-health and bundle-drift checks no longer report "Authentication
   expired" against valid credentials.** `scripts/check_rpc_health.py` and
   `scripts/capture_rpc_registry.py` loaded auth through the flat
-  `load_auth_from_storage()` mapping, which drops every cookie's domain. Under
-  `NOTEBOOKLM_AUTH_JSON` there is no storage file to recover them from, so
+  `load_auth_from_storage()` mapping, which drops every cookie's domain, so
   host-scoped cookies (`OSID` on the NotebookLM host, `LSID` on
   `accounts.google.com`) were broadcast to every `*.google.com` host. Once
   Google's `notebook.google.com` cutover landed, the stale broadcast `OSID`
   collided with the freshly minted host cookie and dead-ended the sign-in chain
-  on `accounts.google.com/CookieMismatch`. Both scripts now use the
-  domain-preserving loaders the CLI already used
+  on `accounts.google.com/CookieMismatch`. The health check lost the domains
+  only under `NOTEBOOKLM_AUTH_JSON`, where there is no storage file to rebuild
+  the jar from; the drift monitor lost them unconditionally, because a plain
+  mapping handed to `httpx.get(cookies=...)` carries no domain at all. Both now
+  use the domain-preserving loaders the CLI already used
   (`AuthTokens.from_storage()` / `build_httpx_cookies_from_storage()`), and a
-  unit guardrail pins that the jar mirrors the `storage_state` domains and that
-  a host-scoped cookie value never reaches a host it was not scoped to
+  unit guardrail pins — for both the env-var and the profile-file
+  configuration — that the jar mirrors the `storage_state` domains and that a
+  host-scoped cookie value never reaches a host it was not scoped to
   ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019),
   [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,15 +47,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `accounts.google.com`) were broadcast to every `*.google.com` host. Once
   Google's `notebook.google.com` cutover landed, the stale broadcast `OSID`
   collided with the freshly minted host cookie and dead-ended the sign-in chain
-  on `accounts.google.com/CookieMismatch`. The health check lost the domains
-  only under `NOTEBOOKLM_AUTH_JSON`, where there is no storage file to rebuild
-  the jar from; the drift monitor lost them unconditionally, because a plain
-  mapping handed to `httpx.get(cookies=...)` carries no domain at all. Both now
-  use the domain-preserving loaders the CLI already used
+  on `accounts.google.com/CookieMismatch`. Flattening also **lost** data
+  outright, which is the more serious half: a flat map has one slot per name,
+  so where `OSID` legitimately existed on both the app host and
+  `accounts.google.com` with different values, the duplicate-name resolution
+  silently discarded one of them before any request was built — the sign-in
+  host then received a value that was never its own. The health check lost the
+  domains only under `NOTEBOOKLM_AUTH_JSON`, where there is no storage file to
+  rebuild the jar from; the drift monitor lost them unconditionally, because a
+  plain mapping handed to `httpx.get(cookies=...)` carries no domain at all.
+  Both now use the domain-preserving loaders the CLI already used
   (`AuthTokens.from_storage()` / `build_httpx_cookies_from_storage()`), and a
   unit guardrail pins — for both the env-var and the profile-file
-  configuration — that the jar mirrors the `storage_state` domains and that a
-  host-scoped cookie value never reaches a host it was not scoped to
+  configuration — that the jar mirrors the `storage_state` domains, that a
+  host-scoped cookie value never reaches a host it was not scoped to, and that
+  the same-named sibling on the other host survives
   ([#2019](https://github.com/teng-lin/notebooklm-py/issues/2019),
   [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018)).
 

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -410,12 +410,12 @@ def fetch_bundle() -> str:
     import httpx
 
     from notebooklm._env import get_base_url
-    from notebooklm.auth import authuser_query, load_auth_from_storage
+    from notebooklm.auth import authuser_query, build_httpx_cookies_from_storage
 
     def _fetch(
         url: str,
         *,
-        cookies: dict[str, str] | None = None,
+        cookies: httpx.Cookies | None = None,
         follow_redirects: bool = False,
         timeout: float = 60.0,
     ) -> httpx.Response:
@@ -429,7 +429,13 @@ def fetch_bundle() -> str:
         response.raise_for_status()
         return response
 
-    cookies = load_auth_from_storage()
+    # Domain-preserving jar, NOT the flat ``load_auth_from_storage()`` mapping:
+    # a plain ``dict`` handed to ``httpx.get(cookies=...)`` carries no domain, so
+    # every cookie is sent to every host in the redirect chain. Host-scoped
+    # cookies (``OSID`` on the NotebookLM host, ``LSID`` on
+    # ``accounts.google.com``) leaking across hosts dead-ends the post-cutover
+    # sign-in chain on ``accounts.google.com/CookieMismatch`` — see issue #2019.
+    cookies = build_httpx_cookies_from_storage()
     html = _fetch(
         f"{get_base_url()}/?{authuser_query(0)}",
         cookies=cookies,

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -61,7 +61,7 @@ from notebooklm._chat.wire import (
     build_streaming_chat_request,
     parse_streaming_chat_response,
 )
-from notebooklm._env import get_default_language
+from notebooklm._env import get_base_url, get_default_language
 from notebooklm._logging import scrub_secrets
 from notebooklm._notebooks import build_create_notebook_params
 from notebooklm.auth import AuthTokens
@@ -226,6 +226,25 @@ def extract_id(data: Any, *indices: int) -> str | None:
         return None
 
 
+def describe_auth_source(storage_path: Path | None) -> str:
+    """Name where credentials were loaded from, for diagnostics."""
+    return "NOTEBOOKLM_AUTH_JSON env var" if storage_path is None else str(storage_path)
+
+
+def describe_cookie_scopes(auth: AuthTokens) -> str:
+    """Summarise the jar as ``name@domain`` pairs — names and domains only.
+
+    #2019 was a cookie-*scoping* failure that produced a generic "authentication
+    expired" line, so the nightly log carried nothing to diagnose it with. Cookie
+    names and domains are not secrets (values are never printed), and having them
+    in the report makes the next scoping regression readable from the log alone.
+    """
+    jar = auth.cookie_jar
+    if jar is None:
+        return "<no jar>"
+    return ", ".join(sorted(f"{cookie.name}@{cookie.domain}" for cookie in jar.jar))
+
+
 async def load_auth(storage_path: Path | None) -> AuthTokens:
     """Load auth from environment or storage file, preserving cookie domains.
 
@@ -248,18 +267,32 @@ async def load_auth(storage_path: Path | None) -> AuthTokens:
     that collides with the freshly minted host cookie, dead-ends the sign-in
     redirect chain on ``accounts.google.com/CookieMismatch``, and made this
     script report "Authentication expired" against perfectly valid credentials.
+
+    Only the three failure classes below are mapped to the AUTH exit code.
+    ``RuntimeError`` (a failed ``NOTEBOOKLM_REFRESH_CMD``) and non-missing-file
+    ``OSError`` still propagate as a traceback, exactly as they did through the
+    old ``fetch_tokens`` call.
     """
     try:
         return await AuthTokens.from_storage(storage_path)
-    except FileNotFoundError:
+    except FileNotFoundError as e:
+        # ``e`` names the storage path that was actually checked — under
+        # profiles that is the only way to see which one the script resolved.
         print(
-            "ERROR: No authentication found.\n"
+            f"ERROR: No authentication found: {scrub_secrets(e)}\n"
             "Set NOTEBOOKLM_AUTH_JSON env var or run 'notebooklm login'",
             file=sys.stderr,
         )
         sys.exit(2)
     except ValueError as e:
-        print(f"ERROR: {scrub_secrets(e)}", file=sys.stderr)
+        # Name the auth source. The file branch of ``_load_storage_state``
+        # re-raises a bare ``json`` error carrying no context at all, so a
+        # corrupt storage_state.json would otherwise print only
+        # "Expecting value: line 1 column 1 (char 0)".
+        print(
+            f"ERROR: {scrub_secrets(e)}\nAuth source: {describe_auth_source(storage_path)}",
+            file=sys.stderr,
+        )
         sys.exit(2)
     except httpx.HTTPError as e:
         # ``httpx`` exception strings can echo full request URLs including
@@ -1301,9 +1334,13 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     temp_resources = TempResources()
     cohort_status = CohortStatus.UNKNOWN
 
-    print("Fetching auth tokens...")
-    auth = await load_auth(resolve_storage_path())
+    storage_path = resolve_storage_path()
+    print(f"Fetching auth tokens... (source: {describe_auth_source(storage_path)})")
+    auth = await load_auth(storage_path)
     print(f"Auth OK (CSRF token length: {len(auth.csrf_token)})")
+    print(f"  base host:     {httpx.URL(get_base_url()).host}")
+    print(f"  account route: {auth.account_route}")
+    print(f"  cookie scopes: {describe_cookie_scopes(auth)}")
     print()
 
     async with httpx.AsyncClient(timeout=30.0) as client:

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -64,13 +64,7 @@ from notebooklm._chat.wire import (
 from notebooklm._env import get_default_language
 from notebooklm._logging import scrub_secrets
 from notebooklm._notebooks import build_create_notebook_params
-from notebooklm.auth import (
-    AuthTokens,
-    fetch_tokens,
-    get_account_email_for_storage,
-    get_authuser_for_storage,
-    load_auth_from_storage,
-)
+from notebooklm.auth import AuthTokens
 from notebooklm.exceptions import ChatError, ChatResponseParseError, DecodingError
 from notebooklm.paths import get_storage_path
 from notebooklm.rpc import (
@@ -232,16 +226,31 @@ def extract_id(data: Any, *indices: int) -> str | None:
         return None
 
 
-def load_auth() -> dict[str, str]:
-    """Load auth from environment or storage file.
+async def load_auth(storage_path: Path | None) -> AuthTokens:
+    """Load auth from environment or storage file, preserving cookie domains.
 
-    Uses the library's load_auth_from_storage() which handles:
-    - NOTEBOOKLM_AUTH_JSON env var (for CI)
-    - ~/.notebooklm/storage_state.json file (for local dev)
-    - Proper cookie domain filtering
+    Routes through :meth:`AuthTokens.from_storage` — the same loader the CLI
+    and library use — which handles:
+
+    - ``NOTEBOOKLM_AUTH_JSON`` env var (for CI) and the profile storage file
+      (for local dev), via ``storage_path`` resolved by
+      :func:`resolve_storage_path`
+    - cookie-domain filtering *and* per-cookie domain preservation
+    - authuser / account-email routing and the CSRF + session token fetch
+
+    Domain preservation is load-bearing (issue #2019). The previous
+    ``load_auth_from_storage()`` + ``fetch_tokens()`` pairing flattened the jar
+    to ``name -> value``; under ``NOTEBOOKLM_AUTH_JSON`` there is no file to
+    reload from, so ``build_cookie_jar`` re-pinned every cookie to
+    ``.google.com``. Host-scoped cookies (``OSID`` / ``__Secure-OSID`` on the
+    NotebookLM host, ``LSID`` on ``accounts.google.com``) were then broadcast to
+    every ``*.google.com`` host. After Google's ``notebook.google.com`` cutover
+    that collides with the freshly minted host cookie, dead-ends the sign-in
+    redirect chain on ``accounts.google.com/CookieMismatch``, and made this
+    script report "Authentication expired" against perfectly valid credentials.
     """
     try:
-        cookies = load_auth_from_storage()
+        return await AuthTokens.from_storage(storage_path)
     except FileNotFoundError:
         print(
             "ERROR: No authentication found.\n"
@@ -250,9 +259,16 @@ def load_auth() -> dict[str, str]:
         )
         sys.exit(2)
     except ValueError as e:
-        print(f"ERROR: Invalid authentication: {e}", file=sys.stderr)
+        print(f"ERROR: {scrub_secrets(e)}", file=sys.stderr)
         sys.exit(2)
-    return cookies
+    except httpx.HTTPError as e:
+        # ``httpx`` exception strings can echo full request URLs including
+        # ``f.sid=<session_id>`` query params, so scrub before logging.
+        print(
+            f"ERROR: Network error while fetching auth tokens: {scrub_secrets(e)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 
 def resolve_storage_path() -> Path | None:
@@ -1275,7 +1291,6 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     exit-coded separately from RPC drift; see :class:`CohortStatus`).
     """
     storage_path = resolve_storage_path()
-    cookies = load_auth()
 
     notebook_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or os.environ.get(
         "NOTEBOOKLM_GENERATION_NOTEBOOK_ID"
@@ -1289,27 +1304,7 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     cohort_status = CohortStatus.UNKNOWN
 
     print("Fetching auth tokens...")
-    try:
-        csrf_token, session_id = await fetch_tokens(cookies, storage_path=storage_path)
-    except ValueError as e:
-        print(f"ERROR: {scrub_secrets(e)}", file=sys.stderr)
-        sys.exit(2)
-    except httpx.HTTPError as e:
-        # ``httpx`` exception strings can echo full request URLs including
-        # ``f.sid=<session_id>`` query params, so scrub before logging.
-        print(
-            f"ERROR: Network error while fetching auth tokens: {scrub_secrets(e)}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    auth = AuthTokens(
-        cookies=cookies,
-        csrf_token=csrf_token,
-        session_id=session_id,
-        storage_path=storage_path,
-        authuser=get_authuser_for_storage(storage_path),
-        account_email=get_account_email_for_storage(storage_path),
-    )
+    auth = await load_auth(storage_path)
     print(f"Auth OK (CSRF token length: {len(auth.csrf_token)})")
     print()
 

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -1290,8 +1290,6 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     the ``sqTeoe`` studio-customization cohort tripwire verdict (reported and
     exit-coded separately from RPC drift; see :class:`CohortStatus`).
     """
-    storage_path = resolve_storage_path()
-
     notebook_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or os.environ.get(
         "NOTEBOOKLM_GENERATION_NOTEBOOK_ID"
     )
@@ -1304,7 +1302,7 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     cohort_status = CohortStatus.UNKNOWN
 
     print("Fetching auth tokens...")
-    auth = await load_auth(storage_path)
+    auth = await load_auth(resolve_storage_path())
     print(f"Auth OK (CSRF token length: {len(auth.csrf_token)})")
     print()
 

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -715,10 +715,12 @@ def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
     monkeypatch.setattr("sys.argv", ["check_rpc_health.py"])
 
-    def _missing() -> dict[str, str]:
-        raise FileNotFoundError("simulated missing storage_state.json")
+    class _MissingAuthTokens:
+        @staticmethod
+        async def from_storage(path: Path | None) -> Any:
+            raise FileNotFoundError("simulated missing storage_state.json")
 
-    monkeypatch.setattr(check_rpc_health, "load_auth_from_storage", _missing)
+    monkeypatch.setattr(check_rpc_health, "AuthTokens", _MissingAuthTokens)
 
     with pytest.raises(SystemExit) as excinfo:
         check_rpc_health.main()

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -12,15 +12,17 @@ These tests pin down the new policy:
     * All OK                     -> exit 0
 
 Priority when statuses collide: MISMATCH (1) > non-transient ERROR (3) > OK (0).
-AUTH (2) is signalled earlier via ``sys.exit(2)`` and is exercised in the
-auth-failure test by invoking ``main()`` with a missing storage env var.
+AUTH (2) is signalled earlier via ``sys.exit(2)``; every failure class
+``load_auth`` maps to it — missing storage, ``ValueError``, ``httpx.HTTPError``
+— is exercised in the auth-failure section near the end of this file.
+
+Cookie-domain scoping of the same ``load_auth`` path is a separate concern and
+lives in ``tests/unit/test_scripts_auth_cookie_domains.py`` (issue #2019).
 """
 
 from __future__ import annotations
 
-import importlib.util
 import json
-import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -29,18 +31,14 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 
-# Load scripts/check_rpc_health.py as a module. The ``scripts`` directory
-# is not a package, so we go through importlib rather than a normal import.
-# Registering the module in ``sys.modules`` before executing it is required
-# so that ``@dataclass`` can resolve forward references back to this module
-# during class construction.
-_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_rpc_health.py"
-_spec = importlib.util.spec_from_file_location("check_rpc_health", _SCRIPT_PATH)
-assert _spec is not None and _spec.loader is not None
-check_rpc_health = importlib.util.module_from_spec(_spec)
-sys.modules["check_rpc_health"] = check_rpc_health
-_spec.loader.exec_module(check_rpc_health)
-
+# ``scripts`` is importable as a namespace package (``pythonpath = ["."]`` in
+# pyproject), so a plain import is enough — and it yields the SAME module object
+# as ``tests/unit/test_capture_rpc_registry.py`` and
+# ``tests/unit/test_scripts_auth_cookie_domains.py`` use. The previous
+# ``importlib.util.spec_from_file_location`` preamble registered a second,
+# independent module under the bare name ``check_rpc_health``; patching one
+# copy left the other untouched.
+from scripts import check_rpc_health
 
 CheckStatus = check_rpc_health.CheckStatus
 CheckResult = check_rpc_health.CheckResult
@@ -701,30 +699,84 @@ async def test_chat_probe_surfaces_class_name_for_empty_message_errors() -> None
 
 
 # ---------------------------------------------------------------------------
-# main() auth-failure path -> exit 2
+# auth-failure paths -> exit 2
+#
+# Every failure class ``load_auth`` maps to the AUTH exit code gets a test.
+# Before #2019 only the missing-file arm was covered, so the ``ValueError`` and
+# ``httpx.HTTPError`` arms — including the ``scrub_secrets`` call that keeps
+# ``f.sid=<session_id>`` out of the CI log — shipped unverified.
 # ---------------------------------------------------------------------------
 
 
-def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Missing ``NOTEBOOKLM_AUTH_JSON`` must surface as exit code 2.
+def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A genuinely absent storage file must surface as exit code 2.
 
-    Even if the developer running the test happens to have a local
-    ``~/.notebooklm/storage_state.json``, we patch the loader to simulate
-    a fresh CI environment with no credentials available.
+    Nothing is patched: ``NOTEBOOKLM_HOME`` is pointed at an empty directory so
+    the real loader resolves a real (nonexistent) path and raises
+    ``FileNotFoundError`` for itself. That also insulates the test from the
+    developer's own ``~/.notebooklm/storage_state.json``.
     """
     monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
     monkeypatch.setattr("sys.argv", ["check_rpc_health.py"])
-
-    class _MissingAuthTokens:
-        @staticmethod
-        async def from_storage(path: Path | None) -> Any:
-            raise FileNotFoundError("simulated missing storage_state.json")
-
-    monkeypatch.setattr(check_rpc_health, "AuthTokens", _MissingAuthTokens)
 
     with pytest.raises(SystemExit) as excinfo:
         check_rpc_health.main()
     assert excinfo.value.code == 2
+
+
+async def _load_auth_raising(monkeypatch: pytest.MonkeyPatch, error: BaseException) -> None:
+    """Run ``load_auth`` with ``AuthTokens.from_storage`` raising ``error``."""
+
+    class _RaisingAuthTokens:
+        @staticmethod
+        async def from_storage(path: Path | None) -> Any:
+            raise error
+
+    monkeypatch.setattr(check_rpc_health, "AuthTokens", _RaisingAuthTokens)
+    await check_rpc_health.load_auth(None)
+
+
+async def test_load_auth_exits_two_and_names_the_source_on_value_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A ``ValueError`` exits 2 and says which auth source produced it.
+
+    The file branch of ``_load_storage_state`` re-raises a bare ``json`` error
+    with no context, so without the source line a corrupt storage_state.json
+    prints only ``Expecting value: line 1 column 1 (char 0)``.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        await _load_auth_raising(monkeypatch, ValueError("Expecting value: line 1 column 1"))
+    assert excinfo.value.code == 2
+
+    stderr = capsys.readouterr().err
+    assert "Expecting value: line 1 column 1" in stderr
+    assert "Auth source: NOTEBOOKLM_AUTH_JSON env var" in stderr
+
+
+async def test_load_auth_exits_two_and_scrubs_secrets_on_http_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A transport failure exits 2 with the session id redacted.
+
+    ``httpx`` exception strings echo the full request URL, which carries
+    ``f.sid=<session_id>``. This report is printed straight into the Actions log
+    and into the auto-filed issue body, so the redaction is load-bearing.
+    """
+    leaky = httpx.ConnectError(
+        "All connection attempts failed for "
+        "https://notebooklm.google.com/batchexecute?f.sid=-8891234567890123456"
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        await _load_auth_raising(monkeypatch, leaky)
+    assert excinfo.value.code == 2
+
+    stderr = capsys.readouterr().err
+    assert "Network error while fetching auth tokens" in stderr
+    assert "-8891234567890123456" not in stderr, (
+        "the session id must not reach the CI log or the auto-filed issue body"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -271,13 +271,12 @@ async def test_check_rpc_health_auth_preserves_domains_for_file_backed_profile(
     _assert_sign_in_hop_correctly_scoped(httpx_mock)
     _assert_app_hop_correctly_scoped(httpx_mock)
 
-    # The rotation was persisted, and persisted with its scope intact.
+    # The rotation was persisted, and persisted with its scope intact — the
+    # accounts-scoped OSID must still be there, untouched, alongside it.
     persisted = json.loads(storage_path.read_text(encoding="utf-8"))
-    assert (
-        _cookie_entry("OSID", _MINTED_OSID, _notebook_host())["name"],
-        _MINTED_OSID,
-        _notebook_host(),
-    ) in {(c["name"], c["value"], c["domain"]) for c in persisted["cookies"]}
+    persisted_triples = {(c["name"], c["value"], c["domain"]) for c in persisted["cookies"]}
+    assert ("OSID", _MINTED_OSID, _notebook_host()) in persisted_triples
+    assert ("OSID", "v-osid-accounts", _ACCOUNTS_HOST) in persisted_triples
 
 
 def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -152,10 +152,16 @@ def _cookies_sent_to(
     ]
 
 
-def _register_sign_in_chain(httpx_mock: HTTPXMock, homepage_url: str) -> None:
+def _register_sign_in_chain(
+    httpx_mock: HTTPXMock, homepage_url: str, *, final_html: str = _HOMEPAGE_HTML
+) -> None:
     """NotebookLM → sign-in → NotebookLM, minting a fresh host OSID at the end.
 
-    This is the post-cutover redirect shape that broke the nightly canary.
+    This is the post-cutover redirect shape that broke the nightly canary. Both
+    scripts follow redirects on their authenticated read, so both go through it;
+    ``final_html`` is the only thing that differs (WIZ tokens for the health
+    check, a bundle URL for the drift monitor).
+
     ``pytest_httpx`` defaults to ``is_reusable=False`` +
     ``assert_all_responses_were_requested=True``, so an extra hop errors loudly
     and a skipped hop fails teardown.
@@ -165,7 +171,7 @@ def _register_sign_in_chain(httpx_mock: HTTPXMock, homepage_url: str) -> None:
     httpx_mock.add_response(
         url=homepage_url,
         status_code=200,
-        html=_HOMEPAGE_HTML,
+        html=final_html,
         headers={"Set-Cookie": f"OSID={_MINTED_OSID}; Path=/; Secure; HttpOnly"},
     )
 
@@ -294,11 +300,13 @@ def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(
     bundle_url = (
         f"https://www.gstatic.com/_/mss/{capture_rpc_registry._APP}/_/js/k=boq.en.abc123.js"
     )
-    homepage_url = f"{get_base_url()}/?authuser=0"
-    httpx_mock.add_response(url=homepage_url, status_code=302, headers={"Location": _SIGN_IN_URL})
-    httpx_mock.add_response(url=_SIGN_IN_URL, status_code=302, headers={"Location": homepage_url})
-    httpx_mock.add_response(
-        url=homepage_url, status_code=200, html=f'<script src="{bundle_url}"></script>'
+    # Same chain the health check walks — only the final body differs. The
+    # ``?authuser=0`` suffix is what ``authuser_query(0)`` produces, so this is
+    # the real request shape, not an approximation of it.
+    _register_sign_in_chain(
+        httpx_mock,
+        f"{get_base_url()}/?authuser=0",
+        final_html=f'<script src="{bundle_url}"></script>',
     )
     httpx_mock.add_response(
         url=bundle_url,

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -20,14 +20,22 @@ collides with it and the chain dead-ends on
 "Authentication expired or invalid".
 
 The live rpc-health workflow cannot gate a PR, so these offline tests pin the
-contract instead: the jar each script authenticates with must mirror the
-``storage_state`` domains exactly, and a host-scoped cookie must never ride
-along to a host it was not scoped to.
+contract instead. Two properties matter, and the fixture is built so neither can
+be satisfied by accident:
+
+* the jar each script authenticates with mirrors the ``storage_state`` domains;
+* **a specific cookie value never reaches a host it was not scoped to.** The
+  fixture deliberately carries ``OSID`` on *both* the NotebookLM host and
+  ``accounts.google.com`` with different values, because same-name-different-
+  domain is the entire reason domains matter — a name-only assertion
+  (``"OSID" not in sent``) would be wrong here, and flattening destroys the
+  accounts-scoped value outright.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -38,11 +46,17 @@ from notebooklm._env import get_base_url
 from scripts import capture_rpc_registry, check_rpc_health
 
 _ACCOUNTS_HOST = "accounts.google.com"
-_SIGN_IN_URL = f"https://{_ACCOUNTS_HOST}/ServiceLogin"
+_SIGN_IN_PATH = "/ServiceLogin"
+_SIGN_IN_URL = f"https://{_ACCOUNTS_HOST}{_SIGN_IN_PATH}"
 
 _HOMEPAGE_HTML = (
     '<html><script>window.WIZ_global_data={"SNlM0e":"csrf_ok","FdrFJe":"sess_ok"};</script></html>'
 )
+
+# The sign-in chain mints a *fresh* host-scoped OSID on the way back — the exact
+# mechanism #2019 describes. Simulating it keeps the jar assertions honest: they
+# must survive a rotation rather than pinning a jar that never changes.
+_MINTED_OSID = "v-osid-minted"
 
 
 def _notebook_host() -> str:
@@ -72,14 +86,19 @@ def _storage_state() -> dict[str, Any]:
     """Storage state spanning three hosts, mirroring a real logged-in profile.
 
     ``SID`` + ``__Secure-1PSIDTS`` are the ``MINIMUM_REQUIRED_COOKIES`` the auth
-    validators demand; ``OSID`` and ``LSID`` are the host-scoped pair the #2019
-    regression broadcast domain-wide.
+    validators demand. ``OSID`` / ``__Secure-OSID`` are the per-product binding
+    cookies Google scopes to the app host, and ``LSID`` is scoped to the sign-in
+    host — the population #2019 broadcast domain-wide. ``OSID`` appears on *two*
+    hosts with different values so the wire assertions can distinguish "the right
+    OSID arrived" from "an OSID arrived".
     """
     return {
         "cookies": [
             _cookie_entry("SID", "v-sid", ".google.com"),
             _cookie_entry("__Secure-1PSIDTS", "v-psidts", ".google.com"),
-            _cookie_entry("OSID", "v-osid", _notebook_host()),
+            _cookie_entry("OSID", "v-osid-app", _notebook_host()),
+            _cookie_entry("__Secure-OSID", "v-secure-osid-app", _notebook_host()),
+            _cookie_entry("OSID", "v-osid-accounts", _ACCOUNTS_HOST),
             _cookie_entry("LSID", "v-lsid", _ACCOUNTS_HOST),
         ],
         "origins": [],
@@ -94,17 +113,91 @@ def _jar_pairs(jar: httpx.Cookies) -> set[tuple[str, str]]:
     return {(cookie.name, cookie.domain) for cookie in jar.jar}
 
 
-def _cookie_names(header: str) -> set[str]:
-    return {pair.split("=", 1)[0].strip() for pair in header.split(";") if pair.strip()}
+def _jar_value(jar: httpx.Cookies, name: str, domain: str) -> str | None:
+    for cookie in jar.jar:
+        if cookie.name == name and cookie.domain == domain:
+            return cookie.value
+    return None
 
 
-def _cookie_names_sent_to(httpx_mock: HTTPXMock, host: str) -> list[set[str]]:
-    """Cookie names carried by each recorded request that reached ``host``."""
+def _cookie_pairs(header: str) -> set[tuple[str, str]]:
+    """``(name, value)`` pairs from a ``Cookie:`` header.
+
+    Values are kept deliberately: the contract is "the *app-host* OSID never
+    reaches the sign-in host", which a name-only view cannot express once the
+    sign-in host legitimately has an OSID of its own.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for chunk in header.split(";"):
+        chunk = chunk.strip()
+        if "=" in chunk:
+            name, value = chunk.split("=", 1)
+            pairs.add((name.strip(), value.strip()))
+    return pairs
+
+
+def _cookies_sent_to(
+    httpx_mock: HTTPXMock, host: str, path: str | None = None
+) -> list[set[tuple[str, str]]]:
+    """``(name, value)`` pairs carried by each recorded request to ``host``.
+
+    ``path`` narrows to one endpoint. The sign-in assertions use it so they
+    cannot be satisfied by the autouse ``accounts.google.com/RotateCookies``
+    keepalive mock in ``tests/conftest.py`` instead of the redirect hop.
+    """
     return [
-        _cookie_names(request.headers.get("cookie", ""))
+        _cookie_pairs(request.headers.get("cookie", ""))
         for request in httpx_mock.get_requests()
-        if request.url.host == host
+        if request.url.host == host and (path is None or request.url.path == path)
     ]
+
+
+def _register_sign_in_chain(httpx_mock: HTTPXMock, homepage_url: str) -> None:
+    """NotebookLM → sign-in → NotebookLM, minting a fresh host OSID at the end.
+
+    This is the post-cutover redirect shape that broke the nightly canary.
+    ``pytest_httpx`` defaults to ``is_reusable=False`` +
+    ``assert_all_responses_were_requested=True``, so an extra hop errors loudly
+    and a skipped hop fails teardown.
+    """
+    httpx_mock.add_response(url=homepage_url, status_code=302, headers={"Location": _SIGN_IN_URL})
+    httpx_mock.add_response(url=_SIGN_IN_URL, status_code=302, headers={"Location": homepage_url})
+    httpx_mock.add_response(
+        url=homepage_url,
+        status_code=200,
+        html=_HOMEPAGE_HTML,
+        headers={"Set-Cookie": f"OSID={_MINTED_OSID}; Path=/; Secure; HttpOnly"},
+    )
+
+
+def _assert_sign_in_hop_correctly_scoped(httpx_mock: HTTPXMock) -> None:
+    """The sign-in hop gets the sign-in host's cookies and nothing else."""
+    sent = _cookies_sent_to(httpx_mock, _ACCOUNTS_HOST, _SIGN_IN_PATH)
+    assert sent, f"expected a {_SIGN_IN_URL} hop"
+    for pairs in sent:
+        assert ("OSID", "v-osid-app") not in pairs, (
+            "the app-host OSID must not be broadcast to the sign-in host "
+            f"(issue #2019); sent: {sorted(pairs)}"
+        )
+        assert ("OSID", _MINTED_OSID) not in pairs
+        assert ("__Secure-OSID", "v-secure-osid-app") not in pairs
+        # Positive controls: the cookies that *are* scoped to the sign-in host
+        # still ride along, so the assertions above cannot pass by dropping
+        # cookies wholesale — including the same-named OSID that belongs here.
+        assert {("OSID", "v-osid-accounts"), ("LSID", "v-lsid"), ("SID", "v-sid")} <= pairs
+
+
+def _assert_app_hop_correctly_scoped(httpx_mock: HTTPXMock) -> None:
+    """The app host gets its own binding cookies and not the sign-in host's."""
+    sent = _cookies_sent_to(httpx_mock, _notebook_host())
+    assert sent, "expected at least one NotebookLM-host request"
+    for pairs in sent:
+        assert ("LSID", "v-lsid") not in pairs, (
+            f"the sign-in-host LSID must not be sent to {_notebook_host()}; sent: {sorted(pairs)}"
+        )
+        assert ("OSID", "v-osid-accounts") not in pairs
+        assert ("__Secure-OSID", "v-secure-osid-app") in pairs
+        assert ("SID", "v-sid") in pairs
 
 
 async def test_check_rpc_health_auth_preserves_cookie_domains(
@@ -112,25 +205,18 @@ async def test_check_rpc_health_auth_preserves_cookie_domains(
 ) -> None:
     """``check_rpc_health.load_auth`` must build a domain-preserving jar.
 
-    Drives the real auth path against a mocked NotebookLM → sign-in →
-    NotebookLM redirect chain (the shape of the post-cutover hop that broke the
-    nightly canary) and asserts both halves of the contract: the resulting jar
-    mirrors ``storage_state``, and the ``accounts.google.com`` hop carries only
-    the cookies actually scoped to it.
+    Drives the real auth path under ``NOTEBOOKLM_AUTH_JSON`` — the CI
+    configuration that exposed the bug — against the post-cutover redirect
+    chain, and pins both halves of the contract: the resulting jar mirrors
+    ``storage_state``, and each hop carries only the cookies scoped to it.
 
     Fails against the pre-#2019 ``load_auth_from_storage`` + ``fetch_tokens``
-    pairing, which collapsed all four cookies onto ``.google.com``.
+    pairing, which collapsed every cookie onto ``.google.com``.
     """
     storage_state = _storage_state()
     monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(storage_state))
+    _register_sign_in_chain(httpx_mock, f"{get_base_url()}/")
 
-    homepage_url = f"{get_base_url()}/"
-    httpx_mock.add_response(url=homepage_url, status_code=302, headers={"Location": _SIGN_IN_URL})
-    httpx_mock.add_response(url=_SIGN_IN_URL, status_code=302, headers={"Location": homepage_url})
-    httpx_mock.add_response(url=homepage_url, status_code=200, html=_HOMEPAGE_HTML)
-
-    # ``resolve_storage_path()`` returns None under NOTEBOOKLM_AUTH_JSON, which
-    # is exactly the CI configuration that exposed the bug.
     storage_path = check_rpc_health.resolve_storage_path()
     assert storage_path is None
     auth = await check_rpc_health.load_auth(storage_path)
@@ -138,69 +224,96 @@ async def test_check_rpc_health_auth_preserves_cookie_domains(
     assert auth.csrf_token == "csrf_ok"
     assert auth.session_id == "sess_ok"
 
-    # 1. Jar-level: every cookie kept its original domain.
+    # Jar-level: the set of (name, domain) pairs still mirrors storage_state
+    # even though one cookie rotated, and the rotated value landed on the app
+    # host only — it did not overwrite the sign-in host's same-named cookie.
     assert auth.cookie_jar is not None
     assert _jar_pairs(auth.cookie_jar) == _name_domain_pairs(storage_state)
+    assert _jar_value(auth.cookie_jar, "OSID", _notebook_host()) == _MINTED_OSID
+    assert _jar_value(auth.cookie_jar, "OSID", _ACCOUNTS_HOST) == "v-osid-accounts"
 
-    # 2. Wire-level: the sign-in hop must not receive the NotebookLM-host OSID.
-    sent_to_accounts = _cookie_names_sent_to(httpx_mock, _ACCOUNTS_HOST)
-    assert sent_to_accounts, "expected at least one accounts.google.com hop"
-    for names in sent_to_accounts:
-        assert "OSID" not in names, (
-            "the NotebookLM-host OSID must not be broadcast to "
-            f"{_ACCOUNTS_HOST} (issue #2019); sent: {sorted(names)}"
-        )
-        # Positive control: the cookies that *are* scoped there still ride along,
-        # so the assertion above cannot pass by dropping cookies wholesale.
-        assert {"SID", "LSID"} <= names
+    # Wire-level, both directions.
+    _assert_sign_in_hop_correctly_scoped(httpx_mock)
+    _assert_app_hop_correctly_scoped(httpx_mock)
 
-    # 3. Positive control on the other side: the NotebookLM host still gets OSID.
-    sent_to_notebook = _cookie_names_sent_to(httpx_mock, _notebook_host())
-    assert sent_to_notebook
-    assert all("OSID" in names for names in sent_to_notebook)
+    # Routing: a storage state with no in-band account record must still resolve
+    # to the default account, so the canary's batchexecute URLs are unchanged.
+    assert auth.authuser == 0
+    assert auth.account_email is None
+
+
+async def test_check_rpc_health_auth_preserves_domains_for_file_backed_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, httpx_mock: HTTPXMock
+) -> None:
+    """The same contract holds when auth comes from a profile file, not the env.
+
+    This is the configuration #2037 moves CI to. It exercises a different branch
+    of ``AuthTokens.from_storage`` (``get_authuser_for_storage`` rather than the
+    in-band storage-state read) and, unlike the env-var path, actually persists
+    rotated cookies — so the rotated ``OSID`` must reach disk still scoped to the
+    app host.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+
+    storage_path = check_rpc_health.resolve_storage_path()
+    assert storage_path is not None
+    storage_state = _storage_state()
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_text(json.dumps(storage_state), encoding="utf-8")
+
+    _register_sign_in_chain(httpx_mock, f"{get_base_url()}/")
+
+    auth = await check_rpc_health.load_auth(storage_path)
+
+    assert auth.cookie_jar is not None
+    assert _jar_pairs(auth.cookie_jar) == _name_domain_pairs(storage_state)
+    _assert_sign_in_hop_correctly_scoped(httpx_mock)
+    _assert_app_hop_correctly_scoped(httpx_mock)
+
+    # The rotation was persisted, and persisted with its scope intact.
+    persisted = json.loads(storage_path.read_text(encoding="utf-8"))
+    assert (
+        _cookie_entry("OSID", _MINTED_OSID, _notebook_host())["name"],
+        _MINTED_OSID,
+        _notebook_host(),
+    ) in {(c["name"], c["value"], c["domain"]) for c in persisted["cookies"]}
 
 
 def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
 ) -> None:
-    """``fetch_bundle`` must hand ``httpx`` a jar, not a domain-less dict.
+    """``fetch_bundle``'s authenticated homepage read must be domain-scoped.
 
-    ``httpx.get(cookies={...})`` attaches a plain mapping to *every* request in
-    the redirect chain regardless of host — the same broadcast the health-check
-    fix removes. Fails against the pre-#2019 ``load_auth_from_storage()`` call,
-    which returned exactly that mapping.
+    The homepage read uses ``follow_redirects=True``, so a domain-less mapping
+    handed to ``httpx.get(cookies=...)`` rides along to every hop in the chain.
+    Asserted on the wire rather than on the argument, so a regression that builds
+    the jar correctly and then flattens it before use is still caught.
     """
-    storage_state = _storage_state()
-    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(storage_state))
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(_storage_state()))
 
     bundle_url = (
         f"https://www.gstatic.com/_/mss/{capture_rpc_registry._APP}/_/js/k=boq.en.abc123.js"
     )
-    captured: list[tuple[str, Any]] = []
-
-    def _fake_get(url: str, **kwargs: Any) -> httpx.Response:
-        captured.append((url, kwargs.get("cookies")))
-        request = httpx.Request("GET", url)
-        if url == bundle_url:
-            return httpx.Response(
-                200,
-                text="/* bundle chunk */",
-                headers={"content-type": "text/javascript"},
-                request=request,
-            )
-        return httpx.Response(200, text=f'<script src="{bundle_url}"></script>', request=request)
-
-    monkeypatch.setattr(httpx, "get", _fake_get)
+    homepage_url = f"{get_base_url()}/?authuser=0"
+    httpx_mock.add_response(url=homepage_url, status_code=302, headers={"Location": _SIGN_IN_URL})
+    httpx_mock.add_response(url=_SIGN_IN_URL, status_code=302, headers={"Location": homepage_url})
+    httpx_mock.add_response(
+        url=homepage_url, status_code=200, html=f'<script src="{bundle_url}"></script>'
+    )
+    httpx_mock.add_response(
+        url=bundle_url,
+        status_code=200,
+        text="/* bundle chunk */",
+        headers={"content-type": "text/javascript"},
+    )
 
     assert capture_rpc_registry.fetch_bundle() == "/* bundle chunk */"
 
-    homepage_url, homepage_cookies = captured[0]
-    assert homepage_url.startswith(get_base_url())
-    assert isinstance(homepage_cookies, httpx.Cookies), (
-        "the authenticated homepage read must use a domain-preserving "
-        "httpx.Cookies jar, not a flat name->value dict (issue #2019)"
-    )
-    assert _jar_pairs(homepage_cookies) == _name_domain_pairs(storage_state)
+    _assert_sign_in_hop_correctly_scoped(httpx_mock)
+    _assert_app_hop_correctly_scoped(httpx_mock)
 
     # The gstatic chunk read stays unauthenticated — it is a public CDN.
-    assert captured[1] == (bundle_url, None)
+    cdn_requests = [r for r in httpx_mock.get_requests() if r.url.host == "www.gstatic.com"]
+    assert cdn_requests
+    assert all("cookie" not in r.headers for r in cdn_requests)

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -37,15 +37,22 @@ from pytest_httpx import HTTPXMock
 from notebooklm._env import get_base_url
 from scripts import capture_rpc_registry, check_rpc_health
 
-# The NotebookLM host is read from the library so this file keeps working
-# through the Gemini Notebook rebrand (ADR-0028) instead of pinning a literal.
-_NOTEBOOK_HOST = httpx.URL(get_base_url()).host
 _ACCOUNTS_HOST = "accounts.google.com"
 _SIGN_IN_URL = f"https://{_ACCOUNTS_HOST}/ServiceLogin"
 
 _HOMEPAGE_HTML = (
     '<html><script>window.WIZ_global_data={"SNlM0e":"csrf_ok","FdrFJe":"sess_ok"};</script></html>'
 )
+
+
+def _notebook_host() -> str:
+    """The NotebookLM host, read from the library rather than pinned literally.
+
+    Resolved at call time (``get_base_url()`` is env-overridable) so the fixture
+    host and the mocked URLs can never disagree, and so this file keeps working
+    through the Gemini Notebook rebrand (ADR-0028).
+    """
+    return httpx.URL(get_base_url()).host
 
 
 def _cookie_entry(name: str, value: str, domain: str) -> dict[str, Any]:
@@ -72,7 +79,7 @@ def _storage_state() -> dict[str, Any]:
         "cookies": [
             _cookie_entry("SID", "v-sid", ".google.com"),
             _cookie_entry("__Secure-1PSIDTS", "v-psidts", ".google.com"),
-            _cookie_entry("OSID", "v-osid", _NOTEBOOK_HOST),
+            _cookie_entry("OSID", "v-osid", _notebook_host()),
             _cookie_entry("LSID", "v-lsid", _ACCOUNTS_HOST),
         ],
         "origins": [],
@@ -89,6 +96,15 @@ def _jar_pairs(jar: httpx.Cookies) -> set[tuple[str, str]]:
 
 def _cookie_names(header: str) -> set[str]:
     return {pair.split("=", 1)[0].strip() for pair in header.split(";") if pair.strip()}
+
+
+def _cookie_names_sent_to(httpx_mock: HTTPXMock, host: str) -> list[set[str]]:
+    """Cookie names carried by each recorded request that reached ``host``."""
+    return [
+        _cookie_names(request.headers.get("cookie", ""))
+        for request in httpx_mock.get_requests()
+        if request.url.host == host
+    ]
 
 
 async def test_check_rpc_health_auth_preserves_cookie_domains(
@@ -115,8 +131,9 @@ async def test_check_rpc_health_auth_preserves_cookie_domains(
 
     # ``resolve_storage_path()`` returns None under NOTEBOOKLM_AUTH_JSON, which
     # is exactly the CI configuration that exposed the bug.
-    assert check_rpc_health.resolve_storage_path() is None
-    auth = await check_rpc_health.load_auth(check_rpc_health.resolve_storage_path())
+    storage_path = check_rpc_health.resolve_storage_path()
+    assert storage_path is None
+    auth = await check_rpc_health.load_auth(storage_path)
 
     assert auth.csrf_token == "csrf_ok"
     assert auth.session_id == "sess_ok"
@@ -126,14 +143,9 @@ async def test_check_rpc_health_auth_preserves_cookie_domains(
     assert _jar_pairs(auth.cookie_jar) == _name_domain_pairs(storage_state)
 
     # 2. Wire-level: the sign-in hop must not receive the NotebookLM-host OSID.
-    sent_to_accounts = [
-        request.headers.get("cookie", "")
-        for request in httpx_mock.get_requests()
-        if request.url.host == _ACCOUNTS_HOST
-    ]
+    sent_to_accounts = _cookie_names_sent_to(httpx_mock, _ACCOUNTS_HOST)
     assert sent_to_accounts, "expected at least one accounts.google.com hop"
-    for header in sent_to_accounts:
-        names = _cookie_names(header)
+    for names in sent_to_accounts:
         assert "OSID" not in names, (
             "the NotebookLM-host OSID must not be broadcast to "
             f"{_ACCOUNTS_HOST} (issue #2019); sent: {sorted(names)}"
@@ -143,13 +155,9 @@ async def test_check_rpc_health_auth_preserves_cookie_domains(
         assert {"SID", "LSID"} <= names
 
     # 3. Positive control on the other side: the NotebookLM host still gets OSID.
-    sent_to_notebook = [
-        request.headers.get("cookie", "")
-        for request in httpx_mock.get_requests()
-        if request.url.host == _NOTEBOOK_HOST
-    ]
+    sent_to_notebook = _cookie_names_sent_to(httpx_mock, _notebook_host())
     assert sent_to_notebook
-    assert all("OSID" in _cookie_names(header) for header in sent_to_notebook)
+    assert all("OSID" in names for names in sent_to_notebook)
 
 
 def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -1,0 +1,198 @@
+"""Cookie-domain preservation guardrail for the two maintenance scripts (#2019).
+
+``scripts/check_rpc_health.py`` and ``scripts/capture_rpc_registry.py`` both
+authenticate against live Google hosts, and both used to load credentials
+through the *flat* ``load_auth_from_storage()`` mapping, which drops every
+cookie's domain. Under ``NOTEBOOKLM_AUTH_JSON`` (how the nightly workflows run)
+there is no storage file to recover the domains from, so:
+
+* ``check_rpc_health`` fed the flat dict to ``fetch_tokens``, whose
+  ``build_cookie_jar`` fallback re-pinned **every** cookie to ``.google.com``;
+* ``capture_rpc_registry`` handed the flat dict straight to
+  ``httpx.get(cookies=...)``, which is domain-less by construction.
+
+Host-scoped cookies (``OSID`` / ``__Secure-OSID`` on the NotebookLM host,
+``LSID`` on ``accounts.google.com``) were therefore broadcast to every
+``*.google.com`` host. After Google's ``notebook.google.com`` cutover the
+sign-in redirect chain mints a fresh host ``OSID``; the stale broadcast copy
+collides with it and the chain dead-ends on
+``accounts.google.com/CookieMismatch``, which the scripts then misreported as
+"Authentication expired or invalid".
+
+The live rpc-health workflow cannot gate a PR, so these offline tests pin the
+contract instead: the jar each script authenticates with must mirror the
+``storage_state`` domains exactly, and a host-scoped cookie must never ride
+along to a host it was not scoped to.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm._env import get_base_url
+from scripts import capture_rpc_registry, check_rpc_health
+
+# The NotebookLM host is read from the library so this file keeps working
+# through the Gemini Notebook rebrand (ADR-0028) instead of pinning a literal.
+_NOTEBOOK_HOST = httpx.URL(get_base_url()).host
+_ACCOUNTS_HOST = "accounts.google.com"
+_SIGN_IN_URL = f"https://{_ACCOUNTS_HOST}/ServiceLogin"
+
+_HOMEPAGE_HTML = (
+    '<html><script>window.WIZ_global_data={"SNlM0e":"csrf_ok","FdrFJe":"sess_ok"};</script></html>'
+)
+
+
+def _cookie_entry(name: str, value: str, domain: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "value": value,
+        "domain": domain,
+        "path": "/",
+        "expires": -1,
+        "httpOnly": True,
+        "secure": True,
+        "sameSite": "None",
+    }
+
+
+def _storage_state() -> dict[str, Any]:
+    """Storage state spanning three hosts, mirroring a real logged-in profile.
+
+    ``SID`` + ``__Secure-1PSIDTS`` are the ``MINIMUM_REQUIRED_COOKIES`` the auth
+    validators demand; ``OSID`` and ``LSID`` are the host-scoped pair the #2019
+    regression broadcast domain-wide.
+    """
+    return {
+        "cookies": [
+            _cookie_entry("SID", "v-sid", ".google.com"),
+            _cookie_entry("__Secure-1PSIDTS", "v-psidts", ".google.com"),
+            _cookie_entry("OSID", "v-osid", _NOTEBOOK_HOST),
+            _cookie_entry("LSID", "v-lsid", _ACCOUNTS_HOST),
+        ],
+        "origins": [],
+    }
+
+
+def _name_domain_pairs(storage_state: dict[str, Any]) -> set[tuple[str, str]]:
+    return {(entry["name"], entry["domain"]) for entry in storage_state["cookies"]}
+
+
+def _jar_pairs(jar: httpx.Cookies) -> set[tuple[str, str]]:
+    return {(cookie.name, cookie.domain) for cookie in jar.jar}
+
+
+def _cookie_names(header: str) -> set[str]:
+    return {pair.split("=", 1)[0].strip() for pair in header.split(";") if pair.strip()}
+
+
+async def test_check_rpc_health_auth_preserves_cookie_domains(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """``check_rpc_health.load_auth`` must build a domain-preserving jar.
+
+    Drives the real auth path against a mocked NotebookLM → sign-in →
+    NotebookLM redirect chain (the shape of the post-cutover hop that broke the
+    nightly canary) and asserts both halves of the contract: the resulting jar
+    mirrors ``storage_state``, and the ``accounts.google.com`` hop carries only
+    the cookies actually scoped to it.
+
+    Fails against the pre-#2019 ``load_auth_from_storage`` + ``fetch_tokens``
+    pairing, which collapsed all four cookies onto ``.google.com``.
+    """
+    storage_state = _storage_state()
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(storage_state))
+
+    homepage_url = f"{get_base_url()}/"
+    httpx_mock.add_response(url=homepage_url, status_code=302, headers={"Location": _SIGN_IN_URL})
+    httpx_mock.add_response(url=_SIGN_IN_URL, status_code=302, headers={"Location": homepage_url})
+    httpx_mock.add_response(url=homepage_url, status_code=200, html=_HOMEPAGE_HTML)
+
+    # ``resolve_storage_path()`` returns None under NOTEBOOKLM_AUTH_JSON, which
+    # is exactly the CI configuration that exposed the bug.
+    assert check_rpc_health.resolve_storage_path() is None
+    auth = await check_rpc_health.load_auth(check_rpc_health.resolve_storage_path())
+
+    assert auth.csrf_token == "csrf_ok"
+    assert auth.session_id == "sess_ok"
+
+    # 1. Jar-level: every cookie kept its original domain.
+    assert auth.cookie_jar is not None
+    assert _jar_pairs(auth.cookie_jar) == _name_domain_pairs(storage_state)
+
+    # 2. Wire-level: the sign-in hop must not receive the NotebookLM-host OSID.
+    sent_to_accounts = [
+        request.headers.get("cookie", "")
+        for request in httpx_mock.get_requests()
+        if request.url.host == _ACCOUNTS_HOST
+    ]
+    assert sent_to_accounts, "expected at least one accounts.google.com hop"
+    for header in sent_to_accounts:
+        names = _cookie_names(header)
+        assert "OSID" not in names, (
+            "the NotebookLM-host OSID must not be broadcast to "
+            f"{_ACCOUNTS_HOST} (issue #2019); sent: {sorted(names)}"
+        )
+        # Positive control: the cookies that *are* scoped there still ride along,
+        # so the assertion above cannot pass by dropping cookies wholesale.
+        assert {"SID", "LSID"} <= names
+
+    # 3. Positive control on the other side: the NotebookLM host still gets OSID.
+    sent_to_notebook = [
+        request.headers.get("cookie", "")
+        for request in httpx_mock.get_requests()
+        if request.url.host == _NOTEBOOK_HOST
+    ]
+    assert sent_to_notebook
+    assert all("OSID" in _cookie_names(header) for header in sent_to_notebook)
+
+
+def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``fetch_bundle`` must hand ``httpx`` a jar, not a domain-less dict.
+
+    ``httpx.get(cookies={...})`` attaches a plain mapping to *every* request in
+    the redirect chain regardless of host — the same broadcast the health-check
+    fix removes. Fails against the pre-#2019 ``load_auth_from_storage()`` call,
+    which returned exactly that mapping.
+    """
+    storage_state = _storage_state()
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(storage_state))
+
+    bundle_url = (
+        f"https://www.gstatic.com/_/mss/{capture_rpc_registry._APP}/_/js/k=boq.en.abc123.js"
+    )
+    captured: list[tuple[str, Any]] = []
+
+    def _fake_get(url: str, **kwargs: Any) -> httpx.Response:
+        captured.append((url, kwargs.get("cookies")))
+        request = httpx.Request("GET", url)
+        if url == bundle_url:
+            return httpx.Response(
+                200,
+                text="/* bundle chunk */",
+                headers={"content-type": "text/javascript"},
+                request=request,
+            )
+        return httpx.Response(200, text=f'<script src="{bundle_url}"></script>', request=request)
+
+    monkeypatch.setattr(httpx, "get", _fake_get)
+
+    assert capture_rpc_registry.fetch_bundle() == "/* bundle chunk */"
+
+    homepage_url, homepage_cookies = captured[0]
+    assert homepage_url.startswith(get_base_url())
+    assert isinstance(homepage_cookies, httpx.Cookies), (
+        "the authenticated homepage read must use a domain-preserving "
+        "httpx.Cookies jar, not a flat name->value dict (issue #2019)"
+    )
+    assert _jar_pairs(homepage_cookies) == _name_domain_pairs(storage_state)
+
+    # The gstatic chunk read stays unauthenticated — it is a public CDN.
+    assert captured[1] == (bundle_url, None)


### PR DESCRIPTION
Fixes #2019. Also fixes the #2018 bundle-drift failures — same root cause, same commit.

> **The short version, if you read nothing else:** flattening cookies to a `name -> value` map is **data loss**, not just an over-broad send. When the same cookie name exists on two hosts — which is exactly the case for `OSID` — `flatten_cookie_map` keeps one and **silently discards the other**. The bundle-drift monitor still does this on `main` today, and #2037 does **not** mask it. Proof is in [Relationship to #2037](#relationship-to-2037), reproduced offline against the merged file-backed profile.

## It is not expired credentials

The auto-filed issue says `ERROR: Authentication expired or invalid. Run 'notebooklm login' to re-authenticate.`, and three people have since piled onto #2019 assuming a rotated cookie snapshot. Two independent pieces of evidence say otherwise.

**1. The secret is valid right now.** Today's nightly `E2E Tests (main@2ba6c313/windows-latest)` **passed** using the same `NOTEBOOKLM_AUTH_JSON` secret (run [30792136468](https://github.com/teng-lin/notebooklm-py/actions/runs/30792136468)). The rpc-health workflow's own "Verify auth secret is present" preflight also never fired — the job reached `Fetching auth tokens...` before dying.

**2. No repo change caused it.** The last green and the first red ran on the *same commit*:

| date | commit | rpc-health |
|---|---|---|
| 2026-07-26 | `45fd4258` | success |
| **2026-07-27** | **`7d0aa42c`** | **success** |
| **2026-07-28** | **`7d0aa42c`** | **failure** ← first red |
| 2026-07-29 → today | `7d0aa42c` … `38d25949` | failure, every run |

Nothing in the tree moved between the last green and the first red. What moved was Google: the `notebook.google.com` cutover.

## Root cause: the two scripts flatten cookie domains; the CLI does not

- `scripts/check_rpc_health.py` called `load_auth_from_storage()`, which returns a flat `name -> value` dict with domains dropped (`src/notebooklm/_auth/tokens.py`).
- Under `NOTEBOOKLM_AUTH_JSON`, `resolve_storage_path()` returns `None`, so `fetch_tokens(cookies, storage_path=None)` rebuilt the jar through `build_cookie_jar` → `normalize_cookie_map`, which pins **every** cookie to `.google.com`:
  ```python
  name, domain, path = key, ".google.com", "/"   # src/notebooklm/_auth/cookies.py
  ```
- `scripts/capture_rpc_registry.py` handed the same flat dict straight to `httpx.get(cookies=...)`. A plain mapping carries no domain at all, so httpx attaches it to every host in the redirect chain.

Host-scoped cookies (`OSID` / `__Secure-OSID` on the NotebookLM host, `LSID` on `accounts.google.com`) were therefore broadcast to all `*.google.com`. Post-cutover, the NotebookLM host redirects through `accounts.google.com/ServiceLogin` → `notebook.google.com/accounts/SetOSID`, which mints an `OSID` for the **new** host; the stale broadcast copy collides with it and the chain dead-ends at `accounts.google.com/CookieMismatch` → `support.google.com/accounts/answer/32050`, served **HTTP 200**.

**Flattening also destroys data outright, which is the more serious half.** A flat `name -> value` map has exactly one slot per name. `OSID` legitimately exists on *both* the app host and `accounts.google.com` with *different* values, so `flatten_cookie_map` resolves the collision by domain priority — the app host wins — and the accounts-scoped `OSID` is **silently dropped before any request is made**. The result is not "the right cookie plus some extras": it is the *wrong* value sent to the sign-in host and the correct one gone. `LSID` leaks the opposite direction at the same time. That is why this is worth landing on its own merits and not only as #2019 insurance — see the wire trace under [Relationship to #2037](#relationship-to-2037), which reproduces it against the *merged* file-backed profile.

Because that is a 200 on a non-`accounts` host, `is_google_auth_redirect()` never fires, `SNlM0e` is absent, and `extract_csrf_from_html`'s body-scan fallback reports "expired". Note the issue text carries **no** `Redirected to: …` line — that is the tell that it came from the body scan, not from the redirect check.

The CLI and library were never affected: `src/notebooklm/cli/auth_runtime.py` special-cases env auth into the domain-preserving `build_httpx_cookies_from_storage(None)`. That is exactly why the Windows E2E job is green on the same secret.

Reproduced offline against the library, no credentials needed:

```
flat dict (what the old scripts passed): {'SID': …, '__Secure-1PSIDTS': …, 'OSID': …, 'LSID': …}
OLD path, storage_path=None  (env-var auth): [('LSID', '.google.com'), ('OSID', '.google.com'), …]
OLD path, storage_path=<file>              : [('LSID', 'accounts.google.com'), ('OSID', 'notebooklm.google.com'), …]
```

## The fix

- **`scripts/check_rpc_health.py`** — `load_auth()` now returns `await AuthTokens.from_storage(storage_path)`, the same env-var-aware, domain-preserving loader the CLI uses, replacing the `fetch_tokens(...)` + hand-built `AuthTokens(...)` pair. The `FileNotFoundError` / `ValueError` / `httpx.HTTPError` → `sys.exit(2)` handling is preserved and consolidated into one place; all three arms now go through `scrub_secrets`, and each names the auth source or the path it checked.
- **`scripts/check_rpc_health.py` diagnostics** — the report now prints the auth source, the base host, the account route, and the jar's `name@domain` scopes (names and domains only, never values). #2019 was a cookie-*scoping* failure that produced a generic "authentication expired" line, so the nightly log carried nothing to diagnose it with. Both open questions below would have been self-evident in the failing run had this been there.
- **`scripts/capture_rpc_registry.py`** — passes `build_httpx_cookies_from_storage()` instead of the flat dict; the `_fetch` annotation becomes `httpx.Cookies | None`. The gstatic chunk reads stay unauthenticated.
- **`tests/unit/test_scripts_auth_cookie_domains.py`** (new guardrail) — the live rpc-health workflow cannot gate a PR, so this pins the contract offline, for **both** scripts and for **both** the env-var and the file-backed (#2037) configuration. The fixture deliberately carries `OSID` on *two* hosts with *different values*, because same-name-different-domain is the entire reason domains matter: a name-only assertion (`"OSID" not in sent`) would be wrong once the sign-in host legitimately has an `OSID` of its own. Assertions are therefore on `(name, value)` pairs — which is also what lets the guardrail catch the **data loss**, not just the broadcast: `assert ("OSID", "v-osid-accounts") in pairs` fails when flattening discards the accounts-scoped value, and the file-backed test makes the same claim against the persisted `storage_state` (`("OSID", "v-osid-accounts", accounts.google.com) in persisted_triples`). The mocked chain also mints a fresh host-scoped `OSID` via `Set-Cookie` — the exact mechanism #2019 describes — so the jar assertions must survive a rotation rather than pinning a jar that never changes. **Verified to fail against the pre-fix code**, on the intended assertions.
- **`tests/unit/test_check_rpc_health.py`** — the `ValueError` and `httpx.HTTPError` arms of `load_auth` had no coverage at all; the `httpx` one carries the `scrub_secrets` call that keeps `f.sid=<session_id>` out of the Actions log and out of the auto-filed issue body. Both are now pinned. The missing-storage test no longer patches anything (empty `NOTEBOOKLM_HOME` → the real loader raises for itself), and the file's `importlib.util.spec_from_file_location` preamble is gone: it built a *second* module object for `scripts/check_rpc_health.py`, so a patch applied to one copy left the other untouched.

### Open question for #2020 (worth resolving before both land)

#2020 (`fix(auth): request + rank notebook.google.com binding cookies`) reports, from a live auth check, that Google now sets `OSID` + `__Secure-OSID` on the bare `notebook.google.com` host, **host-only, no leading dot**. Host-only binding cookies are exactly the population flattening destroys, so at first glance the two PRs are complementary — and they do touch disjoint code (`_auth/cookie_policy.py` vs `scripts/`; only `CHANGELOG.md` overlaps).

But there is a wrinkle I do **not** want to paper over. `get_base_url()` can only return `notebooklm.google.com` or `notebooklm.cloud.google.com` (`_ALLOWED_BASE_HOSTS`, `src/notebooklm/_env.py`) — never `notebook.google.com`. A *correct*, domain-preserving jar therefore **withholds** a `notebook.google.com` host-only cookie from a request to `notebooklm.google.com`; the old flat dict sent it. Probed here:

```
JAR: [('OSID','notebook.google.com'), ('SID','.google.com'), ('__Secure-1PSIDTS','.google.com'), …]
GET https://notebooklm.google.com/  →  cookies: ['SID', '__Secure-1PSIDTS']      # OSID withheld
```

So once #2020 starts populating those cookies, they are inert on the token-fetch path — and, since `_kernel.py` hands the same jar to the client, on the library path too. That is a #2020 question rather than a defect in this PR (this PR only makes the scripts behave the way the CLI already did), but it should be settled between the two rather than after both land, because if it bites the symptom is the *same* "Authentication expired or invalid" string and nothing in the log distinguishes it. The new diagnostics line above is deliberately aimed at that: the jar scopes are printed, so a withheld `OSID` is visible.

## Relationship to #2037

**Rebased onto `27926aa4` (#2037 merged).** Clean rebase, no conflict — #2037 added no `[Unreleased]` CHANGELOG entry. This branch touches **zero** workflow files. The overlap, now **re-verified against the merged code rather than the PR diff**:

**How the merged workflow feeds this script.** `rpc-health.yml` now drops `NOTEBOOKLM_AUTH_JSON` from the run step's `env:` and writes the secret to `~/.notebooklm/profiles/default/storage_state.json`. So `resolve_storage_path()` returns a real `Path` in CI instead of `None`. That changes the *value* passed to `AuthTokens.from_storage(storage_path)`, not the call site or its shape — no code change was needed. Confirmed the layouts actually agree, since a mismatch would be a silent `FileNotFoundError`:

```
NOTEBOOKLM_HOME    : /tmp/tmp_2e4avxp
get_storage_path() : /tmp/tmp_2e4avxp/profiles/default/storage_state.json
#2037 writes       : profiles/default/storage_state.json          → MATCH
```

- **#2037 does mask the health-check half** — re-confirmed. With a real file, `build_cookie_jar` short-circuits to `build_httpx_cookies_from_storage(storage_path)`, so the pre-fix flattening never fires on that path.
- **#2037 does *not* mask the bundle-drift half** — re-confirmed, and it is worse than "unmasked". Probed against the merged file-backed configuration, pre-fix vs post-fix:

```
PRE-FIX (main today), flat dict → httpx.get(cookies=…), FILE-backed profile:
  -> notebooklm.google.com   SID=…; __Secure-1PSIDTS=…; OSID=v-osid-app; LSID=v-lsid
  -> accounts.google.com     SID=…; __Secure-1PSIDTS=…; OSID=v-osid-app; LSID=v-lsid   ← app OSID broadcast
POST-FIX, domain-preserving jar, same file:
  -> notebooklm.google.com   SID=…; __Secure-1PSIDTS=…; OSID=v-osid-app
  -> accounts.google.com     SID=…; __Secure-1PSIDTS=…; OSID=v-osid-accounts; LSID=v-lsid
```

Read the second row pre-fix carefully — there are **three** distinct failures in it, not one:

1. the app-host `OSID=v-osid-app` is **sent to the sign-in host**, which is the collision that dead-ends the chain;
2. the accounts-scoped `OSID=v-osid-accounts` is **gone** — destroyed by `flatten_cookie_map`'s duplicate-name resolution before the request was even built, so the sign-in host receives a value that was never its own;
3. `LSID=v-lsid`, scoped to `accounts.google.com`, **leaks onto the app host**.

Only (1) is an over-broad send. (2) is data loss and (3) is a credential leak across hosts. **On `main` as it stands the drift monitor still does all three, so #2018 will keep firing until this lands** — no amount of workflow-side auth hardening reaches it, because the flattening happens after the credentials are loaded, regardless of where they were loaded from.

So: for **#2018 this is the fix, unconditionally.** For **#2019** it is defense-in-depth plus regression protection — the flattening remains live on every env-var auth path (local runs, forks, anyone who exports the secret), and the guardrail is what stops it coming back.

**The guardrail covers the path the merged workflows actually take.** `test_check_rpc_health_auth_preserves_domains_for_file_backed_profile` drives `resolve_storage_path()` under a temp `NOTEBOOKLM_HOME`, which produces exactly the `profiles/default/storage_state.json` layout above — the #2037 configuration, including the cookie-persistence side that only exists on that branch. The env-var test still covers local dev and forks. Both were re-confirmed **red against the pre-fix scripts** after the rebase.

## Deliberately not fixed here

- **The misdiagnosis itself.** `src/notebooklm/_auth/extraction.py` concludes "authentication expired" from a body scan alone, so **any** `SNlM0e` miss reports as expiry — every signed-in Google page contains an `accounts.google.com` link. That is why #2019 collected three wrong-theory reports. Tracked separately in **#2038**, owned by someone else; untouched here.
- **`scripts/diagnose_get_notebook.py`** carries the same flat-`load_auth_from_storage()` shape. Naming it so it isn't lost, but leaving it: it is a manual one-off diagnostic for issue #114, no workflow runs it, and converting it also means replacing its hand-rolled `"; ".join(auth.cookies.items())` cookie header (a `DomainCookieMap` has tuple keys) — a second unrelated change that the new guardrail would not cover.
- **The RPC phase of `check_rpc_health.py` still hand-builds `"Cookie": auth.cookie_header`** (three call sites). That is `flat_cookies`, whose own docstring says domain-aware HTTP operations should use `cookie_jar` instead — and production does exactly that (`_kernel.py` passes `auth.cookie_jar` to the client). It is *not* the #2019 failure: those are `client.post(...)` calls with httpx's default `follow_redirects=False`, so there is no chain to dead-end, and the behaviour predates this PR. It is left alone because switching to `httpx.AsyncClient(cookies=auth.cookie_jar)` changes which cookies reach batchexecute — and given the open question above about a jar legitimately *withholding* a host-only cookie, that is precisely the kind of change that should not be made blind on a canary I cannot run live. Worth a follow-up so a request-shape drift monitor sends requests the way production sends them.

The last item was flagged in review; downgrading it from "fix now" to "named and deferred" is a deliberate call, not an oversight.

## Behaviour notes for review

- Under `NOTEBOOKLM_AUTH_JSON` (`path is None`) `from_storage`'s `save_cookies_to_storage` is a documented no-op, so the canary still writes nothing. With a real profile path (i.e. after #2037) it now persists rotated cookies back — the same thing every CLI invocation does, and desirable in-run.
- Also under env auth, `from_storage` reads in-band account metadata out of the storage state, whereas the old code passed `storage_path=None` to `read_account_metadata` and always got `{}` → `authuser=0`, `email=None`. Net effect: the script now honours a recorded `authuser` / account email instead of silently defaulting to `0`, matching the library. Today's secret has no `notebooklm.account` namespace, so CI behaviour is unchanged — but the routing rides on every batchexecute call the canary makes, so if a *stale* in-band record were ever added the canary would flip from "auth expired" to wrong-account `NOT_FOUND`. The guardrail asserts `auth.authuser == 0` / `auth.account_email is None` for a record-free storage state, and the new report line prints `account route` so a change is visible rather than silent.

## Verification — read this before trusting the checks

> ✅ **Resolved.** The earlier repo-wide `Code Quality` failure (10 stale `[removed-export] notebooklm.rpc.*` allowlist entries, which made `test.yml`'s `needs: quality` skip the entire matrix) was fixed by #2037's prune. Re-run locally on the rebased branch: `scripts/audit_public_api_compat.py --check-stale` → `OK: public API is compatible with v0.8.0 (0 reviewed break(s) allowlisted)`. The Test matrix now executes for real on this PR.

Verified locally against the repo venv (whole tree, not just the diff):

- `ruff check .` → clean; `ruff format --check .` → 952 files already formatted
- `mypy src/notebooklm --ignore-missing-imports` → clean, 314 source files
- full `pytest` → **12447 passed, 64 skipped, 1 xfailed** (re-run on the rebased branch)
- `tests/_guardrails` → green (incl. the ADR-0007 monkeypatch lint and the string-patch ratchet)

The guardrail was confirmed **red against the pre-fix scripts**, on the intended assertions, before being trusted.
