### PR TITLE
fix(auth): decide PSIDTS recovery by RFC 6265 routing, not domain ranking (#2057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `__Secure-1PSIDTS` recovery gate now decides by RFC 6265 routing instead
+  of a domain-priority ranking.** Whether to fire the healing `RotateCookies`
+  POST was decided from a domain-blind "global winner" projection that ranked
+  duplicate cookie names by domain tier and read that one winner's `expires` —
+  while the POST it gates is routed per RFC 6265. The two could therefore answer
+  different questions about the same cookie set. The ranking was also inverted
+  relative to the action: `accounts.google.com`, the exact host the POST targets,
+  sat in the *lowest* tier, so a host-scoped `__Secure-1PSIDTS` that does route
+  was outranked by app-host cookies that do not. And because the tiers are not
+  all distinct, the winner within a shared tier depended on `storage_state`
+  ordering. The gate now asks whether the `Cookie:` header this jar would send to
+  the rotate URL actually carries `__Secure-1PSIDTS`; the separate "did the heal
+  land?" check stays domain-blind, because it must predict the retrying
+  preflight. No divergence had been observed on measured profiles — this was a
+  latent defect whose failure mode is a silent wrong gate decision surfacing as a
+  spurious missing-cookie error
+  ([#2057](https://github.com/teng-lin/notebooklm-py/issues/2057)).
+
+  Also fixed while in the same code path: a cookie row with a malformed
+  `expires` (`""`, `"never"`, `nan`, `inf`, a list) crashed recovery with
+  `ValueError: could not convert string to float` raised from *inside* the
+  caller's own `except ValueError:` handler — replacing the actionable
+  "Missing required cookies … Run `notebooklm login`" message with a converter
+  traceback, after the rotation throttle slot had already been claimed. One
+  malformed sibling row was enough; it did not have to be the PSIDTS row.
+
+  And an empty `NOTEBOOKLM_AUTH_JSON` no longer redirects recovery at a profile
+  file. The cookie loader tests the variable's *presence* and fails fast with
+  "set but empty", but the recovery path tested its *truthiness* — so an empty
+  value fell through to the default profile, where recovery could fire a
+  `RotateCookies` POST and persist rotated cookies to a profile the caller had
+  deliberately bypassed by setting the variable at all. Both now test presence.
+
 - **`doctor` no longer warns Windows users about permissions the client
   deliberately never sets.** `notebooklm doctor` compared the profile
   directory's POSIX mode against `0o700` on every platform, but the writer

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -644,8 +644,33 @@ rotate URL. That last condition is RFC 6265 selection against the URL the
 decision is about, not a domain-priority ranking: a `__Secure-1PSIDTS` scoped to
 `.notebooklm.google.com` (or, post-rebrand, `.notebook.google.com`) never reaches
 `accounts.google.com`, while a host-scoped one on `accounts.google.com` does
-(issue #2057). The separate "did the heal land?" check is deliberately
-domain-blind instead, because it must predict the retrying preflight. It honors
+(issue #2057).
+
+The separate "did the heal land?" check (`_psidts_is_live`) is deliberately
+domain-blind instead, because it must predict the retrying preflight rather than
+the request jar. **Do not merge the two predicates.** Their differences are
+intentional, and each one has a failure mode behind it:
+
+| | should we fire? (`_psidts_routes_to_rotate`) | did it land? (`_psidts_is_live`) |
+|---|---|---|
+| domain | RFC 6265 routing to the rotate URL | blind — matches the preflight |
+| duplicate `(name, domain, path)` | any expired twin disqualifies the identity, mirroring the jar's one-cookie-per-identity replacement | ignored |
+| malformed `expires` | row cannot be sent, so it does not count → fire | row is on disk and the preflight will see it → counts as present |
+| known-expired row | does not route | does not count (issue #1273) |
+| empty `value` | skipped | skipped |
+
+The duplicate rule is the sharp edge. Applying it to the heal check turns a
+working session into a permanent failure loop: `save_cookies_to_storage`
+CAS-matches the *first* stored row for an identity, so a stale same-identity
+twin survives the save, and the heal would report failure on every load while
+the preflight keeps passing. That twin is issue #1523's data shape — #1523 fixed
+the producer, and nothing on the load/save path removes an existing one.
+
+Note also that `_psidts_is_live` models `extract_cookies_from_storage`
+specifically; the sibling loader `_build_httpx_cookies_from_storage_strict`
+converts every row and can still reject a state it accepts.
+
+Recovery honors
 `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`, and uses a cross-process flock
 (`psidts_recovery.lock`) so concurrent cold-start processes don't fan out identical
 recovery calls. This is what lets the L4 re-mint (which produces `SID` +

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -636,8 +636,16 @@ reclaimed on GC.
 When a profile has the persistent `__Secure-1PSID` but no transient
 `__Secure-1PSIDTS` (a common cold-start snapshot), `_recover_psidts_inline`
 (`_auth/psidts_recovery.py`) makes a preflight `RotateCookies` POST during client
-startup to mint the missing cookie before the first RPC. It fires only when
-`__Secure-1PSID` is present and `__Secure-1PSIDTS` is missing, honors
+startup to mint the missing cookie before the first RPC. It fires only when `SID`
+is present, a secondary binding is intact (`OSID`, or `APISID` + `SAPISID`), and
+no live `__Secure-1PSIDTS` would be **sent to** `accounts.google.com` — that is,
+the cookie is absent, expired, or scoped to a domain that does not route to the
+rotate URL. That last condition is RFC 6265 selection against the URL the
+decision is about, not a domain-priority ranking: a `__Secure-1PSIDTS` scoped to
+`.notebooklm.google.com` (or, post-rebrand, `.notebook.google.com`) never reaches
+`accounts.google.com`, while a host-scoped one on `accounts.google.com` does
+(issue #2057). The separate "did the heal land?" check is deliberately
+domain-blind instead, because it must predict the retrying preflight. It honors
 `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`, and uses a cross-process flock
 (`psidts_recovery.lock`) so concurrent cold-start processes don't fan out identical
 recovery calls. This is what lets the L4 re-mint (which produces `SID` +

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -534,8 +534,24 @@ def _is_allowed_auth_domain(domain: str) -> bool:
 def _auth_domain_priority(domain: str) -> int:
     """Return duplicate-cookie priority for allowed auth domains.
 
-    Higher value wins. Tiers are distinct so the resolved cookie is fully
-    deterministic regardless of storage_state ordering.
+    Higher value wins. Tiers are **not** distinct: several domains share a tier,
+    so the resolved cookie is NOT fully determined by the ranking alone. Where a
+    tier is shared, the first occurrence in ``storage_state`` iteration order
+    wins, and reordering the file changes the result. The collisions are:
+
+    - **tier 3** — ``.notebooklm.google.com``, ``.notebook.google.com``
+      (the Gemini Notebook rebrand host), ``.notebooklm.cloud.google.com``
+    - **tier 2** — the three bare (no leading dot) variants of the above
+    - **tier 0** — every allowlisted domain that is not a Google ccTLD:
+      ``accounts.google.com``, ``drive.google.com``, ``.googleusercontent.com``,
+      ``lh3.google.com``, bare ``google.com``, …
+
+    Tier 0 is worth calling out: it holds ``accounts.google.com``, the host the
+    ``RotateCookies`` POST targets. A host-scoped cookie there — which *does*
+    route to that POST — is outranked by app-host cookies that do not. Ranking
+    by tier is therefore not a substitute for RFC 6265 routing when the question
+    is "would this cookie be sent to URL X"; use a cookie jar for that
+    (issue #2057).
     """
     if domain == ".google.com":
         return 4

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -11,6 +11,7 @@ import http.cookiejar
 import json
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -360,7 +361,10 @@ def load_httpx_cookies(path: Path | None = None) -> httpx.Cookies:
         value = entry.get("value", "")
 
         if _is_allowed_cookie_domain(domain) and name and value:
-            cookies.jar.set_cookie(_storage_entry_to_cookie(entry))
+            cookie = _safe_to_cookie(entry)
+            if cookie is None:
+                continue
+            cookies.jar.set_cookie(cookie)
             cookie_names.add(name)
 
     _validate_required_cookies(cookie_names, context=" for downloads")
@@ -454,9 +458,12 @@ def _build_httpx_cookies_from_storage_strict(path: Path | None) -> httpx.Cookies
         key = (name, domain, entry.get("path") or "/")
         if key in seen_keys:
             continue
+        cookie = _safe_to_cookie(entry)
+        if cookie is None:
+            continue
         seen_keys.add(key)
         seen_names.add(name)
-        cookies.jar.set_cookie(_storage_entry_to_cookie(entry))
+        cookies.jar.set_cookie(cookie)
 
     _validate_required_cookies(seen_names)
     return cookies
@@ -552,6 +559,44 @@ def _storage_entry_to_cookie(entry: dict[str, Any]) -> http.cookiejar.Cookie:
         comment_url=None,
         rest=rest,
     )
+
+
+def _safe_to_cookie(
+    entry: dict[str, Any],
+    to_cookie: Callable[[dict[str, Any]], http.cookiejar.Cookie] | None = None,
+) -> http.cookiejar.Cookie | None:
+    """Convert one storage/rookiepy row, returning ``None`` instead of raising.
+
+    ``http.cookiejar.Cookie.__init__`` coerces the expiry eagerly with
+    ``int(float(expires))``, so a row whose ``expires`` is ``""``, ``"never"``,
+    ``nan`` (``ValueError``), ``inf`` (``OverflowError``), or a list/dict
+    (``TypeError``) blows up at *construction*. Cookie rows reach us from Chrome
+    via rookiepy or from a hand-editable JSON file, so their shape is not ours to
+    guarantee, and one unusable row must not take a whole profile down.
+
+    A row we cannot convert is a row we could never have sent, so dropping it
+    leaves the loaders' own validation to speak: the caller gets the actionable
+    "Missing required cookies … Run 'notebooklm login'" when the dropped row
+    mattered, instead of a raw ``could not convert string to float`` surfacing
+    from deep inside the cookie machinery — which, on the recovery paths, was
+    raised from *inside* an ``except ValueError:`` handler and replaced the
+    diagnostic entirely (issue #2057).
+
+    ``to_cookie`` defaults to :func:`_storage_entry_to_cookie`; the recovery
+    module passes :func:`~notebooklm._auth.psidts_recovery._rookiepy_entry_to_cookie`
+    for snake_case rookiepy rows.
+    """
+    converter = to_cookie or _storage_entry_to_cookie
+    try:
+        return converter(entry)
+    except (ValueError, TypeError, OverflowError) as exc:
+        logger.debug(
+            "Skipping unusable cookie row %r on %r: %s",
+            entry.get("name"),
+            entry.get("domain"),
+            exc,
+        )
+        return None
 
 
 def _cookie_key_variants(key: CookieKey) -> set[CookieKey]:

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -84,11 +84,13 @@ def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
     Duplicate-name resolution mirrors :func:`extract_cookies_from_storage`:
     domains are ranked by :func:`_auth_domain_priority` (``.google.com`` >
     ``.notebooklm.google.com`` > ``notebooklm.google.com`` > regional > other).
-    Named tiers are strictly distinct, so the cross-tier case from #375 (e.g.
-    ``OSID`` on ``myaccount.google.com`` (tier 0) vs ``notebooklm.google.com``
-    (tier 2)) resolves the same way regardless of input order. Within a single
-    tier, first occurrence in iteration order wins — matching
-    :func:`extract_cookies_from_storage`'s within-tier semantics.
+    The cross-tier case from #375 (e.g. ``OSID`` on ``myaccount.google.com``
+    (tier 0) vs ``notebooklm.google.com`` (tier 2)) resolves the same way
+    regardless of input order. But tiers are **not** all distinct — several
+    domains share tier 3, tier 2, and tier 0 — so for a name duplicated *within*
+    one tier the winner is the first occurrence in iteration order and depends
+    on input ordering (issue #2057). Within-tier semantics match
+    :func:`extract_cookies_from_storage`.
 
     Path is intentionally collapsed here (#369): the legacy ``Cookie:`` header
     that consumes the flat shape carries only ``name=value`` pairs, with no slot
@@ -180,9 +182,13 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         5. Other allowlisted domains (e.g. .googleusercontent.com)
 
         Within a single priority tier, the first occurrence in the list wins;
-        later duplicates at the same tier are ignored. Tiers are distinct so the
-        outcome is deterministic regardless of storage_state ordering. See PR #34
-        for the bug this fixes.
+        later duplicates at the same tier are ignored. Tiers are **not** all
+        distinct — several domains share tier 3, tier 2, and tier 0 (see
+        :func:`notebooklm._auth.cookie_policy._auth_domain_priority`) — so for a
+        name duplicated *within* one tier the outcome depends on storage_state
+        ordering. Across distinct tiers it is deterministic. See PR #34 for the
+        bug this fixes, and issue #2057 for why this ranking must not be used to
+        decide whether a cookie would be sent to a particular URL.
 
     Args:
         storage_state: Parsed JSON from Playwright's storage state file.

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -35,6 +35,7 @@ import copy
 import http.cookiejar
 import json
 import logging
+import math
 import os
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -125,6 +126,34 @@ def _safe_to_cookie(
         return None
 
 
+def _allowed_cookie_name(entry: Any) -> str | None:
+    """Return a row's cookie NAME if the row is usable for recovery, else ``None``.
+
+    The single row filter every recovery path shares — the two precondition
+    predicates (:func:`_recovery_cookie_names`, :func:`_iter_routable_psidts_cookies`)
+    and the request-jar builder (:func:`_build_recovery_jar`). Keeping them on one
+    predicate is what makes "the gate reasons about the rows the POST will
+    actually send" true by construction rather than by convention.
+
+    A row qualifies when it is a dict carrying a non-empty string ``name``, a
+    non-empty ``value``, and a domain on the auth allowlist. Cookie rows come
+    from Chrome via rookiepy or from a hand-editable JSON file, so none of that
+    is ours to guarantee: a nameless or valueless cookie isn't meaningfully
+    present on any path, and the domain filter stops a stray ``SID`` from an
+    unrelated site satisfying a precondition. ``or ""`` normalizes a ``null``
+    domain, which :func:`_is_allowed_auth_domain` would otherwise reject with an
+    ``AttributeError`` from inside the caller's ``except ValueError:`` handler.
+    """
+    if not isinstance(entry, dict):
+        return None
+    name = entry.get("name")
+    if not isinstance(name, str) or not name or not entry.get("value"):
+        return None
+    if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
+        return None
+    return name
+
+
 def _recovery_cookie_names(entries: list[dict[str, Any]]) -> set[str]:
     """Return the cookie NAMES present on an allowed auth domain.
 
@@ -133,44 +162,43 @@ def _recovery_cookie_names(entries: list[dict[str, Any]]) -> set[str]:
     and expiry-blind, because that is exactly what the preflight they front
     (:func:`notebooklm._auth.cookie_policy._validate_required_cookies`) checks.
 
-    Only entries on an allowed auth domain are counted, matching the jar-building
-    filter in :func:`_attempt_rotation` / :func:`recover_psidts_in_memory`, so a
-    stray ``SID`` on an unrelated domain can't falsely satisfy the precondition.
-    An entry must carry a non-empty ``name`` *and* ``value``: a nameless or
-    valueless cookie isn't meaningfully present on either recovery path.
-
     No domain ranking is applied. The predecessor of this function
     (``_index_recovery_cookies``) ranked duplicate names by
-    ``_auth_domain_priority`` — but that ranking only ever selected which
-    duplicate's ``expires`` landed in a parallel expiry map, never which name
-    was recorded (``add`` on a set is idempotent). Expiry now lives in
-    :func:`_iter_live_psidts_cookies`, which resolves it per RFC 6265 instead of
+    ``_auth_domain_priority``, but that ranking only ever selected which
+    duplicate's ``expires`` landed in a parallel expiry map, never which name was
+    recorded (``add`` on a set is idempotent). Expiry now lives in
+    :func:`_iter_routable_psidts_cookies`, which resolves it per RFC 6265 instead of
     by tier, so the ranking has no remaining consumer here (issue #2057).
     """
-    names: set[str] = set()
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        name = entry.get("name")
-        if not isinstance(name, str) or not name or not entry.get("value"):
-            continue
-        if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
-            continue
-        names.add(name)
-    return names
+    return {name for entry in entries if (name := _allowed_cookie_name(entry)) is not None}
 
 
-def _iter_live_psidts_cookies(
+def _is_expired(cookie: http.cookiejar.Cookie, now: float | None) -> bool:
+    """``Cookie.is_expired`` against an optional injected clock.
+
+    ``Cookie.expires`` is always an ``int`` after the constructor's
+    ``int(float(...))`` coercion, and ``is_expired`` compares ``expires <= now``.
+    For integer ``e``, ``e <= now`` iff ``e <= floor(now)`` — so flooring is
+    exact, not lossy, and it satisfies the stub's ``int | None`` signature while
+    letting callers pass the float seconds every other clock here uses.
+    ``math.floor`` rather than ``int``: the latter truncates toward zero and
+    would disagree for a negative ``now``.
+    """
+    return cookie.is_expired(None if now is None else math.floor(now))
+
+
+def _iter_routable_psidts_cookies(
     entries: list[dict[str, Any]],
     *,
     to_cookie: _CookieConverter,
     now: float | None = None,
 ) -> Iterator[http.cookiejar.Cookie]:
-    """Yield the LIVE ``__Secure-1PSIDTS`` cookies among ``entries``.
+    """Yield the ``__Secure-1PSIDTS`` cookies a request jar would actually carry.
 
-    "Live" means: on an allowed auth domain, non-empty value, convertible, and
-    not expired. Both recovery predicates are built on this one iterator so a
-    single place decides what freshness means.
+    Feeds :func:`_psidts_routes_to_rotate` ONLY. This models the jar, so its
+    rules are the jar's rules — which is exactly why :func:`_psidts_is_live` must
+    NOT reuse it: that predicate models the caller's preflight instead, and the
+    two disagree in ways that matter (see its docstring).
 
     Only ``__Secure-1PSIDTS`` rows are converted. Restricting by name *before*
     conversion is not just an optimization: ``http.cookiejar.Cookie.__init__``
@@ -182,57 +210,86 @@ def _iter_live_psidts_cookies(
     ``http.cookiejar`` evaluates each cookie independently.
 
     A row whose ``expires`` cannot be coerced (``""``, ``"never"``, ``nan``,
-    ``inf``, a list) is skipped rather than raised on. This is a deliberate
-    change from the predecessor gate, which treated an unparseable expiry as
-    *present → skip recovery*; an unconvertible row now simply does not count,
-    so recovery fires. Firing is the safe direction: the cost is one throttled
-    POST, whereas skipping leaves the session unhealed (issue #2057).
+    ``inf``, a list) is skipped: an unconvertible row cannot be put in a jar, so
+    it cannot be sent, so it must not hold the heal back. Recovery then fires,
+    which is the safe direction — one throttled POST versus an unhealed session.
 
     Duplicate ``(name, domain, path)`` identities are resolved CONSERVATIVELY:
-    an identity is live only when *every* row carrying it is live. ``http.cookiejar``
-    keeps one cookie per identity and lets a later row replace an earlier one, so
-    a jar built from a duplicated identity depends on entry order — precisely the
-    order-sensitivity this gate exists to remove. Poisoning the identity from any
-    dead row is order-independent *and* never over-optimistic, at the cost of a
-    needless POST in the exotic case where a stale duplicate shadows a fresh one.
-    A row that fails conversion has no identity and therefore cannot poison one.
+    an identity routes only when *every* row carrying it is unexpired.
+    ``http.cookiejar`` keeps one cookie per identity — ``set_cookie`` assigns
+    ``_cookies[domain][path][name]`` against the LITERAL domain string, with no
+    leading-dot normalization — and lets a later row replace an earlier one, so a
+    jar built from a duplicated identity depends on entry order, precisely the
+    order-sensitivity this gate exists to remove. Poisoning from any dead row is
+    order-independent *and* never over-optimistic, at the cost of a needless POST
+    when a stale duplicate shadows a fresh one. A row that fails conversion has
+    no identity and therefore cannot poison one.
+
+    Note the identity tuple is deliberately NOT the leading-dot-equivalent key
+    from :func:`notebooklm._auth.cookies._cookie_key_variants`. That equivalence
+    exists for the disk CAS/merge stage; here it would manufacture a false
+    negative, because ``.google.com`` and ``google.com`` both route yet the jar
+    keeps them as two independent cookies, so a stale one would poison a fresh
+    one the jar still sends.
 
     Args:
         entries: Raw cookie dicts (storage_state entries or rookiepy rows).
         to_cookie: Converter matching ``entries``' shape.
         now: Injectable wall-clock seconds for deterministic tests; defaults to
             the current time via :meth:`http.cookiejar.Cookie.is_expired`.
+
+    Yields:
+        One cookie per surviving identity, in first-seen identity order. The
+        SET is order-independent; the sequence is not, so a future consumer
+        that takes only the first element would reintroduce order-sensitivity.
     """
     live: dict[_CookieIdentity, http.cookiejar.Cookie] = {}
     dead: set[_CookieIdentity] = set()
     for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        if entry.get("name") != _PSIDTS_COOKIE or not entry.get("value"):
-            continue
-        # Allowlist BEFORE jar-building. An empty domain is NOT allowlisted, but
-        # http.cookiejar would happily treat it as a host cookie for whatever URL
-        # it is asked about — including the rotate URL. Dropping this filter, or
-        # moving it after the jar is built, silently makes such a row route.
-        if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
+        if _allowed_cookie_name(entry) != _PSIDTS_COOKIE:
             continue
         cookie = _safe_to_cookie(entry, to_cookie)
         if cookie is None:
             continue
         identity = (cookie.name, cookie.domain, cookie.path)
-        # ``Cookie.expires`` is always an ``int`` after the constructor's
-        # ``int(float(...))`` coercion, and ``is_expired`` compares
-        # ``expires <= now``. For integer ``e`` and non-negative ``now``,
-        # ``e <= now`` iff ``e <= floor(now)`` — so truncating is exact, not
-        # lossy, and it satisfies the stub's ``int | None`` signature while
-        # letting callers pass the float seconds every other clock here uses.
-        if cookie.is_expired(None if now is None else int(now)):
+        if _is_expired(cookie, now):
             dead.add(identity)
         else:
-            live.setdefault(identity, cookie)
+            # Last-write-wins, matching ``CookieJar.set_cookie``. The boolean the
+            # predicates read is unaffected either way, but retaining the same
+            # occurrence the jar would retain keeps this function an honest model
+            # of the thing it stands in for.
+            live[identity] = cookie
     for identity, cookie in live.items():
         if identity not in dead:
             yield cookie
+
+
+def _build_recovery_jar(
+    entries: list[dict[str, Any]], to_cookie: _CookieConverter
+) -> httpx.Cookies:
+    """Build the ``RotateCookies`` request jar from raw cookie rows.
+
+    Built manually so the validator is bypassed — this mirrors
+    ``build_httpx_cookies_from_storage`` without its
+    ``_validate_required_cookies`` call, which would raise, and which recovery
+    runs precisely because it already failed.
+
+    Unlike :func:`_iter_routable_psidts_cookies` this keeps ALL usable rows, not just
+    ``__Secure-1PSIDTS``: Google rejects a ``RotateCookies`` POST that does not
+    carry ``SID`` plus the secondary binding. Expiry is not filtered here either
+    — ``http.cookiejar`` drops expired cookies when it builds the header. Rows
+    that fail conversion are skipped rather than raised on
+    (see :func:`_safe_to_cookie`).
+    """
+    jar = httpx.Cookies()
+    for entry in entries:
+        if _allowed_cookie_name(entry) is None:
+            continue
+        cookie = _safe_to_cookie(entry, to_cookie)
+        if cookie is not None:
+            jar.jar.set_cookie(cookie)
+    return jar
 
 
 def _psidts_is_live(
@@ -241,25 +298,51 @@ def _psidts_is_live(
     to_cookie: _CookieConverter,
     now: float | None = None,
 ) -> bool:
-    """Is ANY live ``__Secure-1PSIDTS`` present on an allowed auth domain?
+    """Is ANY ``__Secure-1PSIDTS`` present and not known-expired on an allowed domain?
 
-    This is the "did the heal land?" question. It deliberately does NOT ask
-    about routing to ``accounts.google.com``: its job is to predict whether the
-    caller's retried preflight will pass, and that preflight
+    This is the "did the heal land?" question, and it models the caller's
+    RETRIED PREFLIGHT — not the request jar. That preflight
     (:func:`notebooklm._auth.cookie_policy._validate_required_cookies`) is
     domain-blind name presence. Asking the rotate-URL question here would report
     "not healed" for a PSIDTS persisted only on the app host, re-raising an
     authentication error over a session that actually works — a false negative
     in the direction that hurts (issue #2057).
 
-    It is, however, deliberately STRICTER than the preflight on expiry: the
-    preflight ignores ``expires`` entirely, while this requires an unexpired
-    row. Dropping that would regress issue #1273 — a no-op save over a stale
-    on-disk row would report success and fake a heal. The invariant to hold is
-    an implication, not an equality: live ⇒ the preflight passes on the PSIDTS
-    half (it says nothing about ``SID``).
+    Deliberately a plain existential, NOT the jar model in
+    :func:`_iter_routable_psidts_cookies`. Two rules from there are wrong here,
+    and both cause the same harmful false negative:
+
+    - **No duplicate-identity poisoning.** A stale twin sharing a row's
+      ``(name, domain, path)`` does not stop a name-presence preflight from
+      passing. Poisoning here is not merely pessimistic, it is a PERMANENT
+      failure loop: ``save_cookies_to_storage`` CAS-matches the first stored row
+      and leaves the stale twin on disk, so every subsequent load would fire a
+      POST, write to disk, then re-raise "Missing required cookies" for a
+      session whose preflight passes. The twin is issue #1523's data shape;
+      #1523 fixed the producer, and nothing on the load/save path removes an
+      existing one.
+    - **An unparseable ``expires`` counts as PRESENT.** The row is on disk and
+      the preflight will see it. This mirrors the predecessor gate, which
+      treated an uninterpretable expiry as present rather than guessing.
+
+    It IS deliberately stricter than the preflight in one respect: a row known
+    to be expired does not count, though the preflight ignores ``expires``
+    entirely. Dropping that would regress issue #1273 — a no-op save over a
+    stale on-disk row would report success and fake a heal.
+
+    The invariant to hold is an implication, not an equality: live ⇒ the
+    preflight passes on the PSIDTS half (it says nothing about ``SID``). Note
+    routable ⇒ live still holds, since a routable row is unexpired, allowlisted
+    and non-empty — which is what makes the fused "healed by another process"
+    return in :func:`_recover_psidts_inline` sound.
     """
-    return any(True for _ in _iter_live_psidts_cookies(entries, to_cookie=to_cookie, now=now))
+    for entry in entries:
+        if _allowed_cookie_name(entry) != _PSIDTS_COOKIE:
+            continue
+        cookie = _safe_to_cookie(entry, to_cookie)
+        if cookie is None or not _is_expired(cookie, now):
+            return True
+    return False
 
 
 def _psidts_routes_to_rotate(
@@ -280,7 +363,7 @@ def _psidts_routes_to_rotate(
     host-scoped one on ``accounts.google.com`` — which does route — sat in the
     *lowest* priority tier (issue #2057).
 
-    Expiry is decided by :func:`_iter_live_psidts_cookies` against ``now``, then
+    Expiry is decided by :func:`_iter_routable_psidts_cookies` against ``now``, then
     stripped from the probe copies. ``CookieJar.add_cookie_header`` resets its
     own clock from ``time.time()`` and re-applies its expiry policy on top of
     whatever it is given, so an injected ``now`` would otherwise be a
@@ -288,15 +371,15 @@ def _psidts_routes_to_rotate(
     fresh, and a test asserting "fresh at now=200" would silently fail against
     the real wall clock. The probes exist only to answer the DOMAIN question.
     """
+    probes = [
+        copy.copy(c) for c in _iter_routable_psidts_cookies(entries, to_cookie=to_cookie, now=now)
+    ]
+    if not probes:
+        return False
     jar = httpx.Cookies()
-    found = False
-    for cookie in _iter_live_psidts_cookies(entries, to_cookie=to_cookie, now=now):
-        probe = copy.copy(cookie)
+    for probe in probes:
         probe.expires = None
         jar.jar.set_cookie(probe)
-        found = True
-    if not found:
-        return False
     request = httpx.Request("POST", _keepalive.KEEPALIVE_ROTATE_URL)
     jar.set_cookie_header(request)
     return _PSIDTS_COOKIE in _cookie_header_names(request.headers.get("cookie", ""))
@@ -530,19 +613,13 @@ def _psidts_save_succeeded(
       the expired on-disk row lingers in the request jar, the delta is empty,
       and the save reports success while disk is still unhealed.
 
-    So disk — not the save bool — is the sole arbiter. Re-read it and accept the
+    So disk — not the save bool — is the sole arbiter. Re-read it via
+    :func:`_is_psidts_persisted` (the domain-blind "did it land?" question, NOT
+    the routed precondition gate — see :func:`_psidts_is_live`) and accept the
     heal iff a live PSIDTS is stored, so a stale or expired row (ours or a
     sibling's) doesn't masquerade as a heal. On a decline, the coarse ``result``
     is folded into a diagnostic warning here (the only thing it is used for) so
     callers stay a single boolean branch.
-
-    :func:`_is_psidts_persisted` deliberately does NOT mirror the routed
-    precondition gate (:func:`_psidts_routes_to_rotate`). This is the "did it
-    land?" question, and it must track what the caller's retried preflight
-    validates — domain-blind name presence — not what routes to
-    ``accounts.google.com``. Asking the routed question here would report a
-    PSIDTS persisted only on the app host as unhealed and re-raise over a
-    working session (issue #2057).
     """
     if _is_psidts_persisted(storage_path):
         return True
@@ -568,19 +645,7 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
         )
         return False
 
-    # Build the cookie jar manually so the validator (which would raise) is
-    # bypassed. Mirrors ``build_httpx_cookies_from_storage`` without the
-    # ``_validate_required_cookies`` call.
-    jar = httpx.Cookies()
-    for entry in cookie_entries:
-        if not entry.get("name") or not entry.get("value"):
-            continue
-        if not _is_allowed_auth_domain(entry.get("domain", "")):
-            continue
-        cookie = _safe_to_cookie(entry, _storage_entry_to_cookie)
-        if cookie is None:
-            continue
-        jar.jar.set_cookie(cookie)
+    jar = _build_recovery_jar(cookie_entries, _storage_entry_to_cookie)
 
     # ``httpx.Client(cookies=jar)`` copies the source jar into a private client
     # jar; Set-Cookie responses land in ``client.cookies``, not in ``jar``. So
@@ -732,18 +797,7 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         )
         return False
 
-    jar = httpx.Cookies()
-    for entry in rookiepy_cookies:
-        if not isinstance(entry, dict):
-            continue
-        if not entry.get("name") or not entry.get("value"):
-            continue
-        if not _is_allowed_auth_domain(entry.get("domain", "")):
-            continue
-        cookie = _safe_to_cookie(entry, _rookiepy_entry_to_cookie)
-        if cookie is None:
-            continue
-        jar.jar.set_cookie(cookie)
+    jar = _build_recovery_jar(rookiepy_cookies, _rookiepy_entry_to_cookie)
 
     try:
         with httpx.Client(
@@ -771,15 +825,13 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         )
         return False
 
-    # Index the source jar by RFC 6265 identity so a rotated cookie that
-    # already has a same-(name, domain, path) row REPLACES it in place rather
-    # than appending a second occurrence. Split-state recovery (#1523) hits
-    # this: __Secure-1PSIDTS is missing/expired (so recovery fires) while a
-    # fresh __Secure-3PSIDTS is already present — RotateCookies rotates BOTH,
+    # Index the source rows by RFC 6265 identity so the replace-in-place
+    # contract above can be honoured. Split-state recovery (#1523) is what makes
+    # it necessary: __Secure-1PSIDTS is missing/expired (so recovery fires) while
+    # a fresh __Secure-3PSIDTS is already present — RotateCookies rotates BOTH,
     # and a blind append leaves a duplicate __Secure-3PSIDTS (and a stale
-    # __Secure-1PSIDTS twin) row with no analog in any real browser jar. The
-    # rotation is the value we want to persist, so the rotated occurrence wins
-    # — mirroring the last-occurrence-wins dedup in
+    # __Secure-1PSIDTS twin) row with no analog in any real browser jar. Letting
+    # the rotated occurrence win mirrors the last-occurrence-wins dedup in
     # ``filter_storage_state_cookies_by_domain_policy`` (#1513). ``path or "/"``
     # matches the normalization the loaders and save_cookies_to_storage use.
     index_by_identity: dict[tuple[str, str, str], int] = {}

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -37,7 +37,7 @@ import json
 import logging
 import math
 import os
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -389,15 +389,32 @@ def _psidts_routes_to_rotate(
     fresh, and a test asserting "fresh at now=200" would silently fail against
     the real wall clock. The probes exist only to answer the DOMAIN question.
     """
-    probes = [
-        copy.copy(c) for c in _iter_routable_psidts_cookies(entries, to_cookie=to_cookie, now=now)
-    ]
-    if not probes:
-        return False
-    jar = httpx.Cookies()
-    for probe in probes:
+    probes = []
+    for cookie in _iter_routable_psidts_cookies(entries, to_cookie=to_cookie, now=now):
+        probe = copy.copy(cookie)
         probe.expires = None
-        jar.jar.set_cookie(probe)
+        probes.append(probe)
+    return _cookies_route_psidts(probes)
+
+
+def _cookies_route_psidts(cookies: Iterable[http.cookiejar.Cookie]) -> bool:
+    """Would a jar holding ``cookies`` send ``__Secure-1PSIDTS`` to the rotate URL?
+
+    The shared jar probe behind both the pre-POST gate
+    (:func:`_psidts_routes_to_rotate`, which hands it expiry-stripped copies) and
+    the post-POST mint check in :func:`_attempt_rotation` /
+    :func:`recover_psidts_in_memory` (which hand it the live response jar, expiry
+    intact, so a rotation that somehow arrives already-expired does not count).
+    """
+    jar = httpx.Cookies()
+    found = False
+    for cookie in cookies:
+        if cookie.name != _PSIDTS_COOKIE or not cookie.value:
+            continue
+        jar.jar.set_cookie(cookie)
+        found = True
+    if not found:
+        return False
     request = httpx.Request("POST", _keepalive.KEEPALIVE_ROTATE_URL)
     jar.set_cookie_header(request)
     return _PSIDTS_COOKIE in _cookie_header_names(request.headers.get("cookie", ""))
@@ -683,16 +700,24 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
             )
             response.raise_for_status()
             rotated_jar = client.cookies
-            psidts_present = any(c.name == _PSIDTS_COOKIE for c in rotated_jar.jar)
+            # ROUTABLE, not merely present-by-name. The request jar still holds
+            # whatever PSIDTS was already on disk, so a name-only check would see
+            # that pre-existing cookie and report a mint that never happened —
+            # defeating the withheld-rotation detection below. Asking whether a
+            # PSIDTS now routes to the rotate URL is also proof of NEWNESS here:
+            # we only reach this line because the gate found nothing routable, so
+            # anything routable now must have arrived in the response.
+            psidts_minted = _cookies_route_psidts(rotated_jar.jar)
     except httpx.HTTPError as exc:
         logger.debug("Inline PSIDTS recovery POST failed (non-fatal): %s", exc)
         return False
 
-    if not psidts_present:
+    if not psidts_minted:
         logger.debug(
             "Inline PSIDTS recovery: RotateCookies returned 2xx but did not "
-            "include %s — Google may be withholding the rotation",
+            "mint a %s that routes to %s — Google may be withholding the rotation",
             _PSIDTS_COOKIE,
+            _keepalive.KEEPALIVE_ROTATE_URL,
         )
         return False
 
@@ -834,12 +859,15 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         logger.debug("In-memory PSIDTS recovery POST failed (non-fatal): %s", exc)
         return False
 
-    psidts_present = any(c.name == _PSIDTS_COOKIE for c in rotated_cookies)
-    if not psidts_present:
+    # ROUTABLE, not merely present-by-name — see the matching check in
+    # :func:`_attempt_rotation`. The request jar carries any PSIDTS the caller
+    # already had, so a name-only test would accept a withheld rotation.
+    if not _cookies_route_psidts(rotated_cookies):
         logger.debug(
             "In-memory PSIDTS recovery: RotateCookies returned 2xx but did not "
-            "include %s — Google may be withholding the rotation",
+            "mint a %s that routes to %s — Google may be withholding the rotation",
             _PSIDTS_COOKIE,
+            _keepalive.KEEPALIVE_ROTATE_URL,
         )
         return False
 

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -70,6 +70,7 @@ _KEEPALIVE_ROTATE_HEADERS = _keepalive._KEEPALIVE_ROTATE_HEADERS
 _KEEPALIVE_ROTATE_BODY = _keepalive._KEEPALIVE_ROTATE_BODY
 _load_storage_state = _auth_cookies._load_storage_state
 _storage_entry_to_cookie = _auth_cookies._storage_entry_to_cookie
+_safe_to_cookie = _auth_cookies._safe_to_cookie
 
 logger = logging.getLogger("notebooklm.auth")
 
@@ -101,31 +102,6 @@ def _cookie_header_names(header: str) -> set[str]:
     return {part.split("=", 1)[0].strip() for part in header.split(";") if "=" in part}
 
 
-def _safe_to_cookie(
-    entry: dict[str, Any], to_cookie: _CookieConverter
-) -> http.cookiejar.Cookie | None:
-    """Convert one raw entry, returning ``None`` instead of raising on bad input.
-
-    ``http.cookiejar.Cookie.__init__`` coerces the expiry eagerly with
-    ``int(float(expires))``, so a row whose ``expires`` is ``""``, ``"never"``,
-    ``nan`` (``ValueError``), ``inf`` (``OverflowError``), or a list/dict
-    (``TypeError``) blows up at *construction*. Cookie rows come from Chrome via
-    rookiepy or from a hand-editable JSON file, so their shape is not ours to
-    guarantee.
-
-    Recovery runs from inside an ``except ValueError:`` handler in both file-path
-    callers (``_auth/cookies.py`` and ``_auth/tokens.py``), so an escaping
-    coercion error replaces the actionable "Missing required cookies …
-    Run 'notebooklm login'" diagnostic with a converter traceback. One malformed
-    sibling row was enough to trigger that on the pre-#2057 code, after the
-    rotation throttle slot had already been claimed.
-    """
-    try:
-        return to_cookie(entry)
-    except (ValueError, TypeError, OverflowError):
-        return None
-
-
 def _allowed_cookie_name(entry: Any) -> str | None:
     """Return a row's cookie NAME if the row is usable for recovery, else ``None``.
 
@@ -140,16 +116,24 @@ def _allowed_cookie_name(entry: Any) -> str | None:
     from Chrome via rookiepy or from a hand-editable JSON file, so none of that
     is ours to guarantee: a nameless or valueless cookie isn't meaningfully
     present on any path, and the domain filter stops a stray ``SID`` from an
-    unrelated site satisfying a precondition. ``or ""`` normalizes a ``null``
-    domain, which :func:`_is_allowed_auth_domain` would otherwise reject with an
-    ``AttributeError`` from inside the caller's ``except ValueError:`` handler.
+    unrelated site satisfying a precondition.
+
+    ``name`` and ``domain`` are both type-checked, not merely truthiness-checked.
+    :func:`_is_allowed_auth_domain` does string work, so a non-string domain
+    (``123``, a dict) raises ``AttributeError``/``TypeError`` — and it would do so
+    from inside the caller's ``except ValueError:`` handler, where it escapes as a
+    bare traceback instead of an auth diagnostic. A missing or ``null`` domain
+    normalizes to ``""``, which is simply not allowlisted.
     """
     if not isinstance(entry, dict):
         return None
     name = entry.get("name")
     if not isinstance(name, str) or not name or not entry.get("value"):
         return None
-    if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
+    domain = entry.get("domain")
+    if domain is None:
+        domain = ""
+    if not isinstance(domain, str) or not _is_allowed_auth_domain(domain):
         return None
     return name
 
@@ -166,9 +150,9 @@ def _recovery_cookie_names(entries: list[dict[str, Any]]) -> set[str]:
     (``_index_recovery_cookies``) ranked duplicate names by
     ``_auth_domain_priority``, but that ranking only ever selected which
     duplicate's ``expires`` landed in a parallel expiry map, never which name was
-    recorded (``add`` on a set is idempotent). Expiry now lives in
-    :func:`_iter_routable_psidts_cookies`, which resolves it per RFC 6265 instead of
-    by tier, so the ranking has no remaining consumer here (issue #2057).
+    recorded (``add`` on a set is idempotent). Expiry now lives in :func:`_is_expired` and is
+    consumed by the two PSIDTS predicates, which resolve domain per RFC 6265
+    instead of by tier, so the ranking has no remaining consumer here (#2057).
     """
     return {name for entry in entries if (name := _allowed_cookie_name(entry)) is not None}
 
@@ -456,7 +440,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     Pre-conditions (all must hold; otherwise return ``False`` without firing):
 
     1. ``SID`` present in ``storage_path``.
-    2. No live ``__Secure-1PSIDTS`` in ``storage_path`` ROUTES to
+    2. No ``__Secure-1PSIDTS`` in ``storage_path`` ROUTES to
        ``KEEPALIVE_ROTATE_URL`` — absent, expired, or scoped to a domain that
        never reaches ``accounts.google.com`` (a ``-1``/``None`` session-cookie
        expiry counts as present, not expired — see
@@ -587,8 +571,8 @@ def _read_storage_for_recovery(
     ``cookie_names`` is the domain-filtered name view used by the ``SID`` and
     secondary-binding preconditions (see :func:`_recovery_cookie_names`).
     ``cookie_entries`` is the unfiltered list — both the PSIDTS predicates
-    (:func:`_psidts_routes_to_rotate`, :func:`_psidts_is_live`) and the jar
-    builder in :func:`_attempt_rotation` apply their own domain filter, and the
+    (:func:`_psidts_routes_to_rotate`, :func:`_psidts_is_live`) and the request-jar
+    builder :func:`_build_recovery_jar` apply their own row filter, and the
     predicates need the raw ``expires`` that a name-only view cannot carry.
 
     The narrow exception scope catches the documented raise sites of
@@ -800,7 +784,7 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     :func:`_recover_psidts_inline`):
 
     1. ``SID`` present.
-    2. No live ``__Secure-1PSIDTS`` ROUTES to ``KEEPALIVE_ROTATE_URL`` — absent,
+    2. No ``__Secure-1PSIDTS`` ROUTES to ``KEEPALIVE_ROTATE_URL`` — absent,
        expired, or scoped to a domain that never reaches
        ``accounts.google.com`` (a ``-1``/``None`` session-cookie expiry counts
        as present, not expired — see :func:`_psidts_routes_to_rotate`).
@@ -934,7 +918,7 @@ def validate_with_recovery(
     Wraps :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
     plus :func:`notebooklm._auth.cookies.extract_cookies_from_storage` with one
     retry through :func:`recover_psidts_in_memory` (issue #990). When the
-    recovery preconditions hold (SID present, no live PSIDTS routing to the
+    recovery preconditions hold (SID present, no PSIDTS routing to the
     rotate URL, secondary binding intact — see
     :func:`_psidts_routes_to_rotate`), the
     rotated cookies are merged into ``rookiepy_cookies`` in place by

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -240,8 +240,12 @@ def _iter_routable_psidts_cookies(
 
     Yields:
         One cookie per surviving identity, in first-seen identity order. The
-        SET is order-independent; the sequence is not, so a future consumer
-        that takes only the first element would reintroduce order-sensitivity.
+        IDENTITY SET is order-independent; both the sequence and *which*
+        duplicate occurrence is yielded are not — last-write-wins means
+        ``[fresh_a, fresh_b]`` yields ``fresh_b`` and the reverse yields
+        ``fresh_a``. Harmless while the only consumer reads a boolean, but a
+        future consumer that takes the first element, or reads a cookie's
+        VALUE, would reintroduce order-sensitivity.
     """
     live: dict[_CookieIdentity, http.cookiejar.Cookie] = {}
     dead: set[_CookieIdentity] = set()
@@ -325,16 +329,30 @@ def _psidts_is_live(
       the preflight will see it. This mirrors the predecessor gate, which
       treated an uninterpretable expiry as present rather than guessing.
 
-    It IS deliberately stricter than the preflight in one respect: a row known
-    to be expired does not count, though the preflight ignores ``expires``
-    entirely. Dropping that would regress issue #1273 — a no-op save over a
-    stale on-disk row would report success and fake a heal.
+    It IS deliberately stricter than the preflight in two respects, both in the
+    safe direction:
+
+    - a row known to be expired does not count, though the preflight ignores
+      ``expires`` entirely. Dropping that would regress issue #1273 — a no-op
+      save over a stale on-disk row would report success and fake a heal.
+    - a row with an empty ``value`` does not count, though
+      :func:`~notebooklm._auth.cookies.extract_cookies_from_storage` gates on
+      name alone. Unreachable in practice: the POST writes a real value, and
+      :func:`_build_recovery_jar` skips valueless rows anyway.
 
     The invariant to hold is an implication, not an equality: live ⇒ the
-    preflight passes on the PSIDTS half (it says nothing about ``SID``). Note
-    routable ⇒ live still holds, since a routable row is unexpired, allowlisted
-    and non-empty — which is what makes the fused "healed by another process"
-    return in :func:`_recover_psidts_inline` sound.
+    preflight passes on the PSIDTS half (it says nothing about ``SID``). "The
+    preflight" here means
+    :func:`~notebooklm._auth.cookies.extract_cookies_from_storage`, the
+    name-presence loader. The sibling loader
+    ``_build_httpx_cookies_from_storage_strict`` converts every row and can
+    still reject a state this accepts, because a row whose ``expires`` will not
+    coerce raises there — a pre-existing gap in the shared loader, tracked
+    separately, not something this predicate can close.
+
+    Note routable ⇒ live still holds, since a routable row is unexpired,
+    allowlisted and non-empty — which is what makes the fused "healed by another
+    process" return in :func:`_recover_psidts_inline` sound.
     """
     for entry in entries:
         if _allowed_cookie_name(entry) != _PSIDTS_COOKIE:

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -31,11 +31,12 @@ for this fix.
 
 from __future__ import annotations
 
+import copy
 import http.cookiejar
 import json
 import logging
 import os
-import time
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -60,7 +61,6 @@ from . import storage as _auth_storage
 # ----------------------------------------------------------------------------
 _has_valid_secondary_binding = _cookie_policy._has_valid_secondary_binding
 _is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
-_auth_domain_priority = _cookie_policy._auth_domain_priority
 _rotation_lock_path = _keepalive._rotation_lock_path
 _file_lock_try_exclusive = _keepalive._file_lock_try_exclusive
 _try_claim_rotation = _keepalive._try_claim_rotation
@@ -75,78 +75,79 @@ logger = logging.getLogger("notebooklm.auth")
 _PSIDTS_COOKIE = "__Secure-1PSIDTS"
 
 
-def _psidts_needs_recovery(
-    cookie_names: set[str],
-    cookie_expiry: dict[str, Any],
-    *,
-    now: float | None = None,
-) -> bool:
-    """True when ``__Secure-1PSIDTS`` is absent OR present-but-EXPIRED.
+# Converter from a raw cookie entry to an ``http.cookiejar.Cookie``. Two shapes
+# exist and differ only in the http-only field spelling: storage_state entries
+# (camelCase ``httpOnly``, :func:`_storage_entry_to_cookie`) and rookiepy rows
+# (snake_case ``http_only``, :func:`_rookiepy_entry_to_cookie`). Callers select
+# the converter; nothing is round-tripped through
+# ``convert_rookiepy_cookies_to_storage_state`` on the way.
+_CookieConverter = Callable[[dict[str, Any]], http.cookiejar.Cookie]
 
-    The recovery precondition originally keyed purely on name presence
-    (``_PSIDTS_COOKIE in cookie_names``), so an idle Chrome session whose
-    PSIDTS row is still on disk but already past its ``expires`` epoch silently
-    skipped the one ``RotateCookies`` POST that would heal it — cold-start then
-    failed hard at the first authed GET.
+# RFC 6265 §5.3 cookie identity: ``(name, domain, path)``.
+_CookieIdentity = tuple[str, str, str]
 
-    Expiry semantics mirror the storage round-trip in
-    :func:`notebooklm._auth.cookies._storage_entry_to_cookie`:
 
-    - ``expires`` of ``None`` or ``-1`` is a *session* cookie (Playwright
-      convention) — never treated as expired, so recovery does NOT fire.
-    - a numeric ``expires`` strictly less than ``now`` (default ``time.time()``)
-      is past its lifetime → treat the cookie as ABSENT so recovery fires.
-    - a numeric ``expires`` at or in the future → cookie is fresh; recovery is
-      skipped (current behavior).
+def _cookie_header_names(header: str) -> set[str]:
+    """Return the cookie NAMES present in a ``Cookie:`` request header.
 
-    Args:
-        cookie_names: Set of cookie names present on the source state.
-        cookie_expiry: ``name -> expires`` view over the same entries.
-        now: Injectable wall-clock seconds for deterministic tests; defaults
-            to :func:`time.time` at call time.
-
-    Returns:
-        ``True`` if recovery should proceed (PSIDTS missing or expired),
-        ``False`` if a present, unexpired PSIDTS makes recovery a no-op.
+    Parsing, never substring matching. ``_PSIDTS_COOKIE in header`` would
+    false-positive on a lookalike name (``X__Secure-1PSIDTSY=v``) and on any
+    cookie whose *value* embeds the literal (``NID=__Secure-1PSIDTS=oops``) —
+    and cookie values on allowlisted domains are not shape-controlled by us,
+    they come from Chrome. A false positive here makes the gate skip a needed
+    heal, so the comparison has to be exact.
     """
-    if _PSIDTS_COOKIE not in cookie_names:
-        return True
-    expires = cookie_expiry.get(_PSIDTS_COOKIE)
-    if expires in (None, -1):
-        # Session cookie — no expiry to compare against; treat as present.
-        return False
-    if not isinstance(expires, (int, float)) or isinstance(expires, bool):
-        # Unparseable expiry: fall back to the legacy name-presence behavior
-        # (present → skip) rather than firing a possibly-needless POST.
-        return False
-    reference = time.time() if now is None else now
-    return expires < reference
+    return {part.split("=", 1)[0].strip() for part in header.split(";") if "=" in part}
 
 
-def _index_recovery_cookies(
-    entries: list[dict[str, Any]],
-) -> tuple[set[str], dict[str, Any]]:
-    """Build domain-filtered ``(cookie_names, cookie_expiry)`` views for the gate.
+def _safe_to_cookie(
+    entry: dict[str, Any], to_cookie: _CookieConverter
+) -> http.cookiejar.Cookie | None:
+    """Convert one raw entry, returning ``None`` instead of raising on bad input.
 
-    Only entries on an allowed auth domain (:func:`_is_allowed_auth_domain`)
-    are indexed — this matches the jar-building filter in
-    :func:`_attempt_rotation` / :func:`recover_psidts_in_memory`, so a stray
-    ``__Secure-1PSIDTS`` / ``SID`` on an unrelated domain can't falsely satisfy
-    the precondition and skip the heal.
+    ``http.cookiejar.Cookie.__init__`` coerces the expiry eagerly with
+    ``int(float(expires))``, so a row whose ``expires`` is ``""``, ``"never"``,
+    ``nan`` (``ValueError``), ``inf`` (``OverflowError``), or a list/dict
+    (``TypeError``) blows up at *construction*. Cookie rows come from Chrome via
+    rookiepy or from a hand-editable JSON file, so their shape is not ours to
+    guarantee.
 
-    When the same name appears on multiple allowed domains, the highest
-    :func:`_auth_domain_priority` tier wins (``.google.com`` > regional > …),
-    mirroring :func:`notebooklm._auth.cookies.flatten_cookie_map`. Tiers are
-    strictly distinct, so the resolved expiry is deterministic regardless of
-    storage_state ordering; within a single tier the first occurrence wins.
-
-    An entry must carry a non-empty ``name`` *and* ``value`` to be indexed: a
-    nameless/valueless cookie can't be meaningfully present on either the
-    file-based or in-memory recovery path.
+    Recovery runs from inside an ``except ValueError:`` handler in both file-path
+    callers (``_auth/cookies.py`` and ``_auth/tokens.py``), so an escaping
+    coercion error replaces the actionable "Missing required cookies …
+    Run 'notebooklm login'" diagnostic with a converter traceback. One malformed
+    sibling row was enough to trigger that on the pre-#2057 code, after the
+    rotation throttle slot had already been claimed.
     """
-    cookie_names: set[str] = set()
-    cookie_expiry: dict[str, Any] = {}
-    name_priority: dict[str, int] = {}
+    try:
+        return to_cookie(entry)
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
+def _recovery_cookie_names(entries: list[dict[str, Any]]) -> set[str]:
+    """Return the cookie NAMES present on an allowed auth domain.
+
+    Feeds the two name-presence preconditions — ``SID`` present, and
+    :func:`_has_valid_secondary_binding` — which are deliberately domain-blind
+    and expiry-blind, because that is exactly what the preflight they front
+    (:func:`notebooklm._auth.cookie_policy._validate_required_cookies`) checks.
+
+    Only entries on an allowed auth domain are counted, matching the jar-building
+    filter in :func:`_attempt_rotation` / :func:`recover_psidts_in_memory`, so a
+    stray ``SID`` on an unrelated domain can't falsely satisfy the precondition.
+    An entry must carry a non-empty ``name`` *and* ``value``: a nameless or
+    valueless cookie isn't meaningfully present on either recovery path.
+
+    No domain ranking is applied. The predecessor of this function
+    (``_index_recovery_cookies``) ranked duplicate names by
+    ``_auth_domain_priority`` — but that ranking only ever selected which
+    duplicate's ``expires`` landed in a parallel expiry map, never which name
+    was recorded (``add`` on a set is idempotent). Expiry now lives in
+    :func:`_iter_live_psidts_cookies`, which resolves it per RFC 6265 instead of
+    by tier, so the ranking has no remaining consumer here (issue #2057).
+    """
+    names: set[str] = set()
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -155,12 +156,150 @@ def _index_recovery_cookies(
             continue
         if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
             continue
-        priority = _auth_domain_priority(entry.get("domain", "") or "")
-        if name not in cookie_names or priority > name_priority[name]:
-            cookie_names.add(name)
-            cookie_expiry[name] = entry.get("expires")
-            name_priority[name] = priority
-    return cookie_names, cookie_expiry
+        names.add(name)
+    return names
+
+
+def _iter_live_psidts_cookies(
+    entries: list[dict[str, Any]],
+    *,
+    to_cookie: _CookieConverter,
+    now: float | None = None,
+) -> Iterator[http.cookiejar.Cookie]:
+    """Yield the LIVE ``__Secure-1PSIDTS`` cookies among ``entries``.
+
+    "Live" means: on an allowed auth domain, non-empty value, convertible, and
+    not expired. Both recovery predicates are built on this one iterator so a
+    single place decides what freshness means.
+
+    Only ``__Secure-1PSIDTS`` rows are converted. Restricting by name *before*
+    conversion is not just an optimization: ``http.cookiejar.Cookie.__init__``
+    coerces eagerly (``int(float(expires))``), so a malformed ``expires`` on any
+    unrelated sibling row would otherwise raise from inside a predicate that
+    callers invoke from within an ``except ValueError:`` handler. Narrowing the
+    conversion surface to the rows the question is actually about keeps the
+    blast radius minimal, and the answer is identical either way because
+    ``http.cookiejar`` evaluates each cookie independently.
+
+    A row whose ``expires`` cannot be coerced (``""``, ``"never"``, ``nan``,
+    ``inf``, a list) is skipped rather than raised on. This is a deliberate
+    change from the predecessor gate, which treated an unparseable expiry as
+    *present → skip recovery*; an unconvertible row now simply does not count,
+    so recovery fires. Firing is the safe direction: the cost is one throttled
+    POST, whereas skipping leaves the session unhealed (issue #2057).
+
+    Duplicate ``(name, domain, path)`` identities are resolved CONSERVATIVELY:
+    an identity is live only when *every* row carrying it is live. ``http.cookiejar``
+    keeps one cookie per identity and lets a later row replace an earlier one, so
+    a jar built from a duplicated identity depends on entry order — precisely the
+    order-sensitivity this gate exists to remove. Poisoning the identity from any
+    dead row is order-independent *and* never over-optimistic, at the cost of a
+    needless POST in the exotic case where a stale duplicate shadows a fresh one.
+    A row that fails conversion has no identity and therefore cannot poison one.
+
+    Args:
+        entries: Raw cookie dicts (storage_state entries or rookiepy rows).
+        to_cookie: Converter matching ``entries``' shape.
+        now: Injectable wall-clock seconds for deterministic tests; defaults to
+            the current time via :meth:`http.cookiejar.Cookie.is_expired`.
+    """
+    live: dict[_CookieIdentity, http.cookiejar.Cookie] = {}
+    dead: set[_CookieIdentity] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") != _PSIDTS_COOKIE or not entry.get("value"):
+            continue
+        # Allowlist BEFORE jar-building. An empty domain is NOT allowlisted, but
+        # http.cookiejar would happily treat it as a host cookie for whatever URL
+        # it is asked about — including the rotate URL. Dropping this filter, or
+        # moving it after the jar is built, silently makes such a row route.
+        if not _is_allowed_auth_domain(entry.get("domain", "") or ""):
+            continue
+        cookie = _safe_to_cookie(entry, to_cookie)
+        if cookie is None:
+            continue
+        identity = (cookie.name, cookie.domain, cookie.path)
+        # ``Cookie.expires`` is always an ``int`` after the constructor's
+        # ``int(float(...))`` coercion, and ``is_expired`` compares
+        # ``expires <= now``. For integer ``e`` and non-negative ``now``,
+        # ``e <= now`` iff ``e <= floor(now)`` — so truncating is exact, not
+        # lossy, and it satisfies the stub's ``int | None`` signature while
+        # letting callers pass the float seconds every other clock here uses.
+        if cookie.is_expired(None if now is None else int(now)):
+            dead.add(identity)
+        else:
+            live.setdefault(identity, cookie)
+    for identity, cookie in live.items():
+        if identity not in dead:
+            yield cookie
+
+
+def _psidts_is_live(
+    entries: list[dict[str, Any]],
+    *,
+    to_cookie: _CookieConverter,
+    now: float | None = None,
+) -> bool:
+    """Is ANY live ``__Secure-1PSIDTS`` present on an allowed auth domain?
+
+    This is the "did the heal land?" question. It deliberately does NOT ask
+    about routing to ``accounts.google.com``: its job is to predict whether the
+    caller's retried preflight will pass, and that preflight
+    (:func:`notebooklm._auth.cookie_policy._validate_required_cookies`) is
+    domain-blind name presence. Asking the rotate-URL question here would report
+    "not healed" for a PSIDTS persisted only on the app host, re-raising an
+    authentication error over a session that actually works — a false negative
+    in the direction that hurts (issue #2057).
+
+    It is, however, deliberately STRICTER than the preflight on expiry: the
+    preflight ignores ``expires`` entirely, while this requires an unexpired
+    row. Dropping that would regress issue #1273 — a no-op save over a stale
+    on-disk row would report success and fake a heal. The invariant to hold is
+    an implication, not an equality: live ⇒ the preflight passes on the PSIDTS
+    half (it says nothing about ``SID``).
+    """
+    return any(True for _ in _iter_live_psidts_cookies(entries, to_cookie=to_cookie, now=now))
+
+
+def _psidts_routes_to_rotate(
+    entries: list[dict[str, Any]],
+    *,
+    to_cookie: _CookieConverter,
+    now: float | None = None,
+) -> bool:
+    """Would the ``Cookie:`` header sent to ``KEEPALIVE_ROTATE_URL`` carry PSIDTS?
+
+    This is the "should we fire the POST?" question, and it is asked of the same
+    RFC 6265 machinery that will build the real request. The predecessor gate
+    ranked a single domain-blind global winner by ``_auth_domain_priority`` and
+    read that winner's expiry — but the POST it gates is routed, so the gate and
+    the action could answer different questions about the same cookie set. A
+    PSIDTS scoped to ``.notebooklm.google.com`` (or, post-rebrand,
+    ``.notebook.google.com``) never reaches ``accounts.google.com``, while a
+    host-scoped one on ``accounts.google.com`` — which does route — sat in the
+    *lowest* priority tier (issue #2057).
+
+    Expiry is decided by :func:`_iter_live_psidts_cookies` against ``now``, then
+    stripped from the probe copies. ``CookieJar.add_cookie_header`` resets its
+    own clock from ``time.time()`` and re-applies its expiry policy on top of
+    whatever it is given, so an injected ``now`` would otherwise be a
+    tightening-only seam — it could mark a cookie expired but never keep one
+    fresh, and a test asserting "fresh at now=200" would silently fail against
+    the real wall clock. The probes exist only to answer the DOMAIN question.
+    """
+    jar = httpx.Cookies()
+    found = False
+    for cookie in _iter_live_psidts_cookies(entries, to_cookie=to_cookie, now=now):
+        probe = copy.copy(cookie)
+        probe.expires = None
+        jar.jar.set_cookie(probe)
+        found = True
+    if not found:
+        return False
+    request = httpx.Request("POST", _keepalive.KEEPALIVE_ROTATE_URL)
+    jar.set_cookie_header(request)
+    return _PSIDTS_COOKIE in _cookie_header_names(request.headers.get("cookie", ""))
 
 
 def _resolve_recovery_path(path: Path | str | None) -> Path | None:
@@ -174,10 +313,19 @@ def _resolve_recovery_path(path: Path | str | None) -> Path | None:
     - otherwise → fall back to :func:`notebooklm.paths.get_storage_path`,
       so ``load_auth_from_storage()`` with no args still triggers recovery
       on the default profile file (issue #865 critical-path coverage).
+
+    The env-var test is *presence*, matching ``_load_storage_state``
+    (``"NOTEBOOKLM_AUTH_JSON" in os.environ``), not truthiness. They used to
+    disagree, and an empty-string value fell through the crack: the loader took
+    its env branch and raised "set but empty" without ever inspecting a cookie,
+    while this resolver saw a falsy value and handed back the **default profile
+    file**. Recovery then fired a ``RotateCookies`` POST and persisted rotated
+    cookies to a profile the caller had deliberately bypassed. Found while
+    analysing which callers can reach the gate for issue #2057.
     """
     if path:
         return Path(path)
-    if os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+    if "NOTEBOOKLM_AUTH_JSON" in os.environ:
         return None
     from ..paths import get_storage_path
 
@@ -190,9 +338,11 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     Pre-conditions (all must hold; otherwise return ``False`` without firing):
 
     1. ``SID`` present in ``storage_path``.
-    2. ``__Secure-1PSIDTS`` absent in ``storage_path``, OR present but past its
-       ``expires`` epoch (a ``-1``/``None`` session-cookie expiry counts as
-       present, not expired — see :func:`_psidts_needs_recovery`).
+    2. No live ``__Secure-1PSIDTS`` in ``storage_path`` ROUTES to
+       ``KEEPALIVE_ROTATE_URL`` — absent, expired, or scoped to a domain that
+       never reaches ``accounts.google.com`` (a ``-1``/``None`` session-cookie
+       expiry counts as present, not expired — see
+       :func:`_psidts_routes_to_rotate`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``). Google
        rejects ``RotateCookies`` requests that lack these — see
        :func:`notebooklm._auth.cookie_policy._has_valid_secondary_binding`.
@@ -237,12 +387,12 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     state = _read_storage_for_recovery(storage_path)
     if state is None:
         return False
-    cookie_entries, cookie_names, cookie_expiry = state
+    cookie_entries, cookie_names = state
 
     if "SID" not in cookie_names:
         logger.debug("PSIDTS recovery skipped: SID missing — session is truly broken")
         return False
-    if not _psidts_needs_recovery(cookie_names, cookie_expiry):
+    if _psidts_routes_to_rotate(cookie_entries, to_cookie=_storage_entry_to_cookie):
         return False
     if not _has_valid_secondary_binding(cookie_names):
         logger.debug(
@@ -278,15 +428,22 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         # Re-read inside the lock: another process may have completed its
         # rotation + save between our top-of-function precondition check and
         # acquiring this flock. Mirrors ``_poke_session``'s "one last disk
-        # recheck" pattern at ``_auth/keepalive.py:283-290``. Re-validate the
-        # FULL precondition set against the fresh state (not just PSIDTS-present)
-        # so a concurrent write that dropped SID or the secondary binding
-        # can't slip a doomed POST through.
+        # recheck" pattern at ``_auth/keepalive.py:283-290``. The remaining
+        # preconditions are re-validated against the fresh state so a concurrent
+        # write that dropped SID or the secondary binding can't slip a doomed
+        # POST through. Note the PSIDTS check comes FIRST and returns early, so
+        # the "healed by another process" branch does not re-check SID or the
+        # binding — that ordering predates this gate and is harmless: the caller
+        # simply retries its preflight, which then fails honestly on SID.
         fresh = _read_storage_for_recovery(storage_path)
         if fresh is None:
             return False
-        fresh_entries, fresh_names, fresh_expiry = fresh
-        if not _psidts_needs_recovery(fresh_names, fresh_expiry):
+        fresh_entries, fresh_names = fresh
+        if _psidts_routes_to_rotate(fresh_entries, to_cookie=_storage_entry_to_cookie):
+            # Nothing to fire. Reporting this as a heal is sound because
+            # routed ⇒ live: a cookie that appears in the header for
+            # ``accounts.google.com`` is by construction unexpired and on an
+            # allowed domain, which is exactly what :func:`_psidts_is_live` asks.
             logger.debug(
                 "PSIDTS recovery skipped: file healed by another process while waiting for flock"
             )
@@ -304,20 +461,22 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
 
 def _read_storage_for_recovery(
     storage_path: Path,
-) -> tuple[list[dict], set[str], dict[str, Any]] | None:
+) -> tuple[list[dict], set[str]] | None:
     """Load + filter + name-index storage_state for the recovery preconditions.
 
-    Returns ``(cookie_entries, cookie_names, cookie_expiry)`` on success, or
-    ``None`` on any load/parse failure (caller treats this as "decline
-    recovery"). ``cookie_names`` / ``cookie_expiry`` are domain-filtered,
-    priority-resolved views over the same entries (see
-    :func:`_index_recovery_cookies`) so the precondition gate can treat a
-    present-but-expired PSIDTS as absent (see :func:`_psidts_needs_recovery`).
-    ``cookie_entries`` is the unfiltered list — the jar builder in
-    :func:`_attempt_rotation` applies its own domain filter. The narrow
-    exception scope catches the documented raise sites of ``_load_storage_state``
-    (``OSError`` for missing file, ``json.JSONDecodeError`` for malformed JSON)
-    and lets unexpected ``ValueError`` propagate as an implementation bug.
+    Returns ``(cookie_entries, cookie_names)`` on success, or ``None`` on any
+    load/parse failure (caller treats this as "decline recovery").
+    ``cookie_names`` is the domain-filtered name view used by the ``SID`` and
+    secondary-binding preconditions (see :func:`_recovery_cookie_names`).
+    ``cookie_entries`` is the unfiltered list — both the PSIDTS predicates
+    (:func:`_psidts_routes_to_rotate`, :func:`_psidts_is_live`) and the jar
+    builder in :func:`_attempt_rotation` apply their own domain filter, and the
+    predicates need the raw ``expires`` that a name-only view cannot carry.
+
+    The narrow exception scope catches the documented raise sites of
+    ``_load_storage_state`` (``OSError`` for missing file,
+    ``json.JSONDecodeError`` for malformed JSON) and lets unexpected
+    ``ValueError`` propagate as an implementation bug.
     """
     try:
         storage_state = _load_storage_state(storage_path)
@@ -328,24 +487,28 @@ def _read_storage_for_recovery(
     if not isinstance(raw_entries, list):
         return None
     cookie_entries: list[dict] = [entry for entry in raw_entries if isinstance(entry, dict)]
-    cookie_names, cookie_expiry = _index_recovery_cookies(cookie_entries)
-    return cookie_entries, cookie_names, cookie_expiry
+    return cookie_entries, _recovery_cookie_names(cookie_entries)
 
 
 def _is_psidts_persisted(storage_path: Path) -> bool:
-    """Quick re-read: is a fresh ``__Secure-1PSIDTS`` currently on disk?
+    """Quick re-read: is a live ``__Secure-1PSIDTS`` currently on disk?
 
     Used after a held-flock skip to detect when another process has just healed
-    the file. Treats any load/parse failure as "not persisted" rather than
-    raising — the caller will retry. A present-but-expired PSIDTS counts as
-    *not* persisted (mirrors :func:`_psidts_needs_recovery`) so a stale on-disk
-    row doesn't masquerade as a heal.
+    the file, and after our own save to decide whether the heal landed. Treats
+    any load/parse failure as "not persisted" rather than raising — the caller
+    will retry. A present-but-expired PSIDTS counts as *not* persisted so a
+    stale on-disk row doesn't masquerade as a heal.
+
+    Asks :func:`_psidts_is_live` — the domain-blind "did it land?" question —
+    NOT the routed "should we fire?" question. The two are deliberately
+    different; see :func:`_psidts_is_live` for why routing here would introduce
+    a false negative.
     """
     state = _read_storage_for_recovery(storage_path)
     if state is None:
         return False
-    _, names, expiry = state
-    return not _psidts_needs_recovery(names, expiry)
+    entries, _ = state
+    return _psidts_is_live(entries, to_cookie=_storage_entry_to_cookie)
 
 
 def _psidts_save_succeeded(
@@ -368,11 +531,18 @@ def _psidts_save_succeeded(
       and the save reports success while disk is still unhealed.
 
     So disk — not the save bool — is the sole arbiter. Re-read it and accept the
-    heal iff a present, unexpired PSIDTS is stored. :func:`_is_psidts_persisted`
-    mirrors the precondition gate, so a stale or expired row (ours or a
+    heal iff a live PSIDTS is stored, so a stale or expired row (ours or a
     sibling's) doesn't masquerade as a heal. On a decline, the coarse ``result``
     is folded into a diagnostic warning here (the only thing it is used for) so
     callers stay a single boolean branch.
+
+    :func:`_is_psidts_persisted` deliberately does NOT mirror the routed
+    precondition gate (:func:`_psidts_routes_to_rotate`). This is the "did it
+    land?" question, and it must track what the caller's retried preflight
+    validates — domain-blind name presence — not what routes to
+    ``accounts.google.com``. Asking the routed question here would report a
+    PSIDTS persisted only on the app host as unhealed and re-raise over a
+    working session (issue #2057).
     """
     if _is_psidts_persisted(storage_path):
         return True
@@ -407,7 +577,10 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
             continue
         if not _is_allowed_auth_domain(entry.get("domain", "")):
             continue
-        jar.jar.set_cookie(_storage_entry_to_cookie(entry))
+        cookie = _safe_to_cookie(entry, _storage_entry_to_cookie)
+        if cookie is None:
+            continue
+        jar.jar.set_cookie(cookie)
 
     # ``httpx.Client(cookies=jar)`` copies the source jar into a private client
     # jar; Set-Cookie responses land in ``client.cookies``, not in ``jar``. So
@@ -519,9 +692,10 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     :func:`_recover_psidts_inline`):
 
     1. ``SID`` present.
-    2. ``__Secure-1PSIDTS`` absent, OR present but past its ``expires`` epoch
-       (a ``-1``/``None`` session-cookie expiry counts as present, not
-       expired — see :func:`_psidts_needs_recovery`).
+    2. No live ``__Secure-1PSIDTS`` ROUTES to ``KEEPALIVE_ROTATE_URL`` — absent,
+       expired, or scoped to a domain that never reaches
+       ``accounts.google.com`` (a ``-1``/``None`` session-cookie expiry counts
+       as present, not expired — see :func:`_psidts_routes_to_rotate`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``).
 
     On success, mutates ``rookiepy_cookies`` so the rotated
@@ -544,12 +718,12 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     Returns ``True`` if the rotation succeeded and the in-memory list now
     contains ``__Secure-1PSIDTS``; ``False`` otherwise.
     """
-    cookie_names, cookie_expiry = _index_recovery_cookies(rookiepy_cookies)
+    cookie_names = _recovery_cookie_names(rookiepy_cookies)
 
     if "SID" not in cookie_names:
         logger.debug("In-memory PSIDTS recovery skipped: SID missing")
         return False
-    if not _psidts_needs_recovery(cookie_names, cookie_expiry):
+    if _psidts_routes_to_rotate(rookiepy_cookies, to_cookie=_rookiepy_entry_to_cookie):
         return False
     if not _has_valid_secondary_binding(cookie_names):
         logger.debug(
@@ -566,7 +740,10 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
             continue
         if not _is_allowed_auth_domain(entry.get("domain", "")):
             continue
-        jar.jar.set_cookie(_rookiepy_entry_to_cookie(entry))
+        cookie = _safe_to_cookie(entry, _rookiepy_entry_to_cookie)
+        if cookie is None:
+            continue
+        jar.jar.set_cookie(cookie)
 
     try:
         with httpx.Client(
@@ -659,8 +836,9 @@ def validate_with_recovery(
     Wraps :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`
     plus :func:`notebooklm._auth.cookies.extract_cookies_from_storage` with one
     retry through :func:`recover_psidts_in_memory` (issue #990). When the
-    recovery preconditions hold (SID present, PSIDTS absent or expired,
-    secondary binding intact — see :func:`_psidts_needs_recovery`), the
+    recovery preconditions hold (SID present, no live PSIDTS routing to the
+    rotate URL, secondary binding intact — see
+    :func:`_psidts_routes_to_rotate`), the
     rotated cookies are merged into ``rookiepy_cookies`` in place by
     ``(name, domain, path)`` identity — overwriting an existing same-identity
     row, else appended — so downstream persistence picks them up without

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -11,8 +11,8 @@ integration so the loop stays broken.
 
 from __future__ import annotations
 
+import itertools
 import json
-import random
 import re
 import time
 from pathlib import Path
@@ -375,6 +375,13 @@ class TestPsidtsExpiryGate:
                 s._psidts(".notebooklm.google.com", expires=s._FUTURE),
                 s._psidts(".google.com.sg", expires=s._PAST),
             ],
+            # Duplicate identity + a malformed row: the two cases where an
+            # order-sensitive implementation is most likely to slip through.
+            lambda s: [
+                s._psidts(".google.com", expires=s._FUTURE, value="a"),
+                s._psidts(".google.com", expires=s._PAST, value="b"),
+                s._psidts(".google.com", expires="nonsense", value="c"),
+            ],
         ],
     )
     def test_reordering_storage_state_cannot_change_the_answer(self, entries_factory):
@@ -383,13 +390,20 @@ class TestPsidtsExpiryGate:
         Within a shared priority tier the old index resolved duplicates by
         "first occurrence wins", so reordering the file changed the gate's
         answer. This is the ratchet that replaces that surface.
+
+        Exhaustive over permutations rather than sampled: the PSIDTS rows are
+        few enough that `itertools.permutations` is both cheap and strictly
+        stronger than N random shuffles, and a failure reproduces exactly
+        instead of depending on an unseeded RNG.
         """
-        entries = _RECOVERABLE_COOKIES + entries_factory(self)
-        expected = (self._routes(entries), self._live(entries))
-        for _ in range(8):
-            shuffled = entries[:]
-            random.shuffle(shuffled)
-            assert (self._routes(shuffled), self._live(shuffled)) == expected, shuffled
+        psidts_rows = entries_factory(self)
+        expected = None
+        for ordering in itertools.permutations(psidts_rows):
+            entries = _RECOVERABLE_COOKIES + list(ordering)
+            answer = (self._routes(entries), self._live(entries))
+            if expected is None:
+                expected = answer
+            assert answer == expected, ordering
 
     def test_routed_implies_live(self):
         """``routed ⇒ live`` — the invariant that makes the flock-skip return True safe.
@@ -669,7 +683,8 @@ class TestPsidtsExpiryGate:
 
     # --- flock-held re-read (``_is_psidts_persisted``) ---------------------
 
-    def test_stale_twin_row_does_not_block_the_heal(self, tmp_path):
+    @pytest.mark.no_default_keepalive_mock
+    def test_stale_twin_row_does_not_block_the_heal(self, tmp_path, httpx_mock: HTTPXMock):
         """A stale same-identity twin must not make a completed heal report failure.
 
         End-to-end pin for a permanent failure loop. ``save_cookies_to_storage``
@@ -703,6 +718,17 @@ class TestPsidtsExpiryGate:
             ],
         )
         assert psidts_recovery._is_psidts_persisted(storage_path) is True
+
+        # And the whole recovery agrees. Asserting only `_is_psidts_persisted`
+        # would leave a regression in `_psidts_save_succeeded` or the
+        # `_recover_psidts_inline` wiring green, and that wiring is the thing
+        # that used to loop. Note the POST DOES fire: the routing predicate
+        # poisons the duplicated identity, which is the safe direction. What
+        # must not happen is the heal being reported as a FAILURE afterwards —
+        # that is what made it re-raise on every load, forever.
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+        assert len([r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]) == 1
 
     def test_is_psidts_persisted_false_for_expired_on_disk_row(self, tmp_path):
         """The held-flock re-read must NOT mistake a stale PSIDTS for a heal.
@@ -1427,6 +1453,74 @@ class TestInMemoryRecovery:
         assert _rotate_requests(httpx_mock) == []
         # storage_state still reflects the (incomplete) extraction attempt.
         assert isinstance(storage_state, dict)
+
+
+class TestMalformedExpiresAcrossLoaders:
+    """A row with an uncoercible ``expires`` must not take a whole profile down.
+
+    ``http.cookiejar.Cookie.__init__`` coerces via ``int(float(expires))``, so a
+    single corrupt row raised ``ValueError: could not convert string to float``
+    out of every loader — including from *inside* the recovery paths'
+    ``except ValueError:`` handlers, where it replaced the actionable
+    "Missing required cookies … Run 'notebooklm login'" with a converter
+    traceback. Guarding only the recovery module left
+    ``NotebookLMClient.from_storage`` still broken, and made it worse: recovery
+    would now complete, fire a POST and rewrite the file, while the strict
+    loader kept raising the same error on every load, forever.
+    """
+
+    @staticmethod
+    def _storage_with_bad_row(tmp_path: Path, *, include_psidts: bool) -> Path:
+        rows = list(_RECOVERABLE_COOKIES)
+        if include_psidts:
+            rows.append(
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "fresh",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": 99_999_999_999,
+                }
+            )
+        rows.append(
+            {
+                "name": "NID",
+                "value": "junk",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": "not-a-timestamp",
+            }
+        )
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, rows)
+        return storage_path
+
+    def test_strict_loader_skips_the_bad_row_and_loads(self, tmp_path):
+        """The `NotebookLMClient.from_storage` path: a healthy profile still loads."""
+        storage_path = self._storage_with_bad_row(tmp_path, include_psidts=True)
+        jar = auth_cookies.build_httpx_cookies_from_storage(storage_path)
+        names = {c.name for c in jar.jar}
+        assert "__Secure-1PSIDTS" in names and "SID" in names
+        assert "NID" not in names  # unusable row dropped, not fatal
+
+    def test_download_loader_skips_the_bad_row_and_loads(self, tmp_path):
+        storage_path = self._storage_with_bad_row(tmp_path, include_psidts=True)
+        jar = auth_cookies.load_httpx_cookies(storage_path)
+        names = {c.name for c in jar.jar}
+        assert "__Secure-1PSIDTS" in names
+        assert "NID" not in names
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_bad_row_yields_the_actionable_error_not_a_coercion_traceback(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """When the dropped row mattered, the loaders' own validation speaks."""
+        storage_path = self._storage_with_bad_row(tmp_path, include_psidts=False)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=500)
+
+        with pytest.raises(ValueError, match="Missing required cookies") as excinfo:
+            auth_cookies.build_httpx_cookies_from_storage(storage_path)
+        assert "could not convert string to float" not in str(excinfo.value)
 
 
 class TestMissingCookiesHint:

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -1290,6 +1290,40 @@ class TestInMemoryRecovery:
         assert cookie.get_nonstandard_attr("HttpOnly") == ""
 
     @pytest.mark.no_default_keepalive_mock
+    def test_withheld_rotation_is_detected_despite_a_pre_existing_psidts(
+        self, httpx_mock: HTTPXMock
+    ):
+        """A pre-existing non-routing PSIDTS must not fake a successful mint.
+
+        Routing the gate made this path newly reachable: an app-host-only PSIDTS
+        now fires the POST, and the request jar still carries that cookie. A
+        name-only "did the response include PSIDTS?" check would therefore see
+        the caller's own pre-existing cookie and report success even when Google
+        withheld the rotation — defeating the very detection the surrounding code
+        exists for. The check asks whether a PSIDTS now ROUTES to the rotate URL,
+        which is also proof of newness: the gate only fired because nothing
+        routable was there to begin with.
+        """
+        cookies = _rookiepy_recoverable() + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "app_host_only",
+                "domain": ".notebooklm.google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+            }
+        ]
+        # 2xx, but no Set-Cookie for PSIDTS — Google withholding the rotation.
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response(include_psidts=False))
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        # The POST did fire — the heal was genuinely needed — but it is correctly
+        # reported as failed, and no bogus row was appended.
+        assert len([r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]) == 1
+        assert [c for c in cookies if c["name"] == "__Secure-1PSIDTS"] == [cookies[-1]]
+
+    @pytest.mark.no_default_keepalive_mock
     def test_app_host_only_psidts_still_fires_the_post(self, httpx_mock: HTTPXMock):
         """A PSIDTS that never reaches ``accounts.google.com`` does not block the heal.
 

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -45,6 +45,53 @@ def _write_storage(path: Path, cookies: list[dict]) -> None:
     path.write_text(json.dumps({"cookies": cookies, "origins": []}), encoding="utf-8")
 
 
+def _rotate_requests(httpx_mock: HTTPXMock) -> list[httpx.Request]:
+    """Return only the ``RotateCookies`` POSTs the mock recorded.
+
+    Filtered rather than counted wholesale: the recovery paths run under an
+    autouse keepalive mock that may record unrelated traffic, so "did the POST
+    fire?" has to be asked about this URL specifically.
+    """
+    return [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+
+
+def _rookiepy_recoverable() -> list[dict]:
+    """Rookiepy-shaped cookies meeting the recovery precondition, PSIDTS absent.
+
+    The snake_case twin of :data:`_RECOVERABLE_COOKIES` — rookiepy's own field
+    spelling (``http_only``), which the in-memory path consumes directly without
+    going through ``convert_rookiepy_cookies_to_storage_state``. ``expires`` is
+    omitted (= session cookie); an explicit small ``int`` would be epoch seconds,
+    landing in 1970 and being filtered as expired before reaching the wire.
+    """
+    return [
+        {
+            "name": "SID",
+            "value": "test_sid",
+            "domain": ".google.com",
+            "path": "/",
+            "secure": True,
+            "http_only": False,
+        },
+        {
+            "name": "APISID",
+            "value": "test_apisid",
+            "domain": ".google.com",
+            "path": "/",
+            "secure": False,
+            "http_only": False,
+        },
+        {
+            "name": "SAPISID",
+            "value": "test_sapisid",
+            "domain": ".google.com",
+            "path": "/",
+            "secure": True,
+            "http_only": True,
+        },
+    ]
+
+
 def _make_psidts_response(status_code: int = 200, *, include_psidts: bool = True):
     """Build a response shape matching what Google's RotateCookies returns."""
     headers: list[tuple[str, str]] = []
@@ -83,7 +130,7 @@ class TestRecoveryPreconditions:
         _write_storage(storage_path, cookies)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_psidts_already_present_returns_false_without_post(
@@ -102,7 +149,7 @@ class TestRecoveryPreconditions:
         _write_storage(storage_path, cookies)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_missing_secondary_binding_returns_false_without_post(
@@ -114,7 +161,7 @@ class TestRecoveryPreconditions:
         _write_storage(storage_path, cookies)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_osid_alone_satisfies_secondary_binding(self, tmp_path, httpx_mock: HTTPXMock):
@@ -147,7 +194,7 @@ class TestRecoveryPreconditions:
         monkeypatch.setattr(psidts_recovery, "_try_claim_rotation", lambda _path: False)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
 
 class TestPsidtsExpiryGate:
@@ -376,20 +423,33 @@ class TestPsidtsExpiryGate:
 
     # --- duplicate identities and malformed rows ---------------------------
 
-    def test_duplicate_identity_with_an_expired_row_is_not_live(self):
-        """A dead row poisons its ``(name, domain, path)`` identity, in EITHER order.
+    def test_duplicate_identity_poisons_routing_but_not_liveness(self):
+        """A dead twin blocks ROUTING in either order — but must not block the heal.
 
         ``http.cookiejar`` keeps one cookie per identity and lets a later row
         replace an earlier one, so a jar built from a duplicated identity
-        depends on entry order. Resolving conservatively keeps the answer
-        order-independent and never over-optimistic: the cost is one needless
-        POST, versus silently skipping a heal the session needs.
+        depends on entry order. The routing predicate resolves that
+        conservatively, which is order-independent and never over-optimistic:
+        the cost is one needless POST.
+
+        ``_psidts_is_live`` must NOT inherit that rule. It models the retried
+        preflight, which is name presence and would pass. Poisoning it turns a
+        working session into a PERMANENT failure loop, because
+        ``save_cookies_to_storage`` CAS-matches the first stored row and leaves
+        the stale twin on disk: every load would fire a POST, write to disk,
+        then re-raise "Missing required cookies". The twin is issue #1523's data
+        shape — #1523 fixed the producer, and nothing on the load/save path
+        removes an existing one.
         """
         fresh = self._psidts(expires=self._FUTURE, value="fresh")
         stale = self._psidts(expires=self._PAST, value="stale")
         for ordering in ([fresh, stale], [stale, fresh]):
             assert self._routes(ordering) is False, ordering
-            assert self._live(ordering) is False, ordering
+            assert self._live(ordering) is True, ordering
+            # The preflight the live predicate models does pass on this state.
+            auth_cookies.extract_cookies_from_storage(
+                {"cookies": _RECOVERABLE_COOKIES + ordering, "origins": []}
+            )
 
     def test_duplicate_name_on_distinct_identities_is_unaffected(self):
         """Same name, different domain → different identity → no poisoning."""
@@ -401,15 +461,32 @@ class TestPsidtsExpiryGate:
         assert self._live(entries) is True
 
     @pytest.mark.parametrize("expires", ["", "never", float("nan"), float("inf"), [], {}])
-    def test_malformed_expires_is_treated_as_absent_not_raised(self, expires):
+    def test_malformed_expires_never_raises_and_splits_the_two_predicates(self, expires):
         """``Cookie.__init__`` coerces eagerly; a bad ``expires`` must not escape.
 
         Both predicates run inside the callers' ``except ValueError:`` handlers,
         so a coercion error would replace the actionable "Missing required
-        cookies" diagnostic with a converter traceback. Unconvertible rows are
-        dropped, which makes recovery FIRE — the safe direction.
+        cookies" diagnostic with a converter traceback.
+
+        The two predicates then answer differently, and deliberately so. An
+        unconvertible row cannot go in a jar, so it cannot be sent: routing says
+        "fire", the safe direction. But the row IS on disk and the preflight
+        will see it by name, so liveness says "present" — mirroring the
+        predecessor gate, which treated an uninterpretable expiry as present
+        rather than guessing. Reporting it absent would re-raise over a session
+        whose preflight passes.
         """
         entries = _RECOVERABLE_COOKIES + [self._psidts(expires=expires)]
+        assert self._routes(entries) is False
+        assert self._live(entries) is True
+
+    def test_expired_single_row_is_not_live(self):
+        """A row KNOWN to be expired still does not count as healed (issue #1273).
+
+        The relaxation for duplicates and malformed rows must not weaken this:
+        a no-op save that leaves one stale PSIDTS behind must not fake a heal.
+        """
+        entries = _RECOVERABLE_COOKIES + [self._psidts(expires=self._PAST)]
         assert self._routes(entries) is False
         assert self._live(entries) is False
 
@@ -452,7 +529,7 @@ class TestPsidtsExpiryGate:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
 
-        rotate_requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        rotate_requests = _rotate_requests(httpx_mock)
         assert len(rotate_requests) == 1
         saved = json.loads(storage_path.read_text(encoding="utf-8"))
         fresh = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
@@ -465,7 +542,7 @@ class TestPsidtsExpiryGate:
         _write_storage(storage_path, self._with_psidts(expires=self._FUTURE))
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_present_session_cookie_skips_recovery(self, tmp_path, httpx_mock: HTTPXMock):
@@ -474,7 +551,7 @@ class TestPsidtsExpiryGate:
         _write_storage(storage_path, self._with_psidts(expires=-1))
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     # --- in-memory twin ----------------------------------------------------
 
@@ -482,9 +559,7 @@ class TestPsidtsExpiryGate:
     def test_in_memory_present_but_expired_fires_recovery(self, httpx_mock: HTTPXMock):
         now = time.time()
         cookies = [
-            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
-            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
-            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            *_rookiepy_recoverable(),
             {
                 "name": "__Secure-1PSIDTS",
                 "value": "stale",
@@ -516,9 +591,7 @@ class TestPsidtsExpiryGate:
         """
         now = time.time()
         cookies = [
-            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
-            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
-            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            *_rookiepy_recoverable(),
             # __Secure-1PSIDTS expired → recovery fires.
             {
                 "name": "__Secure-1PSIDTS",
@@ -549,26 +622,22 @@ class TestPsidtsExpiryGate:
             assert rows[0]["value"] == rotated, f"{name} did not carry the rotated value"
 
         # The resulting storage_state must likewise hold exactly one row each.
-        from notebooklm._auth import cookies as _auth_cookies
-
-        state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(cookies)
+        state = auth_cookies.convert_rookiepy_cookies_to_storage_state(cookies)
         for name in ("__Secure-1PSIDTS", "__Secure-3PSIDTS"):
             state_rows = [c for c in state["cookies"] if c["name"] == name]
             assert len(state_rows) == 1, f"{name} duplicated on disk: {state_rows}"
 
         # Auth-relevant binding cookies are all still present and correct.
         names = {c["name"]: c["value"] for c in cookies}
-        assert names["SID"] == "s"
-        assert names["APISID"] == "a"
-        assert names["SAPISID"] == "sa"
+        assert names["SID"] == "test_sid"
+        assert names["APISID"] == "test_apisid"
+        assert names["SAPISID"] == "test_sapisid"
 
     @pytest.mark.no_default_keepalive_mock
     def test_in_memory_present_and_fresh_skips_recovery(self, httpx_mock: HTTPXMock):
         now = time.time()
         cookies = [
-            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
-            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
-            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            *_rookiepy_recoverable(),
             {
                 "name": "__Secure-1PSIDTS",
                 "value": "fresh_on_disk",
@@ -579,15 +648,13 @@ class TestPsidtsExpiryGate:
         ]
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_in_memory_session_cookie_skips_recovery(self, httpx_mock: HTTPXMock):
         """A session-cookie (-1) PSIDTS on the in-memory path is not expired → no POST."""
         cookies = [
-            {"name": "SID", "value": "s", "domain": ".google.com", "path": "/"},
-            {"name": "APISID", "value": "a", "domain": ".google.com", "path": "/"},
-            {"name": "SAPISID", "value": "sa", "domain": ".google.com", "path": "/"},
+            *_rookiepy_recoverable(),
             {
                 "name": "__Secure-1PSIDTS",
                 "value": "session",
@@ -598,9 +665,44 @@ class TestPsidtsExpiryGate:
         ]
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     # --- flock-held re-read (``_is_psidts_persisted``) ---------------------
+
+    def test_stale_twin_row_does_not_block_the_heal(self, tmp_path):
+        """A stale same-identity twin must not make a completed heal report failure.
+
+        End-to-end pin for a permanent failure loop. ``save_cookies_to_storage``
+        CAS-matches the FIRST stored row for an identity, so when disk carries
+        ``__Secure-1PSIDTS`` twice on ``(.google.com, /)`` the rotation lands on
+        one row and the stale twin survives the save. If ``_is_psidts_persisted``
+        treated that twin as disqualifying, every load would fire a POST, write
+        to disk, and then re-raise "Missing required cookies" — for a session
+        whose preflight passes. Issue #1523's data shape; #1523 fixed the
+        producer, not existing files.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(
+            storage_path,
+            _RECOVERABLE_COOKIES
+            + [
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "stale_twin",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": 1_000_000_000,
+                },
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "rotated",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": 99_999_999_999,
+                },
+            ],
+        )
+        assert psidts_recovery._is_psidts_persisted(storage_path) is True
 
     def test_is_psidts_persisted_false_for_expired_on_disk_row(self, tmp_path):
         """The held-flock re-read must NOT mistake a stale PSIDTS for a heal.
@@ -648,7 +750,7 @@ class TestRecoveryHappyPath:
 
         psidts_recovery._recover_psidts_inline(storage_path)
 
-        rotate_requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        rotate_requests = _rotate_requests(httpx_mock)
         assert len(rotate_requests) == 1
         cookie_header = rotate_requests[0].headers.get("cookie", "")
         # Sanity-check the request carries SID + the secondary binding.
@@ -992,7 +1094,7 @@ class TestLoadAuthFromStorageIntegration:
             auth_module.load_auth_from_storage(None)
 
         # Crucially: no RotateCookies POST must have fired for env-var auth.
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_empty_env_var_does_not_fall_back_to_the_default_profile(
@@ -1013,7 +1115,7 @@ class TestLoadAuthFromStorageIntegration:
 
         assert psidts_recovery._resolve_recovery_path(None) is None
         assert psidts_recovery._recover_psidts_inline(None) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
         # The bypassed profile is untouched.
         assert json.loads(default_path.read_text(encoding="utf-8"))["cookies"] == (
             _RECOVERABLE_COOKIES
@@ -1108,43 +1210,9 @@ class TestInMemoryRecovery:
     lock / throttle because the extraction path is a single one-shot CLI run.
     """
 
-    # Rookiepy uses snake_case field names; mirror that shape here so the
-    # in-memory recovery exercises the real format produced by rookiepy.load().
-    # ``expires`` omitted = session cookie; an explicit ``int`` would be epoch
-    # seconds — small values like 9999 land in 1970 and get filtered as expired
-    # before reaching the wire.
-    @staticmethod
-    def _rookiepy_recoverable() -> list[dict]:
-        return [
-            {
-                "name": "SID",
-                "value": "test_sid",
-                "domain": ".google.com",
-                "path": "/",
-                "secure": True,
-                "http_only": False,
-            },
-            {
-                "name": "APISID",
-                "value": "test_apisid",
-                "domain": ".google.com",
-                "path": "/",
-                "secure": False,
-                "http_only": False,
-            },
-            {
-                "name": "SAPISID",
-                "value": "test_sapisid",
-                "domain": ".google.com",
-                "path": "/",
-                "secure": True,
-                "http_only": True,
-            },
-        ]
-
     @pytest.mark.no_default_keepalive_mock
     def test_recovers_psidts_and_mutates_list_in_place(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is True
@@ -1157,12 +1225,12 @@ class TestInMemoryRecovery:
 
     @pytest.mark.no_default_keepalive_mock
     def test_post_carries_existing_cookies(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
 
         psidts_recovery.recover_psidts_in_memory(cookies)
 
-        requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
+        requests = _rotate_requests(httpx_mock)
         assert len(requests) == 1
         header = requests[0].headers.get("cookie", "")
         assert "SID=test_sid" in header
@@ -1171,13 +1239,13 @@ class TestInMemoryRecovery:
 
     @pytest.mark.no_default_keepalive_mock
     def test_no_sid_returns_false_without_post(self, httpx_mock: HTTPXMock):
-        cookies = [c for c in self._rookiepy_recoverable() if c["name"] != "SID"]
+        cookies = [c for c in _rookiepy_recoverable() if c["name"] != "SID"]
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_psidts_already_present_returns_false_without_post(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable() + [
+        cookies = _rookiepy_recoverable() + [
             {
                 "name": "__Secure-1PSIDTS",
                 "value": "already_there",
@@ -1188,7 +1256,7 @@ class TestInMemoryRecovery:
             }
         ]
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_gate_reads_rookiepy_rows_directly_not_via_conversion(
@@ -1211,11 +1279,11 @@ class TestInMemoryRecovery:
             "http_only": True,
             "expires": None,
         }
-        cookies = self._rookiepy_recoverable() + [session_psidts]
+        cookies = _rookiepy_recoverable() + [session_psidts]
 
         # Session expiry -> live -> routes -> no POST.
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
         cookie = psidts_recovery._rookiepy_entry_to_cookie(session_psidts)
         assert cookie.expires is None
@@ -1229,7 +1297,7 @@ class TestInMemoryRecovery:
         satisfying row and skipped. It does not route to the POST's host, so the
         session still needs the mint.
         """
-        cookies = self._rookiepy_recoverable() + [
+        cookies = _rookiepy_recoverable() + [
             {
                 "name": "__Secure-1PSIDTS",
                 "value": "app_host_only",
@@ -1242,15 +1310,13 @@ class TestInMemoryRecovery:
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is True
-        assert len([r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]) == 1
+        assert len(_rotate_requests(httpx_mock)) == 1
 
     @pytest.mark.no_default_keepalive_mock
     def test_missing_secondary_binding_returns_false_without_post(self, httpx_mock: HTTPXMock):
-        cookies = [
-            c for c in self._rookiepy_recoverable() if c["name"] not in {"APISID", "SAPISID"}
-        ]
+        cookies = [c for c in _rookiepy_recoverable() if c["name"] not in {"APISID", "SAPISID"}]
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_osid_satisfies_secondary_binding(self, httpx_mock: HTTPXMock):
@@ -1278,7 +1344,7 @@ class TestInMemoryRecovery:
 
     @pytest.mark.no_default_keepalive_mock
     def test_4xx_response_returns_false(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=401)
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
@@ -1286,7 +1352,7 @@ class TestInMemoryRecovery:
 
     @pytest.mark.no_default_keepalive_mock
     def test_200_without_psidts_returns_false(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response(include_psidts=False))
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
@@ -1294,7 +1360,7 @@ class TestInMemoryRecovery:
 
     @pytest.mark.no_default_keepalive_mock
     def test_network_error_returns_false(self, httpx_mock: HTTPXMock):
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_exception(httpx.ConnectError("simulated network failure"))
 
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
@@ -1302,7 +1368,7 @@ class TestInMemoryRecovery:
     @pytest.mark.no_default_keepalive_mock
     def test_validate_with_recovery_heals_partial_jar(self, httpx_mock: HTTPXMock):
         """End-to-end: validate-with-recovery returns (storage_state, None) after rotation."""
-        cookies = self._rookiepy_recoverable()
+        cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
 
         storage_state, error = psidts_recovery.validate_with_recovery(cookies)
@@ -1317,14 +1383,14 @@ class TestInMemoryRecovery:
     def test_validate_with_recovery_returns_error_on_unrecoverable(self, httpx_mock: HTTPXMock):
         """When recovery declines, the original ValueError is surfaced."""
         # No SID → recovery declines → original ValueError propagates.
-        cookies = [c for c in self._rookiepy_recoverable() if c["name"] != "SID"]
+        cookies = [c for c in _rookiepy_recoverable() if c["name"] != "SID"]
 
         storage_state, error = psidts_recovery.validate_with_recovery(cookies)
 
         assert error is not None
         assert "SID" in str(error)
         # No POST fired (recovery preconditions failed early).
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
         # storage_state still reflects the (incomplete) extraction attempt.
         assert isinstance(storage_state, dict)
 
@@ -1383,7 +1449,7 @@ class TestEdgeCases:
         storage_path.write_text(json.dumps({"cookies": "not-a-list"}), encoding="utf-8")
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_save_returning_false_propagates_as_failure(
@@ -1458,7 +1524,7 @@ class TestEdgeCases:
         monkeypatch.setattr(psidts_recovery, "_file_lock_try_exclusive", held_lock)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_flock_held_returns_true_when_file_already_healed(
@@ -1507,7 +1573,7 @@ class TestEdgeCases:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # No POST — the holder already did the work.
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_post_flock_recheck_skips_post_when_file_healed_meanwhile(
@@ -1547,7 +1613,7 @@ class TestEdgeCases:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # Crucial: no POST — recheck saw the heal before we fired.
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_post_flock_recheck_re_validates_full_preconditions(
@@ -1577,7 +1643,7 @@ class TestEdgeCases:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         # No POST — recheck saw the broken state and aborted before firing.
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []
 
     @pytest.mark.no_default_keepalive_mock
     def test_post_flock_recheck_healed_branch_returns_before_sid_is_rechecked(
@@ -1616,4 +1682,4 @@ class TestEdgeCases:
         monkeypatch.setattr(psidts_recovery, "_load_storage_state", staged_load)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
-        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        assert _rotate_requests(httpx_mock) == []

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -12,6 +12,7 @@ integration so the loop stays broken.
 from __future__ import annotations
 
 import json
+import random
 import re
 import time
 from pathlib import Path
@@ -23,6 +24,7 @@ from pytest_httpx import HTTPXMock
 
 import notebooklm.paths as _nb_paths
 from notebooklm import auth as auth_module
+from notebooklm._auth import cookies as auth_cookies
 from notebooklm._auth import psidts_recovery
 
 _ROTATE_URL_RE = re.compile(r"^https://accounts\.google\.com/RotateCookies$")
@@ -149,14 +151,25 @@ class TestRecoveryPreconditions:
 
 
 class TestPsidtsExpiryGate:
-    """The precondition gate must treat a present-but-EXPIRED PSIDTS as absent.
+    """The precondition gate: RFC 6265 routing, not a domain-priority ranking.
 
-    Tier-0 cold-start fix: ``_recover_psidts_inline`` originally keyed purely on
-    name presence, so an idle Chrome session whose ``__Secure-1PSIDTS`` row is
-    still on disk but past its ``expires`` epoch silently skipped the one
-    ``RotateCookies`` POST that would heal it (cold-start then failed at the
-    first authed GET). A ``-1``/``None`` (session-cookie) expiry stays
-    not-expired, matching ``_storage_entry_to_cookie``.
+    Two questions, two predicates (issue #2057):
+
+    - ``_psidts_routes_to_rotate`` — *should we fire?* Answered against the URL
+      the decision is about, so an absent, expired, or non-routing
+      ``__Secure-1PSIDTS`` all mean "fire".
+    - ``_psidts_is_live`` — *did the heal land?* Deliberately domain-blind,
+      because it must predict the caller's retried preflight, which is
+      name-presence over the allowlist.
+
+    The predecessor gate ranked one global winner by ``_auth_domain_priority``
+    and read that winner's expiry. The tiers are not distinct, so the winner
+    depended on ``storage_state`` ordering; and the ranking was inverted
+    relative to the action it gated, since ``accounts.google.com`` — the host
+    the POST targets — sits in the lowest tier.
+
+    A ``-1``/``None`` (session-cookie) expiry stays not-expired, matching
+    ``_storage_entry_to_cookie``.
     """
 
     _PAST = 1_000_000_000  # 2001-09-09, comfortably in the past
@@ -174,50 +187,66 @@ class TestPsidtsExpiryGate:
             }
         ]
 
-    # --- direct unit tests of the helper with an injectable ``now`` ---------
+    @staticmethod
+    def _psidts(domain=".google.com", *, expires, value="v", path="/") -> dict:
+        return {
+            "name": "__Secure-1PSIDTS",
+            "value": value,
+            "domain": domain,
+            "path": path,
+            "expires": expires,
+            "secure": True,
+        }
 
-    def test_helper_expired_needs_recovery(self):
-        """Present + expires strictly before ``now`` → recovery proceeds."""
-        assert (
-            psidts_recovery._psidts_needs_recovery(
-                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 100.0}, now=200.0
-            )
-            is True
+    @staticmethod
+    def _routes(entries, *, now=None) -> bool:
+        return psidts_recovery._psidts_routes_to_rotate(
+            entries, to_cookie=psidts_recovery._storage_entry_to_cookie, now=now
         )
 
-    def test_helper_fresh_is_skipped(self):
-        """Present + expires at/after ``now`` → recovery is a no-op."""
-        assert (
-            psidts_recovery._psidts_needs_recovery(
-                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 300.0}, now=200.0
-            )
-            is False
+    @staticmethod
+    def _live(entries, *, now=None) -> bool:
+        return psidts_recovery._psidts_is_live(
+            entries, to_cookie=psidts_recovery._storage_entry_to_cookie, now=now
         )
 
-    def test_helper_session_cookie_is_skipped(self):
+    # --- expiry, via the injectable ``now`` seam ----------------------------
+
+    def test_expired_does_not_route_so_recovery_proceeds(self):
+        """Expired against ``now`` → nothing routes → recovery fires."""
+        assert self._routes([self._psidts(expires=100.0)], now=200.0) is False
+
+    def test_fresh_routes_so_recovery_is_skipped(self):
+        """Fresh against ``now`` → routes to the rotate URL → recovery is a no-op.
+
+        Pins the fix for the seam that ``CookieJar.add_cookie_header`` would
+        otherwise destroy: it resets its own clock from ``time.time()``, so an
+        injected ``now`` in the past could only ever mark cookies expired. The
+        probe copies carry no expiry, leaving ``now`` the sole authority.
+        """
+        assert self._routes([self._psidts(expires=300.0)], now=200.0) is True
+
+    def test_session_cookie_routes(self):
         """``expires`` of -1 / None is a session cookie → never expired."""
         for sentinel in (-1, None):
-            assert (
-                psidts_recovery._psidts_needs_recovery(
-                    {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": sentinel}, now=200.0
-                )
-                is False
-            ), sentinel
+            assert self._routes([self._psidts(expires=sentinel)], now=200.0) is True, sentinel
 
-    def test_helper_missing_needs_recovery(self):
-        """Absent PSIDTS → recovery proceeds (current behavior, preserved)."""
-        assert psidts_recovery._psidts_needs_recovery(set(), {}, now=200.0) is True
+    def test_missing_psidts_does_not_route(self):
+        """Absent PSIDTS → recovery proceeds (original behavior, preserved)."""
+        assert self._routes(_RECOVERABLE_COOKIES, now=200.0) is False
 
-    def test_helper_expires_exactly_now_is_skipped(self):
-        """Boundary: ``expires == now`` is fresh (``expires < now`` is strict)."""
-        assert (
-            psidts_recovery._psidts_needs_recovery(
-                {"__Secure-1PSIDTS"}, {"__Secure-1PSIDTS": 200.0}, now=200.0
-            )
-            is False
-        )
+    def test_expires_exactly_now_is_expired(self):
+        """Boundary: ``expires == now`` is EXPIRED.
 
-    # --- domain-filtered / priority-resolved index gate --------------------
+        Deliberate change. The predecessor gate compared ``expires < now``;
+        ``http.cookiejar.Cookie.is_expired`` compares ``expires <= now``, and it
+        is now the single expiry authority. One second, intentionally moved.
+        """
+        assert self._routes([self._psidts(expires=200.0)], now=200.0) is False
+        assert self._live([self._psidts(expires=200.0)], now=200.0) is False
+        assert self._routes([self._psidts(expires=201.0)], now=200.0) is True
+
+    # --- RFC 6265 routing, not domain ranking (issue #2057) ----------------
 
     def test_psidts_on_unallowed_domain_does_not_skip_recovery(self):
         """A PSIDTS on a non-Google domain must NOT satisfy the precondition.
@@ -225,43 +254,192 @@ class TestPsidtsExpiryGate:
         Otherwise a stray ``__Secure-1PSIDTS`` cookie left by an unrelated site
         would falsely mark the Google session healthy and skip the heal.
         """
-        entries = _RECOVERABLE_COOKIES + [
-            {
-                "name": "__Secure-1PSIDTS",
-                "value": "evil",
-                "domain": ".evil.example",
-                "path": "/",
-                "expires": self._FUTURE,
-            }
-        ]
-        names, expiry = psidts_recovery._index_recovery_cookies(entries)
-        assert "__Secure-1PSIDTS" not in names
-        assert psidts_recovery._psidts_needs_recovery(names, expiry) is True
+        entries = _RECOVERABLE_COOKIES + [self._psidts(".evil.example", expires=self._FUTURE)]
+        assert self._routes(entries) is False
+        assert self._live(entries) is False
 
-    def test_index_prefers_base_google_domain_for_duplicates(self):
-        """Duplicate names resolve by ``_auth_domain_priority`` (``.google.com`` wins).
+    @pytest.mark.parametrize(
+        "domain, routes",
+        [
+            (".google.com", True),
+            ("google.com", True),  # no leading dot still routes (cookiejar v0)
+            ("accounts.google.com", True),  # host cookie on the POST's own host
+            (".accounts.google.com", True),
+            (".notebooklm.google.com", False),  # app host never reaches accounts.
+            ("notebooklm.google.com", False),
+            (".notebook.google.com", False),  # Gemini Notebook rebrand host
+            (".google.com.sg", False),  # regional ccTLD
+            (".googleusercontent.com", False),
+        ],
+    )
+    def test_routing_follows_rfc6265_not_domain_tier(self, domain, routes):
+        """Whether recovery fires is decided by routing, not by priority tier.
 
-        Regardless of list order, the ``.google.com`` PSIDTS expiry must win
-        over a regional-domain duplicate so the gate is order-independent.
+        ``accounts.google.com`` — the exact host ``KEEPALIVE_ROTATE_URL``
+        targets — sits in the LOWEST priority tier, while the app hosts that
+        outrank it never reach that host at all. The ranked gate had the
+        ordering exactly inverted relative to the action it gated.
         """
-        fresh_base = {
-            "name": "__Secure-1PSIDTS",
-            "value": "base",
+        entries = [self._psidts(domain, expires=self._FUTURE)]
+        assert self._routes(entries) is routes
+        # Every one of these is live: "did it land?" is domain-blind by design.
+        assert self._live(entries) is True
+
+    def test_path_scoped_psidts_does_not_route(self):
+        """RFC 6265 §5.4 path matching applies — the ranked gate ignored ``path``."""
+        entries = [self._psidts(expires=self._FUTURE, path="/elsewhere")]
+        assert self._routes(entries) is False
+        assert self._live(entries) is True
+
+    def test_divergent_case_stale_ranked_winner_fresh_sibling(self):
+        """The case the ranked gate got wrong (issue #2057).
+
+        ``.google.com`` is tier 4 and outranks everything, so a stale row there
+        made the ranked gate report "needs recovery" / "not persisted" even
+        though a fresh ``accounts.google.com`` sibling both routes to the POST
+        and satisfies the preflight.
+        """
+        entries = [
+            self._psidts(".google.com", expires=self._PAST),
+            self._psidts("accounts.google.com", expires=self._FUTURE),
+        ]
+        assert self._routes(entries) is True
+        assert self._live(entries) is True
+
+    def test_inverse_divergence_app_host_only(self):
+        """Fresh on the app host only: the heal IS needed, and the preflight WILL pass.
+
+        The two predicates must disagree here — that disagreement is the whole
+        point of splitting them.
+        """
+        entries = [self._psidts(".notebooklm.google.com", expires=self._FUTURE)]
+        assert self._routes(entries) is False
+        assert self._live(entries) is True
+
+    @pytest.mark.parametrize(
+        "entries_factory",
+        [
+            lambda s: [s._psidts(".google.com", expires=s._FUTURE)],
+            lambda s: [
+                s._psidts(".google.com", expires=s._PAST),
+                s._psidts("accounts.google.com", expires=s._FUTURE),
+            ],
+            lambda s: [
+                s._psidts(".notebooklm.google.com", expires=s._FUTURE),
+                s._psidts(".google.com.sg", expires=s._PAST),
+            ],
+        ],
+    )
+    def test_reordering_storage_state_cannot_change_the_answer(self, entries_factory):
+        """Order-independence is the property the ranked gate could not offer.
+
+        Within a shared priority tier the old index resolved duplicates by
+        "first occurrence wins", so reordering the file changed the gate's
+        answer. This is the ratchet that replaces that surface.
+        """
+        entries = _RECOVERABLE_COOKIES + entries_factory(self)
+        expected = (self._routes(entries), self._live(entries))
+        for _ in range(8):
+            shuffled = entries[:]
+            random.shuffle(shuffled)
+            assert (self._routes(shuffled), self._live(shuffled)) == expected, shuffled
+
+    def test_routed_implies_live(self):
+        """``routed ⇒ live`` — the invariant that makes the flock-skip return True safe.
+
+        ``_recover_psidts_inline`` reports "healed by another process" purely
+        from the routed predicate. That is only sound because anything routing
+        to ``accounts.google.com`` is necessarily unexpired and on an allowed
+        domain, i.e. also live.
+        """
+        domains = [".google.com", "accounts.google.com", ".notebooklm.google.com", ".evil.example"]
+        expiries = [self._FUTURE, self._PAST, -1, None, "abc", True]
+        for domain in domains:
+            for expires in expiries:
+                for value in ("v", ""):
+                    entries = [self._psidts(domain, expires=expires, value=value)]
+                    if self._routes(entries):
+                        assert self._live(entries), entries
+
+    def test_live_implies_preflight_passes_on_the_psidts_half(self):
+        """``live ⇒ the retried preflight passes`` — pins the §"did it land?" alignment.
+
+        ``_is_psidts_persisted`` exists to predict the caller's preflight. If it
+        were ever stricter in a way the preflight is not, a healthy session
+        would be reported as unhealed and the caller would re-raise.
+        """
+        for domain in (".google.com", "accounts.google.com", ".notebooklm.google.com"):
+            entries = _RECOVERABLE_COOKIES + [self._psidts(domain, expires=self._FUTURE)]
+            assert self._live(entries) is True
+            # The preflight is domain-blind name presence; it must not raise.
+            auth_cookies.extract_cookies_from_storage({"cookies": entries, "origins": []})
+
+    # --- duplicate identities and malformed rows ---------------------------
+
+    def test_duplicate_identity_with_an_expired_row_is_not_live(self):
+        """A dead row poisons its ``(name, domain, path)`` identity, in EITHER order.
+
+        ``http.cookiejar`` keeps one cookie per identity and lets a later row
+        replace an earlier one, so a jar built from a duplicated identity
+        depends on entry order. Resolving conservatively keeps the answer
+        order-independent and never over-optimistic: the cost is one needless
+        POST, versus silently skipping a heal the session needs.
+        """
+        fresh = self._psidts(expires=self._FUTURE, value="fresh")
+        stale = self._psidts(expires=self._PAST, value="stale")
+        for ordering in ([fresh, stale], [stale, fresh]):
+            assert self._routes(ordering) is False, ordering
+            assert self._live(ordering) is False, ordering
+
+    def test_duplicate_name_on_distinct_identities_is_unaffected(self):
+        """Same name, different domain → different identity → no poisoning."""
+        entries = [
+            self._psidts(".google.com", expires=self._FUTURE),
+            self._psidts(".notebooklm.google.com", expires=self._PAST),
+        ]
+        assert self._routes(entries) is True
+        assert self._live(entries) is True
+
+    @pytest.mark.parametrize("expires", ["", "never", float("nan"), float("inf"), [], {}])
+    def test_malformed_expires_is_treated_as_absent_not_raised(self, expires):
+        """``Cookie.__init__`` coerces eagerly; a bad ``expires`` must not escape.
+
+        Both predicates run inside the callers' ``except ValueError:`` handlers,
+        so a coercion error would replace the actionable "Missing required
+        cookies" diagnostic with a converter traceback. Unconvertible rows are
+        dropped, which makes recovery FIRE — the safe direction.
+        """
+        entries = _RECOVERABLE_COOKIES + [self._psidts(expires=expires)]
+        assert self._routes(entries) is False
+        assert self._live(entries) is False
+
+    def test_numeric_string_expires_is_honoured(self):
+        """A numeric string coerces to a real timestamp rather than being skipped."""
+        assert self._routes([self._psidts(expires=str(self._FUTURE))]) is True
+        assert self._routes([self._psidts(expires=str(self._PAST))]) is False
+
+    def test_header_name_match_is_exact_not_substring(self):
+        """A lookalike name, or a value embedding the literal, must not satisfy the gate.
+
+        Cookie values on allowlisted domains come from Chrome and are not
+        shape-controlled by us. A substring test would let one skip a real heal.
+        """
+        lookalike = {
+            "name": "X__Secure-1PSIDTSY",
+            "value": "v",
             "domain": ".google.com",
             "path": "/",
             "expires": self._FUTURE,
         }
-        expired_regional = {
-            "name": "__Secure-1PSIDTS",
-            "value": "regional",
-            "domain": ".google.com.sg",
+        value_embeds = {
+            "name": "NID",
+            "value": "__Secure-1PSIDTS=oops",
+            "domain": ".google.com",
             "path": "/",
-            "expires": self._PAST,
+            "expires": self._FUTURE,
         }
-        for ordering in ([fresh_base, expired_regional], [expired_regional, fresh_base]):
-            names, expiry = psidts_recovery._index_recovery_cookies(_RECOVERABLE_COOKIES + ordering)
-            assert expiry["__Secure-1PSIDTS"] == self._FUTURE, ordering
-            assert psidts_recovery._psidts_needs_recovery(names, expiry) is False, ordering
+        assert self._routes([lookalike, value_embeds]) is False
+        assert self._live([lookalike, value_embeds]) is False
 
     # --- file-based recovery end-to-end ------------------------------------
 
@@ -755,6 +933,38 @@ class TestLoadAuthFromStorageIntegration:
             auth_module.load_auth_from_storage(storage_path)
 
     @pytest.mark.no_default_keepalive_mock
+    def test_malformed_expires_on_a_sibling_row_keeps_the_actionable_error(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """A corrupt ``expires`` must not turn an auth diagnostic into a traceback.
+
+        Regression for a crash reachable on the pre-#2057 code: the jar builder
+        in ``_attempt_rotation`` converted every allowed-domain entry with no
+        guard, and ``http.cookiejar.Cookie.__init__`` coerces via
+        ``int(float(expires))``. One malformed sibling row — not even the PSIDTS
+        row — raised ``ValueError: could not convert string to float`` from
+        inside ``load_auth_from_storage``'s own ``except ValueError:`` handler,
+        replacing "Missing required cookies … Run 'notebooklm login'" with a
+        converter internal, after the rotation throttle slot had been claimed.
+        """
+        cookies = _RECOVERABLE_COOKIES + [
+            {
+                "name": "NID",
+                "value": "junk",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": "not-a-timestamp",
+            }
+        ]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=500)
+
+        with pytest.raises(ValueError, match="Missing required cookies") as excinfo:
+            auth_module.load_auth_from_storage(storage_path)
+        assert "could not convert string to float" not in str(excinfo.value)
+
+    @pytest.mark.no_default_keepalive_mock
     def test_propagates_value_error_when_recovery_post_fails(self, tmp_path, httpx_mock: HTTPXMock):
         """Recovery attempts but fails at the POST → original ValueError."""
         storage_path = tmp_path / "storage_state.json"
@@ -783,6 +993,31 @@ class TestLoadAuthFromStorageIntegration:
 
         # Crucially: no RotateCookies POST must have fired for env-var auth.
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_empty_env_var_does_not_fall_back_to_the_default_profile(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """An EMPTY ``NOTEBOOKLM_AUTH_JSON`` must not redirect recovery to a profile file.
+
+        The loader tests env-var *presence* and raises "set but empty" without
+        inspecting a cookie; ``_resolve_recovery_path`` used to test
+        *truthiness*, so an empty string fell through to the default profile.
+        Recovery would then POST and persist rotated cookies to a profile the
+        caller had explicitly bypassed by setting the variable at all.
+        """
+        default_path = tmp_path / "default_storage_state.json"
+        _write_storage(default_path, _RECOVERABLE_COOKIES)
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", "")
+        monkeypatch.setattr(_nb_paths, "get_storage_path", Mock(return_value=default_path))
+
+        assert psidts_recovery._resolve_recovery_path(None) is None
+        assert psidts_recovery._recover_psidts_inline(None) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+        # The bypassed profile is untouched.
+        assert json.loads(default_path.read_text(encoding="utf-8"))["cookies"] == (
+            _RECOVERABLE_COOKIES
+        )
 
     @pytest.mark.no_default_keepalive_mock
     def test_recovers_when_path_is_none_with_no_env_var(
@@ -954,6 +1189,60 @@ class TestInMemoryRecovery:
         ]
         assert psidts_recovery.recover_psidts_in_memory(cookies) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_gate_reads_rookiepy_rows_directly_not_via_conversion(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """Site 4 selects the rookiepy converter; it does not convert the list first.
+
+        ``_rookiepy_entry_to_cookie`` reads snake_case ``http_only`` (the
+        storage_state mirror reads camelCase ``httpOnly``), and a rookiepy
+        ``expires`` of ``None`` is a session cookie that is NOT pre-mapped to
+        ``-1`` the way ``convert_rookiepy_cookies_to_storage_state`` would. Both
+        shapes must be honoured on the raw rows.
+        """
+        session_psidts = {
+            "name": "__Secure-1PSIDTS",
+            "value": "session_value",
+            "domain": ".google.com",
+            "path": "/",
+            "secure": True,
+            "http_only": True,
+            "expires": None,
+        }
+        cookies = self._rookiepy_recoverable() + [session_psidts]
+
+        # Session expiry -> live -> routes -> no POST.
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+        cookie = psidts_recovery._rookiepy_entry_to_cookie(session_psidts)
+        assert cookie.expires is None
+        assert cookie.get_nonstandard_attr("HttpOnly") == ""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_app_host_only_psidts_still_fires_the_post(self, httpx_mock: HTTPXMock):
+        """A PSIDTS that never reaches ``accounts.google.com`` does not block the heal.
+
+        The ranked gate treated ``.notebooklm.google.com`` as a high-priority
+        satisfying row and skipped. It does not route to the POST's host, so the
+        session still needs the mint.
+        """
+        cookies = self._rookiepy_recoverable() + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "app_host_only",
+                "domain": ".notebooklm.google.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+            }
+        ]
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+        assert len([r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]) == 1
 
     @pytest.mark.no_default_keepalive_mock
     def test_missing_secondary_binding_returns_false_without_post(self, httpx_mock: HTTPXMock):
@@ -1288,4 +1577,43 @@ class TestEdgeCases:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         # No POST — recheck saw the broken state and aborted before firing.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_post_flock_recheck_healed_branch_returns_before_sid_is_rechecked(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """The "healed by another process" branch returns BEFORE the SID recheck.
+
+        Pins a deliberate asymmetry. The PSIDTS check precedes the ``SID`` and
+        secondary-binding rechecks, so a concurrent write that lands a routable
+        PSIDTS *and* drops ``SID`` takes the early ``return True`` without
+        revalidating the rest. That is sound rather than a hole: the caller
+        simply retries its preflight, which then fails honestly on the missing
+        ``SID`` — no POST is fired and nothing is written. Firing here instead
+        would send a request Google is guaranteed to reject.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        healed_but_sid_lost = [c for c in _RECOVERABLE_COOKIES if c["name"] != "SID"] + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "healed_by_sibling",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": 99_999_999_999,
+            }
+        ]
+        call_counter = {"n": 0}
+
+        def staged_load(_p):
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return {"cookies": _RECOVERABLE_COOKIES}
+            return {"cookies": healed_but_sid_lost}
+
+        monkeypatch.setattr(psidts_recovery, "_load_storage_state", staged_load)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []


### PR DESCRIPTION
Closes #2057.

## The defect

`_psidts_needs_recovery` decided whether to fire the healing `RotateCookies` POST from a **domain-blind global winner**: duplicate cookie names were ranked by `_auth_domain_priority` and that one winner's `expires` was read. The POST it gates is **RFC 6265 routed**, so gate and action could answer different questions about the same cookie set.

The ranking was also **inverted relative to the action**. `accounts.google.com` — the exact host `KEEPALIVE_ROTATE_URL` targets — sits in the *lowest* tier, so a host-scoped `__Secure-1PSIDTS` that does route was outranked by app-host cookies that do not. And because the tiers are not all distinct, the winner within a shared tier depended on `storage_state` iteration order.

## The fix: two questions, two predicates

| | question | answers against |
|---|---|---|
| `_psidts_routes_to_rotate` | should we fire? | the **cookie jar** — would the `Cookie:` header for the rotate URL carry PSIDTS |
| `_psidts_is_live` | did the heal land? | the **caller's retried preflight** — domain-blind name presence |

Expiry falls out of RFC 6265 selection, so absent, expired and non-routing all answer "fire" with no expiry arithmetic and no ranking.

**The ranking then deletes itself.** It only ever selected which duplicate's `expires` landed in a parallel map — never which *name* was recorded, since `set.add` is idempotent. Proven by differential fuzz over 30k random entry lists: the name set is bit-identical with and without ranking. So `_index_recovery_cookies` collapses to `_recovery_cookie_names`.

## Why the two predicates must not share an implementation

The first attempt shared one iterator. That was a regression, caught in review and verified end-to-end before fixing — worth recording, because it is the part a future reader would "simplify" back out.

Applying the *routing* rules (duplicate-identity poisoning, skipping rows whose `expires` will not coerce) to the *heal* check creates a **permanent failure loop**. `save_cookies_to_storage` CAS-matches the **first** stored row for an identity, so when disk carries `__Secure-1PSIDTS` twice on `(.google.com, /)` the rotation lands on one row and the stale twin **survives the save**:

```
preflight on the twin state : PASSES        (the session is fine)
save                        : ok=False, cas_rejected={('__Secure-1PSIDTS','.google.com','/')}
stale twin after save       : still present
poisoned heal check         : False -> re-raise "Missing required cookies"
preflight after save        : STILL PASSES
```

That is a POST, a disk write, and a hard auth failure on **every load, forever**, for a working session. It is reachable: that twin is #1523's exact data shape — #1523 fixed the producer, and nothing on the load/save path removes an existing one.

So routing keeps the jar's rules because it models the jar; liveness is a plain existential because it models the preflight. `routable ⇒ live` is preserved, which is what makes the flock-skip's fused "healed by another process" return sound.

## Two adjacent defects fixed

Both surfaced from analysing *which callers can reach the gate*, and both are pre-existing on `main`:

1. **A malformed `expires` crashed recovery.** `Cookie.__init__` coerces via `int(float(expires))`, and the jar builder ran unguarded inside the callers' own `except ValueError:` handlers — so one malformed *sibling* row (not even the PSIDTS row) replaced `Missing required cookies … Run 'notebooklm login'` with `ValueError: could not convert string to float`, after the rotation throttle slot had been claimed. Reproduced end-to-end.
2. **An empty `NOTEBOOKLM_AUTH_JSON` redirected recovery at a profile file.** The loader tests *presence* and fails fast with "set but empty"; `_resolve_recovery_path` tested *truthiness*, so an empty value fell through to the default profile — where recovery could POST and persist to a profile the caller deliberately bypassed. Both now test presence.

## Behaviour changes, stated up front

- `expires == now` flips fresh → **expired** (`Cookie.is_expired` is `<=`; the old gate was `<`). One second, intentional.
- A malformed `expires` flips **skip → fire** for routing, and stays **present** for liveness.
- String/bool expiries change meaning: `"-1"` coerces to `-1`, which is *expired*, not a session cookie (only the **int** `-1` hits the sentinel); `True`/`False` → `1`/`0` → expired; numeric strings are honoured.
- **Public surface:** `recover_psidts_in_memory` (guarded-importable) now **fires a POST** where it previously no-op'd, for a PSIDTS present only on the app host. Correct direction — that cookie never reaches `accounts.google.com`, so the heal genuinely is needed.
- Site 2 fires **less** in one case: stale `.google.com` + fresh `accounts.google.com` now reports "healed by another process" instead of POSTing.
- `SID` and secondary-binding checks stay expiry-blind, matching the preflight. Unchanged.

## Docs

Corrects **four** docstrings claiming the tiers are strictly distinct and the outcome order-independent — `psidts_recovery`, `cookie_policy._auth_domain_priority`, `extract_cookies_from_storage`, and `flatten_cookie_map` (the issue lists three; grep finds four). Also `docs/auth-cookie-lifecycle.md` §5.4, which described a fire condition the code never had (it named `__Secure-1PSID` and "missing", when the real gate was `SID` + secondary binding + missing-or-expired).

## Verification

- Full suite **12772 passed, 0 failed**; `ruff check`, `ruff format --check`, `mypy` clean.
- 97 tests in `test_auth_psidts_recovery.py`. Every pre-existing end-to-end recovery test passes **unchanged** — they use `.google.com` with session expiry, which routes.
- **Exploratory** fuzz (run locally during development and review, *not* committed to CI): 30k shuffled entry lists with duplicate identities, malformed expiries and multiple paths — 0 order-dependence violations, 0 `routable ⇒ live` violations, 0 escaping exceptions. The same figure backs the "ranking is dead weight" claim above. What is actually **pinned in CI** is narrower and deliberately so: `test_reordering_storage_state_cannot_change_the_answer` shuffles 8 times across 3 parametrized entry-list shapes, plus targeted pins for the divergent case, the stale twin, and each malformed-expiry shape. Read the 30k numbers as evidence for the design, not as committed coverage.

## Deliberately out of scope

- The `_auth_domain_priority` ranking itself in `extract_cookies_from_storage` / `flatten_cookie_map` — #2054's territory. Docstrings only here.
- Making `_storage_entry_to_cookie` total for its other two call sites (`load_httpx_cookies`, `_build_httpx_cookies_from_storage_strict`). That is a shared-loader contract change — silently dropping a malformed row instead of raising is a design decision deserving its own PR and tests across all three sites. Consequence while it stands: the strict loader can still reject a state `_psidts_is_live` accepts. Not a regression (`main` reaches the same terminal error), documented in the predicate's docstring. **Follow-up issue to file.**
- No new `tests/_guardrails/` pin. An AST ban on `_auth_domain_priority` in this one file would bar a *spelling*, not a property — `flatten_cookie_map` and a hand-rolled `max(..., key=tier)` would stay green — and it collides with the Boundary moratorium (`docs/architecture.md:844-860`), whose "prefer deletion over carve-out" clause this PR already satisfies by removing the alias. The ratchet is the order-independence property test instead.

## Review

Plan and implementation were reviewed across several rounds by independent Claude reviewers and Codex; two blocking defects (the `now=` seam being silently overridden by the jar's own clock, and the shared-iterator regression above) were found and fixed before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie routing compliance with RFC 6265 standards
  * Fixed handling of malformed or missing authentication cookies
  * Enhanced authentication recovery for edge cases including expired, duplicate, and empty cookies

* **Documentation**
  * Updated authentication cookie lifecycle documentation with recovery behavior details

* **Tests**
  * Expanded test coverage for authentication recovery scenarios including routing, expiry, and malformed cookie handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->