### PR TITLE
fix(auth): honour NOTEBOOKLM_AUTH_JSON over a profile, as documented (#2083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`NOTEBOOKLM_AUTH_JSON` now beats a profile everywhere, as documented.** The
+  precedence `--storage` > `NOTEBOOKLM_AUTH_JSON` > profile file is stated in
+  `docs/configuration.md`, drawn in `docs/architecture.md`, and implemented by
+  `cli.services.auth_source.AuthSource` — but three library call sites spelled
+  the predicate themselves and two of them ranked the profile *above* the env
+  var. Running any command with both an active profile and inline env auth
+  produced a client assembled from **two different accounts**: the CLI resolved
+  the storage path through `AuthSource` (`None`, meaning env auth) and passed
+  the profile name alongside, so `fetch_tokens_with_domains` re-resolved to the
+  profile's `storage_state.json` and minted CSRF/session tokens from it while
+  the cookie jar was loaded from the env var
+  ([#2083](https://github.com/teng-lin/notebooklm-py/issues/2083)).
+
+  The predicate now lives in one place, `_auth.cookies.resolve_auth_storage_path`,
+  so the three sites cannot drift apart again. It also tests *presence* rather
+  than truthiness, matching the loader: an empty `NOTEBOOKLM_AUTH_JSON` is a
+  configuration error reported by name, not a silent fall-through to a file.
+
+  Relatedly, `NOTEBOOKLM_REFRESH_CMD` no longer fires for env-only auth. It had
+  been falling back to `get_storage_path(profile=...)`, so it would lock,
+  rewrite and then read a profile file the caller had bypassed — silently
+  converting env auth into file auth and mutating a profile that may belong to
+  another account. It could not have helped anyway: `NOTEBOOKLM_AUTH_JSON` is
+  scrubbed from the refresh subprocess's environment, so the command cannot
+  re-mint the credential actually in use. The original auth error is preserved
+  and the env-only caller stays side-effect free.
+
+  **What changes for you:** if you set `NOTEBOOKLM_AUTH_JSON` *and* select a
+  profile (via `--profile`, `-p`, or `NOTEBOOKLM_PROFILE`), the env var now wins
+  consistently instead of half-winning. Use `--storage PATH` to authenticate
+  from a file while the env var is set — it still overrides both.
+
 - **A present-but-unusable `__Secure-1PSIDTS` now triggers recovery instead of
   failing on the first RPC.** The cookie-load preflight checked required cookie
   *names* and nothing else, and PSIDTS recovery only ever runs from the `except`

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -341,6 +341,35 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
     return cookies
 
 
+def resolve_auth_storage_path(path: Path | None, profile: str | None) -> Path | None:
+    """Resolve which storage file auth should read, or ``None`` for env auth.
+
+    The single source of the library-side precedence, mirroring
+    ``cli.services.auth_source.AuthSource``:
+
+    1. an explicit ``path`` (the ``--storage`` override) wins outright;
+    2. inline ``NOTEBOOKLM_AUTH_JSON`` → ``None``, so the loaders read the env
+       var and nothing writes to disk;
+    3. otherwise the profile's ``storage_state.json``.
+
+    A profile does **not** re-resolve a file when env auth is present. Three
+    call sites used to spell this predicate themselves and two of them ranked
+    profile above the env var, so ``--profile x`` with ``NOTEBOOKLM_AUTH_JSON``
+    set produced a client whose CSRF/session tokens were minted from the
+    profile file while its cookie jar came from the env var — two accounts in
+    one client (#2083). Keep the rule here, not at the call sites.
+
+    Presence, not truthiness: an empty ``NOTEBOOKLM_AUTH_JSON`` is a
+    configuration error :func:`_load_storage_state` reports, not a silent
+    fall-through to a file. This matches ``_resolve_recovery_path``.
+    """
+    if path is not None:
+        return path
+    if "NOTEBOOKLM_AUTH_JSON" in os.environ:
+        return None
+    return get_storage_path(profile=profile)
+
+
 def _load_storage_state(path: Path | None = None) -> dict[str, Any]:
     """Load Playwright storage state from file or environment variable.
 

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -522,6 +522,17 @@ async def _fetch_tokens_with_refresh(
                     return csrf, session_id, True, recovery.snapshot
         if not _should_try_refresh(err):
             raise
+        if storage_path is None and "NOTEBOOKLM_AUTH_JSON" in os.environ:
+            # Env auth has no writable backing store, so the fallback below
+            # would lock, rewrite and then read a profile file this caller
+            # bypassed — converting env auth into file auth and mutating a
+            # profile that may belong to another account. The refresh command
+            # cannot help either: NOTEBOOKLM_AUTH_JSON is scrubbed from its
+            # environment, so it cannot re-mint the credential in use (#2083).
+            logger.debug(
+                "Skipping %s: env auth has no file to refresh into", NOTEBOOKLM_REFRESH_CMD_ENV
+            )
+            raise
         logger.warning(
             "NotebookLM auth failed (%s). Running %s to refresh cookies.",
             err,
@@ -903,8 +914,7 @@ async def fetch_tokens_with_domains(
         ValueError: If tokens cannot be extracted from response.
         RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails.
     """
-    if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
-        path = get_storage_path(profile=profile)
+    path = _auth_cookies.resolve_auth_storage_path(path, profile)
     jar = build_httpx_cookies_from_storage(path)
     # Capture the open-time snapshot before any rotation could fire. The
     # snapshot is the input to the dirty-flag/delta merge that closes the
@@ -976,8 +986,7 @@ async def fetch_tokens_passive(
         httpx.HTTPError: If request fails.
         ValueError: If tokens cannot be extracted (e.g. redirected to sign-in).
     """
-    if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
-        path = get_storage_path(profile=profile)
+    path = _auth_cookies.resolve_auth_storage_path(path, profile)
     # Strict (no-recovery) loader: a missing/expired PSIDTS raises ``ValueError``
     # here rather than triggering the inline ``RotateCookies`` rotation + save
     # that ``build_httpx_cookies_from_storage`` would. A readiness probe reports

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -458,8 +458,14 @@ async def _fetch_tokens_with_refresh(
     account_email: str | None = None,
     force_authuser_query: bool = False,
     allow_headless: bool = False,
+    env_auth: bool = False,
 ) -> tuple[str, str, bool, _auth_storage.CookieSnapshot | None]:
     """Fetch tokens, optionally running NOTEBOOKLM_REFRESH_CMD on auth expiry.
+
+    ``env_auth`` is set only by callers whose credentials came from inline
+    ``NOTEBOOKLM_AUTH_JSON``. It cannot be inferred from ``storage_path is None``
+    plus the ambient env var — ``fetch_tokens`` passes explicit cookies with no
+    path, and suppressing its refresh for an unrelated env var breaks it (#2084).
 
     Returns ``(csrf, session_id, refreshed, post_refresh_snapshot)``.
 
@@ -522,16 +528,12 @@ async def _fetch_tokens_with_refresh(
                     return csrf, session_id, True, recovery.snapshot
         if not _should_try_refresh(err):
             raise
-        if storage_path is None and "NOTEBOOKLM_AUTH_JSON" in os.environ:
-            # Env auth has no writable backing store, so the fallback below
-            # would lock, rewrite and then read a profile file this caller
-            # bypassed — converting env auth into file auth and mutating a
-            # profile that may belong to another account. The refresh command
-            # cannot help either: NOTEBOOKLM_AUTH_JSON is scrubbed from its
-            # environment, so it cannot re-mint the credential in use (#2083).
-            logger.debug(
-                "Skipping %s: env auth has no file to refresh into", NOTEBOOKLM_REFRESH_CMD_ENV
-            )
+        if env_auth:
+            # No writable backing store: the fallback below would lock, rewrite
+            # and then read a profile file this caller bypassed. The refresh
+            # command cannot help anyway — NOTEBOOKLM_AUTH_JSON is scrubbed from
+            # its environment, so it cannot re-mint the credential in use (#2083).
+            logger.debug("Skipping %s: env auth has no file", NOTEBOOKLM_REFRESH_CMD_ENV)
             raise
         logger.warning(
             "NotebookLM auth failed (%s). Running %s to refresh cookies.",
@@ -920,7 +922,7 @@ async def fetch_tokens_with_domains(
     # snapshot is the input to the dirty-flag/delta merge that closes the
     # stale-overwrite-fresh race (docs/auth-cookie-lifecycle.md §3.4.1).
     snapshot = snapshot_cookie_jar(jar)
-    refresh_options: dict[str, Any] = {}
+    refresh_options: dict[str, Any] = {"env_auth": path is None}
     if authuser is not None:
         refresh_options.update(authuser=authuser, force_authuser_query=True)
     if account_email is not None:

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -292,6 +292,7 @@ class AuthTokens:
                 authuser=authuser,
                 account_email=account_email,
                 allow_headless=allow_headless,
+                env_auth=True,
             )
         elif allow_headless:
             fetch_result = await _auth_refresh._fetch_tokens_with_refresh(

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypeAlias
 
 import httpx
 
-from ..paths import get_storage_path
 from . import account as _auth_account
 from . import cookies as _auth_cookies
 from . import psidts_recovery as _auth_psidts_recovery
@@ -259,8 +257,7 @@ class AuthTokens:
             # Load from a specific profile
             auth = await AuthTokens.from_storage(profile="work")
         """
-        if path is None and (profile is not None or not os.environ.get("NOTEBOOKLM_AUTH_JSON")):
-            path = get_storage_path(profile=profile)
+        path = _auth_cookies.resolve_auth_storage_path(path, profile)
 
         if path is None:
             authuser = 0

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -908,7 +908,9 @@ class TestRefreshCmdResnapshot:
 
         # Stub the token fetch to return refreshed=True and mutate the jar
         # in place (mirroring _replace_cookie_jar after NOTEBOOKLM_REFRESH_CMD).
-        async def fake_fetch_with_refresh(cookie_jar, storage_path, profile, *, authuser=0):
+        async def fake_fetch_with_refresh(
+            cookie_jar, storage_path, profile, *, authuser=0, env_auth=False
+        ):
             # Simulate the wholesale jar swap: clear & repopulate with new values.
             cookie_jar.jar.clear()
             cookie_jar.set("SID", "post", domain=".google.com", path="/")
@@ -955,7 +957,9 @@ class TestRefreshCmdResnapshot:
             ],
         )
 
-        async def fake_fetch_with_refresh(cookie_jar, storage_path, profile, *, authuser=0):
+        async def fake_fetch_with_refresh(
+            cookie_jar, storage_path, profile, *, authuser=0, env_auth=False
+        ):
             cookie_jar.jar.clear()
             cookie_jar.set("SID", "post", domain=".google.com", path="/")
             cookie_jar.set("__Secure-1PSIDTS", "post_refresh", domain=".google.com", path="/")
@@ -1182,7 +1186,9 @@ class TestBaselineNotAdvancedOnSaveFailure:
             ],
         )
 
-        async def fake_fetch_with_refresh(cookie_jar, storage_path, profile, *, authuser=0):
+        async def fake_fetch_with_refresh(
+            cookie_jar, storage_path, profile, *, authuser=0, env_auth=False
+        ):
             _set_cookie_value(cookie_jar, "__Secure-1PSIDTS", "mutated")
             return ("csrf", "session", False, None)
 
@@ -1516,7 +1522,9 @@ class TestCASVariantAware:
             ],
         )
 
-        async def fake_fetch_with_refresh(cookie_jar, storage_path, profile, *, authuser=0):
+        async def fake_fetch_with_refresh(
+            cookie_jar, storage_path, profile, *, authuser=0, env_auth=False
+        ):
             # Drop the bare-host OSID from the jar and re-key it on the
             # leading-dot variant so the in-memory jar diverges from disk on
             # domain shape — the exact variance the variant-aware CAS lookup

--- a/tests/unit/test_auth_env_precedence_2083.py
+++ b/tests/unit/test_auth_env_precedence_2083.py
@@ -1,0 +1,185 @@
+"""Env-auth precedence contracts for issue #2083.
+
+``NOTEBOOKLM_AUTH_JSON`` supplies auth inline, with no writable backing file.
+``cli.services.auth_source.AuthSource`` documents the precedence — explicit
+``--storage`` > env var > profile file — but three library call sites used to
+spell the predicate themselves and two ranked the profile *above* the env var.
+The observable consequence was a client assembled from two accounts: the CLI's
+``get_client`` resolved the path through ``AuthSource`` (``None`` for env auth)
+and passed the profile alongside, so the token fetch re-resolved to the profile
+file while the cookie jar came from the env var.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm._auth import cookies, refresh, tokens
+from notebooklm._env import get_base_url
+from notebooklm.cli.services.auth_source import AuthSource
+
+_ENV = "NOTEBOOKLM_AUTH_JSON"
+
+
+def _state(sid: str) -> dict:
+    expires = time.time() + 86400
+    rows = [
+        ("SID", sid),
+        ("APISID", "apisid"),
+        ("SAPISID", "sapisid"),
+        ("LSID", "lsid"),
+        ("__Secure-1PSIDTS", "psidts"),
+    ]
+    return {
+        "cookies": [
+            {"name": n, "value": v, "domain": ".google.com", "path": "/", "expires": expires}
+            for n, v in rows
+        ],
+        "origins": [],
+    }
+
+
+@pytest.fixture
+def profiled_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A ``work`` profile on disk plus inline env auth for a *different* account."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    from notebooklm.paths import get_storage_path
+
+    work = get_storage_path(profile="work")
+    work.parent.mkdir(parents=True, exist_ok=True)
+    work.write_text(json.dumps(_state("sid-from-profile-file")), encoding="utf-8")
+    monkeypatch.setenv(_ENV, json.dumps(_state("sid-from-env-var")))
+    return work
+
+
+def test_resolver_ranks_explicit_path_then_env_then_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The single resolver implements exactly what ``AuthSource`` documents."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    explicit = tmp_path / "explicit.json"
+
+    monkeypatch.setenv(_ENV, json.dumps(_state("x")))
+    assert cookies.resolve_auth_storage_path(explicit, "work") == explicit
+    assert cookies.resolve_auth_storage_path(None, "work") is None
+    assert cookies.resolve_auth_storage_path(None, None) is None
+
+    monkeypatch.delenv(_ENV)
+    assert cookies.resolve_auth_storage_path(None, "work") is not None
+
+
+def test_resolver_treats_an_empty_env_value_as_env_auth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Presence, not truthiness — matching ``_load_storage_state``.
+
+    An empty value is a configuration error the loader reports by name. Falling
+    through to a profile file would hide it and silently authenticate as a
+    different account.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.setenv(_ENV, "")
+
+    assert cookies.resolve_auth_storage_path(None, "work") is None
+    with pytest.raises(ValueError, match="set but empty"):
+        cookies._load_storage_state(None)
+
+
+def test_library_and_authsource_agree_on_env_over_profile(profiled_home: Path) -> None:
+    """The divergence that produced a two-account client (#2083)."""
+    source = AuthSource.from_components(storage_override=None, profile="work")
+    assert source.has_env_auth is True
+    assert source.resolve() is None
+
+    assert cookies.resolve_auth_storage_path(None, "work") is None
+
+
+@pytest.mark.asyncio
+async def test_token_fetch_and_cookie_jar_read_the_same_account(profiled_home: Path) -> None:
+    """``get_client``'s two halves must not disagree.
+
+    It calls ``fetch_tokens_with_domains(resolved_path, profile)`` and then
+    ``load_auth_from_storage(resolved_path)``. With env auth the resolved path
+    is ``None``; before the fix the profile argument made only the first half
+    re-resolve to the profile file.
+    """
+    seen: dict[str, object] = {}
+    real = refresh.build_httpx_cookies_from_storage
+
+    def spy(path=None):
+        seen["path"] = path
+        return real(path)
+
+    with (
+        patch.object(refresh, "build_httpx_cookies_from_storage", spy),
+        pytest.raises(Exception),  # noqa: B017 - the network call is not the subject
+    ):
+        await refresh.fetch_tokens_with_domains(None, "work")
+
+    assert seen["path"] is None, "token fetch must not re-resolve the profile file"
+    assert tokens.load_auth_from_storage(None)["SID"] == "sid-from-env-var"
+
+
+@pytest.mark.asyncio
+async def test_auth_tokens_from_storage_keeps_env_auth_under_a_profile(
+    profiled_home: Path,
+) -> None:
+    """``AuthTokens.from_storage(profile=...)`` must not silently become file auth."""
+    seen: dict[str, object] = {}
+
+    def spy(path=None):
+        seen["path"] = path
+        raise RuntimeError("stop after resolution")
+
+    # ``from_storage`` loads through ``cookies.build_httpx_cookies_from_storage``.
+    with (
+        patch.object(cookies, "build_httpx_cookies_from_storage", spy),
+        pytest.raises(Exception),  # noqa: B017 - resolution is the subject
+    ):
+        await tokens.AuthTokens.from_storage(profile="work")
+
+    assert seen.get("path", "unset") is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_cmd_does_not_run_or_touch_a_profile_under_env_auth(
+    profiled_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Env auth has no file to refresh into, so the hook must not fire.
+
+    Running it would lock, rewrite and then *read* a profile file the caller
+    bypassed — converting env auth into file auth. It also cannot succeed:
+    ``NOTEBOOKLM_AUTH_JSON`` is scrubbed from the subprocess environment, so
+    the command cannot re-mint the credential actually in use.
+    """
+    marker = tmp_path / "refresh-cmd-ran"
+    monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", f"touch {marker}")
+    before = profiled_home.read_bytes()
+
+    # A real sign-in redirect, not a patched failure: the homepage GET bounces
+    # to the login page, extraction reports "redirected to ...", and that string
+    # is one of the auth signals ``_should_try_refresh`` fires on.
+    httpx_mock.add_response(
+        url=f"{get_base_url()}/",
+        status_code=302,
+        headers={"Location": "https://accounts.google.com/signin"},
+    )
+    httpx_mock.add_response(
+        url="https://accounts.google.com/signin",
+        content=b"<html>Login</html>",
+    )
+
+    with pytest.raises(ValueError):
+        await refresh.fetch_tokens_with_domains(None, "work")
+
+    assert not marker.exists(), "the refresh command must not run for env-only auth"
+    assert profiled_home.read_bytes() == before, "a bypassed profile must not be rewritten"

--- a/tests/unit/test_auth_env_precedence_2083.py
+++ b/tests/unit/test_auth_env_precedence_2083.py
@@ -13,6 +13,7 @@ file while the cookie jar came from the env var.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -200,6 +201,10 @@ async def test_explicit_cookies_still_refresh_when_env_var_is_merely_present(
     Inferring it would silently disable ``NOTEBOOKLM_REFRESH_CMD`` for every
     explicit-cookie caller in a mixed environment (#2084 review).
     """
+    # The whole point is a *mixed* environment, and that precondition arrives
+    # via the fixture rather than this body — state it so it cannot erode
+    # silently and leave the test passing for the wrong reason.
+    assert _ENV in os.environ, "this test is only meaningful with ambient env auth set"
     marker = tmp_path / "refresh-cmd-ran"
     monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", f"touch {marker}")
     # Two rounds: the initial fetch, then the post-refresh retry.

--- a/tests/unit/test_auth_env_precedence_2083.py
+++ b/tests/unit/test_auth_env_precedence_2083.py
@@ -183,3 +183,37 @@ async def test_refresh_cmd_does_not_run_or_touch_a_profile_under_env_auth(
 
     assert not marker.exists(), "the refresh command must not run for env-only auth"
     assert profiled_home.read_bytes() == before, "a bypassed profile must not be rewritten"
+
+
+@pytest.mark.asyncio
+async def test_explicit_cookies_still_refresh_when_env_var_is_merely_present(
+    profiled_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``fetch_tokens(cookies=...)`` did not load from the env var, so the hook applies.
+
+    The env-auth suppression must key off how *this* caller obtained its
+    credentials, not off ``storage_path is None`` plus an ambient
+    ``NOTEBOOKLM_AUTH_JSON`` that may belong to something else in the process.
+    Inferring it would silently disable ``NOTEBOOKLM_REFRESH_CMD`` for every
+    explicit-cookie caller in a mixed environment (#2084 review).
+    """
+    marker = tmp_path / "refresh-cmd-ran"
+    monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", f"touch {marker}")
+    # Two rounds: the initial fetch, then the post-refresh retry.
+    for _ in range(2):
+        httpx_mock.add_response(
+            url=f"{get_base_url()}/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin", content=b"<html>Login</html>"
+        )
+
+    with pytest.raises(Exception):  # noqa: B017 - the refresh attempt is the subject
+        await refresh.fetch_tokens({"SID": "sid", "__Secure-1PSIDTS": "psidts"}, profile="work")
+
+    assert marker.exists(), "explicit-cookie callers must keep their refresh hook"


### PR DESCRIPTION
Closes #2083.

## This is a conformance bug, not a design choice

The precedence is already decided and written down in three places:

| where | what it says |
| --- | --- |
| `docs/configuration.md:335` | `--storage` → `NOTEBOOKLM_AUTH_JSON` → profile path |
| `docs/architecture.md:598` | `--storage > NOTEBOOKLM_AUTH_JSON > active profile storage` |
| `cli/services/auth_source.py` | a module docstring, a "single-import policy", and `AuthSource.resolve()` |

Three library call sites spelled the predicate themselves anyway, and two of them ranked the profile **above** the env var:

```python
if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
    path = get_storage_path(profile=profile)
```

`_auth/headers.py` had it right (`storage_path is None and "NOTEBOOKLM_AUTH_JSON" in os.environ`). `_auth/refresh.py` ×2 and `_auth/tokens.py` did not.

## What actually happens: a split client, masked by the retry path

`cli/auth_runtime.py:get_client` resolves the path through `AuthSource` — `None` for env auth — and then passes the profile name **alongside** it:

```python
csrf, session_id = helpers.run_async(fetch_tokens_with_domains(typed_storage_path, profile))
cookies = helpers.load_auth_from_storage(resolved_storage_path)
```

`fetch_tokens_with_domains(None, "work")` hit the buggy predicate and re-resolved to the profile's `storage_state.json`, so the CSRF/session pair was minted from one account while the cookie jar came from the other. In-process, before the fix:

```
AuthSource (the documented SoT): has_env_auth=True resolve()=None
fetch_tokens_with_domains(None, profile='work') loaded from:
  /tmp/.../profiles/work/storage_state.json
load_auth_from_storage(None) returned SID: SID-FROM-ENV-VAR
```

**Live-verified against two real accounts** — env var holding account A (27 notebooks), profile `work` holding account B (16 notebooks), each count established independently first:

| | `main` | this PR |
| --- | --- | --- |
| notebooks returned | **27** (account A) | **27** (account A) |
| failed RPCs | **1** — `LIST_NOTEBOOKS` → HTTP **400**, then `Token refresh successful, retrying` | **0** |
| bypassed profile on disk | **rewritten** | **untouched** |

Two things worth stating plainly, because they cut against how I first wrote this up:

1. **It does not read the wrong account's data.** Identity follows the cookie jar, so the server answers as account A either way. The mismatched CSRF is rejected with a 400 rather than honoured. My original framing — "a client assembled from two accounts" — is accurate about the *construction* and overstated about the *consequence*; it is a wasted round-trip, not cross-account access.
2. **The stale-CSRF recovery path masks it entirely.** The 400 is caught, tokens are re-minted, the retry succeeds, and the user sees correct output with exit 0. That is why this has gone unnoticed: the only symptoms are one wasted RPC per command, a `WARNING` in the log, and a silent write to a profile the caller bypassed.

The disk write is the part with no upside: with `NOTEBOOKLM_AUTH_JSON` set, a `--profile` the CLI had already decided to ignore still gets locked, rotated and rewritten.

## The fix

**One resolver, not three predicates.** `_auth.cookies.resolve_auth_storage_path(path, profile)` now owns the rule and the three sites call it. This is the same single-source discipline #2061 applied to the preflight/recovery pair — a triplicated predicate is what let these drift in the first place, so removing the duplication is the actual fix and the behaviour change falls out of it.

**Presence, not truthiness.** `tokens.py` used `not os.environ.get(...)`, so an empty `NOTEBOOKLM_AUTH_JSON=""` fell through to a profile file while `AuthSource.has_env_auth` (presence) said env, and `_load_storage_state` would have reported "set but empty". `_resolve_recovery_path`'s docstring already documents this exact crack from #2057; `tokens.py` was the last caller on the wrong side of it.

**`NOTEBOOKLM_REFRESH_CMD` no longer fires for env-only auth.** It fell back to `get_storage_path(profile=...)`, so it would lock, rewrite, and then *read* a profile file the caller bypassed — silently converting env auth into file auth and mutating a profile that may belong to a different account. It could not have helped regardless: `NOTEBOOKLM_AUTH_JSON` is scrubbed from the subprocess environment (`refresh.py:367`), so the command cannot re-mint the credential actually in use. The original auth error is preserved and the env-only caller stays side-effect free.

## What changes for you

With `NOTEBOOKLM_AUTH_JSON` set **and** a profile selected, the env var now wins consistently instead of half-winning. `--storage PATH` still overrides both and remains the way to authenticate from a file while the env var is set. Users with only one of the two are unaffected.

## Verification

- Full suite green: **13,160 passed**, 64 skipped, 1 xfailed. `ruff check`, `ruff format --check`, `mypy` clean tree-wide.
- **No existing test pinned the old behaviour** — the only initial failure was the module-size ratchet from my own comments, which the single-resolver refactor then resolved (`refresh.py` 1019 → 998, under the ADR-0008 cap).
- Six new tests in `tests/unit/test_auth_env_precedence_2083.py`, all of which fail on unmodified `main`. Three are genuine behavioural proofs (`test_token_fetch_and_cookie_jar_read_the_same_account`, `test_auth_tokens_from_storage_keeps_env_auth_under_a_profile`, `test_refresh_cmd_does_not_run_or_touch_a_profile_under_env_auth`); the other three exercise the new resolver and fail on `main` only because the symbol does not exist there.
- The refresh-command test drives a real sign-in redirect through `httpx_mock` rather than patching a private helper, so the ADR-0007 forbidden-monkeypatch allowlist stays at zero. My first draft patched `_fetch_tokens_with_jar` and the guardrail correctly rejected it.

**No documentation changed** — the docs were already right and the code was wrong.

Live verification used two real accounts on a throwaway `NOTEBOOKLM_HOME` populated with copies, so no real profile was mutated by the test itself. Account identifiers are omitted here deliberately; the notebook counts are what distinguish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udm7maQPJeGPXnHr6cG9By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication precedence so environment-based credentials consistently override profile authentication.
  * Explicit storage paths remain the highest-priority authentication option.
  * Empty authentication environment values now produce a clear configuration error.
  * Prevented refresh commands from modifying or falling back to profile files during environment-only authentication.
* **Tests**
  * Added coverage for authentication precedence, token loading, cookie handling, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->