### PR TITLE
fix(sources): make idempotent creates title-safe

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -41,7 +41,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, Generic, TypeVar
 
 from .exceptions import (
     IdempotencyVariantError,
@@ -54,6 +54,22 @@ from .rpc.types import RPCMethod
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+class _CreateResultKind(str, Enum):
+    """How an idempotent create obtained its result."""
+
+    CREATED = "created"
+    PROBED = "probed"
+
+
+@dataclass(frozen=True)
+class _IdempotentCreateResult(Generic[T]):
+    """Private provenance carrier for idempotent create callers."""
+
+    value: T
+    kind: _CreateResultKind
+
 
 # The translated exception types that ``rpc_call`` raises when the
 # request fails in a way that *might* have committed the write on the
@@ -80,7 +96,7 @@ async def idempotent_create(
     *,
     max_attempts: int = 2,
     label: str = "create",
-) -> T:
+) -> _IdempotentCreateResult[T]:
     """Probe-then-retry wrapper for mutating create RPCs.
 
     Args:
@@ -100,8 +116,9 @@ async def idempotent_create(
         label: Diagnostic label embedded in log messages.
 
     Returns:
-        The result of a successful ``create()`` call, or the value
-        returned by ``probe()`` after a transient transport failure.
+        A private result carrying the value and whether it came from a
+        successful create or a probe match. Callers must unwrap ``value``
+        before returning it from a public API.
 
     Raises:
         Whatever ``create()`` raises on the final attempt if the probe
@@ -121,7 +138,7 @@ async def idempotent_create(
 
     for attempt in range(1, max_attempts + 1):
         try:
-            return await create()
+            return _IdempotentCreateResult(value=await create(), kind=_CreateResultKind.CREATED)
         except _RETRYABLE_TRANSPORT_ERRORS as exc:
             last_error = exc
             logger.warning(
@@ -140,7 +157,7 @@ async def idempotent_create(
                     label,
                     attempt,
                 )
-                return existing
+                return _IdempotentCreateResult(value=existing, kind=_CreateResultKind.PROBED)
             # Probe returned None: the create did not land. Loop and
             # retry as long as we have attempts remaining.
             logger.debug(

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -71,6 +71,13 @@ class _IdempotentCreateResult(Generic[T]):
     kind: _CreateResultKind
 
 
+def _coerce_create_result(value: T | _IdempotentCreateResult[T]) -> _IdempotentCreateResult[T]:
+    """Attach fresh-create provenance to a legacy value-only result."""
+    if isinstance(value, _IdempotentCreateResult):
+        return value
+    return _IdempotentCreateResult(value=value, kind=_CreateResultKind.CREATED)
+
+
 # The translated exception types that ``rpc_call`` raises when the
 # request fails in a way that *might* have committed the write on the
 # server. With ``disable_internal_retries=True``, the middleware retry loop

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -608,11 +608,12 @@ class NotebooksAPI:
                 )
             return None
 
-        return await idempotent_create(
+        result = await idempotent_create(
             _create,
             _probe,
             label=f"notebooks.create[{title!r}]",
         )
+        return result.value
 
     async def _raise_quota_error_if_detected(self, error: RPCError) -> None:
         """Convert CREATE_NOTEBOOK invalid-argument failures into quota errors."""

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from typing import Any
 from urllib.parse import parse_qs
 
-from .._idempotency import _IdempotentCreateResult, idempotent_create
+from .._idempotency import _CreateResultKind, _IdempotentCreateResult, idempotent_create
 from .._runtime.contracts import RpcCaller
 from ..exceptions import (
     AuthError,
@@ -76,6 +76,23 @@ async def honor_requested_title(
     # would drop url / kind / status. Keep the fully-hydrated added source and swap in
     # just the new title — mirrors the file-upload rename (``_source/upload.py``).
     return replace(source, title=(renamed.title if renamed else None) or requested)
+
+
+async def honor_requested_title_if_fresh(
+    rename: RenameSource,
+    notebook_id: str,
+    result: Source | _IdempotentCreateResult[Source],
+    requested_title: str | None,
+    logger: logging.Logger,
+) -> Source:
+    """Apply a requested title only to a source created by this call."""
+    if isinstance(result, _IdempotentCreateResult):
+        if result.kind is _CreateResultKind.PROBED:
+            return result.value
+        source = result.value
+    else:
+        source = result
+    return await honor_requested_title(rename, notebook_id, source, requested_title, logger)
 
 
 class SourceAddService:

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from typing import Any
 from urllib.parse import parse_qs
 
-from .._idempotency import idempotent_create
+from .._idempotency import _IdempotentCreateResult, idempotent_create
 from .._runtime.contracts import RpcCaller
 from ..exceptions import (
     AuthError,
@@ -95,7 +95,8 @@ class SourceAddService:
         extract_youtube_video_id: Callable[[str], str | None],
         is_youtube_url: YoutubeDetector,
         logger: logging.Logger,
-    ) -> Source:
+        return_result: bool = False,
+    ) -> Source | _IdempotentCreateResult[Source]:
         """Add a URL source to a notebook."""
         logger.debug("Adding URL source to notebook %s: %s", notebook_id, url[:80])
         video_id = extract_youtube_video_id(url)
@@ -149,16 +150,18 @@ class SourceAddService:
                     return source
             return None
 
-        source = await idempotent_create(
+        result = await idempotent_create(
             _create,
             _probe,
             label=f"sources.add_url[{url[:40]}]",
         )
+        source = result.value
 
         if wait:
-            return await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
+            source = await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
+            result = replace(result, value=source)
 
-        return source
+        return result if return_result else source
 
     async def add_text(
         self,
@@ -238,7 +241,8 @@ class SourceAddService:
         list_sources: ListSources,
         wait_until_ready: WaitUntilReady,
         logger: logging.Logger,
-    ) -> Source:
+        return_result: bool = False,
+    ) -> Source | _IdempotentCreateResult[Source]:
         """Add a Google Drive document as a source.
 
         Drive sources go through the same probe-then-create idempotency
@@ -346,16 +350,18 @@ class SourceAddService:
                     return source
             return None
 
-        source = await idempotent_create(
+        result = await idempotent_create(
             _create,
             _probe,
             label=f"sources.add_drive[{file_id}]",
         )
+        source = result.value
 
         if wait:
-            return await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
+            source = await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
+            result = replace(result, value=source)
 
-        return source
+        return result if return_result else source
 
     def extract_youtube_video_id(
         self,

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -420,10 +420,7 @@ class SourceUploadPipeline(LoopBoundPrimitive):
                     if not handed_off:
                         file_obj.close()
 
-        needs_title_rename = (
-            title is not None
-            and title != filename
-        )
+        needs_title_rename = title is not None and title != filename
         if wait:
             source = await self.wait_until_ready(
                 notebook_id,

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -423,7 +423,6 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         needs_title_rename = (
             title is not None
             and title != filename
-            and registration.kind is _CreateResultKind.CREATED
         )
         if wait:
             source = await self.wait_until_ready(

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -9,14 +9,14 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
-from typing import IO, TYPE_CHECKING, Any, Protocol, cast
+from typing import IO, TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
 import httpx
 
 from .._auth.account import authuser_query, format_authuser_value
 from .._callbacks import maybe_await_callback
 from .._env import get_base_url
-from .._idempotency import idempotent_create
+from .._idempotency import _CreateResultKind, _IdempotentCreateResult, idempotent_create
 from .._loop_bound import LoopBoundPrimitive
 from .._runtime.config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
@@ -397,7 +397,10 @@ class SourceUploadPipeline(LoopBoundPrimitive):
                 file_obj, file_size = await asyncio.to_thread(_open_and_stat, file_path)
                 handed_off = False
                 try:
-                    source_id = await self.register_file_source(notebook_id, filename)
+                    registration = await self._register_file_source_for_upload(
+                        notebook_id, filename
+                    )
+                    source_id = registration.value
                     upload_url = await self.start_resumable_upload(
                         notebook_id,
                         filename,
@@ -417,7 +420,11 @@ class SourceUploadPipeline(LoopBoundPrimitive):
                     if not handed_off:
                         file_obj.close()
 
-        needs_title_rename = title is not None and title != filename
+        needs_title_rename = (
+            title is not None
+            and title != filename
+            and registration.kind is _CreateResultKind.CREATED
+        )
         if wait:
             source = await self.wait_until_ready(
                 notebook_id,
@@ -458,6 +465,7 @@ class SourceUploadPipeline(LoopBoundPrimitive):
 
         return source
 
+    @overload
     async def register_file_source(
         self,
         notebook_id: str,
@@ -467,7 +475,75 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         logger: Any | None = None,
         get_source_limit: GetSourceLimit | None = None,
         rpc_call: RpcCallback | None = None,
-    ) -> str:
+        with_provenance: Literal[True],
+    ) -> _IdempotentCreateResult[str]: ...
+
+    @overload
+    async def register_file_source(
+        self,
+        notebook_id: str,
+        filename: str,
+        *,
+        list_sources: ListSources | None = None,
+        logger: Any | None = None,
+        get_source_limit: GetSourceLimit | None = None,
+        rpc_call: RpcCallback | None = None,
+        with_provenance: Literal[False] = False,
+    ) -> str: ...
+
+    async def register_file_source(
+        self,
+        notebook_id: str,
+        filename: str,
+        *,
+        list_sources: ListSources | None = None,
+        logger: Any | None = None,
+        get_source_limit: GetSourceLimit | None = None,
+        rpc_call: RpcCallback | None = None,
+        with_provenance: bool = False,
+    ) -> str | _IdempotentCreateResult[str]:
+        """Register a file source, preserving the historical string result."""
+        result = await self._register_file_source_result(
+            notebook_id,
+            filename,
+            list_sources=list_sources,
+            logger=logger,
+            get_source_limit=get_source_limit,
+            rpc_call=rpc_call,
+        )
+        if with_provenance:
+            return result
+        return result.value
+
+    async def _register_file_source_for_upload(
+        self, notebook_id: str, filename: str
+    ) -> _IdempotentCreateResult[str]:
+        """Normalize built-in and legacy registration seams for ``add_file``."""
+        register = self.register_file_source
+        registration: str | _IdempotentCreateResult[str]
+        if getattr(register, "__func__", None) is SourceUploadPipeline.register_file_source:
+            registration = await register(notebook_id, filename, with_provenance=True)
+        else:
+            # Preserve injected and overridden legacy seams that only accept
+            # the historical (notebook_id, filename) call shape.
+            registration = await register(notebook_id, filename)
+        if isinstance(registration, _IdempotentCreateResult):
+            return registration
+        return _IdempotentCreateResult(
+            value=registration,
+            kind=_CreateResultKind.CREATED,
+        )
+
+    async def _register_file_source_result(
+        self,
+        notebook_id: str,
+        filename: str,
+        *,
+        list_sources: ListSources | None = None,
+        logger: Any | None = None,
+        get_source_limit: GetSourceLimit | None = None,
+        rpc_call: RpcCallback | None = None,
+    ) -> _IdempotentCreateResult[str]:
         """Register a file source intent and get SOURCE_ID.
 
         Uses the same probe-then-create idempotency pattern as ``add_url`` /

--- a/src/notebooklm/_source/upload.py
+++ b/src/notebooklm/_source/upload.py
@@ -9,14 +9,14 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
-from typing import IO, TYPE_CHECKING, Any, Literal, Protocol, cast, overload
+from typing import IO, TYPE_CHECKING, Any, Protocol, cast
 
 import httpx
 
 from .._auth.account import authuser_query, format_authuser_value
 from .._callbacks import maybe_await_callback
 from .._env import get_base_url
-from .._idempotency import _CreateResultKind, _IdempotentCreateResult, idempotent_create
+from .._idempotency import _coerce_create_result, _IdempotentCreateResult, idempotent_create
 from .._loop_bound import LoopBoundPrimitive
 from .._runtime.config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
@@ -461,7 +461,6 @@ class SourceUploadPipeline(LoopBoundPrimitive):
 
         return source
 
-    @overload
     async def register_file_source(
         self,
         notebook_id: str,
@@ -471,45 +470,18 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         logger: Any | None = None,
         get_source_limit: GetSourceLimit | None = None,
         rpc_call: RpcCallback | None = None,
-        with_provenance: Literal[True],
-    ) -> _IdempotentCreateResult[str]: ...
-
-    @overload
-    async def register_file_source(
-        self,
-        notebook_id: str,
-        filename: str,
-        *,
-        list_sources: ListSources | None = None,
-        logger: Any | None = None,
-        get_source_limit: GetSourceLimit | None = None,
-        rpc_call: RpcCallback | None = None,
-        with_provenance: Literal[False] = False,
-    ) -> str: ...
-
-    async def register_file_source(
-        self,
-        notebook_id: str,
-        filename: str,
-        *,
-        list_sources: ListSources | None = None,
-        logger: Any | None = None,
-        get_source_limit: GetSourceLimit | None = None,
-        rpc_call: RpcCallback | None = None,
-        with_provenance: bool = False,
-    ) -> str | _IdempotentCreateResult[str]:
-        """Register a file source, preserving the historical string result."""
-        result = await self._register_file_source_result(
-            notebook_id,
-            filename,
-            list_sources=list_sources,
-            logger=logger,
-            get_source_limit=get_source_limit,
-            rpc_call=rpc_call,
-        )
-        if with_provenance:
-            return result
-        return result.value
+    ) -> str:
+        """Register a file source intent and return its source ID."""
+        return (
+            await self._register_file_source_result(
+                notebook_id,
+                filename,
+                list_sources=list_sources,
+                logger=logger,
+                get_source_limit=get_source_limit,
+                rpc_call=rpc_call,
+            )
+        ).value
 
     async def _register_file_source_for_upload(
         self, notebook_id: str, filename: str
@@ -518,17 +490,12 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         register = self.register_file_source
         registration: str | _IdempotentCreateResult[str]
         if getattr(register, "__func__", None) is SourceUploadPipeline.register_file_source:
-            registration = await register(notebook_id, filename, with_provenance=True)
+            registration = await self._register_file_source_result(notebook_id, filename)
         else:
             # Preserve injected and overridden legacy seams that only accept
             # the historical (notebook_id, filename) call shape.
             registration = await register(notebook_id, filename)
-        if isinstance(registration, _IdempotentCreateResult):
-            return registration
-        return _IdempotentCreateResult(
-            value=registration,
-            kind=_CreateResultKind.CREATED,
-        )
+        return _coerce_create_result(registration)
 
     async def _register_file_source_result(
         self,
@@ -540,16 +507,10 @@ class SourceUploadPipeline(LoopBoundPrimitive):
         get_source_limit: GetSourceLimit | None = None,
         rpc_call: RpcCallback | None = None,
     ) -> _IdempotentCreateResult[str]:
-        """Register a file source intent and get SOURCE_ID.
+        """Register a file source intent and retain create/probe provenance.
 
-        Uses the same probe-then-create idempotency pattern as ``add_url`` /
-        ``add_drive`` (the ADD_SOURCE_FILE RPC is mutating, so a 5xx/network
-        failure between commit and response could duplicate on a naive retry).
-        Because filenames are NOT identity-bearing (two uploads of ``report.pdf``
-        are legitimately distinct), the probe captures a baseline of source IDs
-        BEFORE the first create and only matches IDs new since then; an ambiguous
-        match (>1 new source, e.g. a concurrent uploader) raises ``SourceAddError``
-        rather than guessing.
+        Filenames are not identity-bearing, so the probe matches only source IDs
+        that appeared after the pre-create baseline and rejects ambiguity.
         """
         params = build_register_file_source_params(filename, notebook_id)
         if rpc_call is None:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ._idempotency import _CreateResultKind, _IdempotentCreateResult
 from ._lookup import unwrap_or_raise
 from ._row_adapters.sources import interpret_source_freshness
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
@@ -404,7 +405,7 @@ class SourcesAPI:
         Example:
             source = await client.sources.add_url(nb_id, url, wait=True)
         """
-        source = await self._adder.add_url(
+        result = await self._adder.add_url(
             notebook_id,
             url,
             wait=wait,
@@ -416,7 +417,16 @@ class SourcesAPI:
             extract_youtube_video_id=self._extract_youtube_video_id,
             is_youtube_url=is_youtube_url,
             logger=logger,
+            return_result=True,
         )
+        if isinstance(result, _IdempotentCreateResult):
+            source = result.value
+            is_fresh = result.kind is _CreateResultKind.CREATED
+        else:  # Keep injected/private service seams source-compatible.
+            source = result
+            is_fresh = True
+        if not is_fresh:
+            return source
         return await honor_requested_title(self.rename, notebook_id, source, title, logger)
 
     async def add_text(
@@ -564,7 +574,7 @@ class SourcesAPI:
                 notebook_id, file_id="1abc123xyz", title="My Document",
                 mime_type=DriveMimeType.GOOGLE_DOC.value, wait=True)
         """
-        source = await self._adder.add_drive(
+        result = await self._adder.add_drive(
             notebook_id,
             file_id,
             title,
@@ -575,7 +585,16 @@ class SourcesAPI:
             list_sources=self.list,
             wait_until_ready=self.wait_until_ready,
             logger=logger,
+            return_result=True,
         )
+        if isinstance(result, _IdempotentCreateResult):
+            source = result.value
+            is_fresh = result.kind is _CreateResultKind.CREATED
+        else:  # Keep injected/private service seams source-compatible.
+            source = result
+            is_fresh = True
+        if not is_fresh:
+            return source
         return await honor_requested_title(self.rename, notebook_id, source, title, logger)
 
     async def add_drive_file(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -11,14 +11,13 @@ from urllib.parse import urlparse
 
 import httpx
 
-from ._idempotency import _CreateResultKind, _IdempotentCreateResult
 from ._lookup import unwrap_or_raise
 from ._row_adapters.sources import interpret_source_freshness
 from ._runtime.config import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._runtime.contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._source import upload as _source_upload
-from ._source.add import SourceAddService, honor_requested_title
+from ._source.add import SourceAddService, honor_requested_title_if_fresh
 from ._source.content import SourceContentRenderer
 from ._source.drive_import import DriveFetcher, DriveImportService
 from ._source.listing import SourceLister
@@ -35,7 +34,6 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
-
 
 _SOURCE_ID_UUID_PATTERN = _source_upload._SOURCE_ID_UUID_PATTERN
 _extract_register_file_source_id = _source_upload._extract_register_file_source_id
@@ -419,15 +417,7 @@ class SourcesAPI:
             logger=logger,
             return_result=True,
         )
-        if isinstance(result, _IdempotentCreateResult):
-            source = result.value
-            is_fresh = result.kind is _CreateResultKind.CREATED
-        else:  # Keep injected/private service seams source-compatible.
-            source = result
-            is_fresh = True
-        if not is_fresh:
-            return source
-        return await honor_requested_title(self.rename, notebook_id, source, title, logger)
+        return await honor_requested_title_if_fresh(self.rename, notebook_id, result, title, logger)
 
     async def add_text(
         self,
@@ -587,15 +577,7 @@ class SourcesAPI:
             logger=logger,
             return_result=True,
         )
-        if isinstance(result, _IdempotentCreateResult):
-            source = result.value
-            is_fresh = result.kind is _CreateResultKind.CREATED
-        else:  # Keep injected/private service seams source-compatible.
-            source = result
-            is_fresh = True
-        if not is_fresh:
-            return source
-        return await honor_requested_title(self.rename, notebook_id, source, title, logger)
+        return await honor_requested_title_if_fresh(self.rename, notebook_id, result, title, logger)
 
     async def add_drive_file(
         self,
@@ -635,10 +617,9 @@ class SourcesAPI:
             ),
             add_file=self.add_file,
         )
-        # Gate the whole download→upload op on a DEDICATED download semaphore (not
-        # the upload one — ``add_file`` needs that, so reusing it would deadlock) so
-        # concurrent remote-MCP calls can't each buffer a 200 MiB temp and exhaust
-        # disk; at most ``max_concurrent_uploads`` temps exist at once.
+        # Gate the whole download→upload op on a DEDICATED download semaphore;
+        # reusing the upload one would deadlock because ``add_file`` needs it.
+        # It bounds temporary-file fan-out to ``max_concurrent_uploads``.
         async with self._uploader.get_download_semaphore():
             return await service.add_drive_file(
                 notebook_id, document_id, title=title, wait=wait, wait_timeout=wait_timeout

--- a/tests/unit/test_idempotent_create_contract.py
+++ b/tests/unit/test_idempotent_create_contract.py
@@ -1,0 +1,125 @@
+"""Focused regression coverage for idempotent-create provenance (#1988)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._idempotency import (
+    _CreateResultKind,
+    _IdempotentCreateResult,
+    idempotent_create,
+)
+from notebooklm._source.add import SourceAddService
+from notebooklm._sources import SourcesAPI
+from notebooklm.exceptions import NetworkError
+from notebooklm.types import Source
+
+
+@pytest.mark.asyncio
+async def test_idempotent_create_marks_fresh_create() -> None:
+    result = await idempotent_create(
+        AsyncMock(return_value="created"), AsyncMock(return_value=None)
+    )
+    assert result == _IdempotentCreateResult("created", _CreateResultKind.CREATED)
+
+
+@pytest.mark.asyncio
+async def test_idempotent_create_marks_probe_match_without_retry() -> None:
+    create = AsyncMock(side_effect=NetworkError("lost response"))
+    probe = AsyncMock(return_value="existing")
+
+    result = await idempotent_create(create, probe)
+
+    assert result.value == "existing"
+    assert result.kind is _CreateResultKind.PROBED
+    create.assert_awaited_once()
+    probe.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_create_retries_after_probe_miss() -> None:
+    create = AsyncMock(side_effect=[NetworkError("first"), "second"])
+    probe = AsyncMock(return_value=None)
+
+    result = await idempotent_create(create, probe)
+
+    assert result.value == "second"
+    assert result.kind is _CreateResultKind.CREATED
+    assert create.await_count == 2
+    assert probe.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_create_reraises_last_exception_by_identity() -> None:
+    error = NetworkError("still unavailable")
+    create = AsyncMock(side_effect=[NetworkError("first"), error])
+
+    with pytest.raises(NetworkError) as raised:
+        await idempotent_create(create, AsyncMock(return_value=None))
+
+    assert raised.value is error
+
+
+@pytest.mark.asyncio
+async def test_probe_result_never_honors_url_title_even_after_wait() -> None:
+    api = SourcesAPI(MagicMock(), uploader=MagicMock())
+    existing = Source(id="existing", title="Drive title", url="https://example.test")
+    api._adder.add_url = AsyncMock(
+        return_value=_IdempotentCreateResult(existing, _CreateResultKind.PROBED)
+    )
+    api.wait_until_ready = AsyncMock(return_value=Source(id="existing", title="Ready"))  # type: ignore[method-assign]
+    api.rename = AsyncMock()  # type: ignore[method-assign]
+
+    result = await api.add_url("nb", existing.url, title="Do not retitle", wait=True)
+
+    assert result.title == "Drive title"
+    api.wait_until_ready.assert_not_awaited()
+    api.rename.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_private_service_default_return_remains_source() -> None:
+    service = SourceAddService()
+    source = Source(id="fresh", title="Upstream")
+
+    result = await service.add_url(
+        "nb",
+        "https://example.test",
+        add_youtube_source=AsyncMock(),
+        add_url_source=AsyncMock(return_value=[[[["fresh"], "Upstream"]]]),
+        list_sources=AsyncMock(return_value=[]),
+        wait_until_ready=AsyncMock(),
+        extract_youtube_video_id=MagicMock(return_value=None),
+        is_youtube_url=MagicMock(return_value=False),
+        logger=MagicMock(),
+    )
+
+    assert isinstance(result, Source)
+    assert result.id == source.id
+
+
+@pytest.mark.asyncio
+async def test_private_service_preserves_probe_provenance_through_wait() -> None:
+    service = SourceAddService()
+    existing = Source(id="existing", title="Upstream", url="https://example.test")
+    ready = Source(id="existing", title="Ready", url=existing.url)
+
+    result = await service.add_url(
+        "nb",
+        existing.url,
+        wait=True,
+        add_youtube_source=AsyncMock(),
+        add_url_source=AsyncMock(side_effect=NetworkError("lost response")),
+        list_sources=AsyncMock(return_value=[existing]),
+        wait_until_ready=AsyncMock(return_value=ready),
+        extract_youtube_video_id=MagicMock(return_value=None),
+        is_youtube_url=MagicMock(return_value=False),
+        logger=MagicMock(),
+        return_result=True,
+    )
+
+    assert isinstance(result, _IdempotentCreateResult)
+    assert result.kind is _CreateResultKind.PROBED
+    assert result.value is ready

--- a/tests/unit/test_idempotent_create_contract.py
+++ b/tests/unit/test_idempotent_create_contract.py
@@ -69,7 +69,9 @@ async def test_probe_result_never_honors_url_title_even_after_wait() -> None:
     api._adder.add_url = AsyncMock(
         return_value=_IdempotentCreateResult(existing, _CreateResultKind.PROBED)
     )
-    api.wait_until_ready = AsyncMock(return_value=Source(id="existing", title="Ready"))  # type: ignore[method-assign]
+    api.wait_until_ready = AsyncMock(  # type: ignore[method-assign]
+        return_value=Source(id="existing", title="Ready")
+    )
     api.rename = AsyncMock()  # type: ignore[method-assign]
 
     result = await api.add_url("nb", existing.url, title="Do not retitle", wait=True)


### PR DESCRIPTION
## Summary
- Preserve provenance when idempotent create operations recover through probing.
- Avoid renaming recovered sources, preventing title mutation on retries.
- Keep public and injected service seams backward-compatible.

## Issue
Closes #1988

## Test plan
- `uv run pytest tests/unit/test_idempotent_create_contract.py -q`
- `uv run ruff check src/notebooklm/_idempotency.py src/notebooklm/_notebooks.py src/notebooklm/_source/add.py src/notebooklm/_source/upload.py src/notebooklm/_sources.py tests/unit/test_idempotent_create_contract.py`
- `uv run mypy src/notebooklm`
- `git diff --check`

## Deferred polish findings
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Source creation can optionally report whether a source was newly created or already existed.
  - Existing source additions preserve their current titles and state.

- **Bug Fixes**
  - Improved handling of repeated URL, Drive, and file additions.
  - Avoids unnecessary readiness waits and title changes for existing sources.
  - Improved retry behavior when creation checks initially find no match.
  - Notebook creation continues to return the created notebook directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->