### PR TITLE
Post-flip host references: e2e instructions and src docstrings that still name the legacy host

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,6 +14,8 @@ from urllib.parse import urlsplit
 
 import pytest
 
+from notebooklm._env import get_base_url
+
 if TYPE_CHECKING:
     from notebooklm.client import NotebookLMClient
 
@@ -663,7 +665,7 @@ def read_only_notebook_id():
             "\n\nERROR: NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID environment variable is not set.\n\n"
             "E2E tests require YOUR OWN test notebook with content.\n\n"
             "Setup instructions:\n"
-            "  1. Create a notebook at https://notebooklm.google.com\n"
+            f"  1. Create a notebook at {get_base_url()}\n"
             "  2. Add sources (text, URL, PDF, etc.)\n"
             "  3. Generate some artifacts (audio, quiz, etc.)\n"
             "  4. Copy notebook ID from URL and run:\n"

--- a/tests/e2e/test_notes.py
+++ b/tests/e2e/test_notes.py
@@ -3,6 +3,7 @@
 import pytest
 
 from notebooklm import NoteNotFoundError
+from notebooklm._env import get_base_url
 
 from .conftest import requires_auth
 
@@ -157,7 +158,7 @@ class TestSaveAnswerAsNote:
 
             print(
                 f"\n[Manual hover-anchor check] Open "
-                f"https://notebooklm.google.com/notebook/{temp_notebook.id}, "
+                f"{get_base_url()}/notebook/{temp_notebook.id}, "
                 f"find note '{note.title}' (id={note.id[:8]}...), hover any "
                 f"[N] marker, confirm the popup shows the cited passage."
             )


### PR DESCRIPTION
Follow-up to #2072 (the `notebook.google.com` default-host flip). Two commits, no behaviour change — but both fix text that tells a reader something false.

## 1. E2E instructions aimed a human at the wrong host (`e084e229`)

The Nightly run on `36221e0d` printed:

```
[Manual hover-anchor check] Open https://notebooklm.google.com/notebook/0130cff0-...
```

- `tests/e2e/test_notes.py` asked a human to verify hover anchors **on a host the client under test is not using**.
- `tests/e2e/conftest.py` told a new contributor to create their fixture notebook at the legacy host, then the suite looks on the default one.

These are the only strings in the suite a person is asked to *act on*, so a stale host misleads more than a stale literal in an assertion would. Both now derive from `get_base_url()`.

## 2. Full `src/` sweep — docstrings still naming the legacy host as current (`d35e7365`)

The centralization guardrail only covers **executable code**; it deliberately skips docstrings and comments. So the flip left prose asserting things that are now false. Nine files.

**Outright wrong:**

- `_auth/account.py` documented probing `https://notebooklm.google.com/?authuser=N` while the code has used `get_base_url()` since well before the flip — the docstring named a host the function does not request.
- `_auth/cookie_policy.py` called the legacy host *"the API host — all CLI RPCs land here"* and demoted the rebrand host to a parenthetical. Inverted: RPCs land on the default. Both bullets rewritten so each names its real role and both stay visibly required.

**Named a concrete host where they meant "wherever the client is pointed":** keepalive's rotation note, `session_cmd`'s keepalive description, `browser_capture`'s streaming-SPA comments, `extraction`'s page-source docstrings, `_url_utils`'s region-gate comments. Now "the app host" / "the configured base URL" — they cannot go stale on the next move, which is the actual lesson.

**Two subtler ones:** `_auth/cookies.py` gave the duplicate-resolution ranking as a chain naming only the legacy host, reading as though it outranks the default (both share a tier at each level); and `login_wait_trace`'s illustrative *"waiting for X, landed on Y"* example pointed backwards post-flip.

## Deliberately NOT changed — each verified individually

- `_env.py` `PERSONAL_LEGACY_HOST` — the role constant itself.
- `_source/_upload_decode.py` — Scotty genuinely returns **legacy-host** upload URLs post-rebrand (all 6 recorded `upload_id=` hosts are legacy). Retargeting would model something that does not happen.
- `_auth/extraction.py`'s ServiceLogin trace — a verbatim live capture from 2026-08-03, quoted as captured.
- `_url_utils.py`'s `notebooklm.google` vs `notebooklm.google.com` suffix distinction, and every cookie-tier table naming both hosts — all still true.

## Verification

- `ruff check` + `format --check` clean; `mypy` clean (325 files)
- unit + guardrails + integration: **12,756 passed**, 64 skipped, 1 xfailed
- `tests/e2e` collects clean (225)

**Note for reviewers on 4 local-only guardrail failures.** `test_docs_module_refs`, `test_type_boundaries` and `test_adr_reference_format` scan the real filesystem and pick up files CI never sees — untracked scratch under `docs/notes/` and `docs/plans/`, and gitignored `.sisyphus/` planning files. Verified unrelated: with the untracked docs stashed the first three pass, and the ADR one reports only `.sisyphus/` paths (gitignored, so `stash -u` does not touch them).