### PR TITLE
fix(auth): stop reporting a wrong page as an expired login (#2038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whether or not the browser is on disk — so the probe now resolves
   Playwright's own `chromium.executable_path` (in an isolated, timeout-bounded
   interpreter) and tests that path.
+- **Token-extraction failures no longer misreport a wrong page as an expired
+  login.** When `SNlM0e` / `FdrFJe` could not be extracted, `extract_csrf_from_html`
+  and `extract_session_id_from_html` fell back to scanning the page *body* for any
+  `accounts.google.com` URL and, on a hit, raised `Authentication expired or
+  invalid. Run 'notebooklm login' to re-authenticate.` — with no URL attached.
+  Practically every Google-served page carries such a link, so a valid session that
+  simply landed on the wrong page was reported as expired. The scheduled
+  `rpc-health` workflow failed this way every day from 2026-07-28 to 2026-08-03
+  while the credentials were provably valid, and three users piled onto the
+  auto-filed issue diagnosing an unrelated login bug
+  ([#2038](https://github.com/teng-lin/notebooklm-py/issues/2038),
+  [#2019](https://github.com/teng-lin/notebooklm-py/issues/2019)).
+
+  The body scan is gone; classification is now driven by the authoritative final
+  URL, and **every** failure message carries it. Four conditions are now
+  distinguishable: the region/anti-abuse gate, a cookie mismatch, a genuine auth
+  redirect, and a token-missing response — the last split into "we never reached a
+  NotebookLM app host" (a redirect/environment problem) versus "the app answered
+  but the token moved" (a real page-structure change worth filing). The
+  `"CSRF token not found"` / `"Session ID not found"` / `"Authentication expired"`
+  message substrings and the `ValueError` type are unchanged.
+
+- **A `accounts.google.com/CookieMismatch` hop is now its own diagnostic.** It
+  means the cookies were sent to a host they were not scoped for — commonly a
+  `storage_state.json` whose per-cookie domains were flattened — which needs a
+  different fix than re-authenticating. Because the interstitial redirects onward
+  to a `support.google.com` help article, it is invisible to the final URL alone,
+  so `_fetch_tokens_with_jar` now threads the redirect history into the extractors
+  via a new optional keyword-only `redirect_urls` argument on
+  `extract_csrf_from_html` / `extract_session_id_from_html` (additive; existing
+  positional calls are unaffected)
+  ([#2038](https://github.com/teng-lin/notebooklm-py/issues/2038)).
 
 ## [0.8.0] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   positional calls are unaffected)
   ([#2038](https://github.com/teng-lin/notebooklm-py/issues/2038)).
 
+- **`notebook.google.com` is now recognised as a NotebookLM app host** when
+  deciding whether a token-less response actually reached the app. Google serves
+  the personal app from this alias after the "Gemini Notebook" rebrand, and
+  `_auth/browser_capture.url_matches_base_host` already honoured it; without the
+  matching entry a genuine app response would have been reported as "the request
+  never reached the app". The alias is deliberately *not* added to
+  `_ALLOWED_BASE_HOSTS` — that set governs where credentials may be sent, which
+  is a narrower question than where a response may have come from
+  ([#2038](https://github.com/teng-lin/notebooklm-py/issues/2038)).
+
 ## [0.8.0] - 2026-08-03
 
 The headline of 0.8.0 is **integrations**: NotebookLM is now reachable from AI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,10 +139,29 @@ notebooklm login
 **Cause:** The CSRF token (`SNlM0e`) couldn't be extracted from the NotebookLM page response. The exact wording depends on which code path raised it:
 
 - `Failed to extract CSRF token (SNlM0e). Page structure may have changed or authentication expired. Preview: '...'` — raised by `refresh_auth()` when the WIZ_global_data extraction fails ([`client.py`](../src/notebooklm/client.py)).
-- `CSRF token not found in HTML. Final URL: <url> This may indicate the page structure has changed.` — raised by the lower-level extractor when no auth redirect was detected ([`auth.py`](../src/notebooklm/auth.py)).
+- `CSRF token not found in HTML. Final URL: <url> This may indicate the page structure has changed.` — raised by the lower-level extractor when the response *did* come from a NotebookLM app host but carried no token ([`auth.py`](../src/notebooklm/auth.py)). This is the genuine "file a bug" case.
+- `CSRF token not found in HTML. Final URL: <url> The response did not come from a NotebookLM app host, so the request never reached the app …` — same extractor, but the chain landed somewhere else entirely. **The final URL is the diagnosis**: follow it to see where the request actually went. Nothing is wrong with your login.
 - `Failed to extract 'SNlM0e' from NotebookLM HTML response. This usually means Google changed the page structure. Preview: '...'` — raised as `AuthExtractionError` directly (rare; usually wrapped by one of the messages above) ([`exceptions.py`](../src/notebooklm/exceptions.py)).
 
-A related auth-redirect message — `Authentication expired. Run 'notebooklm login' to re-authenticate.` (or `Authentication expired or invalid. ...`) — surfaces the same root cause when the page redirected to Google's login flow.
+A related auth-redirect message — `Authentication expired. Run 'notebooklm login' to re-authenticate.` (or `Authentication expired or invalid. Final URL: …` / `… Redirected to: …`) — surfaces the same root cause when the page redirected to Google's login flow. Every one of these messages carries the final URL; if it does not name `accounts.google.com`, the session did not expire.
+
+> **Note:** the "did not come from a NotebookLM app host" wording exists because these two conditions used to be indistinguishable. A page-body scan for `accounts.google.com` links reported *any* Google-served page (help articles, the region gate, the app itself) as an expired login — see [#2038](https://github.com/teng-lin/notebooklm-py/issues/2038) and the six-day false alarm in [#2019](https://github.com/teng-lin/notebooklm-py/issues/2019). If you are reading an older error that says "Authentication expired" with **no URL at all**, it came from that removed code path and should not be trusted.
+
+#### "Google's CookieMismatch page was reached during this request"
+
+**Cause:** the request's redirect chain passed through `accounts.google.com/CookieMismatch` (which then forwards to a `support.google.com` help article). Google rejected the cookies as not matching the host they were sent to. This is a cookie **scoping** problem, not necessarily an expired session — the credentials themselves may be perfectly valid.
+
+Common causes:
+
+- a `storage_state.json` whose per-cookie `domain` values were flattened to a single host, so cookies scoped to `.google.com` get sent to hosts they were never issued for,
+- cookies belonging to a different Google account or session than the one being addressed,
+- a stale `__Secure-1PSIDTS` that Google could not reconcile.
+
+**Solution:**
+```bash
+notebooklm login   # re-extract cookies with their original domains
+```
+If it recurs, inspect `storage_state.json` and confirm each cookie kept its own `domain` field rather than being rewritten to one host. See [`docs/auth-cookie-lifecycle.md`](auth-cookie-lifecycle.md) for the cookie-domain model.
 
 **Note:** These errors should rarely surface, since the client automatically retries with a fresh CSRF token on auth failures (see *Automatic Token Refresh* above). When one does reach you, the automatic refresh also failed.
 

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -285,15 +285,29 @@ def _url_only_extraction_failure(final_url: str, redirect_urls: Sequence[str]) -
     This is the **single source of truth for branch order**, shared with
     ``_auth.refresh._fetch_tokens_with_jar``. That caller must run these checks
     *before* handing the body to :func:`extract_csrf_from_html`, and not merely
-    as an optimisation: Google's own ``accounts.google.com`` login page ships a
-    ``WIZ_global_data`` block containing its own ``SNlM0e``, so passing a login
-    page to the extractor would happily return **the login page's token**
-    instead of raising. The pre-check is what keeps that token out of the client.
+    as an optimisation.
 
-    Because both paths now call this one function, they cannot drift out of
-    order — an earlier revision hand-rolled the same checks in ``refresh.py``
-    and got the gate/mismatch precedence wrong there while the extractor had it
-    right (caught in review of #2038).
+    Google's sign-in page carries a ``WIZ_global_data`` block with **its own**
+    ``SNlM0e`` and ``FdrFJe``, so the extractors — which key purely on the
+    presence of those fields and never check what host answered — return the
+    *sign-in page's* tokens rather than raising. Live-captured 2026-08-03,
+    anonymous (no cookies), Chrome UA::
+
+        GET https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fnotebooklm.google.com%2F
+        -> 200 https://accounts.google.com/v3/signin/identifier?...&flowName=GlifWebSignIn
+           ...,"SNlM0e":"ALX_<redacted>:1785760591977","FdrFJe":"<19 digits>",...
+
+    Note the reproducibility caveat: a *bare* ``/ServiceLogin`` with no
+    ``continue=`` serves a different, smaller page with neither field. The
+    ``continue=`` form is the one our own redirect chain produces, which is
+    exactly the case that matters here. Google serves this surface differently
+    by UA, cookies and flow, so treat the shape — not the byte count — as the
+    finding.
+
+    Because both paths call this one function they cannot drift out of order —
+    an earlier revision hand-rolled the same checks in ``refresh.py`` and got
+    the gate/mismatch precedence wrong there while the extractor had it right
+    (caught in review of #2038).
     """
     if is_notebooklm_unavailable_redirect(final_url):
         return ValueError(_unavailable_redirect_message(final_url))

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -23,8 +23,10 @@ Private helpers (also re-exported as white-box affordances for tests):
 
 * :func:`_build_wiz_field_patterns` — the ordered regex patterns.
 * :func:`_safe_url` — credential-stripping URL formatter for error messages.
-* :func:`_cookie_mismatch_message` — shared with ``_auth.refresh``, which
-  classifies the same hop before its own auth-redirect pre-check.
+* :func:`_url_only_extraction_failure` — the single source of truth for the
+  gate → cookie-mismatch → auth-redirect precedence. ``_auth.refresh`` calls it
+  before parsing a response body, because Google's login page carries its own
+  ``SNlM0e`` and would otherwise be mistaken for a valid app page.
 """
 
 from __future__ import annotations
@@ -277,6 +279,35 @@ def _token_not_found_message(what: str, final_url: str) -> str:
     return f"{what} not found in HTML. Final URL: {_safe_url(final_url)}\n{detail}"
 
 
+def _url_only_extraction_failure(final_url: str, redirect_urls: Sequence[str]) -> ValueError | None:
+    """Classify the failures that are decidable from the URLs alone, else ``None``.
+
+    This is the **single source of truth for branch order**, shared with
+    ``_auth.refresh._fetch_tokens_with_jar``. That caller must run these checks
+    *before* handing the body to :func:`extract_csrf_from_html`, and not merely
+    as an optimisation: Google's own ``accounts.google.com`` login page ships a
+    ``WIZ_global_data`` block containing its own ``SNlM0e``, so passing a login
+    page to the extractor would happily return **the login page's token**
+    instead of raising. The pre-check is what keeps that token out of the client.
+
+    Because both paths now call this one function, they cannot drift out of
+    order — an earlier revision hand-rolled the same checks in ``refresh.py``
+    and got the gate/mismatch precedence wrong there while the extractor had it
+    right (caught in review of #2038).
+    """
+    if is_notebooklm_unavailable_redirect(final_url):
+        return ValueError(_unavailable_redirect_message(final_url))
+    hop = find_cookie_mismatch_hop((*redirect_urls, final_url))
+    if hop is not None:
+        return ValueError(_cookie_mismatch_message(hop, final_url))
+    if is_google_auth_redirect(final_url):
+        return ValueError(
+            f"Authentication expired or invalid. Final URL: {_safe_url(final_url)}\n"
+            "Run 'notebooklm login' to re-authenticate."
+        )
+    return None
+
+
 def _extraction_failure(what: str, final_url: str, redirect_urls: Sequence[str]) -> ValueError:
     """Classify a failed ``WIZ_global_data`` extraction into an actionable error.
 
@@ -292,6 +323,15 @@ def _extraction_failure(what: str, final_url: str, redirect_urls: Sequence[str])
     3. **Auth redirect** — re-authenticate. Driven by the *final URL* only.
     4. **Token missing** — see :func:`_token_not_found_message`.
 
+    Note that branch 2 wins on a mismatch hop *anywhere* in the chain, including
+    the (unobserved) shape where the chain passes through ``/CookieMismatch`` and
+    then recovers back onto an app host. That precedence is deliberate: a
+    mismatch hop is strong evidence of a cookie fault, and an app host that
+    answers without a token after one is far more likely to be serving a
+    degraded/signed-out shell than to have changed its page structure. The
+    message still names where the chain actually ended, so the alternative
+    reading stays available to the operator.
+
     Deliberately takes no ``html`` argument: the page body is not consulted at
     all. The old ``contains_google_auth_redirect(html)`` fallback matched any
     ``accounts.google.com`` URL anywhere in the body, which nearly every
@@ -300,20 +340,16 @@ def _extraction_failure(what: str, final_url: str, redirect_urls: Sequence[str])
     evidence that would have identified the real fault. Every branch below
     carries the URL.
 
+    Branches 1-3 are delegated to :func:`_url_only_extraction_failure` so this
+    ordering exists in exactly one place; only branch 4 needs the page itself.
+
     Returns the error rather than raising it so each caller's ``raise``
     statement keeps the function's ``NoReturn``-free control flow obvious to
     both readers and type checkers.
     """
-    if is_notebooklm_unavailable_redirect(final_url):
-        return ValueError(_unavailable_redirect_message(final_url))
-    hop = find_cookie_mismatch_hop((*redirect_urls, final_url))
-    if hop is not None:
-        return ValueError(_cookie_mismatch_message(hop, final_url))
-    if is_google_auth_redirect(final_url):
-        return ValueError(
-            f"Authentication expired or invalid. Final URL: {_safe_url(final_url)}\n"
-            "Run 'notebooklm login' to re-authenticate."
-        )
+    url_failure = _url_only_extraction_failure(final_url, redirect_urls)
+    if url_failure is not None:
+        return url_failure
     return ValueError(_token_not_found_message(what, final_url))
 
 

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -12,10 +12,19 @@ Public surface (re-exported from ``notebooklm.auth``):
 * :func:`extract_csrf_from_html` — convenience wrapper for ``SNlM0e``.
 * :func:`extract_session_id_from_html` — convenience wrapper for ``FdrFJe``.
 
+This module also owns the *failure taxonomy* for a missing token — see
+:func:`_extraction_failure`. Classification is driven exclusively by the final
+URL (plus, optionally, the redirect history); the page **body is never scanned**
+for auth signals. Scanning it for ``accounts.google.com`` links is the defect
+fixed in #2038: nearly every Google-served page carries such a link, so the scan
+reported a valid session as expired (#2019).
+
 Private helpers (also re-exported as white-box affordances for tests):
 
 * :func:`_build_wiz_field_patterns` — the ordered regex patterns.
 * :func:`_safe_url` — credential-stripping URL formatter for error messages.
+* :func:`_cookie_mismatch_message` — shared with ``_auth.refresh``, which
+  classifies the same hop before its own auth-redirect pre-check.
 """
 
 from __future__ import annotations
@@ -253,16 +262,18 @@ def _token_not_found_message(what: str, final_url: str) -> str:
     ``"Session ID"``); the ``"<what> not found in HTML"`` prefix is a documented
     message contract and is preserved in both branches.
     """
-    detail = (
-        "This may indicate the page structure has changed."
-        if not final_url or is_notebooklm_app_host(final_url)
-        else (
+    # No URL at all is treated as the on-app-host case: the caller gave us
+    # nothing to contradict "the app answered but the token moved", and that is
+    # the message this path has always emitted.
+    if not final_url or is_notebooklm_app_host(final_url):
+        detail = "This may indicate the page structure has changed."
+    else:
+        detail = (
             "The response did not come from a NotebookLM app host, so the request never "
             "reached the app — this is a redirect/environment problem, not a page-structure "
             "change. Note that most Google-served pages carry accounts.google.com links, so "
             "their presence in the body is not evidence that the session expired."
         )
-    )
     return f"{what} not found in HTML. Final URL: {_safe_url(final_url)}\n{detail}"
 
 

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -21,11 +21,13 @@ Private helpers (also re-exported as white-box affordances for tests):
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from urllib.parse import urlparse
 
 from .._url_utils import (
-    contains_google_auth_redirect,
+    find_cookie_mismatch_hop,
     is_google_auth_redirect,
+    is_notebooklm_app_host,
     is_notebooklm_unavailable_redirect,
     notebooklm_unavailable_location,
 )
@@ -203,7 +205,113 @@ def _unavailable_redirect_message(final_url: str) -> str:
     )
 
 
-def extract_csrf_from_html(html: str, final_url: str = "") -> str:
+def _cookie_mismatch_message(hop: str, final_url: str) -> str:
+    """Build the diagnostic for a redirect chain that hit ``/CookieMismatch``.
+
+    Google serves that interstitial when the cookies presented do not match the
+    host they were sent to, then 302s onward to a ``support.google.com`` help
+    article. The landing page is an ordinary HTTP 200 whose body is full of
+    ``accounts.google.com`` links, which is exactly what used to make this
+    report as an expired login (#2038; six days of false alarms on #2019).
+
+    The remediation is cookie *scoping*, not merely re-authentication, so the
+    message names the mismatch explicitly. ``_safe_url`` would redact the path
+    of any ``accounts.google.com`` URL, which would erase the very marker being
+    reported, so the hop is rendered from its already-validated parts
+    (scheme + host + the literal ``/CookieMismatch``) — userinfo, query and
+    fragment are dropped exactly as ``_safe_url`` would drop them.
+    """
+    parsed = urlparse(hop)
+    hop_display = f"{parsed.scheme}://{parsed.hostname or ''}/CookieMismatch"
+    landed = _safe_url(final_url)
+    chain = f"{hop_display}, and the chain ended at {landed}" if landed else hop_display
+    return (
+        f"Google's CookieMismatch page was reached during this request: {chain}. Google "
+        "rejected the cookies as not matching the host they were sent to. This is a "
+        "cookie-scoping problem and NOT necessarily an expired session — the credentials "
+        "may be perfectly valid. Common causes: a storage_state.json whose per-cookie "
+        "domains were flattened to a single host, cookies belonging to a different Google "
+        "account or session, or a stale __Secure-1PSIDTS. Run 'notebooklm login' to re-extract "
+        "cookies; if it recurs, verify that storage_state.json preserves each cookie's "
+        "original domain."
+    )
+
+
+def _token_not_found_message(what: str, final_url: str) -> str:
+    """Build the "token missing" diagnostic, split by where the response landed.
+
+    Two genuinely different failures used to share one message (and, worse, were
+    routinely mislabelled "Authentication expired" by a body scan):
+
+    * **Off the app host** — we never reached NotebookLM at all, so the page
+      simply has no ``WIZ_global_data`` to find. That is a redirect/environment
+      problem, and the final URL is the whole diagnosis.
+    * **On the app host** — the app answered but the token is not where we look,
+      i.e. a real page-structure change worth filing a bug about.
+
+    ``what`` is the human name of the missing field (``"CSRF token"`` /
+    ``"Session ID"``); the ``"<what> not found in HTML"`` prefix is a documented
+    message contract and is preserved in both branches.
+    """
+    detail = (
+        "This may indicate the page structure has changed."
+        if not final_url or is_notebooklm_app_host(final_url)
+        else (
+            "The response did not come from a NotebookLM app host, so the request never "
+            "reached the app — this is a redirect/environment problem, not a page-structure "
+            "change. Note that most Google-served pages carry accounts.google.com links, so "
+            "their presence in the body is not evidence that the session expired."
+        )
+    )
+    return f"{what} not found in HTML. Final URL: {_safe_url(final_url)}\n{detail}"
+
+
+def _extraction_failure(what: str, final_url: str, redirect_urls: Sequence[str]) -> ValueError:
+    """Classify a failed ``WIZ_global_data`` extraction into an actionable error.
+
+    Four outcomes, each with a different remediation, ordered so the strongest
+    evidence wins:
+
+    1. **Region / anti-abuse gate** (``notebooklm.google``) — fix the network
+       environment. Checked first because that gate page carries an
+       ``accounts.google.com`` sign-in link (#1630).
+    2. **Cookie mismatch** — fix cookie scoping. Checked before the auth branch
+       because the interstitial lives on ``accounts.google.com`` and would
+       otherwise be reported as an expiry (#2038).
+    3. **Auth redirect** — re-authenticate. Driven by the *final URL* only.
+    4. **Token missing** — see :func:`_token_not_found_message`.
+
+    Deliberately takes no ``html`` argument: the page body is not consulted at
+    all. The old ``contains_google_auth_redirect(html)`` fallback matched any
+    ``accounts.google.com`` URL anywhere in the body, which nearly every
+    Google-served page contains, so it converted "wrong page" into
+    "Authentication expired" and discarded the final URL — the one piece of
+    evidence that would have identified the real fault. Every branch below
+    carries the URL.
+
+    Returns the error rather than raising it so each caller's ``raise``
+    statement keeps the function's ``NoReturn``-free control flow obvious to
+    both readers and type checkers.
+    """
+    if is_notebooklm_unavailable_redirect(final_url):
+        return ValueError(_unavailable_redirect_message(final_url))
+    hop = find_cookie_mismatch_hop((*redirect_urls, final_url))
+    if hop is not None:
+        return ValueError(_cookie_mismatch_message(hop, final_url))
+    if is_google_auth_redirect(final_url):
+        return ValueError(
+            f"Authentication expired or invalid. Final URL: {_safe_url(final_url)}\n"
+            "Run 'notebooklm login' to re-authenticate."
+        )
+    return ValueError(_token_not_found_message(what, final_url))
+
+
+def extract_csrf_from_html(
+    html: str,
+    final_url: str = "",
+    *,
+    redirect_urls: Sequence[str] = (),
+) -> str:
     """
     Extract CSRF token (SNlM0e) from NotebookLM page HTML.
 
@@ -213,6 +321,11 @@ def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     Args:
         html: Page HTML content from notebooklm.google.com
         final_url: The final URL after redirects (for error messages)
+        redirect_urls: The redirect chain that preceded ``final_url``, in order
+            (``[str(r.url) for r in response.history]``). Optional, and only
+            used to build a better diagnostic: Google's ``/CookieMismatch``
+            interstitial 302s onward, so it is invisible to ``final_url`` alone.
+            Omitting it costs only that one classification.
 
     Returns:
         CSRF token value (typically starts with "AF1_QpN-")
@@ -224,32 +337,24 @@ def extract_csrf_from_html(html: str, final_url: str = "") -> str:
             the ``"CSRF token not found"`` / ``"Authentication expired"``
             message substrings, so we intentionally keep the legacy type.
             Internally we delegate to :func:`extract_wiz_field` so the regex
-            matrix (double-quoted / single-quoted / HTML-escaped) is shared.
+            matrix (double-quoted / single-quoted / HTML-escaped) is shared,
+            and to :func:`_extraction_failure` so the failure taxonomy is
+            shared with :func:`extract_session_id_from_html`.
     """
     # Tolerant extraction via the unified helper — accepts canonical,
     # single-quoted, and HTML-escaped variants of the WIZ_global_data field.
     token = extract_wiz_field(html, "SNlM0e", strict=False)
     if token is not None:
         return token
-    # Drift path: differentiate "access gate" / "auth expired" / "shape changed"
-    # because the remediation differs (fix environment / re-login / file a bug).
-    # The *final URL* is the authoritative landing signal, so it is checked
-    # before the weaker ``contains_google_auth_redirect(html)`` body scan — the
-    # ``notebooklm.google`` gate page itself carries an ``accounts.google.com``
-    # sign-in link, which would otherwise mis-route it to "auth expired" (#1630).
-    if is_notebooklm_unavailable_redirect(final_url):
-        raise ValueError(_unavailable_redirect_message(final_url))
-    if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
-        raise ValueError(
-            "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
-        )
-    raise ValueError(
-        f"CSRF token not found in HTML. Final URL: {_safe_url(final_url)}\n"
-        "This may indicate the page structure has changed."
-    )
+    raise _extraction_failure("CSRF token", final_url, redirect_urls)
 
 
-def extract_session_id_from_html(html: str, final_url: str = "") -> str:
+def extract_session_id_from_html(
+    html: str,
+    final_url: str = "",
+    *,
+    redirect_urls: Sequence[str] = (),
+) -> str:
     """
     Extract session ID (FdrFJe) from NotebookLM page HTML.
 
@@ -259,6 +364,8 @@ def extract_session_id_from_html(html: str, final_url: str = "") -> str:
     Args:
         html: Page HTML content from notebooklm.google.com
         final_url: The final URL after redirects (for error messages)
+        redirect_urls: The redirect chain that preceded ``final_url``. See
+            :func:`extract_csrf_from_html`.
 
     Returns:
         Session ID value
@@ -272,15 +379,4 @@ def extract_session_id_from_html(html: str, final_url: str = "") -> str:
     sid = extract_wiz_field(html, "FdrFJe", strict=False)
     if sid is not None:
         return sid
-    # Final-URL landing host is authoritative; check it before the body scan
-    # (the gate page carries an accounts.google.com link). See extract_csrf.
-    if is_notebooklm_unavailable_redirect(final_url):
-        raise ValueError(_unavailable_redirect_message(final_url))
-    if is_google_auth_redirect(final_url) or contains_google_auth_redirect(html):
-        raise ValueError(
-            "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
-        )
-    raise ValueError(
-        f"Session ID not found in HTML. Final URL: {_safe_url(final_url)}\n"
-        "This may indicate the page structure has changed."
-    )
+    raise _extraction_failure("Session ID", final_url, redirect_urls)

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -28,7 +28,6 @@ from typing import Any
 import httpx
 
 from .._env import get_base_url
-from .._url_utils import find_cookie_mismatch_hop, is_google_auth_redirect
 from ..paths import get_storage_path, resolve_profile
 from . import cookies as _auth_cookies
 from . import extraction as _auth_extraction
@@ -62,6 +61,10 @@ extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
 extract_session_id_from_html = _auth_extraction.extract_session_id_from_html
 _safe_url = _auth_extraction._safe_url
 _cookie_mismatch_message = _auth_extraction._cookie_mismatch_message
+# Shared URL-only failure classifier — the single source of truth for the
+# gate -> cookie-mismatch -> auth-redirect precedence used by both this module's
+# pre-check and the extractors themselves.
+_url_only_extraction_failure = _auth_extraction._url_only_extraction_failure
 _resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
 
 # Env-var names live in ``_auth.paths``; aliased so the refresh bodies can
@@ -752,21 +755,18 @@ async def _fetch_tokens_with_jar(
         # loses this one classification rather than misreporting it.)
         redirect_urls = tuple(str(hop.url) for hop in response.history)
 
-        # A cookie-mismatch hop is a cookie-*scoping* failure with its own
-        # remediation, so classify it before the generic auth-redirect check —
-        # the interstitial lives on accounts.google.com and would otherwise be
-        # reported as an expired login (#2038, the six-day #2019 false alarm).
-        mismatch_hop = find_cookie_mismatch_hop((*redirect_urls, final_url))
-        if mismatch_hop is not None:
-            raise ValueError(_cookie_mismatch_message(mismatch_hop, final_url))
-
-        # Check if we were redirected to login
-        if is_google_auth_redirect(final_url):
-            raise ValueError(
-                "Authentication expired or invalid. "
-                "Redirected to: " + _safe_url(final_url) + "\n"
-                "Run 'notebooklm login' to re-authenticate."
-            )
+        # Classify everything decidable from the URLs BEFORE touching the body.
+        # This is not an optimisation: Google's accounts.google.com login page
+        # ships its own ``WIZ_global_data`` with its own ``SNlM0e``, so handing a
+        # login page to ``extract_csrf_from_html`` would return *that* token
+        # rather than raising. Delegating to the shared classifier (instead of
+        # re-implementing the checks here) keeps the gate -> cookie-mismatch ->
+        # auth-redirect precedence identical on both paths; hand-rolling it here
+        # is exactly how this path once let a mismatch hop preempt the #1630
+        # region gate (#2038).
+        url_failure = _url_only_extraction_failure(final_url, redirect_urls)
+        if url_failure is not None:
+            raise url_failure
 
         csrf = extract_csrf_from_html(response.text, final_url, redirect_urls=redirect_urls)
         session_id = extract_session_id_from_html(

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -59,11 +59,12 @@ snapshot_cookie_jar = _auth_storage.snapshot_cookie_jar
 save_cookies_to_storage = _auth_storage.save_cookies_to_storage
 extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
 extract_session_id_from_html = _auth_extraction.extract_session_id_from_html
-_safe_url = _auth_extraction._safe_url
-_cookie_mismatch_message = _auth_extraction._cookie_mismatch_message
 # Shared URL-only failure classifier — the single source of truth for the
 # gate -> cookie-mismatch -> auth-redirect precedence used by both this module's
-# pre-check and the extractors themselves.
+# pre-check and the extractors themselves. It supersedes the former ``_safe_url``
+# / ``_cookie_mismatch_message`` aliases here: those existed only for the
+# hand-rolled pre-check this module used to carry, and message formatting now
+# lives entirely behind the classifier.
 _url_only_extraction_failure = _auth_extraction._url_only_extraction_failure
 _resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
 

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -28,7 +28,7 @@ from typing import Any
 import httpx
 
 from .._env import get_base_url
-from .._url_utils import is_google_auth_redirect
+from .._url_utils import find_cookie_mismatch_hop, is_google_auth_redirect
 from ..paths import get_storage_path, resolve_profile
 from . import cookies as _auth_cookies
 from . import extraction as _auth_extraction
@@ -61,6 +61,7 @@ save_cookies_to_storage = _auth_storage.save_cookies_to_storage
 extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
 extract_session_id_from_html = _auth_extraction.extract_session_id_from_html
 _safe_url = _auth_extraction._safe_url
+_cookie_mismatch_message = _auth_extraction._cookie_mismatch_message
 _resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
 
 # Env-var names live in ``_auth.paths``; aliased so the refresh bodies can
@@ -744,6 +745,20 @@ async def _fetch_tokens_with_jar(
         response.raise_for_status()
 
         final_url = str(response.url)
+        # Redirect hops, in order. Google's ``/CookieMismatch`` interstitial 302s
+        # onward to a support.google.com help article, so it is only ever visible
+        # here — never in ``final_url``. (The curl_cffi transport rebuilds a
+        # synthetic response and reports an empty history; that path simply
+        # loses this one classification rather than misreporting it.)
+        redirect_urls = tuple(str(hop.url) for hop in response.history)
+
+        # A cookie-mismatch hop is a cookie-*scoping* failure with its own
+        # remediation, so classify it before the generic auth-redirect check —
+        # the interstitial lives on accounts.google.com and would otherwise be
+        # reported as an expired login (#2038, the six-day #2019 false alarm).
+        mismatch_hop = find_cookie_mismatch_hop((*redirect_urls, final_url))
+        if mismatch_hop is not None:
+            raise ValueError(_cookie_mismatch_message(mismatch_hop, final_url))
 
         # Check if we were redirected to login
         if is_google_auth_redirect(final_url):
@@ -753,8 +768,10 @@ async def _fetch_tokens_with_jar(
                 "Run 'notebooklm login' to re-authenticate."
             )
 
-        csrf = extract_csrf_from_html(response.text, final_url)
-        session_id = extract_session_id_from_html(response.text, final_url)
+        csrf = extract_csrf_from_html(response.text, final_url, redirect_urls=redirect_urls)
+        session_id = extract_session_id_from_html(
+            response.text, final_url, redirect_urls=redirect_urls
+        )
 
         # httpx copies the input Cookies object into the client. Copy any
         # redirect Set-Cookie updates back to the caller's jar before it is

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -757,10 +757,12 @@ async def _fetch_tokens_with_jar(
         redirect_urls = tuple(str(hop.url) for hop in response.history)
 
         # Classify everything decidable from the URLs BEFORE touching the body.
-        # This is not an optimisation: Google's accounts.google.com login page
-        # ships its own ``WIZ_global_data`` with its own ``SNlM0e``, so handing a
-        # login page to ``extract_csrf_from_html`` would return *that* token
-        # rather than raising. Delegating to the shared classifier (instead of
+        # This is not an optimisation: Google's sign-in page carries its own
+        # ``WIZ_global_data`` with its own ``SNlM0e``/``FdrFJe`` (live-captured;
+        # see ``_url_only_extraction_failure`` for the exact request), and the
+        # extractors never check which host answered — so handing a sign-in page
+        # to ``extract_csrf_from_html`` returns *that* page's token instead of
+        # raising. Delegating to the shared classifier (instead of
         # re-implementing the checks here) keeps the gate -> cookie-mismatch ->
         # auth-redirect precedence identical on both paths; hand-rolling it here
         # is exactly how this path once let a mismatch hop preempt the #1630

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -20,6 +20,14 @@ ENTERPRISE_BASE_HOST = "notebooklm.cloud.google.com"
 
 _ALLOWED_BASE_HOSTS = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
 
+# Alias host the personal app is also served from after Google's "Gemini
+# Notebook" rebrand. It is deliberately NOT in ``_ALLOWED_BASE_HOSTS``: that set
+# validates ``NOTEBOOKLM_BASE_URL`` (what we may *send credentials to*), whereas
+# this constant answers "did a response come from the app?" — a strictly wider,
+# read-only question. ``_auth/browser_capture.url_matches_base_host`` recognises
+# the same alias.
+PERSONAL_APP_ALIAS_HOST = "notebook.google.com"
+
 
 def get_base_url() -> str:
     """Return the configured NotebookLM base URL.

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -5,7 +5,10 @@ flagged by CodeQL (py/incomplete-url-substring-sanitization).
 """
 
 import re
+from collections.abc import Iterable
 from urllib.parse import parse_qs, unquote, urlparse
+
+from ._env import ENTERPRISE_BASE_HOST, PERSONAL_BASE_HOST
 
 # Control characters (C0, DEL, C1) that ``unquote`` can reintroduce into a
 # derived display title — a NUL/newline must never reach a source title.
@@ -21,6 +24,21 @@ _MAX_URL_TITLE_LEN = 200
 # This is distinct from the ``accounts.google.com`` login redirect (expired or
 # invalid auth) and from a genuine page-structure change.
 _NOTEBOOKLM_MARKETING_HOST = "notebooklm.google"
+
+# The NotebookLM *app* hosts — the only hosts that can legitimately serve a page
+# carrying ``WIZ_global_data``. Landing anywhere else means the request never
+# reached the app, which is a different failure from "the app's page changed".
+# Sourced from ``_env`` so the enterprise host and any future addition stay in
+# one place. (``_env`` imports nothing from this module, so there is no cycle.)
+_NOTEBOOKLM_APP_HOSTS: frozenset[str] = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
+
+# Google's cookie-mismatch interstitial. Reaching it means Google rejected the
+# cookies as not matching the host they were presented to (a cookie *scoping*
+# failure), which is emphatically not the same as an expired session — see
+# issue #2038. The page 302s onward to a ``support.google.com`` help article, so
+# it is only ever visible in the redirect *history*, never as the final URL of a
+# followed chain.
+_COOKIE_MISMATCH_PATH = "cookiemismatch"
 
 
 def pdf_url_display_title(url: str) -> str | None:
@@ -110,7 +128,28 @@ def contains_google_auth_redirect(text: str) -> bool:
     """Check if text (HTML/JSON) contains a Google auth redirect URL.
 
     Extracts URLs from text and checks if any point to accounts.google.com.
-    Used to detect login page redirects in HTML response bodies.
+
+    .. warning::
+       **Never use this to conclude that a session expired.** Practically every
+       Google-served page — the NotebookLM app itself, the region/anti-abuse
+       gate page, and ordinary ``support.google.com`` help articles — carries an
+       ``accounts.google.com`` link somewhere (sign-in, account chooser,
+       manage-account menu, privacy footer). A body hit is therefore evidence of
+       almost nothing.
+
+       The authoritative signal for "we were bounced to login" is the **final
+       URL** (:func:`is_google_auth_redirect`). Two separate false positives
+       have already been traced to using this helper as an auth classifier:
+       issue #1630 (the ``notebooklm.google`` gate page) and issue #2038 /
+       #2019, where a ``support.google.com`` help article reached via a
+       ``CookieMismatch`` hop was reported to users as an expired login for six
+       consecutive days while the credentials were in fact valid.
+
+       :func:`notebooklm._auth.account._probe_authuser` and
+       :mod:`notebooklm._auth.extraction` both deliberately check only the final
+       URL for this reason. This helper is retained as a public export for
+       backward compatibility and for callers that genuinely want the literal
+       question "does this text mention a Google login URL?".
 
     Args:
         text: HTML or JSON text that may contain URLs
@@ -122,6 +161,79 @@ def contains_google_auth_redirect(text: str) -> bool:
     url_pattern = r'https?://[^\s"\'<>]+'
     urls = re.findall(url_pattern, text)
     return any(is_google_auth_redirect(url) for url in urls)
+
+
+def is_notebooklm_app_host(url: str) -> bool:
+    """Check whether ``url`` is served by a NotebookLM *app* host.
+
+    True only for the consumer host (``notebooklm.google.com``) and the
+    enterprise host (``notebooklm.cloud.google.com``) — the two hosts that can
+    serve a page containing ``WIZ_global_data``. Deliberately an exact-host
+    match: the marketing/gate host ``notebooklm.google`` is a different host
+    (no ``.com``) and must not qualify, and no subdomain of the app hosts serves
+    the app shell.
+
+    Used to split a token-extraction failure into "the app's page shape changed"
+    (we are on the app host — file a bug) versus "we never reached the app"
+    (we are somewhere else — a redirect/environment problem). Before issue
+    #2038 both collapsed into a misleading "Authentication expired".
+
+    Args:
+        url: URL to check (typically ``response.url`` after redirects).
+
+    Returns:
+        True if the URL's host is a NotebookLM app host.
+    """
+    try:
+        hostname = (urlparse(url).hostname or "").lower()
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return hostname in _NOTEBOOKLM_APP_HOSTS
+
+
+def is_cookie_mismatch_redirect(url: str) -> bool:
+    """Check whether ``url`` is Google's ``accounts.google.com/CookieMismatch``.
+
+    Google serves this interstitial when the cookies presented do not match the
+    host they were sent to — a cookie *scoping* problem (a ``storage_state.json``
+    whose per-cookie domains were flattened, cookies belonging to a different
+    Google session, or a stale ``__Secure-1PSIDTS``). It is not an expired
+    login, and re-running ``notebooklm login`` is only one of several possible
+    remediations, so it warrants its own diagnostic (#2038).
+
+    The path is matched case-insensitively and ignores any trailing slash;
+    the query string (which carries a ``continue=`` target) is not considered.
+
+    Args:
+        url: URL to check — usually a hop from ``response.history``, since the
+            interstitial 302s onward and is rarely the final URL.
+
+    Returns:
+        True if the URL is the cookie-mismatch interstitial.
+    """
+    if not is_google_auth_redirect(url):
+        return False
+    try:
+        path = urlparse(url).path
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return path.strip("/").lower() == _COOKIE_MISMATCH_PATH
+
+
+def find_cookie_mismatch_hop(urls: Iterable[str]) -> str | None:
+    """Return the first cookie-mismatch URL in ``urls``, or ``None``.
+
+    ``response.url`` alone cannot see the interstitial because it 302s onward to
+    a ``support.google.com`` help article, so callers pass the redirect history
+    followed by the final URL. See :func:`is_cookie_mismatch_redirect`.
+
+    Args:
+        urls: Candidate URLs in chain order (redirect history, then final URL).
+
+    Returns:
+        The first matching URL, or ``None`` when the chain has no such hop.
+    """
+    return next((url for url in urls if is_cookie_mismatch_redirect(url)), None)
 
 
 def is_notebooklm_unavailable_redirect(url: str) -> bool:

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Iterable
 from urllib.parse import parse_qs, unquote, urlparse
 
-from ._env import ENTERPRISE_BASE_HOST, PERSONAL_BASE_HOST
+from ._env import ENTERPRISE_BASE_HOST, PERSONAL_APP_ALIAS_HOST, PERSONAL_BASE_HOST
 
 # Control characters (C0, DEL, C1) that ``unquote`` can reintroduce into a
 # derived display title — a NUL/newline must never reach a source title.
@@ -25,12 +25,20 @@ _MAX_URL_TITLE_LEN = 200
 # invalid auth) and from a genuine page-structure change.
 _NOTEBOOKLM_MARKETING_HOST = "notebooklm.google"
 
-# The NotebookLM *app* hosts — the only hosts that can legitimately serve a page
+# The NotebookLM *app* hosts — the hosts that can legitimately serve a page
 # carrying ``WIZ_global_data``. Landing anywhere else means the request never
 # reached the app, which is a different failure from "the app's page changed".
 # Sourced from ``_env`` so the enterprise host and any future addition stay in
 # one place. (``_env`` imports nothing from this module, so there is no cycle.)
-_NOTEBOOKLM_APP_HOSTS: frozenset[str] = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
+#
+# This set is deliberately WIDER than ``_env._ALLOWED_BASE_HOSTS``: that one
+# validates where we may *send credentials*, while this one answers the
+# read-only question "did this response come from the app?". The post-rebrand
+# alias ``notebook.google.com`` serves the personal app shell, so omitting it
+# would make a genuine app response report as "never reached the app".
+_NOTEBOOKLM_APP_HOSTS: frozenset[str] = frozenset(
+    {PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST, PERSONAL_APP_ALIAS_HOST}
+)
 
 # Google's cookie-mismatch interstitial. Reaching it means Google rejected the
 # cookies as not matching the host they were presented to (a cookie *scoping*
@@ -166,12 +174,13 @@ def contains_google_auth_redirect(text: str) -> bool:
 def is_notebooklm_app_host(url: str) -> bool:
     """Check whether ``url`` is served by a NotebookLM *app* host.
 
-    True only for the consumer host (``notebooklm.google.com``) and the
-    enterprise host (``notebooklm.cloud.google.com``) — the two hosts that can
-    serve a page containing ``WIZ_global_data``. Deliberately an exact-host
-    match: the marketing/gate host ``notebooklm.google`` is a different host
-    (no ``.com``) and must not qualify, and no subdomain of the app hosts serves
-    the app shell.
+    True for the consumer host (``notebooklm.google.com``), its post-rebrand
+    alias (``notebook.google.com``), and the enterprise host
+    (``notebooklm.cloud.google.com``) — the hosts that can serve a page
+    containing ``WIZ_global_data``. Deliberately an exact-host match: the
+    marketing/gate host ``notebooklm.google`` is a different host (no ``.com``)
+    and must not qualify, and no subdomain of the app hosts serves the app
+    shell.
 
     Used to split a token-extraction failure into "the app's page shape changed"
     (we are on the app host — file a bug) versus "we never reached the app"

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -213,11 +213,11 @@ def is_cookie_mismatch_redirect(url: str) -> bool:
     """
     if not is_google_auth_redirect(url):
         return False
-    try:
-        path = urlparse(url).path
-    except (AttributeError, TypeError, ValueError):
-        return False
-    return path.strip("/").lower() == _COOKIE_MISMATCH_PATH
+    # No parse guard needed here: ``is_google_auth_redirect`` only returns True
+    # after ``urlparse(url)`` succeeded, so the identical re-parse below cannot
+    # raise. Malformed input (e.g. an unterminated IPv6 literal) is swallowed by
+    # that helper and short-circuits above.
+    return urlparse(url).path.strip("/").lower() == _COOKIE_MISMATCH_PATH
 
 
 def find_cookie_mismatch_hop(urls: Iterable[str]) -> str | None:

--- a/tests/_guardrails/test_app_host_literals_centralized.py
+++ b/tests/_guardrails/test_app_host_literals_centralized.py
@@ -56,14 +56,24 @@ KNOWN_BARE_LITERALS: frozenset[str] = frozenset({"_auth/browser_capture.py"})
 
 
 def _alias_host(env_module: Path = ENV_MODULE) -> str:
-    """Return the value of ``PERSONAL_APP_ALIAS_HOST`` declared in ``_env.py``."""
+    """Return the value of ``PERSONAL_APP_ALIAS_HOST`` declared in ``_env.py``.
+
+    Handles both the bare ``NAME = "..."`` form and the annotated
+    ``NAME: str = "..."`` one. The constant is unannotated today, but a future
+    typed pass over ``_env.py`` would otherwise turn this lint into a confusing
+    "constant not found" failure for a change that broke nothing.
+    """
     tree = ast.parse(env_module.read_text(encoding="utf-8"), filename=str(env_module))
     for node in tree.body:
-        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+        if isinstance(node, ast.Assign):
+            targets: list[ast.expr] = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
             continue
-        if any(
-            isinstance(t, ast.Name) and t.id == ALIAS_CONSTANT_NAME for t in node.targets
-        ) and isinstance(node.value.value, str):
+        if not isinstance(node.value, ast.Constant) or not isinstance(node.value.value, str):
+            continue
+        if any(isinstance(t, ast.Name) and t.id == ALIAS_CONSTANT_NAME for t in targets):
             return node.value.value
     raise AssertionError(f"{ALIAS_CONSTANT_NAME} not found in {env_module}")
 

--- a/tests/_guardrails/test_app_host_literals_centralized.py
+++ b/tests/_guardrails/test_app_host_literals_centralized.py
@@ -1,0 +1,141 @@
+"""Guard that the app's post-rebrand host alias lives only in ``_env.py``.
+
+Two independent notions of "which host is the NotebookLM app?" that disagree is
+exactly the shape that produced #2019: a valid session was reported as expired
+because one code path's idea of the app host did not match reality. The fix for
+#2038 added :data:`notebooklm._env.PERSONAL_APP_ALIAS_HOST` so the post-rebrand
+alias ``notebook.google.com`` has a single home alongside ``PERSONAL_BASE_HOST``
+and ``ENTERPRISE_BASE_HOST``.
+
+This lint keeps it that way: no module under ``src/notebooklm/`` may hardcode the
+alias in executable code. Import the constant from ``_env`` instead, so a future
+rename is one line rather than a grep.
+
+Scope is deliberately narrow -- **only the alias**, and **only real code**:
+
+* The long-established hosts (``notebooklm.google.com`` and friends) appear in
+  dozens of legitimate places: docstrings that explain behaviour, cookie-domain
+  tables, URL builders. Policing those would be an eager burndown, which this
+  repo explicitly does not do. The alias is the fact #2038 just centralised, so
+  it is the one worth protecting from being re-copied.
+* Docstrings and bare string expressions are skipped. Prose that *mentions* the
+  alias (including the docstrings written for #2038) is documentation, not a
+  second source of truth.
+
+**Passive ratchet, not a burndown.** ``KNOWN_BARE_LITERALS`` allowlists sites that
+predate the constant. Entries should be deleted, never added -- adding one means
+a new copy of a domain fact was introduced, which is the thing this lint exists
+to prevent.
+
+The alias value is read from ``_env.py`` via AST so this lint cannot drift from
+the source of truth and pulls in no import side effects.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = PROJECT_ROOT / "src" / "notebooklm"
+ENV_MODULE = SRC_ROOT / "_env.py"
+
+# The single constant this lint protects. Read by name so the value can change
+# in ``_env.py`` without touching this file.
+ALIAS_CONSTANT_NAME = "PERSONAL_APP_ALIAS_HOST"
+
+# Pre-existing bare literals, allowlisted so this ratchet lands without
+# cross-editing files another PR owns.
+#
+# * ``_auth/browser_capture.py`` -- ``url_matches_base_host`` has hardcoded the
+#   alias since #2015. PR #2042 owned that file when #2038 landed, so folding it
+#   onto ``PERSONAL_APP_ALIAS_HOST`` is left to whoever touches it next.
+#   ``test_allowlist_entries_are_still_real`` fails once that happens, prompting
+#   deletion of this entry.
+KNOWN_BARE_LITERALS: frozenset[str] = frozenset({"_auth/browser_capture.py"})
+
+
+def _alias_host(env_module: Path = ENV_MODULE) -> str:
+    """Return the value of ``PERSONAL_APP_ALIAS_HOST`` declared in ``_env.py``."""
+    tree = ast.parse(env_module.read_text(encoding="utf-8"), filename=str(env_module))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if any(
+            isinstance(t, ast.Name) and t.id == ALIAS_CONSTANT_NAME for t in node.targets
+        ) and isinstance(node.value.value, str):
+            return node.value.value
+    raise AssertionError(f"{ALIAS_CONSTANT_NAME} not found in {env_module}")
+
+
+def _docstring_nodes(tree: ast.AST) -> set[int]:
+    """Return ``id()``s of Constant nodes that are docstrings / bare strings.
+
+    Any string that is the whole of an expression statement is prose, not a
+    value the code uses -- module, class and function docstrings all take this
+    shape, as do free-floating explanatory strings.
+    """
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+    }
+
+
+def _code_string_constants(module: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, value)`` for string constants used as *values*."""
+    tree = ast.parse(module.read_text(encoding="utf-8"), filename=str(module))
+    prose = _docstring_nodes(tree)
+    return [
+        (node.lineno, node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and id(node) not in prose
+    ]
+
+
+def test_env_module_declares_the_alias():
+    """Non-empty vocabulary, else the lint below would silently pass."""
+    assert _alias_host() == "notebook.google.com"
+
+
+def test_no_bare_alias_literals_outside_env():
+    """No module may hardcode the alias in code; import it from ``_env``."""
+    alias = _alias_host()
+    violations: list[str] = []
+
+    for module in sorted(SRC_ROOT.rglob("*.py")):
+        if module == ENV_MODULE:
+            continue
+        relative = module.relative_to(SRC_ROOT).as_posix()
+        if relative in KNOWN_BARE_LITERALS:
+            continue
+        for lineno, value in _code_string_constants(module):
+            if alias in value:
+                violations.append(f"{relative}:{lineno} hardcodes {alias!r}")
+
+    assert not violations, (
+        f"Import {ALIAS_CONSTANT_NAME} from notebooklm._env instead of inlining "
+        f"{alias!r} (two copies of a domain fact is what produced #2019):\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_allowlist_entries_are_still_real():
+    """A stale allowlist entry means the fold already happened -- delete it.
+
+    Without this, an entry could outlive the literal it excuses and silently
+    re-permit a bare alias in that file.
+    """
+    alias = _alias_host()
+    stale: list[str] = []
+    for relative in sorted(KNOWN_BARE_LITERALS):
+        module = SRC_ROOT / relative
+        if not module.exists():
+            stale.append(f"{relative} (file is gone)")
+            continue
+        if not any(alias in value for _, value in _code_string_constants(module)):
+            stale.append(f"{relative} no longer hardcodes {alias!r}")
+
+    assert not stale, "Remove these now-unnecessary KNOWN_BARE_LITERALS entries:\n  " + "\n  ".join(
+        stale
+    )

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -839,23 +839,21 @@ class TestExtractionFailureTaxonomy:
     _APP_HTML = "<html><body><div id='app'>NotebookLM</div></body></html>"
     _APP_URL = "https://notebooklm.google.com/"
 
+    @staticmethod
+    def _message(html: str, final_url: str, *redirect_urls: str) -> str:
+        """Run one fixture through the classifier and return the message it raised."""
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(html, final_url, redirect_urls=redirect_urls)
+        return str(exc.value)
+
     def _messages(self) -> dict[str, str]:
-        """Raise all four fixtures and collect their messages."""
-        cases: dict[str, tuple[tuple[str, str], dict[str, tuple[str, ...]]]] = {
-            "expiry": ((self._LOGIN_HTML, self._LOGIN_URL), {}),
-            "mismatch": (
-                (self._HELP_HTML, self._SUPPORT_URL),
-                {"redirect_urls": (self._MISMATCH_HOP,)},
-            ),
-            "false_positive": ((self._HELP_HTML, self._SUPPORT_URL), {}),
-            "structure": ((self._APP_HTML, self._APP_URL), {}),
+        """Raise all four fixtures and collect their messages, keyed by condition."""
+        return {
+            "expiry": self._message(self._LOGIN_HTML, self._LOGIN_URL),
+            "mismatch": self._message(self._HELP_HTML, self._SUPPORT_URL, self._MISMATCH_HOP),
+            "false_positive": self._message(self._HELP_HTML, self._SUPPORT_URL),
+            "structure": self._message(self._APP_HTML, self._APP_URL),
         }
-        out = {}
-        for name, (args, kwargs) in cases.items():
-            with pytest.raises(ValueError) as exc:
-                extract_csrf_from_html(*args, **kwargs)
-            out[name] = str(exc.value)
-        return out
 
     def test_all_four_messages_are_distinct(self):
         """The whole point: four conditions, four messages."""

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -693,12 +693,20 @@ class TestExtractCSRFRedirect:
         with pytest.raises(ValueError, match="Authentication expired"):
             extract_csrf_from_html(html, final_url)
 
-    def test_raises_on_redirect_to_accounts_in_html(self):
-        """Test raises error when redirected to accounts.google.com (HTML content)."""
+    def test_accounts_link_in_body_alone_is_not_an_expiry(self):
+        """An accounts.google.com link in the BODY must not be read as expiry (#2038).
+
+        This previously raised "Authentication expired or invalid" via the
+        ``contains_google_auth_redirect(html)`` fallback. Nearly every
+        Google-served page carries such a link, so the fallback made a
+        wrong-page failure indistinguishable from a real expiry. Without a
+        final URL saying otherwise, the honest answer is "token not found".
+        """
         html = '<html><body><a href="https://accounts.google.com/signin">Sign in</a></body></html>'
 
-        with pytest.raises(ValueError, match="Authentication expired"):
+        with pytest.raises(ValueError, match="CSRF token not found") as exc:
             extract_csrf_from_html(html)
+        assert "Authentication expired" not in str(exc.value)
 
 
 class TestExtractSessionIdRedirect:
@@ -712,12 +720,13 @@ class TestExtractSessionIdRedirect:
         with pytest.raises(ValueError, match="Authentication expired"):
             extract_session_id_from_html(html, final_url)
 
-    def test_raises_on_redirect_to_accounts_in_html(self):
-        """Test raises error when redirected to accounts.google.com (HTML content)."""
+    def test_accounts_link_in_body_alone_is_not_an_expiry(self):
+        """Body-scan symmetry with the CSRF sibling — see that test's rationale."""
         html = '<html><body><a href="https://accounts.google.com/signin">Sign in</a></body></html>'
 
-        with pytest.raises(ValueError, match="Authentication expired"):
+        with pytest.raises(ValueError, match="Session ID not found") as exc:
             extract_session_id_from_html(html)
+        assert "Authentication expired" not in str(exc.value)
 
 
 class TestUnavailableRedirectClassification:
@@ -786,3 +795,176 @@ class TestUnavailableRedirectClassification:
             )
         lowered = str(exc.value).lower()
         assert not any(signal in lowered for signal in _AUTH_ERROR_SIGNALS)
+
+
+class TestExtractionFailureTaxonomy:
+    """Each distinct extraction failure must produce a distinguishable message (#2038).
+
+    Before this taxonomy existed, the drift path fell back to
+    ``contains_google_auth_redirect(html)`` — a scan that returns True for any
+    ``accounts.google.com`` URL anywhere in the body. Practically every
+    Google-served page qualifies, so a wrong-page failure was reported as
+    "Authentication expired or invalid. Run 'notebooklm login' to
+    re-authenticate." with no final URL attached.
+
+    That is not hypothetical: the scheduled ``rpc-health`` workflow failed with
+    exactly that message every day from 2026-07-28 to 2026-08-03 (#2019) while
+    the credentials were valid the whole time — proven by a passing nightly
+    Windows E2E run on the same ``NOTEBOOKLM_AUTH_JSON``. Three users piled onto
+    the auto-filed issue assuming an unrelated login bug.
+
+    The four fixtures below are the four real conditions. They must never
+    collapse into one another again.
+    """
+
+    # 1. Genuine expiry — the chain actually landed on the login host.
+    _LOGIN_HTML = "<html><body>Sign in to continue</body></html>"
+    _LOGIN_URL = "https://accounts.google.com/ServiceLogin"
+
+    # 2. Cookie mismatch — the interstitial 302s onward, so it is visible ONLY
+    #    in the redirect history. This is the real #2019 chain.
+    _MISMATCH_HOP = "https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fx"
+    _SUPPORT_URL = "https://support.google.com/accounts/answer/32050"
+
+    # 3. False positive — an ordinary HTTP 200 Google help article. Its body is
+    #    full of accounts.google.com links; the session is fine.
+    _HELP_HTML = (
+        "<html><body><h1>Why Google signed you out</h1>"
+        '<a href="https://accounts.google.com/signin">Sign in</a>'
+        '<a href="https://accounts.google.com/b/0/AddMailService">Add account</a>'
+        "</body></html>"
+    )
+
+    # 4. Real structure change — served BY the app host, but no WIZ_global_data.
+    _APP_HTML = "<html><body><div id='app'>NotebookLM</div></body></html>"
+    _APP_URL = "https://notebooklm.google.com/"
+
+    def _messages(self) -> dict[str, str]:
+        """Raise all four fixtures and collect their messages."""
+        cases: dict[str, tuple[tuple[str, str], dict[str, tuple[str, ...]]]] = {
+            "expiry": ((self._LOGIN_HTML, self._LOGIN_URL), {}),
+            "mismatch": (
+                (self._HELP_HTML, self._SUPPORT_URL),
+                {"redirect_urls": (self._MISMATCH_HOP,)},
+            ),
+            "false_positive": ((self._HELP_HTML, self._SUPPORT_URL), {}),
+            "structure": ((self._APP_HTML, self._APP_URL), {}),
+        }
+        out = {}
+        for name, (args, kwargs) in cases.items():
+            with pytest.raises(ValueError) as exc:
+                extract_csrf_from_html(*args, **kwargs)
+            out[name] = str(exc.value)
+        return out
+
+    def test_all_four_messages_are_distinct(self):
+        """The whole point: four conditions, four messages."""
+        messages = self._messages()
+        assert len(set(messages.values())) == 4, messages
+
+    def test_every_message_carries_the_final_url(self):
+        """Requirement 1 — the final URL is the single most useful evidence."""
+        messages = self._messages()
+        expected_host = {
+            "expiry": "accounts.google.com",
+            "mismatch": "support.google.com",
+            "false_positive": "support.google.com",
+            "structure": "notebooklm.google.com",
+        }
+        for name, message in messages.items():
+            assert expected_host[name] in message, f"{name} lost the final URL: {message!r}"
+
+    def test_genuine_expiry_still_says_expired(self):
+        """The legacy substring contract survives, now with the URL attached."""
+        message = self._messages()["expiry"]
+        assert "Authentication expired" in message
+        assert "notebooklm login" in message
+        # accounts.google.com paths are credential-shaped and stay redacted.
+        assert "ServiceLogin" not in message
+
+    def test_cookie_mismatch_is_its_own_diagnostic(self):
+        """Requirement 2 — a CookieMismatch hop is NOT folded into "expired"."""
+        message = self._messages()["mismatch"]
+        assert "CookieMismatch" in message
+        assert "Authentication expired" not in message
+        assert "cookie-scoping" in message
+        # The ``continue=`` target is credential-shaped and must not leak.
+        assert "continue=" not in message
+
+    def test_false_positive_is_not_reported_as_expiry(self):
+        """Regression for #2019: a help article is not an expired session.
+
+        Written to FAIL against the pre-#2038 implementation, which raised
+        "Authentication expired or invalid" here.
+        """
+        message = self._messages()["false_positive"]
+        assert "Authentication expired" not in message
+        assert "CSRF token not found" in message
+        assert "never reached the app" in message
+
+    def test_structure_change_still_says_page_structure(self):
+        """A token-less page served BY the app host is a real drift signal."""
+        message = self._messages()["structure"]
+        assert "page structure has changed" in message
+        assert "Authentication expired" not in message
+        # ...and must NOT be mistaken for the off-host case.
+        assert "never reached the app" not in message
+
+    def test_taxonomy_is_symmetric_for_session_id(self):
+        """``extract_session_id_from_html`` shares the classifier, not a copy."""
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(
+                self._HELP_HTML, self._SUPPORT_URL, redirect_urls=(self._MISMATCH_HOP,)
+            )
+        assert "CookieMismatch" in str(exc.value)
+
+        with pytest.raises(ValueError) as exc:
+            extract_session_id_from_html(self._HELP_HTML, self._SUPPORT_URL)
+        message = str(exc.value)
+        assert "Authentication expired" not in message
+        assert "Session ID not found" in message
+
+    def test_cookie_mismatch_as_final_url_also_classified(self):
+        """An unfollowed chain that ENDS on the interstitial must not say "expired".
+
+        ``final_url`` is checked alongside the history, so a caller that stopped
+        at the interstitial (or a transport that reports no history) still gets
+        the cookie-scoping diagnosis rather than the auth-redirect one.
+        """
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(self._LOGIN_HTML, "https://accounts.google.com/CookieMismatch")
+        message = str(exc.value)
+        assert "CookieMismatch" in message
+        assert "Authentication expired" not in message
+
+    def test_cookie_mismatch_still_drives_refresh_cmd(self):
+        """Behaviour preservation: this case triggered NOTEBOOKLM_REFRESH_CMD before.
+
+        Today the same chain raises "Authentication expired ... run 'notebooklm
+        login'", which matches ``_AUTH_ERROR_SIGNALS`` and fires the refresh
+        command. Re-extracting cookies genuinely can fix a flattened-domain jar,
+        so the reworded message must keep matching — unlike the environmental
+        gate message, which deliberately does not (see
+        ``test_gate_message_does_not_trigger_auto_refresh``).
+        """
+        from notebooklm._auth.refresh import _AUTH_ERROR_SIGNALS
+
+        message = self._messages()["mismatch"].lower()
+        assert any(signal in message for signal in _AUTH_ERROR_SIGNALS)
+
+    def test_gate_still_wins_over_cookie_mismatch_ordering(self):
+        """#1630 must not regress: the region gate is classified first."""
+        with pytest.raises(ValueError) as exc:
+            extract_csrf_from_html(
+                self._HELP_HTML,
+                "https://notebooklm.google/?location=unsupported",
+                redirect_urls=(self._MISMATCH_HOP,),
+            )
+        assert "region / anti-abuse access gate" in str(exc.value)
+
+    def test_redirect_urls_is_keyword_only_and_optional(self):
+        """The added parameter must not break positional callers."""
+        with pytest.raises(ValueError, match="CSRF token not found"):
+            extract_csrf_from_html(self._APP_HTML, self._APP_URL)
+        with pytest.raises(TypeError):
+            extract_csrf_from_html(self._APP_HTML, self._APP_URL, (self._MISMATCH_HOP,))  # type: ignore[misc]

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -90,6 +90,42 @@ class TestFetchTokens:
             await fetch_tokens(cookies)
 
     @pytest.mark.asyncio
+    async def test_fetch_tokens_cookie_mismatch_chain_is_not_reported_as_expiry(
+        self, httpx_mock: HTTPXMock
+    ):
+        """End-to-end replay of the #2019 chain: it must not say "expired" (#2038).
+
+        The real rpc-health failure went
+        ``notebooklm.google.com`` -> ``accounts.google.com/CookieMismatch`` ->
+        ``support.google.com/...`` (HTTP 200 help article). The mismatch hop is
+        mid-chain, so ``response.url`` alone cannot see it — this test is what
+        proves the redirect *history* is actually threaded from the transport
+        down into the classifier, not merely accepted as a parameter.
+        """
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/CookieMismatch"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/CookieMismatch",
+            status_code=302,
+            headers={"Location": "https://support.google.com/accounts/answer/32050"},
+        )
+        httpx_mock.add_response(
+            url="https://support.google.com/accounts/answer/32050",
+            content=b'<html><a href="https://accounts.google.com/signin">Sign in</a></html>',
+        )
+
+        cookies = {"SID": "valid_sid", "__Secure-1PSIDTS": "test_1psidts"}
+        with pytest.raises(ValueError) as exc:
+            await fetch_tokens(cookies)
+
+        message = str(exc.value)
+        assert "CookieMismatch" in message
+        assert "Authentication expired" not in message
+
+    @pytest.mark.asyncio
     async def test_fetch_tokens_redirect_to_login_strips_query_and_fragment(self, monkeypatch):
         """Redirect error must not expose query params or fragments from final_url."""
 

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -126,6 +126,72 @@ class TestFetchTokens:
         assert "Authentication expired" not in message
 
     @pytest.mark.asyncio
+    async def test_fetch_tokens_gate_wins_over_mismatch_hop(self, httpx_mock: HTTPXMock):
+        """The #1630 region gate must outrank a cookie-mismatch hop HERE too.
+
+        ``_extraction_failure`` gets this precedence right, and
+        ``TestExtractionFailureTaxonomy::test_gate_still_wins_over_cookie_mismatch_ordering``
+        pins it — but that test calls the extractor directly, so it cannot see
+        the production ``_fetch_tokens_with_jar`` path, which classifies before
+        the body is ever parsed. An earlier revision hand-rolled the checks
+        there and got the order wrong; both paths now share one classifier.
+        """
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/CookieMismatch"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/CookieMismatch",
+            status_code=302,
+            headers={"Location": "https://notebooklm.google/?location=unsupported"},
+        )
+        httpx_mock.add_response(
+            url="https://notebooklm.google/?location=unsupported",
+            content=b"<html>NotebookLM</html>",
+        )
+
+        cookies = {"SID": "valid_sid", "__Secure-1PSIDTS": "test_1psidts"}
+        with pytest.raises(ValueError) as exc:
+            await fetch_tokens(cookies)
+
+        message = str(exc.value)
+        assert "region / anti-abuse access gate" in message
+        assert "CookieMismatch" not in message
+
+    @pytest.mark.asyncio
+    async def test_fetch_tokens_never_accepts_the_login_pages_own_token(
+        self, httpx_mock: HTTPXMock
+    ):
+        """A login page carries its OWN ``SNlM0e``; we must never return it.
+
+        This is why the URL-only classification runs *before* the body is
+        parsed rather than as a fast path: handing this response to
+        ``extract_csrf_from_html`` would succeed and hand the caller Google's
+        login-page CSRF token instead of raising.
+        """
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/ServiceLogin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/ServiceLogin",
+            content=(
+                b'<html><script>window.WIZ_global_data={"SNlM0e":"LOGIN_PAGE_TOKEN",'
+                b'"FdrFJe":"LOGIN_PAGE_SESSION"};</script></html>'
+            ),
+        )
+
+        cookies = {"SID": "expired_sid", "__Secure-1PSIDTS": "test_1psidts"}
+        with pytest.raises(ValueError) as exc:
+            await fetch_tokens(cookies)
+
+        message = str(exc.value)
+        assert "Authentication expired" in message
+        assert "LOGIN_PAGE_TOKEN" not in message
+
+    @pytest.mark.asyncio
     async def test_fetch_tokens_redirect_to_login_strips_query_and_fragment(self, monkeypatch):
         """Redirect error must not expose query params or fragments from final_url."""
 

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -160,15 +160,31 @@ class TestFetchTokens:
         assert "CookieMismatch" not in message
 
     @pytest.mark.asyncio
-    async def test_fetch_tokens_never_accepts_the_login_pages_own_token(
+    async def test_fetch_tokens_never_accepts_the_sign_in_pages_own_token(
         self, httpx_mock: HTTPXMock
     ):
-        """A login page carries its OWN ``SNlM0e``; we must never return it.
+        """Never return tokens harvested from Google's own sign-in page.
 
-        This is why the URL-only classification runs *before* the body is
-        parsed rather than as a fast path: handing this response to
-        ``extract_csrf_from_html`` would succeed and hand the caller Google's
-        login-page CSRF token instead of raising.
+        The extractors key purely on the presence of ``SNlM0e``/``FdrFJe`` and
+        never check which host answered, so *any* page carrying those fields
+        parses "successfully". Google's sign-in page is such a page — verified
+        against a live anonymous capture on 2026-08-03::
+
+            GET accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fnotebooklm.google.com%2F
+            -> 200 accounts.google.com/v3/signin/identifier?...&flowName=GlifWebSignIn
+               WIZ_global_data = {...,"SNlM0e":"ALX_...:1785760591977","FdrFJe":"84070..."}
+
+        and `extract_csrf_from_html(that_html)` returned the token instead of
+        raising. (A *bare* ``/ServiceLogin`` with no ``continue=`` serves a
+        different page with neither field, so the parameter matters when
+        reproducing.)
+
+        The token values below are placeholders standing in for that shape — the
+        real capture is not committed because it contains live session values.
+        This test therefore pins **our** invariant (an auth-redirected response
+        never yields tokens), which holds regardless of what Google happens to
+        serve on any given day; the capture is why the invariant is worth having
+        rather than what the test asserts.
         """
         httpx_mock.add_response(
             url="https://notebooklm.google.com/",
@@ -178,8 +194,9 @@ class TestFetchTokens:
         httpx_mock.add_response(
             url="https://accounts.google.com/ServiceLogin",
             content=(
-                b'<html><script>window.WIZ_global_data={"SNlM0e":"LOGIN_PAGE_TOKEN",'
-                b'"FdrFJe":"LOGIN_PAGE_SESSION"};</script></html>'
+                b'<html><script>window.WIZ_global_data = {"S06Grb":"",'
+                b'"SNlM0e":"ALX_PLACEHOLDER_SIGNIN_TOKEN:1785760591977",'
+                b'"FdrFJe":"8407000850280974490"};</script></html>'
             ),
         )
 
@@ -189,7 +206,25 @@ class TestFetchTokens:
 
         message = str(exc.value)
         assert "Authentication expired" in message
-        assert "LOGIN_PAGE_TOKEN" not in message
+        assert "ALX_PLACEHOLDER_SIGNIN_TOKEN" not in message
+
+    def test_extractors_alone_would_accept_a_sign_in_page(self):
+        """Pin the hazard the pre-check exists to prevent.
+
+        If this ever starts raising, the extractors have gained host awareness
+        of their own and the URL-only pre-check in ``_fetch_tokens_with_jar``
+        could be reconsidered. Until then, deleting that pre-check would let
+        Google's sign-in-page tokens through — which is precisely the refactor
+        two reviewers proposed on #2045.
+        """
+        from notebooklm._auth.extraction import extract_csrf_from_html
+
+        signin_html = (
+            '<html><script>window.WIZ_global_data = {"S06Grb":"",'
+            '"SNlM0e":"ALX_PLACEHOLDER_SIGNIN_TOKEN:1785760591977"};</script></html>'
+        )
+        # No final_url -> classification cannot help; the body alone decides.
+        assert extract_csrf_from_html(signin_html) == "ALX_PLACEHOLDER_SIGNIN_TOKEN:1785760591977"
 
     @pytest.mark.asyncio
     async def test_fetch_tokens_redirect_to_login_strips_query_and_fragment(self, monkeypatch):

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -344,9 +344,26 @@ class TestIsNotebookLMAppHost:
             "https://notebooklm.google.com/notebook/abc",
             "https://NotebookLM.Google.COM/",  # host comparison is case-insensitive
             "https://notebooklm.cloud.google.com/",  # enterprise host
+            # Post-rebrand personal alias. Omitting it would make a genuine app
+            # response report as "the request never reached the app".
+            "https://notebook.google.com/",
         ],
     )
     def test_app_hosts(self, url: str):
+        assert is_notebooklm_app_host(url) is True
+
+    def test_alias_host_agrees_with_browser_capture(self):
+        """The alias must match the one ``browser_capture`` already recognises.
+
+        ``_auth/browser_capture.url_matches_base_host`` treats
+        ``notebook.google.com`` as the personal-app alias. Two independent
+        notions of "is this the app?" that disagree is how a valid app response
+        gets reported as an environment problem, so pin them together.
+        """
+        from notebooklm._auth.browser_capture import url_matches_base_host
+
+        url = "https://notebook.google.com/"
+        assert url_matches_base_host(url) is True
         assert is_notebooklm_app_host(url) is True
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -8,7 +8,10 @@ import pytest
 
 from notebooklm._url_utils import (
     contains_google_auth_redirect,
+    find_cookie_mismatch_hop,
+    is_cookie_mismatch_redirect,
     is_google_auth_redirect,
+    is_notebooklm_app_host,
     is_notebooklm_unavailable_redirect,
     is_youtube_url,
     notebooklm_unavailable_location,
@@ -188,6 +191,12 @@ class TestUrlParsingExceptionPaths:
     def test_is_notebooklm_unavailable_redirect_swallows_parse_error(self):
         assert is_notebooklm_unavailable_redirect(self.MALFORMED_IPV6) is False
 
+    def test_is_notebooklm_app_host_swallows_parse_error(self):
+        assert is_notebooklm_app_host(self.MALFORMED_IPV6) is False
+
+    def test_is_cookie_mismatch_redirect_swallows_parse_error(self):
+        assert is_cookie_mismatch_redirect(self.MALFORMED_IPV6) is False
+
     def test_notebooklm_unavailable_location_swallows_parse_error(self):
         assert notebooklm_unavailable_location(self.MALFORMED_IPV6) is None
 
@@ -323,3 +332,91 @@ class TestPdfUrlDisplayTitle:
     @pytest.mark.parametrize("bad", [None, 123, ["x"]])
     def test_non_string_input_returns_none(self, bad):
         assert pdf_url_display_title(bad) is None
+
+
+class TestIsNotebookLMAppHost:
+    """Tests for is_notebooklm_app_host() — "did we actually reach the app?" (#2038)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://notebooklm.google.com/",
+            "https://notebooklm.google.com/notebook/abc",
+            "https://NotebookLM.Google.COM/",  # host comparison is case-insensitive
+            "https://notebooklm.cloud.google.com/",  # enterprise host
+        ],
+    )
+    def test_app_hosts(self, url: str):
+        assert is_notebooklm_app_host(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # The marketing/gate host is a DIFFERENT host (no ``.com``) — the
+            # exact-match rule is what keeps #1630's gate out of the app set.
+            "https://notebooklm.google/?location=unsupported",
+            "https://support.google.com/accounts/answer/32050",
+            "https://accounts.google.com/signin",
+            # Subdomains do not serve the app shell.
+            "https://x.notebooklm.google.com/",
+            # Substring-bypass shapes (CodeQL py/incomplete-url-substring-sanitization).
+            "https://notebooklm.google.com.evil.com/",
+            "https://evil.com/notebooklm.google.com/",
+            "",
+            "not-a-url",
+        ],
+    )
+    def test_non_app_hosts(self, url: str):
+        assert is_notebooklm_app_host(url) is False
+
+
+class TestCookieMismatchRedirect:
+    """Tests for the ``accounts.google.com/CookieMismatch`` interstitial (#2038)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://accounts.google.com/CookieMismatch",
+            "https://accounts.google.com/CookieMismatch/",
+            "https://accounts.google.com/cookiemismatch",  # path match is case-insensitive
+            "https://accounts.google.com/CookieMismatch?continue=https%3A%2F%2Fx",
+        ],
+    )
+    def test_matches(self, url: str):
+        assert is_cookie_mismatch_redirect(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Right host, different page — a plain login redirect, not a mismatch.
+            "https://accounts.google.com/signin",
+            "https://accounts.google.com/",
+            # Right path, wrong host — must not be spoofable.
+            "https://evil.com/CookieMismatch",
+            "https://accounts.google.com.evil.com/CookieMismatch",
+            # Not a prefix/suffix match on the path segment.
+            "https://accounts.google.com/CookieMismatchFoo",
+            "https://accounts.google.com/b/0/CookieMismatch",
+            "",
+        ],
+    )
+    def test_non_matches(self, url: str):
+        assert is_cookie_mismatch_redirect(url) is False
+
+    def test_find_hop_returns_first_match_in_chain(self):
+        chain = (
+            "https://notebooklm.google.com/",
+            "https://accounts.google.com/CookieMismatch?continue=x",
+            "https://support.google.com/accounts/answer/32050",
+        )
+        assert find_cookie_mismatch_hop(chain) == chain[1]
+
+    def test_find_hop_returns_none_for_clean_chain(self):
+        chain = (
+            "https://notebooklm.google.com/",
+            "https://accounts.google.com/signin",
+        )
+        assert find_cookie_mismatch_hop(chain) is None
+
+    def test_find_hop_handles_empty_chain(self):
+        assert find_cookie_mismatch_hop(()) is None


### PR DESCRIPTION
Fixes #2038. Real-world case: #2019.

## The defect

When `SNlM0e` / `FdrFJe` could not be extracted from a page, the drift path fell back to `contains_google_auth_redirect(html)` and, on a hit, raised:

```
Authentication expired or invalid. Run 'notebooklm login' to re-authenticate.
```

That helper regex-extracts **every** URL in the body and returns `True` if any points at `accounts.google.com`:

```python
url_pattern = r'https?://[^\s"\'<>]+'
urls = re.findall(url_pattern, text)
return any(is_google_auth_redirect(url) for url in urls)
```

Practically every Google-served page qualifies — sign-in links, account choosers, privacy footers. So a **perfectly valid session that merely landed on the wrong page** was reported as expired, and the message discarded the final URL: the single most useful piece of evidence.

The same hazard was already documented one module away, in `_auth/account.py::_probe_authuser`:

> Only checks the *final* URL for an auth redirect. The page body is not scanned because a healthy NotebookLM page legitimately contains many `accounts.google.com` links … that would fool `contains_google_auth_redirect`.

The extraction path never got that treatment.

### It cost real triage time

The scheduled `rpc-health` workflow failed with exactly this message every day from **2026-07-28 to 2026-08-03** while the credentials were valid the whole time — proven by a passing nightly `E2E Tests (windows-latest)` on the same `NOTEBOOKLM_AUTH_JSON`. The actual cause was cookie-domain flattening sending the chain to `accounts.google.com/CookieMismatch` → `support.google.com/accounts/answer/32050` (HTTP 200) — a help article whose body is full of `accounts.google.com` links. Three users then piled onto the auto-filed #2019 diagnosing an unrelated login bug.

The only thing that let a human tell the two apart was that genuine expiry raises from `_auth/refresh.py` **with** a `Redirected to:` prefix and this path has none. The code should not require that trick.

> **Complements #2044**, which fixes the *root cause* (cookie-domain preservation in the RPC-health auth path). This PR fixes the *misdiagnosis*, so the next unrelated wrong-page failure is legible instead of being blamed on the user's login. The two are independent and non-conflicting.

## The fix

The body scan is gone from the extraction path. Classification is driven by the authoritative **final URL**, and **every** message now carries it. Four conditions, four distinguishable messages:

| Condition | Message | Remediation |
|---|---|---|
| Region / anti-abuse gate | `NotebookLM redirected this request to its region / anti-abuse access gate: …` | fix the environment (#1630, unchanged) |
| **Cookie mismatch** | `Google's CookieMismatch page was reached during this request: … cookie-scoping problem and NOT necessarily an expired session …` | **new** — fix cookie scoping |
| Genuine auth redirect | `Authentication expired or invalid. Final URL: <url>` | re-authenticate |
| Token missing, **off** app host | `CSRF token not found in HTML. Final URL: <url>` + *"did not come from a NotebookLM app host … the request never reached the app"* | follow the URL; nothing wrong with your login |
| Token missing, **on** app host | `CSRF token not found in HTML. Final URL: <url>` + *"page structure has changed"* | genuine drift — file a bug |

A `CookieMismatch` hop gets its own diagnostic because the remediation is completely different from re-login: the cookies were sent to a host they were not scoped for. Since the interstitial 302s onward, it is **invisible to the final URL alone** — so `_fetch_tokens_with_jar` now threads the redirect history in via a new optional keyword-only `redirect_urls` argument.

### One classifier, two call sites

`_url_only_extraction_failure` is the single source of truth for the gate → cookie-mismatch → auth-redirect precedence. Both `_extraction_failure` and `_fetch_tokens_with_jar` call it.

This came out of review: the first revision hand-rolled the checks in `refresh.py`, and `chatgpt-codex-connector` caught that the copy had the precedence **wrong** — a `/CookieMismatch` hop preempted the #1630 region gate on the production path, contradicting an invariant this PR's own test asserts. The test could not see it because it calls the extractor directly.

The pre-check in `refresh.py` could not simply be deleted in favour of the extractor, which was the other suggested fix. The extractors key purely on the presence of `SNlM0e`/`FdrFJe` and **never check which host answered**, so any page carrying those fields parses "successfully" — and Google's sign-in page is such a page. Live capture, anonymous (no cookies), Chrome UA, 2026-08-03:

```
GET https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fnotebooklm.google.com%2F
 -> 200 https://accounts.google.com/v3/signin/identifier?...&flowName=GlifWebSignIn   (1.23 MB)

    WIZ_global_data = {...,"SNlM0e":"ALX_<redacted>:1785760591977","FdrFJe":"<19 digits>",...}

extract_csrf_from_html(that_html)        -> "ALX_<redacted>:1785760591977"   # returns, does not raise
extract_session_id_from_html(that_html)  -> "84070…"                          # returns, does not raise
```

**Reproducibility caveat, because it bit a reviewer:** a *bare* `/ServiceLogin` with no `continue=` serves a different, smaller page carrying **neither** field. The `continue=` form is the one our own redirect chain produces, which is the case that matters here. Google varies this surface by UA, cookies and flow, so treat the shape as the finding rather than any byte count.

So classifying from URLs *before* parsing the body is load-bearing: it is what stops the client adopting sign-in-page tokens. The real capture is **not** committed (it carries live session values); `test_fetch_tokens_never_accepts_the_sign_in_pages_own_token` pins *our* invariant — an auth-redirected response never yields tokens — which holds regardless of what Google serves on a given day, and `test_extractors_alone_would_accept_a_sign_in_page` pins the hazard that makes the invariant worth having.

## Design decision: why the body scan was *deleted*, not tightened

Three options were evaluated, as the issue requires:

1. **Require real sign-in-page markers instead of any URL** (e.g. a `<meta http-equiv=refresh>` or `window.location=` pointing at `accounts.google.com`). **Rejected.** It is still a markup heuristic over a page Google controls and changes without notice, and the failure mode of getting it wrong is *precisely the bug being fixed* — a confident false "your login expired". It would buy a better message only for a hypothetical 200-with-JS-redirect login interstitial, for which there is no evidence: NotebookLM's auth redirect is an HTTP 302, which `_auth/refresh.py` already pre-checks on the final URL.
2. **Keep the scan but route it to an honest "could not extract token, final URL was X"**. **Rejected.** Since ~every Google page trips it, the hint would fire on essentially every drift error. That is noise, not signal — it would make the message longer without making it more discriminating.
3. **Drop it and rely on the final URL** — **chosen.** The final URL is authoritative, it is what `_probe_authuser` already relies on for the same reason, and it is what the operator actually needs. The genuine-expiry case is unaffected because an expired session *does* land on `accounts.google.com`.

The residual loss is a token-less 200 served *from the app host* that is secretly a login page. The new message for that case still tells the truth (`token not found at <app URL>`) rather than the confident lie the old code told in the far more common case, so the trade is strongly positive.

`contains_google_auth_redirect` is **retained as a public export** (removing it would be a breaking API change) but now documents in a `.. warning::` that it must never be used as an auth classifier, citing both false positives it has caused (#1630, #2038/#2019).

## Contracts preserved

- **`ValueError` kept.** No new public exception type, no new `_app.errors` ErrorCategory.
- **Message substrings kept**: `"CSRF token not found"`, `"Session ID not found"`, `"Authentication expired"`. Grepped across `src/`, `tests/` and `docs/`; every dependent matcher still passes. Detail was added, nothing depended-upon was removed.
- **#1630 not regressed.** The `notebooklm.google` gate page carries an `accounts.google.com` sign-in link, which is why the gate is classified *first*; `TestUnavailableRedirectClassification` passes untouched, and a new test pins the gate winning over a cookie-mismatch hop.
- **Auto-refresh behaviour preserved.** The cookie-mismatch message deliberately still matches `_AUTH_ERROR_SIGNALS`, so it keeps driving `NOTEBOOKLM_REFRESH_CMD` exactly as the old message did (re-extracting cookies genuinely can fix a flattened-domain jar) — unlike the gate message, which deliberately does not. Both directions are pinned by tests.
- **`redirect_urls` is additive**: keyword-only with a default, so every existing positional call is unaffected. `scripts/audit_public_api_compat.py` reports `OK: public API is compatible with v0.8.0`. **No allowlist entry was added.**
- `extract_session_id_from_html` (the `FdrFJe` sibling) had the identical defect and is fixed symmetrically — both now share one classifier rather than a copy-paste.
- **`notebook.google.com` is recognised as an app host.** Google serves the personal app from this alias post-rebrand and `_auth/browser_capture.url_matches_base_host` already honoured it; without a matching entry a genuine app response would have hit this PR's *new* off-host branch and been reported as "the request never reached the app". It is deliberately **not** added to `_ALLOWED_BASE_HOSTS` — that set governs where credentials may be *sent*, a narrower question than where a response may have *come from*. A test pins the two notions of "is this the app?" together.

### Guardrail: no third copy of the alias

This PR introduces `_env.PERSONAL_APP_ALIAS_HOST`, while `_auth/browser_capture.py` still hardcodes the same string (inherited from #2015). Two places holding one domain fact with nothing keeping them in sync is the shape that produced #2019, so `tests/_guardrails/test_app_host_literals_centralized.py` blocks a **third** copy.

It is a passive ratchet, not a burndown: `browser_capture.py` is allowlisted rather than cross-edited, because **#2042 owns that file** and the fold belongs to whoever touches it next. A companion test fails once the literal is gone, so the allowlist entry cannot outlive what it excuses.

Scope is deliberately narrow, and both narrowings matter — a first draft policed every app host and flagged ~30 sites (docstrings, cookie-domain tables, URL builders), nearly all legitimate. It now covers only the alias, and only non-docstring strings. Verified it bites: injecting a bare literal into `_url_utils.py` fails it with file and line; removing it passes.

## Tests

Four distinct fixtures, as the issue requires, asserting all four messages are **distinct** and all four **carry the final URL**:

1. genuine expiry (`accounts.google.com` final URL),
2. a `CookieMismatch` chain (hop mid-chain, only visible via history),
3. the #2019 false positive — a 200 help article full of `accounts.google.com` links,
4. a real structure change (valid app page, no `SNlM0e`).

Plus an **end-to-end `fetch_tokens` replay of the real #2019 redirect chain** (`notebooklm.google.com` → `accounts.google.com/CookieMismatch` → `support.google.com/...`), which is what proves the history is actually threaded from the transport down into the classifier rather than merely accepted as a parameter.

Plus review-driven regression tests, each verified to fail against the pre-review commit: `test_fetch_tokens_gate_wins_over_mismatch_hop`, `test_fetch_tokens_never_accepts_the_sign_in_pages_own_token`, `test_extractors_alone_would_accept_a_sign_in_page`, and `test_alias_host_agrees_with_browser_capture`.

**All 13 original new tests fail against `v0.8.0`** — verified before trusting them. On base, the end-to-end test reproduces the incident message verbatim:

```
assert 'CookieMismatch' in "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
```

Adversarial checks done on the security-sensitive parts: `_cookie_mismatch_message` bypasses `_safe_url` on purpose (that scrubber redacts `accounts.google.com` paths, which would erase the very marker being reported) and rebuilds `scheme://hostname/CookieMismatch` by hand — verified that userinfo, port, query (`?continue=`) and fragment all drop. Spoofing vectors (`evil.com/CookieMismatch`, `accounts.google.com.evil.com/...`, percent-encoded and traversal paths, IDN lookalikes) are all correctly rejected.

## Verification

Whole-tree, using the repo venv with `PYTHONPATH` pointed at this worktree (`uv run` does not work in a worktree):

- `ruff check .` → **All checks passed!**
- `ruff format --check .` → **950 files already formatted**
- `mypy src/notebooklm --ignore-missing-imports` → **Success: no issues found in 314 source files**
- `pytest` → **12482 passed, 64 skipped, 1 xfailed**
- `scripts/audit_public_api_compat.py` → **OK: public API is compatible with v0.8.0 (0 reviewed break(s) allowlisted)**

Rebased onto `27926aa4` now that #2037 has landed the post-v0.8.0 allowlist prune, so `Code Quality` is unblocked and the Test matrix executes for real rather than skipping. The rebase was clean: #2037 was CI-only and never touched `CHANGELOG.md`, so the `## [Unreleased]` section had nothing to merge against. No allowlist entry was added by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WddM9PnqkU8S3wmFYPorD5
