### PR TITLE
feat(artifacts): add support for listing and downloading CUSTOM artifact types (type 10)

### DIFF
--- a/src/notebooklm/_app/download_specs.py
+++ b/src/notebooklm/_app/download_specs.py
@@ -202,6 +202,13 @@ DOWNLOAD_REGISTRY: tuple[DownloadRegistryEntry, ...] = (
         download_attr="download_report",
     ),
     DownloadRegistryEntry(
+        name="custom",
+        kind=ArtifactType.CUSTOM,
+        default_output=DownloadFormatSpec(".bin", "application/octet-stream"),
+        default_dir="./custom",
+        download_attr="download_custom",
+    ),
+    DownloadRegistryEntry(
         name="mind-map",
         kind=ArtifactType.MIND_MAP,
         default_output=DownloadFormatSpec(".json", "application/json"),

--- a/src/notebooklm/_artifact/downloads.py
+++ b/src/notebooklm/_artifact/downloads.py
@@ -533,6 +533,57 @@ class ArtifactDownloadService:
                 cause=e,
             ) from e
 
+    async def download_custom(
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: list[Any] | None = None,
+    ) -> str:
+        """Download a custom artifact as binary to output_path."""
+        if artifacts_data is None:
+            artifacts_data = await self._list_raw(notebook_id)
+
+        custom_art = self._select_artifact(
+            artifacts_data,
+            artifact_id,
+            "Custom artifact",
+            "custom",
+            type_code=ArtifactTypeCode.CUSTOM,
+        )
+
+        try:
+            url = custom_art.artifact_url(ArtifactTypeCode.CUSTOM.value, suppress_drift=True)
+            if url:
+                return await self.download_url(url, output_path)
+
+            markdown_content = custom_art.report_markdown
+
+            if isinstance(markdown_content, str):
+                output = Path(output_path)
+                output.parent.mkdir(parents=True, exist_ok=True)
+
+                def _write_binary() -> None:
+                    output.write_bytes(markdown_content.encode("utf-8"))
+
+                await asyncio.to_thread(_write_binary)
+                return str(output)
+
+            raise ArtifactParseError(
+                "custom_content",
+                artifact_id=artifact_id,
+                details="Could not extract download URL or content from custom artifact",
+            )
+
+        except (IndexError, TypeError, UnknownRPCMethodError) as e:
+            raise ArtifactParseError(
+                "custom",
+                artifact_id=artifact_id,
+                details=f"Failed to parse structure: {e}",
+                cause=e,
+            ) from e
+
     async def download_mind_map(
         self,
         notebook_id: str,

--- a/src/notebooklm/_artifact/listing.py
+++ b/src/notebooklm/_artifact/listing.py
@@ -36,6 +36,7 @@ _ARTIFACT_TYPE_CODES_BY_KIND = {
     ArtifactType.INFOGRAPHIC: ArtifactTypeCode.INFOGRAPHIC.value,
     ArtifactType.SLIDE_DECK: ArtifactTypeCode.SLIDE_DECK.value,
     ArtifactType.DATA_TABLE: ArtifactTypeCode.DATA_TABLE.value,
+    ArtifactType.CUSTOM: ArtifactTypeCode.CUSTOM.value,
 }
 _KNOWN_ARTIFACT_TYPE_CODES = frozenset(_ARTIFACT_TYPE_CODES_BY_KIND.values())
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -580,6 +580,19 @@ class ArtifactsAPI:
             notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
         )
 
+    async def download_custom(
+        self,
+        notebook_id: str,
+        output_path: str,
+        artifact_id: str | None = None,
+        *,
+        artifacts_data: builtins.list[Any] | None = None,
+    ) -> str:
+        """Download a custom artifact as a binary file."""
+        return await self._downloads.download_custom(
+            notebook_id, output_path, artifact_id, artifacts_data=artifacts_data
+        )
+
     async def download_mind_map(
         self,
         notebook_id: str,

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -179,6 +179,7 @@ class ArtifactRow:
     _TIMESTAMP_POS: ClassVar[int] = 15
     _SLIDE_DECK_METADATA_POS: ClassVar[int] = 16
     _DATA_TABLE_PAYLOAD_POS: ClassVar[int] = 18
+    _CUSTOM_METADATA_POS: ClassVar[int] = 24
 
     # Per-type location of the user's generation prompt: the top-level block
     # index that holds the artifact's content, followed by the sub-path to the
@@ -194,6 +195,7 @@ class ArtifactRow:
         ArtifactTypeCode.INFOGRAPHIC.value: (_INFOGRAPHIC_METADATA_POS, 0, 0),
         ArtifactTypeCode.SLIDE_DECK.value: (_SLIDE_DECK_METADATA_POS, 0, 0),
         ArtifactTypeCode.DATA_TABLE.value: (_DATA_TABLE_PAYLOAD_POS, 1, 0),
+        ArtifactTypeCode.CUSTOM.value: (_REPORT_MARKDOWN_POS, 1, 5),
     }
 
     _AUDIO_MEDIA_LIST_POS: ClassVar[int] = 5
@@ -490,6 +492,20 @@ class ArtifactRow:
         return url if self._is_valid_artifact_url(url) else None
 
     @property
+    def custom_url(self) -> str | None:
+        """Download URL for a custom artifact."""
+        metadata = self._list_at_top_level(self._CUSTOM_METADATA_POS)
+        if metadata is None or len(metadata) <= 3:
+            return None
+        url = safe_index(
+            metadata,
+            3,
+            method_id=self.method_id,
+            source="ArtifactRow.custom_url",
+        )
+        return url if self._is_valid_artifact_url(url) else None
+
+    @property
     def report_markdown(self) -> str | None:
         """Report markdown, accepting the direct-string and one-element wrapper shapes."""
         if len(self._raw) <= self._REPORT_MARKDOWN_POS:
@@ -588,6 +604,14 @@ class ArtifactRow:
                 return self.infographic_url
             if type_code == ArtifactTypeCode.SLIDE_DECK.value:
                 return self.slide_deck_pdf_url
+            if type_code == ArtifactTypeCode.CUSTOM.value:
+                return (
+                    self.custom_url
+                    or self.infographic_url
+                    or self.slide_deck_pdf_url
+                    or self.audio_url
+                    or self.video_url
+                )
             return None
         except UnknownRPCMethodError:
             if suppress_drift:

--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -47,6 +47,7 @@ class ArtifactType(str, Enum):
     INFOGRAPHIC = "infographic"
     SLIDE_DECK = "slide_deck"
     DATA_TABLE = "data_table"
+    CUSTOM = "custom"
     UNKNOWN = "unknown"
 
 
@@ -61,6 +62,7 @@ _ARTIFACT_TYPE_CODE_MAP: dict[int, ArtifactType] = {
     7: ArtifactType.INFOGRAPHIC,
     8: ArtifactType.SLIDE_DECK,
     9: ArtifactType.DATA_TABLE,
+    10: ArtifactType.CUSTOM,
 }
 
 

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -275,6 +275,7 @@ def get_artifact_type_display(artifact: Artifact) -> str:
         ArtifactType.INFOGRAPHIC: "🖼️ Infographic",
         ArtifactType.SLIDE_DECK: "📊 Slide Deck",
         ArtifactType.DATA_TABLE: "📈 Data Table",
+        ArtifactType.CUSTOM: "📄 Custom",
     }
 
     if kind == ArtifactType.REPORT:

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -203,6 +203,7 @@ def register(mcp: Any) -> None:
         # pins the schema enum equal to ``STUDIO_KINDS`` so the two can't drift.
         kind: Literal[
             "audio",
+            "custom",
             "data-table",
             "flashcards",
             "infographic",

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -190,6 +190,8 @@ class ArtifactTypeCode(int, Enum):
     INFOGRAPHIC = 7
     SLIDE_DECK = 8
     DATA_TABLE = 9
+    CUSTOM = 10
+
 
 
 # Variant codes at artifact_data[9][1][0], distinguishing sub-kinds within the


### PR DESCRIPTION
Adds support for listing and downloading custom artifact types (type 10) in NotebookLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom artifacts, including recognition, listing, filtering, and display.
  - Added custom artifact downloads with binary output and automatic handling of available content or URLs.
  - Added custom artifact metadata, generation prompts, and URL access.
  - Added the `custom` studio listing filter.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->