### PR TITLE
fix(cli): derive master_token.json beside --storage, as every reader does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`login --master-token` now honors `--storage` for `master_token.json` too
+  (#2103).** The login writer resolved the storage path from `--storage` but the
+  master-token path from the profile dir, so under a `--storage` override the
+  durable token landed where no reader ever looks — the L4 master-token recovery
+  rung silently reported "no token", `auth check` reported `present: False`
+  immediately after a successful login, and the full-account credential was
+  written into the default profile dir the user had explicitly redirected away
+  from. The writer now derives the token path as a sibling of the storage path,
+  matching every reader (`_auth/recovery.py`, `_app/auth_check.py`,
+  `cli/services/auth_refresh.py`). Behavior without `--storage` is unchanged.
+  The same fix covers `login --master-token-refresh --storage …`, and the
+  account-ownership guard now checks the token that actually sits beside the
+  target storage instead of the active profile's.
+
 - **`NOTEBOOKLM_AUTH_JSON` now beats a profile everywhere, as documented.** The
   precedence `--storage` > `NOTEBOOKLM_AUTH_JSON` > profile file is stated in
   `docs/configuration.md`, drawn in `docs/architecture.md`, and implemented by

--- a/src/notebooklm/cli/master_token_login.py
+++ b/src/notebooklm/cli/master_token_login.py
@@ -12,7 +12,7 @@ import asyncio
 from pathlib import Path
 
 from ..auth import MasterTokenError, generate_android_id, read_master_token
-from ..paths import get_master_token_path, get_storage_path
+from ..paths import get_storage_path
 from .error_handler import exit_with_code
 from .rendering import console
 from .services.login import master_token as mt_service
@@ -33,7 +33,13 @@ def run_master_token_login(
     """Bootstrap or refresh headless master-token auth (see ``login --master-token``)."""
     profile = ctx.obj.get("profile") if ctx.obj else None
     storage_path = Path(storage) if storage else get_storage_path(profile=profile)
-    master_token_path = get_master_token_path(profile)
+    # Sibling invariant (#2103): master_token.json lives beside storage_state.json.
+    # Every reader derives it from the storage path (_auth/recovery.py L4 rung,
+    # _app/auth_check.py, cli/services/auth_refresh.py), so the writer must too —
+    # ``get_master_token_path(profile)`` ignores a ``--storage`` override and would
+    # write the token where no reader ever looks. Identical to the old behavior
+    # when ``--storage`` is absent (both paths then live in the profile dir).
+    master_token_path = storage_path.with_name("master_token.json")
 
     try:
         if refresh:

--- a/tests/unit/cli/test_login_master_token.py
+++ b/tests/unit/cli/test_login_master_token.py
@@ -45,6 +45,54 @@ def test_master_token_refresh_calls_service(tmp_path, monkeypatch):
     assert result.output.strip() == f"Re-minted cookies -> {storage}"
 
 
+def test_master_token_refresh_storage_override_keeps_sibling_token_path(tmp_path, monkeypatch):
+    """#2103: ``--storage`` must relocate master_token.json alongside the storage.
+
+    Every reader (the L4 recovery rung, ``auth check``, the missing-storage
+    bootstrap) derives the token path as a sibling of the storage path; before
+    the fix the login writer resolved it from the profile dir instead, writing
+    the token where no reader ever looks.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    override_dir = tmp_path / "elsewhere"
+    override_dir.mkdir()
+    storage = override_dir / "foo.json"
+    storage.write_text(json.dumps({"cookies": []}), encoding="utf-8")
+    with patch.object(mt_service, "refresh", new=AsyncMock()) as ref:
+        result = CliRunner().invoke(
+            cli, ["login", "--master-token-refresh", "--storage", str(storage)]
+        )
+    assert result.exit_code == 0, result.output
+    ref.assert_awaited_once_with(
+        storage_path=storage,
+        master_token_path=storage.with_name("master_token.json"),
+    )
+
+
+def test_master_token_bootstrap_storage_override_keeps_sibling_token_path(tmp_path, monkeypatch):
+    """#2103: the bootstrap path pair must honor ``--storage`` for both files."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    storage = tmp_path / "elsewhere" / "foo.json"
+    storage.parent.mkdir()
+    with patch.object(mt_service, "bootstrap", new=AsyncMock(return_value=7)) as boot:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "login",
+                "--master-token",
+                "--account",
+                "e@x.com",
+                "--oauth-token",
+                "TOK",
+                "--storage",
+                str(storage),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert boot.call_args.kwargs["storage_path"] == storage
+    assert boot.call_args.kwargs["master_token_path"] == storage.with_name("master_token.json")
+
+
 def test_master_token_refresh_help_marks_forced_route_legacy():
     result = CliRunner().invoke(cli, ["login", "--help"])
 


### PR DESCRIPTION
## Why

Fixes #2103. `login --master-token --storage <path>` resolved the two halves of one profile independently: the storage path honored `--storage`, the master-token path came from the profile dir (`cli/master_token_login.py:36`). Every reader derives the token path as a **sibling** of the storage path — the L4 recovery rung (`_auth/recovery.py:223`), `auth check` (`_app/auth_check.py:231`), and the missing-storage bootstrap (`cli/services/auth_refresh.py:62`) — so the writer put the durable full-account token where no reader ever looks.

Consequences (all user-visible):
1. **L4 master-token recovery silently unavailable** — `try_master_token_reauth` finds no token at the derived sibling and returns `False`, indistinguishable from "never had a token".
2. **`auth check` misreports** — `present: False` immediately after a successful `login --master-token --storage …`.
3. **The 0600 full-account credential lands in the default profile dir** the user explicitly redirected away from.

The corollary: `assert_account_writable` received the mismatched pair, so under `--storage` it validated ownership against a *different profile's* token — able to both raise a spurious conflict and miss a real one.

## What changed

One resolution site: the writer now derives `master_token_path = storage_path.with_name("master_token.json")`, matching all three readers. Without `--storage` this is byte-identical to the old behavior (both files live in the profile dir), which the existing `test_master_token_refresh_calls_service` continues to pin.

Two regression tests cover the `--storage` case for both entry points (`--master-token`, `--master-token-refresh`), asserting the service receives a sibling pair.

Note one intentional behavior change under `--storage` + `--master-token-refresh`: the token is now read from beside the target storage rather than from the active profile. The old cross-profile read was the bug's mirror image, is promised nowhere (`docs/cli-reference.md:437` says "the stored master token"), and could mint one account's cookies into another profile's storage file.

## Scope

Tactical fix only. The structural version — a single derivation chokepoint in `_auth/paths` with a literal-string guardrail, so the sibling invariant is enforced by construction instead of per-call-site vigilance (the three readers currently use three different canonicalization policies) — is scoped to the planned master-token relocation PR, per the discussion on #2103.

## Verification

- `uv run pytest` — 13331 passed, 64 skipped, 1 xfailed
- `ruff check . && ruff format --check .` — clean whole-tree
- `mypy src/notebooklm --ignore-missing-imports` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Master-token login and refresh now store `master_token.json` alongside the specified `--storage` location.
  - Account-ownership checks use the token associated with the selected storage location.
  - Default behavior remains unchanged when `--storage` is not provided.

- **Documentation**
  - Updated the changelog to document storage-specific master-token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->