### PR TITLE
fix(auth): stop building requests from a domain-blind cookie projection (#2054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`AuthTokens.cookie_header_for(url)` — a domain-correct `Cookie:` header.**
+  Selects cookies per RFC 6265 for a specific URL via the session's
+  `cookie_jar`, so a cookie scoped to one host is never sent to another. Use it
+  instead of `AuthTokens.cookie_header`, which collapses every domain into one
+  `name -> value` slot and therefore has to pick an arbitrary winner when the
+  same name exists on two hosts. `url` is required — a default would
+  reintroduce the fabricated target the method exists to remove — and a
+  non-`https` URL raises rather than returning a quietly truncated header
+  ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
+
 ### Fixed
+
+- **The nightly RPC-health probes no longer send one host's cookies to
+  another.** All three authenticated probes in `scripts/check_rpc_health.py`
+  — two `batchexecute` calls and one streamed-chat call —
+  hand-built their `Cookie:` header from the flat `AuthTokens.cookie_header`
+  projection, so the `accounts.google.com`-scoped `LSID` was sent to the app
+  host on **every** request, and where a name existed on more than one host
+  (`OSID` and `__Secure-OSID` legitimately do, post-rebrand, with different
+  values per host) the surviving value was arbitrary — decided by
+  `storage_state` iteration order, because the domain-priority tiers are not
+  all distinct. The probes now share one client carrying the domain-scoped jar.
+  This is the same defect class as [#2019](https://github.com/teng-lin/notebooklm-py/issues/2019)
+  / [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018), which fixed
+  the script's *auth* path and left its *request* path untouched
+  ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
+
+- **`scripts/diagnose_get_notebook.py` can authenticate again, and honours
+  `NOTEBOOKLM_BASE_URL`.** Two independent defects in the same ~40 lines: it
+  built its `Cookie:` header by joining `AuthTokens.cookies`, whose keys became
+  `(name, domain, path)` tuples in #369 — emitting a syntactically malformed
+  `('SID', '.google.com', '/')=…` header, so the script has been unable to
+  authenticate for anyone since — and it read the eager module-level
+  `BATCHEXECUTE_URL` constant, ignoring `NOTEBOOKLM_BASE_URL` and so pointing
+  enterprise users at the consumer host. Neither half is independently
+  testable, so both are fixed together
+  ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
 
 - **`doctor` no longer warns Windows users about permissions the client
   deliberately never sets.** `notebooklm doctor` compared the profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `('SID', '.google.com', '/')=…` header, so the script has been unable to
   authenticate for anyone since — and it read the eager module-level
   `BATCHEXECUTE_URL` constant, ignoring `NOTEBOOKLM_BASE_URL` and so pointing
-  enterprise users at the consumer host. Neither half is independently
-  testable, so both are fixed together
+  enterprise users at the consumer host. Both are fixed together, and the
+  script now loads auth domain-preserving (`extract_cookies_with_domains`)
+  rather than through the flat map, so its jar routes per host instead of
+  broadcasting
   ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
 
 - **`doctor` no longer warns Windows users about permissions the client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   built its `Cookie:` header by joining `AuthTokens.cookies`, whose keys became
   `(name, domain, path)` tuples in #369 — emitting a syntactically malformed
   `('SID', '.google.com', '/')=…` header, so the script has been unable to
-  authenticate for anyone since — and it read the eager module-level
+  authenticate for anyone since [#369](https://github.com/teng-lin/notebooklm-py/issues/369) —
+  and it read the eager module-level
   `BATCHEXECUTE_URL` constant, ignoring `NOTEBOOKLM_BASE_URL` and so pointing
   enterprise users at the consumer host. Both are fixed together, and the
   script now loads auth domain-preserving (`extract_cookies_with_domains`)

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -311,6 +311,26 @@ def resolve_storage_path() -> Path | None:
     return get_storage_path()
 
 
+def build_probe_client(auth: AuthTokens) -> httpx.AsyncClient:
+    """Build the HTTP client every probe shares, with domain-scoped cookies.
+
+    Extracted as a named seam so a test can assert that the *shipped* client
+    carries the jar. Each probe used to hand-build a ``Cookie:`` header from
+    ``auth.cookie_header``, which collapses every domain into one name→value
+    slot: the accounts-scoped ``LSID`` reached the app host on every request,
+    and when a name existed on two hosts the survivor was arbitrary (issue
+    #2054). Letting httpx select per RFC 6265 from ``auth.cookie_jar`` fixes
+    both.
+
+    Note ``httpx`` **copies** the jar rather than sharing it, so cookies the
+    service rotates during a run (``SIDCC``, ``__Secure-1PSIDCC``, …) land on
+    the client's private copy and are discarded at exit. Not a regression — the
+    script previously sent a fixed header and kept no jar at all — but it does
+    mean a probe run cannot persist a rotation.
+    """
+    return httpx.AsyncClient(timeout=30.0, cookies=auth.cookie_jar)
+
+
 async def make_rpc_request(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -343,10 +363,7 @@ async def make_rpc_request(
     rpc_request = encode_rpc_request(method, params)
     body = build_request_body(rpc_request, auth.csrf_token)
 
-    headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": auth.cookie_header,
-    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     try:
         response = await client.post(url, content=body, headers=headers)
@@ -840,7 +857,6 @@ async def check_chat_query(
     )
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": auth.cookie_header,
         **extra_headers,
     }
 
@@ -956,10 +972,7 @@ async def make_raw_rpc_request(
     # actually lands in the body, kept identical to the ``rpcids=`` query param.
     rpc_request = encode_rpc_request(RPCMethod.LIST_NOTEBOOKS, params, rpc_id_override=rpc_id)
     body = build_request_body(rpc_request, auth.csrf_token)
-    headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": auth.cookie_header,
-    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
     try:
         response = await client.post(url, content=body, headers=headers)
         response.raise_for_status()
@@ -1343,7 +1356,7 @@ async def run_health_check(full_mode: bool = False) -> tuple[list[CheckResult], 
     print(f"  cookie scopes: {describe_cookie_scopes(auth)}")
     print()
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
+    async with build_probe_client(auth) as client:
         try:
             if full_mode:
                 print("Creating temp resources for full testing...")

--- a/scripts/diagnose_get_notebook.py
+++ b/scripts/diagnose_get_notebook.py
@@ -26,7 +26,8 @@ from urllib.parse import urlencode
 import httpx
 
 from notebooklm._auth.cookies import _load_storage_state
-from notebooklm.auth import AuthTokens, extract_cookies_with_domains, fetch_tokens
+from notebooklm._auth.refresh import _fetch_tokens_with_jar
+from notebooklm.auth import AuthTokens, build_cookie_jar, extract_cookies_with_domains
 from notebooklm.rpc import (
     RPCMethod,
     build_request_body,
@@ -147,13 +148,20 @@ async def run_diagnosis(notebook_id: str | None = None) -> None:
     cookies = load_auth()
 
     print("Fetching auth tokens...")
+    # Fetch through a jar we keep, rather than `fetch_tokens(cookies)`. That
+    # helper builds a jar internally and copies it back only when
+    # NOTEBOOKLM_REFRESH_CMD ran, so on the ordinary path a Set-Cookie from the
+    # sign-in redirect -- a rotated host-scoped OSID, say -- is discarded, and
+    # the RPCs below would then be rejected despite token extraction having
+    # succeeded. `poke=False` keeps this read-only: no RotateCookies POST.
+    jar = build_cookie_jar(cookies=cookies)
     try:
-        csrf_token, session_id = await fetch_tokens(cookies)
+        csrf_token, session_id = await _fetch_tokens_with_jar(jar, None, poke=False)
     except (ValueError, httpx.HTTPError) as e:
         print(f"ERROR: Failed to fetch auth tokens: {e}")
         print("Try running: notebooklm login")
         sys.exit(1)
-    auth = AuthTokens(cookies=cookies, csrf_token=csrf_token, session_id=session_id)
+    auth = AuthTokens(cookies=cookies, csrf_token=csrf_token, session_id=session_id, cookie_jar=jar)
     print(f"Auth OK (CSRF length: {len(auth.csrf_token)})")
 
     async with httpx.AsyncClient(

--- a/scripts/diagnose_get_notebook.py
+++ b/scripts/diagnose_get_notebook.py
@@ -25,12 +25,13 @@ from urllib.parse import urlencode
 
 import httpx
 
-from notebooklm.auth import AuthTokens, fetch_tokens, load_auth_from_storage
+from notebooklm._auth.cookies import _load_storage_state
+from notebooklm.auth import AuthTokens, extract_cookies_with_domains, fetch_tokens
 from notebooklm.rpc import (
-    BATCHEXECUTE_URL,
     RPCMethod,
     build_request_body,
     encode_rpc_request,
+    get_batchexecute_url,
 )
 from notebooklm.rpc.decoder import (
     collect_rpc_ids,
@@ -40,10 +41,22 @@ from notebooklm.rpc.decoder import (
 )
 
 
-def load_auth() -> dict[str, str]:
-    """Load auth cookies from storage."""
+def load_auth() -> dict[tuple[str, str, str], str]:
+    """Load auth cookies from storage with their domains intact.
+
+    Deliberately **not** ``load_auth_from_storage()``: that returns a flat
+    ``name -> value`` map, and ``AuthTokens`` then widens every entry to
+    ``.google.com`` -- so the jar would broadcast the accounts-scoped ``LSID``
+    and an arbitrary ``OSID`` to the app host, which is the defect this script
+    exists to help diagnose (#2054).
+
+    Also not ``build_httpx_cookies_from_storage()``: that fires PSIDTS
+    recovery (a network POST and a disk write) exactly when auth is
+    incomplete -- i.e. it would heal the state a diagnostic is trying to
+    observe.
+    """
     try:
-        return load_auth_from_storage()
+        return extract_cookies_with_domains(_load_storage_state(None))
     except FileNotFoundError:
         print(
             "ERROR: No authentication found.\n"
@@ -72,16 +85,12 @@ async def make_rpc_request(
             "rt": "c",
         }
     )
-    url = f"{BATCHEXECUTE_URL}?{query}"
+    url = f"{get_batchexecute_url()}?{query}"
 
     rpc_request = encode_rpc_request(method, params)
     body = build_request_body(rpc_request, auth.csrf_token)
 
-    cookie_header = "; ".join(f"{k}={v}" for k, v in auth.cookies.items())
-    headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": cookie_header,
-    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
     response = await client.post(url, content=body, headers=headers)
     response.raise_for_status()
@@ -147,7 +156,9 @@ async def run_diagnosis(notebook_id: str | None = None) -> None:
     auth = AuthTokens(cookies=cookies, csrf_token=csrf_token, session_id=session_id)
     print(f"Auth OK (CSRF length: {len(auth.csrf_token)})")
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, read=60.0)) as client:
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(10.0, read=60.0), cookies=auth.cookie_jar
+    ) as client:
         # 1. LIST_NOTEBOOKS
         print("\n--- LIST_NOTEBOOKS ---")
         list_raw = await make_rpc_request(client, auth, RPCMethod.LIST_NOTEBOOKS, [])

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -143,6 +143,20 @@ class AuthTokens:
                 answer, so a silent empty string would hide a malformed URL
                 (``https:/typo`` parses fine and matches nothing) behind a
                 plausible-looking result.
+
+        .. note::
+           Not a pure query: ``http.cookiejar.add_cookie_header`` ends by calling
+           ``clear_expired_cookies()``, so reading a header can prune expired
+           entries from :attr:`cookie_jar`. Harmless today — pruning changes what
+           the jar *holds*, never what a request *sends*, and Playwright writes
+           session cookies as ``expires: -1`` (mapped to ``None``, never expired),
+           so the eligible population is normally empty.
+
+           **Revisit if this method ever gains a caller inside**
+           ``AuthTokens.from_storage``: between ``snapshot_cookie_jar`` and
+           ``save_cookies_to_storage`` a prune would be persisted to disk as a
+           deletion. Correct in itself, but it would make a read-shaped call a
+           write.
         """
         parsed = httpx.URL(url)
         if parsed.scheme != "https":

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -101,12 +101,85 @@ class AuthTokens:
             ")"
         )
 
-    @property
-    def cookie_header(self) -> str:
-        """Generate Cookie header value for HTTP requests.
+    def cookie_header_for(self, url: str) -> str:
+        """Return the ``Cookie:`` header this session would send to ``url``.
+
+        This is the domain-correct way to build a raw header. Cookie selection
+        follows RFC 6265 §5.4 via :attr:`cookie_jar`, so a cookie scoped to one
+        host is not sent to another — unlike :attr:`cookie_header`, which
+        collapses every domain into one name→value slot and therefore has to
+        pick an arbitrary winner when the same name exists on two hosts
+        (issue #2054).
+
+        ``url`` is required and deliberately has no default: a default would
+        reintroduce the fabricated target that this method exists to remove.
+
+        .. important::
+           Routing is only as good as the jar. An ``AuthTokens`` built from a
+           bare ``name -> value`` mapping has no domains to preserve, so
+           ``__post_init__`` widens every entry to ``.google.com`` and this
+           method returns the **same broadcast header for every host** — the
+           behaviour it exists to replace, without an error to say so. Build
+           from ``storage_state`` (``AuthTokens.from_storage``, or pass
+           ``storage_path``) to get real per-host selection.
+
+        Args:
+            url: Absolute URL the header is being built for. Must be ``https``:
+                selection is ``Secure``-aware, so an ``http`` URL either drops
+                the ``Secure`` cookies without saying so or — for a jar built
+                from a bare cookie map, where nothing is marked ``Secure`` —
+                hands back credentials for a cleartext request. Both are wrong
+                for auth, so the scheme is rejected instead.
 
         Returns:
-            Semicolon-separated cookie string (e.g., "SID=abc; HSID=def")
+            Semicolon-separated ``name=value`` pairs, or ``""`` when no stored
+            cookie matches ``url``.
+
+        Raises:
+            ValueError: If ``url`` is not an absolute ``https`` URL with a host,
+                or if this session has no cookie jar. Every failure here is
+                raised rather than returned as ``""``: an empty header is
+                indistinguishable from "no cookie matched", which is a legitimate
+                answer, so a silent empty string would hide a malformed URL
+                (``https:/typo`` parses fine and matches nothing) behind a
+                plausible-looking result.
+        """
+        parsed = httpx.URL(url)
+        if parsed.scheme != "https":
+            raise ValueError(
+                f"cookie_header_for() requires an https URL (got {parsed.scheme!r}). "
+                "Auth cookies are Secure-scoped and must not be built for cleartext."
+            )
+        if not parsed.host:
+            raise ValueError(
+                f"cookie_header_for() requires an absolute URL with a host (got {url!r}). "
+                "A hostless URL matches no cookie and would return an empty header."
+            )
+        if self.cookie_jar is None:
+            raise ValueError(
+                "cookie_header_for() requires a cookie jar; this AuthTokens has none. "
+                "Cookie selection is per-host, and the flat `cookies` mapping cannot "
+                "answer a per-host question."
+            )
+        request = httpx.Request("GET", parsed)
+        self.cookie_jar.set_cookie_header(request)
+        return request.headers.get("cookie", "")
+
+    @property
+    def cookie_header(self) -> str:
+        """Generate a domain-blind Cookie header value.
+
+        .. warning::
+           **Not correct for building a request.** This is :attr:`flat_cookies`
+           joined into header syntax, so it inherits that projection's one slot
+           per cookie name: when the same name exists on more than one domain —
+           ``OSID`` on both the app host and ``accounts.google.com``, for
+           instance — all but one value is discarded, arbitrarily (issue
+           #2054). Use :meth:`cookie_header_for` instead, which selects cookies
+           per RFC 6265 for a specific URL.
+
+        Returns:
+            Semicolon-separated cookie string (e.g., "SID=abc; HSID=def").
         """
         return "; ".join(f"{k}={v}" for k, v in self.flat_cookies.items())
 
@@ -119,10 +192,19 @@ class AuthTokens:
     def flat_cookies(self) -> FlatCookieMap:
         """Return a legacy name→value cookie mapping.
 
-        Duplicate-name resolution follows :func:`_auth_domain_priority` so the
-        result matches what :func:`load_auth_from_storage` produces for the same
-        storage state (see issue #375). Domain-aware HTTP operations should use
-        ``cookie_jar`` or ``cookies`` directly instead.
+        .. warning::
+           **Lossy, and not correct for building a request.** One slot per
+           cookie name means duplicates across domains are discarded. Ranking
+           is by :func:`notebooklm._auth.cookie_policy._auth_domain_priority`,
+           whose named tiers are **not** all distinct — ``.notebooklm.google.com`` and
+           ``.notebook.google.com`` share a tier, as do their bare variants,
+           and tiers 0 and 1 hold many domains each. Within a tier the first
+           entry in iteration order wins, so the survivor is arbitrary and
+           changes if ``storage_state`` is reordered (issue #2054).
+
+           Kept for backward compatibility — see the migration note in the
+           v0.4.0 CHANGELOG entry that recommended it. For HTTP use
+           :meth:`cookie_header_for`, :attr:`cookie_jar`, or :attr:`cookies`.
         """
         return _auth_cookies.flatten_cookie_map(self.cookies)
 

--- a/tests/_guardrails/test_no_flat_cookies_on_the_wire.py
+++ b/tests/_guardrails/test_no_flat_cookies_on_the_wire.py
@@ -8,13 +8,17 @@ the highest populated tier in ``storage_state`` iteration order. Reordering the
 file changes the result (issue #2054).
 
 That is harmless as a *display* projection and fatal as a *request* input. The
-affordance has already produced four bad call sites across two files --
-``scripts/check_rpc_health.py`` (three probe POSTs) and
-``scripts/diagnose_get_notebook.py`` -- every one written by an author who had
-the "use ``cookie_jar``" docstring available. #2019 fixed the auth half of the
-first script and the request half survived it, which is why a docstring is not
-enough here: the property is *named* ``cookie_header``, and the name is an
-instruction.
+affordance produced three bad call sites in one file -- the probe POSTs in
+``scripts/check_rpc_health.py`` -- each written by an author who had the "use
+``cookie_jar``" docstring available. #2019 fixed that script's auth half and the
+request half survived it, which is why a docstring is not enough here: the
+property is *named* ``cookie_header``, and the name is an instruction.
+
+(``scripts/diagnose_get_notebook.py`` was broken in the same commit range but by
+a *different* defect -- it joined the domain-preserving ``AuthTokens.cookies``
+map, whose keys are ``(name, domain, path)`` tuples, into a syntactically
+malformed header. This lint does not catch that and should not be read as
+covering it.)
 
 So this lint enforces the one rule the docstrings ask for -- **a flat projection
 may not reach an HTTP request** -- rather than restating it in prose:
@@ -28,9 +32,9 @@ selection for a specific URL) or pass ``auth.cookie_jar`` to the client.
 
 **Passive ratchet, not a burndown.** ``KNOWN_FLAT_WIRE_SITES`` exists so a
 pre-existing site can be recorded rather than block unrelated work. It is empty
-today because #2054 cleared both files; entries should be deleted, never added.
-Adding one means a fifth wire-facing flat projection was introduced, which is
-precisely what this lint exists to stop.
+today because #2054 cleared every site it detects; entries should be deleted,
+never added. Adding one means a new wire-facing flat projection was introduced,
+which is precisely what this lint exists to stop.
 
 Scope is deliberately narrow. Reading ``auth.flat_cookies`` to *print* cookie
 names, to compare sets, or in a test fixture is legitimate and untouched -- only
@@ -61,26 +65,46 @@ def _is_flat_source(node: ast.AST) -> bool:
     followed later by ``headers={"Cookie": cookies}`` is a known blind spot;
     closing it needs real alias tracking, which is a different tool. The lint's
     job is to stop the *idiom* being re-copied, and every real instance so far
-    (four of them, across two files) was written inline.
+    (three of them, in one file) was written inline.
     """
     if isinstance(node, ast.Attribute):
         # ``auth.flat_cookies.copy`` -- the outer attribute is ``copy``, so keep
         # walking left until a projection name is found or the chain runs out.
         return node.attr in FLAT_SOURCES or _is_flat_source(node.value)
-    if isinstance(node, ast.Name) and node.id in FLAT_SOURCES:
-        return True
-    # ``auth.cookie_header.strip()`` / ``auth.flat_cookies.copy()`` -- a method
-    # call *on* a projection is still the projection.
+    # Deliberately NO bare ``ast.Name`` branch. Matching a local by name flags
+    # the *correct* pattern -- ``cookie_header = auth.cookie_header_for(url)``
+    # followed by ``{"Cookie": cookie_header}`` -- which would punish the fix
+    # this lint exists to encourage. ``load_auth_from_storage(...)`` is still
+    # caught below as a Call.
     if isinstance(node, ast.Call):
-        return _is_flat_source(node.func)
-    # ``f"{auth.cookie_header}"`` and ``"; ".join(auth.flat_cookies)`` -- wrapping
-    # it in a string does not make it domain-aware.
+        # A bare name in *callee* position is unambiguous -- ``load_auth_from_storage()``
+        # is the loader, whereas a bare name in *value* position may be a local
+        # holding a correctly-routed header. That asymmetry is why the general
+        # Name branch is omitted but this one is not.
+        if isinstance(node.func, ast.Name) and node.func.id in FLAT_SOURCES:
+            return True
+        # The callee chain (``auth.flat_cookies.copy()``) and the arguments
+        # (``dict(auth.flat_cookies)``, ``"; ".join(... auth.flat_cookies.items())``)
+        # -- wrapping a projection in another call does not make it domain-aware.
+        if _is_flat_source(node.func):
+            return True
+        return any(
+            _is_flat_source(arg) for arg in [*node.args, *(kw.value for kw in node.keywords)]
+        )
+    # ``f"{auth.cookie_header}"`` / ``"a" + auth.cookie_header``.
     if isinstance(node, ast.JoinedStr):
         return any(
             _is_flat_source(v.value) for v in node.values if isinstance(v, ast.FormattedValue)
         )
     if isinstance(node, ast.BinOp):
         return _is_flat_source(node.left) or _is_flat_source(node.right)
+    # ``f"{k}={v}" for k, v in auth.flat_cookies.items()`` -- the generator that
+    # ``cookie_header`` is itself built from, i.e. the first thing an author
+    # writes after being told not to use the property.
+    if isinstance(node, ast.GeneratorExp | ast.ListComp | ast.SetComp):
+        return any(_is_flat_source(gen.iter) for gen in node.generators)
+    if isinstance(node, ast.DictComp):
+        return any(_is_flat_source(gen.iter) for gen in node.generators)
     return False
 
 
@@ -103,6 +127,17 @@ def _flat_wire_sites(tree: ast.AST) -> list[int]:
         elif isinstance(node, ast.Call):
             for kw in node.keywords:
                 if kw.arg == "cookies" and _is_flat_source(kw.value):
+                    hits.append(node.lineno)
+        # Shape 3: headers["Cookie"] = <flat> -- the most ordinary way to set a
+        # header in Python, and invisible to a dict-literal-only matcher.
+        elif isinstance(node, ast.Assign) and _is_flat_source(node.value):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.slice, ast.Constant)
+                    and isinstance(target.slice.value, str)
+                    and target.slice.value.lower() == "cookie"
+                ):
                     hits.append(node.lineno)
 
     return hits
@@ -153,6 +188,16 @@ def test_lint_actually_detects_the_shapes_it_polices() -> None:
     )
 
     fstring_shape = ast.parse('headers = {"Cookie": f"{auth.cookie_header}"}')
+    subscript_shape = ast.parse('headers["Cookie"] = auth.cookie_header')
+    comprehension_shape = ast.parse(
+        'h = {"Cookie": "; ".join(f"{k}={v}" for k, v in auth.flat_cookies.items())}'
+    )
+    wrapper_shape = ast.parse("client = httpx.AsyncClient(cookies=dict(auth.flat_cookies))")
+    # The *correct* pattern must not be flagged: punishing the fix is worse
+    # than missing a violation, because it teaches authors to avoid the lint.
+    correct_shape = ast.parse(
+        'cookie_header = auth.cookie_header_for(url)\nheaders = {"Cookie": cookie_header}'
+    )
     method_shape = ast.parse("client = httpx.AsyncClient(cookies=auth.flat_cookies.copy())")
 
     assert _flat_wire_sites(header_shape), 'the {"Cookie": <flat>} shape must be detected'
@@ -160,7 +205,17 @@ def test_lint_actually_detects_the_shapes_it_polices() -> None:
     assert _flat_wire_sites(call_shape), "a flat loader call must be detected"
     assert _flat_wire_sites(fstring_shape), "an f-string wrapper must not defeat the lint"
     assert _flat_wire_sites(method_shape), "a method call on a projection is still the projection"
+    assert _flat_wire_sites(subscript_shape), 'headers["Cookie"] = <flat> must be detected'
+    assert _flat_wire_sites(comprehension_shape), (
+        "the generator cookie_header is built from must be detected -- it is what an "
+        "author writes next after being told not to use the property"
+    )
+    assert _flat_wire_sites(wrapper_shape), "a dict() wrapper must not defeat the lint"
     assert not _flat_wire_sites(clean_shape), "domain-aware usage must not be flagged"
+    assert not _flat_wire_sites(correct_shape), (
+        "cookie_header_for() assigned to a local named cookie_header is the CORRECT "
+        "pattern and must never be flagged"
+    )
 
 
 def test_allowlist_is_empty_so_the_lint_cannot_be_silenced() -> None:

--- a/tests/_guardrails/test_no_flat_cookies_on_the_wire.py
+++ b/tests/_guardrails/test_no_flat_cookies_on_the_wire.py
@@ -1,0 +1,195 @@
+"""Guard that no request is built from a domain-blind cookie projection.
+
+The flat ``name -> value`` shape has one slot per cookie name, so when the same
+name exists on two domains -- ``OSID`` on the app host *and* on
+``accounts.google.com``, which is the ordinary post-rebrand state -- every value
+but one is discarded, and *which* one survives is arbitrary: the first entry of
+the highest populated tier in ``storage_state`` iteration order. Reordering the
+file changes the result (issue #2054).
+
+That is harmless as a *display* projection and fatal as a *request* input. The
+affordance has already produced four bad call sites across two files --
+``scripts/check_rpc_health.py`` (three probe POSTs) and
+``scripts/diagnose_get_notebook.py`` -- every one written by an author who had
+the "use ``cookie_jar``" docstring available. #2019 fixed the auth half of the
+first script and the request half survived it, which is why a docstring is not
+enough here: the property is *named* ``cookie_header``, and the name is an
+instruction.
+
+So this lint enforces the one rule the docstrings ask for -- **a flat projection
+may not reach an HTTP request** -- rather than restating it in prose:
+
+* no ``"Cookie"`` header value derived from ``cookie_header`` / ``flat_cookies``
+  / ``load_auth_from_storage(...)``
+* no ``cookies=`` keyword to an ``httpx`` client or request built from one
+
+Use :meth:`notebooklm._auth.tokens.AuthTokens.cookie_header_for` (RFC 6265
+selection for a specific URL) or pass ``auth.cookie_jar`` to the client.
+
+**Passive ratchet, not a burndown.** ``KNOWN_FLAT_WIRE_SITES`` exists so a
+pre-existing site can be recorded rather than block unrelated work. It is empty
+today because #2054 cleared both files; entries should be deleted, never added.
+Adding one means a fifth wire-facing flat projection was introduced, which is
+precisely what this lint exists to stop.
+
+Scope is deliberately narrow. Reading ``auth.flat_cookies`` to *print* cookie
+names, to compare sets, or in a test fixture is legitimate and untouched -- only
+the two request-building shapes above are policed.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCANNED_ROOTS = (REPO_ROOT / "src" / "notebooklm", REPO_ROOT / "scripts")
+
+#: Attribute/function names whose result is a domain-blind ``name -> value`` map.
+FLAT_SOURCES = frozenset({"cookie_header", "flat_cookies", "load_auth_from_storage"})
+
+#: ``repo-relative path::line`` for sites that predate the rule. Delete, never add.
+KNOWN_FLAT_WIRE_SITES: frozenset[str] = frozenset()
+
+
+def _is_flat_source(node: ast.AST) -> bool:
+    """Return True when ``node`` evaluates -- or wraps -- a flat cookie projection.
+
+    Deliberately structural, not data-flow: it recognises the expression shapes
+    a flat projection is written in at the point of use, and does **not** chase
+    a value through an intervening variable. ``cookies = auth.cookie_header``
+    followed later by ``headers={"Cookie": cookies}`` is a known blind spot;
+    closing it needs real alias tracking, which is a different tool. The lint's
+    job is to stop the *idiom* being re-copied, and every real instance so far
+    (four of them, across two files) was written inline.
+    """
+    if isinstance(node, ast.Attribute):
+        # ``auth.flat_cookies.copy`` -- the outer attribute is ``copy``, so keep
+        # walking left until a projection name is found or the chain runs out.
+        return node.attr in FLAT_SOURCES or _is_flat_source(node.value)
+    if isinstance(node, ast.Name) and node.id in FLAT_SOURCES:
+        return True
+    # ``auth.cookie_header.strip()`` / ``auth.flat_cookies.copy()`` -- a method
+    # call *on* a projection is still the projection.
+    if isinstance(node, ast.Call):
+        return _is_flat_source(node.func)
+    # ``f"{auth.cookie_header}"`` and ``"; ".join(auth.flat_cookies)`` -- wrapping
+    # it in a string does not make it domain-aware.
+    if isinstance(node, ast.JoinedStr):
+        return any(
+            _is_flat_source(v.value) for v in node.values if isinstance(v, ast.FormattedValue)
+        )
+    if isinstance(node, ast.BinOp):
+        return _is_flat_source(node.left) or _is_flat_source(node.right)
+    return False
+
+
+def _flat_wire_sites(tree: ast.AST) -> list[int]:
+    """Return line numbers where a flat projection feeds an HTTP request."""
+    hits: list[int] = []
+
+    for node in ast.walk(tree):
+        # Shape 1: {"Cookie": <flat>} -- a hand-built header.
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values, strict=False):
+                if (
+                    isinstance(key, ast.Constant)
+                    and isinstance(key.value, str)
+                    and key.value.lower() == "cookie"
+                    and _is_flat_source(value)
+                ):
+                    hits.append(node.lineno)
+        # Shape 2: cookies=<flat> -- passed to a client or request constructor.
+        elif isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "cookies" and _is_flat_source(kw.value):
+                    hits.append(node.lineno)
+
+    return hits
+
+
+def _python_files() -> list[Path]:
+    return sorted(p for root in SCANNED_ROOTS for p in root.rglob("*.py"))
+
+
+def test_no_flat_cookie_projection_reaches_an_http_request() -> None:
+    """A flat ``name -> value`` map must never build a request (issue #2054)."""
+    offenders: list[str] = []
+
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for lineno in _flat_wire_sites(tree):
+            site = f"{rel}::{lineno}"
+            if site not in KNOWN_FLAT_WIRE_SITES:
+                offenders.append(site)
+
+    assert not offenders, (
+        "A domain-blind cookie projection is being used to build an HTTP request. "
+        "It keeps one value per cookie name, so a name present on two domains "
+        "loses all but one -- arbitrarily (#2054).\n"
+        "Use auth.cookie_header_for(url) for a raw header, or pass "
+        "auth.cookie_jar as the client's cookies=.\n"
+        f"Offending sites: {offenders}"
+    )
+
+
+def test_lint_actually_detects_the_shapes_it_polices() -> None:
+    """Fail loudly if the matcher stops matching -- a silent pass is the failure mode.
+
+    Without this, a refactor of ``_flat_wire_sites`` that matched nothing would
+    leave the guardrail green forever while policing nothing. That vacuous-pass
+    mode is exactly the defect class tracked in #2055.
+    """
+    header_shape = ast.parse(
+        'headers = {"Content-Type": "x", "Cookie": auth.cookie_header}',
+    )
+    kwarg_shape = ast.parse("client = httpx.AsyncClient(cookies=auth.flat_cookies)")
+    call_shape = ast.parse('headers = {"Cookie": load_auth_from_storage(path)}')
+    clean_shape = ast.parse(
+        "client = httpx.AsyncClient(cookies=auth.cookie_jar)\n"
+        "names = sorted(auth.flat_cookies)\n"
+        "header = auth.cookie_header_for(url)\n"
+    )
+
+    fstring_shape = ast.parse('headers = {"Cookie": f"{auth.cookie_header}"}')
+    method_shape = ast.parse("client = httpx.AsyncClient(cookies=auth.flat_cookies.copy())")
+
+    assert _flat_wire_sites(header_shape), 'the {"Cookie": <flat>} shape must be detected'
+    assert _flat_wire_sites(kwarg_shape), "the cookies=<flat> shape must be detected"
+    assert _flat_wire_sites(call_shape), "a flat loader call must be detected"
+    assert _flat_wire_sites(fstring_shape), "an f-string wrapper must not defeat the lint"
+    assert _flat_wire_sites(method_shape), "a method call on a projection is still the projection"
+    assert not _flat_wire_sites(clean_shape), "domain-aware usage must not be flagged"
+
+
+def test_allowlist_is_empty_so_the_lint_cannot_be_silenced() -> None:
+    """``KNOWN_FLAT_WIRE_SITES`` must stay empty.
+
+    The allowlist exists so a *pre-existing* site could be recorded rather than
+    block unrelated work — but #2054 cleared both files, so there is nothing
+    left to excuse. Without this assertion the cheapest way to satisfy the lint
+    is to add the offending line to the allowlist, which turns a ratchet into a
+    rubber stamp. If a genuinely unavoidable site ever appears, delete this test
+    deliberately and say why in the PR.
+    """
+    assert frozenset() == KNOWN_FLAT_WIRE_SITES, (
+        "the lint is being silenced by allowlisting rather than by fixing the call site"
+    )
+
+
+def test_the_scan_reaches_the_files_this_rule_exists_for() -> None:
+    """Fail if the roots stop resolving -- an empty scan is a vacuous pass.
+
+    ``test_no_flat_cookie_projection_reaches_an_http_request`` iterates whatever
+    ``_python_files()`` yields, so a moved directory or a mistyped root would
+    turn it green while policing nothing (the #2055 defect class). Unparseable
+    files need no guard of their own: ``ast.parse`` raises there and fails the
+    scan loudly. What it cannot notice is a file never handed to it, so this
+    pins the two the rule was written for by name.
+    """
+    scanned = {p.relative_to(REPO_ROOT).as_posix() for p in _python_files()}
+
+    assert "scripts/check_rpc_health.py" in scanned
+    assert "scripts/diagnose_get_notebook.py" in scanned
+    assert "src/notebooklm/_auth/tokens.py" in scanned

--- a/tests/unit/test_auth_cookie_header_routing.py
+++ b/tests/unit/test_auth_cookie_header_routing.py
@@ -1,0 +1,236 @@
+"""Domain-correct cookie selection for raw ``Cookie:`` headers (issue #2054).
+
+The flat ``name -> value`` projection behind :attr:`AuthTokens.cookie_header`
+keeps one value per cookie name, so a name that legitimately exists on two hosts
+loses all but one -- and *which* one survives is arbitrary, because
+``_auth_domain_priority``'s named tiers are not all distinct (the two app hosts
+share a tier, as do their dotted variants) and within a tier the first entry in
+iteration order wins.
+
+Every assertion here is on ``(name, value)`` pairs rather than names. A name-only
+view cannot express the contract that matters -- "the *app-host* ``OSID`` never
+reaches the sign-in host" -- once the sign-in host legitimately carries an
+``OSID`` of its own, which is the ordinary post-rebrand state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._auth.cookies import extract_cookies_from_storage
+from notebooklm._auth.tokens import AuthTokens
+
+APP_HOST = "notebooklm.google.com"
+ALIAS_HOST = "notebook.google.com"
+SIGN_IN_HOST = "accounts.google.com"
+
+
+def _cookie_pairs(header: str) -> set[tuple[str, str]]:
+    """``(name, value)`` pairs from a ``Cookie:`` header."""
+    pairs: set[tuple[str, str]] = set()
+    for chunk in header.split(";"):
+        chunk = chunk.strip()
+        if "=" in chunk:
+            name, value = chunk.split("=", 1)
+            pairs.add((name.strip(), value.strip()))
+    return pairs
+
+
+@pytest.fixture
+def collided_auth() -> AuthTokens:
+    """A session whose ``OSID`` exists on three hosts with three distinct values.
+
+    This is the shape a real profile has after the rebrand: direct inspection of
+    a live ``storage_state.json`` shows host-scoped ``OSID`` / ``__Secure-OSID``
+    on **both** app hosts with **different values**, alongside the sign-in host's
+    own. The collision is the whole point -- a fixture carrying one ``OSID``
+    would pass every assertion below against a broken implementation.
+    """
+    return AuthTokens(
+        cookies={
+            ("SID", ".google.com", "/"): "v-sid",
+            ("__Secure-1PSIDTS", ".google.com", "/"): "v-psidts",
+            ("OSID", APP_HOST, "/"): "osid-app",
+            ("OSID", ALIAS_HOST, "/"): "osid-alias",
+            ("OSID", SIGN_IN_HOST, "/"): "osid-signin",
+            ("LSID", SIGN_IN_HOST, "/"): "v-lsid",
+        },
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+@pytest.mark.parametrize(
+    ("host", "expected_osid"),
+    [(APP_HOST, "osid-app"), (ALIAS_HOST, "osid-alias"), (SIGN_IN_HOST, "osid-signin")],
+)
+def test_each_host_receives_its_own_binding_cookie(
+    collided_auth: AuthTokens, host: str, expected_osid: str
+) -> None:
+    """Presence: the routed header carries the ``OSID`` minted for that host."""
+    pairs = _cookie_pairs(collided_auth.cookie_header_for(f"https://{host}/x"))
+    assert ("OSID", expected_osid) in pairs
+
+
+@pytest.mark.parametrize(
+    ("host", "forbidden"),
+    [
+        (APP_HOST, {("OSID", "osid-alias"), ("OSID", "osid-signin"), ("LSID", "v-lsid")}),
+        (ALIAS_HOST, {("OSID", "osid-app"), ("OSID", "osid-signin"), ("LSID", "v-lsid")}),
+        (SIGN_IN_HOST, {("OSID", "osid-app"), ("OSID", "osid-alias")}),
+    ],
+)
+def test_no_host_receives_another_hosts_cookies(
+    collided_auth: AuthTokens, host: str, forbidden: set[tuple[str, str]]
+) -> None:
+    """Absence: a cookie scoped to one host never reaches another.
+
+    Presence alone is satisfiable by broadcasting everything to everyone, which
+    is exactly the pre-fix behaviour -- so absence is the assertion that has
+    teeth. ``LSID`` is the concrete leak #2054 reported: accounts-scoped, and
+    sent to the app host on every probe by the flat projection.
+    """
+    pairs = _cookie_pairs(collided_auth.cookie_header_for(f"https://{host}/x"))
+    assert not (pairs & forbidden)
+
+
+def test_domain_wide_cookies_reach_every_host(collided_auth: AuthTokens) -> None:
+    """Negative control: ``.google.com`` cookies are *supposed* to be broadcast.
+
+    Without this, an implementation that sent nothing at all would satisfy every
+    absence assertion above.
+    """
+    for host in (APP_HOST, ALIAS_HOST, SIGN_IN_HOST):
+        pairs = _cookie_pairs(collided_auth.cookie_header_for(f"https://{host}/x"))
+        assert ("SID", "v-sid") in pairs
+        assert ("__Secure-1PSIDTS", "v-psidts") in pairs
+
+
+def test_flat_projection_leaks_across_hosts(collided_auth: AuthTokens) -> None:
+    """Characterize the projection this method replaces (passes on ``origin/main``).
+
+    Not a regression test -- it pins the documented behaviour of
+    :attr:`AuthTokens.cookie_header` so that changing it without updating the
+    docstring fails here. The leak is real: the accounts-scoped ``LSID`` appears
+    in a header a caller would send to the app host, and exactly one of the three
+    ``OSID`` values survives.
+    """
+    pairs = _cookie_pairs(collided_auth.cookie_header)
+    assert ("LSID", "v-lsid") in pairs, "flat projection is domain-blind by construction"
+    surviving = {value for name, value in pairs if name == "OSID"}
+    assert len(surviving) == 1, "one slot per name means two OSID values are discarded"
+
+
+def test_non_https_url_is_rejected(collided_auth: AuthTokens) -> None:
+    """An ``http`` URL must raise, not silently return some other header.
+
+    Selection is ``Secure``-aware, and what a jar carries depends on how it was
+    built: ``build_cookie_jar`` marks nothing ``Secure`` when widening a bare
+    cookie map, while ``build_httpx_cookies_from_storage`` preserves the flag
+    from disk. So an ``http`` URL returns anything from the full header to a
+    partial one to none at all -- no single emptiness assertion covers it, and
+    every outcome is wrong for auth. Rejecting the scheme is the contract.
+    """
+    with pytest.raises(ValueError, match="https"):
+        collided_auth.cookie_header_for(f"http://{APP_HOST}/x")
+
+
+#: Tier-1 cookies every storage fixture needs, or the loader rejects it outright.
+_REQUIRED = [
+    {"name": "SID", "value": "v-sid", "domain": ".google.com", "path": "/"},
+    {"name": "__Secure-1PSIDTS", "value": "v-psidts", "domain": ".google.com", "path": "/"},
+]
+
+
+def _storage(cookies: list[dict[str, object]]) -> dict[str, object]:
+    return {"cookies": [*_REQUIRED, *cookies], "origins": []}
+
+
+def test_same_tier_resolution_is_order_dependent() -> None:
+    """The tie is real and observable -- two orderings, two answers.
+
+    ``.notebooklm.google.com`` and ``.notebook.google.com`` share a tier, so the
+    winner is whichever appears first. Deliberately two fixed orderings rather
+    than a shuffle: a randomized gate would detect a real collision only ~50% of
+    the time and the first green re-run would be believed.
+    """
+    entries = [
+        {"name": "OSID", "value": "from-legacy", "domain": APP_HOST, "path": "/"},
+        {"name": "OSID", "value": "from-alias", "domain": ALIAS_HOST, "path": "/"},
+    ]
+    forward = extract_cookies_from_storage(_storage(entries))
+    reverse = extract_cookies_from_storage(_storage(list(reversed(entries))))
+
+    assert {forward["OSID"], reverse["OSID"]} == {"from-legacy", "from-alias"}, (
+        "same-tier duplicates must resolve by input order -- if this fails, the "
+        "tier table changed and the docstrings describing it need updating too"
+    )
+
+
+def test_cross_tier_resolution_is_order_independent() -> None:
+    """Negative control: distinct tiers resolve the same either way.
+
+    Without this, an implementation that made *everything* order-dependent
+    would satisfy the test above.
+    """
+    entries = [
+        {"name": "OSID", "value": "from-wide", "domain": ".google.com", "path": "/"},
+        {"name": "OSID", "value": "from-host", "domain": APP_HOST, "path": "/"},
+    ]
+    forward = extract_cookies_from_storage(_storage(entries))
+    reverse = extract_cookies_from_storage(_storage(list(reversed(entries))))
+
+    assert forward["OSID"] == reverse["OSID"]
+
+
+def test_flat_construction_degrades_to_broadcast() -> None:
+    """A jar with no real domains cannot route -- and says so in the docstring.
+
+    ``AuthTokens(cookies={flat})`` has no domains to preserve, so
+    ``__post_init__`` widens every entry to ``.google.com`` and the "routed"
+    header becomes the same broadcast for every host. Pinned because it is a
+    silent degradation: ``cookie_header_for`` still returns a plausible header,
+    just not a selective one. Callers get per-host selection only by building
+    from ``storage_state``.
+    """
+    flat = AuthTokens(
+        cookies={"SID": "v-sid", "OSID": "osid-only", "LSID": "v-lsid"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+    app = _cookie_pairs(flat.cookie_header_for(f"https://{APP_HOST}/x"))
+    sign_in = _cookie_pairs(flat.cookie_header_for(f"https://{SIGN_IN_HOST}/x"))
+
+    assert app == sign_in, "a domain-less jar broadcasts; it cannot select per host"
+    assert ("LSID", "v-lsid") in app, "including cookies that should never reach the app host"
+
+
+@pytest.mark.parametrize(
+    ("bad_url", "match"),
+    [("http://" + APP_HOST + "/x", "https"), ("https:/typo", "host"), ("https://", "host")],
+)
+def test_malformed_urls_raise_rather_than_returning_empty(
+    collided_auth: AuthTokens, bad_url: str, match: str
+) -> None:
+    """A URL that cannot match must raise, not return ``""``.
+
+    ``""`` is a legitimate answer -- it means "no stored cookie is scoped to
+    this host". So returning it for a *malformed* URL makes a typo
+    indistinguishable from a correct negative, which is how a request ends up
+    silently unauthenticated. ``https:/typo`` parses without error and matches
+    nothing.
+    """
+    with pytest.raises(ValueError, match=match):
+        collided_auth.cookie_header_for(bad_url)
+
+
+def test_missing_jar_raises_rather_than_returning_empty() -> None:
+    """No jar means the per-host question cannot be answered at all."""
+    auth = AuthTokens(
+        cookies={("SID", ".google.com", "/"): "v-sid"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+    auth.cookie_jar = None
+    with pytest.raises(ValueError, match="cookie jar"):
+        auth.cookie_header_for(f"https://{APP_HOST}/x")

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -176,7 +176,16 @@ def test_partition_errors_separates_transient_from_real() -> None:
 
 
 @pytest.mark.asyncio
-async def test_make_rpc_request_uses_flat_cookie_header_and_auth_route() -> None:
+async def test_make_rpc_request_builds_the_url_and_auth_route() -> None:
+    """Query shape and CSRF body for a probe request.
+
+    Cookies are deliberately *not* asserted here. They no longer travel in a
+    hand-built header — the probes share one client carrying the
+    domain-scoped jar (#2054) — so a ``FakeClient`` cannot observe them.
+    Cookie coverage lives in ``test_scripts_auth_cookie_domains.py``, which
+    drives the real ``build_probe_client`` and asserts on the recorded
+    request, the only view that would notice a re-added manual header.
+    """
     captured: dict[str, Any] = {}
 
     class FakeClient:
@@ -219,10 +228,9 @@ async def test_make_rpc_request_uses_flat_cookie_header_and_auth_route() -> None
 
     assert response_text == ")]}'\n\n[]"
     assert error is None
-    cookie_header = captured["headers"]["Cookie"]
-    assert "SID=sid" in cookie_header
-    assert "__Secure-1PSIDTS=ts" in cookie_header
-    assert "('SID'," not in cookie_header
+    assert "Cookie" not in captured["headers"], (
+        "the probe must not hand-build a Cookie header; the client jar carries them"
+    )
     query = parse_qs(urlparse(captured["url"]).query)
     assert query["rpcids"] == [check_rpc_health.RPCMethod.CREATE_NOTEBOOK.value]
     assert query["source-path"] == ["/notebook/nb_123"]

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -345,10 +345,12 @@ def _auth_tokens_with_collision() -> AuthTokens:
 # ---------------------------------------------------------------------------
 # The probe POSTs themselves (#2054)
 #
-# Everything above pins the *auth* path. The three batchexecute probes were a
-# separate leak: each hand-built ``{"Cookie": auth.cookie_header}``, the flat
-# projection, so the accounts-scoped ``LSID`` was sent to the app host on every
-# request and one of several same-name cookies survived arbitrarily.
+# Everything above pins the *auth* path. The three probe request paths -- two
+# batchexecute calls and the streamed-chat call, which posts to a hardcoded v1
+# path rather than a method id -- were a separate leak: each hand-built
+# ``{"Cookie": auth.cookie_header}``, the flat projection, so the
+# accounts-scoped ``LSID`` was sent to the app host on every request and one of
+# several same-name cookies survived arbitrarily.
 #
 # These assert on the header of the POST itself, driven through the *shipped*
 # ``build_probe_client``. That indirection is the point: httpx lets an explicit

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -34,6 +34,7 @@ be satisfied by accident:
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+from notebooklm._auth.tokens import AuthTokens
 from notebooklm._env import get_base_url
 from scripts import capture_rpc_registry, check_rpc_health
 
@@ -324,3 +326,127 @@ def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(
     cdn_requests = [r for r in httpx_mock.get_requests() if r.url.host == "www.gstatic.com"]
     assert cdn_requests
     assert all("cookie" not in r.headers for r in cdn_requests)
+
+
+def _auth_tokens_with_collision() -> AuthTokens:
+    """AuthTokens built from the module's own collision fixture.
+
+    Reuses ``_storage_state()`` so the probe assertions cannot drift from the
+    auth-path assertions above -- both see the same ``OSID`` on two hosts with
+    two values, which is what makes an absence assertion meaningful.
+    """
+    cookies = {
+        (entry["name"], entry["domain"], entry.get("path", "/")): entry["value"]
+        for entry in _storage_state()["cookies"]
+    }
+    return AuthTokens(cookies=cookies, csrf_token="csrf", session_id="session")
+
+
+# ---------------------------------------------------------------------------
+# The probe POSTs themselves (#2054)
+#
+# Everything above pins the *auth* path. The three batchexecute probes were a
+# separate leak: each hand-built ``{"Cookie": auth.cookie_header}``, the flat
+# projection, so the accounts-scoped ``LSID`` was sent to the app host on every
+# request and one of several same-name cookies survived arbitrarily.
+#
+# These assert on the header of the POST itself, driven through the *shipped*
+# ``build_probe_client``. That indirection is the point: httpx lets an explicit
+# ``Cookie`` header silently override the client jar, with no merge and no
+# error, so a test that supplied its own client would still pass if the fix
+# were reverted at the construction site.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_client_is_the_seam_that_carries_the_jar() -> None:
+    """``build_probe_client`` must attach the domain-scoped jar itself."""
+    auth = _auth_tokens_with_collision()
+    client = check_rpc_health.build_probe_client(auth)
+    request = httpx.Request("POST", f"https://{_notebook_host()}/probe")
+    client.cookies.set_cookie_header(request)
+    sent = _cookie_pairs(request.headers.get("cookie", ""))
+
+    assert ("OSID", "v-osid-app") in sent, "the app host must receive its own OSID"
+    assert ("LSID", "v-lsid") not in sent, "the accounts-scoped LSID must not leak"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("probe", ["rpc", "raw_rpc"])
+async def test_probe_post_carries_domain_scoped_cookies(httpx_mock: HTTPXMock, probe: str) -> None:
+    """The batchexecute POST itself must not carry another host's cookies.
+
+    Asserted on the recorded request rather than on the client, because that is
+    the only view that would notice a re-added manual ``Cookie`` header.
+    """
+    auth = _auth_tokens_with_collision()
+    httpx_mock.add_response(method="POST", text=")]}'\n[]")
+
+    async with check_rpc_health.build_probe_client(auth) as client:
+        if probe == "rpc":
+            await check_rpc_health.make_rpc_request(
+                client, auth, check_rpc_health.RPCMethod.LIST_NOTEBOOKS, []
+            )
+        else:
+            # A second entry point that also POSTs batchexecute. Parametrised
+            # because each probe used to hand-build its own header, so fixing
+            # one and leaving another would be invisible: httpx prefers an
+            # explicit Cookie header over the jar, silently.
+            await check_rpc_health.make_raw_rpc_request(
+                client, auth, check_rpc_health.RPCMethod.LIST_NOTEBOOKS.value, []
+            )
+
+    posts = [r for r in httpx_mock.get_requests() if r.method == "POST"]
+    assert posts, "the probe must have issued a POST"
+    for request in posts:
+        sent = _cookie_pairs(request.headers.get("cookie", ""))
+        assert ("OSID", "v-osid-app") in sent
+        assert ("OSID", "v-osid-accounts") not in sent
+        assert ("LSID", "v-lsid") not in sent
+
+
+def test_probe_client_construction_has_exactly_one_home() -> None:
+    """``build_probe_client`` must be the *only* place a probe client is built.
+
+    The seam makes the jar assertable, but a test that calls
+    ``build_probe_client`` directly proves only that the helper is correct --
+    it cannot notice ``main()`` quietly going back to a bare
+    ``httpx.AsyncClient(timeout=30.0)``. That mutation is silent and total: the
+    manual ``Cookie`` headers are gone, so the probes would send **no** cookies
+    at all and every other test here would still pass.
+
+    So this pins the structure instead: exactly one ``AsyncClient`` construction
+    in the module, and it lives inside the helper that attaches the jar.
+    """
+    source = Path(check_rpc_health.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    constructions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "AsyncClient"
+    ]
+    assert len(constructions) == 1, (
+        "expected exactly one httpx.AsyncClient construction; a second one would "
+        "bypass the jar that build_probe_client attaches"
+    )
+
+    builder = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "build_probe_client"
+    )
+    builder_lines = range(builder.lineno, (builder.end_lineno or builder.lineno) + 1)
+    assert constructions[0].lineno in builder_lines, (
+        "the AsyncClient construction moved out of build_probe_client -- the probes "
+        "would no longer carry the domain-scoped jar"
+    )
+
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "build_probe_client"
+        and node.lineno not in builder_lines
+        for node in ast.walk(tree)
+    ), "build_probe_client is defined but never called"


### PR DESCRIPTION
Fixes #2054.

## The defect

`AuthTokens.cookie_header` / `flat_cookies` collapse every domain into one `name -> value` slot. When a cookie name exists on two hosts, all but one value is discarded — and **which survives is arbitrary**: the first entry of the highest populated tier in `storage_state` iteration order, because `_auth_domain_priority`'s named tiers are not all distinct. Reordering the file changes the result.

That is not hypothetical. Direct inspection of a live post-rebrand profile (value hashes, never values):

```
OSID           notebook.google.com     65192f66bb2c
OSID           notebooklm.google.com   8af6f77373b2     <- different value
__Secure-OSID  notebook.google.com     7c2ab8c1b01a
__Secure-OSID  notebooklm.google.com   c06064f97c26     <- different value
```

Both binding cookies exist on both hosts with different values. A 400-shuffle harness over a realistic fixture yields **4 distinct resolved outcomes at ~25% each**, and `OSID` / `__Secure-OSID` resolve *independently* — so **half the time the client assembles a mismatched pair**, one host's `OSID` with the other host's `__Secure-OSID`. That is a more plausible `/CookieMismatch` trigger than a consistently-wrong choice.

## Two live instances

- **`scripts/check_rpc_health.py`** hand-built each of its three authenticated probes' `Cookie:` header from the flat map, so the `accounts.google.com`-scoped **`LSID` was sent to the app host on every request**. #2019 fixed this script's *auth* path and left its *request* path untouched — the guardrail added there asserts the jar and `load_auth`'s hops, never the POST headers.
- **`scripts/diagnose_get_notebook.py`** joined `AuthTokens.cookies`, whose keys became `(name, domain, path)` tuples in #369, emitting `('SID', '.google.com', '/')=value` — syntactically malformed. **This script has been unable to authenticate for anyone since.** It also read the eager module-level `BATCHEXECUTE_URL`, so `NOTEBOOKLM_BASE_URL` was ignored and enterprise users were pointed at the consumer host. Neither half is independently smoke-testable, so both are fixed together.

## The change

**`AuthTokens.cookie_header_for(url)`** — RFC 6265 selection via the existing `cookie_jar`, using the idiom already in `_curl_cffi_transport.py`. Purely additive. `url` is **required**: a default would reintroduce the fabricated target the method exists to remove. Malformed and non-`https` URLs **raise** rather than returning `""`, because `""` is a legitimate answer meaning "no cookie is scoped to this host" — returning it for a typo makes an unauthenticated request indistinguishable from a correct negative.

**`build_probe_client(auth)`** — a named seam in the health script so the assertion lands on the *shipped* construction. This matters more than it looks: httpx lets an explicit `Cookie` header **silently override** the client jar, with no merge and no error, so a partial migration would be invisible. All three headers are deleted, verified 3 → 0.

**AST guardrail** — a flat projection may not reach an HTTP request. Verified against the *unfixed* files from `origin/main`: it flags the three real sites (`check_rpc_health.py` 346/841/959) and is clean after. It does **not** catch the `diagnose_get_notebook.py` defect — that one joined the *domain-preserving* `AuthTokens.cookies` map with tuple keys, a different bug, and an earlier draft of the lint only appeared to catch it via a variable-name coincidence. Corrected rather than left overstated.

## Verification

Every behavioural test was run against `origin/main` to confirm it fails there:

| check | result |
|---|---|
| full suite | 12763 passed, 64 skipped, 1 xfailed |
| mypy | clean, 322 source files |
| ruff + format | clean, whole tree |
| new probe tests vs `origin/main` | fail (as required) |
| guardrail vs `origin/main` | flags all 4 sites |

The mutation rev-testability described was performed, not assumed: reverting `main()` to a bare `AsyncClient(timeout=30.0)` while leaving `build_probe_client` intact leaves the probes sending **zero** cookies. `test_probe_client_construction_has_exactly_one_home` fails on exactly that; the other tests stayed green, confirming they were blind to it.

## Stated limitations

- **`cookie_header_for` is only as good as the jar.** An `AuthTokens` built from a bare `name -> value` map has every entry widened to `.google.com`, so the "routed" header broadcasts to every host — the behaviour it replaces, without an error to say so. Documented on the method and pinned by `test_flat_construction_degrades_to_broadcast`. Fixing the ingest fabrication is a separate change.
- **The lint is structural, not data-flow.** `cookies = auth.cookie_header` followed later by `headers={"Cookie": cookies}` is a known blind spot; closing it needs alias tracking. All four real instances were written inline.
- **`AsyncClient(cookies=jar)` copies rather than shares**, so cookies the service rotates mid-run land on a private copy and are discarded. Not a regression — the script previously kept no jar at all — but it means a probe run cannot persist a rotation.

## Deliberately out of scope

- **#2057** — the same ranking gates PSIDTS recovery. Six call sites across two different questions ("should we fire?" vs "did it land?"), one of which is documented as *"the sole arbiter"* of whether a heal landed. A wrong answer there is a bad **write**, not a bad read.
- **The false determinism claims** in `cookie_policy.py:536-538` and `cookies.py:182-185` ("tiers are distinct … deterministic regardless of ordering") are measurably wrong but belong to a separate comments-and-test-only PR. Note this PR's `tokens.py` docstrings now state the truth, so source and consumer disagree until that lands — an existing falsehood now has a correct statement beside it.

Refs #2018, #2019, #2055, #2057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added domain-aware authentication cookie handling for secure HTTPS requests.
  * Restored authentication and configurable base URL support in notebook diagnostics.

* **Bug Fixes**
  * Prevented cookies from being sent to the wrong host during RPC health checks and diagnostic requests.
  * Improved handling of authentication cookies shared across multiple domains, preventing cross-host leakage.

* **Tests**
  * Added coverage for cookie routing, host isolation, HTTPS validation, diagnostics, and RPC probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->