### PR TITLE
fix(api): automate compatibility allowlist pruning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,11 +198,16 @@ jobs:
           exit 1
         fi
         echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
+        if [[ "$current_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "baseline_ref=$current_tag" >> "$GITHUB_OUTPUT"
+        else
+          echo "baseline_ref=$previous_tag" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Prune stale entries from immutable release tag
       run: |
         python scripts/audit_public_api_compat.py \
-          --baseline-ref "${{ steps.baseline.outputs.previous_tag }}" \
+          --baseline-ref "${{ steps.baseline.outputs.baseline_ref }}" \
           --prune
 
     - name: Create or safely reuse automation branch and PR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,9 @@ jobs:
       with:
         python-version: "3.12"
 
+    - name: Install package for API inspection
+      run: python -m pip install --disable-pip-version-check --editable .
+
     - name: Validate tag matches version
       run: |
         TAG_VERSION=${GITHUB_REF#refs/tags/v}
@@ -48,21 +51,15 @@ jobs:
       run: |
         set -euo pipefail
         current_tag="${GITHUB_REF_NAME}"
+        current_sha=$(git rev-list -n 1 "$current_tag")
         previous_tag=""
-        seen_current_tag=false
         while IFS= read -r tag; do
-          if [ "$tag" = "$current_tag" ]; then
-            seen_current_tag=true
-            continue
-          fi
-          # The descending version order can include another tag on the same
-          # commit (or a higher alias). Do not call such a tag "previous".
-          [ "$seen_current_tag" = true ] || continue
-          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+            [ "$(git rev-list -n 1 "$tag")" != "$current_sha" ]; then
             previous_tag="$tag"
             break
           fi
-        done < <(git tag --sort=-version:refname --merged "$current_tag")
+        done < <(git tag --sort=-version:refname --merged "$current_sha")
         if [ -z "$previous_tag" ]; then
           echo "No previous stable release tag found before $current_tag." >&2
           echo "Fetch complete tag history or create a prior stable tag, then rerun the release." >&2
@@ -169,7 +166,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        ref: ${{ github.ref_name }}
+        ref: ${{ github.ref }}
         fetch-depth: 0
         persist-credentials: false
 
@@ -186,21 +183,15 @@ jobs:
       run: |
         set -euo pipefail
         current_tag="${GITHUB_REF_NAME}"
+        current_sha=$(git rev-list -n 1 "$current_tag")
         previous_tag=""
-        seen_current_tag=false
         while IFS= read -r tag; do
-          if [ "$tag" = "$current_tag" ]; then
-            seen_current_tag=true
-            continue
-          fi
-          # The descending version order can include another tag on the same
-          # commit (or a higher alias). Do not call such a tag "previous".
-          [ "$seen_current_tag" = true ] || continue
-          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] &&
+            [ "$(git rev-list -n 1 "$tag")" != "$current_sha" ]; then
             previous_tag="$tag"
             break
           fi
-        done < <(git tag --sort=-version:refname --merged "$current_tag")
+        done < <(git tag --sort=-version:refname --merged "$current_sha")
         if [ -z "$previous_tag" ]; then
           echo "No previous stable release tag found before $current_tag." >&2
           echo "Fetch complete tag history or create a prior stable tag, then rerun the release." >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Set up Python 3.12
@@ -41,6 +42,40 @@ jobs:
           exit 1
         fi
         echo "Version validated: $TOML_VERSION"
+
+    - name: Resolve previous stable API baseline
+      id: baseline
+      run: |
+        set -euo pipefail
+        current_tag="${GITHUB_REF_NAME}"
+        previous_tag=""
+        seen_current_tag=false
+        while IFS= read -r tag; do
+          if [ "$tag" = "$current_tag" ]; then
+            seen_current_tag=true
+            continue
+          fi
+          # The descending version order can include another tag on the same
+          # commit (or a higher alias). Do not call such a tag "previous".
+          [ "$seen_current_tag" = true ] || continue
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            previous_tag="$tag"
+            break
+          fi
+        done < <(git tag --sort=-version:refname --merged "$current_tag")
+        if [ -z "$previous_tag" ]; then
+          echo "No previous stable release tag found before $current_tag." >&2
+          echo "Fetch complete tag history or create a prior stable tag, then rerun the release." >&2
+          exit 1
+        fi
+        echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
+        echo "Using previous stable API baseline: $previous_tag"
+
+    - name: Audit public API compatibility before artifact publication
+      run: |
+        python scripts/audit_public_api_compat.py \
+          --baseline-ref "${{ steps.baseline.outputs.previous_tag }}" \
+          --check-stale
 
     - name: Install build tools
       run: |
@@ -120,3 +155,124 @@ jobs:
         # in-toto attestation for the uploaded artifacts and publishes it
         # via PyPI's Trusted Publishing flow (OIDC, no API token).
         attestations: true
+
+  prune-api-compat:
+    name: Open post-tag API allowlist prune PR
+    needs: publish
+    runs-on: ubuntu-latest
+    # This job uses its repository-write permission only for the generated
+    # automation branch; the script never pushes main directly.
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ github.ref_name }}
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+
+    - name: Install package for API inspection
+      run: python -m pip install --disable-pip-version-check --editable .
+
+    - name: Resolve previous stable API baseline
+      id: baseline
+      run: |
+        set -euo pipefail
+        current_tag="${GITHUB_REF_NAME}"
+        previous_tag=""
+        seen_current_tag=false
+        while IFS= read -r tag; do
+          if [ "$tag" = "$current_tag" ]; then
+            seen_current_tag=true
+            continue
+          fi
+          # The descending version order can include another tag on the same
+          # commit (or a higher alias). Do not call such a tag "previous".
+          [ "$seen_current_tag" = true ] || continue
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            previous_tag="$tag"
+            break
+          fi
+        done < <(git tag --sort=-version:refname --merged "$current_tag")
+        if [ -z "$previous_tag" ]; then
+          echo "No previous stable release tag found before $current_tag." >&2
+          echo "Fetch complete tag history or create a prior stable tag, then rerun the release." >&2
+          exit 1
+        fi
+        echo "previous_tag=$previous_tag" >> "$GITHUB_OUTPUT"
+
+    - name: Prune stale entries from immutable release tag
+      run: |
+        python scripts/audit_public_api_compat.py \
+          --baseline-ref "${{ steps.baseline.outputs.previous_tag }}" \
+          --prune
+
+    - name: Create or safely reuse automation branch and PR
+      env:
+        GH_TOKEN: ${{ github.token }}
+        AUTOMATION_BRANCH: automation/api-compat-prune-${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        if git diff --quiet -- scripts/api-compat-allowlist.json; then
+          echo "No stale API-compat entries found; no prune PR is needed."
+          exit 0
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add scripts/api-compat-allowlist.json
+        git commit -m "chore(api): prune stale compatibility allowances"
+        generated_tree=$(git rev-parse HEAD^{tree})
+
+        existing_commit=$(git ls-remote --quiet origin "refs/heads/$AUTOMATION_BRANCH" | awk 'NR == 1 {print $1}')
+        if [ -n "$existing_commit" ]; then
+          git fetch --no-tags origin "refs/heads/$AUTOMATION_BRANCH:refs/remotes/origin/$AUTOMATION_BRANCH"
+          existing_tree=$(git rev-parse "refs/remotes/origin/$AUTOMATION_BRANCH^{tree}")
+          if [ "$existing_tree" != "$generated_tree" ]; then
+            echo "Automation branch $AUTOMATION_BRANCH exists with a different tree." >&2
+            echo "Review or remove that human-modified branch, then rerun; no force-push was attempted." >&2
+            exit 1
+          fi
+          pr_count=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$AUTOMATION_BRANCH" --base main --state open --json number --jq 'length')
+          if [ "$pr_count" -eq 0 ]; then
+            echo "Automation branch $AUTOMATION_BRANCH already exists, but no open PR was found." >&2
+            echo "Open the matching PR or remove the stale automation branch, then rerun." >&2
+            exit 1
+          fi
+          echo "Reused identical automation branch and existing PR for $AUTOMATION_BRANCH."
+          exit 0
+        fi
+
+        gh auth setup-git
+        git branch "$AUTOMATION_BRANCH"
+        if ! git push origin "refs/heads/$AUTOMATION_BRANCH"; then
+          echo "Automation branch appeared during creation; verifying its contents."
+          git fetch --no-tags origin "refs/heads/$AUTOMATION_BRANCH:refs/remotes/origin/$AUTOMATION_BRANCH"
+          existing_tree=$(git rev-parse "refs/remotes/origin/$AUTOMATION_BRANCH^{tree}")
+          if [ "$existing_tree" != "$generated_tree" ]; then
+            echo "Automation branch $AUTOMATION_BRANCH exists with a different tree." >&2
+            echo "Review or remove that human-modified branch, then rerun; no force-push was attempted." >&2
+            exit 1
+          fi
+          pr_count=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$AUTOMATION_BRANCH" --base main --state open --json number --jq 'length')
+          if [ "$pr_count" -eq 0 ]; then
+            echo "Automation branch $AUTOMATION_BRANCH already exists, but no open PR was found." >&2
+            echo "Open the matching PR or remove the stale automation branch, then rerun." >&2
+            exit 1
+          fi
+          echo "Reused identical automation branch and existing PR for $AUTOMATION_BRANCH."
+          exit 0
+        fi
+        gh pr create \
+          --repo "$GITHUB_REPOSITORY" \
+          --head "$AUTOMATION_BRANCH" \
+          --base main \
+          --title "chore(api): prune stale compatibility allowances for $GITHUB_REF_NAME" \
+          --body "Automated post-tag cleanup for $GITHUB_REF_NAME. This PR removes only allowlist entries that are stale against the immutable release tag; review and merge it before the next release."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -426,26 +426,39 @@ The lifecycle to keep in mind:
 - **allowlist** = the intentional breaks pending the *next* release. It should
   reset to (near) empty at each release boundary.
 
-Concretely, **after the tag is pushed**, prune the entries that just shipped:
+The tag-triggered `publish.yml` workflow now performs this mechanically after
+publishing. It checks out the immutable tag, runs the audit with the explicit
+previous stable tag, and opens a PR from
+`automation/api-compat-prune-vX.Y.Z` when stale entries exist. Its repository
+write permission is used only for that generated branch; the workflow never
+pushes `main`. Review the generated diff and merge the PR before the next
+release.
+Reruns reuse the branch only when its complete generated tree is identical and
+an open matching PR exists. A human-modified branch or a branch without its PR
+fails without force-pushing; review or remove that branch, then rerun the
+workflow.
 
-- [ ] In a follow-up PR (on `main`, after the tag exists), remove from
-  `scripts/api-compat-allowlist.json` every `allowed_breaks` entry that
-  described a `vPREV → vX.Y.Z` change. These are now baked into the `vX.Y.Z`
-  baseline. List the stale entries with:
-  ```bash
-  uv run python scripts/audit_public_api_compat.py --json \
-    | python -c "import json,sys; print('\n'.join(f\"{e['code']}  {e['object']}\" for e in json.load(sys.stdin)['stale_allowances']))"
-  ```
+For local recovery or a dry review of the generated change, use the explicit
+write operation (always pass the baseline you intend to compare):
+
+```bash
+uv run python scripts/audit_public_api_compat.py --baseline-ref vPREV --prune
+```
+
+`--prune` is never implied by a normal audit. It removes only stale
+`allowed_breaks` entries, preserves `extra_public_names` and other policy
+fields, and performs a deterministic atomic rewrite. It is idempotent and
+reports each removed entry. Malformed, missing, or unwritable allowlists fail
+with an actionable error; fix the file or permissions and rerun the command.
+
 - [ ] Re-run the gate in strict mode — it must report **no stale entries**:
   ```bash
-  uv run python scripts/audit_public_api_compat.py --check-stale
+  uv run python scripts/audit_public_api_compat.py --baseline-ref vPREV --check-stale
   ```
 
 > **Forcing function:** the Code Quality job runs the audit with `--check-stale`,
 > which **fails** on any allowlist entry that matches no break against the
-> baseline. So the moment `vX.Y.Z` is tagged, the just-shipped entries become
-> stale and CI goes red until this prune PR lands — the prune is mandatory, not
-> a checklist nicety. The pair-aware rule keeps the two path-views of a callable
+> baseline. The pair-aware rule keeps the two path-views of a callable
 > (`notebooklm.X` and `notebooklm.client.X`) together: a unit is pruned only when
 > *neither* view still matches a break.
 

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -817,11 +817,12 @@ def prune_allowlist(path: Path, stale: list[Allowance]) -> list[Allowance]:
             os.fsync(temporary.fileno())
         os.chmod(temporary_path, original_mode)
         os.replace(temporary_path, path)
-        directory_fd = os.open(path.parent, os.O_DIRECTORY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        if hasattr(os, "O_DIRECTORY"):
+            directory_fd = os.open(path.parent, os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
     except OSError as exc:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -10,11 +10,14 @@ Usage:
     uv run python scripts/audit_public_api_compat.py --baseline-ref v0.4.1
     uv run python scripts/audit_public_api_compat.py --json
     uv run python scripts/audit_public_api_compat.py --check-stale
+    uv run python scripts/audit_public_api_compat.py --prune
 
 ``--check-stale`` additionally fails when an ``allowed_breaks`` entry matches no
-current break against the baseline (it is already in the baseline). This keeps
-the allowlist from silently accumulating cruft — prune such entries at each
-release boundary (see ``docs/releasing.md`` → prune-allowlist-at-release).
+current break against the baseline (it is already in the baseline). ``--prune``
+explicitly removes those stale entries from the allowlist, preserving all other
+policy fields and atomically rewriting the file only when entries changed.
+Use it at a release boundary (see ``docs/releasing.md`` →
+prune-allowlist-at-release).
 
 Exit codes:
     0  No unapproved compatibility breaks (and, with --check-stale, none stale).
@@ -34,6 +37,7 @@ import sys
 import tarfile
 import tempfile
 import textwrap
+from collections import Counter
 from dataclasses import asdict, dataclass
 from fnmatch import fnmatchcase
 from pathlib import Path
@@ -713,17 +717,26 @@ def compare_manifests(baseline: dict[str, Any], current: dict[str, Any]) -> list
     return sorted(breaks, key=lambda item: (item.code, item.object, item.detail))
 
 
+def _read_policy_payload(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"could not read allowlist {path}: {exc}") from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{path} must contain a JSON object")
+    return payload
+
+
 def load_policy(path: Path | None) -> tuple[list[Allowance], dict[str, list[str]]]:
     if path is None or str(path) == "":
         return [], {}
     if not path.exists():
         raise RuntimeError(f"allowlist file not found: {path}")
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"invalid JSON in {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"{path} must contain a JSON object")
+    payload = _read_policy_payload(path)
     schema_version = payload.get("schema_version", 1)
     if schema_version != 1:
         raise RuntimeError(f"{path}: unsupported schema_version {schema_version!r} (expected 1)")
@@ -755,6 +768,65 @@ def load_policy(path: Path | None) -> tuple[list[Allowance], dict[str, list[str]
             ) from exc
         allowances.append(Allowance(code=code, object=obj, reason=reason))
     return allowances, normalized_extra_names
+
+
+def prune_allowlist(path: Path, stale: list[Allowance]) -> list[Allowance]:
+    """Remove exactly stale entries and atomically rewrite *path*.
+
+    Matching includes the reason and is multiset-aware, so duplicate or
+    similarly-shaped entries cannot cause an unrelated allowance to be removed.
+    A no-op does not touch the file. The raw payload is retained so unknown
+    top-level and per-entry fields survive the deterministic rewrite.
+    """
+    if not path.exists():
+        raise RuntimeError(f"allowlist file not found: {path}")
+    load_policy(path)  # Validate the complete policy, including known fields.
+    payload = _read_policy_payload(path)
+    entries = payload.get("allowed_breaks", [])
+    stale_counts = Counter((item.code, item.object, item.reason) for item in stale)
+    removed: list[Allowance] = []
+    kept: list[dict[str, Any]] = []
+    for entry in entries:
+        key = (str(entry["code"]), str(entry["object"]), str(entry["reason"]))
+        if stale_counts[key]:
+            stale_counts[key] -= 1
+            removed.append(Allowance(*key))
+        else:
+            kept.append(entry)
+
+    if not removed:
+        return []
+
+    payload["allowed_breaks"] = kept
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    temporary_path: Path | None = None
+    try:
+        original_mode = path.stat().st_mode
+        if not original_mode & 0o222:
+            raise RuntimeError(f"allowlist is not writable: {path}")
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(serialized)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.chmod(temporary_path, original_mode)
+        os.replace(temporary_path, path)
+        directory_fd = os.open(path.parent, os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except OSError as exc:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise RuntimeError(f"could not atomically rewrite allowlist {path}: {exc}") from exc
+    return removed
 
 
 def partition_allowed(
@@ -896,6 +968,11 @@ def main(argv: list[str] | None = None) -> int:
             "baseline (it is already in the baseline — prune it)."
         ),
     )
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help="Remove stale allowlist entries and atomically rewrite the allowlist.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -914,6 +991,16 @@ def main(argv: list[str] | None = None) -> int:
         breakages = compare_manifests(baseline_manifest, current_manifest)
         unapproved, approved = partition_allowed(breakages, allowances)
         stale = stale_allowances(breakages, allowances)
+        pruned: list[Allowance] = []
+        if args.prune:
+            if allowlist_path is None:
+                raise RuntimeError("--prune requires an allowlist file")
+            if unapproved:
+                raise RuntimeError(
+                    "refusing to prune while unapproved compatibility breaks exist; "
+                    "resolve the audit failure first"
+                )
+            pruned = prune_allowlist(allowlist_path, stale)
     except RuntimeError as exc:
         if args.json:
             print(json.dumps({"error": str(exc)}, sort_keys=True))
@@ -923,7 +1010,7 @@ def main(argv: list[str] | None = None) -> int:
 
     allowlist_display = allowlist_path or DEFAULT_ALLOWLIST
     # ``--check-stale`` promotes stale entries from informational to a gate.
-    stale_blocks = args.check_stale and bool(stale)
+    stale_blocks = args.check_stale and bool(stale) and not args.prune
     failed = bool(unapproved) or stale_blocks
 
     if args.json:
@@ -937,6 +1024,7 @@ def main(argv: list[str] | None = None) -> int:
                     ],
                     "unapproved": [asdict(item) for item in unapproved],
                     "stale_allowances": [asdict(allowance) for allowance in stale],
+                    "pruned_allowances": [asdict(allowance) for allowance in pruned],
                 },
                 indent=2,
                 sort_keys=True,
@@ -983,6 +1071,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if stale_blocks:
         print("\n" + _render_stale(stale, baseline_ref, allowlist_display), file=sys.stderr)
+    if pruned:
+        print(
+            "Pruned stale allowlist entries:\n"
+            + "\n".join(f"  - [{item.code}] {item.object}" for item in pruned)
+        )
 
     return 1 if failed else 0
 

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -675,6 +675,18 @@ def test_audit_json_includes_stale_allowances_field(script, tmp_path, monkeypatc
     _stub_manifests()
     assert script.main(["--check-stale", "--allowlist", str(allowlist)]) == 1
 
+    # ``--prune`` performs the explicit write and reports the removed entry.
+    _stub_manifests()
+    assert script.main(["--prune", "--allowlist", str(allowlist)]) == 0
+    assert json.loads(allowlist.read_text(encoding="utf-8"))["allowed_breaks"] == [
+        {
+            "code": "removed-export",
+            "object": "notebooklm.GoneExport",
+            "reason": "intentional, pending next release",
+        }
+    ]
+    assert "Pruned stale allowlist entries" in capsys.readouterr().out
+
 
 def test_stale_allowances_does_not_collide_on_same_object_different_codes(script):
     # Two allowances for the SAME object but different codes must be tracked
@@ -692,6 +704,130 @@ def test_stale_allowances_does_not_collide_on_same_object_different_codes(script
     # or last in the comprehension that builds the match map.
     assert script.stale_allowances([brk], [live, stale]) == [stale]
     assert script.stale_allowances([brk], [stale, live]) == [stale]
+
+
+def test_prune_allowlist_preserves_policy_fields_and_removes_exact_entries(tmp_path, script):
+    policy = tmp_path / "policy.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "z_future_policy": {"enabled": True},
+                "schema_version": 1,
+                "extra_public_names": {"notebooklm": ["KeptName"]},
+                "allowed_breaks": [
+                    {
+                        "code": "removed-export",
+                        "object": "notebooklm.Stale",
+                        "reason": "shipped",
+                        "review_url": "https://example.invalid/review",
+                    },
+                    {
+                        "code": "removed-export",
+                        "object": "notebooklm.Live",
+                        "reason": "still intentional",
+                    },
+                    {
+                        "code": "removed-export",
+                        "object": "notebooklm.Stale",
+                        "reason": "different reason; keep",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    stale = [script.Allowance(code="removed-export", object="notebooklm.Stale", reason="shipped")]
+
+    removed = script.prune_allowlist(policy, stale)
+
+    assert removed == stale
+    rewritten = json.loads(policy.read_text(encoding="utf-8"))
+    assert rewritten["z_future_policy"] == {"enabled": True}
+    assert rewritten["extra_public_names"] == {"notebooklm": ["KeptName"]}
+    assert rewritten["allowed_breaks"] == [
+        {
+            "code": "removed-export",
+            "object": "notebooklm.Live",
+            "reason": "still intentional",
+        },
+        {
+            "code": "removed-export",
+            "object": "notebooklm.Stale",
+            "reason": "different reason; keep",
+        },
+    ]
+    assert policy.read_text(encoding="utf-8").endswith("\n")
+    before = policy.stat().st_mtime_ns
+    assert script.prune_allowlist(policy, stale) == []
+    assert policy.stat().st_mtime_ns == before
+
+
+def test_prune_allowlist_is_idempotent_and_pair_aware(tmp_path, script):
+    policy = tmp_path / "policy.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "allowed_breaks": [
+                    {
+                        "code": "removed-member",
+                        "object": "notebooklm.client.NotebookLMClient.sources.get",
+                        "reason": "same pair",
+                    },
+                    {
+                        "code": "removed-member",
+                        "object": "notebooklm.NotebookLMClient.sources.get",
+                        "reason": "same pair",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    pair_break = script.ApiBreak(
+        code="removed-member",
+        object="notebooklm.NotebookLMClient.sources.get",
+        detail="still breaking",
+    )
+    stale = script.stale_allowances(
+        [pair_break],
+        script.load_policy(policy)[0],
+    )
+
+    assert stale == []
+    before = policy.stat().st_mtime_ns
+    assert script.prune_allowlist(policy, stale) == []
+    assert policy.stat().st_mtime_ns == before
+
+
+def test_prune_allowlist_reports_malformed_and_rewrite_errors(tmp_path, script, monkeypatch):
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        script.prune_allowlist(malformed, [])
+
+    policy = tmp_path / "policy.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "allowed_breaks": [
+                    {"code": "removed-export", "object": "notebooklm.X", "reason": "old"}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        script.os, "replace", lambda *_args: (_ for _ in ()).throw(OSError("read-only filesystem"))
+    )
+    with pytest.raises(
+        RuntimeError, match="could not atomically rewrite allowlist.*read-only filesystem"
+    ):
+        script.prune_allowlist(
+            policy,
+            [script.Allowance("removed-export", "notebooklm.X", "old")],
+        )
 
 
 def test_check_stale_does_not_print_ok_when_stale_blocks(script, tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add explicit, atomic allowlist pruning for stale public API compatibility entries
- run release-boundary pruning from the immutable tag and open a generated follow-up PR
- document recovery and add focused unit coverage

Closes #2053

## Test plan
- uv run pytest tests/unit/test_public_api_compat_audit.py
- uv run ruff check scripts/audit_public_api_compat.py tests/unit/test_public_api_compat_audit.py
- git diff --check

## Deferred polish findings
None; implementation and polish were completed before delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publishing now checks public API compatibility against the previous stable release.
  * Stale compatibility entries can be removed automatically, with a cleanup pull request created when needed.
  * Added a local pruning and recovery workflow for reviewing and applying compatibility cleanup.
  * Cleanup is idempotent, preserves policy settings, and validates changes before publication.

* **Documentation**
  * Updated release guidance with the automated cleanup process, safeguards, recovery steps, and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->