### PR TITLE
docs(src): correct docstrings that still name the legacy host as current

### DIFF
--- a/src/notebooklm/_auth/account.py
+++ b/src/notebooklm/_auth/account.py
@@ -85,7 +85,7 @@ def extract_email_from_html(html: str) -> str | None:
     (e.g. ``support@google.com``, ``noreply@accounts.google.com``).
 
     Args:
-        html: Page HTML from ``notebooklm.google.com/?authuser=N``.
+        html: Page HTML from ``<configured base URL>/?authuser=N``.
 
     Returns:
         The account's email, or ``None`` if no plausible address was found
@@ -105,7 +105,7 @@ def extract_email_from_html(html: str) -> str | None:
 # UA, Google serves a stripped-down page that omits the WIZ_global_data block
 # (and therefore the active user's email), and ``extract_email_from_html``
 # returns None — looking like "no signed-in account". Empirically validated
-# against ``notebooklm.google.com/?authuser=N``.
+# against ``<configured base URL>/?authuser=N``.
 _BROWSER_UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
@@ -143,7 +143,8 @@ async def enumerate_accounts(
 ) -> list[Account]:
     """Enumerate Google accounts visible to the given cookie jar.
 
-    Probes ``https://notebooklm.google.com/?authuser=N`` for ``N`` in
+    Probes ``<configured base URL>/?authuser=N`` (see
+    :func:`~notebooklm._env.get_base_url`) for ``N`` in
     ``0..max_authuser`` and parses the active user's email from each response.
 
     Stop condition: when the email at index ``N>0`` matches the email at
@@ -178,7 +179,7 @@ async def enumerate_accounts(
         # The browser's on-disk cookie DB rotates ``__Secure-1PSIDTS`` every
         # few minutes, but only when Chrome itself is actively running. A
         # ``--browser-cookies`` extraction against an idle Chrome lands here
-        # with a stale SIDTS — the SID is fine, but ``notebooklm.google.com``
+        # with a stale SIDTS — the SID is fine, but the app host
         # responds with a redirect to ``accounts.google.com`` and we'd
         # incorrectly conclude the user is signed out. Poke once to fetch
         # fresh SIDTS via Set-Cookie before the probes start.

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -456,7 +456,7 @@ def run_browser_capture(
             # Retry navigation on transient connection errors with backoff
             for attempt in range(1, LOGIN_MAX_RETRIES + 1):
                 try:
-                    # wait_until="commit": notebooklm.google.com is a streaming
+                    # wait_until="commit": the app host serves a streaming
                     # SPA that never fires the "load" event (readyState stays
                     # "interactive"), so Playwright's default wait_until="load"
                     # would block until timeout. "commit" resolves once response
@@ -819,7 +819,7 @@ def run_cdp_capture(
             # is actively using.
             page = context.new_page()
             # wait_until="commit": same streaming-SPA reason as the headed login
-            # arm -- the default "load" never fires on notebooklm.google.com, so
+            # arm -- the default "load" never fires on the app host, so
             # this CDP re-auth goto would otherwise waste 30s then TimeoutError
             # before landing classification. See #1697.
             page.goto(f"{get_base_url()}/", wait_until="commit", timeout=30000)

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -361,9 +361,12 @@ def missing_cookies_hint(
 # (``tests/cassettes/*.yaml``) and the live auth-refresh path. Only the
 # following domains are actually exercised during login + token refresh +
 # source-add + chat-ask flows:
-#   - ``notebooklm.google.com`` (the API host — all CLI RPCs land here)
-#   - ``notebook.google.com`` (the Gemini Notebook rebrand host; Google sets
-#     the per-product ``OSID`` / ``__Secure-OSID`` binding cookies here too)
+#   - ``notebook.google.com`` (the default app host since #2067 — CLI RPCs
+#     land here, and Google sets the per-product ``OSID`` /
+#     ``__Secure-OSID`` binding cookies here)
+#   - ``notebooklm.google.com`` (the pre-rebrand host; still served, still
+#     selectable via ``NOTEBOOKLM_BASE_URL``, and sets the same binding
+#     cookies — both must stay accepted)
 #   - ``.google.com`` (carries ``SID``/``HSID``/``SSID``/etc.)
 #   - ``accounts.google.com`` (token refresh + ``RotateCookies`` endpoint at
 #     :data:`KEEPALIVE_ROTATE_URL`)

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -84,7 +84,8 @@ def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
 
     Duplicate-name resolution mirrors :func:`extract_cookies_from_storage`:
     domains are ranked by :func:`_auth_domain_priority` (``.google.com`` >
-    ``.notebooklm.google.com`` > ``notebooklm.google.com`` > regional > other).
+    dotted app hosts > their no-dot variants > regional > other; both personal
+    hosts share a tier at each level, so neither outranks the other).
     The cross-tier case from #375 (e.g. ``OSID`` on ``myaccount.google.com``
     (tier 0) vs ``notebooklm.google.com`` (tier 2)) resolves the same way
     regardless of input order. But tiers are **not** all distinct — several
@@ -177,8 +178,10 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         .google.com and .google.com.sg), we use this priority order:
 
         1. .google.com (base domain) - ALWAYS preferred when present
-        2. .notebooklm.google.com (Playwright canonical NotebookLM subdomain)
-        3. notebooklm.google.com (no-dot NotebookLM subdomain)
+        2. Dotted app-host domains (``.notebook.google.com``,
+           ``.notebooklm.google.com``) — the Playwright canonical form
+        3. Their no-dot variants (``notebook.google.com``,
+           ``notebooklm.google.com``)
         4. Regional domains (e.g. .google.de, .google.com.sg, .google.co.uk)
         5. Other allowlisted domains (e.g. .googleusercontent.com)
 

--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -390,7 +390,7 @@ def extract_csrf_from_html(
     It's required for all RPC calls to prevent cross-site request forgery.
 
     Args:
-        html: Page HTML content from notebooklm.google.com
+        html: Page HTML content from the configured app host
         final_url: The final URL after redirects (for error messages)
         redirect_urls: The redirect chain that preceded ``final_url``, in order
             (``[str(r.url) for r in response.history]``). Optional, and only
@@ -433,7 +433,7 @@ def extract_session_id_from_html(
     It's passed in URL query parameters for RPC calls.
 
     Args:
-        html: Page HTML content from notebooklm.google.com
+        html: Page HTML content from the configured app host
         final_url: The final URL after redirects (for error messages)
         redirect_urls: The redirect chain that preceded ``final_url``. See
             :func:`extract_csrf_from_html`.

--- a/src/notebooklm/_auth/keepalive.py
+++ b/src/notebooklm/_auth/keepalive.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("notebooklm.auth")
 # partners of __Secure-1PSID / __Secure-3PSID. Their server-side validity window
 # is short (minutes-to-hours scale) and Google only emits a rotated value when
 # the client asks the identity surface to rotate. Pure RPC traffic against
-# notebooklm.google.com never triggers rotation, so a long-lived storage_state
+# the app host never triggers rotation, so a long-lived storage_state
 # silently stales out and every subsequent call fails with the
 # "Authentication expired or invalid" redirect (see issue #312).
 #
@@ -208,7 +208,7 @@ async def _poke_session(client: httpx.AsyncClient, storage_path: Path | None = N
     """Best-effort POST to ``accounts.google.com/RotateCookies`` to rotate SIDTS.
 
     Failures are logged at DEBUG and swallowed: this is purely a freshness
-    optimisation. The caller's request to notebooklm.google.com is the
+    optimisation. The caller's request to the app host is the
     authoritative health check.
 
     Three layered guards keep the POST from stampeding ``accounts.google.com``:

--- a/src/notebooklm/_auth/login_wait_trace.py
+++ b/src/notebooklm/_auth/login_wait_trace.py
@@ -53,8 +53,8 @@ def trace_url(url: str) -> str:
     the host.
 
     Nothing is lost: the entire diagnostic this tracing exists to provide is
-    *which host the browser is on* — "waiting for notebooklm.google.com, landed
-    on notebook.google.com". The path never contributed to that answer.
+    *which host the browser is on* — "waiting for notebook.google.com, landed
+    on notebooklm.google.com". The path never contributed to that answer.
 
     Userinfo (``https://TOKEN@host/``) is dropped by rebuilding from
     ``hostname``; query and fragment are dropped by never reading them.

--- a/src/notebooklm/_url_utils.py
+++ b/src/notebooklm/_url_utils.py
@@ -17,7 +17,7 @@ _TITLE_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 _MAX_URL_TITLE_LEN = 200
 
 # The NotebookLM marketing/landing host (note: no ``.com``). A request to the
-# app host ``notebooklm.google.com`` is redirected here — typically
+# app host (either personal host) is redirected here — typically
 # ``notebooklm.google/?location=unsupported`` — when Google's region /
 # anti-abuse risk-control declines the request's *environment* (VPN/proxy or
 # datacenter IP, IP/timezone/language mismatch, non-browser access pattern).
@@ -249,7 +249,7 @@ def find_cookie_mismatch_hop(urls: Iterable[str]) -> str | None:
 def is_notebooklm_unavailable_redirect(url: str) -> bool:
     """Check if a URL is the NotebookLM marketing/landing host (an access gate).
 
-    A request to the app (``notebooklm.google.com``) redirected to the bare
+    A request to an app host redirected to the bare
     ``notebooklm.google`` host means Google's region / anti-abuse risk-control
     declined the request's environment — *not* expired auth (that goes to
     ``accounts.google.com``) and *not* a page-structure change. The bare host is

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -882,7 +882,7 @@ def register_session_commands(cli):
         Default mode is a one-shot keepalive: opens a session, runs the
         layer-1 poke against ``accounts.google.com`` to elicit
         ``__Secure-1PSIDTS`` rotation, fetches CSRF + session ID from
-        ``notebooklm.google.com`` (discarded; their side effect is the cookie
+        the configured app host (discarded; their side effect is the cookie
         jar), and persists the rotated jar to ``storage_state.json`` on close.
 
         With ``--browser-cookies``, re-extracts cookies from the selected


### PR DESCRIPTION
Follow-up to #2072 (the `notebook.google.com` default-host flip) and #2076. Comments and docstrings only — **no behaviour change**.

This is the result of sweeping every `notebooklm.google.com` occurrence in `src/`. The centralization guardrail only covers **executable code** — it deliberately skips docstrings and bare string expressions as prose — so the flip left documentation asserting things that are now false. Nine files.

## Outright wrong

- **`_auth/account.py`** documented probing `https://notebooklm.google.com/?authuser=N`, while the code has used `get_base_url()` since well before the flip. The docstring named a host the function does not request.
- **`_auth/cookie_policy.py`** called the legacy host *"the API host — all CLI RPCs land here"* and demoted the rebrand host to a parenthetical. That is inverted: RPCs land on the default. Both bullets rewritten so each names its real role and both stay visibly required.

## Named a concrete host where they meant "wherever the client is pointed"

`keepalive`'s rotation note, `session_cmd`'s keepalive description, `browser_capture`'s streaming-SPA comments, `extraction`'s page-source docstrings, `_url_utils`'s region-gate comments.

All now read "the app host" or "the configured base URL" — so they cannot go stale on the next move. That is the actual lesson here: naming a concrete host in prose is what made these rot in the first place.

## Two subtler ones

- `_auth/cookies.py` gave the duplicate-resolution ranking as a chain naming only the legacy host, which reads as though it outranks the default. Both personal hosts share a tier at each level; the text now says so.
- `_auth/login_wait_trace.py`'s illustrative *"waiting for X, landed on Y"* example pointed backwards post-flip.

## Deliberately NOT changed — each verified individually

- `_env.py` `PERSONAL_LEGACY_HOST` — the role constant itself.
- `_source/_upload_decode.py` — Scotty genuinely returns **legacy-host** upload URLs post-rebrand (all 6 recorded `upload_id=` hosts in the cassettes are legacy). The example is accurate; retargeting it would model something that does not happen.
- `_auth/extraction.py`'s ServiceLogin trace — a verbatim live capture from 2026-08-03, quoted as captured.
- `_url_utils.py`'s `notebooklm.google` vs `notebooklm.google.com` suffix distinction, and every cookie-tier table that names both hosts — all still true.

## Verification

- `ruff check` + `ruff format --check` clean
- `mypy src/notebooklm` clean (325 files)
- unit + guardrails + integration green (**12,756 passed**, 64 skipped, 1 xfailed) — run before rebasing onto current main

**Note for reviewers on local-only guardrail failures.** `test_docs_module_refs`, `test_type_boundaries` and `test_adr_reference_format` scan the real filesystem and pick up files CI never sees: untracked scratch under `docs/notes/` and `docs/plans/`, plus gitignored `.sisyphus/` planning files. Verified unrelated — with the untracked docs stashed the first two pass, and the ADR one reports only `.sisyphus/` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authentication refresh now retrieves session information from the configured NotebookLM application host, improving support for alternate supported hosts.

- **Documentation**
  - Updated authentication, cookie, redirect, navigation, and keepalive documentation to accurately describe the default and legacy NotebookLM hosts.
  - Clarified cookie handling and host-sharing behavior across supported application domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->