### PR TITLE
fix(cli): canonicalize --storage before deriving the master-token sibling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   account-ownership guard now checks the token that actually sits beside the
   target storage instead of the active profile's.
 
+- **A symlinked or relative `--storage` alias now selects the same
+  `master_token.json` the recovery ladder reads (#2104 review).** `--storage`
+  was used verbatim when deriving the token sibling, so an alias — a relative
+  path, a `~` prefix, or a symlinked directory — wrote the token beside the
+  *alias* while the L4 master-token recovery rung, which canonicalizes through
+  `canonical_storage_key` (`expanduser().resolve()`) before taking the parent
+  directory, looked beside the resolved target and found nothing. The login
+  driver now canonicalizes an explicit `--storage` the same way the
+  `cli.services.auth_source` resolver already does, so every syntactic spelling
+  of one storage file collapses to one token location. Profile-derived paths
+  were already absolute and are unaffected.
+
 - **`NOTEBOOKLM_AUTH_JSON` now beats a profile everywhere, as documented.** The
   precedence `--storage` > `NOTEBOOKLM_AUTH_JSON` > profile file is stated in
   `docs/configuration.md`, drawn in `docs/architecture.md`, and implemented by

--- a/src/notebooklm/cli/master_token_login.py
+++ b/src/notebooklm/cli/master_token_login.py
@@ -32,7 +32,14 @@ def run_master_token_login(
 ):
     """Bootstrap or refresh headless master-token auth (see ``login --master-token``)."""
     profile = ctx.obj.get("profile") if ctx.obj else None
-    storage_path = Path(storage) if storage else get_storage_path(profile=profile)
+    # Canonicalize an explicit ``--storage`` exactly like the auth-source resolver
+    # does (``cli/services/auth_source.py``): a symlinked/relative alias must select
+    # the same profile as its target, or the token would be written beside the alias
+    # while the L4 recovery rung (which resolves via ``canonical_storage_key``) looks
+    # beside the real file. Profile-derived paths are already absolute.
+    storage_path = (
+        Path(storage).expanduser().resolve() if storage else get_storage_path(profile=profile)
+    )
     # Sibling invariant (#2103): master_token.json lives beside storage_state.json.
     # Every reader derives it from the storage path (_auth/recovery.py L4 rung,
     # _app/auth_check.py, cli/services/auth_refresh.py), so the writer must too —

--- a/tests/unit/cli/test_login_master_token.py
+++ b/tests/unit/cli/test_login_master_token.py
@@ -63,9 +63,42 @@ def test_master_token_refresh_storage_override_keeps_sibling_token_path(tmp_path
             cli, ["login", "--master-token-refresh", "--storage", str(storage)]
         )
     assert result.exit_code == 0, result.output
+    # The driver canonicalizes an explicit --storage (matching auth_source), so a
+    # symlink/relative alias selects the same sibling the L4 recovery rung derives.
+    resolved = storage.resolve()
     ref.assert_awaited_once_with(
-        storage_path=storage,
-        master_token_path=storage.with_name("master_token.json"),
+        storage_path=resolved,
+        master_token_path=resolved.with_name("master_token.json"),
+    )
+
+
+def test_master_token_refresh_storage_symlink_selects_target_sibling(tmp_path, monkeypatch):
+    """#2104 review: a symlinked ``--storage`` alias selects the target's sibling.
+
+    The L4 recovery rung resolves the storage path (``canonical_storage_key``)
+    before deriving ``master_token.json``, so the writer must canonicalize too —
+    otherwise login writes the token beside the alias while recovery looks
+    beside the real file.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    storage = real_dir / "foo.json"
+    storage.write_text(json.dumps({"cookies": []}), encoding="utf-8")
+    alias_dir = tmp_path / "alias"
+    try:
+        alias_dir.symlink_to(real_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - Windows without privilege
+        pytest.skip("platform cannot create directory symlinks")
+    with patch.object(mt_service, "refresh", new=AsyncMock()) as ref:
+        result = CliRunner().invoke(
+            cli, ["login", "--master-token-refresh", "--storage", str(alias_dir / "foo.json")]
+        )
+    assert result.exit_code == 0, result.output
+    resolved = storage.resolve()  # tmp_path itself may be a symlink (macOS /tmp)
+    ref.assert_awaited_once_with(
+        storage_path=resolved,
+        master_token_path=resolved.with_name("master_token.json"),
     )
 
 
@@ -89,8 +122,9 @@ def test_master_token_bootstrap_storage_override_keeps_sibling_token_path(tmp_pa
             ],
         )
     assert result.exit_code == 0, result.output
-    assert boot.call_args.kwargs["storage_path"] == storage
-    assert boot.call_args.kwargs["master_token_path"] == storage.with_name("master_token.json")
+    resolved = storage.resolve()
+    assert boot.call_args.kwargs["storage_path"] == resolved
+    assert boot.call_args.kwargs["master_token_path"] == resolved.with_name("master_token.json")
 
 
 def test_master_token_refresh_help_marks_forced_route_legacy():


### PR DESCRIPTION
Follow-up to the #2104 review (P2 finding, [comment 3731587648](https://github.com/teng-lin/notebooklm-py/pull/2104#discussion_r3731587648)). Refs #2103.

## Why

#2104 established the sibling invariant — `master_token.json` lives beside the storage file, because **every reader derives it that way** — but the writer used the raw `--storage` value.

The L4 master-token recovery rung canonicalizes *first*. `try_master_token_reauth` runs the path through `canonical_storage_key` (which is `expanduser().resolve()`) and only then takes the parent:

```python
canonical_path = canonical_storage_key(storage_path)
master_token_path = canonical_path.parent / "master_token.json"
```
<sub>`src/notebooklm/_auth/recovery.py:221-223`</sub>

## The alias failure mode

Any alias for the same storage file — a relative path, a `~` prefix, or a symlinked directory — splits the writer and the reader apart:

| | path used | token location |
|---|---|---|
| `login --master-token --storage ~/link/auth.json` | verbatim | `~/link/master_token.json` |
| L4 recovery rung | resolved | `/real/dir/master_token.json` |

Login reports success, the token is on disk, and the recovery ladder still reports "no token" — the same silent failure #2103 fixed, reached through a different spelling of the path. `auth check` reports `present: False` for the same reason.

## The fix

Canonicalize an explicit `--storage` in the login driver, exactly as the auth-source resolver already does for the very same option:

```python
storage_override = Path(raw_storage).expanduser().resolve()
```
<sub>`src/notebooklm/cli/services/auth_source.py:111`</sub>

Every syntactic spelling of one storage file now collapses to one token location, and the writer agrees with the reader by construction rather than by coincidence. Profile-derived paths are already absolute, so the no-`--storage` branch is byte-for-byte unchanged.

## Test coverage

- New `test_master_token_refresh_storage_symlink_selects_target_sibling` — creates a symlinked directory alias and asserts the token lands beside the **target**. Verified to fail without the source fix (it writes `alias/master_token.json` instead of `real/`), and skipped where the platform cannot create directory symlinks.
- The two #2103 regression tests now assert the resolved paths.
- Full suite green: 13332 passed, 64 skipped, 1 xfailed. `ruff check` / `ruff format --check` whole tree, `mypy src/notebooklm` clean.

## Not in scope

The P1 finding on #2104 ([comment 3731587652](https://github.com/teng-lin/notebooklm-py/pull/2104#discussion_r3731587652)) — two custom storage files in one directory sharing a single `master_token.json`, unlike `get_context_path`'s per-storage namespacing — is a real cross-account hazard on the L4 read side, but fixing it changes the ADR-0023 on-disk layout contract and every reader. It is deferred to the planned master-token structural-move PR tracked from #2103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit storage paths are now consistently resolved before locating or creating the master token.
  * Relative paths, home-directory shortcuts, and symlinked storage paths now correctly map to the same token location used during recovery.

* **Documentation**
  * Added an Unreleased changelog entry describing the storage path resolution improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->