### PR TITLE
refactor(auth): pin the public surface to the docs, gate constant values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot fingerprint differently under a different `PYTHONHASHSEED` — and a change
   surfaces as a `changed-constant-value` break requiring an allowlist entry. The
   three real changes above are recorded there now rather than being invisible.
+
+- **`NOTEBOOKLM_AUTH_JSON` is now read through a single helper.** The env var was
   checked at ~7 auth-layer call sites that had drifted on
   presence-vs-truthiness (the #2057 / #2083 class of bug, where a *set-but-empty*
   value fell through to a profile file at some sites and raised at others). All

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`NOTEBOOKLM_AUTH_JSON` is now read through a single helper.** The env var was
+- **`notebooklm.auth.__all__` is now exactly the documented public surface (38 →
+  6 names).** `__all__` had been doing double duty: the CLI boundary lint forbids
+  `cli/` from importing `notebooklm._*`, so every auth helper the CLI needed was
+  reached through the `notebooklm.auth` facade — and the external-imports audit
+  then *forced* that name into `__all__`. "The CLI needs it" silently became "it
+  is public API", and the published surface grew to 38 names against the 6 that
+  docs/stability.md ever promised (`AuthTokens`,
+  `convert_rookiepy_cookies_to_storage_state`, the three cookie-domain constants,
+  and `LockUnavailableError`).
+
+  The other 32 are **de-advertised, not removed** — the #1592 mechanism:
+  `notebooklm.auth.<name>` keeps resolving exactly as before, with one reviewed
+  `removed-export` allowance each in `scripts/api-compat-allowlist.json`. No
+  runtime behaviour changes and no import breaks; only `from notebooklm.auth
+  import *` (which no supported usage relies on) and static-analysis views of the
+  advertised surface are affected. The 30 names first-party code genuinely needs
+  across the boundary are now tracked by their own list,
+  `AUTH_CROSS_BOUNDARY_NAMES` in `tests/_guardrails/test_public_surface.py`, which
+  grants importability *without* publishing — so a future CLI need can no longer
+  re-inflate the public API. Two names (`KEEP_ACCOUNT`, `LoginWriteOutcome`) had
+  no importer at all and are simply unblessed. Publishing a name now requires
+  changing `__all__`, the docs, and the manifest together:
+  `test_auth_all_matches_documented_public_surface` fails the build if the three
+  disagree.
+
+- **The API-compat audit now compares the VALUE of designated public constants.**
+  `scripts/audit_public_api_compat.py` reasoned about shape only — a module
+  constant contributed just its `kind`, so rebinding one compared as "str vs str"
+  and passed. The Gemini Notebook rebrand went through that blind spot: the audit
+  stayed green while `config.DEFAULT_BASE_URL` and `config.PERSONAL_BASE_HOST`
+  changed host and `auth.REQUIRED_COOKIE_DOMAINS` gained members. Constants listed
+  in the new `VALUE_TRACKED_CONSTANTS` (those five, minus the unchanged optional
+  tiers) now carry an order-insensitive fingerprint — sorted so a `frozenset`
+  cannot fingerprint differently under a different `PYTHONHASHSEED` — and a change
+  surfaces as a `changed-constant-value` break requiring an allowlist entry. The
+  three real changes above are recorded there now rather than being invisible.
   checked at ~7 auth-layer call sites that had drifted on
   presence-vs-truthiness (the #2057 / #2083 class of bug, where a *set-but-empty*
   value fell through to a profile file at some sites and raised at others). All

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -126,7 +126,7 @@ ChatGoal, ChatResponseLength, ChatMode
 DriveMimeType, ExportType
 
 # Auth
-AuthTokens
+AuthTokens                # also re-exported as notebooklm.auth.AuthTokens
 notebooklm.paths.get_storage_path()
 
 # Logging and Correlation
@@ -149,7 +149,19 @@ notebooklm.auth.convert_rookiepy_cookies_to_storage_state  # requires `pip insta
 notebooklm.auth.REQUIRED_COOKIE_DOMAINS
 notebooklm.auth.OPTIONAL_COOKIE_DOMAINS
 notebooklm.auth.OPTIONAL_COOKIE_DOMAINS_BY_LABEL
+
+# Storage-writer failure - imported from notebooklm.auth
+notebooklm.auth.LockUnavailableError  # canonical home: notebooklm.exceptions; also an OSError via TimeoutError (ADR-0029)
 ```
+
+Every `notebooklm.auth.<name>` above is **exactly** the `__all__` of the
+`notebooklm.auth` module: `test_auth_all_matches_documented_public_surface`
+(`tests/_guardrails/test_public_surface.py`) parses this section and fails the
+build if the module publishes a name this list does not, or vice versa. The rest
+of `notebooklm.auth` — including the ~30 helpers `cli/` and `_app/` import across
+the package boundary — is internal and may change without notice; those are
+tracked as `AUTH_CROSS_BOUNDARY_NAMES` in the same test module, which grants
+importability without any stability promise.
 
 ### Internal helpers exported for compatibility
 
@@ -173,7 +185,7 @@ UnknownTypeWarning        # Warning category emitted when .kind falls back to UN
 # These are NOT part of the public API:
 notebooklm.rpc.*          # RPC protocol internals, except documented power-user imports
 notebooklm._*.py          # All underscore-prefixed modules
-notebooklm.auth.*         # Auth internals (except documented AuthTokens, cookie conversion, and cookie-domain constants)
+notebooklm.auth.*         # Auth internals (except the six documented names listed above: AuthTokens, cookie conversion, the cookie-domain constants, and LockUnavailableError)
 ```
 
 For raw-RPC power-user calls, import the documented RPC helpers explicitly:

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -1,10 +1,156 @@
 {
-  "schema_version": 1,
+  "allowed_breaks": [
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.Account",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.Account, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.GOOGLE_REGIONAL_CCTLDS",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.GOOGLE_REGIONAL_CCTLDS, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.MasterTokenError",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.MasterTokenError, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.build_cookie_jar",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.build_cookie_jar, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.build_httpx_cookies_from_storage",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.build_httpx_cookies_from_storage, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.clear_account_metadata",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.clear_account_metadata, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.cookie_names_from_storage",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.cookie_names_from_storage, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.enumerate_accounts",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.enumerate_accounts, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.exchange_master_token",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.exchange_master_token, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_cookies_from_storage",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.extract_cookies_from_storage, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_cookies_with_domains",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.extract_cookies_with_domains, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.extract_email_from_html",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.extract_email_from_html, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.fetch_tokens_passive",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.fetch_tokens_passive, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.fetch_tokens_with_domains",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.fetch_tokens_with_domains, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.generate_android_id",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.generate_android_id, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.get_account_email_for_storage",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.get_account_email_for_storage, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.get_authuser_for_storage",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.get_authuser_for_storage, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.mint_cookies",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.mint_cookies, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.missing_cookies_hint",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.missing_cookies_hint, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.persist_minted_jar",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.persist_minted_jar, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.read_account_metadata",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.read_account_metadata, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.read_account_metadata_from_storage_state",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.read_account_metadata_from_storage_state, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.read_master_token",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.read_master_token, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.validate_with_recovery",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.validate_with_recovery, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.write_account_metadata",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.write_account_metadata, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "removed-export",
+      "object": "notebooklm.auth.write_master_token",
+      "reason": "De-blessed from notebooklm.auth.__all__ when the module's public surface was pinned to the six names docs/stability.md promises. It was published only because __all__ doubled as the cli/_app cross-boundary import allowlist, never as a documented API. De-advertisement, not removal: still importable as notebooklm.auth.write_master_token, frozen by AUTH_CROSS_BOUNDARY_NAMES in tests/_guardrails/test_public_surface.py."
+    },
+    {
+      "code": "changed-constant-value",
+      "object": "notebooklm.config.DEFAULT_BASE_URL",
+      "reason": "Gemini Notebook rebrand (#2013 / #2067, shipped in #2072): the default app host moved to notebook.google.com while both hosts still serve. Reviewed and documented in CHANGELOG + ADR-0028; NOTEBOOKLM_BASE_URL remains the rollback lever. Surfaced only now because constant VALUES were invisible to this audit."
+    },
+    {
+      "code": "changed-constant-value",
+      "object": "notebooklm.config.PERSONAL_BASE_HOST",
+      "reason": "Gemini Notebook rebrand (#2013 / #2067, shipped in #2072): companion flip to DEFAULT_BASE_URL \u2014 the personal-tier host constant now names notebook.google.com. Same review and rollback lever."
+    },
+    {
+      "code": "changed-constant-value",
+      "object": "notebooklm.auth.REQUIRED_COOKIE_DOMAINS",
+      "reason": "Gemini Notebook rebrand (#2013, shipped in #2020): notebook.google.com and .notebook.google.com joined the required cookie-domain tier because Google sets the per-product binding cookies (OSID / __Secure-OSID) on that host. Additive for the constant's documented use (an extractor allowlist); a narrower set would drop binding cookies and break login."
+    }
+  ],
   "extra_public_names": {
     "notebooklm": [
       "configure_logging",
       "DEFAULT_STORAGE_PATH"
     ]
   },
-  "allowed_breaks": []
+  "schema_version": 1
 }

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -313,15 +313,21 @@ def kind_of(obj) -> str:
 # script that runs in a subprocess, so a triple-quoted string here would end it.)
 def stable_value_repr(value) -> str:
     if isinstance(value, (frozenset, set)):
-        return "{" + ", ".join(sorted(stable_value_repr(item) for item in value)) + "}"
+        # Tag the container type: a bare "{...}" would render a set, a frozenset
+        # and an empty dict identically, so swapping a public constant's container
+        # (frozenset -> set makes it mutable by callers) would fingerprint as no
+        # change at all.
+        rendered = ", ".join(sorted(stable_value_repr(item) for item in value))
+        label = "frozenset" if isinstance(value, frozenset) else "set"
+        return f"{label}({{{rendered}}})"
     if isinstance(value, dict):
         return (
-            "{"
+            "dict({"
             + ", ".join(
                 f"{key!r}: {stable_value_repr(item)}"
                 for key, item in sorted(value.items(), key=lambda kv: repr(kv[0]))
             )
-            + "}"
+            + "})"
         )
     if isinstance(value, (list, tuple)):
         # Order IS meaningful for sequences — render in place.

--- a/scripts/audit_public_api_compat.py
+++ b/scripts/audit_public_api_compat.py
@@ -60,6 +60,39 @@ CLIENT_NAMESPACE_ATTRIBUTES = (
     "sources",
 )
 
+# Public constants whose VALUE is part of the contract, not just their existence.
+#
+# The rest of this audit reasons about *shape* — a name's kind, its signature, its
+# class members, its enum member values. For a plain module constant it recorded
+# only ``kind`` ("str", "frozenset"), so rebinding one to a different value read as
+# no change at all. That blind spot is not theoretical: the Gemini Notebook rebrand
+# (#2072) repointed ``DEFAULT_BASE_URL`` / ``PERSONAL_BASE_HOST`` at a different
+# host and the audit stayed green, and ``REQUIRED_COOKIE_DOMAINS`` — a documented
+# public constant that callers feed to cookie extractors — has since gained
+# members the same way.
+#
+# Names listed here additionally capture an order-insensitive value fingerprint, so
+# a value change surfaces as a reviewable ``changed-constant-value`` break that has
+# to be acknowledged in the allowlist like any other. Keep the list SHORT and
+# deliberate: it is for constants downstream code compares against or feeds to an
+# API, not for every module-level literal. A name must be in the module's ``__all__``
+# (or ``extra_public_names``) to be collected at all.
+VALUE_TRACKED_CONSTANTS: dict[str, frozenset[str]] = {
+    "notebooklm.auth": frozenset(
+        {
+            "OPTIONAL_COOKIE_DOMAINS",
+            "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+            "REQUIRED_COOKIE_DOMAINS",
+        }
+    ),
+    "notebooklm.config": frozenset(
+        {
+            "DEFAULT_BASE_URL",
+            "PERSONAL_BASE_HOST",
+        }
+    ),
+}
+
 
 @dataclass(frozen=True)
 class ApiBreak:
@@ -176,6 +209,14 @@ EXTRA_PACKAGES = tuple(json.loads(sys.argv[6]))
 # lack __all__ on some public modules; raising there would abort the baseline
 # collection before any diff runs (issue #1493 review).
 ENFORCE_ALL = (sys.argv[7] == "1") if len(sys.argv) > 7 else True
+# {module: [constant names]} whose VALUE is captured, not just their kind. Passed
+# in from the driver (VALUE_TRACKED_CONSTANTS) so BOTH the baseline export and the
+# current checkout are collected against the same tracked set.
+VALUE_TRACKED = (
+    {module: set(names) for module, names in json.loads(sys.argv[8]).items()}
+    if len(sys.argv) > 8
+    else {}
+)
 
 
 def discover_modules() -> list[str]:
@@ -257,6 +298,39 @@ def kind_of(obj) -> str:
     if inspect.ismodule(obj):
         return "module"
     return type(obj).__name__
+
+
+# Return an order-insensitive fingerprint of a constant's value.
+#
+# repr() alone is unusable here: set/frozenset/dict iteration order varies with
+# PYTHONHASHSEED, so the same constant would fingerprint differently between the
+# baseline export and the current checkout and every run would report a spurious
+# break. Containers are therefore rendered sorted and recursively; everything else
+# falls back to repr. Exotic values degrade to a placeholder rather than raising --
+# the audit must never fail to *collect* a surface it is asked to compare.
+#
+# (Comments, not a docstring: this function lives inside the raw-string collector
+# script that runs in a subprocess, so a triple-quoted string here would end it.)
+def stable_value_repr(value) -> str:
+    if isinstance(value, (frozenset, set)):
+        return "{" + ", ".join(sorted(stable_value_repr(item) for item in value)) + "}"
+    if isinstance(value, dict):
+        return (
+            "{"
+            + ", ".join(
+                f"{key!r}: {stable_value_repr(item)}"
+                for key, item in sorted(value.items(), key=lambda kv: repr(kv[0]))
+            )
+            + "}"
+        )
+    if isinstance(value, (list, tuple)):
+        # Order IS meaningful for sequences — render in place.
+        rendered = ", ".join(stable_value_repr(item) for item in value)
+        return f"[{rendered}]" if isinstance(value, list) else f"({rendered})"
+    try:
+        return repr(value)
+    except Exception:  # pragma: no cover - defensive; repr should not raise
+        return f"<unreprable {type(value).__name__}>"
 
 
 def unwrap_member(obj):
@@ -371,6 +445,7 @@ def collect_module(module_name: str) -> dict:
         if name not in names:
             names.append(name)
     payload = {"exports": {}, "has_all": has_all}
+    value_tracked = VALUE_TRACKED.get(module_name, set())
     for name in names:
         try:
             value = getattr(module, name)
@@ -390,6 +465,10 @@ def collect_module(module_name: str) -> dict:
         }
         if inspect.isclass(value):
             entry.update(collect_class(value))
+        elif name in value_tracked:
+            # Only for plain constants: a class/function is already compared by
+            # shape, and fingerprinting one would report a break on every edit.
+            entry["constant_value"] = stable_value_repr(value)
         payload["exports"][name] = entry
     return payload
 
@@ -469,6 +548,10 @@ def collect_manifest(
             json.dumps(sorted(EXCLUDED_TOP_LEVEL_MODULES)),
             json.dumps(EXTRA_PUBLIC_PACKAGES),
             "1" if enforce_all else "0",
+            json.dumps(
+                {module: sorted(names) for module, names in VALUE_TRACKED_CONSTANTS.items()},
+                sort_keys=True,
+            ),
         ],
         cwd=source_root,
         env=env,
@@ -626,6 +709,23 @@ def _compare_export(
             )
         )
         return breaks
+
+    # Value-tracked constants (VALUE_TRACKED_CONSTANTS). Both sides are collected
+    # by THIS script — the baseline is an export of the old source imported by the
+    # current code — so a missing key means the name is not value-tracked, not that
+    # the baseline predates the feature. Comparing only when both sides carry a
+    # fingerprint keeps adding/removing a name from the tracked set from firing a
+    # break on its own.
+    old_value = old.get("constant_value")
+    new_value = new.get("constant_value")
+    if old_value is not None and new_value is not None and old_value != new_value:
+        breaks.append(
+            ApiBreak(
+                "changed-constant-value",
+                path,
+                f"value changed from {old_value} to {new_value}",
+            )
+        )
 
     if old["kind"] in {"function", "class", "enum"}:
         reason = _signature_breakage(old.get("signature"), new.get("signature"))

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -141,58 +141,39 @@ _is_allowed_cookie_domain = _cookie_policy._is_allowed_cookie_domain
 
 
 # Public surface for ``from notebooklm.auth import *`` and for downstream
-# static-analysis tools (mypy, ruff F401 checks). ``notebooklm.auth.*`` is internal
-# (docs/stability.md) except the documented power-user imports plus the cohesive
-# operations the CLI/_app need across the public boundary. The 23 core/test-only
-# re-exports de-blessed in #1592 were removed from this list but remain importable
-# as module attributes for back-compat — first-party code now imports them from
-# their ``notebooklm._auth.<sub>`` home, and one ``removed-export`` allowance each
-# lives in scripts/api-compat-allowlist.json. Underscore-prefixed names remain
-# accessible on the module as whitebox test affordances but are intentionally NOT
-# blessed here. See ``tests/_guardrails/test_public_surface.py``:
-# ``test_auth_module_has_expected_all`` snapshot-checks the exact ordering, and
+# static-analysis tools (mypy, ruff F401 checks). This list is EXACTLY the
+# ``notebooklm.auth`` surface documented in docs/stability.md — nothing else.
+# Everything else in this module is internal (docs/stability.md: "notebooklm.auth.*
+# — Auth internals").
+#
+# ``__all__`` used to double as the CLI/_app cross-boundary import allowlist: the
+# CLI boundary lint (tests/_guardrails/test_cli_boundary.py) forbids ``cli/`` from
+# importing ``notebooklm._*``, so every helper the CLI needed was reached through
+# this facade — and the external-imports audit then FORCED that name into
+# ``__all__``. "The CLI needs it" silently became "it is public API", and the list
+# grew to 38 names, 32 of which docs/stability.md never promised. Those 32 are
+# de-blessed here (the #1592 mechanism: dropped from ``__all__``, still importable
+# as module attributes, one ``removed-export`` allowance each in
+# scripts/api-compat-allowlist.json) and are now tracked by their own
+# first-party-only list, ``AUTH_CROSS_BOUNDARY_NAMES`` in
+# ``tests/_guardrails/test_public_surface.py``. Adding a name there does NOT
+# publish it. Underscore-prefixed names remain accessible on the module as whitebox
+# test affordances but are intentionally NOT blessed here.
+#
+# See ``tests/_guardrails/test_public_surface.py``:
+# ``test_auth_module_has_expected_all`` snapshot-checks the exact ordering,
+# ``test_auth_all_matches_documented_public_surface`` pins this list to
+# docs/stability.md and the manifest in ``test_public_surface_manifest.py``, and
 # ``test_auth_all_matches_external_imports_audit`` AST-scans ``src/``/``tests/``/
-# ``docs/`` to fail if a public name is imported externally from ``notebooklm.auth``
-# without being added here.
+# ``docs/`` to fail if a name is imported externally from ``notebooklm.auth``
+# without being in ``__all__`` OR ``AUTH_CROSS_BOUNDARY_NAMES``.
 __all__ = [
-    "Account",
-    "AccountRecord",
     "AuthTokens",
-    "build_cookie_jar",
-    "build_httpx_cookies_from_storage",
-    "CLEAR_ACCOUNT",
-    "clear_account_metadata",
     "convert_rookiepy_cookies_to_storage_state",
-    "cookie_names_from_storage",
-    "drop_legacy_account_key",
-    "enumerate_accounts",
-    "exchange_master_token",
-    "extract_cookies_from_storage",
-    "extract_cookies_with_domains",
-    "extract_email_from_html",
-    "fetch_tokens_passive",
-    "fetch_tokens_with_domains",
-    "generate_android_id",
-    "get_account_email_for_storage",
-    "get_authuser_for_storage",
-    "GOOGLE_REGIONAL_CCTLDS",
-    "KEEP_ACCOUNT",
     "LockUnavailableError",
-    "LoginWriteOutcome",
-    "MasterTokenError",
-    "mint_cookies",
-    "missing_cookies_hint",
     "OPTIONAL_COOKIE_DOMAINS",
     "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
-    "persist_minted_jar",
-    "read_account_metadata",
-    "read_account_metadata_from_storage_state",
-    "read_master_token",
-    "replace_from_login",
     "REQUIRED_COOKIE_DOMAINS",
-    "validate_with_recovery",
-    "write_account_metadata",
-    "write_master_token",
 ]
 
 

--- a/tests/_guardrails/_public_import_manifest.py
+++ b/tests/_guardrails/_public_import_manifest.py
@@ -1,0 +1,72 @@
+"""Shared manifest of the documented public import surface (stability spec).
+
+Lives in a ``_``-prefixed non-test module because two guardrail modules consume
+it — ``test_public_surface_manifest.py`` (does every documented import still
+resolve?) and ``test_public_surface.py`` (does ``notebooklm.auth.__all__`` still
+equal what the docs promise?). ``tests/_guardrails/test_no_cross_test_imports.py``
+forbids one ``test_*`` module importing another, so the shared symbol is hoisted
+here rather than imported across (issue #1431/#1445).
+
+This is the public import surface documented in the user-facing API docs. Keep
+the manifest explicit: if docs add a new supported import path, add it here in
+the same PR; if docs intentionally remove one, remove it here with the docs
+change.
+"""
+
+from __future__ import annotations
+
+_DOCUMENTED_PUBLIC_IMPORTS = {
+    "notebooklm": [
+        "ArtifactType",
+        "AudioFormat",
+        "AudioLength",
+        "AuthTokens",
+        "ChatGoal",
+        "ChatResponseLength",
+        "ConnectionLimits",
+        "correlation_id",
+        "ExportType",
+        "NonIdempotentRetryError",
+        "NotebookLMClient",
+        "QuizDifficulty",
+        "QuizQuantity",
+        "ReportFormat",
+        "RPCError",
+        "SharePermission",
+        "ShareViewLevel",
+        "SourceType",
+        "VideoFormat",
+        "VideoStyle",
+    ],
+    "notebooklm.auth": [
+        "AuthTokens",
+        "convert_rookiepy_cookies_to_storage_state",
+        "LockUnavailableError",
+        "OPTIONAL_COOKIE_DOMAINS",
+        "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+        "REQUIRED_COOKIE_DOMAINS",
+    ],
+    "notebooklm.config": [
+        "DEFAULT_BASE_URL",
+        "get_base_url",
+    ],
+    "notebooklm.log": [
+        "install_redaction",
+    ],
+    "notebooklm.research": [
+        "extract_report_urls",
+        "normalize_url",
+        "select_cited_sources",
+    ],
+    "notebooklm.rpc": [
+        "resolve_rpc_id",
+        "RPCMethod",
+    ],
+    "notebooklm.types": [
+        "ConnectionLimits",
+    ],
+    "notebooklm.urls": [
+        "is_google_auth_redirect",
+        "is_youtube_url",
+    ],
+}

--- a/tests/_guardrails/test_public_surface.py
+++ b/tests/_guardrails/test_public_surface.py
@@ -27,12 +27,14 @@ from __future__ import annotations
 
 import ast
 import pathlib
+import re
 from functools import lru_cache
 
 import pytest
 
 import notebooklm.auth as auth_module
 import notebooklm.client as client_module
+from tests._guardrails._public_import_manifest import _DOCUMENTED_PUBLIC_IMPORTS
 
 pytestmark = pytest.mark.repo_lint
 
@@ -49,15 +51,46 @@ _SCAN_ROOTS = ("src", "tests", "docs")
 
 EXPECTED_CLIENT_ALL: list[str] = ["NotebookLMClient"]
 
+# The ``notebooklm.auth`` PUBLIC surface — exactly what docs/stability.md
+# promises, and nothing else. ``test_auth_all_matches_documented_public_surface``
+# pins this list to the doc and to the manifest in
+# ``test_public_surface_manifest.py``, so the three can never drift apart.
+#
+# Do NOT add a name here just because first-party code imports it across the
+# CLI/_app boundary — that is what ``AUTH_CROSS_BOUNDARY_NAMES`` below is for.
+# Adding a name here is a public-API commitment and needs the docs change to
+# match.
 EXPECTED_AUTH_ALL: list[str] = [
+    "AuthTokens",
+    "convert_rookiepy_cookies_to_storage_state",
+    "LockUnavailableError",
+    "OPTIONAL_COOKIE_DOMAINS",
+    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+    "REQUIRED_COOKIE_DOMAINS",
+]
+
+# First-party-only names reachable at ``notebooklm.auth.<name>``: importable, NOT
+# public API, NOT in ``__all__``.
+#
+# These exist because the CLI boundary lint (tests/_guardrails/test_cli_boundary.py)
+# forbids ``cli/`` from importing ``notebooklm._*``, so ``cli/`` and ``_app/`` reach
+# auth helpers through the ``notebooklm.auth`` facade. Before this list existed, the
+# external-imports audit resolved that need by forcing each name into ``__all__`` —
+# i.e. "the CLI needs it" auto-published it as public API, and ``auth.__all__``
+# reached 38 names against 6 documented ones. Splitting the two roles keeps the
+# published surface pinned to the docs while the boundary need is still tracked and
+# enforced (importability + no-dead-entries below).
+#
+# Adding a name here does NOT publish it, and carries no stability guarantee. It is
+# still a real cost — every entry is a name the auth layer cannot move freely — so
+# prefer routing new CLI needs through ``_app/`` service functions instead.
+AUTH_CROSS_BOUNDARY_NAMES: list[str] = [
     "Account",
     "AccountRecord",
-    "AuthTokens",
     "build_cookie_jar",
     "build_httpx_cookies_from_storage",
     "CLEAR_ACCOUNT",
     "clear_account_metadata",
-    "convert_rookiepy_cookies_to_storage_state",
     "cookie_names_from_storage",
     "drop_legacy_account_key",
     "enumerate_accounts",
@@ -71,30 +104,29 @@ EXPECTED_AUTH_ALL: list[str] = [
     "get_account_email_for_storage",
     "get_authuser_for_storage",
     "GOOGLE_REGIONAL_CCTLDS",
-    "KEEP_ACCOUNT",
-    "LockUnavailableError",
-    "LoginWriteOutcome",
     "MasterTokenError",
     "mint_cookies",
     "missing_cookies_hint",
-    "OPTIONAL_COOKIE_DOMAINS",
-    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
     "persist_minted_jar",
     "read_account_metadata",
     "read_account_metadata_from_storage_state",
     "read_master_token",
     "replace_from_login",
-    "REQUIRED_COOKIE_DOMAINS",
     "validate_with_recovery",
     "write_account_metadata",
     "write_master_token",
 ]
 
-# Names de-blessed from ``auth.__all__`` in PR-1 (#1592): removed from the
-# advertised surface but kept importable as module attributes for back-compat
-# (the rpc-tranche mechanism — see scripts/api-compat-allowlist.json). The freeze
-# test below locks that promise so a future change can't silently drop importability
-# or re-bless a name.
+# Names de-blessed from ``auth.__all__``: removed from the advertised surface but
+# kept importable as module attributes for back-compat (the rpc-tranche mechanism —
+# see scripts/api-compat-allowlist.json). The freeze test below locks that promise
+# so a future change can't silently drop importability or re-bless a name.
+#
+# 23 entries came from PR-1 (#1592). ``KEEP_ACCOUNT`` and ``LoginWriteOutcome`` were
+# added when ``__all__`` was pinned to the documented surface: they were blessed
+# additively alongside the storage-writer refactor but no caller — first-party or
+# test — ever imported them, so they are covered here rather than in
+# ``AUTH_CROSS_BOUNDARY_NAMES`` (which requires a live first-party importer).
 _AUTH_DEBLESSED_KEEP_IMPORTABLE: list[str] = [
     "advance_cookie_snapshot_after_save",
     "ALLOWED_COOKIE_DOMAINS",
@@ -108,9 +140,11 @@ _AUTH_DEBLESSED_KEEP_IMPORTABLE: list[str] = [
     "extract_wiz_field",
     "fetch_tokens",
     "format_authuser_value",
+    "KEEP_ACCOUNT",
     "KEEPALIVE_ROTATE_URL",
     "load_auth_from_storage",
     "load_httpx_cookies",
+    "LoginWriteOutcome",
     "MINIMUM_REQUIRED_COOKIES",
     "normalize_cookie_map",
     "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
@@ -144,13 +178,16 @@ def test_client_all_entries_resolve_on_module() -> None:
 
 
 def test_auth_module_has_expected_all() -> None:
-    """``notebooklm.auth.__all__`` matches the audited externally-imported set.
+    """``notebooklm.auth.__all__`` matches the documented public surface.
 
-    This test is the canonical record of what the audit found on 2026-05-17.
     If you intentionally add or remove a public name from ``auth.py``, update
-    ``EXPECTED_AUTH_ALL`` above to match and re-run the audit to confirm no
-    external caller is broken (search for ``from notebooklm.auth import`` and
-    ``from ..auth import`` across ``src/``, ``tests/``, ``docs/``).
+    ``EXPECTED_AUTH_ALL`` above AND docs/stability.md in the same PR — the two
+    are cross-checked by
+    ``test_auth_all_matches_documented_public_surface``.
+
+    Needing a name across the CLI/_app boundary is NOT a reason to add it here;
+    add it to ``AUTH_CROSS_BOUNDARY_NAMES`` instead, which grants importability
+    without publishing it.
     """
     assert hasattr(auth_module, "__all__"), (
         "notebooklm.auth must declare __all__ to pin its public surface."
@@ -209,13 +246,18 @@ def test_auth_all_excludes_private_names() -> None:
 
 
 @lru_cache(maxsize=1)
-def _collect_external_imports_by_module() -> dict[str, frozenset[str]]:
-    """Return public names imported from ``notebooklm.<module>`` by module.
+def _collect_external_imports_by_root() -> dict[tuple[str, str], frozenset[str]]:
+    """Return public names imported from ``notebooklm.<module>``, keyed ``(root, module)``.
 
     The auth/client audit tests both walk the same tree. Cache the scan so
     adding a second audited module does not double the unit-suite cost.
+
+    Results stay split per scan root because the two questions differ: "is this
+    name imported anywhere (incl. tests/docs)?" gates the declared-somewhere
+    audit, while "does ``src/`` still import it?" is what makes a cross-boundary
+    entry live rather than dead.
     """
-    imports_by_module: dict[str, set[str]] = {}
+    imports: dict[tuple[str, str], set[str]] = {}
     src_root = _REPO_ROOT / "src"
     for root in _SCAN_ROOTS:
         for path in (_REPO_ROOT / root).rglob("*.py"):
@@ -258,43 +300,154 @@ def _collect_external_imports_by_module() -> dict[str, frozenset[str]]:
                 for alias in node.names:
                     if alias.name == "*" or alias.name.startswith("_"):
                         continue
-                    imports_by_module.setdefault(module_basename, set()).add(alias.name)
-    return {name: frozenset(names) for name, names in imports_by_module.items()}
+                    imports.setdefault((root, module_basename), set()).add(alias.name)
+    return {key: frozenset(names) for key, names in imports.items()}
+
+
+def _collect_auth_imports_under(root: str) -> set[str]:
+    """Return public ``notebooklm.auth`` names imported by files under ``root``."""
+    return set(_collect_external_imports_by_root().get((root, "auth"), frozenset()))
 
 
 def _collect_external_imports(module_basename: str) -> set[str]:
     """Return the set of public names imported from ``notebooklm.<module_basename>``.
 
-    Reads from the cached repo-wide scan in
-    :func:`_collect_external_imports_by_module`, which walks every ``.py``
+    Unions every scan root of the cached repo-wide scan in
+    :func:`_collect_external_imports_by_root`, which walks every ``.py``
     file under ``src/``, ``tests/``, ``docs/`` once per process.
     """
-    return set(_collect_external_imports_by_module().get(module_basename, frozenset()))
+    by_root = _collect_external_imports_by_root()
+    return {
+        name
+        for (_root, module), names in by_root.items()
+        if module == module_basename
+        for name in names
+    }
 
 
 def test_auth_all_matches_external_imports_audit() -> None:
-    """``auth.__all__`` is a superset of every public name actually imported.
+    """Every name imported from ``notebooklm.auth`` is declared somewhere.
 
     This is the dynamic counterpart to ``test_auth_module_has_expected_all``.
     Where the former pins to a snapshotted list, this one scans the live
-    codebase (``src/``, ``tests/``, ``docs/``) and fails if any externally
-    imported public name has been added without updating ``__all__``.
+    codebase (``src/``, ``tests/``, ``docs/``) and fails if a name is imported
+    from ``notebooklm.auth`` without appearing in either declared list.
+
+    Note the deliberate asymmetry with the pre-#1592-era rule: an imported name
+    satisfies this audit via ``AUTH_CROSS_BOUNDARY_NAMES`` *or* ``__all__``. A
+    new CLI/_app import therefore no longer forces a name onto the public
+    surface — publishing stays an explicit, docs-backed decision.
     """
-    declared = set(auth_module.__all__)
+    declared = set(auth_module.__all__) | set(AUTH_CROSS_BOUNDARY_NAMES)
+    declared |= set(_AUTH_DEBLESSED_KEEP_IMPORTABLE)
     actually_imported = _collect_external_imports("auth")
     missing = actually_imported - declared
     assert not missing, (
-        "Public names imported from notebooklm.auth but missing from "
-        f"auth.__all__: {sorted(missing)}\n"
-        "Add them to __all__ (and to EXPECTED_AUTH_ALL above) so the public "
-        "surface stays explicit."
+        "Names imported from notebooklm.auth but declared in neither list: "
+        f"{sorted(missing)}\n"
+        "First-party (cli/ or _app/) need? Add to AUTH_CROSS_BOUNDARY_NAMES.\n"
+        "Genuinely public API? Add to EXPECTED_AUTH_ALL, auth.__all__, and "
+        "docs/stability.md together."
+    )
+
+
+def test_auth_all_matches_documented_public_surface() -> None:
+    """``auth.__all__`` == docs/stability.md == the public-import manifest.
+
+    The forcing function that kept ``auth.__all__`` honest used to be "is it
+    imported somewhere?", which is a question about first-party convenience, not
+    about what was promised to users. This test replaces it with the right
+    question: the published surface must equal what the docs promise.
+
+    Three sources are cross-checked so none can drift alone:
+
+    1. ``notebooklm.auth.__all__`` (the runtime surface),
+    2. every ``notebooklm.auth.<Name>`` reference in docs/stability.md (the
+       user-facing promise — the ``notebooklm.auth.*`` internals line does not
+       match, ``*`` not being an identifier),
+    3. ``_DOCUMENTED_PUBLIC_IMPORTS["notebooklm.auth"]`` (the machine-readable
+       manifest, shared with ``test_public_surface_manifest.py``).
+    """
+    declared = set(auth_module.__all__)
+
+    doc_path = _REPO_ROOT / "docs" / "stability.md"
+    documented = set(
+        re.findall(r"notebooklm\.auth\.([A-Za-z_][A-Za-z0-9_]*)", doc_path.read_text())
+    )
+    assert declared == documented, (
+        "notebooklm.auth public surface drifted from docs/stability.md.\n"
+        f"  in __all__ but undocumented: {sorted(declared - documented)}\n"
+        f"  documented but not in __all__: {sorted(documented - declared)}\n"
+        "Publishing a name means updating both — that is the point of this gate.\n"
+        "Note the scan is doc-wide: writing a bare `notebooklm.auth.some_internal` "
+        "anywhere in stability.md reads as a promise. Refer to internals as "
+        "`notebooklm._auth.<sub>.some_internal` in prose instead."
+    )
+
+    manifest = set(_DOCUMENTED_PUBLIC_IMPORTS["notebooklm.auth"])
+    assert declared == manifest, (
+        "notebooklm.auth public surface drifted from the documented public-import "
+        "manifest in tests/_guardrails/test_public_surface_manifest.py.\n"
+        f"  in __all__ but not in the manifest: {sorted(declared - manifest)}\n"
+        f"  in the manifest but not in __all__: {sorted(manifest - declared)}"
+    )
+
+
+def test_auth_cross_boundary_names_stay_importable_and_unblessed() -> None:
+    """First-party boundary names resolve on the facade but are not published.
+
+    Both halves matter: dropping importability breaks ``cli/``/``_app/`` (which
+    the CLI boundary lint forbids from reaching ``notebooklm._auth`` directly),
+    and re-blessing a name silently re-publishes it as API.
+    """
+    assert len(AUTH_CROSS_BOUNDARY_NAMES) == len(set(AUTH_CROSS_BOUNDARY_NAMES)), (
+        "AUTH_CROSS_BOUNDARY_NAMES must not contain duplicates: "
+        f"{sorted({n for n in AUTH_CROSS_BOUNDARY_NAMES if AUTH_CROSS_BOUNDARY_NAMES.count(n) > 1})}"
+    )
+    private = [name for name in AUTH_CROSS_BOUNDARY_NAMES if name.startswith("_")]
+    assert not private, (
+        "AUTH_CROSS_BOUNDARY_NAMES tracks the non-underscore facade surface; the "
+        f"CLI boundary lint already forbids private-name imports: {private}"
+    )
+
+    sentinel = object()
+    declared = set(auth_module.__all__)
+    for name in AUTH_CROSS_BOUNDARY_NAMES:
+        assert getattr(auth_module, name, sentinel) is not sentinel, (
+            f"cross-boundary {name!r} must stay importable from notebooklm.auth"
+        )
+        assert name not in declared, (
+            f"cross-boundary {name!r} is in auth.__all__ — it is first-party-only. "
+            "If it is genuinely public API, move it to EXPECTED_AUTH_ALL and "
+            "document it in docs/stability.md."
+        )
+
+
+def test_auth_cross_boundary_names_have_first_party_importers() -> None:
+    """No dead entries: every cross-boundary name is really imported by ``src/``.
+
+    The list is a cost, not a catalogue — each entry pins a name the auth layer
+    cannot move freely. An entry whose last caller went away should be deleted,
+    not carried forever (this is how the surface silently re-inflates).
+    """
+    imported_by_src = _collect_auth_imports_under("src")
+    unused = [name for name in AUTH_CROSS_BOUNDARY_NAMES if name not in imported_by_src]
+    assert not unused, (
+        "AUTH_CROSS_BOUNDARY_NAMES entries with no importer under src/: "
+        f"{sorted(unused)}\n"
+        "Drop them from the list (they stay importable via "
+        "_AUTH_DEBLESSED_KEEP_IMPORTABLE only if an external caller still needs them)."
     )
 
 
 def test_auth_deblessed_names_stay_importable_but_unblessed() -> None:
-    """PR-1 (#1592): de-blessed auth names stay importable for back-compat but are
-    absent from ``__all__`` — the rpc-tranche freeze guard, applied to auth."""
-    assert len(_AUTH_DEBLESSED_KEEP_IMPORTABLE) == 23
+    """De-blessed auth names stay importable for back-compat but are absent from
+    ``__all__`` — the rpc-tranche freeze guard, applied to auth.
+
+    23 from PR-1 (#1592), plus ``KEEP_ACCOUNT`` / ``LoginWriteOutcome``, which had
+    no importer at all when ``__all__`` was pinned to the documented surface.
+    """
+    assert len(_AUTH_DEBLESSED_KEEP_IMPORTABLE) == 25
     assert len(_AUTH_DEBLESSED_KEEP_IMPORTABLE) == len(set(_AUTH_DEBLESSED_KEEP_IMPORTABLE)), (
         "_AUTH_DEBLESSED_KEEP_IMPORTABLE must not contain duplicates"
     )

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -28,73 +28,13 @@ from tests._baselines.registry import (
     baseline_by_name,
 )
 
+# The documented public import manifest (stability spec) lives in a shared
+# ``_``-prefixed module because ``test_public_surface.py`` cross-checks
+# ``notebooklm.auth.__all__`` against it, and one ``test_*`` module may not import
+# another (tests/_guardrails/test_no_cross_test_imports.py).
+from tests._guardrails._public_import_manifest import _DOCUMENTED_PUBLIC_IMPORTS
+
 pytestmark = pytest.mark.repo_lint
-
-# ---------------------------------------------------------------------------
-# Documented public import manifest (stability spec)
-#
-# This is the public import surface documented in the user-facing API docs.
-# Keep this manifest explicit: if docs add a new supported import path, add it
-# here in the same PR; if docs intentionally remove one, remove it here with
-# the docs change.
-# ---------------------------------------------------------------------------
-
-
-_DOCUMENTED_PUBLIC_IMPORTS = {
-    "notebooklm": [
-        "ArtifactType",
-        "AudioFormat",
-        "AudioLength",
-        "AuthTokens",
-        "ChatGoal",
-        "ChatResponseLength",
-        "ConnectionLimits",
-        "correlation_id",
-        "ExportType",
-        "NonIdempotentRetryError",
-        "NotebookLMClient",
-        "QuizDifficulty",
-        "QuizQuantity",
-        "ReportFormat",
-        "RPCError",
-        "SharePermission",
-        "ShareViewLevel",
-        "SourceType",
-        "VideoFormat",
-        "VideoStyle",
-    ],
-    "notebooklm.auth": [
-        "AuthTokens",
-        "convert_rookiepy_cookies_to_storage_state",
-        "LockUnavailableError",
-        "OPTIONAL_COOKIE_DOMAINS",
-        "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
-        "REQUIRED_COOKIE_DOMAINS",
-    ],
-    "notebooklm.config": [
-        "DEFAULT_BASE_URL",
-        "get_base_url",
-    ],
-    "notebooklm.log": [
-        "install_redaction",
-    ],
-    "notebooklm.research": [
-        "extract_report_urls",
-        "normalize_url",
-        "select_cited_sources",
-    ],
-    "notebooklm.rpc": [
-        "resolve_rpc_id",
-        "RPCMethod",
-    ],
-    "notebooklm.types": [
-        "ConnectionLimits",
-    ],
-    "notebooklm.urls": [
-        "is_google_auth_redirect",
-        "is_youtube_url",
-    ],
-}
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/mcp_vcr/test_notebooks.py
+++ b/tests/integration/mcp_vcr/test_notebooks.py
@@ -61,7 +61,10 @@ async def test_mcp_notebook_list_crosses_adapter_to_client_boundary() -> None:
     assert isinstance(notebooks, list) and notebooks
     assert isinstance(notebooks[0], dict)
     assert notebooks[0]["id"] == "f66923f0-1df4-4ffe-9822-3ed63c558b1c"
-    assert notebooks[0]["title"] == "GENERATION: Claude Code Deep Dive: Skills, Agents, Commands & Plugins"
+    assert (
+        notebooks[0]["title"]
+        == "GENERATION: Claude Code Deep Dive: Skills, Agents, Commands & Plugins"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import sys
@@ -509,6 +510,63 @@ def test_collect_manifest_constant_fingerprint_is_hash_seed_stable(script, monke
         }
 
     assert _tracked_constants("1") == _tracked_constants("2")
+
+
+def _stable_value_repr(script):
+    """Return the real ``stable_value_repr`` from the collector source.
+
+    The function lives inside the ``_COLLECTOR`` script that the audit runs in a
+    subprocess, so it is not an attribute of the loaded module. Lift the actual
+    function definition out of that source rather than re-implementing it here —
+    a copy would happily keep passing after the shipped one regressed.
+    """
+    tree = ast.parse(script._COLLECTOR)
+    node = next(
+        item
+        for item in tree.body
+        if isinstance(item, ast.FunctionDef) and item.name == "stable_value_repr"
+    )
+    namespace: dict = {}
+    exec(compile(ast.Module(body=[node], type_ignores=[]), "<collector>", "exec"), namespace)
+    return namespace["stable_value_repr"]
+
+
+def test_stable_value_repr_is_order_insensitive_for_containers(script):
+    """Set and dict members render sorted, so iteration order cannot leak in."""
+    stable_value_repr = _stable_value_repr(script)
+
+    assert stable_value_repr(frozenset({"b", "a"})) == stable_value_repr(frozenset({"a", "b"}))
+    assert stable_value_repr({"b": 1, "a": 2}) == stable_value_repr({"a": 2, "b": 1})
+    # Sequences keep their order — reordering a public tuple IS a change.
+    assert stable_value_repr(("a", "b")) != stable_value_repr(("b", "a"))
+
+
+def test_stable_value_repr_distinguishes_container_types(script):
+    """A ``frozenset`` and a ``set`` with equal members must not fingerprint alike.
+
+    Swapping the container of a published constant is a real contract change —
+    a ``set`` lets callers mutate the library's own state — so an untagged
+    ``{...}`` rendering (which also collides with an empty dict) would let it pass
+    as no change.
+    """
+    stable_value_repr = _stable_value_repr(script)
+
+    assert stable_value_repr(frozenset({"a"})) != stable_value_repr({"a"})
+    assert stable_value_repr(frozenset()) != stable_value_repr({})
+    # Nested, too: the members are equal, only the inner container type differs.
+    assert stable_value_repr({"k": frozenset({"a"})}) != stable_value_repr({"k": {"a"}})
+
+
+def test_compare_manifests_detects_nested_container_type_change(script):
+    """The nested change above reaches ``compare_manifests`` as a break."""
+    stable_value_repr = _stable_value_repr(script)
+    baseline = _manifest({"TIERS": _constant(stable_value_repr({"k": frozenset({"a"})}))})
+    current = _manifest({"TIERS": _constant(stable_value_repr({"k": {"a"}}))})
+
+    breaks = script.compare_manifests(baseline, current)
+
+    assert [item.code for item in breaks] == ["changed-constant-value"]
+    assert breaks[0].object == "notebooklm.TIERS"
 
 
 def test_compare_manifests_detects_removed_enum_member(script):

--- a/tests/unit/test_public_api_compat_audit.py
+++ b/tests/unit/test_public_api_compat_audit.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+import notebooklm.config as notebooklm_config
+
 pytestmark = pytest.mark.repo_lint
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -62,6 +64,11 @@ def _class(*, members: dict | None = None, signature: dict | None = None) -> dic
         "members": members or {},
         "enum_members": {},
     }
+
+
+def _constant(value_repr: str) -> dict:
+    """A value-tracked module constant entry (VALUE_TRACKED_CONSTANTS)."""
+    return {"kind": "str", "signature": None, "constant_value": value_repr}
 
 
 def _manifest(exports: dict) -> dict:
@@ -425,6 +432,83 @@ def test_compare_manifests_detects_enum_value_change(script):
 
     assert [item.code for item in breaks] == ["changed-enum-value"]
     assert breaks[0].object == "notebooklm.SourceType.PDF"
+
+
+def test_compare_manifests_detects_changed_constant_value(script):
+    """A value-tracked constant rebound to a different value is a reviewable break.
+
+    Before this, a public constant carried only its ``kind`` into the manifest, so
+    repointing ``DEFAULT_BASE_URL`` at a different host compared as "str vs str" —
+    identical — and the audit stayed green through the host flip.
+    """
+    baseline = _manifest({"DEFAULT_BASE_URL": _constant("'https://old.example'")})
+    current = _manifest({"DEFAULT_BASE_URL": _constant("'https://new.example'")})
+
+    breaks = script.compare_manifests(baseline, current)
+
+    assert [item.code for item in breaks] == ["changed-constant-value"]
+    assert breaks[0].object == "notebooklm.DEFAULT_BASE_URL"
+    assert "old.example" in breaks[0].detail and "new.example" in breaks[0].detail
+
+
+def test_compare_manifests_ignores_untracked_constant(script):
+    """Only names in ``VALUE_TRACKED_CONSTANTS`` carry a fingerprint.
+
+    Both sides lack ``constant_value``, so nothing is compared — adding or removing
+    a name from the tracked set must not fire a break by itself.
+    """
+    baseline = _manifest({"SOME_CONSTANT": {"kind": "str"}})
+    current = _manifest({"SOME_CONSTANT": {"kind": "str"}})
+
+    assert script.compare_manifests(baseline, current) == []
+
+
+def test_compare_manifests_ignores_one_sided_constant_fingerprint(script):
+    """Newly tracking a constant is not itself a break.
+
+    The baseline predates the name being tracked, so only one side has a
+    fingerprint and there is nothing to compare against.
+    """
+    baseline = _manifest({"DEFAULT_BASE_URL": {"kind": "str"}})
+    current = _manifest({"DEFAULT_BASE_URL": _constant("'https://new.example'")})
+
+    assert script.compare_manifests(baseline, current) == []
+
+
+def test_collect_manifest_captures_tracked_constant_values(script):
+    """The tracked cookie-domain / host constants really do carry a fingerprint."""
+    manifest = script.collect_manifest(REPO_ROOT)
+
+    config_exports = manifest["modules"]["notebooklm.config"]["exports"]
+    assert config_exports["DEFAULT_BASE_URL"]["constant_value"] == repr(
+        notebooklm_config.DEFAULT_BASE_URL
+    )
+
+    auth_exports = manifest["modules"]["notebooklm.auth"]["exports"]
+    required = auth_exports["REQUIRED_COOKIE_DOMAINS"]["constant_value"]
+    assert ".google.com" in required
+    # Untracked public exports stay fingerprint-free — the capture is opt-in.
+    assert "constant_value" not in auth_exports["AuthTokens"]
+
+
+def test_collect_manifest_constant_fingerprint_is_hash_seed_stable(script, monkeypatch):
+    """Set/dict fingerprints must not depend on PYTHONHASHSEED.
+
+    ``REQUIRED_COOKIE_DOMAINS`` is a frozenset, and each collection runs in a fresh
+    subprocess. A raw ``repr()`` would order its members by hash and differ between
+    the baseline run and the current run, reporting a break on every invocation
+    while the value never changed.
+    """
+
+    def _tracked_constants(seed: str) -> dict[str, str]:
+        monkeypatch.setenv("PYTHONHASHSEED", seed)
+        exports = script.collect_manifest(REPO_ROOT)["modules"]["notebooklm.auth"]["exports"]
+        return {
+            name: exports[name]["constant_value"]
+            for name in script.VALUE_TRACKED_CONSTANTS["notebooklm.auth"]
+        }
+
+    assert _tracked_constants("1") == _tracked_constants("2")
 
 
 def test_compare_manifests_detects_removed_enum_member(script):


### PR DESCRIPTION
## Why

Auditing `main` for auth/cookie API compatibility turned up two structural gaps. Neither is a bug in shipped behaviour — both are gaps in what the gates can *see*.

**1. `notebooklm.auth.__all__` was publishing 38 names against 6 documented ones.**

`__all__` was doing double duty. The CLI boundary lint (`test_cli_boundary.py`) forbids `cli/` from importing `notebooklm._*`, so every auth helper the CLI needed was reached through the `notebooklm.auth` facade — and `test_auth_all_matches_external_imports_audit` then **forced** that name into `__all__`. "The CLI needs it" silently became "it is public API". Meanwhile `docs/stability.md` says `notebooklm.auth.*` is internal except a handful of names.

| | before | after |
|---|---|---|
| `auth.__all__` | 38 | **6** |
| documented in `docs/stability.md` | 6 | 6 |
| undocumented-but-published | 32 | **0** |

**2. The compat audit could not see constant *values*.**

`scripts/audit_public_api_compat.py` reasons about shape — kind, signature, class members, enum values. A plain module constant contributed only its `kind`, so rebinding one compared as "str vs str" and passed. The Gemini Notebook rebrand went straight through that blind spot: the audit stayed green while `config.DEFAULT_BASE_URL` and `config.PERSONAL_BASE_HOST` changed host (#2072) and `auth.REQUIRED_COOKIE_DOMAINS` gained members (#2020).

## What changed

**Split the two roles of `__all__`** — `__all__` is now exactly the documented surface. The other 32 names are **de-advertised, not removed**, via the established #1592 mechanism: `notebooklm.auth.<name>` keeps resolving exactly as before, with one reviewed `removed-export` allowance each in `api-compat-allowlist.json`. The 30 that first-party code genuinely imports across the boundary are tracked by a new `AUTH_CROSS_BOUNDARY_NAMES` list, which grants importability **without publishing** — so a future CLI need can no longer re-inflate the public API. `KEEP_ACCOUNT` and `LoginWriteOutcome` had no importer anywhere and are simply unblessed.

**Gated `__all__` against the docs** — `test_auth_all_matches_documented_public_surface` cross-checks three sources that could previously drift alone: the runtime `__all__`, every `notebooklm.auth.<Name>` reference in `docs/stability.md`, and `_DOCUMENTED_PUBLIC_IMPORTS`. Publishing a name now requires changing all three together. This replaces "is it imported somewhere?" (a question about first-party convenience) with "is it promised?" (a question about the contract). The manifest moved to a shared `tests/_guardrails/_public_import_manifest.py` because `test_no_cross_test_imports.py` forbids one `test_*` module importing another.

**Anti-rot on the new list** — `test_auth_cross_boundary_names_have_first_party_importers` fails on entries with no importer under `src/`. The list is a cost (each entry pins a name the auth layer cannot move freely), not a catalogue.

**Value-aware compat gate** — constants named in the new `VALUE_TRACKED_CONSTANTS` now capture an order-insensitive fingerprint, and a change surfaces as a `changed-constant-value` break requiring an allowlist entry. Sorting matters: each collection runs in a fresh subprocess, so a raw `repr()` of a `frozenset` would order by hash and report a spurious break on every run under a different `PYTHONHASHSEED`. `test_collect_manifest_constant_fingerprint_is_hash_seed_stable` collects twice under different seeds and compares — verified to fail when the sorting is removed.

The three real value changes are now **recorded** in the allowlist with reviewer-readable reasons instead of being invisible.

## Compatibility

**No runtime behaviour changes. No import breaks.** Every de-blessed name resolves exactly as before; only `from notebooklm.auth import *` (which no supported usage relies on) and static-analysis views of the advertised surface differ. The audit reports 29 reviewed breaks, all allowlisted with reasons.

## Also included

`tests/integration/mcp_vcr/test_notebooks.py` is reformatted. It landed unformatted in #2096 — that PR's CI run was cancelled, so the whole-tree `ruff format` gate never completed — and it currently fails `pre-commit run --all-files` on `main`. Without it this PR cannot go green for an unrelated reason.

## Verification

- `uv run pytest` — 13324 passed, 64 skipped, 1 xfailed
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- `ruff check . && ruff format --check .` — clean whole-tree
- `uv run python scripts/audit_public_api_compat.py` — OK, 29 reviewed breaks allowlisted

## Follow-up (not in this PR)

**Correction to an earlier draft of this section.** It said routing the CLI's auth needs through `_app/` service functions would collapse the cross-boundary list toward zero. That is wrong: `tests/_guardrails/test_app_boundary.py` forbids `_app/` from importing `notebooklm._*` just as `test_cli_boundary.py` forbids it for `cli/` — `_app` "may only depend on the public facade". Verified by pointing one `_app` import at `_auth` and watching the guardrail reject it. Relocating code between `cli/` and `_app/` therefore moves the requirement, it does not remove it.

An audit of the 30 names (see the thread below) puts the real lever elsewhere: they cluster into six cohesive operations, and the count reflects **granularity**, not need — master-token login alone spends 7 names on what is one operation. Coarsening those clusters into a few facade entry points is what would shrink the list; that is a separate design change, not a relocation.

Independently, three command-layer modules reach for auth primitives their own service already owns — `cli/master_token_login.py` re-reads the master token the service reads one call later, and `cli/_cookie_import.py` runs the whole extract→validate→write pipeline in a module that documents itself as "presentation-adjacent". Fixing that does not shrink the list but does fix the layering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the supported authentication API, stable exports, supported error types, and compatibility expectations.

* **Changes**
  * Reduced the advertised authentication API to six documented exports while preserving backward importability for existing names.
  * Added compatibility tracking for selected public constant values.

* **Quality Improvements**
  * Strengthened public API guardrails and cross-boundary import checks.
  * Expanded automated coverage for authentication exports, public imports, and compatibility auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->