### PR TITLE
test(e2e): assert live traffic reaches the configured app host

### DIFF
--- a/tests/e2e/test_app_host.py
+++ b/tests/e2e/test_app_host.py
@@ -34,12 +34,18 @@ import httpx
 import pytest
 
 from notebooklm._env import PERSONAL_BASE_HOST, get_base_url
+from notebooklm._runtime.init import _resolve_async_client_factory
 
 from .conftest import requires_auth
 
 #: Google's cookie-rotation endpoint. Not app traffic, and legitimately a
 #: different host — ``RotateCookies`` is accounts-scoped by construction.
 _ACCOUNTS_HOST = "accounts.google.com"
+
+#: Path prefix of the data plane: batchexecute and streamed chat both live under
+#: it. This is the traffic "are we hitting the right host?" is really about, and
+#: the traffic for which a redirect is unambiguously wrong.
+_DATA_PLANE_PREFIX = "/_/"
 
 
 class _RequestLog:
@@ -52,33 +58,68 @@ class _RequestLog:
         """Entries excluding the accounts-scoped cookie rotation."""
         return [e for e in self.entries if e[0] != _ACCOUNTS_HOST]
 
+    def data_plane_entries(self) -> list[tuple[str, str, int, str | None]]:
+        """App entries for batchexecute / streamed chat only.
+
+        Forward-looking, not currently load-bearing: the e2e ``client`` fixture
+        is built from pre-loaded ``AuthTokens``, so ``notebooks.list()`` issues
+        exactly one request today — the batchexecute POST — and this filter
+        removes nothing (measured 2026-08-04).
+
+        It exists because the session-bootstrapping paths *do* issue a landing
+        ``GET /``, and pointed at the legacy host via the documented rollback
+        lever that request legitimately 302s to the rebrand host while the data
+        plane keeps serving on the configured host. Should the fixture ever grow
+        such a request, asserting over it would report a working rollback as a
+        failure. Scoping now costs nothing and removes that trap.
+        """
+        return [e for e in self.app_entries() if e[1].startswith(_DATA_PLANE_PREFIX)]
+
     def hosts(self) -> set[str]:
         return {e[0] for e in self.entries}
 
 
 @pytest.fixture
 def request_log(monkeypatch: pytest.MonkeyPatch) -> _RequestLog:
-    """Record every HTTP request the client under test issues.
+    """Record every HTTP request the client under test issues, hops included.
 
     Wraps ``httpx.AsyncClient.send`` rather than injecting a client factory:
     ``async_client_factory`` is deliberately kept off the public constructor
     (see ``client.py``), and routing this test around that constructor would
     stop it testing the thing it exists to test. Wrapping the transport instead
     observes whatever the shipped construction path actually built.
+
+    Skips when the resolved transport is not ``httpx.AsyncClient``. Under
+    ``NOTEBOOKLM_TRANSPORT=curl_cffi`` the client is a ``CurlCffiAsyncClient``,
+    which exposes ``get``/``post``/``stream`` and no ``send`` at all — this
+    wrapper would silently record nothing and the assertions would fail with an
+    empty log despite perfectly good live traffic. The resolver is the library's
+    own, so this check cannot drift from what the client actually builds.
     """
+    if _resolve_async_client_factory(None) is not httpx.AsyncClient:
+        pytest.skip("resolved transport is not httpx.AsyncClient (NOTEBOOKLM_TRANSPORT is set)")
+
     log = _RequestLog()
     original = httpx.AsyncClient.send
 
     async def recording_send(self: httpx.AsyncClient, request: httpx.Request, **kwargs: object):
         response = await original(self, request, **kwargs)
-        log.entries.append(
-            (
-                request.url.host,
-                request.url.path,
-                response.status_code,
-                response.headers.get("location"),
+        # ``Kernel.open`` builds its client with ``follow_redirects=True``
+        # (``_kernel.py``), so ``send`` returns the TERMINAL response and the
+        # 3xx hops survive only in ``response.history`` — while ``request`` is
+        # the FIRST request, not the last. Recording that pair alone would log a
+        # bounce off the configured host as ``(configured host, 200)``, leaving
+        # this test blind to precisely the state it exists to catch. Walking
+        # ``history`` and reading each hop's own ``request`` fixes both halves.
+        for hop in (*response.history, response):
+            log.entries.append(
+                (
+                    hop.request.url.host,
+                    hop.request.url.path,
+                    hop.status_code,
+                    hop.headers.get("location"),
+                )
             )
-        )
         return response
 
     monkeypatch.setattr(httpx.AsyncClient, "send", recording_send)
@@ -108,25 +149,34 @@ class TestAppHost:
         await client.notebooks.list()
 
         expected = httpx.URL(get_base_url()).host
-        app = request_log.app_entries()
-        assert app, "no app requests were observed — the recording fixture did not engage"
+        data_plane = request_log.data_plane_entries()
+        assert data_plane, (
+            "no data-plane requests were observed — the recording fixture did not "
+            f"engage; entries seen: {request_log.entries}"
+        )
 
-        wrong_host = [e for e in app if e[0] != expected]
+        wrong_host = [e for e in data_plane if e[0] != expected]
         assert not wrong_host, f"requests left the configured host {expected}: {wrong_host}"
 
-        redirected = [e for e in app if 300 <= e[2] < 400]
+        redirected = [e for e in data_plane if 300 <= e[2] < 400]
         assert not redirected, (
             f"the app host answered with a redirect, so the client is aimed at the "
             f"wrong host and is being bounced: {redirected}"
         )
 
-        assert any("batchexecute" in e[1] for e in app), (
-            f"no batchexecute request was observed; paths seen: {[e[1] for e in app]}"
+        assert any("batchexecute" in e[1] for e in data_plane), (
+            f"no batchexecute request was observed; paths seen: {[e[1] for e in data_plane]}"
         )
 
     @pytest.mark.asyncio
     async def test_unconfigured_runs_reach_the_rebrand_host(self, client, request_log):
-        """With no override set, that configured host is the rebrand host.
+        """With no override set, every app request reaches the rebrand host.
+
+        This is the CI case, and it makes the unconditional claim over *all* app
+        traffic rather than the data plane alone — so if the fixture ever grows
+        a session-bootstrapping request, this test covers it too. That is safe
+        on the default host, which serves the shell directly; only the legacy
+        host bounces.
 
         Skips rather than fails when ``NOTEBOOKLM_BASE_URL`` is set: pointing a
         run at the legacy host is a supported configuration (ADR-0028), and a
@@ -139,3 +189,6 @@ class TestAppHost:
 
         assert httpx.URL(get_base_url()).host == PERSONAL_BASE_HOST
         assert request_log.hosts() - {_ACCOUNTS_HOST} == {PERSONAL_BASE_HOST}
+
+        bounced = [e for e in request_log.app_entries() if 300 <= e[2] < 400]
+        assert not bounced, f"app traffic was redirected on the default host: {bounced}"

--- a/tests/e2e/test_app_host.py
+++ b/tests/e2e/test_app_host.py
@@ -1,0 +1,141 @@
+"""Live assertion that real traffic reaches the configured app host.
+
+Three layers already pin the host offline, and none of them can fail the way
+that matters:
+
+* ``tests/_guardrails/test_public_surface_manifest.py`` pins
+  ``DEFAULT_BASE_URL`` to the rebrand host and asserts ``get_base_url()``
+  agrees — but that is the *constant*, not the socket.
+* ``tests/_guardrails/test_app_host_literals_centralized.py`` forbids a second
+  source of truth in ``src/notebooklm/`` — but a path that reads the right
+  constant can still be handed to the wrong client.
+* VCR replay is structurally incapable of covering this: ``tests/vcr_config.py``
+  matches on ``host``, so a cassette replays whatever host it was recorded
+  against, and the corpus deliberately retains pre-rebrand entries (#2067).
+
+So the whole offline suite can be green while every live request goes somewhere
+else. That gap is what this module closes: it watches the requests a *real*
+call actually issues, built through the public constructor the e2e ``client``
+fixture uses, so it exercises the path users take rather than a test shell.
+
+Asserted against ``get_base_url()`` rather than a literal, so a run using the
+documented ``NOTEBOOKLM_BASE_URL`` rollback lever (ADR-0028) still passes — the
+question here is "does traffic follow the configuration", and the guardrail
+above is what pins what the configuration defaults to. When nothing is
+configured, this additionally asserts the default resolves to the rebrand host,
+so the CI run makes the unconditional statement too.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from notebooklm._env import PERSONAL_BASE_HOST, get_base_url
+
+from .conftest import requires_auth
+
+#: Google's cookie-rotation endpoint. Not app traffic, and legitimately a
+#: different host — ``RotateCookies`` is accounts-scoped by construction.
+_ACCOUNTS_HOST = "accounts.google.com"
+
+
+class _RequestLog:
+    """Records ``(host, path, status, location)`` for every request issued."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, str, int, str | None]] = []
+
+    def app_entries(self) -> list[tuple[str, str, int, str | None]]:
+        """Entries excluding the accounts-scoped cookie rotation."""
+        return [e for e in self.entries if e[0] != _ACCOUNTS_HOST]
+
+    def hosts(self) -> set[str]:
+        return {e[0] for e in self.entries}
+
+
+@pytest.fixture
+def request_log(monkeypatch: pytest.MonkeyPatch) -> _RequestLog:
+    """Record every HTTP request the client under test issues.
+
+    Wraps ``httpx.AsyncClient.send`` rather than injecting a client factory:
+    ``async_client_factory`` is deliberately kept off the public constructor
+    (see ``client.py``), and routing this test around that constructor would
+    stop it testing the thing it exists to test. Wrapping the transport instead
+    observes whatever the shipped construction path actually built.
+    """
+    log = _RequestLog()
+    original = httpx.AsyncClient.send
+
+    async def recording_send(self: httpx.AsyncClient, request: httpx.Request, **kwargs: object):
+        response = await original(self, request, **kwargs)
+        log.entries.append(
+            (
+                request.url.host,
+                request.url.path,
+                response.status_code,
+                response.headers.get("location"),
+            )
+        )
+        return response
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", recording_send)
+    return log
+
+
+@requires_auth
+@pytest.mark.readonly
+class TestAppHost:
+    """Both tests issue a single ``notebooks.list()`` and mutate nothing.
+
+    Marked ``readonly`` so the release-branch lane (``-m "readonly and not
+    variants"`` in ``nightly.yml``) carries the host assertion too — a release
+    build aimed at the wrong host is exactly the case worth catching.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rpc_traffic_reaches_the_configured_host(self, client, request_log):
+        """A real RPC lands on the configured app host, with no redirect hop.
+
+        The redirect assertion carries as much weight as the host one. Being
+        *bounced* to the right host and *addressing* it are different states:
+        the first means the client is aimed at the wrong host and the service is
+        covering for it, which is precisely the condition that would rot
+        unnoticed until the bounce stops.
+        """
+        await client.notebooks.list()
+
+        expected = httpx.URL(get_base_url()).host
+        app = request_log.app_entries()
+        assert app, "no app requests were observed — the recording fixture did not engage"
+
+        wrong_host = [e for e in app if e[0] != expected]
+        assert not wrong_host, f"requests left the configured host {expected}: {wrong_host}"
+
+        redirected = [e for e in app if 300 <= e[2] < 400]
+        assert not redirected, (
+            f"the app host answered with a redirect, so the client is aimed at the "
+            f"wrong host and is being bounced: {redirected}"
+        )
+
+        assert any("batchexecute" in e[1] for e in app), (
+            f"no batchexecute request was observed; paths seen: {[e[1] for e in app]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_runs_reach_the_rebrand_host(self, client, request_log):
+        """With no override set, that configured host is the rebrand host.
+
+        Skips rather than fails when ``NOTEBOOKLM_BASE_URL`` is set: pointing a
+        run at the legacy host is a supported configuration (ADR-0028), and a
+        test that failed for it would punish the rollback lever for working.
+        """
+        if os.environ.get("NOTEBOOKLM_BASE_URL", "").strip():
+            pytest.skip("NOTEBOOKLM_BASE_URL is set — this asserts the *unconfigured* default")
+
+        await client.notebooks.list()
+
+        assert httpx.URL(get_base_url()).host == PERSONAL_BASE_HOST
+        assert request_log.hosts() - {_ACCOUNTS_HOST} == {PERSONAL_BASE_HOST}


### PR DESCRIPTION
Closes the one layer of "are we actually talking to `notebook.google.com`?" that nothing enforces.

## The gap

Three layers already pin the host, and none of them can fail the way that matters:

| Layer | What it pins | Why it isn't enough |
| --- | --- | --- |
| `test_public_surface_manifest.py:722` | `DEFAULT_BASE_URL == "https://notebook.google.com"`, `get_base_url()` agrees | pins the **constant**, not the socket |
| `test_app_host_literals_centralized.py` | no second source of truth in `src/notebooklm/` | a path reading the right constant can still be handed to the wrong client |
| VCR integration suite | — | **structurally incapable**: `tests/vcr_config.py` matches on `host`, so a cassette replays whatever host it recorded, and the corpus deliberately retains pre-rebrand entries (#2067) |

So the entire offline suite can be green while every live request goes somewhere else. Nothing under `tests/e2e/` asserted a host before this PR.

## What this adds

One `notebooks.list()` through the **public constructor the e2e `client` fixture already uses** — not a test shell, so it exercises the path users take — with every request recorded, asserting:

1. no request leaves the configured host;
2. the app host does not answer with a **redirect**;
3. a batchexecute call was actually observed (so the recorder can't pass vacuously).

**The redirect assertion matters as much as the host one.** Being *bounced* to the right host and *addressing* it are different states. The first means the client is aimed wrong and the service is covering for it — which rots unnoticed until the bounce stops.

## Design notes for review

- **Asserted against `get_base_url()`, not a literal.** A run using the documented `NOTEBOOKLM_BASE_URL` rollback lever (ADR-0028) still passes; a test that failed for the rollback lever would punish it for working. The unconditional claim is pinned separately by the second test, which asserts that with nothing configured the default resolves to the rebrand host and nothing but `accounts.google.com` cookie rotation goes elsewhere. That test *skips* (not fails) when an override is set.
- **Transport wrapping, not `async_client_factory`.** The factory seam is deliberately kept off the public constructor (`client.py`), and routing this test around that constructor would stop it testing the thing it exists to test. Wrapping `httpx.AsyncClient.send` observes whatever the shipped construction path actually built. It's a third-party class, so the `notebooklm._` monkeypatch lint doesn't apply, and `monkeypatch` undoes it.
- **`readonly` marker** — both tests mutate nothing, so the release-branch lane (`-m "readonly and not variants"`) carries the assertion too. A release build aimed at the wrong host is exactly the case worth catching.
- **Out of scope: uploads.** Scotty uses a server-supplied URL, so "which host" there comes from the response, not `get_base_url()`. That's the same gap the canary reports as `upload NOT_PROBED`.

## Verification

Run live against `main`:

- Both tests pass.
- **Negative control** — forcing the expected host to `example.invalid` fails with the recorded entry `('notebook.google.com', '/_/LabsTailwindUi/data/batchexecute', 200, None)`. That proves the recorder engages and the assertion reads real data instead of passing vacuously, and it's also direct evidence that live traffic hits the rebrand host with no redirect.
- **Rollback lever** — `NOTEBOOKLM_BASE_URL=https://notebooklm.google.com` passes the first test and skips the second, as designed.
- Offline suite green (13093 passed), `mypy` and `ruff` clean tree-wide.

Corroborating CI evidence from the RPC Health run on `main` ([30959877164](https://github.com/teng-lin/notebooklm-py/actions/runs/30959877164)), from a different account than the local runs: `base host: notebook.google.com (from: default)`, `BUILDLBL CURRENT`, `RESULT: PASS`.

Test-only change; no CHANGELOG entry since there is no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udm7maQPJeGPXnHr6cG9By


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added authenticated end-to-end coverage confirming application traffic reaches the configured host without unexpected redirects or missing RPC requests.
  * Added validation that default configuration routes traffic to the rebranded host.
  * Covered cookie-rotation traffic exclusions and custom base URL configurations.
  * Added handling for unsupported curl-based transports by skipping those scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->