### PR TITLE
fix(auth): secondary binding also needs LSID when OSID is absent (#1977)

### DIFF
--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -80,7 +80,7 @@ from .browser_launch_errors import CHANNEL_BROWSERS, classify_launch_failure
 # sanctions as an import site, and the CLI's own cookie-refresh advice
 # (``cli/services/login/cookie_jar.py``) must not grow a second, drifting copy
 # of that caveat.
-from .cookie_policy import app_host_scope_note, build_cookie_domain_allowlist
+from .cookie_policy import app_host_scope_note
 
 # DEBUG tracing for the login wait lives in its own leaf (ADR-0008) and is
 # re-exported here because ``browser_capture`` is the only ``_auth`` module the

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -213,8 +213,9 @@ def app_host_scope_note() -> str:
     Both recoveries are real, and ordered deliberately:
 
     1. Re-run ``notebooklm login`` and complete the sign-in. That re-mints the
-       account-wide ``.google.com`` cookies, and ``APISID`` + ``SAPISID`` (which
-       live on ``.google.com``) satisfy the binding on *either* host — see
+       account-wide cookies. ``APISID`` + ``SAPISID`` live on ``.google.com``
+       and ``LSID`` on ``accounts.google.com``, so none of them are host-scoped
+       and together they satisfy the binding on *either* host — see
        :func:`_has_valid_secondary_binding`.
     2. Select the host that actually holds the cookies via
        ``NOTEBOOKLM_BASE_URL``.
@@ -260,8 +261,9 @@ def app_host_scope_note() -> str:
         f"which is the host this client is configured to use.\n"
         f"If the binding is still missing afterwards it landed on {other_host}: "
         f"re-run 'notebooklm login' and complete the sign-in (that re-mints the "
-        f"account-wide .google.com binding APISID+SAPISID, which both hosts "
-        f"accept), or select the host that has the cookies with "
+        f"account-wide binding APISID+SAPISID+LSID, none of which are "
+        f"host-scoped, so both hosts accept it), or select the host that has "
+        f"the cookies with "
         f"NOTEBOOKLM_BASE_URL=https://{other_host}{caveat}."
     )
 
@@ -329,7 +331,7 @@ def missing_cookies_hint(
     if psidts_missing and not has_secondary:
         return _with_scope_note(
             f"Your {browser_phrase} session is signed in to Google but is missing "
-            f"the cookies NotebookLM needs (OSID or APISID+SAPISID, plus "
+            f"the cookies NotebookLM needs (OSID, or APISID+SAPISID+LSID, plus "
             f"__Secure-1PSIDTS).\n"
             f"Open https://{get_base_host()} in {browser_phrase} (sign in if "
             f"prompted), reload the page, then re-run this command."
@@ -349,7 +351,7 @@ def missing_cookies_hint(
     if not has_secondary:
         return _with_scope_note(
             f"Your {browser_phrase} cookies are missing the NotebookLM binding "
-            f"(OSID, or APISID+SAPISID).\n"
+            f"(OSID, or all of APISID, SAPISID and LSID).\n"
             f"Open https://{get_base_host()} in {browser_phrase} (sign in if "
             f"prompted), reload the page, then re-run this command."
         )

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -73,15 +73,75 @@ _SECONDARY_BINDING_WARNED = False
 def _has_valid_secondary_binding(cookie_names: set[str]) -> bool:
     """Tier 2 acceptance check (see ``MINIMUM_REQUIRED_COOKIES``).
 
-    Pair-wise ablation against a live Google session reveals that the
-    NotebookLM homepage GET requires *at least one* of two redundant
-    secondary-binding paths in addition to Tier 1:
+    The homepage GET requires *at least one* of two secondary-binding paths in
+    addition to Tier 1:
 
     - ``OSID`` (recent-sign-in binding), OR
-    - both ``APISID`` AND ``SAPISID`` (legacy XSSI binding pair).
+    - ``APISID`` AND ``SAPISID`` (legacy XSSI pair) **AND** bare ``LSID``.
 
-    Without either, Google 302s to ``accounts.google.com/v3/signin`` even when
-    ``SID`` and ``__Secure-1PSIDTS`` are present and otherwise valid.
+    Without one of those, Google 302s to ``accounts.google.com/v3/signin`` even
+    when ``SID`` and ``__Secure-1PSIDTS`` are present and otherwise valid.
+
+    The ``LSID`` conjunct is the correction. The original pair-wise ablation
+    only varied ``OSID`` and the XSSI pair; because ``APISID``/``SAPISID`` are
+    ``.google.com``-scoped they survived every domain filter, so the XSSI branch
+    was never tested *without* them and the ``LSID`` dependency stayed hidden.
+    A three-way ablation, replicated on two unrelated accounts (2026-08-04,
+    issue #1977), gives:
+
+    ==========  =====================  ============  ========
+    ``OSID``    ``APISID``+``SAPISID``  bare ``LSID``  result
+    ==========  =====================  ============  ========
+    present     --                     --            works
+    present     present                --            works
+    --          present                present       works
+    --          present                --            **fails**
+    --          --                     present       fails
+    ==========  =====================  ============  ========
+
+    Row 4 is what this function used to get wrong. Two consequences worth
+    keeping straight:
+
+    * ``OSID`` alone is sufficient — a profile with **no** ``LSID`` anywhere
+      authenticates (row 1, verified with every ``accounts.google.com`` cookie
+      stripped). ``LSID`` is required *only* when ``OSID`` is absent.
+    * ``__Host-1PLSID`` / ``__Host-3PLSID`` do **not** substitute for bare
+      ``LSID``; row 4 retains them and still fails.
+
+    Deliberately domain-blind, and that is not the #2054 mistake. ``LSID`` is
+    ``accounts.google.com``-scoped and never routes to the app host, while
+    ``OSID`` is app-host-scoped — the binding spans hosts because the auth flow
+    does (app-host GET, redirect through accounts, back). A check restricted to
+    what routes to the *target* URL would reject working profiles. Host-aware,
+    were it ever needed, would mean "``OSID`` routable to the app host, or the
+    XSSI pair routable there plus ``LSID`` present for the accounts hop" — not a
+    single routed header.
+    """
+    if "OSID" in cookie_names:
+        return True
+    return {"APISID", "SAPISID", "LSID"} <= cookie_names
+
+
+def _has_rotatable_secondary_binding(cookie_names: set[str]) -> bool:
+    """Whether a ``RotateCookies`` attempt is worth making — deliberately weaker.
+
+    This is **not** :func:`_has_valid_secondary_binding` and must not be
+    collapsed into it. That one answers "will the homepage GET succeed with
+    these cookies *as they stand*". This one answers "is this set intact enough
+    that rotating ``__Secure-1PSIDTS`` could plausibly produce a working
+    session" — a precondition for attempting recovery, not for succeeding.
+
+    The difference is the ``LSID`` conjunct. Rotation POSTs to
+    ``accounts.google.com``; whether that hop can itself re-establish the
+    accounts-side session (and so supply the missing ``LSID``) has not been
+    ablated. Requiring the *post*-recovery condition before *attempting*
+    recovery would gate off the rotation that might satisfy it — checking the
+    destination as a precondition for the journey. That is the failure shape of
+    #2061, where an over-strict heal check never converged.
+
+    So this keeps the pre-#1977 rule until someone ablates the rotation hop. Its
+    cost when wrong is one wasted POST; the strict version's cost when wrong is
+    a recoverable session left unrecovered.
     """
     if "OSID" in cookie_names:
         return True
@@ -127,8 +187,9 @@ def _validate_required_cookies(
         if not _SECONDARY_BINDING_WARNED:
             _SECONDARY_BINDING_WARNED = True
             logger.warning(
-                "Cookie set lacks a secondary binding (need OSID, or both APISID "
-                "and SAPISID). Google may reject auth on the next call. %s",
+                "Cookie set lacks a secondary binding (need OSID, or all three of "
+                "APISID, SAPISID and LSID). Google may reject auth on the next "
+                "call. %s",
                 _EXTRACTION_HINT,
             )
 

--- a/src/notebooklm/_auth/master_token.py
+++ b/src/notebooklm/_auth/master_token.py
@@ -43,6 +43,11 @@ _MASTER_APP = "com.google.android.apps.chromecast.app"
 _MASTER_SIG = "24bb24c05e47e0aefa68a58a766179d9b613a600"
 _OAUTHLOGIN_SERVICE = "oauth2:https://www.google.com/accounts/OAuthLogin"
 
+# Aligned with ``_has_rotatable_secondary_binding``, NOT the strict
+# ``_has_valid_secondary_binding``: this set feeds ``_recover_psidts_inline``, so
+# it answers "is a rotation worth attempting", which is the permissive question.
+# It is therefore *not* stale relative to the ``LSID`` conjunct added in #1977 —
+# do not "fix" it by adding LSID here.
 # MergeSession requires SID + a secondary binding (APISID+SAPISID or OSID) so the
 # client's _recover_psidts_inline can mint __Secure-1PSIDTS on first load.
 _REQUIRED_MINTED_COOKIES = {"SID", "APISID", "SAPISID"}

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -60,7 +60,7 @@ from . import storage as _auth_storage
 # Tests must patch these aliases at this module's path, not at the
 # canonical owner's path, because aliases are import-time bound.
 # ----------------------------------------------------------------------------
-_has_valid_secondary_binding = _cookie_policy._has_valid_secondary_binding
+_has_rotatable_secondary_binding = _cookie_policy._has_rotatable_secondary_binding
 _is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
 _rotation_lock_path = _keepalive._rotation_lock_path
 _file_lock_try_exclusive = _keepalive._file_lock_try_exclusive
@@ -496,7 +496,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         return False
     if _psidts_routes_to_rotate(cookie_entries, to_cookie=_storage_entry_to_cookie):
         return False
-    if not _has_valid_secondary_binding(cookie_names):
+    if not _has_rotatable_secondary_binding(cookie_names):
         logger.debug(
             "PSIDTS recovery skipped: secondary binding incomplete "
             "(need OSID, or both APISID and SAPISID)"
@@ -553,7 +553,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         if "SID" not in fresh_names:
             logger.debug("PSIDTS recovery skipped: SID missing after flock acquisition")
             return False
-        if not _has_valid_secondary_binding(fresh_names):
+        if not _has_rotatable_secondary_binding(fresh_names):
             logger.debug(
                 "PSIDTS recovery skipped: secondary binding incomplete after flock acquisition"
             )
@@ -817,7 +817,7 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         return False
     if _psidts_routes_to_rotate(rookiepy_cookies, to_cookie=_rookiepy_entry_to_cookie):
         return False
-    if not _has_valid_secondary_binding(cookie_names):
+    if not _has_rotatable_secondary_binding(cookie_names):
         logger.debug(
             "In-memory PSIDTS recovery skipped: secondary binding incomplete "
             "(need OSID, or both APISID and SAPISID)"

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -878,8 +878,9 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         path = entry.get("path")
         index_by_identity[(name, domain, (path if isinstance(path, str) else "") or "/")] = pos
 
-    # ``LSID`` rides along: it is half of the secondary binding when ``OSID`` is
-    # absent (#1977), and this path allows the POST on ``APISID``+``SAPISID``
+    # ``LSID`` rides along: when ``OSID`` is absent the fallback binding needs
+    # all three of ``APISID``, ``SAPISID`` and ``LSID`` (#1977) — ``LSID`` is one
+    # of the three, not half of a pair. This path allows the POST on ``APISID``+``SAPISID``
     # alone — so a rotation that *supplies* the missing ``LSID`` is exactly the
     # case worth keeping. Dropping it here would discard the cookie that makes
     # the set usable. The file-backed ``_attempt_rotation`` already persists the

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -142,7 +142,7 @@ def _recovery_cookie_names(entries: list[dict[str, Any]]) -> set[str]:
     """Return the cookie NAMES present on an allowed auth domain.
 
     Feeds the two name-presence preconditions — ``SID`` present, and
-    :func:`_has_valid_secondary_binding` — which are deliberately domain-blind
+    :func:`_has_rotatable_secondary_binding` — which are deliberately domain-blind
     and expiry-blind, because that is exactly what the preflight they front
     (:func:`notebooklm._auth.cookie_policy._validate_required_cookies`) checks.
 
@@ -447,7 +447,10 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
        :func:`_psidts_routes_to_rotate`).
     3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``). Google
        rejects ``RotateCookies`` requests that lack these — see
-       :func:`notebooklm._auth.cookie_policy._has_valid_secondary_binding`.
+       :func:`notebooklm._auth.cookie_policy._has_rotatable_secondary_binding`
+       (rotation eligibility — deliberately weaker than the strict
+       :func:`~notebooklm._auth.cookie_policy._has_valid_secondary_binding`
+       session-validity rule).
     4. Cross-process rotation flock available
        (:func:`notebooklm._auth.keepalive._file_lock_try_exclusive` against
        :func:`notebooklm._auth.keepalive._rotation_lock_path`). Mirrors
@@ -875,8 +878,14 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
         path = entry.get("path")
         index_by_identity[(name, domain, (path if isinstance(path, str) else "") or "/")] = pos
 
+    # ``LSID`` rides along: it is half of the secondary binding when ``OSID`` is
+    # absent (#1977), and this path allows the POST on ``APISID``+``SAPISID``
+    # alone — so a rotation that *supplies* the missing ``LSID`` is exactly the
+    # case worth keeping. Dropping it here would discard the cookie that makes
+    # the set usable. The file-backed ``_attempt_rotation`` already persists the
+    # whole rotated jar and so never had this gap.
     for cookie in rotated_cookies:
-        if cookie.name not in {_PSIDTS_COOKIE, "__Secure-3PSIDTS"}:
+        if cookie.name not in {_PSIDTS_COOKIE, "__Secure-3PSIDTS", "LSID"}:
             continue
         if not cookie.value or not cookie.domain:
             continue

--- a/src/notebooklm/cli/_cookie_import.py
+++ b/src/notebooklm/cli/_cookie_import.py
@@ -197,7 +197,10 @@ def _import_cookie_json(
     # are present-but-empty can pass required-cookie validation yet be unusable.
     # Reject that specific false-"ok". Like the login flow (which only warns), we
     # stay silent when no secondary-binding cookie is present at all.
-    secondary_present = {"OSID", "APISID", "SAPISID"} & set(cookie_names)
+    # ``LSID`` is in the set: without it an LSID-only import has an empty
+    # ``secondary_present``, skips the check entirely, and persists a state the
+    # canonical rule rejects. It also belongs in the ``Present:`` diagnostic.
+    secondary_present = {"OSID", "APISID", "SAPISID", "LSID"} & set(cookie_names)
     if secondary_present and not _has_usable_secondary_binding(filtered_state):
         raise click.ClickException(  # cli-input-validation: import-cookies secondary-binding validation
             "Secondary-binding cookies are present but do not form a usable "

--- a/src/notebooklm/cli/_cookie_import.py
+++ b/src/notebooklm/cli/_cookie_import.py
@@ -118,13 +118,20 @@ def _nonempty_cookie_names(filtered_state: dict[str, Any]) -> set[str]:
 def _has_usable_secondary_binding(filtered_state: dict[str, Any]) -> bool:
     """Whether ``filtered_state`` carries a non-empty secondary auth binding.
 
-    Mirrors the name-level check in ``_auth.cookie_policy`` (``OSID``, or both
-    ``APISID`` and ``SAPISID``) but at the **value** level — that check counts a
-    present-but-empty cookie as satisfying the binding, which import-cookies must
-    not accept as a usable login.
+    Restates the canonical rule from ``_auth.cookie_policy`` at the **value**
+    level: that check counts a present-but-empty cookie as satisfying the
+    binding, which import-cookies must not accept as a usable login.
+
+    This is a deliberate copy, not an oversight. ``cli/`` may not import
+    ``_private`` names out of public modules (``tests/_guardrails/
+    test_cli_boundary.py``), and promoting an auth-policy predicate to the
+    public surface is a bigger decision than this needs. The copy drifted once
+    already — it kept the pre-``LSID`` rule when the canonical one gained its
+    conjunct (#1977) — so ``test_cli_binding_rule_matches_cookie_policy`` pins
+    the two together and fails if they diverge again.
     """
     nonempty = _nonempty_cookie_names(filtered_state)
-    return "OSID" in nonempty or {"APISID", "SAPISID"} <= nonempty
+    return "OSID" in nonempty or {"APISID", "SAPISID", "LSID"} <= nonempty
 
 
 def _backup_existing_storage(storage_path: Path) -> Path | None:
@@ -193,9 +200,10 @@ def _import_cookie_json(
     secondary_present = {"OSID", "APISID", "SAPISID"} & set(cookie_names)
     if secondary_present and not _has_usable_secondary_binding(filtered_state):
         raise click.ClickException(  # cli-input-validation: import-cookies secondary-binding validation
-            "Secondary-binding cookies are present but have empty values "
-            "(need a non-empty OSID, or non-empty APISID and SAPISID): "
-            + ", ".join(sorted(secondary_present))
+            "Secondary-binding cookies are present but do not form a usable "
+            "binding — either their values are empty or the set is incomplete "
+            "(need a non-empty OSID, or all of APISID, SAPISID and LSID). "
+            "Present: " + ", ".join(sorted(secondary_present))
         )
 
     storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -37,6 +37,9 @@ def _valid_cookie_export(extra_cookies=None):
         },
         {"name": "APISID", "value": "fixture-apisid", "domain": ".google.com", "path": "/"},
         {"name": "SAPISID", "value": "fixture-sapisid", "domain": ".google.com", "path": "/"},
+        # LSID completes the secondary binding: APISID+SAPISID alone is not a
+        # usable set without OSID (#1977).
+        {"name": "LSID", "value": "fixture-lsid", "domain": "accounts.google.com", "path": "/"},
     ]
     if extra_cookies:
         cookies.extend(extra_cookies)
@@ -73,7 +76,7 @@ class TestAuthImportCookiesCommand:
         assert "imported" in result.output
         stored = json.loads(storage_path.read_text(encoding="utf-8"))
         stored_names = {cookie["name"] for cookie in stored["cookies"]}
-        assert {"SID", "__Secure-1PSIDTS", "APISID", "SAPISID"} <= stored_names
+        assert {"SID", "__Secure-1PSIDTS", "APISID", "SAPISID", "LSID"} <= stored_names
         assert "UNRELATED" not in stored_names
 
     def test_import_cookies_accepts_playwright_storage_state_from_stdin(self, runner, tmp_path):
@@ -89,7 +92,8 @@ class TestAuthImportCookiesCommand:
         assert result.exit_code == 0, result.output
         output = json.loads(result.output)
         assert output["success"] is True
-        assert output["cookie_count"] == 4
+        # 5, not 4: the shared fixture gained LSID to form a usable binding (#1977).
+        assert output["cookie_count"] == 5
         assert json.loads(storage_path.read_text(encoding="utf-8"))["cookies"]
 
     def test_import_cookies_drops_origins_from_playwright_storage_state(self, runner, tmp_path):
@@ -355,7 +359,8 @@ class TestAuthImportCookiesCommand:
         )
 
         assert result.exit_code != 0
-        assert "present but have empty values" in result.output
+        assert "do not form a usable binding" in result.output
+        assert "their values are empty" in result.output
         assert "OSID" in result.output
         assert not storage_path.exists()
 
@@ -2420,3 +2425,33 @@ class TestAuthInspect:
         assert data["accounts"][0]["email"] == "alice@example.com"
         assert "authuser" not in data["accounts"][0]
         assert data["accounts"][0]["is_default"] is True
+
+
+def test_cli_binding_rule_matches_cookie_policy() -> None:
+    """``cli/_cookie_import`` must not drift from the canonical binding rule.
+
+    The CLI keeps its own copy because ``tests/_guardrails/test_cli_boundary.py``
+    forbids importing ``_private`` names out of public modules. That copy already
+    drifted once: it kept ``OSID or APISID+SAPISID`` after the canonical rule
+    gained its ``LSID`` conjunct (#1977), so ``import-cookies`` would have
+    accepted a set the client cannot authenticate with.
+
+    Exhaustive over the four cookies the rule mentions, so a change to either
+    side that the other does not mirror fails here rather than in the field.
+    """
+    from itertools import combinations
+
+    from notebooklm._auth.cookie_policy import _has_valid_secondary_binding
+    from notebooklm.cli._cookie_import import _has_usable_secondary_binding
+
+    names = ("OSID", "APISID", "SAPISID", "LSID")
+    for r in range(len(names) + 1):
+        for combo in combinations(names, r):
+            state = {
+                "cookies": [
+                    {"name": n, "value": "v", "domain": ".google.com", "path": "/"} for n in combo
+                ]
+            }
+            assert _has_usable_secondary_binding(state) == _has_valid_secondary_binding(
+                set(combo)
+            ), f"CLI and cookie_policy disagree for {combo!r}"

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -335,6 +335,48 @@ class TestAuthImportCookiesCommand:
         secure_cookie = next(c for c in stored["cookies"] if c["name"] == "__Secure-1PSIDTS")
         assert secure_cookie["secure"] is True
 
+    def test_import_cookies_rejects_lsid_only_binding(self, runner, tmp_path):
+        """An ``LSID``-only set must be rejected, not silently persisted.
+
+        Guards the *call site*, not the predicate. ``secondary_present`` decides
+        whether ``_has_usable_secondary_binding`` is consulted at all, so while
+        ``LSID`` was missing from that set an ``LSID``-only import produced an
+        empty ``secondary_present``, skipped the guard entirely, and wrote a
+        state the canonical rule rejects.
+
+        ``test_cli_binding_rule_matches_cookie_policy`` cannot catch this: it
+        pins the two predicates to each other but never exercises the gate that
+        chooses whether to call one.
+        """
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        cookies = [
+            {"name": "SID", "value": "fixture-sid", "domain": ".google.com", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "fixture-psidts",
+                "domain": ".google.com",
+                "path": "/",
+            },
+            # No OSID and no APISID/SAPISID: LSID alone is not a binding.
+            {
+                "name": "LSID",
+                "value": "fixture-lsid",
+                "domain": "accounts.google.com",
+                "path": "/",
+            },
+        ]
+        input_path.write_text(json.dumps(cookies), encoding="utf-8")
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "do not form a usable binding" in result.output
+        assert "LSID" in result.output
+        assert not storage_path.exists()
+
     def test_import_cookies_rejects_present_but_empty_secondary_binding(self, runner, tmp_path):
         input_path = tmp_path / "cookies.json"
         storage_path = tmp_path / "storage_state.json"

--- a/tests/unit/cli/test_login_cookie_recovery.py
+++ b/tests/unit/cli/test_login_cookie_recovery.py
@@ -113,6 +113,18 @@ _RECOVERABLE_BROWSER_COOKIES = [
         "secure": True,
         "http_only": True,
     },
+    # LSID completes the secondary binding (#1977). Without it this set has no
+    # valid binding, so ``missing_cookies_hint`` takes the "sign in again" branch
+    # instead of the RotateCookies-recovery one these tests assert on. PSIDTS
+    # recovery itself still fires either way — that gate is deliberately weaker.
+    {
+        "domain": "accounts.google.com",
+        "name": "LSID",
+        "value": "browser_lsid",
+        "path": "/",
+        "secure": True,
+        "http_only": True,
+    },
 ]
 
 

--- a/tests/unit/test_auth_cookie_policy.py
+++ b/tests/unit/test_auth_cookie_policy.py
@@ -1490,3 +1490,24 @@ class TestSecondaryBindingRequiresLsidWithoutOsid:
     def test_lsid_alone_is_not_sufficient(self) -> None:
         """Without ``OSID`` *or* the XSSI pair, ``LSID`` on its own does not bind."""
         assert not _has_valid_secondary_binding({"LSID"})
+
+
+class TestBindingDiagnosticsNameLsid:
+    """Every strict-binding diagnostic must name ``LSID`` (#1977 review).
+
+    The predicate and the messages drifted apart once already: the rule gained
+    its ``LSID`` conjunct while the hints still told users ``APISID``+``SAPISID``
+    was enough, which is advice that walks them back into the same failure.
+    """
+
+    def test_missing_binding_hint_names_lsid(self) -> None:
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint({"SID", "__Secure-1PSIDTS"}, browser_label="chrome")
+        assert "LSID" in hint
+
+    def test_missing_binding_and_psidts_hint_names_lsid(self) -> None:
+        from notebooklm._auth.cookie_policy import missing_cookies_hint
+
+        hint = missing_cookies_hint({"SID"}, browser_label="chrome")
+        assert "LSID" in hint

--- a/tests/unit/test_auth_cookie_policy.py
+++ b/tests/unit/test_auth_cookie_policy.py
@@ -12,6 +12,7 @@ from typing import Any
 import httpx
 import pytest
 
+from notebooklm._auth.cookie_policy import _has_valid_secondary_binding
 from notebooklm._auth.cookies import load_httpx_cookies
 from notebooklm._auth.storage import save_cookies_to_storage, snapshot_cookie_jar
 from notebooklm.auth import (
@@ -1453,3 +1454,39 @@ class TestAllowedCookieDomains:
 # =============================================================================
 # REGIONAL GOOGLE DOMAIN TESTS (Issue #20 fix)
 # =============================================================================
+
+
+class TestSecondaryBindingRequiresLsidWithoutOsid:
+    """The XSSI branch also needs bare ``LSID`` (#1977).
+
+    Three-way ablation on two unrelated live accounts, 2026-08-04. The original
+    pair-wise ablation only varied ``OSID`` and the ``APISID``/``SAPISID`` pair;
+    those two are ``.google.com``-scoped so they survived every domain filter,
+    which left the XSSI branch never tested without them and hid the ``LSID``
+    dependency.
+    """
+
+    def test_osid_alone_is_sufficient(self) -> None:
+        """Row 1: verified with every accounts.google.com cookie stripped."""
+        assert _has_valid_secondary_binding({"OSID"})
+
+    def test_osid_wins_without_lsid(self) -> None:
+        """``LSID`` is required only when ``OSID`` is absent, never alongside it."""
+        assert _has_valid_secondary_binding({"OSID", "APISID", "SAPISID"})
+
+    def test_xssi_pair_with_lsid_is_sufficient(self) -> None:
+        assert _has_valid_secondary_binding({"APISID", "SAPISID", "LSID"})
+
+    def test_xssi_pair_without_lsid_is_rejected(self) -> None:
+        """The row this predicate used to get wrong: reported valid, failed live."""
+        assert not _has_valid_secondary_binding({"APISID", "SAPISID"})
+
+    def test_host_prefixed_lsid_does_not_substitute(self) -> None:
+        """``__Host-1PLSID``/``__Host-3PLSID`` are not interchangeable with bare ``LSID``."""
+        assert not _has_valid_secondary_binding(
+            {"APISID", "SAPISID", "__Host-1PLSID", "__Host-3PLSID"}
+        )
+
+    def test_lsid_alone_is_not_sufficient(self) -> None:
+        """Without ``OSID`` *or* the XSSI pair, ``LSID`` on its own does not bind."""
+        assert not _has_valid_secondary_binding({"LSID"})

--- a/tests/unit/test_auth_host_guidance.py
+++ b/tests/unit/test_auth_host_guidance.py
@@ -31,7 +31,9 @@ from notebooklm._env import ENTERPRISE_BASE_HOST, PERSONAL_APP_ALIAS_HOST, PERSO
 
 # Cookie sets that steer ``missing_cookies_hint`` into each branch.
 _BINDING_MISSING = {"SID", "__Secure-1PSIDTS"}
-_PSIDTS_MISSING = {"SID", "APISID", "SAPISID"}
+# LSID included so the secondary binding is *complete* (#1977) and this set
+# reaches the psidts-only branch rather than the "no binding either" one.
+_PSIDTS_MISSING = {"SID", "APISID", "SAPISID", "LSID"}
 _EVERYTHING_MISSING = {"SID"}
 
 

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -1540,7 +1540,9 @@ class TestMissingCookiesHint:
     def test_missing_psidts_with_binding_suggests_rotation_or_visit(self):
         from notebooklm._auth.cookie_policy import missing_cookies_hint
 
-        hint = missing_cookies_hint({"SID", "APISID", "SAPISID"}, browser_label="firefox")
+        # LSID completes the binding (#1977); without it this set has no valid
+        # secondary binding at all and takes the other branch.
+        hint = missing_cookies_hint({"SID", "APISID", "SAPISID", "LSID"}, browser_label="firefox")
         assert "__Secure-1PSIDTS" in hint
         assert "RotateCookies recovery" in hint
         assert "firefox" in hint

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -1237,6 +1237,33 @@ class TestInMemoryRecovery:
     """
 
     @pytest.mark.no_default_keepalive_mock
+    def test_rotation_keeps_a_returned_lsid(self, httpx_mock: HTTPXMock):
+        """A rotated ``LSID`` must survive the write-back (#1977 review).
+
+        This path allows the POST on ``APISID``+``SAPISID`` alone, so a rotation
+        that *supplies* the missing ``LSID`` is exactly the case worth keeping —
+        without it the set still has no valid secondary binding and the recovery
+        accomplished nothing. The write-back previously kept only the two PSIDTS
+        names and dropped it silently.
+        """
+        response = _make_psidts_response()
+        response["headers"] = list(response["headers"]) + [
+            (
+                "Set-Cookie",
+                "LSID=fresh_lsid_value; Domain=accounts.google.com; "
+                "Path=/; Secure; HttpOnly; SameSite=Lax",
+            )
+        ]
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **response)
+
+        cookies = _rookiepy_recoverable()
+        assert psidts_recovery.recover_psidts_in_memory(cookies) is True
+
+        lsid = [c for c in cookies if c["name"] == "LSID"]
+        assert lsid, "a rotated LSID must be written back into the in-memory list"
+        assert lsid[0]["value"] == "fresh_lsid_value"
+
+    @pytest.mark.no_default_keepalive_mock
     def test_recovers_psidts_and_mutates_list_in_place(self, httpx_mock: HTTPXMock):
         cookies = _rookiepy_recoverable()
         httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())


### PR DESCRIPTION
## Summary

`_has_valid_secondary_binding` accepted `APISID`+`SAPISID` alone. That set does
not authenticate — the homepage GET 302s to `accounts.google.com` unless bare
`LSID` is also present. The check reported healthy auth for profiles that then
failed on the wire, which is the #2038 class of bug: a confident answer about a
condition it was not actually testing.

Fixes the rule and splits it by purpose. Closes the open item from #1977; also
relevant to #2067, which listed this as a prerequisite for any base-host flip.

## Evidence

Three-way ablation, **replicated on two unrelated live accounts** (2026-08-04).
Synthetic profiles carried no `master_token.json`, so no recovery layer could
mask a result.

| `OSID` | `APISID`+`SAPISID` | bare `LSID` | old check | reality |
|---|---|---|---|---|
| ✓ | — | — | valid | works |
| ✓ | ✓ | — | valid | works |
| — | ✓ | ✓ | valid | works |
| — | ✓ | — | valid | **fails** |
| — | — | ✓ | invalid | fails |

Row 4 is the defect. Two things worth keeping straight:

- **`OSID` alone is sufficient.** A profile with no `LSID` anywhere authenticates
  (row 1, verified with every `accounts.google.com` cookie stripped). `LSID` is
  required *only* when `OSID` is absent.
- **`__Host-1PLSID` / `__Host-3PLSID` do not substitute** for bare `LSID` — row 4
  retains them and still fails.

### Why this was missed originally

The original ablation varied `OSID` and the XSSI pair only. Both are
`.google.com`-scoped, so they survived every domain filter — the XSSI branch was
never exercised *without* them, and the `LSID` dependency stayed invisible. My
own first pass at this reached the opposite wrong conclusion ("`LSID` is the
gate") for the same reason, and is corrected in #1977.

## The split, and why not just tighten it

Applying the strict rule everywhere broke ~280 tests — all of them
`RotateCookies` **not being called**, because the gates in `psidts_recovery.py`
skipped recovery for exactly the sets that need it.

That is the wrong question at that call site. Recovery asks *"is a rotation
attempt worth making"*, not *"will this succeed as-is"*. Whether the rotation hop
can itself re-establish the accounts-side session and supply the missing `LSID`
has not been ablated — so requiring the post-recovery condition as a
precondition for attempting recovery gates off the thing that might satisfy it.
That is the non-convergent shape of #2061.

So:

| Predicate | Question | Used by |
|---|---|---|
| `_has_valid_secondary_binding` (strict) | will the homepage GET succeed as-is? | Tier-2 warning, user-facing hints, `import-cookies` validation |
| `_has_rotatable_secondary_binding` (prior rule) | is a rotation attempt worth making? | the three PSIDTS recovery gates |

Cost of the permissive gate being wrong is one wasted POST. Cost of the strict
gate being wrong there is a recoverable session left unrecovered.

## Deliberately domain-blind

Not the #2054 mistake, and worth stating because the obvious next suggestion is
to route it. `LSID` is `accounts.google.com`-scoped and never reaches the app
host; `OSID` is app-host-scoped. The binding spans hosts because the auth flow
does — app-host GET, redirect through accounts, back. A check limited to the
routed header for the target URL would reject working profiles. If it ever needs
to be host-*aware*, that means "`OSID` routable to the app host, **or** the XSSI
pair routable there plus `LSID` present for the accounts hop" — not one routed
header.

## Drift guard

`cli/_cookie_import.py` keeps its own value-level copy, because
`tests/_guardrails/test_cli_boundary.py` forbids importing `_private` names into
`cli/` and promoting an auth predicate to the public surface is a bigger decision
than this warrants. That copy had already drifted — it kept the pre-`LSID` rule
— so `test_cli_binding_rule_matches_cookie_policy` now pins the two exhaustively
over all 16 subsets of the four cookies and fails if they diverge again.

## Testing

`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`:

- `tests/unit` + `tests/server` + `tests/_guardrails` — **12118 passed**, 0 failed
- `tests/integration` — **860 passed**, 0 failed
- ruff, ruff-format, mypy (323 files), `audit_public_api_compat --check-stale` — clean

Fixture updates are behavioural, not cosmetic: sets that previously stood in for
"has a binding" genuinely did not have one, so they now carry `LSID`.

## Caveats

- Two accounts on one machine and IP. Google's behaviour may be cohort-dependent.
- Ablated against the homepage token fetch. Whether `RotateCookies` can supply a
  missing `LSID` is untested — that is precisely why the recovery gate stays
  permissive.
- Left `_auth/master_token.py`'s statement of the rule alone: it describes
  Google's **MergeSession** endpoint, a different API I have no evidence for.

Refs #1977, #2067. Related: #2054/#2058, #2057/#2059, #2068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udm7maQPJeGPXnHr6cG9By


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie validation to recognize complete secondary authentication bindings, including the required LSID cookie.
  * Refined cookie recovery checks to distinguish valid sessions from those eligible for rotation.
  * Preserved rotated cookies during in-memory recovery.
  * Updated import and recovery diagnostics with clearer guidance for incomplete cookie combinations.

* **Tests**
  * Added comprehensive coverage for cookie-binding combinations, validation rules, and recovery scenarios.
  * Updated browser-cookie fixtures to include the required binding information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->