### PR TITLE
fix(auth): align cookie docs and RPC health baselines

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -180,10 +180,10 @@ jobs:
     # forever. Restore-only + a run-scoped save key, because cache entries are
     # immutable: a fixed key would pin the first night's answer permanently.
     #
-    # A cache miss is harmless by construction: ``load_rebrand_state`` falls
-    # back to the documented ABSENT baseline, so the worst case is that a
-    # genuine PRESENT is announced twice — never a false alarm out of the
-    # steady state.
+    # On a cache miss, ``load_rebrand_state`` falls back to the checkout's
+    # last-acknowledged status for each capability. A transition acknowledged
+    # in that checked-in baseline is not replayed merely because the cache
+    # disappeared; a contrary live observation is still reported as new.
     - name: Restore rebrand-host lane state
       uses: actions/cache/restore@v6
       continue-on-error: true
@@ -220,9 +220,9 @@ jobs:
       # cannot change ``exit_code`` here — see the "Rebrand host" steps below
       # for its own, separately-deduped issues.
       #
-      # No ``--base-url``: the nightly MUST stay on the default host, otherwise
-      # the legacy signal (the only named trigger for a future default flip)
-      # stops being collected. The flag exists for manual investigation.
+      # No ``--base-url``: the nightly stays on the default host so the main,
+      # exit-coded signal exercises the host users receive. The flag exists for
+      # manual investigation.
       continue-on-error: true
       shell: bash
       env:
@@ -539,15 +539,14 @@ jobs:
     # Rebrand-host lane (notebook.google.com) — SEPARATE from everything
     # above. It has no exit code: the script keeps its probes out of
     # ``compute_exit_code`` entirely. That separation is the whole point.
-    # The legacy "Non-transient ERROR detected" issue is deduped by TITLE
+    # The main "Non-transient ERROR detected" issue is deduped by TITLE
     # ALONE, so a rebrand probe reported through it would open one issue on
-    # the first failing night and then suppress every legacy-degradation
+    # the first failing night and then suppress every main-lane degradation
     # issue after it — disabling the very gate this lane feeds.
     #
     # This lane therefore has: its own titles, its own PER-CAPABILITY dedup
-    # keys, and a state-change trigger (ABSENT -> PRESENT) rather than a
-    # recurring error. A rebrand host that never serves RPC files nothing,
-    # ever.
+    # keys, and a state-change trigger (for example, PRESENT -> ABSENT) rather
+    # than a recurring error. An unchanged capability files nothing.
     #
     # Step order matters: detect -> report -> save. The cached state is the
     # baseline the NEXT run compares against, so it may only be advanced once
@@ -643,8 +642,8 @@ jobs:
             echo "**Commit:** ${GITHUB_SHA}"
             echo ""
             echo "This is the rebrand-host lane of the nightly RPC health check. It"
-            echo "carries NO exit code and is independent of the legacy-host signal;"
-            echo "the legacy lane's issues are unaffected by anything reported here."
+            echo "carries NO exit code and is independent of the exit-coded main signal;"
+            echo "the main lane's issues are unaffected by anything reported here."
             echo ""
             grep '^REBRAND' health-report.txt || echo "(no rebrand lane output)"
             echo ""
@@ -656,8 +655,9 @@ jobs:
             echo "manual authenticated capture (upload-session start only, no bytes),"
             echo "scrubbed via \`tests/cassette_patterns.py\` before it leaves the machine."
             echo ""
-            echo "A PRESENT verdict here is evidence the host serves that endpoint from"
-            echo "these credentials — it is NOT on its own a reason to change any default."
+            echo "A PRESENT verdict is evidence the host served the endpoint from these"
+            echo "credentials. ABSENT means a non-auth, non-transient response did not"
+            echo "demonstrate it. Neither verdict alone is a reason to change any default."
           } > rebrand-issue-body.md
           if ! existing=$(TITLE="$TITLE" gh issue list --repo "$GITHUB_REPOSITORY" \
             --state open --label automated \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `auth inspect` likewise keeps probing before validating, so a network outage
   is still reported as a network outage rather than as a bad cookie set.
 
+- **Authentication docs now match the executable secondary-binding rule.** The
+  `APISID`/`SAPISID` path also requires bare `LSID` when `OSID` is absent;
+  `__Host-1PLSID` and `__Host-3PLSID` do not substitute for it. A documentation
+  guard now checks the published predicate against runtime across every cookie
+  subset and pins the Tier 1 cookie set
+  ([#2074](https://github.com/teng-lin/notebooklm-py/issues/2074)).
+
+- **The rebrand-host health lane now acknowledges the availability transitions
+  it already reported.** The authenticated nightly run at commit `36221e0`
+  reached `notebook.google.com` with HTTP 200 for both `LIST_NOTEBOOKS`
+  (`batchexecute`, with `wXbhsf` echoed) and a parsed
+  `GenerateFreeFormStreamed` response. Its checked-in fallback still said both
+  capabilities were `ABSENT`, so losing the run-to-run cache could re-file the
+  already handled transitions. The fallback now records the last acknowledged
+  status per capability (`PRESENT` for both observations); a later contrary
+  observation remains a reportable transition. This changes only advisory
+  reporting state: the lane still carries no exit code, makes no default-host
+  decision, and continues to report upload as `NOT_PROBED` because the workflow
+  issues no `/upload/_/` POST
+  ([#2077](https://github.com/teng-lin/notebooklm-py/issues/2077),
+  [#2078](https://github.com/teng-lin/notebooklm-py/issues/2078)).
+
 - **The pinned frontend build label is current again, and can no longer rot
   unwatched.** `_env.DEFAULT_BL` — the `bl` value sent on the chat streaming
   endpoint — had been pinned to `boq_labs-tailwind-frontend_20260301.03_p0` since
@@ -218,7 +240,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   error. The lane carries **no exit code**, deliberately: the existing
   "Non-transient ERROR detected" issue dedups by title alone, so a rebrand probe
   that legitimately failed every night would file one issue and then suppress
-  every later legacy-degradation issue. `UNKNOWN` (transport failure, 429, 5xx)
+  every later main-lane degradation issue. `UNKNOWN` (transport failure, 429, 5xx)
   carries the previous state forward instead of manufacturing a transition. Two
   new flags support it: `--base-url` (point a whole manual run at a specific
   personal app host) and `--rebrand-state-file` (where the lane reads and writes

--- a/docs/adr/0028-gemini-notebook-rename.md
+++ b/docs/adr/0028-gemini-notebook-rename.md
@@ -25,14 +25,25 @@ POST https://notebook.google.com/_/LabsTailwindUi/data/batchexecute   -> 400 (en
 `batchexecute` is **dual-served**. The RPC backend has not moved out from under
 us, which is why most sessions still work against the legacy default.
 
+The nightly health check later strengthened the rebrand-host evidence from an
+endpoint-level 400 to an authenticated application response: at commit
+`36221e0`, `LIST_NOTEBOOKS` returned HTTP 200 and echoed its `wXbhsf` RPC ID
+(#2077). This records availability for that credential cohort; it is not, by
+itself, a default-host policy decision.
+
+The same authenticated nightly probe confirmed the rebrand host's
+`GenerateFreeFormStreamed` chat endpoint too: HTTP 200 with a parsed stream on
+2026-08-04 (#2078). This does not answer whether `/upload/_/` (Scotty) is served
+there; the health check issues no upload POST, so that remains unprobed.
+
 Two things follow, and they are easy to conflate:
 
-- **Our own coverage has never exercised rebrand-host RPC.** Every request
-  recorded against `notebook.google.com` in `tests/cassettes/` is a `GET /`
-  returning the app shell (12 such, all in `collection_*`); no `batchexecute`
-  POST to that host has been captured. That is a gap in our testing, not a
-  statement about the service — until this change the base-URL allowlist
-  rejected the host, so no client we ship *could* have issued one.
+- **Before the default flip, recorded integration coverage had never exercised
+  rebrand-host RPC.** Every request then recorded against `notebook.google.com`
+  in `tests/cassettes/` was a `GET /` returning the app shell (12 such, all in
+  `collection_*`); no `batchexecute` POST to that host had been captured. That
+  was a gap in our testing, not a statement about the service — before the
+  allowlist change no client we shipped *could* have issued one.
 - **Dual-serving is a transitional state, not a guarantee.** It is the thing to
   monitor, which is why `scripts/check_rpc_health.py` probes the rebrand host in
   its own reporting lane.

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -434,16 +434,18 @@ anything.
 ### 3.3 Empirical cookie requirements
 
 Which cookies does Google *actually* require? This backs the library's two-tier
-`_validate_required_cookies()` pre-flight (see `_auth/cookies.py` —
+`_validate_required_cookies()` pre-flight (see `_auth/cookie_policy.py` —
 `MINIMUM_REQUIRED_COOKIES` and `_has_valid_secondary_binding()` for the
 authoritative values; the historical permissive `{"SID"}` check was replaced in
 [#371](https://github.com/teng-lin/notebooklm-py/issues/371)).
 
-Method: take a known-good `storage_state.json`, drop one or two cookies at a time,
-run `notebooklm list`, and record whether Google accepts the call or redirects to
-login. Single-cookie removal is highly recoverable — every cookie except `SID` can
-be dropped individually with the call still succeeding (Google reissues most of
-them mid-call). Pair-wise removal exposes a precise accept-rule.
+Method: take a known-good `storage_state.json`, drop one, two, or three cookies
+at a time, run `notebooklm list`, and record whether Google accepts the call or
+redirects to login. Single-cookie removal is highly recoverable — every cookie
+except `SID` can be dropped individually with the call still succeeding (Google
+reissues most of them mid-call). Pair-wise removal exposed the original
+accept-rule; a follow-up three-way ablation of `OSID`, the `APISID`/`SAPISID`
+pair, and bare `LSID` corrected its secondary-binding branch.
 
 **The accept-rule model.** Google accepts the NotebookLM homepage GET when both
 hold:
@@ -451,8 +453,11 @@ hold:
 1. **Identity present:** `SID` is valid, and `__Secure-1PSIDTS` is either directly
    present or recoverable via a `RotateCookies` POST — which itself requires the
    full ambient cookie set to authenticate.
-2. **At least one secondary binding present:** `OSID`, OR both `APISID` and
-   `SAPISID`.
+2. **At least one secondary binding present:** `OSID`, OR all three of
+   `APISID`, `SAPISID`, and bare `LSID`.
+
+The singleton and pair-wise ablations established Tier 1 and the two candidate
+secondary-binding routes:
 
 | Variant | `SID` | `OSID` | `APISID+SAPISID` | `__Secure-1PSIDTS` (or recoverable) | Result |
 |---|:-:|:-:|:-:|:-:|:-:|
@@ -464,6 +469,23 @@ hold:
 | Drop `APISID + OSID` | ✓ | ✗ | ✗ | ✓ | FAIL |
 | Drop `SAPISID + OSID` | ✓ | ✗ | ✗ | ✓ | FAIL |
 
+Holding `SID` and a live (or recoverable) `__Secure-1PSIDTS` constant, the
+corrected three-way ablation is:
+
+| `OSID` | `APISID` + `SAPISID` | bare `LSID` | Result |
+|:-:|:-:|:-:|:-:|
+| present | absent | absent | OK |
+| present | present | absent | OK |
+| absent | present | present | OK |
+| absent | present | absent | **FAIL** |
+| absent | absent | present | FAIL |
+
+The first row confirms that `OSID` alone is sufficient, even when every
+`accounts.google.com` cookie (including `LSID`) is absent. `LSID` is required
+only for the `APISID`/`SAPISID` branch. The fourth row retains
+`__Host-1PLSID` and `__Host-3PLSID`, so neither host-prefixed cookie substitutes
+for bare `LSID`.
+
 Before #371 the library trusted any storage with `SID` present, which let
 Google-rejected cookie sets reach the wire — the "auth expires immediately after
 `notebooklm login`" pattern
@@ -474,7 +496,14 @@ catches it with a two-tier check:
 ```python
 MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}  # Tier 1: raise
 
+
 def _has_valid_secondary_binding(cookie_names: set[str]) -> bool:  # Tier 2: warn
+    if "OSID" in cookie_names:
+        return True
+    return {"APISID", "SAPISID", "LSID"} <= cookie_names
+
+
+def _has_rotatable_secondary_binding(cookie_names: set[str]) -> bool:  # recovery only
     if "OSID" in cookie_names:
         return True
     return {"APISID", "SAPISID"} <= cookie_names
@@ -484,11 +513,13 @@ Tier 1 raises on unambiguous evidence; Tier 2 warns once per process so partial
 extractions surface without breaking edge-case flows (e.g. Workspace SSO) that
 haven't been ablated.
 
-**Caveats.** These observations came from a single non-Workspace, stable-IP
-profile, testing `notebooks.list`. Workspace accounts may have different
-accept-rules. This is a model fit, not a confirmed server mechanism, and the
-freshness clock (§3.1) still applies on top of it — a session with a valid
-accept-tuple can still be killed by Google's risk model.
+**Caveats.** The singleton and pair-wise observations came from a single
+non-Workspace, stable-IP profile, testing `notebooks.list`. The corrected
+three-way secondary-binding ablation was replicated on two unrelated accounts
+(2026-08-04, issue #1977). Workspace accounts may have different accept-rules.
+This is a model fit, not a confirmed server mechanism, and the freshness clock
+(§3.1) still applies on top of it — a session with a valid accept-tuple can still
+be killed by Google's risk model.
 
 ---
 
@@ -666,9 +697,10 @@ When a profile has the persistent `__Secure-1PSID` but no transient
 `__Secure-1PSIDTS` (a common cold-start snapshot), `_recover_psidts_inline`
 (`_auth/psidts_recovery.py`) makes a preflight `RotateCookies` POST during client
 startup to mint the missing cookie before the first RPC. It fires only when `SID`
-is present, a secondary binding is intact (`OSID`, or `APISID` + `SAPISID`), and
-no live `__Secure-1PSIDTS` would be **sent to** `accounts.google.com` — that is,
-the cookie is absent, expired, or scoped to a domain that does not route to the
+is present, a **rotatable** secondary binding is intact (`OSID`, or `APISID` +
+`SAPISID`), and no live `__Secure-1PSIDTS` would be **sent to**
+`accounts.google.com` — that is, the cookie is absent, expired, or scoped to a
+domain that does not route to the
 rotate URL. That last condition is RFC 6265 selection against the URL the
 decision is about, not a domain-priority ranking: a `__Secure-1PSIDTS` scoped to
 `.notebooklm.google.com` (or, post-rebrand, `.notebook.google.com`) never reaches
@@ -706,9 +738,17 @@ The net effect is a heal *attempt* in states that previously went straight to a
 failing RPC, and no new terminal failures: every state that loaded before still
 loads.
 
+This is deliberately the weaker `_has_rotatable_secondary_binding()` recovery
+precondition: unlike the strict post-recovery predicate in §3.3, it does not
+require bare `LSID`, because the rotation hop may restore that accounts-side
+cookie. See `_auth/cookie_policy.py` for why
+`_has_rotatable_secondary_binding` and `_has_valid_secondary_binding` must
+remain distinct.
+
 The separate "did the heal land?" check (`_psidts_is_live`) is deliberately
 domain-blind instead, because it must predict the retrying preflight rather than
-the request jar. **Do not merge the two predicates.** Their differences are
+the request jar. **Do not merge `_psidts_routes_to_rotate` and
+`_psidts_is_live`.** Their differences are
 intentional, and each one has a failure mode behind it:
 
 | | should we fire? (`_psidts_routes_to_rotate`) | did it land? (`_psidts_is_live`) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -493,7 +493,7 @@ notebooklm auth import-cookies JSON_PATH [OPTIONS]
 
 Accepts either a Playwright `storage_state` object (`{"cookies": [...]}`) or a bare JSON list of cookie objects (the shape most browser cookie-export tools produce). Use `-` to read JSON from stdin. Common export fields are normalized (e.g. `expirationDate` → `expires`), `__Secure-`/`__Host-` cookies are forced `Secure`, and any `storage_state` `origins` (localStorage/sessionStorage) are dropped.
 
-Imported cookies are filtered through the **same domain allowlist** used by browser login, validated locally for the NotebookLM-required cookies (and a usable secondary binding — `OSID`, or `APISID`+`SAPISID`), and written atomically with private (`0o600`) permissions. Invalid input never overwrites an existing session, and an existing `storage_state.json` is first copied to `storage_state.json.bak` so a stale import can be rolled back (one step — each run overwrites the previous `.bak`).
+Imported cookies are filtered through the **same domain allowlist** used by browser login and validated locally for the Tier 1 NotebookLM-required cookies. The required `__Secure-1PSIDTS` entry must also be live and RFC 6265-routable to the `accounts.google.com/RotateCookies` endpoint. If any secondary-binding cookie is present, the supplied set must form a usable binding — `OSID`, or `APISID`+`SAPISID` together with bare `LSID`; a completely absent Tier 2 set is preserved after a warning for compatibility with unablated account flows. The result is written atomically with private (`0o600`) permissions. Invalid input never overwrites an existing session, and an existing `storage_state.json` is first copied to `storage_state.json.bak` so a stale import can be rolled back (one step — each run overwrites the previous `.bak`).
 
 Incompatible with `NOTEBOOKLM_AUTH_JSON`: unset that env var first, or the command exits with an error (it does not silently fall back to the env auth).
 
@@ -740,7 +740,7 @@ notebooklm auth check --json
 **Checks performed:**
 1. Storage file exists and is readable
 2. JSON structure is valid
-3. Required cookies (`SID` + `__Secure-1PSIDTS`) are present (the Tier 1 `MINIMUM_REQUIRED_COOKIES` set; either `OSID` or the `APISID`+`SAPISID` pair is also needed for the secondary-binding check — see [auth-cookie-lifecycle.md](auth-cookie-lifecycle.md) §3.5)
+3. Required cookies (`SID` + `__Secure-1PSIDTS`) are present (the Tier 1 `MINIMUM_REQUIRED_COOKIES` set). The loader also evaluates the warning-only secondary-binding check — `OSID`, or `APISID`+`SAPISID` together with bare `LSID` — but `auth check` does not mark a Tier 2 warning as failure; see [auth-cookie-lifecycle.md](auth-cookie-lifecycle.md#33-empirical-cookie-requirements)
 4. Cookie domains are correct (.google.com vs regional)
 5. (With `--test`) Token fetch succeeds
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,9 +69,9 @@ Contains the authentication data extracted from your browser session:
 }
 ```
 
-**Cookie requirements** (empirically validated via single- and pair-wise ablation, see `auth-cookie-lifecycle.md` §3.5; enforced by `_validate_required_cookies()` in `auth.py`):
+**Cookie requirements** (empirically validated via single-, pair-, and three-way ablation; see [auth-cookie-lifecycle.md](auth-cookie-lifecycle.md#33-empirical-cookie-requirements); enforced by `_validate_required_cookies()` in `_auth/cookie_policy.py`):
 
-- **Tier 1 — strictly required (raises on absence):** `SID` AND `__Secure-1PSIDTS`. `SID` is the only individually-required cookie (`__Secure-1PSIDTS` is removable on its own because Google can re-mint it via `RotateCookies`), but the pair-wise check uncovered that as soon as `__Secure-1PSIDTS` and any one other auth cookie are both missing, Google rejects with `Authentication expired or invalid`. The library therefore enforces both up-front. Authoritative value: `MINIMUM_REQUIRED_COOKIES` in `auth.py`.
+- **Tier 1 — strictly required (raises on absence):** `SID` AND `__Secure-1PSIDTS`. `SID` is the only individually-required cookie (`__Secure-1PSIDTS` is removable on its own because Google can re-mint it via `RotateCookies`), but the pair-wise check uncovered that as soon as `__Secure-1PSIDTS` and any one other auth cookie are both missing, Google rejects with `Authentication expired or invalid`. The library therefore enforces both up-front. Authoritative value: `MINIMUM_REQUIRED_COOKIES` in `_auth/cookie_policy.py`.
 - **Tier 2 — secondary binding (logs a warning if absent):** either `OSID` is present, or `APISID` and `SAPISID` are present **together with bare `LSID`** (the `LSID` conjunct is required — the pair alone fails, per the three-way ablation in #1977). Without this, even valid Tier 1 cookies can't authenticate the homepage GET. Logged rather than raised so unverified edge-case flows (e.g. Workspace SSO) aren't broken by a too-strict client check.
 
 In practice: extract the full cookie set via `notebooklm login` and don't try to subset it. Partial extractions (a known failure mode of browser-cookies tooling under Chrome 127+ App-Bound Encryption) are the leading suspect for "auth expires immediately" reports — see [#371](https://github.com/teng-lin/notebooklm-py/issues/371).

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -588,31 +588,32 @@ The same nightly run also probes the post-rebrand host — batchexecute and
   `compute_exit_code` cannot see them. This is deliberate and load-bearing: the
   "Non-transient ERROR detected" issue is deduped **by title alone**, so a probe
   that legitimately fails every night would open one issue and then suppress
-  every later legacy-degradation issue filed under the same title.
-- It reports a **state change** (`batchexecute: ABSENT->PRESENT`), not a
-  recurring error, against the previous run's state (cached between runs; a
-  cache miss falls back to the documented `ABSENT` baseline). A host that never
-  serves RPC therefore files nothing, ever.
+  every later main-lane degradation issue filed under the same title.
+- It reports a **state change** (for example, `batchexecute:
+  PRESENT->ABSENT`), not a recurring error, against the previous run's state.
+  That state is cached between runs; a cache miss falls back to the checked-in
+  last-acknowledged status for each capability. An unchanged capability files
+  nothing.
 - On a change it opens its own issue, **"Rebrand host RPC availability
   changed"** (label `automated`), with its own dedup search.
 - `UNKNOWN` (transport failure, 429, 5xx) is never recorded: a flake carries the
   previous state forward instead of manufacturing a transition.
 - It runs **last** in the check and is paced like the method loop, so its two
   extra requests cannot push the account into a rate limit that would then be
-  attributed to a legacy probe.
+  attributed to a main-lane probe.
 
-**Recorded decision:** this lane is the first time the project's CI credentials
-are presented to `notebook.google.com`. Both hosts are Google's and both are
-already origins of the same app, so the exposure is the same credential to the
-same operator — but it is a deliberate choice, written down rather than arriving
-as a side effect.
+**Recorded decision (when the lane was introduced):** this was the first time
+the project's CI credentials were presented to `notebook.google.com`. Both
+hosts are Google's and are origins of the same app, so the exposure was the same
+credential to the same operator — but it was a deliberate choice, written down
+rather than arriving as a side effect.
 
 Two flags support it:
 
 ```bash
 # Point the WHOLE run at a specific personal app host. Manual investigation
 # only — validated against notebooklm._env.PERSONAL_APP_HOSTS, and the nightly
-# must stay on the default so the legacy signal keeps being collected.
+# stays on the default so the main, exit-coded signal exercises that host.
 uv run python scripts/check_rpc_health.py --base-url https://notebook.google.com
 
 # Where the lane reads/writes its previous state (omit: baseline-only, no write).

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -38,11 +38,11 @@ Rebrand-host lane (``notebook.google.com``):
     A SEPARATE reporting lane answers "does the post-rebrand host serve RPC?".
     It NEVER contributes to the exit codes above and never lands in the
     ``CheckResult`` list — see :func:`probe_rebrand_host`. That separation is
-    load-bearing: the legacy lane's non-transient-ERROR issue is deduped by
+    load-bearing: the main lane's non-transient-ERROR issue is deduped by
     title alone, so a rebrand probe folded into it would open one issue on the
-    first failing night and then SUPPRESS every legacy-degradation issue after
-    it. The lane reports a *state change* (``ABSENT -> PRESENT``) against the
-    previous run's recorded state, under its own issue title.
+    first failing night and then SUPPRESS every main-lane degradation issue after
+    it. The lane reports a *state change* (for example, ``PRESENT -> ABSENT``)
+    against the previous run's recorded state, under its own issue title.
 
     The lane answers two of the three migration sub-questions — batchexecute and
     ``GenerateFreeFormStreamed``. The third, ``/upload/_/`` (Scotty), is NOT
@@ -63,7 +63,7 @@ Usage:
     python scripts/check_rpc_health.py          # Quick mode (skip destructive)
     python scripts/check_rpc_health.py --full   # Full mode (create temp notebook)
     # Point the WHOLE run at the rebrand host (manual investigation only — the
-    # nightly must stay on the default host so the legacy signal is preserved):
+    # nightly stays on the default host so the main signal exercises that host):
     python scripts/check_rpc_health.py --base-url https://notebook.google.com
 """
 
@@ -1138,19 +1138,22 @@ REBRAND_BATCHEXECUTE = "batchexecute"
 REBRAND_CHAT = "chat"
 REBRAND_UPLOAD = "upload"
 
-# What the repository already knows, used as the previous state on the very
-# first run (or whenever the state file is missing/unreadable). The cassette
-# corpus contains 12 recorded requests to the rebrand host, all ``GET /`` — zero
-# batchexecute, zero streamed chat. So ABSENT is the documented baseline, and an
-# ABSENT observation on the first run is "as expected", not news.
+# The last availability evidence acknowledged in the repository, used as the
+# previous state on the first run (or whenever the cached state is unavailable).
+# Keep each capability independent: the authenticated nightly probe at 36221e0
+# observed LIST_NOTEBOOKS over batchexecute (#2077) and parsed a streamed-chat
+# response (#2078) on the rebrand host. The entries remain independent so later
+# evidence can advance one capability without changing the other.
 REBRAND_BASELINE_STATE: dict[str, str] = {
-    REBRAND_BATCHEXECUTE: RebrandProbeStatus.ABSENT.value,
-    REBRAND_CHAT: RebrandProbeStatus.ABSENT.value,
+    REBRAND_BATCHEXECUTE: RebrandProbeStatus.PRESENT.value,
+    REBRAND_CHAT: RebrandProbeStatus.PRESENT.value,
 }
 
-# Bumped only if the state file's shape changes; a mismatch is treated as "no
-# usable previous state" and falls back to REBRAND_BASELINE_STATE.
-REBRAND_STATE_VERSION = 1
+# Bumped when the file shape changes or the checked-in evidence baseline
+# advances. A mismatch is treated as "no usable previous state" and falls back
+# to REBRAND_BASELINE_STATE; version 2 prevents a pre-#2077/#2078 cached ABSENT
+# document from overriding the newly acknowledged PRESENT observations.
+REBRAND_STATE_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -1315,7 +1318,7 @@ async def probe_rebrand_batchexecute(
         # ``RPCError`` is what the decoder raises for a body it cannot read as
         # batchexecute at all (the HTML app shell hits exactly this). In THIS
         # lane that is the answer — "the host served something else" — not the
-        # drift signal it would be on the legacy lane.
+        # parse/drift signal it would be on the exit-coded main lane.
         return RebrandProbe(
             REBRAND_BATCHEXECUTE,
             RebrandProbeStatus.ABSENT,
@@ -1430,17 +1433,15 @@ async def probe_rebrand_host(
 
     Deliberately returns ``RebrandProbe`` objects, NOT ``CheckResult`` objects:
     nothing here may reach ``partition_errors`` / ``compute_exit_code``, because
-    the legacy lane's issue is deduped by title alone and a permanently-failing
+    the main lane's issue is deduped by title alone and a permanently-failing
     rebrand probe folded into it would suppress every subsequent
-    legacy-degradation issue.
+    main-lane degradation issue.
 
     Runs LAST in the check, and paced like the method loop, so it cannot push
-    the account into a rate limit that would then be attributed to a legacy
-    probe. Recorded decision: this is the first time this project's CI
-    credentials are presented to the rebrand host. Both hosts are Google's and
-    both are already the app's own origins, so the exposure is the same
-    credential to the same operator — but it is a deliberate choice, not a side
-    effect.
+    the account into a rate limit that would then be attributed to a main-lane
+    probe. When this lane was introduced, it deliberately presented the
+    project's CI credentials to the rebrand host for the first time; both hosts
+    are Google's and are origins of the same app.
     """
     target = host or rebrand_probe_host()
     await asyncio.sleep(CALL_DELAY)
@@ -1451,13 +1452,13 @@ async def probe_rebrand_host(
 
 
 def load_rebrand_state(path: Path | None) -> dict[str, str]:
-    """Return the previously recorded rebrand state, or the documented baseline.
+    """Return the previously recorded state or checked-in acknowledged baseline.
 
     Any problem — no path, no file, unreadable, wrong schema version — degrades
-    to :data:`REBRAND_BASELINE_STATE`. That degradation is safe by construction:
-    the baseline is ABSENT, so a lost state file can only ever *re-announce* a
-    PRESENT that is genuinely news; it can never manufacture a spurious alarm
-    out of the steady state.
+    to :data:`REBRAND_BASELINE_STATE`. That checked-in fallback records the last
+    acknowledged observation per capability. A missing cache therefore does not
+    replay a transition acknowledged by this checkout, while a contrary live
+    observation is still reported as a new transition.
     """
     if path is None or not path.exists():
         return dict(REBRAND_BASELINE_STATE)
@@ -1471,8 +1472,13 @@ def load_rebrand_state(path: Path | None) -> dict[str, str]:
     if not isinstance(recorded, dict):
         return dict(REBRAND_BASELINE_STATE)
     merged = dict(REBRAND_BASELINE_STATE)
-    for key, value in recorded.items():
-        if isinstance(key, str) and isinstance(value, str):
+    recorded_statuses = {
+        RebrandProbeStatus.PRESENT.value,
+        RebrandProbeStatus.ABSENT.value,
+    }
+    for key in REBRAND_BASELINE_STATE:
+        value = recorded.get(key)
+        if value in recorded_statuses:
             merged[key] = value
     return merged
 
@@ -2048,8 +2054,8 @@ async def run_health_check(
     reads the last run's from (defaulting to the same file, which is what a
     local invocation wants). CI keeps them apart so the file the workflow reads
     back can only be one this run wrote — see the "Detect rebrand-host state
-    change" step. ``None`` compares against the documented baseline and persists
-    nothing. ``rebrand_run_id`` stamps the written document; see
+    change" step. ``None`` compares against the checked-in acknowledged baseline
+    and persists nothing. ``rebrand_run_id`` stamps the written document; see
     :func:`build_rebrand_state`.
     """
     notebook_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or os.environ.get(
@@ -2151,7 +2157,7 @@ async def run_health_check(
 
             # Rebrand-host lane. Runs LAST and in its own bucket: its probes
             # never join ``results``, so they cannot reach ``partition_errors``
-            # / ``compute_exit_code`` and cannot poison the legacy lane's
+            # / ``compute_exit_code`` and cannot poison the main lane's
             # title-deduped issue.
             rebrand_probes = await probe_rebrand_host(client, auth, notebook_id)
             rebrand_state = build_rebrand_state(
@@ -2263,7 +2269,7 @@ def compute_exit_code(
     exit code of its own and contributes to none of the above: the workflow's
     non-transient-ERROR issue is deduped by title alone, so a rebrand probe that
     failed every night would open one issue and then suppress every subsequent
-    legacy-degradation issue — disabling the gate the lane exists to feed.
+    main-lane degradation issue.
     """
     if counts[CheckStatus.MISMATCH] > 0:
         return 1
@@ -2462,8 +2468,8 @@ def main() -> int:
         help=(
             "Point the whole run at a specific personal app host "
             f"({', '.join(sorted(PERSONAL_APP_HOSTS))}). Manual investigation only — "
-            "the nightly run must stay on the default host so the legacy signal "
-            "is preserved. Overrides NOTEBOOKLM_BASE_URL."
+            "the nightly run stays on the default host so the main signal exercises "
+            "that host. Overrides NOTEBOOKLM_BASE_URL."
         ),
     )
     parser.add_argument(
@@ -2473,8 +2479,8 @@ def main() -> int:
         help=(
             "Path the rebrand-host lane writes this run's state to (and, unless "
             "--rebrand-previous-state-file is given, also reads the previous "
-            "run's state from). Omitted: compare against the documented ABSENT "
-            "baseline and persist nothing."
+            "run's state from). Omitted: compare against the checked-in "
+            "last-acknowledged baseline and persist nothing."
         ),
     )
     parser.add_argument(

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -1472,13 +1472,10 @@ def load_rebrand_state(path: Path | None) -> dict[str, str]:
     if not isinstance(recorded, dict):
         return dict(REBRAND_BASELINE_STATE)
     merged = dict(REBRAND_BASELINE_STATE)
-    recorded_statuses = {
-        RebrandProbeStatus.PRESENT.value,
-        RebrandProbeStatus.ABSENT.value,
-    }
+    recorded_statuses = {status.value for status in RECORDED_REBRAND_STATUSES}
     for key in REBRAND_BASELINE_STATE:
         value = recorded.get(key)
-        if value in recorded_statuses:
+        if isinstance(value, str) and value in recorded_statuses:
             merged[key] = value
     return merged
 

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -55,8 +55,8 @@ def cookie_names_from_storage(storage_state: Mapping[str, Any]) -> set[str]:
 #   recoverable via the RotateCookies POST when other auth cookies are intact.
 #   When neither path is viable the homepage GET 302s to login.
 #
-# See ``docs/auth-cookie-lifecycle.md`` §3.5 for the ablation methodology and the full
-# 16-pair failure table backing this set.
+# See ``docs/auth-cookie-lifecycle.md`` §3.3 for the singleton/pair-wise Tier 1
+# evidence and the corrected three-way secondary-binding table.
 MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}
 
 

--- a/tests/_guardrails/test_auth_cookie_docs.py
+++ b/tests/_guardrails/test_auth_cookie_docs.py
@@ -1,0 +1,142 @@
+"""Keep the documented secondary-binding rule aligned with runtime policy.
+
+The authoritative auth lifecycle guide once retained the superseded
+``APISID`` + ``SAPISID`` predicate after runtime added the bare ``LSID``
+conjunct (#1977/#2074). These gates compare both executable documentation
+predicates with runtime and keep user-facing summaries of the strict rule from
+silently dropping bare ``LSID`` again.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import itertools
+import re
+import textwrap
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from notebooklm._auth.cookie_policy import (
+    MINIMUM_REQUIRED_COOKIES,
+    _has_rotatable_secondary_binding,
+    _has_valid_secondary_binding,
+)
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIFECYCLE_DOC = REPO_ROOT / "docs" / "auth-cookie-lifecycle.md"
+CLI_REFERENCE = REPO_ROOT / "docs" / "cli-reference.md"
+CONFIGURATION = REPO_ROOT / "docs" / "configuration.md"
+PREDICATE_NAMES = {
+    "_has_rotatable_secondary_binding",
+    "_has_valid_secondary_binding",
+}
+SNIPPET_MARKER = "```python\nMINIMUM_REQUIRED_COOKIES ="
+SECONDARY_BINDING_COOKIE_NAMES = {"APISID", "LSID", "OSID", "SAPISID"}
+
+
+def _documented_policy() -> tuple[
+    dict[str, Callable[[set[str]], bool]],
+    dict[str, ast.FunctionDef],
+    set[str],
+]:
+    text = LIFECYCLE_DOC.read_text(encoding="utf-8")
+    marker_at = text.find(SNIPPET_MARKER)
+    assert marker_at >= 0, (
+        f"{LIFECYCLE_DOC.relative_to(REPO_ROOT)} must retain the executable cookie-policy "
+        "snippet so its rule can be checked against runtime"
+    )
+    code_at = marker_at + len("```python\n")
+    fence_at = text.find("\n```", code_at)
+    assert fence_at >= 0, "cookie-policy documentation snippet has no closing fence"
+
+    tree = ast.parse(text[code_at:fence_at], filename=str(LIFECYCLE_DOC))
+    predicate_nodes = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in PREDICATE_NAMES
+    }
+    assert set(predicate_nodes) == PREDICATE_NAMES, (
+        "cookie-policy documentation snippet must define both secondary-binding "
+        "predicates exactly once"
+    )
+
+    namespace: dict[str, object] = {}
+    exec(compile(tree, str(LIFECYCLE_DOC), "exec"), namespace)
+    predicates = {name: namespace[name] for name in PREDICATE_NAMES}
+    minimum_required = namespace["MINIMUM_REQUIRED_COOKIES"]
+    assert all(callable(predicate) for predicate in predicates.values())
+    assert isinstance(minimum_required, set)
+    assert all(isinstance(name, str) for name in minimum_required)
+    return predicates, predicate_nodes, set(minimum_required)
+
+
+def _cookie_names(predicate_node: ast.FunctionDef) -> set[str]:
+    body = predicate_node.body
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    return {
+        node.value
+        for statement in body
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+def test_lifecycle_predicate_snippet_matches_runtime_for_every_cookie_subset() -> None:
+    """The guide's executable predicates must remain truth-table-equivalent to runtime."""
+    documented, documented_nodes, documented_minimum = _documented_policy()
+    assert documented_minimum == MINIMUM_REQUIRED_COOKIES
+
+    runtime_predicates = {
+        "_has_rotatable_secondary_binding": _has_rotatable_secondary_binding,
+        "_has_valid_secondary_binding": _has_valid_secondary_binding,
+    }
+    documented_cookie_names: set[str] = set()
+    for name, runtime in runtime_predicates.items():
+        runtime_tree = ast.parse(textwrap.dedent(inspect.getsource(runtime)))
+        runtime_node = runtime_tree.body[0]
+        assert isinstance(runtime_node, ast.FunctionDef)
+
+        cookie_names = sorted(_cookie_names(documented_nodes[name]) | _cookie_names(runtime_node))
+        documented_cookie_names.update(cookie_names)
+        for size in range(len(cookie_names) + 1):
+            for present in itertools.combinations(cookie_names, size):
+                cookie_set = set(present)
+                assert documented[name](cookie_set) is runtime(cookie_set), (
+                    f"documented {name} disagrees with runtime for cookies {sorted(cookie_set)}"
+                )
+    assert documented_cookie_names == SECONDARY_BINDING_COOKIE_NAMES
+
+
+def test_user_facing_secondary_binding_summaries_match_strict_rule() -> None:
+    """User-facing summaries must retain both branches and the bare-LSID conjunct."""
+    paragraphs = re.split(r"\n\s*\n", CLI_REFERENCE.read_text(encoding="utf-8"))
+    binding_summaries = [
+        paragraph
+        for paragraph in paragraphs
+        if "Imported cookies are filtered" in paragraph or "secondary-binding check" in paragraph
+    ]
+    assert len(binding_summaries) == 2, "CLI reference must retain both guarded summaries"
+    strict_cli_rule = "`OSID`, or `APISID`+`SAPISID` together with bare `LSID`"
+    assert all(strict_cli_rule in paragraph for paragraph in binding_summaries), (
+        "every CLI summary must retain OSID OR APISID+SAPISID+bare-LSID semantics"
+    )
+
+    configuration = CONFIGURATION.read_text(encoding="utf-8")
+    strict_configuration_rule = (
+        "either `OSID` is present, or `APISID` and `SAPISID` are present "
+        "**together with bare `LSID`**"
+    )
+    assert strict_configuration_rule in configuration, (
+        "configuration summary must retain OSID OR APISID+SAPISID+bare-LSID semantics"
+    )

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -1359,14 +1359,17 @@ def test_rebrand_state_round_trips(tmp_path: Path) -> None:
     assert load_rebrand_state(path)[check_rpc_health.REBRAND_CHAT] == "ABSENT"
 
 
-def test_rebrand_state_ignores_unknown_capabilities_and_invalid_statuses(tmp_path: Path) -> None:
+@pytest.mark.parametrize("invalid_status", ["PRESNT", ["PRESENT"], {"value": "PRESENT"}])
+def test_rebrand_state_ignores_unknown_capabilities_and_invalid_statuses(
+    tmp_path: Path, invalid_status: object
+) -> None:
     path = tmp_path / "rebrand-state.json"
     path.write_text(
         json.dumps(
             {
                 "version": check_rpc_health.REBRAND_STATE_VERSION,
                 "state": {
-                    check_rpc_health.REBRAND_BATCHEXECUTE: "PRESNT",
+                    check_rpc_health.REBRAND_BATCHEXECUTE: invalid_status,
                     check_rpc_health.REBRAND_CHAT: "ABSENT",
                     "future-capability": "ABSENT",
                 },

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -946,7 +946,7 @@ def test_print_summary_gated_is_pass(capsys: pytest.CaptureFixture[str]) -> None
 # rebrand probe must never reach ``compute_exit_code``. The workflow files ONE
 # non-transient-ERROR issue deduped by title alone, so a rebrand probe folded
 # into that lane would open an issue on the first failing night and then
-# suppress every legacy-degradation issue after it — disabling the gate the
+# suppress every main-lane degradation issue after it — disabling the gate the
 # lane exists to feed. These tests pin that isolation, the state-change
 # semantics, and the deliberately-unanswered upload sub-question.
 # ---------------------------------------------------------------------------
@@ -972,13 +972,13 @@ def test_compute_exit_code_cannot_see_the_rebrand_lane() -> None:
     """Structural guard: no rebrand input may reach the exit-code computation.
 
     If a future change threads the lane in here, the naive-implementation trap
-    is back — one permanently-failing rebrand probe would suppress the legacy
+    is back — one permanently-failing rebrand probe would suppress the main
     lane's title-deduped issue forever.
 
     The exact parameter list is pinned too, so exit-coding ANY new lane stays a
     deliberate decision. ``build_label_status`` is such a decision: it has its own
     exit code (5) and its own deduped issue title, so it cannot suppress the
-    legacy lane's the way a rebrand probe would.
+    main lane's issue the way a rebrand probe would.
     """
     import ast
     import inspect
@@ -1225,11 +1225,20 @@ async def test_probe_rebrand_host_returns_all_three_capabilities(
 # --- state / transition semantics -------------------------------------------
 
 
+def test_rebrand_acknowledged_baseline_epoch() -> None:
+    """The #2077/#2078 evidence and cache epoch must advance together."""
+    assert check_rpc_health.REBRAND_STATE_VERSION == 2
+    assert {
+        check_rpc_health.REBRAND_BATCHEXECUTE: RebrandProbeStatus.PRESENT.value,
+        check_rpc_health.REBRAND_CHAT: RebrandProbeStatus.PRESENT.value,
+    } == check_rpc_health.REBRAND_BASELINE_STATE
+
+
 def test_rebrand_steady_state_reports_no_change() -> None:
-    """ABSENT on the documented ABSENT baseline is not news — and files nothing."""
+    """Acknowledged PRESENT observations are steady state and file nothing."""
     probes = [
-        _probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.ABSENT),
-        _probe(check_rpc_health.REBRAND_CHAT, RebrandProbeStatus.ABSENT),
+        _probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.PRESENT),
+        _probe(check_rpc_health.REBRAND_CHAT, RebrandProbeStatus.PRESENT),
         check_rpc_health.rebrand_upload_probe(),
     ]
     state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(None))
@@ -1239,7 +1248,8 @@ def test_rebrand_steady_state_reports_no_change() -> None:
 
 def test_rebrand_absent_to_present_is_a_state_change() -> None:
     probes = [_probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.PRESENT)]
-    state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(None))
+    previous = {check_rpc_health.REBRAND_BATCHEXECUTE: RebrandProbeStatus.ABSENT.value}
+    state = build_rebrand_state("notebook.google.com", probes, previous)
     assert state["changed"] is True
     assert state["transitions"] == [
         {
@@ -1249,6 +1259,23 @@ def test_rebrand_absent_to_present_is_a_state_change() -> None:
             "detail": "detail",
         }
     ]
+
+
+def test_rebrand_present_to_absent_is_a_state_change() -> None:
+    probes = [_probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.ABSENT)]
+    state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(None))
+    assert state["changed"] is True
+    assert state["transitions"] == [
+        {
+            "capability": check_rpc_health.REBRAND_BATCHEXECUTE,
+            "from": "PRESENT",
+            "to": "ABSENT",
+            "detail": "detail",
+        }
+    ]
+    assert "STATE CHANGE: batchexecute: PRESENT->ABSENT" in "\n".join(
+        check_rpc_health.format_rebrand_lane(state, probes)
+    )
 
 
 def test_rebrand_present_stays_quiet_on_the_next_run() -> None:
@@ -1326,10 +1353,32 @@ def test_rebrand_state_records_the_run_that_wrote_it() -> None:
 
 def test_rebrand_state_round_trips(tmp_path: Path) -> None:
     path = tmp_path / "nested" / "rebrand-state.json"
-    probes = [_probe(check_rpc_health.REBRAND_CHAT, RebrandProbeStatus.PRESENT)]
+    probes = [_probe(check_rpc_health.REBRAND_CHAT, RebrandProbeStatus.ABSENT)]
     state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(path))
     check_rpc_health.write_rebrand_state(path, state)
-    assert load_rebrand_state(path)[check_rpc_health.REBRAND_CHAT] == "PRESENT"
+    assert load_rebrand_state(path)[check_rpc_health.REBRAND_CHAT] == "ABSENT"
+
+
+def test_rebrand_state_ignores_unknown_capabilities_and_invalid_statuses(tmp_path: Path) -> None:
+    path = tmp_path / "rebrand-state.json"
+    path.write_text(
+        json.dumps(
+            {
+                "version": check_rpc_health.REBRAND_STATE_VERSION,
+                "state": {
+                    check_rpc_health.REBRAND_BATCHEXECUTE: "PRESNT",
+                    check_rpc_health.REBRAND_CHAT: "ABSENT",
+                    "future-capability": "ABSENT",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_rebrand_state(path) == {
+        check_rpc_health.REBRAND_BATCHEXECUTE: "PRESENT",
+        check_rpc_health.REBRAND_CHAT: "ABSENT",
+    }
 
 
 @pytest.mark.parametrize(
@@ -1337,16 +1386,20 @@ def test_rebrand_state_round_trips(tmp_path: Path) -> None:
     [
         "not json at all",
         json.dumps({"version": 999, "state": {"batchexecute": "PRESENT"}}),
-        json.dumps({"version": 1, "state": "not-a-mapping"}),
+        # The prior baseline epoch must not replay its now-acknowledged ABSENT
+        # values if an older cache entry is restored after #2077/#2078.
+        json.dumps({"version": 1, "state": {"batchexecute": "ABSENT", "chat": "ABSENT"}}),
+        json.dumps(
+            {
+                "version": check_rpc_health.REBRAND_STATE_VERSION,
+                "state": "not-a-mapping",
+            }
+        ),
         json.dumps(["not", "a", "mapping"]),
     ],
 )
 def test_rebrand_unusable_state_file_degrades_to_baseline(tmp_path: Path, content: str) -> None:
-    """A lost/corrupt state file can only re-announce a real PRESENT.
-
-    It can never manufacture an alarm out of the steady state, because the
-    fallback baseline is exactly what the steady state observes.
-    """
+    """A lost/corrupt cache falls back to acknowledged repository evidence."""
     path = tmp_path / "rebrand-state.json"
     path.write_text(content, encoding="utf-8")
     assert load_rebrand_state(path) == check_rpc_health.REBRAND_BASELINE_STATE
@@ -1364,7 +1417,8 @@ def test_format_rebrand_lane_lines() -> None:
         _probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.PRESENT),
         check_rpc_health.rebrand_upload_probe(),
     ]
-    state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(None))
+    previous = {check_rpc_health.REBRAND_BATCHEXECUTE: RebrandProbeStatus.ABSENT.value}
+    state = build_rebrand_state("notebook.google.com", probes, previous)
     lines = check_rpc_health.format_rebrand_lane(state, probes)
     joined = "\n".join(lines)
     assert "STATE CHANGE: batchexecute: ABSENT->PRESENT" in joined
@@ -1385,7 +1439,7 @@ def test_format_rebrand_lane_flags_an_auth_failure_as_inconclusive() -> None:
 
 
 def test_format_rebrand_lane_says_so_when_nothing_changed() -> None:
-    probes = [_probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.ABSENT)]
+    probes = [_probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.PRESENT)]
     state = build_rebrand_state("notebook.google.com", probes, load_rebrand_state(None))
     joined = "\n".join(check_rpc_health.format_rebrand_lane(state, probes))
     assert "STATE CHANGE" not in joined
@@ -1508,7 +1562,7 @@ def test_main_threads_the_rebrand_state_into_the_report(
         state = build_rebrand_state(
             "notebook.google.com",
             [_probe(check_rpc_health.REBRAND_BATCHEXECUTE, RebrandProbeStatus.PRESENT)],
-            load_rebrand_state(None),
+            {check_rpc_health.REBRAND_BATCHEXECUTE: RebrandProbeStatus.ABSENT.value},
         )
         return (
             [_result("ok", CheckStatus.OK)],

--- a/tests/unit/test_rpc_health_rebrand_lane.py
+++ b/tests/unit/test_rpc_health_rebrand_lane.py
@@ -4,13 +4,11 @@ The nightly health workflow files its "Non-transient ERROR detected" issue with
 a dedup probe that searches **by title alone**. So an issue-filing lane that can
 fail every night is not merely noisy — after its first issue opens, the dedup
 check suppresses every subsequent issue sharing that title, including the
-legacy-degradation issue that is the only named trigger for revisiting the
-default backend host.
+main health-check degradation issue.
 
-The rebrand-host probe (``notebook.google.com``) is exactly such a lane: nothing
-in this repository has ever observed that host serving batchexecute, so it may
-legitimately report "absent" forever. It therefore gets its own titles, a dedup
-key PER CAPABILITY, and a *state-change* trigger rather than a recurring error.
+The rebrand-host probe (``notebook.google.com``) therefore gets its own titles,
+a dedup key PER CAPABILITY, and a *state-change* trigger rather than a recurring
+error. It can report either direction without changing the main lane's exit code.
 
 The same reasoning applies one level down (#2062): the lane's state file is the
 next run's baseline, so anything it records must have been genuinely observed
@@ -40,9 +38,9 @@ pytestmark = pytest.mark.repo_lint
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rpc-health.yml"
 
-# The legacy lane's title. The rebrand lane must never reuse it, nor any string
+# The main lane's title. The rebrand lane must never reuse it, nor any string
 # that would collide with its ``in:title "..."`` dedup search.
-LEGACY_ERROR_TITLE = "RPC Health Check: Non-transient ERROR detected"
+MAIN_ERROR_TITLE = "RPC Health Check: Non-transient ERROR detected"
 REBRAND_TITLE = "Rebrand host RPC availability changed"
 
 DETECT_STEP = "Detect rebrand-host state change"
@@ -111,9 +109,8 @@ def test_previous_and_current_state_live_in_separate_files() -> None:
 def test_nightly_never_forces_a_base_url() -> None:
     """The scheduled run must stay on the default host.
 
-    ``--base-url`` exists for manual investigation. Pointing the nightly at the
-    rebrand host would stop collecting the legacy signal, which is the only
-    named trigger for revisiting the default.
+    ``--base-url`` exists for manual investigation. The scheduled main signal
+    must exercise whichever host the shipped configuration selects by default.
     """
     assert "--base-url" not in _step("Run RPC Health Check")["run"]
 
@@ -121,7 +118,7 @@ def test_nightly_never_forces_a_base_url() -> None:
 def test_rebrand_issue_title_is_distinct_from_every_other_lane() -> None:
     """The rebrand lane files through ``gh``, never through a shared title."""
     titles = [step["with"]["title"] for step in _issue_steps()]
-    assert LEGACY_ERROR_TITLE in titles
+    assert MAIN_ERROR_TITLE in titles
     assert len(titles) == len(set(titles)), f"duplicate issue titles share a dedup key: {titles}"
     # No pinned-action lane may claim the rebrand title: that lane's titles are
     # built per capability inside the report step.
@@ -131,7 +128,7 @@ def test_rebrand_issue_title_is_distinct_from_every_other_lane() -> None:
 def test_rebrand_dedup_probe_searches_its_own_title() -> None:
     run = _step(REPORT_STEP)["run"]
     assert f'in:title "{REBRAND_TITLE}"' in run
-    assert LEGACY_ERROR_TITLE not in run
+    assert MAIN_ERROR_TITLE not in run
 
 
 def test_rebrand_dedup_key_is_per_capability() -> None:
@@ -168,7 +165,7 @@ def test_baseline_is_saved_after_reporting_and_only_on_success() -> None:
     assert "steps.rebrand_report.outcome != 'failure'" in condition
 
 
-def test_legacy_issue_lanes_are_untouched_by_the_rebrand_lane() -> None:
+def test_main_issue_lanes_are_untouched_by_the_rebrand_lane() -> None:
     """Every health-script lane still keys off ``steps.health.outputs.exit_code``.
 
     The bundle-drift lane is a different script (``steps.bundle``) and keeps its
@@ -177,7 +174,7 @@ def test_legacy_issue_lanes_are_untouched_by_the_rebrand_lane() -> None:
     expected = {
         "RPC ID Mismatch Detected": "1",
         "RPC Health Check: Authentication Failure": "2",
-        LEGACY_ERROR_TITLE: "3",
+        MAIN_ERROR_TITLE: "3",
         "Studio customization cohort flipped — re-capture VideoStyle codes": "4",
     }
     seen = set()
@@ -297,7 +294,7 @@ def _gh_calls(workdir: Path) -> list[list[str]]:
 
 def _state_doc(run_id: str | None, transitions: list[dict[str, str]]) -> dict[str, Any]:
     return {
-        "version": 1,
+        "version": 2,
         "host": "notebook.google.com",
         "run_id": run_id,
         "state": {"batchexecute": "PRESENT", "chat": "PRESENT"},


### PR DESCRIPTION
## Summary

- Correct the strict secondary-binding documentation and add executable parity guards for both strict and recovery predicates.
- Acknowledge the observed PRESENT baselines for rebrand-host batchexecute and chat probes, with a new state epoch to prevent replaying stale transitions.
- Harden cached health-state parsing, preserve the upload NOT_PROBED contract, and clarify direction-neutral transition reporting.

## Issues

Closes #2074
Closes #2077
Closes #2078

## Test plan

- Full pytest suite: 11,679 passed, 85 skipped, 1 expected failure
- Ruff lint: passed
- Ruff Python/pyi format scope: 992 files formatted
- mypy: clean across 329 source files
- Diff whitespace check: passed

## Polish

Three independent review passes completed with no Critical or Important findings outstanding. Two optional follow-ups remain: consider separating the cache schema version from its evidence epoch, and consider direction-aware issue lifecycle for future reverse transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication cookie requirements, validation, recovery bindings, and CLI guidance.
  * Updated RPC health guidance for acknowledged state, fallback behavior, transitions, and independent reporting.
  * Documented current rebrand-host RPC and chat observations.

* **Bug Fixes**
  * Improved handling of invalid cached health data and capability status transitions.
  * Corrected main and rebrand health-lane terminology and reporting behavior.

* **Tests**
  * Added coverage for authentication documentation and runtime cookie behavior.
  * Expanded RPC health tests for fallback, transitions, deduplication, and independent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->