### PR TITLE
docs(auth): correct cookie-domain ranking documented as deterministic (#2054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Corrected the last cookie-domain tier claim that still said the ranking is
+  decisive.** #2057 rewrote the `_auth_domain_priority` docstring and its two
+  consumers, but the tier comment added by
+  [#2020](https://github.com/teng-lin/notebooklm-py/pull/2020) still said the
+  canonical app host "still wins when both hosts carry" a cookie name. It does
+  not: `.notebooklm.google.com` and `.notebook.google.com` are both tier 3, and
+  their bare variants both tier 2, so those pairs tie and the winner falls to
+  `storage_state` iteration order. Also renames `test_priority_strict_ordering`
+  — which asserted "no ties between named tiers" over a sample holding exactly
+  one domain per tier, and so passed while four tiers were shared — and adds a
+  test pinning the real tie structure. Comments and tests only; no behaviour
+  change ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
+
 ### Added
 
 - **`AuthTokens.cookie_header_for(url)` — a domain-correct `Cookie:` header.**

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -559,12 +559,15 @@ def _auth_domain_priority(domain: str) -> int:
         return 3
     if domain == "notebooklm.google.com":
         return 2
-    # Gemini Notebook rebrand host (issue #2013): same tier as the legacy
-    # ``notebooklm.google.com`` host so a same-name cookie set on either is
-    # resolved deterministically. The dotted variant outranks the bare host
-    # (mirroring the notebooklm.google.com tier split), and both sit below
-    # ``.notebooklm.google.com`` so a cookie on the canonical app host still
-    # wins when both hosts carry it.
+    # Gemini Notebook rebrand host (issue #2013). The dotted variant sits at the
+    # same tier as ``.notebooklm.google.com`` and the bare variant at the same
+    # tier as ``notebooklm.google.com`` -- deliberately, so neither host is
+    # ranked below the other now that Google mints host-scoped cookies on both.
+    #
+    # It does NOT mean the canonical app host wins when both carry a name:
+    # 3 == 3 and 2 == 2, so those pairs tie and the winner falls to
+    # ``storage_state`` iteration order. This comment claimed the opposite until
+    # #2054; the docstring above now describes the real tier structure.
     if domain == f".{PERSONAL_APP_ALIAS_HOST}":
         return 3
     if domain == PERSONAL_APP_ALIAS_HOST:

--- a/tests/unit/test_auth_cookie_policy.py
+++ b/tests/unit/test_auth_cookie_policy.py
@@ -365,8 +365,15 @@ class TestAuthDomainPriority:
 
         assert _auth_domain_priority(domain) == expected
 
-    def test_priority_strict_ordering(self):
-        """Higher tiers strictly outrank lower tiers — no ties between named tiers."""
+    def test_priority_ordering_within_this_sample(self):
+        """These five domains descend strictly — but that is a fact about the sample.
+
+        It holds exactly one domain per tier, so of course no two tie. Read as
+        the general "no ties between named tiers" guarantee its old name
+        claimed, it would be false: tiers 3, 2 and 0 are each shared by several
+        domains (see ``test_named_tiers_are_shared_not_unique``). Renamed in
+        #2054 to say what it can actually check.
+        """
         from notebooklm.auth import _auth_domain_priority
 
         priorities = [
@@ -388,8 +395,16 @@ class TestAuthDomainPriority:
         Google now sets the per-product binding cookies (``OSID``,
         ``__Secure-OSID``) on ``notebook.google.com`` in addition to
         ``notebooklm.google.com``. The dotted and bare variants must mirror
-        the legacy host's tier split (3 / 2) so neither host silently
-        starves the other at load time.
+        the legacy host's tier split (3 / 2) so neither host is ranked below
+        the other at load time.
+
+        Note what the equality does **not** buy: because the tiers are equal
+        rather than ordered, a name carried by both hosts with different values
+        — the ordinary post-rebrand state for ``OSID`` — resolves by
+        ``storage_state`` iteration order, not by host. This docstring described
+        the equality as preventing starvation until #2054; measurement showed
+        the tie is itself the ambiguity, and #2057 removed the ranking from the
+        PSIDTS gate rather than re-ordering these tiers.
         """
         from notebooklm.auth import _auth_domain_priority
 
@@ -398,6 +413,36 @@ class TestAuthDomainPriority:
         )
         assert _auth_domain_priority("notebook.google.com") == _auth_domain_priority(
             "notebooklm.google.com"
+        )
+
+    def test_named_tiers_are_shared_not_unique(self):
+        """Several *named* domains share a tier, so ranking cannot disambiguate them.
+
+        Pinned because three docstrings and a comment claimed the opposite until
+        #2054/#2057, and code was written trusting them. If a future change ever
+        makes the tiers a total order this fails — which is the moment to ask
+        whether the remaining callers still need a global winner, not to update
+        the expected numbers.
+        """
+        from notebooklm.auth import _auth_domain_priority
+
+        assert (
+            _auth_domain_priority(".notebooklm.google.com")
+            == _auth_domain_priority(".notebook.google.com")
+            == _auth_domain_priority(".notebooklm.cloud.google.com")
+        )
+        assert (
+            _auth_domain_priority("notebooklm.google.com")
+            == _auth_domain_priority("notebook.google.com")
+            == _auth_domain_priority("notebooklm.cloud.google.com")
+        )
+        # Tier 0 is a catch-all holding the sign-in host that the PSIDTS
+        # rotation POST targets -- ranked below hosts it never reaches, which
+        # is why #2057 replaced that gate's ranking with RFC 6265 routing.
+        assert (
+            _auth_domain_priority("accounts.google.com")
+            == _auth_domain_priority("myaccount.google.com")
+            == _auth_domain_priority("drive.google.com")
         )
 
 


### PR DESCRIPTION
Comments and tests only. **No behaviour change** — every added line under `src/` is a comment.

## Scope reduced after #2059 landed

This PR originally corrected three docstrings and one comment. **#2059 (implementing #2057) has since landed and fixed three of the four**, in equivalent or better form — `_auth_domain_priority`'s docstring, `flatten_cookie_map`'s, and the `psidts_recovery` index. Rather than force a stale branch through, I reset to `main` and reduced this to what is *still* wrong.

## What remains

**The tier comment added by #2020** (`_auth/cookie_policy.py`) still reads:

> …both sit below `.notebooklm.google.com` so a cookie on the canonical app host still wins when both hosts carry it.

It does not. `.notebooklm.google.com` and `.notebook.google.com` both return **3**; their bare variants both return **2**. Those pairs tie, so the winner falls to `storage_state` iteration order — and that is the state a live post-rebrand profile is actually in, carrying different `OSID` values on each host. The docstring directly above it now describes the real structure, so the file currently contradicts itself.

**Two misleading tests:**

- `test_priority_strict_ordering` asserted *"no ties between named tiers"* over a five-domain sample containing **exactly one domain per tier** — true of the sample, false as the guarantee its name claimed, and passing today while four tiers are shared. Renamed to `test_priority_ordering_within_this_sample`.
- `test_gemini_notebook_rebrand_host_matches_app_host_tiers` justified the tie as stopping either host "silently starving the other". Measurement shows the tie *is* the ambiguity; #2057 resolved it by removing the ranking from the PSIDTS gate, not by re-ordering tiers.

**Added** `test_named_tiers_are_shared_not_unique`, pinning the real structure — including that tier 0, the catch-all, holds `accounts.google.com`, the host the PSIDTS rotation POST actually targets, ranked *below* hosts it never reaches.

## Verification

Full suite 12806 passed / 64 skipped / 1 xfailed; mypy clean on 322 files; ruff and format clean whole-tree. Verified mechanically that every added line under `src/` is a comment, so this cannot change behaviour.

Refs #2054, #2057, #2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected documentation of cookie-domain ranking behavior when multiple domains share the same priority.
  * Clarified that tied domains are resolved according to cookie storage order, while URL-specific selection follows cookie-jar routing.

* **Tests**
  * Expanded coverage for shared priority tiers across NotebookLM, Notebook, and Google product domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->