### PR TITLE
fix(rpc): name the host in RPC errors, pin the default-host contract (#2067 precursor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,23 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NOTEBOOKLM_BASE_URL` selects between them. A wrong-host session previously
   surfaced as `Client error 404 calling LIST_NOTEBOOKS: Not Found`, which is
   indistinguishable from "this account cannot see that notebook", so the one
-  recovery lever available was one the user could not tell they needed. 4xx,
-  5xx and 429 messages now read `… calling LIST_NOTEBOOKS on
-  notebooklm.google.com: …`
-  ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
-
-### Added
-
-- **Host-contract tests for the RPC path.** `get_batchexecute_url()` /
-  `get_query_url()` / `get_upload_url()` are now asserted against a bare host
-  literal under the *default* environment — previously covered only under the
-  enterprise override, so a change to the default was invisible — and the
-  streamed-chat builder is pinned to send no origin-bound header. The latter
-  matters because such headers are host-bound and appear in no VCR `match_on`,
-  so one naming the wrong host would pass every offline test and fail every
-  live call ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
-
-### Fixed
+  recovery lever available was one the user could not tell they needed. Every
+  HTTP-status message now reads `… calling LIST_NOTEBOOKS on
+  notebooklm.google.com: …` — 4xx (including the 401/403 fallback), 5xx, and
+  429 on both the mapper and the retry-exhausted transport path, which is the
+  one a real 429 actually reaches. The host is read from the request that
+  failed rather than re-read from `NOTEBOOKLM_BASE_URL`, so a re-point while an
+  RPC is in flight cannot make the message name a host that failure never
+  touched ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
 
 - **Corrected the last cookie-domain tier claim that still said the ranking is
   decisive.** #2057 rewrote the `_auth_domain_priority` docstring and its two
@@ -47,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
 
 ### Added
+
+- **Host-contract tests for the RPC path.** `get_batchexecute_url()` /
+  `get_query_url()` / `get_upload_url()` are now asserted against a bare host
+  literal under the *default* environment — previously covered only under the
+  enterprise override, so a change to the default was invisible — and the
+  streamed-chat builder is pinned to send no origin-bound header. The latter
+  matters because such headers are host-bound and appear in no VCR `match_on`,
+  so one naming the wrong host would pass every offline test and fail every
+  live call ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
 
 - **`notebook.google.com` is now an accepted `NOTEBOOKLM_BASE_URL` value.**
   Google serves the personal app from this host after the "Gemini Notebook"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **RPC errors now name the host, not just the method.** Google serves the
+  personal app from two hosts — `notebooklm.google.com` and, since the Gemini
+  Notebook rebrand, `notebook.google.com` (ADR-0028) — and
+  `NOTEBOOKLM_BASE_URL` selects between them. A wrong-host session previously
+  surfaced as `Client error 404 calling LIST_NOTEBOOKS: Not Found`, which is
+  indistinguishable from "this account cannot see that notebook", so the one
+  recovery lever available was one the user could not tell they needed. 4xx,
+  5xx and 429 messages now read `… calling LIST_NOTEBOOKS on
+  notebooklm.google.com: …`
+  ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
+
+### Added
+
+- **Host-contract tests for the RPC path.** `get_batchexecute_url()` /
+  `get_query_url()` / `get_upload_url()` are now asserted against a bare host
+  literal under the *default* environment — previously covered only under the
+  enterprise override, so a change to the default was invisible — and the
+  streamed-chat builder is pinned to send no origin-bound header. The latter
+  matters because such headers are host-bound and appear in no VCR `match_on`,
+  so one naming the wrong host would pass every offline test and fail every
+  live call ([#2067](https://github.com/teng-lin/notebooklm-py/issues/2067)).
+
+### Fixed
+
 - **Corrected the last cookie-domain tier claim that still said the ranking is
   decisive.** #2057 rewrote the `_auth_domain_priority` docstring and its two
   consumers, but the tier comment added by

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -80,7 +80,7 @@ from .browser_launch_errors import CHANNEL_BROWSERS, classify_launch_failure
 # sanctions as an import site, and the CLI's own cookie-refresh advice
 # (``cli/services/login/cookie_jar.py``) must not grow a second, drifting copy
 # of that caveat.
-from .cookie_policy import app_host_scope_note, build_cookie_domain_allowlist
+from .cookie_policy import app_host_scope_note
 
 # DEBUG tracing for the login wait lives in its own leaf (ADR-0008) and is
 # re-exported here because ``browser_capture`` is the only ``_auth`` module the

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -55,6 +55,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _error_host_suffix(request: httpx.Request | None) -> str:
+    """Return ``" on <host>"`` for an error message, or ``""`` if no host is known.
+
+    The host is taken from the request that actually failed rather than re-read
+    from the environment. ``NOTEBOOKLM_BASE_URL`` is resolved lazily on every
+    endpoint build, so in a long-running process a re-point while an RPC is in
+    flight would otherwise make the message name a host this failure never
+    touched -- and a re-point to an *invalid* value would raise ``ValueError``
+    out of the ``except`` block, masking the HTTP error entirely.
+
+    The configured base URL is only a fallback, for the paths where no request
+    object survived. It degrades to an unsuffixed message rather than raising:
+    an error mapper must never fail in place of the error it is reporting.
+    """
+    host = request.url.host if request is not None else ""
+    if not host:
+        try:
+            host = httpx.URL(get_base_url()).host
+        except (ValueError, httpx.InvalidURL):
+            return ""
+    return f" on {host}" if host else ""
+
+
 class DecodeResponse(Protocol):
     def __call__(self, raw: str, rpc_id: str, *, allow_null: bool = False) -> Any: ...
 
@@ -267,7 +290,13 @@ class RpcExecutor:
         except TransportRateLimited as exc:
             elapsed = time.perf_counter() - start
             logger.error("RPC %s failed after %.3fs: HTTP 429", method.name, elapsed)
-            msg = f"API rate limit exceeded calling {method.name}"
+            # This branch -- not the 429 arm of ``raise_rpc_error_from_http_status``
+            # -- is what a real HTTP 429 reaches: the transport converts it to
+            # ``TransportRateLimited`` once the retry budget is exhausted, or
+            # immediately when retries are disabled. It carries the same host
+            # suffix so the two 429 paths stay indistinguishable to the user.
+            on_host = _error_host_suffix(exc.original.request)
+            msg = f"API rate limit exceeded calling {method.name}{on_host}"
             if exc.retry_after:
                 msg += f". Retry after {exc.retry_after} seconds"
             raise RateLimitError(
@@ -431,27 +460,28 @@ class RpcExecutor:
     ) -> NoReturn:
         """Map an HTTP-status failure onto the RPC error hierarchy.
 
-        4xx/5xx messages name the **host** as well as the method. Google serves
-        the personal app from two hosts (``notebooklm.google.com`` and, since the
-        Gemini Notebook rebrand, ``notebook.google.com`` -- see ADR-0028), and
-        ``NOTEBOOKLM_BASE_URL`` selects between them. Without the host in the
-        message, "talking to the wrong host" and "this account cannot see that
-        notebook" are the same 404 to a user, and the only recovery lever is one
-        they cannot tell they need.
+        Every message names the **host** as well as the method -- including the
+        401/403 fallback, which is where a wrong-host session is just as likely
+        to land. Google serves the personal app from two hosts
+        (``notebooklm.google.com`` and, since the Gemini Notebook rebrand,
+        ``notebook.google.com`` -- see ADR-0028), and ``NOTEBOOKLM_BASE_URL``
+        selects between them. Without the host in the message, "talking to the
+        wrong host" and "this account cannot see that notebook" are the same 404
+        to a user, and the only recovery lever is one they cannot tell they need.
         """
         status = exc.response.status_code
-        host = httpx.URL(get_base_url()).host
+        on_host = _error_host_suffix(exc.request)
 
         if status == 429:
             retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
-            msg = f"API rate limit exceeded calling {method.name} on {host}"
+            msg = f"API rate limit exceeded calling {method.name}{on_host}"
             if retry_after:
                 msg += f". Retry after {retry_after} seconds"
             raise RateLimitError(msg, method_id=method.value, retry_after=retry_after) from exc
 
         if 500 <= status < 600:
             raise ServerError(
-                f"Server error {status} calling {method.name} on {host}: "
+                f"Server error {status} calling {method.name}{on_host}: "
                 f"{exc.response.reason_phrase}",
                 method_id=method.value,
                 status_code=status,
@@ -459,14 +489,14 @@ class RpcExecutor:
 
         if 400 <= status < 500 and status not in (401, 403):
             raise ClientError(
-                f"Client error {status} calling {method.name} on {host}: "
+                f"Client error {status} calling {method.name}{on_host}: "
                 f"{exc.response.reason_phrase}",
                 method_id=method.value,
                 status_code=status,
             ) from exc
 
         raise RPCError(
-            f"HTTP {status} calling {method.name}: {exc.response.reason_phrase}",
+            f"HTTP {status} calling {method.name}{on_host}: {exc.response.reason_phrase}",
             method_id=method.value,
         ) from exc
 

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -17,7 +17,7 @@ import httpx
 from ._auth.account import format_authuser_value
 from ._auth_refresh_retry import RefreshBudget, refresh_and_count
 from ._deadline import RuntimeDeadline
-from ._env import get_default_language
+from ._env import get_base_url, get_default_language
 from ._idempotency import (
     IDEMPOTENCY_REGISTRY,
     resolve_effective_disable_internal_retries,
@@ -429,26 +429,38 @@ class RpcExecutor:
         exc: httpx.HTTPStatusError,
         method: RPCMethod,
     ) -> NoReturn:
-        """Map an HTTP-status failure onto the RPC error hierarchy."""
+        """Map an HTTP-status failure onto the RPC error hierarchy.
+
+        4xx/5xx messages name the **host** as well as the method. Google serves
+        the personal app from two hosts (``notebooklm.google.com`` and, since the
+        Gemini Notebook rebrand, ``notebook.google.com`` -- see ADR-0028), and
+        ``NOTEBOOKLM_BASE_URL`` selects between them. Without the host in the
+        message, "talking to the wrong host" and "this account cannot see that
+        notebook" are the same 404 to a user, and the only recovery lever is one
+        they cannot tell they need.
+        """
         status = exc.response.status_code
+        host = httpx.URL(get_base_url()).host
 
         if status == 429:
             retry_after = parse_retry_after(exc.response.headers.get("retry-after"))
-            msg = f"API rate limit exceeded calling {method.name}"
+            msg = f"API rate limit exceeded calling {method.name} on {host}"
             if retry_after:
                 msg += f". Retry after {retry_after} seconds"
             raise RateLimitError(msg, method_id=method.value, retry_after=retry_after) from exc
 
         if 500 <= status < 600:
             raise ServerError(
-                f"Server error {status} calling {method.name}: {exc.response.reason_phrase}",
+                f"Server error {status} calling {method.name} on {host}: "
+                f"{exc.response.reason_phrase}",
                 method_id=method.value,
                 status_code=status,
             ) from exc
 
         if 400 <= status < 500 and status not in (401, 403):
             raise ClientError(
-                f"Client error {status} calling {method.name}: {exc.response.reason_phrase}",
+                f"Client error {status} calling {method.name} on {host}: "
+                f"{exc.response.reason_phrase}",
                 method_id=method.value,
                 status_code=status,
             ) from exc

--- a/tests/unit/test_rpc_host_contract.py
+++ b/tests/unit/test_rpc_host_contract.py
@@ -18,17 +18,39 @@ Both assertions use **bare literals** deliberately. Writing them against
 ``get_base_url()`` would make them tautologies that pass under any value — the
 defect class catalogued in #2055 — and the whole point is to fail loudly if the
 default host changes without that change being intended.
+
+The rest of the module pins the third property: **every HTTP-status error names
+the host**, on all of the paths a real failure can take — the mapper's 4xx/5xx
+arms, its 401/403 fallback, and the retry-exhausted transport 429 that bypasses
+the mapper entirely.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+import httpx
 import pytest
 
 from notebooklm._chat.wire import build_streaming_chat_request
 from notebooklm._request_types import AuthSnapshot
-from notebooklm.rpc import get_batchexecute_url, get_query_url, get_upload_url
+from notebooklm._transport_errors import TransportRateLimited
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import (
+    ClientError,
+    RateLimitError,
+    RPCError,
+    RPCMethod,
+    ServerError,
+    get_batchexecute_url,
+    get_query_url,
+    get_upload_url,
+)
+from tests._helpers.client_factory import build_client_shell_for_tests
 
 DEFAULT_HOST = "https://notebooklm.google.com"
+
+REQUEST_HOST = "rpc.example.test"
 
 
 @pytest.mark.parametrize(
@@ -75,3 +97,118 @@ def test_streaming_chat_sends_no_origin_bound_header() -> None:
         "(Origin/Referer/X-Same-Domain/SAPISIDHASH) it must derive from the "
         "configured host and needs its own host-literal assertion — see #2067"
     )
+
+
+def _status_error(
+    status: int,
+    *,
+    url: str = f"https://{REQUEST_HOST}/_/LabsTailwindUi/data/batchexecute",
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def _executor() -> Any:
+    tokens = AuthTokens(cookies={"SID": "sid"}, csrf_token="CSRF", session_id="SID")
+    return build_client_shell_for_tests(tokens)._rpc_executor
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_type"),
+    [
+        (429, RateLimitError),
+        (404, ClientError),
+        (500, ServerError),
+        # 401/403 fall through to the bare ``RPCError``. They are excluded from
+        # the ClientError arm because the auth layer owns them, but a wrong-host
+        # session is at least as likely to surface here as a 404 — so the
+        # fallback needs the host too.
+        (401, RPCError),
+        (403, RPCError),
+    ],
+    ids=["429", "404", "500", "401", "403"],
+)
+def test_every_status_error_names_the_host(status: int, expected_type: type[Exception]) -> None:
+    """No HTTP-status arm may drop the host, including the 401/403 fallback."""
+    with pytest.raises(expected_type) as raised:
+        _executor().raise_rpc_error_from_http_status(
+            _status_error(status), RPCMethod.LIST_NOTEBOOKS
+        )
+
+    assert f"on {REQUEST_HOST}" in str(raised.value), (
+        f"HTTP {status} lost the host from its message; a wrong-host session is "
+        "then indistinguishable from a permissions failure (#2067)"
+    )
+
+
+def test_host_comes_from_the_failed_request_not_the_environment(monkeypatch) -> None:
+    """The message names the host that failed, not whatever the env says *now*.
+
+    Endpoint builders resolve ``NOTEBOOKLM_BASE_URL`` lazily on every call, so a
+    re-point while an RPC is in flight would otherwise attribute the failure to
+    a host it never touched.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebook.google.com")
+
+    with pytest.raises(ClientError) as raised:
+        _executor().raise_rpc_error_from_http_status(_status_error(404), RPCMethod.LIST_NOTEBOOKS)
+
+    assert f"on {REQUEST_HOST}" in str(raised.value)
+    assert "notebook.google.com" not in str(raised.value)
+
+
+def test_mapper_does_not_raise_over_an_unusable_base_url(monkeypatch) -> None:
+    """An unresolvable host degrades the message; it never masks the HTTP error.
+
+    Reached when the failed request carries no host *and* the configured base
+    URL is invalid. An error mapper that raised in place of the error it reports
+    would turn a diagnosable 404 into a ``ValueError`` from the ``except`` block.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://not-a-google-host.example")
+
+    with pytest.raises(ClientError) as raised:
+        _executor().raise_rpc_error_from_http_status(
+            _status_error(404, url="file:///tmp/no-host"),
+            RPCMethod.LIST_NOTEBOOKS,
+        )
+
+    assert "calling LIST_NOTEBOOKS:" in str(raised.value)
+    assert " on " not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted_429_names_the_host(monkeypatch) -> None:
+    """The 429 a real RPC reaches is the transport's, not the mapper's.
+
+    ``RuntimeTransport`` converts HTTP 429 into ``TransportRateLimited`` once the
+    retry budget is exhausted — or immediately when retries are disabled — so
+    ``_execute_once`` handles it before the status mapper is ever consulted.
+    Pinning the host here keeps the two 429 paths from drifting apart.
+    """
+    core = build_client_shell_for_tests(
+        AuthTokens(cookies={"SID": "sid"}, csrf_token="CSRF", session_id="SID")
+    )
+    original = _status_error(429)
+
+    async def _rate_limited(**_kwargs: Any) -> httpx.Response:
+        raise TransportRateLimited(
+            "429",
+            retry_after=7,
+            response=original.response,
+            original=original,
+        )
+
+    monkeypatch.setattr(core._composed.transport, "perform_authed_post", _rate_limited)
+
+    with pytest.raises(RateLimitError) as raised:
+        await core._rpc_executor._execute_once(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/notebook/abc",
+            True,
+            False,
+        )
+
+    assert f"on {REQUEST_HOST}" in str(raised.value)
+    assert raised.value.retry_after == 7

--- a/tests/unit/test_rpc_host_contract.py
+++ b/tests/unit/test_rpc_host_contract.py
@@ -1,0 +1,77 @@
+"""Host contract for the RPC path (#2067 precursor).
+
+Google serves the personal app from two hosts — ``notebooklm.google.com`` and,
+since the Gemini Notebook rebrand, ``notebook.google.com`` (ADR-0028) — and
+``NOTEBOOKLM_BASE_URL`` selects between them. Two properties of the RPC path
+are load-bearing when that selection changes and neither was asserted:
+
+1. **Which host the endpoint builders target under the default env.** Existing
+   coverage (``test_rpc_types.py``, ``test_env_base_url.py``) asserts these only
+   under the *enterprise* override, so a change to the default was invisible.
+2. **That the RPC path sends no origin-bound header.** It sends none today —
+   both request builders return an empty header dict, and this client computes
+   no ``SAPISIDHASH``. Pinning that makes *adding* one a reviewed decision
+   rather than a drive-by, which matters because such a header is bound to a
+   host and nothing offline would catch it naming the wrong one.
+
+Both assertions use **bare literals** deliberately. Writing them against
+``get_base_url()`` would make them tautologies that pass under any value — the
+defect class catalogued in #2055 — and the whole point is to fail loudly if the
+default host changes without that change being intended.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._chat.wire import build_streaming_chat_request
+from notebooklm._request_types import AuthSnapshot
+from notebooklm.rpc import get_batchexecute_url, get_query_url, get_upload_url
+
+DEFAULT_HOST = "https://notebooklm.google.com"
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [get_batchexecute_url, get_query_url, get_upload_url],
+    ids=lambda f: f.__name__,
+)
+def test_endpoint_builders_target_the_default_host(monkeypatch, builder) -> None:
+    """Under the default env every RPC endpoint is on the default host.
+
+    Asserted against a literal, not ``get_base_url()``. If the default moves,
+    this fails — which is the intent: the move should be a deliberate edit here,
+    not a silent consequence elsewhere.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+    assert builder().startswith(f"{DEFAULT_HOST}/"), (
+        f"{builder.__name__} does not target {DEFAULT_HOST}; if the default host "
+        "moved deliberately, update this literal and the CHANGELOG together"
+    )
+
+
+def test_streaming_chat_sends_no_origin_bound_header() -> None:
+    """The chat builder sends no ``Origin`` / ``Referer`` / ``X-Same-Domain``.
+
+    A wire census of the recorded corpus shows zero such headers on any
+    batchexecute or streamed-chat request. They are host-bound, and no VCR
+    ``match_on`` includes them, so one naming the wrong host would pass every
+    offline test and fail every live call. This pins the current contract so
+    adding one is a decision someone makes on purpose.
+    """
+    snapshot = AuthSnapshot(csrf_token="csrf", session_id="sid", authuser=0, account_email=None)
+    _url, _body, extra_headers = build_streaming_chat_request(
+        snapshot=snapshot,
+        notebook_id="nb",
+        question="hi",
+        source_ids=[],
+        conversation_history=None,
+        conversation_id=None,
+        reqid=1,
+    )
+
+    assert extra_headers == {}, (
+        "the streamed-chat path gained a header. If it is origin-bound "
+        "(Origin/Referer/X-Same-Domain/SAPISIDHASH) it must derive from the "
+        "configured host and needs its own host-literal assertion — see #2067"
+    )


### PR DESCRIPTION
Precursor to #2067. **Both changes are correct at today's default** and do not depend on whether it ever moves — that is the point of splitting them out.

## Why

Google serves the personal app from two hosts — `notebooklm.google.com` and, since the Gemini Notebook rebrand, `notebook.google.com` (ADR-0028) — and `NOTEBOOKLM_BASE_URL` selects between them. Today a wrong-host session surfaces as:

```
ClientError: Client error 404 calling LIST_NOTEBOOKS: Not Found
```

Method named, **host not**. That is indistinguishable from "this account cannot see that notebook", so the single recovery lever available (`NOTEBOOKLM_BASE_URL`) is one the user cannot tell they need. 4xx, 5xx and 429 now carry the configured host.

## The two tests, and why they use bare literals

Both are written against **bare host literals**, not `get_base_url()`. Deriving the expectation from the same function production uses makes the test pass under *any* value — the defect class catalogued in #2055, where this repo found eight instances in a day.

- **The three endpoint builders target the default host under the default env.** `test_rpc_types.py` and `test_env_base_url.py` assert these only under the *enterprise override*, so the default was genuinely unasserted. If the default moves, this test fails — which is the intent: the move should be a deliberate edit here, paired with a CHANGELOG entry.
- **The streamed-chat builder sends no origin-bound header.** It sends none today: a wire census of all 472 recorded interactions shows **zero** `Origin` / `Referer` / `X-Same-Domain` on any batchexecute or streamed-chat request, and this client computes no `SAPISIDHASH` anywhere. Those headers are host-bound and appear in **no VCR `match_on`**, so one naming the wrong host would pass every offline test and fail every live call. Pinning the current contract makes adding one a reviewed decision rather than a drive-by.

## Scope

Deliberately excluded, and tracked for the flip PR itself:

- the `PERSONAL_LEGACY_HOST` constant split and cookie-policy rewrite — larger, and it deserves review attention that a ~900-line cassette diff would drown;
- the nightly probe-lane inversion — it is only correct *after* a flip has baked, and doing it early removes the rollback-availability monitor exactly when it matters;
- `_has_valid_secondary_binding` routing.

One item originally scoped here turned out to be **already fixed on `main`**: `_env.py`'s comment no longer claims the rebrand host is unproven.

## Verification

`ruff` + `ruff format` clean whole-tree · `mypy` clean across 323 source files · `tests/unit` + `tests/_guardrails`: **11783 passed, 62 skipped, 1 xfailed**.

Refs #2067, ADR-0028, #2055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RPC error messages for client, server, and rate-limit failures now identify the target host, including requests that fail after retries.
  * Error reporting now preserves the original failure details even when fallback connection settings are invalid.

* **Tests**
  * Added coverage validating default RPC and upload URLs.
  * Added checks confirming streamed chat requests use the expected headers and host-specific error details across common HTTP failure responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->