### PR TITLE
ci(auth): ship only the master token; stop shipping a cookie snapshot

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -225,9 +225,9 @@ jobs:
     # replaces the old inline-env auth: env-var auth never engages the layer-4
     # master-token re-mint (it only fires when master_token.json sits BESIDE
     # the profile's storage_state.json — src/notebooklm/_auth/session.py), so
-    # a rotated cookie secret used to hard-fail the run. With a file-based
-    # profile plus the optional NOTEBOOKLM_MASTER_TOKEN_JSON secret, expired
-    # cookies are re-minted in-process and the job survives rotation.
+    # a rotated cookie secret used to hard-fail the run. The master token is
+    # now MANDATORY (empty secret or 3 failed mints both exit 1) — it is the
+    # only credential shipped, so there is no snapshot to degrade onto.
     - name: Materialize auth profile
       if: needs.resolve-branch.outputs.is_standard == 'true'
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,7 @@ jobs:
     #    secret-bearing steps below are belt-and-suspenders so the gate
     #    stays visible if the job-level guard is ever loosened.
     # 2. ``environment: protected-readonly`` (unconditional). The secrets
-    #    this job consumes (``NOTEBOOKLM_AUTH_JSON`` and friends) live only
+    #    this job consumes (``NOTEBOOKLM_MASTER_TOKEN_JSON`` and friends) live only
     #    in that environment, so the binding has to be unconditional —
     #    issue #1009 surfaced the scheduled cron failing when the previous
     #    conditional (``workflow_dispatch``-only) form fell back to
@@ -219,8 +219,8 @@ jobs:
       run: uv run playwright install-deps chromium
 
     # Fail-fast preflight + profile materialization. The empty-secret check
-    # keeps the issue #1009 guarantee: without it, an empty NOTEBOOKLM_AUTH_JSON
-    # lets the E2E suite proceed; pytest then skips every auth-requiring test
+    # keeps the issue #1009 guarantee: without it, an empty auth secret lets
+    # the E2E suite proceed; pytest then skips every auth-requiring test
     # silently and the job lands green with 0 tests run. The write-to-disk part
     # replaces the old inline-env auth: env-var auth never engages the layer-4
     # master-token re-mint (it only fires when master_token.json sits BESIDE
@@ -231,13 +231,12 @@ jobs:
     - name: Materialize auth profile
       if: needs.resolve-branch.outputs.is_standard == 'true'
       env:
-        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets.NOTEBOOKLM_MASTER_TOKEN_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
       shell: bash
       run: |
-        if [ -z "${NOTEBOOKLM_AUTH_JSON:-}" ]; then
-          echo "::error::NOTEBOOKLM_AUTH_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
+        if [ -z "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
+          echo "::error::NOTEBOOKLM_MASTER_TOKEN_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
           exit 1
         fi
         if [ -z "${NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID:-}" ]; then
@@ -246,31 +245,39 @@ jobs:
         fi
         umask 077
         mkdir -p ~/.notebooklm/profiles/default
-        printf '%s' "$NOTEBOOKLM_AUTH_JSON" > ~/.notebooklm/profiles/default/storage_state.json
-        chmod 600 ~/.notebooklm/profiles/default/storage_state.json
-        if [ -n "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
-          printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
-          chmod 600 ~/.notebooklm/profiles/default/master_token.json
-          # Pre-mint fresh cookies NOW: consumers that fetch tokens eagerly
-          # (AuthTokens.from_storage in the e2e session fixture) raise on a
-          # dead cookie snapshot BEFORE any client exists, so the in-client
-          # layer-4 hook alone cannot rescue a stale secret at startup. The
-          # explicit re-mint overwrites storage_state.json with a fresh
-          # session; layer-4 then covers mid-run expiry. Non-fatal: if the
-          # mint fails but the cookie snapshot is still live, the run can
-          # proceed on cookies alone.
-          # unset is load-bearing: `login` refuses to run while
-          # NOTEBOOKLM_AUTH_JSON is set (env-var auth conflicts with
-          # file-writing login), and both secrets are already on disk.
-          unset NOTEBOOKLM_AUTH_JSON NOTEBOOKLM_MASTER_TOKEN_JSON
+        printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
+        chmod 600 ~/.notebooklm/profiles/default/master_token.json
+        # The master token is now the ONLY credential shipped. A cookie
+        # snapshot cannot be: Google supersedes __Secure-1PSIDTS on a ~600 s
+        # cadence and a superseded value is rejected shortly after, so a
+        # secret minted on a workstation is routinely dead before the run
+        # starts. A master token does not rotate, so it cannot go stale.
+        # The mint below bootstraps storage_state.json from it (verified: the
+        # command creates the file when none exists); layer-4 then covers
+        # mid-run expiry. `unset` is load-bearing: `login` refuses to run
+        # while inline env auth is set, and the secret is already on disk.
+        unset NOTEBOOKLM_MASTER_TOKEN_JSON
+        minted=""
+        for attempt in 1 2 3; do
           if uv run notebooklm login --master-token-refresh; then
-            echo "Auth profile materialized (master token; fresh cookies minted)."
-          else
-            echo "::warning::master-token re-mint failed — proceeding with the cookie snapshot only."
+            minted=1
+            break
           fi
-        else
-          echo "::warning::NOTEBOOKLM_MASTER_TOKEN_JSON secret is empty/absent — cookie-only profile (no rotation immunity)."
+          echo "::warning::master-token mint attempt ${attempt} failed."
+          if [ "$attempt" -lt 3 ]; then
+            # Jitter: nightly's ubuntu/windows legs mint concurrently from the
+            # same token, so a fixed backoff would have them retry in lockstep
+            # and collide again on whatever throttled the first attempt.
+            sleep $((attempt * 15 + RANDOM % 20))
+          fi
+        done
+        # Fatal, unlike before: there is no cookie snapshot left to fall back
+        # to, so a failed mint means the job has no credentials at all.
+        if [ -z "$minted" ]; then
+          echo "::error::master-token mint failed after 3 attempts — no auth available."
+          exit 1
         fi
+        echo "Auth profile materialized (master token; fresh cookies minted)."
 
     - name: Run E2E tests
       id: e2e
@@ -283,8 +290,8 @@ jobs:
       if: needs.resolve-branch.outputs.is_standard == 'true'
       # Don't fail the job here — the retry step below gets a 10-min cool-down
       # shot at any failures, and its exit code is what marks the job red.
-      # Auth comes from the profile materialized above (NOT an inline
-      # NOTEBOOKLM_AUTH_JSON env var) so the layer-4 re-mint can engage.
+      # Auth comes from the profile materialized above (no inline env-var
+      # credential is shipped at all) so the layer-4 re-mint can engage.
       continue-on-error: true
       env:
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -63,7 +63,7 @@ jobs:
     concurrency:
       group: rpc-health-${{ needs.resolve-branch.outputs.branch }}
       cancel-in-progress: true
-    # Secret-bearing job. ``NOTEBOOKLM_AUTH_JSON`` and friends live only in
+    # Secret-bearing job. ``NOTEBOOKLM_MASTER_TOKEN_JSON`` and friends live only in
     # the ``protected-readonly`` GitHub Environment (issue #1009: relying on
     # repo-level fallback for the scheduled-cron branch broke when those
     # secrets were migrated env-only). Binding the env unconditionally is
@@ -126,13 +126,12 @@ jobs:
     # in-process and the job survives rotation.
     - name: Materialize auth profile
       env:
-        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets.NOTEBOOKLM_MASTER_TOKEN_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
       shell: bash
       run: |
-        if [ -z "${NOTEBOOKLM_AUTH_JSON:-}" ]; then
-          echo "::error::NOTEBOOKLM_AUTH_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
+        if [ -z "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
+          echo "::error::NOTEBOOKLM_MASTER_TOKEN_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
           exit 1
         fi
         if [ -z "${NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID:-}" ]; then
@@ -141,30 +140,40 @@ jobs:
         fi
         umask 077
         mkdir -p ~/.notebooklm/profiles/default
-        printf '%s' "$NOTEBOOKLM_AUTH_JSON" > ~/.notebooklm/profiles/default/storage_state.json
-        chmod 600 ~/.notebooklm/profiles/default/storage_state.json
-        if [ -n "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
-          printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
-          chmod 600 ~/.notebooklm/profiles/default/master_token.json
-          # Pre-mint fresh cookies NOW: the health/drift scripts fetch tokens
-          # eagerly (load_auth / direct homepage read) and fail on a dead
-          # cookie snapshot before any client-side recovery can run, so the
-          # sibling master_token.json alone cannot rescue a stale secret at
-          # startup. The explicit re-mint overwrites storage_state.json with
-          # a fresh session. Non-fatal: if the mint fails but the cookie
-          # snapshot is still live, the run can proceed on cookies alone.
-          # unset is load-bearing: `login` refuses to run while
-          # NOTEBOOKLM_AUTH_JSON is set (env-var auth conflicts with
-          # file-writing login), and both secrets are already on disk.
-          unset NOTEBOOKLM_AUTH_JSON NOTEBOOKLM_MASTER_TOKEN_JSON
+        printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
+        chmod 600 ~/.notebooklm/profiles/default/master_token.json
+        # The master token is now the ONLY credential shipped. A cookie
+        # snapshot cannot be: Google supersedes __Secure-1PSIDTS on a ~600 s
+        # cadence and a superseded value is rejected shortly after, so a
+        # secret minted on a workstation is routinely dead before the run
+        # starts. A master token does not rotate, so it cannot go stale.
+        # The health/drift scripts fetch tokens eagerly, which is exactly why
+        # the mint runs here rather than relying on in-run recovery; it also
+        # bootstraps storage_state.json when none exists. `unset` is
+        # load-bearing: `login` refuses to run while inline env auth is set,
+        # and the secret is already on disk.
+        unset NOTEBOOKLM_MASTER_TOKEN_JSON
+        minted=""
+        for attempt in 1 2 3; do
           if uv run notebooklm login --master-token-refresh; then
-            echo "Auth profile materialized (master token; fresh cookies minted)."
-          else
-            echo "::warning::master-token re-mint failed — proceeding with the cookie snapshot only."
+            minted=1
+            break
           fi
-        else
-          echo "::warning::NOTEBOOKLM_MASTER_TOKEN_JSON secret is empty/absent — cookie-only profile (no rotation immunity)."
+          echo "::warning::master-token mint attempt ${attempt} failed."
+          if [ "$attempt" -lt 3 ]; then
+            # Jitter: nightly's ubuntu/windows legs mint concurrently from the
+            # same token, so a fixed backoff would have them retry in lockstep
+            # and collide again on whatever throttled the first attempt.
+            sleep $((attempt * 15 + RANDOM % 20))
+          fi
+        done
+        # Fatal, unlike before: there is no cookie snapshot left to fall back
+        # to, so a failed mint means the job has no credentials at all.
+        if [ -z "$minted" ]; then
+          echo "::error::master-token mint failed after 3 attempts — no auth available."
+          exit 1
         fi
+        echo "Auth profile materialized (master token; fresh cookies minted)."
 
     # Rebrand-host lane state, carried between nightly runs so the lane can
     # report a *state change* rather than re-announcing the same observation
@@ -200,8 +209,8 @@ jobs:
 
     - name: Run RPC Health Check
       id: health
-      # Auth comes from the profile materialized above (NOT an inline
-      # NOTEBOOKLM_AUTH_JSON env var) so the layer-4 re-mint can engage.
+      # Auth comes from the profile materialized above (no inline env-var
+      # credential is shipped at all) so the layer-4 re-mint can engage.
       #
       # The rebrand-host lane reads its previous state from the restored-and-
       # renamed ``rebrand-state-prev.json`` and writes this run's state to

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -121,9 +121,9 @@ jobs:
     # auth never engages the layer-4 master-token re-mint (it only fires when
     # master_token.json sits BESIDE the profile's storage_state.json —
     # src/notebooklm/_auth/session.py), so a rotated cookie secret used to
-    # hard-fail the run. With a file-based profile plus the optional
-    # NOTEBOOKLM_MASTER_TOKEN_JSON secret, expired cookies are re-minted
-    # in-process and the job survives rotation.
+    # hard-fail the run. The master token is now MANDATORY (empty secret or
+    # 3 failed mints both exit 1) — it is the only credential shipped, so
+    # there is no snapshot to degrade onto.
     - name: Materialize auth profile
       env:
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets.NOTEBOOKLM_MASTER_TOKEN_JSON }}

--- a/.github/workflows/verify-artifacts.yml
+++ b/.github/workflows/verify-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
     name: Verify Artifacts
     runs-on: ubuntu-latest
     if: github.repository == 'teng-lin/notebooklm-py'
-    # Secret-bearing job. ``NOTEBOOKLM_AUTH_JSON`` and friends live only in
+    # Secret-bearing job. ``NOTEBOOKLM_MASTER_TOKEN_JSON`` and friends live only in
     # the ``protected-readonly`` GitHub Environment (issue #1009), so the
     # env binding is unconditional — every trigger sees the same secret
     # values. Add a ``required reviewers`` rule on the environment if you
@@ -40,30 +40,65 @@ jobs:
     - name: Install dependencies
       # `uv sync --frozen` reproduces the lockfile-pinned dep tree. The
       # inline verification script below only touches the public client API
-      # (no playwright / pytest / markdownify), so no extras are needed.
-      run: uv sync --frozen
+      # (no playwright / pytest / markdownify). `--extra headless` = gpsoauth,
+      # required for the master-token mint that materializes the auth profile.
+      run: uv sync --frozen --extra headless
 
-    # Fail-fast preflight. Without this, ``NotebookLMClient.from_storage()``
-    # below would die with a confusing "no storage" error when the secret
-    # resolves empty (issue #1009).
-    - name: Verify auth secret is present
+    # Fail-fast preflight + profile materialization. Without the empty-secret
+    # check, ``NotebookLMClient.from_storage()`` below would die with a
+    # confusing "no storage" error when the secret resolves empty (#1009).
+    #
+    # This step used to hand the script an inline NOTEBOOKLM_AUTH_JSON. That
+    # credential is a cookie snapshot, and Google supersedes __Secure-1PSIDTS
+    # on a ~600 s cadence — a superseded value is rejected shortly after, so
+    # the secret was routinely dead before the run started. A master token
+    # does not rotate; the mint below turns it into a fresh session on disk,
+    # which also lets the layer-4 re-mint engage for mid-run expiry.
+    - name: Materialize auth profile
       env:
-        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
+        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets.NOTEBOOKLM_MASTER_TOKEN_JSON }}
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
       shell: bash
       run: |
-        if [ -z "${NOTEBOOKLM_AUTH_JSON:-}" ]; then
-          echo "::error::NOTEBOOKLM_AUTH_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
+        if [ -z "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
+          echo "::error::NOTEBOOKLM_MASTER_TOKEN_JSON resolved to empty. Env binding or secret config is broken — see docs/development.md → Workflow secret gates."
           exit 1
         fi
         if [ -z "${NOTEBOOKLM_GENERATION_NOTEBOOK_ID:-}" ]; then
           echo "::error::NOTEBOOKLM_GENERATION_NOTEBOOK_ID resolved to empty."
           exit 1
         fi
+        umask 077
+        mkdir -p ~/.notebooklm/profiles/default
+        printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
+        chmod 600 ~/.notebooklm/profiles/default/master_token.json
+        # `unset` is load-bearing: `login` refuses to run while inline env
+        # auth is set, and the secret is already on disk.
+        unset NOTEBOOKLM_MASTER_TOKEN_JSON
+        minted=""
+        for attempt in 1 2 3; do
+          if uv run notebooklm login --master-token-refresh; then
+            minted=1
+            break
+          fi
+          echo "::warning::master-token mint attempt ${attempt} failed."
+          if [ "$attempt" -lt 3 ]; then
+            # Jitter: nightly's ubuntu/windows legs mint concurrently from the
+            # same token, so a fixed backoff would have them retry in lockstep
+            # and collide again on whatever throttled the first attempt.
+            sleep $((attempt * 15 + RANDOM % 20))
+          fi
+        done
+        if [ -z "$minted" ]; then
+          echo "::error::master-token mint failed after 3 attempts — no auth available."
+          exit 1
+        fi
+        echo "Auth profile materialized (master token; fresh cookies minted)."
 
     - name: Verify artifacts exist
+      # Auth comes from the profile materialized above (no inline env-var
+      # credential is shipped at all) so the layer-4 re-mint can engage.
       env:
-        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
       run: |
         uv run python -c "

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -19,8 +19,7 @@ jobs:
   verify:
     name: Verify from ${{ inputs.source }}
     runs-on: ubuntu-latest
-    # Secret-bearing job (steps below reference secrets.NOTEBOOKLM_AUTH_JSON
-    # + secrets.NOTEBOOKLM_MASTER_TOKEN_JSON
+    # Secret-bearing job (steps below reference secrets.NOTEBOOKLM_MASTER_TOKEN_JSON
     # + secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID for the live E2E pass). The
     # workflow is workflow_dispatch-only, so every run is human-initiated;
     # this `protected-readonly` environment requires a maintainer to approve
@@ -161,57 +160,60 @@ jobs:
       if: github.repository == 'teng-lin/notebooklm-py'
       shell: bash
       env:
-        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets.NOTEBOOKLM_MASTER_TOKEN_JSON }}
       run: |
-        # Write the auth secrets to a real on-disk profile instead of handing
-        # pytest an inline NOTEBOOKLM_AUTH_JSON env var. Env-var auth never
-        # engages the layer-4 master-token re-mint (it only fires when
+        # Write the master token to a real on-disk profile and mint from it.
+        # Inline env auth never engages the layer-4 re-mint (it only fires when
         # master_token.json sits BESIDE the profile's storage_state.json —
         # src/notebooklm/_auth/session.py), so a rotated cookie secret used to
-        # hard-fail the run (e.g. run 30799508786). With a file-based profile
-        # plus the optional NOTEBOOKLM_MASTER_TOKEN_JSON secret, expired
-        # cookies are re-minted in-process and the job survives rotation.
-        if [ -z "${NOTEBOOKLM_AUTH_JSON:-}" ]; then
-          echo "::error::NOTEBOOKLM_AUTH_JSON secret is not configured"
+        # hard-fail the run (e.g. run 30799508786).
+        if [ -z "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
+          echo "::error::NOTEBOOKLM_MASTER_TOKEN_JSON secret is not configured"
           exit 1
         fi
         umask 077
         mkdir -p ~/.notebooklm/profiles/default
-        printf '%s' "$NOTEBOOKLM_AUTH_JSON" > ~/.notebooklm/profiles/default/storage_state.json
-        chmod 600 ~/.notebooklm/profiles/default/storage_state.json
-        if [ -n "${NOTEBOOKLM_MASTER_TOKEN_JSON:-}" ]; then
-          printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
-          chmod 600 ~/.notebooklm/profiles/default/master_token.json
-          # Pre-mint fresh cookies NOW: consumers that fetch tokens eagerly
-          # (AuthTokens.from_storage in the e2e session fixture) raise on a
-          # dead cookie snapshot BEFORE any client exists, so the in-client
-          # layer-4 hook alone cannot rescue a stale secret at startup. The
-          # explicit re-mint overwrites storage_state.json with a fresh
-          # session; layer-4 then covers mid-run expiry. Non-fatal: if the
-          # mint fails but the cookie snapshot is still live, the run can
-          # proceed on cookies alone.
-          # unset is load-bearing: `login` refuses to run while
-          # NOTEBOOKLM_AUTH_JSON is set (env-var auth conflicts with
-          # file-writing login), and both secrets are already on disk.
-          unset NOTEBOOKLM_AUTH_JSON NOTEBOOKLM_MASTER_TOKEN_JSON
-          source .venv/bin/activate
+        printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
+        chmod 600 ~/.notebooklm/profiles/default/master_token.json
+        # The master token is now the ONLY credential shipped. A cookie
+        # snapshot cannot be: Google supersedes __Secure-1PSIDTS on a ~600 s
+        # cadence and a superseded value is rejected shortly after, so a
+        # secret minted on a workstation is routinely dead before the run
+        # starts. A master token does not rotate, so it cannot go stale.
+        # The mint below bootstraps storage_state.json from it; layer-4 then
+        # covers mid-run expiry. `unset` is load-bearing: `login` refuses to
+        # run while inline env auth is set, and the secret is already on disk.
+        unset NOTEBOOKLM_MASTER_TOKEN_JSON
+        source .venv/bin/activate
+        minted=""
+        for attempt in 1 2 3; do
           if notebooklm login --master-token-refresh; then
-            echo "Auth profile materialized (master token; fresh cookies minted)."
-          else
-            echo "::warning::master-token re-mint failed — proceeding with the cookie snapshot only."
+            minted=1
+            break
           fi
-        else
-          echo "::warning::NOTEBOOKLM_MASTER_TOKEN_JSON secret is empty/absent — cookie-only profile (no rotation immunity)."
+          echo "::warning::master-token mint attempt ${attempt} failed."
+          if [ "$attempt" -lt 3 ]; then
+            # Jitter: nightly's ubuntu/windows legs mint concurrently from the
+            # same token, so a fixed backoff would have them retry in lockstep
+            # and collide again on whatever throttled the first attempt.
+            sleep $((attempt * 15 + RANDOM % 20))
+          fi
+        done
+        # Fatal, unlike before: there is no cookie snapshot left to fall back
+        # to, so a failed mint means the job has no credentials at all.
+        if [ -z "$minted" ]; then
+          echo "::error::master-token mint failed after 3 attempts — no auth available."
+          exit 1
         fi
+        echo "Auth profile materialized (master token; fresh cookies minted)."
 
     - name: Run E2E tests
       id: e2e
       if: github.repository == 'teng-lin/notebooklm-py'
       # Don't fail the job here — the retry step below gets a 10-min cool-down
       # shot at any failures, and its exit code is what marks the job red.
-      # Auth comes from the profile materialized above (NOT the inline
-      # NOTEBOOKLM_AUTH_JSON env var) so the layer-4 re-mint can engage.
+      # Auth comes from the profile materialized above (no inline env-var
+      # credential is shipped at all) so the layer-4 re-mint can engage.
       continue-on-error: true
       shell: bash
       env:

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -326,17 +326,39 @@ Playwright-minted one. Extraction asks for the full multi-domain set
 specific paths (e.g. losing `.notebooklm.google.com` cookies breaks artifact
 downloads).
 
-### 2.5 Three timers people confuse
+### 2.5 Four timers people confuse
 
 | Timer | Magnitude | Lives in | Meaning |
 |---|---|---|---|
-| **`*PSIDTS` rotation cadence** | ~600 s | Google's identity surface | Recommended active-client refresh interval (`["identity.hfcr",600]`). Not a hard rejection TTL — prior values stay valid much longer on stable profiles. |
+| **`*PSIDTS` rotation cadence** | ~600 s | Google's identity surface | Recommended active-client refresh interval, advertised in the `RotateCookies` response body as `["identity.hfcr",600]`. Re-measured 2026-08-05: still 600. |
+| **`*PSIDTS` supersede grace** | **short, and not ours to set** | Google's identity surface | How long a *superseded* value keeps working after a newer one is issued. Undocumented, server-side, and observed to have tightened sharply — see the warning below. |
 | **`*SIDCC` sliding window** | ~5 min | Google's RPC surface | A different cookie family; rotates on nearly every request; not load-bearing for our auth. |
 | **Client-side rotation throttle** | 60 s | `_auth/keepalive.py` | Don't fire two `RotateCookies` POSTs within a minute (avoids 429). Unrelated to how often Google *requires* rotation. |
 
-Reports that "cookies are expiring faster" usually trace to the session entering a
-risk-flagged state (§3.1) or to the rotation mechanism failing until `*SID` finally
-ages out — not to a shorter hard rejection TTL.
+> **The supersede grace collapsed (observed 2026-08).** This document used to
+> assert that "prior values stay valid much longer on stable profiles," and that
+> reports of faster expiry trace to a risk-flagged session (§3.1) rather than a
+> shorter TTL. That advice is no longer safe to follow. A cookie snapshot copied
+> out of a working profile has been observed dying **within ~30 minutes**, while
+> the cadence (600 s) and the cookie's own `expires` stamp (365 days, verified
+> across every local profile) are both unchanged.
+>
+> Two consequences worth internalising:
+>
+> * **The expiry field tells you nothing.** A snapshot whose `__Secure-1PSIDTS`
+>   is a year from expiring can already be rejected. Nothing client-side can
+>   detect this in advance — the only signal is the request failing.
+> * **Any other active client kills your copy.** At a 600 s cadence, a
+>   workstation, a second CI job, or a keepalive supersedes the value you
+>   shipped within ten minutes; the grace period then decides how long your copy
+>   limps on. That is why a cookie snapshot is no longer a viable CI credential
+>   and why the ladder's persistence steps are load-bearing rather than an
+>   optimisation.
+>
+> The durable answer is a credential that does not rotate: ship
+> `master_token.json` and let §4.4 mint a session per run. All four of this
+> repo's secret-bearing workflows do exactly that and ship no cookie snapshot at
+> all.
 
 ### 2.6 Domain tiering: REQUIRED vs OPTIONAL cookie domains
 

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -28,10 +28,12 @@ friends) extracted from a real browser sign-in. Two clocks govern their validity
 
 - **`__Secure-1PSIDTS` has a *recommended* rotation cadence of ~600 s**
   (self-reported by Google as `["identity.hfcr",600]` on the `RotateCookies`
-  response). This is a *hint*, not a hard rejection TTL: the prior value keeps
-  authenticating far longer — commonly hours to days on a stable IP / non-Workspace
-  account. Worst-case profiles (datacenter egress, cross-IP, Workspace policy,
-  incomplete extraction) can collapse that to hours or less.
+  response). This is a *hint*, not a hard rejection TTL — but see §2.5: once a
+  newer value has been issued, the **superseded** one is now rejected within
+  roughly half an hour. The "hours to days" figure below applies only while no
+  other client has rotated the session out from under you; a copied snapshot
+  does not qualify. Worst-case profiles (datacenter egress, cross-IP, Workspace
+  policy, incomplete extraction) collapse it further.
 - **`SID` and `__Secure-1PSID`** have very long server-side lifetimes (months to
   years) and effectively don't expire under normal usage.
 - **Cookie set completeness matters more than freshness.** Google rejects cookie
@@ -155,7 +157,9 @@ on a schedule:
    (off-minute schedule avoids fleet collision).
 4. Keeping the source browser running with a Google tab adds resilience, but even
    a closed browser works for hours-to-days while `RotateCookies` keeps
-   succeeding from `SID` alone.
+   succeeding from `SID` alone — provided this is the only client using the
+   session. A second client rotating the same session supersedes your value;
+   see §2.5.
 
 > **Browser support:** `--browser-cookies` accepts any of the ~16 browsers rookiepy
 > reads on the host (`arc`, `brave`, `chrome`, `edge`, `firefox`, `opera`, `safari`,
@@ -408,7 +412,7 @@ Cookie decay clocks by class:
 
 | Cookie | Rotation / expiry signal | Lifecycle |
 |---|---|---|
-| `__Secure-1PSIDTS` / `*-3PSIDTS` | Recommended cadence ~600 s (`["identity.hfcr",600]`); not a hard TTL | Refreshed opportunistically; stale values work for hours-to-days, then drift into sign-in redirects |
+| `__Secure-1PSIDTS` / `*-3PSIDTS` | Recommended cadence ~600 s (`["identity.hfcr",600]`); not a hard TTL | Refreshed opportunistically. An *un-superseded* stale value works for hours-to-days; a **superseded** one dies within ~30 min (§2.5) |
 | `SIDCC` / `__Secure-*SIDCC` | ~5 min sliding window | Ephemeral; generally not load-bearing for auth |
 | `SID`, `HSID`, `SSID`, `APISID`, `SAPISID` (+ `__Secure-` cousins) | Months → ~1 year | Long-lived identity; not rotated by us |
 | `OSID`, `__Secure-OSID` | Per-product session | Re-issued on each sign-in |

--- a/docs/development.md
+++ b/docs/development.md
@@ -870,24 +870,29 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 
 ### Setting Up Nightly E2E Tests
 
-1. Get storage state: `cat ~/.notebooklm/profiles/default/storage_state.json`
+1. Bootstrap a master token once: `notebooklm login --master-token --account <you@gmail.com>`
+   (needs the `[headless]` extra; see
+   [installation.md → master-token auth](installation.md#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry)).
 2. Add GitHub secrets:
-   - `NOTEBOOKLM_AUTH_JSON`: Storage state JSON
+   - `NOTEBOOKLM_MASTER_TOKEN_JSON` (**required**): contents of
+     `~/.notebooklm/profiles/default/master_token.json`. The workflows exit `1`
+     when it is empty — it is the only credential they ship.
    - `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`: Your test notebook ID
-   - `NOTEBOOKLM_MASTER_TOKEN_JSON` (optional but recommended): contents of
-     `~/.notebooklm/profiles/default/master_token.json`, produced by a one-time
-     `notebooklm login --master-token` bootstrap (see
-     [installation.md → master-token auth](installation.md#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry)).
 
-The live-E2E workflows (`verify-package.yml`, `nightly.yml`, `rpc-health.yml`)
-do not hand pytest an inline `NOTEBOOKLM_AUTH_JSON` env var. Their
-"Materialize auth profile" step writes the secrets to a real on-disk profile
-(`~/.notebooklm/profiles/default/storage_state.json` + `master_token.json`,
-mode `0600`) because the layer-4 master-token re-mint only engages when
-`master_token.json` sits beside the profile's `storage_state.json` — env-var
-auth bypasses it entirely. With the master-token secret set, the step then
-runs the legacy forced route `notebooklm login --master-token-refresh` to pre-mint fresh cookies
-before any test touches them, preserving a deterministic fresh-jar CI setup;
+   `NOTEBOOKLM_AUTH_JSON` is **no longer used by any workflow**. A cookie
+   snapshot is superseded by any other active client within ~10 minutes and
+   rejected shortly after, so it was routinely dead before a scheduled run
+   started (see
+   [auth-cookie-lifecycle.md §2.5](auth-cookie-lifecycle.md#25-four-timers-people-confuse)).
+
+The live-E2E workflows (`verify-package.yml`, `nightly.yml`, `rpc-health.yml`,
+`verify-artifacts.yml`) ship no inline credential at all. Their "Materialize
+auth profile" step writes `master_token.json` to a real on-disk profile (mode
+`0600`) because the layer-4 re-mint only engages when the token sits beside the
+profile's `storage_state.json` — env-var auth bypasses it entirely. The step
+then runs `notebooklm login --master-token-refresh`, which **bootstraps**
+`storage_state.json` from the token, preserving a deterministic fresh-jar CI
+setup;
 ordinary file-backed cold loading now also reaches layer 4 after a confirmed
 login redirect, and layer 4 continues to cover mid-run expiry. So as long as
 the pre-mint succeeds, a cookie secret that Google has rotated no longer fails

--- a/docs/development.md
+++ b/docs/development.md
@@ -879,10 +879,11 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
      when it is empty — it is the only credential they ship.
    - `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`: Your test notebook ID
 
-   `NOTEBOOKLM_AUTH_JSON` is **no longer used by any workflow**. A cookie
-   snapshot is superseded by any other active client within ~10 minutes and
-   rejected shortly after, so it was routinely dead before a scheduled run
-   started (see
+   `NOTEBOOKLM_AUTH_JSON` is **no longer used by any workflow**. Any other
+   active client supersedes a cookie snapshot within ~10 minutes (the ~600 s
+   rotation cadence), and a *superseded* value has been observed failing
+   within roughly half an hour — so a snapshot exported on a workstation was
+   routinely dead before a scheduled run started (see
    [auth-cookie-lifecycle.md §2.5](auth-cookie-lifecycle.md#25-four-timers-people-confuse)).
 
 The live-E2E workflows (`verify-package.yml`, `nightly.yml`, `rpc-health.yml`,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -258,7 +258,7 @@ print(notebooklm.__version__)
 
    > **CI notes:**
    > - The mint **bootstraps** `storage_state.json` when none exists, so the token is the only credential you ship. Layer-4 then covers mid-run expiry.
-   > - `master_token.json` is a **full-account credential** — it mints OAuth for many Google services, does not rotate, and stays valid until you change the password or revoke the device. Keep it in a protected environment, `0600` on disk, and `unset` it from the environment once written (a file is not inherited by child processes; an env var is).
+   > - `master_token.json` is a **full-account credential** — it mints OAuth for many Google services and does not rotate. **It survives a password change**: the only remediation for a leaked token is explicit revocation (Google Account → Security → Your devices → remove the device/session), so do not treat a password reset as containment. Use a dedicated/throwaway account, keep it in a protected environment, `0600` on disk, and `unset` it from the environment once written (a file is not inherited by child processes; an env var is). See the security warning under [master-token auth](#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry).
    > - Requires the `[headless]` extra (`gpsoauth`) on the runner.
    > - This repo's four secret-bearing workflows all use exactly this shape and ship no cookie snapshot ([development.md](development.md#setting-up-nightly-e2e-tests)).
    > - Inline `NOTEBOOKLM_AUTH_JSON` still works for a single short-lived invocation, but it never engages the layer-4 re-mint and cannot persist a rotation, so it is not suitable for scheduled or long-lived jobs. See [master-token auth](#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -231,17 +231,32 @@ print(notebooklm.__version__)
    scp ~/.notebooklm/profiles/default/storage_state.json \
        user@server:~/.notebooklm/profiles/default/storage_state.json
    ```
-   or stuff the contents into a CI / deployment env var (preferred for ephemeral runners):
-   <!-- not mirrored: headless-server bootstrap step 2b (env var); not part of contributor flow -->
+   **For CI, ship the master token — not a cookie snapshot.** A cookie snapshot
+   is superseded by any other active client within ~10 minutes and is rejected
+   shortly after (see [auth-cookie-lifecycle.md §2.5](auth-cookie-lifecycle.md#25-four-timers-people-confuse)),
+   so a secret exported on a workstation is routinely dead before the run starts.
+   A master token does not rotate. Write it to a file and mint a session per run:
+
+   <!-- not mirrored: headless-server bootstrap step 2b (CI secret); not part of contributor flow -->
    ```bash
-   export NOTEBOOKLM_AUTH_JSON="$(cat ~/.notebooklm/profiles/default/storage_state.json)"
+   # one-off, on the workstation
+   gh secret set NOTEBOOKLM_MASTER_TOKEN_JSON < ~/.notebooklm/profiles/default/master_token.json
+
+   # in the job, before anything that authenticates
+   umask 077
+   mkdir -p ~/.notebooklm/profiles/default
+   printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json
+   chmod 600 ~/.notebooklm/profiles/default/master_token.json
+   unset NOTEBOOKLM_MASTER_TOKEN_JSON     # `login` refuses to run while inline env auth is set
+   notebooklm login --master-token-refresh   # bootstraps storage_state.json from the token
    ```
 
-   > **CI env-var notes:**
-   > - `storage_state.json` is typically 4–15 KB — well under GitHub Actions' 48 KB single-secret cap.
-   > - Watch for trailing newlines: pipe with `tr -d '\n'` if your secret-set tool adds one (`cat ... | tr -d '\n' | gh secret set NOTEBOOKLM_AUTH_JSON`).
-   > - For **ephemeral runners** (GitHub Actions, GitLab CI — no persistent disk between runs), the layer-5 in-process refresh from [troubleshooting.md](troubleshooting.md#authentication-errors) cannot persist rotated cookies. Run `notebooklm auth refresh` periodically on a workstation cron and push the refreshed file with `gh secret set NOTEBOOKLM_AUTH_JSON < ~/.notebooklm/profiles/default/storage_state.json`.
-   > - **Rotation immunity:** inline env-var auth never engages the layer-4 master-token re-mint below. To make CI survive Google's cookie rotations, write the secrets to real files on the runner instead (`~/.notebooklm/profiles/default/storage_state.json` plus `master_token.json`, both mode `0600`) and run without `NOTEBOOKLM_AUTH_JSON` set. Cold token loading re-mints automatically after a confirmed login redirect; if only the token was shipped, first run `notebooklm auth refresh` to mint and passively validate the initial cookie file. See [master-token auth](#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry). This repo's own live-E2E workflows use a `NOTEBOOKLM_MASTER_TOKEN_JSON` secret ([development.md](development.md#setting-up-nightly-e2e-tests)).
+   > **CI notes:**
+   > - The mint **bootstraps** `storage_state.json` when none exists, so the token is the only credential you ship. Layer-4 then covers mid-run expiry.
+   > - `master_token.json` is a **full-account credential** — it mints OAuth for many Google services, does not rotate, and stays valid until you change the password or revoke the device. Keep it in a protected environment, `0600` on disk, and `unset` it from the environment once written (a file is not inherited by child processes; an env var is).
+   > - Requires the `[headless]` extra (`gpsoauth`) on the runner.
+   > - This repo's four secret-bearing workflows all use exactly this shape and ship no cookie snapshot ([development.md](development.md#setting-up-nightly-e2e-tests)).
+   > - Inline `NOTEBOOKLM_AUTH_JSON` still works for a single short-lived invocation, but it never engages the layer-4 re-mint and cannot persist a rotation, so it is not suitable for scheduled or long-lived jobs. See [master-token auth](#alternative-master-token-auth-no-cookie-file-to-ship-survives-expiry).
 3. **On the server**, run any non-`login` command:
    <!-- not mirrored: headless-server smoke test; not part of contributor flow -->
    ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -239,10 +239,15 @@ print(notebooklm.__version__)
 
    <!-- not mirrored: headless-server bootstrap step 2b (CI secret); not part of contributor flow -->
    ```bash
-   # one-off, on the workstation
+   # one-off, on the workstation: mint the master token, then ship it.
+   # Plain `notebooklm login` (step 1) does NOT create master_token.json.
+   pip install "notebooklm-py[headless]"
+   notebooklm login --master-token   # writes ~/.notebooklm/profiles/default/master_token.json
    gh secret set NOTEBOOKLM_MASTER_TOKEN_JSON < ~/.notebooklm/profiles/default/master_token.json
 
-   # in the job, before anything that authenticates
+   # in the job, before anything that authenticates.
+   # [headless] pulls gpsoauth, without which the mint below cannot run.
+   pip install "notebooklm-py[headless]"
    umask 077
    mkdir -p ~/.notebooklm/profiles/default
    printf '%s' "$NOTEBOOKLM_MASTER_TOKEN_JSON" > ~/.notebooklm/profiles/default/master_token.json

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -344,9 +344,9 @@ async def load_auth(storage_path: Path | None) -> AuthTokens:
     Routes through :meth:`AuthTokens.from_storage` — the same loader the CLI
     and library use — which handles:
 
-    - ``NOTEBOOKLM_AUTH_JSON`` env var (for CI) and the profile storage file
-      (for local dev), via ``storage_path`` resolved by
-      :func:`resolve_storage_path`
+    - the profile storage file (what CI and local dev both use) and the
+      short-lived ``NOTEBOOKLM_AUTH_JSON`` env var, via ``storage_path``
+      resolved by :func:`resolve_storage_path`
     - cookie-domain filtering *and* per-cookie domain preservation
     - authuser / account-email routing and the CSRF + session token fetch
 

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -52,7 +52,8 @@ Rebrand-host lane (``notebook.google.com``):
     lane as a green one.
 
 Environment variables:
-    NOTEBOOKLM_AUTH_JSON - Playwright storage state JSON (required)
+    NOTEBOOKLM_AUTH_JSON - Playwright storage state JSON (optional; the
+        profile's storage_state.json is used when unset, which is what CI does)
     NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID - Notebook ID for read operations
     NOTEBOOKLM_GENERATION_NOTEBOOK_ID - Notebook ID for write operations
     NOTEBOOKLM_RPC_DELAY - Delay between RPC calls in seconds (default: 1.0)


### PR DESCRIPTION
Takes CI off the credential that now dies every ~30 minutes, and corrects the docs that misdiagnose it.

## What changed under us

Measured live on 2026-08-05:

| quantity | value | changed? |
| --- | --- | --- |
| advertised rotation cadence | `RotateCookies` → `[["identity.hfcr",600],["di",44]]` — 600 s | **no** |
| `__Secure-1PSIDTS` expiry stamp | 8760 h (365 d), on every local profile | **no** |
| grace for a *superseded* value | ~30 min, was ~weeks | **yes — and it is the one nothing can see** |

At a 600 s cadence, any other active client — a workstation, a sibling job, a keepalive — supersedes a copied snapshot within ten minutes. Previously that didn't matter because superseded values kept working. Now they don't, so a `NOTEBOOKLM_AUTH_JSON` secret is routinely dead before the run starts, and **no client-side check can detect it**: the cookie's `expires` still reads a year out.

## The change

All four secret-bearing workflows now ship **only** `NOTEBOOKLM_MASTER_TOKEN_JSON`. A master token does not rotate, so it cannot go stale between runs.

Three of them were most of the way there already — they wrote the token to `0600` `master_token.json`, `unset` the env, and pre-minted. What was missing is that `AUTH_JSON` was the **mandatory** secret while the token was optional, with a cookie-only fallback. This inverts that, which is mostly deletions.

`verify-artifacts.yml` needed more: it was the last genuine consumer of inline env auth (`NotebookLMClient.from_storage()` with the secret in the step env, no files at all), so it gains a materialize step and `--extra headless` for `gpsoauth`.

Verified before relying on it: `login --master-token-refresh` **bootstraps** `storage_state.json` when none exists —

```
start: master_token.json   (no cookie file)
$ notebooklm login --master-token-refresh
Re-minted cookies -> .../profiles/default/storage_state.json
$ AuthTokens.from_storage()  →  OK, 24 cookies, correct account
```

## Two consequences worth reviewing carefully

**A failed mint is now fatal.** There is no snapshot left to fall back to, so `::warning::… proceeding with the cookie snapshot only` becomes `exit 1`. A transient OAuth blip that used to degrade now reds the job. Mitigated with 3 attempts and backoff — but it is a genuine change to the failure profile, not a pure improvement.

**Parallel runs get safer, not riskier — measured, not assumed.** nightly's ubuntu and windows legs run concurrently (the concurrency group keys on `matrix.os`) and **both already minted from this token**, so concurrent minting is existing production behaviour, not something introduced here.

The question that decides whether that is safe is whether a second mint invalidates the first session. It does not — each mint is a distinct session:

```
session A minted   ->  works
session B minted   ->  works
  A and B carry DIFFERENT SID and __Secure-1PSIDTS values
  A STILL works after B was minted   ->  yes
  both still working at +2 min       ->  yes
```

Different SIDs matter because the PSIDTS supersede mechanic is **per-session**: two independent lineages cannot supersede each other. That is precisely what the old fallback got wrong — a leg whose mint failed dropped back to the *shared* snapshot, putting both legs on **one** SID rotating **one** lineage, each superseding the other. Removing the fallback removes the sharing.

Retry backoff carries jitter so the two legs don't retry in lockstep after whatever throttled the first attempt.

A longer run then covered the duration of a real nightly leg — two sessions minted concurrently, both probed every 10 minutes:

```
+10min  A=OK  B=OK
+20min  A=OK  B=OK
+30min  A=OK  B=OK
+40min  A=OK  B=OK      <- co-existence confirmed
```

Limits, stated plainly: **two** sessions, **40 minutes**, **one** account. It does not rule out a per-account session cap that evicts older sessions at greater concurrency depth, and it does not cover a leg that runs longer than 40 minutes. What it does establish is that the specific hazard — a second mint killing the first session — does not occur, across the window a nightly leg actually occupies.

Cross-workflow overlap is unlikely by schedule (6/7/8 AM UTC, staggered) and the e2e suite is single-process, so there is no intra-job profile sharing.

## Docs

- **`auth-cookie-lifecycle.md` §2.5** asserted *"prior values stay valid much longer on stable profiles"* and told anyone reporting faster expiry to look at risk-flagged sessions "not a shorter hard rejection TTL". That is the opposite of the correct diagnosis today, so it was actively sending people the wrong way. Rewritten with the measurements and a fourth timer — the supersede grace — called out explicitly.
- **`installation.md`** CI recipe now shows the token shape, and notes that `master_token.json` is a full-account credential that should be `unset` from the environment once written (a `0600` file is not inherited by child processes; an env var is).
- **`check_rpc_health.py`** no longer documents `NOTEBOOKLM_AUTH_JSON` as *required* — it routes through `AuthTokens.from_storage` and accepts either source.

## Verification

- `scripts/check_workflow_secret_gates.py` and `check_workflow_permissions.py` both pass; all workflow YAML parses.
- Offline suite green: **11,984 passed**, 62 skipped, 1 xfailed. `ruff` clean.
- Workflow-inspecting tests (`test_check_workflow_secret_gates`, `test_ci_install_parity`, `test_ci_test_matrix`, `test_rpc_health_rebrand_lane`) pass: 59 tests.

**Not verifiable offline:** whether the real workflows behave correctly end-to-end — that needs a live dispatch. The mint-and-bootstrap path is verified locally against a real account, but the YAML itself is only checked for syntax and secret gating. I'd suggest a manual `verify-artifacts` dispatch before trusting the scheduled runs, since it changed the most.

Follow-ups, deliberately not in this PR: deprecating `NOTEBOOKLM_AUTH_JSON` in the library (it is still set in 36 test files), and retiring the `proto/master-token-env` experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Udm7maQPJeGPXnHr6cG9By

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI workflows now authenticate using durable master-token profiles and automatically refresh session cookies with retries.
  * Artifact verification supports headless installation and profile-based authentication.

* **Documentation**
  * Updated installation and development guidance for master-token setup, security, permissions, and refresh behavior.
  * Clarified cookie rotation, invalidation, and lifecycle expectations.
  * Documented profile-file authentication for RPC health checks.

* **Bug Fixes**
  * Authentication jobs now fail clearly when session renewal cannot be completed instead of using stale cookie fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->