### PR TITLE
fix(source): preserve markdown fulltext formatting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -973,6 +973,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_source/add.py` | Core service layer for adding text, URL, or Google Drive sources |
 | `_source/drive_import.py` | Auto-route add-from-Drive (#1884): download + upload the upload-only Drive types (epub/docx/txt/…); native import (`add_drive`) instead takes Docs/Slides/Sheets + PDF by reference; header-first cookie-authed streaming fetch behind injected seams |
 | `_source/content.py` | Core service layer for fetching source HTML/markdown content |
+| `_source/markdown.py` | Source fulltext HTML-to-Markdown conversion policy, including Markdown-source and LaTeX/table handling |
 | `_source/listing.py` | Core service layer for listing notebook sources |
 | `_source/polling.py` | Poll coordination service for active source conversions |
 | `_source/upload.py` | Concurrency-gated upload pipeline for source files |
@@ -1134,6 +1135,7 @@ src/notebooklm/
 │   ├── _upload_decode.py        # Pure URL/source-id/content-type decode + validation helpers (extracted from upload.py)
 │   ├── add.py                   # Source addition coordinator
 │   ├── content.py               # Source content fetcher
+│   ├── markdown.py               # Source fulltext HTML-to-Markdown conversion policy
 │   ├── drive_import.py          # Auto-route add-from-Drive (#1884): DriveImportService + DriveFetcher — parse id/URL, cookie-authed header-first streaming download of the upload-only Drive types (epub/docx/txt/…), confirm-token handling + 0600 temp cleanup, then hand to add_file (native Docs/Slides/Sheets → pointer error)
 │   ├── listing.py               # Source listing helper
 │   ├── polling.py               # Source polling coordinator

--- a/src/notebooklm/_source/content.py
+++ b/src/notebooklm/_source/content.py
@@ -53,12 +53,13 @@ class SourceContentRenderer:
 
         if output_format == "markdown":
             try:
-                from markdownify import markdownify as md
+                import markdownify  # noqa: F401  # presence guard; conversion is below
             except ImportError:
                 raise ImportError(
                     "The 'markdown' format requires the 'markdownify' package. "
                     "Install it with: pip install 'notebooklm-py[markdown]'"
                 ) from None
+            from .markdown import html_to_markdown
 
         params = [[source_id], [3], [3]] if output_format == "markdown" else [[source_id], [2], [2]]
 
@@ -120,7 +121,7 @@ class SourceContentRenderer:
             # rendition" (warned + empty below).
             html_content = fulltext_row.html_content
             if html_content is not None:
-                content = md(html_content, heading_style="ATX")
+                content = html_to_markdown(html_content, source_type=source_type)
             else:
                 self._logger.warning(
                     "Source %s (type=%s) has no HTML rendition for output_format='markdown'; "

--- a/src/notebooklm/_source/markdown.py
+++ b/src/notebooklm/_source/markdown.py
@@ -1,0 +1,113 @@
+"""HTML-to-Markdown conversion for source fulltext."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from markdownify import MarkdownConverter
+
+# Keep inline and display math out of markdownify's normal escaping. The
+# whitespace guards distinguish math from common currency such as "$5 and
+# $10". An escaped dollar is ordinary source text, not a math delimiter.
+_MATH_SPAN = re.compile(
+    r"(?<!\\)(?P<delimiter>\$\$|\$)(?!\s)"
+    r"(?P<body>.*?)"
+    r"(?<!\s)(?P=delimiter)",
+    re.DOTALL,
+)
+
+# NotebookLM can put Markdown emphasis tags across a math span. Once
+# markdownify has converted those tags, the resulting delimiters can straddle
+# the closing dollar sign. This repair is deliberately narrow and only runs
+# for spans containing a LaTeX escape.
+_MANGLED_MATH = re.compile(
+    r"(?P<lead>(?:\\?\*\\?\*)*)"
+    r"(?<!\$)\$(?!\$)"
+    r"(?P<body>[^\n$]+?)"
+    r"(?<!\$)\$(?!\$)"
+    r"(?P<trail>(?:\\?\*\\?\*)*)"
+)
+_BOLD_RUN = re.compile(r"\\?\*\\?\*")
+
+# Wire type code used by NotebookLM for imported Markdown sources.
+_MARKDOWN_SOURCE_TYPE_CODE = 8
+
+
+def _has_math_signal(body: str) -> bool:
+    """Whether a dollar span contains LaTeX or Markdown-sensitive math."""
+    return "\\" in body or any(char in body for char in "_*^{}")
+
+
+class _SourceMarkdownConverter(MarkdownConverter):
+    """Convert NotebookLM Markdown-source renditions without re-escaping them."""
+
+    def escape(self, text: str, parent_tags: Any) -> str:
+        return text or ""
+
+    def convert_br(self, el: Any, text: str, parent_tags: Any) -> str:
+        return "<br>"
+
+
+class _SourceHtmlConverter(MarkdownConverter):
+    """Convert HTML sources while preserving math and table-cell breaks."""
+
+    def escape(self, text: str, parent_tags: Any) -> str:
+        if not text:
+            return ""
+
+        parts: list[str] = []
+        end = 0
+        for match in _MATH_SPAN.finditer(text):
+            parts.append(
+                super().escape(text[end : match.start()], parent_tags)  # type: ignore[misc]
+            )
+            if _has_math_signal(match.group("body")):
+                parts.append(match.group(0))
+            else:
+                parts.append(super().escape(match.group(0), parent_tags))  # type: ignore[misc]
+            end = match.end()
+        parts.append(super().escape(text[end:], parent_tags))  # type: ignore[misc]
+        return "".join(parts)
+
+    def convert_br(self, el: Any, text: str, parent_tags: Any) -> str:
+        if "td" in parent_tags or "th" in parent_tags:
+            return "<br>"
+        return super().convert_br(el, text, parent_tags)  # type: ignore[misc]
+
+
+def _repair_mangled_math(text: str) -> str:
+    """Repair emphasis delimiters that cross an inline LaTeX span."""
+
+    def fix(match: re.Match[str]) -> str:
+        body = match.group("body")
+        if not (_has_math_signal(body) or _BOLD_RUN.search(body)):
+            return match.group(0)
+
+        body = body.replace("\\_", "_").replace("\\*", "*")
+        body = _BOLD_RUN.sub("", body)
+        lead, trail = match.group("lead"), match.group("trail")
+        if lead and trail:
+            return f"{lead}${body}${trail}"
+        return f"${body}$"
+
+    return _MANGLED_MATH.sub(fix, text)
+
+
+def html_to_markdown(html: str, *, source_type: int | None = None) -> str:
+    """Convert a source HTML rendition to Markdown.
+
+    Imported Markdown sources contain a hybrid HTML/Markdown rendition, so
+    their text must not be escaped again. Other source types use normal HTML
+    escaping with math spans protected from Markdown escaping.
+    """
+    converter: MarkdownConverter
+    if source_type == _MARKDOWN_SOURCE_TYPE_CODE:
+        converter = _SourceMarkdownConverter(heading_style="ATX")
+    else:
+        converter = _SourceHtmlConverter(heading_style="ATX")
+
+    return _repair_mangled_math(converter.convert(html))
+
+
+__all__ = ["html_to_markdown"]

--- a/src/notebooklm/_source/markdown.py
+++ b/src/notebooklm/_source/markdown.py
@@ -81,12 +81,14 @@ def _repair_mangled_math(text: str) -> str:
 
     def fix(match: re.Match[str]) -> str:
         body = match.group("body")
+        lead, trail = match.group("lead"), match.group("trail")
+        if not (lead or trail):
+            return match.group(0)
         if not (_has_math_signal(body) or _BOLD_RUN.search(body)):
             return match.group(0)
 
         body = body.replace("\\_", "_").replace("\\*", "*")
         body = _BOLD_RUN.sub("", body)
-        lead, trail = match.group("lead"), match.group("trail")
         if lead and trail:
             return f"{lead}${body}${trail}"
         return f"${body}$"

--- a/src/notebooklm/_source/markdown.py
+++ b/src/notebooklm/_source/markdown.py
@@ -13,22 +13,22 @@ from markdownify import MarkdownConverter
 _MATH_SPAN = re.compile(
     r"(?<!\\)(?P<delimiter>\$\$|\$)(?!\s)"
     r"(?P<body>.*?)"
-    r"(?<!\s)(?P=delimiter)",
+    r"(?<![\\\s])(?P=delimiter)",
     re.DOTALL,
 )
 
 # NotebookLM can put Markdown emphasis tags across a math span. Once
 # markdownify has converted those tags, the resulting delimiters can straddle
 # the closing dollar sign. This repair is deliberately narrow and only runs
-# for spans containing a LaTeX escape.
+# for spans containing a LaTeX escape or crossed emphasis delimiters.
 _MANGLED_MATH = re.compile(
-    r"(?P<lead>(?:\\?\*\\?\*)*)"
+    r"(?P<lead>(?:(?:\\?[*_]){1,2})?)"
     r"(?<!\$)\$(?!\$)"
     r"(?P<body>[^\n$]+?)"
     r"(?<!\$)\$(?!\$)"
-    r"(?P<trail>(?:\\?\*\\?\*)*)"
+    r"(?P<trail>(?:(?:\\?[*_]){1,2})?)"
 )
-_BOLD_RUN = re.compile(r"\\?\*\\?\*")
+_EMPHASIS_RUN = re.compile(r"(?:(?:\\?[*_]){1,2})")
 
 # Wire type code used by NotebookLM for imported Markdown sources.
 _MARKDOWN_SOURCE_TYPE_CODE = 8
@@ -42,7 +42,7 @@ def _has_math_signal(body: str) -> bool:
 class _SourceMarkdownConverter(MarkdownConverter):
     """Convert NotebookLM Markdown-source renditions without re-escaping them."""
 
-    def escape(self, text: str, parent_tags: Any) -> str:
+    def escape(self, text: str, parent_tags: Any = None) -> str:
         return text or ""
 
     def convert_br(self, el: Any, text: str, parent_tags: Any) -> str:
@@ -52,26 +52,34 @@ class _SourceMarkdownConverter(MarkdownConverter):
 class _SourceHtmlConverter(MarkdownConverter):
     """Convert HTML sources while preserving math and table-cell breaks."""
 
-    def escape(self, text: str, parent_tags: Any) -> str:
+    def escape(self, text: str, parent_tags: Any = None) -> str:
         if not text:
             return ""
 
         parts: list[str] = []
         end = 0
         for match in _MATH_SPAN.finditer(text):
-            parts.append(
-                super().escape(text[end : match.start()], parent_tags)  # type: ignore[misc]
-            )
+            parts.append(self._escape_plain(text[end : match.start()], parent_tags))
             if _has_math_signal(match.group("body")):
                 parts.append(match.group(0))
             else:
-                parts.append(super().escape(match.group(0), parent_tags))  # type: ignore[misc]
+                parts.append(self._escape_plain(match.group(0), parent_tags))
             end = match.end()
-        parts.append(super().escape(text[end:], parent_tags))  # type: ignore[misc]
+        parts.append(self._escape_plain(text[end:], parent_tags))
         return "".join(parts)
 
+    def _escape_plain(self, text: str, parent_tags: Any) -> str:
+        try:
+            return super().escape(text, parent_tags)  # type: ignore[misc]
+        except TypeError:
+            return super().escape(text)  # type: ignore[misc]
+
     def convert_br(self, el: Any, text: str, parent_tags: Any) -> str:
-        if "td" in parent_tags or "th" in parent_tags:
+        in_table_cell = (
+            isinstance(parent_tags, (set, frozenset, list, tuple))
+            and ("td" in parent_tags or "th" in parent_tags)
+        ) or getattr(el, "find_parent", lambda *_args: None)(("td", "th")) is not None
+        if in_table_cell:
             return "<br>"
         return super().convert_br(el, text, parent_tags)  # type: ignore[misc]
 
@@ -84,11 +92,15 @@ def _repair_mangled_math(text: str) -> str:
         lead, trail = match.group("lead"), match.group("trail")
         if not (lead or trail):
             return match.group(0)
-        if not (_has_math_signal(body) or _BOLD_RUN.search(body)):
+        if not (_has_math_signal(body) or _EMPHASIS_RUN.search(body)):
             return match.group(0)
 
         body = body.replace("\\_", "_").replace("\\*", "*")
-        body = _BOLD_RUN.sub("", body)
+        marker = lead.replace("\\", "")
+        if not trail and body.endswith(marker):
+            body = body[: -len(marker)]
+        elif not lead and body.startswith(trail.replace("\\", "")):
+            body = body[len(trail.replace("\\", "")) :]
         if lead and trail:
             return f"{lead}${body}${trail}"
         return f"${body}$"

--- a/tests/unit/test_source_content_renderer.py
+++ b/tests/unit/test_source_content_renderer.py
@@ -99,6 +99,52 @@ async def test_markdown_mode_uses_html_rpc_shape_and_converts_html() -> None:
 
 
 @pytest.mark.asyncio
+async def test_markdown_mode_preserves_hybrid_markdown_source() -> None:
+    pytest.importorskip("markdownify")
+    rpc = RecordingRpc(
+        [
+            ["src_md", "Markdown Source", [None, None, None, None, 8]],
+            None,
+            None,
+            None,
+            [
+                None,
+                "<p>| A | B |<br>| --- | --- |<br>| x <br> y | z |</p>",
+            ],
+        ]
+    )
+    renderer = SourceContentRenderer(rpc)
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_md", output_format="markdown")
+
+    assert "| x <br> y | z |" in fulltext.content
+    assert "| A | B |  \n" not in fulltext.content
+
+
+@pytest.mark.asyncio
+async def test_markdown_mode_repairs_latex_emphasis_overlap() -> None:
+    pytest.importorskip("markdownify")
+    rpc = RecordingRpc(
+        [
+            ["src_math", "Math Source", [None, None, None, None, 5]],
+            None,
+            None,
+            None,
+            [
+                None,
+                "<p><strong>(B)</strong> <strong>membrane-bound</strong> "
+                "<strong>$LT\\alpha_1\\beta_2</strong>$</p>",
+            ],
+        ]
+    )
+    renderer = SourceContentRenderer(rpc)
+
+    fulltext = await renderer.get_fulltext("nb_1", "src_math", output_format="markdown")
+
+    assert fulltext.content == "**(B)** **membrane-bound** $LT\\alpha_1\\beta_2$"
+
+
+@pytest.mark.asyncio
 async def test_markdown_mode_missing_dependency_fails_before_rpc(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_source_markdown.py
+++ b/tests/unit/test_source_markdown.py
@@ -54,6 +54,12 @@ def test_simple_math_emphasis_overlap_is_repaired() -> None:
     assert output == "$x = y$"
 
 
+def test_math_asterisks_without_emphasis_are_preserved() -> None:
+    output = html_to_markdown("<p>$a**b$</p>")
+
+    assert output == "$a**b$"
+
+
 @pytest.mark.parametrize(
     ("html", "expected"),
     [

--- a/tests/unit/test_source_markdown.py
+++ b/tests/unit/test_source_markdown.py
@@ -54,6 +54,12 @@ def test_simple_math_emphasis_overlap_is_repaired() -> None:
     assert output == "$x = y$"
 
 
+def test_italic_math_emphasis_overlap_is_repaired() -> None:
+    output = html_to_markdown("<p><em>$x_1</em>$</p>")
+
+    assert output == "$x_1$"
+
+
 def test_math_asterisks_without_emphasis_are_preserved() -> None:
     output = html_to_markdown("<p>$a**b$</p>")
 
@@ -66,6 +72,8 @@ def test_math_asterisks_without_emphasis_are_preserved() -> None:
         ("<p>prices $5 and $10</p>", "prices $5 and $10"),
         ("<p>bold price <strong>$5</strong></p>", "bold price **$5**"),
         ("<p>display $$E=mc^2$$</p>", "display $$E=mc^2$$"),
+        ("<p>$x+\\$y_1$</p>", "$x+\\$y_1$"),
+        ("<p>$file\\_name$</p>", "$file\\_name$"),
         (
             "<p>We have $5 and we need$10*2 dollars</p>",
             "We have $5 and we need$10\\*2 dollars",

--- a/tests/unit/test_source_markdown.py
+++ b/tests/unit/test_source_markdown.py
@@ -1,0 +1,72 @@
+"""Unit tests for source HTML-to-Markdown conversion."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("markdownify")
+
+from notebooklm._source.markdown import html_to_markdown  # noqa: E402
+
+
+def test_html_table_cell_break_is_preserved() -> None:
+    output = html_to_markdown("<table><tr><td>Column 1 <br> Line 2</td><td>Value</td></tr></table>")
+
+    assert "Column 1 <br> Line 2" in output
+    row = next(line for line in output.splitlines() if "Column 1" in line)
+    assert row.count("|") == 3
+
+
+def test_markdown_source_break_is_preserved_inside_pipe_table() -> None:
+    output = html_to_markdown(
+        "<p>| A | B |<br>| --- | --- |<br>| x <br> y | z |</p>",
+        source_type=8,
+    )
+
+    assert output == "| A | B |<br>| --- | --- |<br>| x <br> y | z |"
+
+
+def test_break_outside_table_keeps_normal_html_behavior() -> None:
+    output = html_to_markdown("<p>a<br>b</p>")
+
+    assert "<br>" not in output
+    assert "a" in output and "b" in output
+
+
+def test_inline_latex_is_not_escaped() -> None:
+    output = html_to_markdown("<p>$LT\\alpha_1\\beta_2$</p>")
+
+    assert output == "$LT\\alpha_1\\beta_2$"
+
+
+def test_latex_emphasis_overlap_is_repaired() -> None:
+    output = html_to_markdown(
+        "<p><strong>(B)</strong> <strong>membrane-bound</strong> "
+        "<strong>$LT\\alpha_1\\beta_2</strong>$</p>"
+    )
+
+    assert output == "**(B)** **membrane-bound** $LT\\alpha_1\\beta_2$"
+
+
+def test_simple_math_emphasis_overlap_is_repaired() -> None:
+    output = html_to_markdown("<p><strong>$x = y</strong>$</p>")
+
+    assert output == "$x = y$"
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        ("<p>prices $5 and $10</p>", "prices $5 and $10"),
+        ("<p>bold price <strong>$5</strong></p>", "bold price **$5**"),
+        ("<p>display $$E=mc^2$$</p>", "display $$E=mc^2$$"),
+        (
+            "<p>We have $5 and we need$10*2 dollars</p>",
+            "We have $5 and we need$10\\*2 dollars",
+        ),
+    ],
+)
+def test_non_target_dollar_text_is_preserved(html: str, expected: str) -> None:
+    output = html_to_markdown(html)
+
+    assert output == expected


### PR DESCRIPTION
## Summary

- add a source-fulltext Markdown converter with separate Markdown-source and HTML-source policies
- preserve hybrid Markdown table breaks and LaTeX spans in `get_fulltext(output_format="markdown")`
- add regressions for #1899 and #1900, including currency/display-math negatives

Closes #1899
Closes #1900

## Verification

- `uv run pytest -q` — 11795 passed, 85 skipped, 1 xfailed
- `uv run ruff check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved HTML-to-Markdown conversion for NotebookLM sources.
  - Preserves LaTeX math formatting, including emphasis overlapping mathematical expressions.
  - Maintains line breaks in table cells and preserves Markdown table formatting.
  - Avoids unnecessary conversion or escaping for content already provided as Markdown.

- **Bug Fixes**
  - Fixed formatting issues affecting tables, line breaks, emphasis, and mathematical notation when rendering source content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->