### PR TITLE
fix(migration): make legacy-layout migration crash-safe via temp+rename

### DIFF
--- a/src/notebooklm/migration.py
+++ b/src/notebooklm/migration.py
@@ -6,7 +6,9 @@ Handles transparent migration of ~/.notebooklm/ files into
 The migration is:
 - Automatic: triggered by ensure_profiles_dir() on CLI startup
 - Idempotent: safe to run multiple times
-- Crash-safe: uses copy-then-delete with marker file
+- Crash-safe: uses copy-then-delete with marker file; each copy lands via
+  temp-name + atomic rename, so a crash mid-copy can never leave a torn
+  file/dir at its final destination name
 - Non-destructive: originals kept until all copies succeed
 - Single-writer: cross-process ``filelock`` serializes concurrent CLI
   invocations so a container start-up race cannot interleave copies.
@@ -14,6 +16,7 @@ The migration is:
 
 import json
 import logging
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -21,7 +24,7 @@ from typing import Any
 
 from filelock import FileLock, Timeout
 
-from ._atomic_io import atomic_update_json
+from ._atomic_io import atomic_update_json, replace_file_atomically
 from .paths import get_config_path, get_home_dir
 
 logger = logging.getLogger(__name__)
@@ -44,6 +47,19 @@ _MIGRATION_LOCK_TIMEOUT = 30.0
 # Legacy files that should be moved into profiles/default/
 _LEGACY_FILES = ["storage_state.json", "context.json"]
 _LEGACY_DIRS = ["browser_profile"]
+
+# Copies land under a dot-prefixed temp name first and are renamed into place
+# only once complete, so a path at its *final* name is always a complete copy.
+_MIGRATION_TMP_SUFFIX = ".migrating"
+
+# Credential-equivalent files get 0o600 on the migrated copy regardless of the
+# legacy file's (possibly world-readable) mode. POSIX only.
+_SECRET_LEGACY_FILES = frozenset({"storage_state.json"})
+
+
+def _migration_tmp_path(dst: Path) -> Path:
+    """Deterministic temp sibling for ``dst`` (single writer via migration lock)."""
+    return dst.parent / f".{dst.name}{_MIGRATION_TMP_SUFFIX}"
 
 
 class MigrationLockTimeoutError(RuntimeError):
@@ -146,24 +162,39 @@ def _migrate_to_profiles_locked(home: Path) -> bool:
     logger.info("Migrating legacy layout to profiles/default/")
 
     # Copy files — overwrite if source is newer (e.g., login wrote fresh
-    # cookies to the legacy root path after a previous migration).
+    # cookies to the legacy root path after a previous migration). Copies go
+    # through a temp name + os.replace so an interrupted copy can never leave
+    # a torn file at the final name: a dst that exists here is complete, and
+    # its mtime (preserved from src by copy2 + rename) is trustworthy.
     for src in legacy_files:
         dst = default_dir / src.name
+        tmp = _migration_tmp_path(dst)
+        tmp.unlink(missing_ok=True)  # stale partial from a prior interrupted run
         if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
             logger.debug("Skipping %s (profile copy is same age or newer)", src.name)
         else:
-            shutil.copy2(src, dst)
+            shutil.copy2(src, tmp)
             if sys.platform != "win32":
-                dst.chmod(src.stat().st_mode)
+                # Secrets never inherit a loose legacy mode (e.g. 0o644).
+                if src.name in _SECRET_LEGACY_FILES:
+                    tmp.chmod(0o600)
+                else:
+                    tmp.chmod(src.stat().st_mode)
+            replace_file_atomically(tmp, dst)
             logger.debug("Copied %s → %s", src.name, dst)
 
-    # Copy directories (skip if destination already exists)
+    # Copy directories — same temp + rename discipline, so a dst dir that
+    # exists at its final name was created by a completed copytree.
     for src in legacy_dirs:
         dst = default_dir / src.name
+        tmp = _migration_tmp_path(dst)
+        if tmp.exists():
+            shutil.rmtree(tmp, ignore_errors=True)  # stale partial from a prior run
         if dst.exists():
             logger.debug("Skipping %s/ (already exists in profile)", src.name)
         else:
-            shutil.copytree(src, dst)
+            shutil.copytree(src, tmp)
+            os.replace(tmp, dst)
             logger.debug("Copied %s/ → %s/", src.name, dst)
 
     # Remove originals (copies already in place as fallback). Tolerate

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import stat
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -179,6 +181,74 @@ class TestMigrateToProfiles:
         # Profile copy is preserved, legacy file is cleaned up
         assert json.loads(fresh_profile.read_text()) == {"cookies": ["fresh"]}
         assert not stale_legacy.exists()
+
+    def test_stale_temp_file_is_cleaned_and_copy_completes(self, tmp_path):
+        """A torn copy from an interrupted run never becomes the migrated file.
+
+        Copies land under a dot-prefixed temp name and are renamed into place
+        only once complete, so an interrupted run can leave a partial only at
+        the temp name — with an mtime *newer* than the intact legacy source.
+        The retry must discard the stale temp (not let it satisfy any
+        freshness check) and complete the copy from the intact original.
+        """
+        src = tmp_path / "storage_state.json"
+        src.write_text('{"cookies":["intact"]}')
+        os.utime(src, (1000, 1000))
+
+        default_dir = tmp_path / "profiles" / "default"
+        default_dir.mkdir(parents=True)
+        stale_tmp = default_dir / ".storage_state.json.migrating"
+        stale_tmp.write_text('{"cook')  # truncated; mtime is "now" (newer than src)
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+            migrate_to_profiles()
+
+        dst = default_dir / "storage_state.json"
+        assert json.loads(dst.read_text()) == {"cookies": ["intact"]}
+        assert not stale_tmp.exists()
+        assert not src.exists()
+
+    def test_stale_temp_dir_is_cleaned_and_copy_completes(self, tmp_path):
+        """A partial temp dir from an interrupted copytree is discarded on retry."""
+        legacy = tmp_path / "browser_profile"
+        legacy.mkdir()
+        (legacy / "data").write_text("chrome data")
+        (legacy / "prefs").write_text("prefs data")
+
+        default_dir = tmp_path / "profiles" / "default"
+        default_dir.mkdir(parents=True)
+        stale_tmp = default_dir / ".browser_profile.migrating"
+        stale_tmp.mkdir()
+        (stale_tmp / "data").write_text("chr")  # partial copy, missing "prefs"
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+            migrate_to_profiles()
+
+        dst = default_dir / "browser_profile"
+        assert (dst / "data").read_text() == "chrome data"
+        assert (dst / "prefs").read_text() == "prefs data"
+        assert not stale_tmp.exists()
+        assert not legacy.exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
+    def test_storage_state_permissions_tightened(self, tmp_path):
+        """A world-readable legacy storage_state.json migrates to a 0600 copy."""
+        src = tmp_path / "storage_state.json"
+        src.write_text('{"cookies":[]}')
+        src.chmod(0o644)
+        ctx = tmp_path / "context.json"
+        ctx.write_text('{"notebook_id":"nb1"}')
+        ctx.chmod(0o644)
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+            migrate_to_profiles()
+
+        default_dir = tmp_path / "profiles" / "default"
+        # Secret-bearing file is tightened regardless of legacy mode
+        migrated = default_dir / "storage_state.json"
+        assert stat.S_IMODE(migrated.stat().st_mode) == 0o600
+        # Non-secret files keep the legacy mode
+        assert stat.S_IMODE((default_dir / "context.json").stat().st_mode) == 0o644
 
 
 class TestEnsureProfilesDir:


### PR DESCRIPTION
## Summary

An interrupted legacy-layout migration could permanently destroy the user's only copy of `storage_state.json`. `shutil.copy2` interrupted mid-copy leaves a partial destination whose mtime is *newer* than the source (copystat never ran), so the retry's skip-if-newer guard kept the truncated file — and the migration then unconditionally deleted the intact legacy originals. Interrupted `copytree` had the same hole via the bare `dst.exists()` skip.

This change makes every migration copy land under a dot-prefixed temp name (`.<name>.migrating`) and renames it into place atomically, so a path at its *final* name is always a complete copy and both skip guards become trustworthy. Found during a cookie/auth-subsystem audit.

## Related Issue

N/A — found by internal audit, no tracking issue.

## Changes

- `src/notebooklm/migration.py`: file copies go through temp + `replace_file_atomically`; directory copies go through temp + `os.replace`; stale temps from prior interrupted runs are cleaned before each retry; originals are still only deleted after the copy loops complete.
- Migrated `storage_state.json` is tightened to `0o600` on POSIX instead of inheriting a loose legacy mode (e.g. `0644`); non-secret files keep the legacy mode as before. Windows behavior unchanged.
- Module docstring updated to state the temp+rename guarantee it now actually provides.
- `tests/unit/test_migration.py`: three regression tests — stale partial temp file (newer mtime) is discarded and the intact legacy content wins; stale partial temp dir is discarded and the full copytree completes; loose 0644 legacy mode is tightened to 0600 on the migrated copy (POSIX-only).

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [ ] If this PR changes architectural shape, an ADR has been added or updated.

## Notes

- `tests/unit/test_migration.py` is 18/18 green (15 prior + 3 new); the full unit suite at this commit passes (11647 passed, 85 skipped, 1 xfailed). No ADR needed — no architectural shape change.
- Deliberate behavior retention: the "profile copy is same age or newer" skip (a post-migration login writing fresh cookies to the legacy root must not be clobbered) is preserved — `copy2` + rename keep the source mtime, so the `>=` comparison still works across retries.
- A companion fix for a separate audit finding (write-time cookie-domain filtering on the browser-cookie login path) is in progress and will land on this branch as a follow-up commit unless a separate branch/PR is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RMas6ZjhYgUQtqS7zgw2y

---
_Generated by [Claude Code](https://claude.ai/code/session_017RMas6ZjhYgUQtqS7zgw2y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration reliability by preventing incomplete files or directories after interruptions.
  - Automatically cleans up leftover temporary migration data and safely retries interrupted operations.
  - Secured migrated `storage_state.json` files with restricted permissions on supported systems.
  - Preserved original permissions for other migrated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->