### PR TITLE
fix(test): replace httpbin.org/html with example.com in E2E tests

### DIFF
--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -30,11 +30,11 @@ class TestSourceOperations:
     @pytest.mark.asyncio
     async def test_add_url_source(self, client, temp_notebook):
         """Test adding a URL source to an owned notebook."""
-        source = await client.sources.add_url(temp_notebook.id, "https://httpbin.org/html")
+        source = await client.sources.add_url(temp_notebook.id, "https://example.com")
         assert isinstance(source, Source)
         assert source.id is not None
         # URL may or may not be returned in response
-        # assert source.url == "https://httpbin.org/html"
+        # assert source.url == "https://example.com"
 
     @pytest.mark.asyncio
     async def test_add_youtube_source(self, client, temp_notebook):
@@ -139,7 +139,7 @@ class TestSourceMutations:
     async def test_refresh_source(self, client, temp_notebook):
         """Test refreshing a URL source."""
         # Add a URL source
-        source = await client.sources.add_url(temp_notebook.id, "https://httpbin.org/html")
+        source = await client.sources.add_url(temp_notebook.id, "https://example.com")
         assert source.id is not None
 
         # Refresh it
@@ -153,7 +153,7 @@ class TestSourceMutations:
     async def test_check_freshness(self, client, temp_notebook):
         """Test checking source freshness."""
         # Add a URL source
-        source = await client.sources.add_url(temp_notebook.id, "https://httpbin.org/html")
+        source = await client.sources.add_url(temp_notebook.id, "https://example.com")
         assert source.id is not None
 
         await asyncio.sleep(2)  # Wait for processing


### PR DESCRIPTION
### Summary
This PR resolves sporadic failures and timeouts in the E2E test suite by replacing the unstable/rate-limited `https://httpbin.org/html` target URL with `https://example.com`. Because E2E tests run against the live NotebookLM service, Google's backend fetcher must be able to reliably reach the target URL. Using a stable, widely allowed domain like `example.com` ensures reliable E2E test executions in CI.

### Local Verification Commands Run:
- `uv run pytest tests/e2e/test_sources.py -v` (passed cleanly)
- `uv run pytest tests/integration` (passed cleanly)
- `uv run mypy src/notebooklm` (passed cleanly)
- `uv run pre-commit run --all-files` (passed cleanly)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated URL-source end-to-end tests to use `https://example.com` for creation, refresh, and freshness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->