### PR TITLE
refactor(auth): single RotateCookies wire contract + ADR-0031 credential-tier model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One RotateCookies wire contract (ADR-0031 Stage 0).** The POST to
+  `accounts.google.com/RotateCookies` was independently assembled at four
+  sites — the keepalive poke, the file-based and in-memory PSIDTS recoveries,
+  and the master-token mint's completing leg — and the mint leg alone omitted
+  `raise_for_status`, so a 429/5xx there passed silently. All four now route
+  through a single wire implementation in `notebooklm._auth.keepalive`
+  (guardrail-enforced). Two observable deltas, both on the mint leg only: a
+  rejected rotation is now logged and skipped instead of silently ignored, and
+  the leg uses the canonical 15 s rotation timeout instead of inheriting the
+  mint client's 30 s. See the new
+  [ADR-0031](docs/adr/0031-credential-tier-auth-model.md) for the
+  credential-tier model this is the first stage of.
+
 - **`notebooklm.auth.__all__` is now exactly the documented public surface (38 →
   6 names).** `__all__` had been doing double duty: the CLI boundary lint forbids
   `cli/` from importing `notebooklm._*`, so every auth helper the CLI needed was

--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Proposed (Stage 0 — the single RotateCookies wire contract — landed with this
-ADR; Stages 1–5 are sequenced follow-up work, each independently shippable).
+Proposed — Stage 0 (the single RotateCookies wire contract) landed with this
+ADR; Stages 1–5 are sequenced follow-up work, each independently shippable.
 
 Companion to [ADR-0029](0029-canonical-storage-writer.md) (write side) and
 [ADR-0030](0030-one-recovery-ladder.md) (recovery/refresh side). Where those
@@ -47,7 +47,7 @@ describe. Concretely:
 
 The model the docstrings already describe is a **credential tier system**:
 
-```
+```text
 Tier 0: DURABLE   master_token.json | persistent browser profile | refresh_cmd
         (~years)        │ mint
                         ▼
@@ -126,7 +126,7 @@ vocabulary — types and named tier operations — never a mode's internals.
   manifest) need same-PR bookkeeping; Stage 4 is a real public-API change
   and must not ship as a side effect of an internal stage.
 - Stages are ordered by risk-to-value: each is independently green,
-  independently revertable, and none blocks the others except 4-after-1.
+  independently reversible, and none blocks the others except 4-after-1.
 
 ## Alternatives considered
 

--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -1,0 +1,147 @@
+# ADR-0031: Credential-tier domain model for `_auth`
+
+## Status
+
+Proposed (Stage 0 — the single RotateCookies wire contract — landed with this
+ADR; Stages 1–5 are sequenced follow-up work, each independently shippable).
+
+Companion to [ADR-0029](0029-canonical-storage-writer.md) (write side) and
+[ADR-0030](0030-one-recovery-ladder.md) (recovery/refresh side). Where those
+unified one *flow* each, this ADR names the domain model both flows already
+implement implicitly, so future auth work has types and named operations to
+land on instead of free functions to scatter.
+
+## Context
+
+The auth cross-boundary ledger audit (#2139 and its follow-up review) traced
+every name `cli/`/`_app/` import from the `notebooklm.auth` facade and found
+that the hard-to-classify cases were all symptoms of one gap: `_auth` is
+organized by *topic* (`cookies.py`, `account.py`, `cookie_policy.py`,
+`storage_writer.py`) rather than by the domain model its own docstrings
+describe. Concretely:
+
+- **Noun sprawl.** A cookie exists in six shapes: the raw Playwright
+  storage-state dict, the rookiepy dict, `DomainCookieMap`
+  (`(name, domain, path) → value`), `FlatCookieMap` (`name → value`),
+  `LegacyDomainCookieMap`, and the "sanitized entries" list
+  (`cookies._sanitized_auth_entries`). `AuthTokens` carries cookies **twice**
+  (`cookies: DomainCookieMap` + `cookie_jar: httpx.Cookies`) and reconciles
+  the pair in `__post_init__`.
+- **Verb sprawl.** Ten-plus verbs (mint / bootstrap / exchange / remint /
+  rotate / poke / recover / heal / reauth / refresh / validate) name about six
+  concepts. Worst case: the POST to `accounts.google.com/RotateCookies` was
+  independently assembled at **four** sites (`keepalive._rotate_cookies`,
+  `psidts_recovery._attempt_rotation`, `psidts_recovery.recover_psidts_in_memory`,
+  and the mint leg in `master_token.mint_cookies`), one of which
+  silently omitted `raise_for_status` — protocol drift in the
+  credential-rotation path with nothing keeping the copies in sync.
+- **Coupling with no owner.** Validation helpers
+  (`_validate_required_cookies`, `_has_valid_secondary_binding`,
+  `_validate_routable_entries`) are shared between the core recovery ladder
+  and the CLI browser-cookie import — not because those flows are related,
+  but because "is this cookie set usable" has no type to be a method of, so
+  every flow reaches for the same scattered private functions. This is what
+  made several "move it across the boundary" proposals in the audit unsafe:
+  three names that looked adapter-local turned out core-coupled through
+  hidden private-helper fan-out.
+
+The model the docstrings already describe is a **credential tier system**:
+
+```
+Tier 0: DURABLE   master_token.json | persistent browser profile | refresh_cmd
+        (~years)        │ mint
+                        ▼
+Tier 1: SESSION   cookie jar (SID, PSIDTS, bindings…)
+        (~days)         │ rotate (PSIDTS) · validate/heal · persist/load
+                        ▼ fetch
+Tier 2: REQUEST   csrf_token + session_id            (~minutes, per RPC)
+```
+
+Every operation in the subsystem is one of five things: **mint** (tier N →
+N+1), **rotate/heal** (refresh a component within a tier), **validate**
+(check a tier is usable), **persist/load** (move a tier to/from the profile),
+**identify** (bind credentials to `{email, authuser}`). The ADR-0030 ladder
+is "walk down the tiers until something works, then mint back up": L1
+re-fetches Tier 2, L2 rotates within Tier 1, L3/L4 re-mint Tier 1 from two
+different Tier-0 sources.
+
+## Decision
+
+Adopt the credential-tier model as the organizing principle for `_auth`, and
+introduce its objects and operations in independently shippable stages:
+
+- **Stage 0 (this PR): one RotateCookies wire contract.** The POST lives only
+  in `_auth/keepalive.py` (`_ROTATE_POST_KWARGS` + `_rotate_post` /
+  `_rotate_post_sync` / `_rotation_http_client`); the four former sites are
+  thin policy wrappers. Enforced by
+  `tests/_guardrails/test_rotate_wire_contract.py`.
+- **Stage 1: `CookieJar`** — one canonical cookie type with constructors
+  (`from_storage_state` / `from_rookiepy` / `from_flat`) and converters
+  (`to_httpx` / `to_storage_state`), introduced as a non-breaking wrapper
+  delegating to today's free functions. New code uses jar methods; a ratchet
+  blocks new imports of the legacy conversion functions.
+- **Stage 2: `validate` / `heal` split** — `validate(jar) → ValidationResult`
+  is pure (extends the closed-enum reason
+  `RequiredCookieValidationError` grew in #2061); `heal` is the explicit
+  composition point whose only strategy today is the Stage-0 rotate.
+  `validate_with_recovery` survives as a compatibility wrapper.
+- **Stage 3: `ProfileStore`** — the eight free functions in
+  `storage_writer.py` become transactions on one object owning the
+  lock-acquire → read → mutate → atomic-write template they each hand-roll
+  today. Method names stay initially; `persist_minted_jar`'s #2108
+  ownership-guard and write-ordering semantics are preserved bit-for-bit.
+- **Stage 4: `AuthTokens.cookies: CookieJar`** — the dual
+  `cookies`/`cookie_jar` fields collapse. The only stage touching documented
+  public API; requires a `Mapping`-compatible shim or a deprecation runway
+  per the breaking-change policy.
+- **Stage 5: mode packages** — the acquisition modes (master-token,
+  browser-cookie import, Playwright login) become self-contained packages
+  composing the named operations, mirroring what `browser_capture.py`
+  already is for the Playwright capture half.
+
+**Boundary principle** (resolves the recurring "does this belong in
+`_auth`/`_app`/`cli`" question): a mint strategy that runs **unattended**
+(master-token remint, headless capture, refresh_cmd, rotation) belongs to the
+library and may sit on the automatic ladder; a strategy that needs a
+**human** (interactive Playwright login, browser-cookie extraction, OAuth
+capture) is driven by the CLI. Both produce the same session jar and persist
+through the same writer. What crosses the facade boundary is the shared
+vocabulary — types and named tier operations — never a mode's internals.
+
+## Consequences
+
+- A protocol change to Google's rotation contract now lands in one place;
+  the guardrail makes a fifth bespoke POST a test failure, not a review
+  catch. The mint leg additionally gains the `raise_for_status` the other
+  sites already had (a silent 4xx/5xx becomes a logged, skipped rotation —
+  same control flow, better observability).
+- Each later stage retires a class of scattered helpers by giving them an
+  owner, which is what makes future boundary questions answerable
+  structurally ("does the type cross?") instead of by hand-tracing call
+  graphs.
+- **Costs, honestly:** every stage churns ADR-0007 patch seams (tests patch
+  owning modules at bare-name call sites, so relocating a body moves its
+  seam — this bit #2139's Phase 4 directly); the guardrail ledgers
+  (`AUTH_CROSS_BOUNDARY_NAMES`, de-blessed lists, the public-import
+  manifest) need same-PR bookkeeping; Stage 4 is a real public-API change
+  and must not ship as a side effect of an internal stage.
+- Stages are ordered by risk-to-value: each is independently green,
+  independently revertable, and none blocks the others except 4-after-1.
+
+## Alternatives considered
+
+- **Keep shrinking the cross-boundary ledger case-by-case.** Rejected: the
+  #2139 audit ended with every remaining entry either core-critical, a
+  documented feature, or irreducible without exactly the type/operation
+  consolidation this ADR names. The ledger is a symptom meter, not the
+  disease.
+- **Move adapter-local names into `cli/`/`_app/` wholesale.** Rejected on
+  evidence: three candidates that looked CLI-only (`build_cookie_jar`,
+  `validate_with_recovery`, `extract_cookies_from_storage`) turned out to be
+  load-bearing in the client's own token-construction and recovery chains
+  through internal `_auth` call paths the facade-level audit cannot see.
+  Moving code before the model exists just relocates hidden coupling.
+- **One big rewrite.** Rejected: the same audit produced three separate
+  "obviously safe" changes that were wrong on first pass. Staged, per-stage
+  verification is the only approach that has actually held up in this
+  subsystem.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,7 +65,7 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed — v3, single-release 0.9.0 flip |
 | [0029](0029-canonical-storage-writer.md) | Single canonical `storage_state.json` writer | Accepted (rolling out) |
 | [0030](0030-one-recovery-ladder.md) | One recovery ladder (single-flight core + off-loop loaders) | Accepted (rolling out) |
-| [0031](0031-credential-tier-auth-model.md) | Credential-tier domain model for `_auth` | Proposed (Stage 0 landed) |
+| [0031](0031-credential-tier-auth-model.md) | Credential-tier domain model for `_auth` | Proposed — Stage 0 landed |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,7 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0028](0028-gemini-notebook-rename.md) | Renaming the package for Google's "Gemini Notebook" rebrand | Proposed — v3, single-release 0.9.0 flip |
 | [0029](0029-canonical-storage-writer.md) | Single canonical `storage_state.json` writer | Accepted (rolling out) |
 | [0030](0030-one-recovery-ladder.md) | One recovery ladder (single-flight core + off-loop loaders) | Accepted (rolling out) |
+| [0031](0031-credential-tier-auth-model.md) | Credential-tier domain model for `_auth` | Proposed (Stage 0 landed) |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/src/notebooklm/_auth/keepalive.py
+++ b/src/notebooklm/_auth/keepalive.py
@@ -75,6 +75,57 @@ _KEEPALIVE_PRECISION_TOLERANCE = 2.0
 # keepalive bodies can reference it without an extra module hop.
 NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV = _auth_paths.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV
 
+# --- The single RotateCookies wire contract ----------------------------------
+# Every rotation path — the layer-1/layer-2 keepalive pokes (async, live
+# client), the file-based inline PSIDTS recovery, the in-memory
+# browser-extraction recovery, and the master-token mint's completing leg —
+# sends exactly this request through :func:`_rotate_post` /
+# :func:`_rotate_post_sync` below. There is ONE contract; the sync/async pair
+# exists only because httpx splits ``Client``/``AsyncClient``. A change to
+# Google's RotateCookies protocol is made here and nowhere else (enforced by
+# ``tests/_guardrails/test_rotate_wire_contract.py``).
+#
+# ``follow_redirects=True`` is defensive: empirically RotateCookies answers 200
+# directly with the rotated Set-Cookie, but if Google ever routes a 30x through
+# an identity hop we still pick up cookies from the terminal response.
+_ROTATE_POST_KWARGS: dict[str, Any] = {
+    "headers": _KEEPALIVE_ROTATE_HEADERS,
+    "content": _KEEPALIVE_ROTATE_BODY,
+    "follow_redirects": True,
+    "timeout": _KEEPALIVE_POKE_TIMEOUT,
+}
+
+
+async def _rotate_post(client: httpx.AsyncClient) -> httpx.Response:
+    """THE async ``RotateCookies`` POST. Wire only — no guards, no swallowing.
+
+    Raises ``httpx.HTTPError`` on transport failure *and* on a 4xx/5xx status:
+    httpx does not auto-raise on error statuses, and without the explicit
+    ``raise_for_status`` a 429 or 5xx from Google would log nothing while the
+    caller proceeds assuming the rotation happened.
+    """
+    response = await client.post(KEEPALIVE_ROTATE_URL, **_ROTATE_POST_KWARGS)
+    response.raise_for_status()
+    return response
+
+
+def _rotate_post_sync(client: httpx.Client) -> httpx.Response:
+    """Sync twin of :func:`_rotate_post` for the one-shot recovery clients."""
+    response = client.post(KEEPALIVE_ROTATE_URL, **_ROTATE_POST_KWARGS)
+    response.raise_for_status()
+    return response
+
+
+def _rotation_http_client(jar: httpx.Cookies) -> httpx.Client:
+    """Ephemeral sync client for a one-shot rotation against a prepared jar.
+
+    ``httpx.Client(cookies=jar)`` copies the source jar into a private client
+    jar; the rotated ``Set-Cookie`` values land in ``client.cookies``, never in
+    ``jar`` — callers read the client's jar after the POST.
+    """
+    return httpx.Client(cookies=jar, follow_redirects=True, timeout=_KEEPALIVE_POKE_TIMEOUT)
+
+
 # In-process state for rotation throttling, keyed per-profile and per-loop.
 #
 # - Per-profile (``storage_path``) so a rotation against profile A doesn't
@@ -378,20 +429,6 @@ async def _rotate_cookies(client: httpx.AsyncClient, storage_path: Path | None =
         )
         return
     try:
-        # ``follow_redirects=True`` is defensive: empirically RotateCookies
-        # answers 200 directly with the rotated Set-Cookie, but if Google ever
-        # routes a 30x through an identity hop we still pick up cookies from
-        # the terminal response.
-        response = await client.post(
-            KEEPALIVE_ROTATE_URL,
-            headers=_KEEPALIVE_ROTATE_HEADERS,
-            content=_KEEPALIVE_ROTATE_BODY,
-            follow_redirects=True,
-            timeout=_KEEPALIVE_POKE_TIMEOUT,
-        )
-        # httpx does not auto-raise on 4xx/5xx; without this, a 429 or 5xx from
-        # Google would log nothing and the caller would proceed assuming the
-        # rotation happened.
-        response.raise_for_status()
+        await _rotate_post(client)
     except httpx.HTTPError as exc:
         logger.debug("Keepalive RotateCookies POST failed (non-fatal): %s", exc)

--- a/src/notebooklm/_auth/master_token.py
+++ b/src/notebooklm/_auth/master_token.py
@@ -183,23 +183,16 @@ async def mint_cookies(email: str, master_token: str, android_id: str) -> httpx.
             )
             # Mint __Secure-1PSIDTS now too (the rotating freshness partner of
             # __Secure-1PSID) so the stored jar is complete and valid at rest — no
-            # first-call recovery needed and `auth check` passes immediately. This
-            # is the same RotateCookies POST the keepalive/inline recovery use; it
-            # needs the SID + APISID/SAPISID binding the MergeSession jar already
-            # carries. Best-effort: Google may withhold it, and inline recovery
-            # remains the fallback, so a failure here must not fail the mint.
-            from .keepalive import (  # noqa: PLC0415 (low-level; avoid import cycle)
-                _KEEPALIVE_ROTATE_BODY,
-                _KEEPALIVE_ROTATE_HEADERS,
-                KEEPALIVE_ROTATE_URL,
-            )
+            # first-call recovery needed and `auth check` passes immediately.
+            # ``_rotate_post`` is the same single-wire-contract RotateCookies
+            # POST every other rotation path uses; it needs the SID +
+            # APISID/SAPISID binding the MergeSession jar already carries.
+            # Best-effort: Google may withhold it, and inline recovery remains
+            # the fallback, so a failure here must not fail the mint.
+            from .keepalive import _rotate_post  # noqa: PLC0415 (avoid import cycle)
 
             try:
-                await client.post(
-                    KEEPALIVE_ROTATE_URL,
-                    headers=_KEEPALIVE_ROTATE_HEADERS,
-                    content=_KEEPALIVE_ROTATE_BODY,
-                )
+                await _rotate_post(client)
             except httpx.HTTPError as exc:
                 logger.debug("RotateCookies during mint failed (non-fatal): %s", exc)
             jar = httpx.Cookies()

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -66,9 +66,12 @@ _is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
 _rotation_lock_path = _keepalive._rotation_lock_path
 _file_lock_try_exclusive = _keepalive._file_lock_try_exclusive
 _try_claim_rotation = _keepalive._try_claim_rotation
-_KEEPALIVE_POKE_TIMEOUT = _keepalive._KEEPALIVE_POKE_TIMEOUT
-_KEEPALIVE_ROTATE_HEADERS = _keepalive._KEEPALIVE_ROTATE_HEADERS
-_KEEPALIVE_ROTATE_BODY = _keepalive._KEEPALIVE_ROTATE_BODY
+# The RotateCookies POST itself is _keepalive's single wire contract (see the
+# ``_ROTATE_POST_KWARGS`` block there); this module composes recovery policy
+# around it and never re-assembles the request from the raw
+# headers/body/timeout constants.
+_rotate_post_sync = _keepalive._rotate_post_sync
+_rotation_http_client = _keepalive._rotation_http_client
 _load_storage_state = _auth_cookies._load_storage_state
 _storage_entry_to_cookie = _auth_cookies._storage_entry_to_cookie
 _safe_to_cookie = _auth_cookies._safe_to_cookie
@@ -745,18 +748,9 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
     # keepalive in ``_runtime.lifecycle.save_cookies`` reads ``client.cookies``.
     observation = _recovery_observation(cookie_entries)
     try:
-        with httpx.Client(
-            cookies=jar,
-            follow_redirects=True,
-            timeout=_KEEPALIVE_POKE_TIMEOUT,
-        ) as client:
+        with _rotation_http_client(jar) as client:
             snapshot = _auth_storage.snapshot_cookie_jar(client.cookies)
-            response = client.post(
-                _keepalive.KEEPALIVE_ROTATE_URL,
-                headers=_KEEPALIVE_ROTATE_HEADERS,
-                content=_KEEPALIVE_ROTATE_BODY,
-            )
-            response.raise_for_status()
+            _rotate_post_sync(client)
             rotated_jar = client.cookies
             # ROUTABLE, not merely present-by-name. The request jar still holds
             # whatever PSIDTS was already on disk, so a name-only check would see
@@ -891,17 +885,8 @@ def recover_psidts_in_memory(rookiepy_cookies: list[dict[str, Any]]) -> bool:
     jar = _build_recovery_jar(rookiepy_cookies, _rookiepy_entry_to_cookie)
 
     try:
-        with httpx.Client(
-            cookies=jar,
-            follow_redirects=True,
-            timeout=_KEEPALIVE_POKE_TIMEOUT,
-        ) as client:
-            response = client.post(
-                _keepalive.KEEPALIVE_ROTATE_URL,
-                headers=_KEEPALIVE_ROTATE_HEADERS,
-                content=_KEEPALIVE_ROTATE_BODY,
-            )
-            response.raise_for_status()
+        with _rotation_http_client(jar) as client:
+            _rotate_post_sync(client)
             rotated_cookies = list(client.cookies.jar)
     except httpx.HTTPError as exc:
         logger.debug(

--- a/tests/_guardrails/test_rotate_wire_contract.py
+++ b/tests/_guardrails/test_rotate_wire_contract.py
@@ -1,0 +1,109 @@
+"""Single-wire-contract gate for the ``RotateCookies`` POST.
+
+Before this gate, the POST to ``accounts.google.com/RotateCookies`` was
+independently assembled at FOUR sites — the async keepalive poke
+(``_auth/keepalive.py``), the file-based inline PSIDTS recovery and the
+in-memory browser-extraction recovery (both ``_auth/psidts_recovery.py``),
+and the master-token mint's completing leg (``_auth/master_token.py``) —
+each re-listing the URL/headers/body/redirect/timeout quintet, and one of
+them (the mint leg) silently missing ``raise_for_status``. A change to
+Google's rotation protocol, or a fix to the request policy, had four places
+to land and nothing keeping them in sync — in the credential-rotation path,
+where drift is a correctness/security risk, not a style nit.
+
+The contract now lives ONLY in ``_auth/keepalive.py`` (the
+``_ROTATE_POST_KWARGS`` block plus the ``_rotate_post`` /
+``_rotate_post_sync`` pair); every other module composes policy around those
+entry points. This gate keeps a fifth bespoke assembly from creeping back:
+
+1. the URL literal may appear in exactly one ``src/`` module (keepalive);
+2. the request-body sentinel literal likewise;
+3. no ``.post(...)`` call outside keepalive may take ``KEEPALIVE_ROTATE_URL``
+   as its target (constructing a *non-sending* ``httpx.Request`` for the
+   routability computation in ``psidts_recovery._psidts_routes_to_rotate``
+   remains allowed — the gate matches ``.post`` calls, not the constant).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+_WIRE_OWNER = _SRC_ROOT / "_auth" / "keepalive.py"
+
+_ROTATE_URL_LITERAL = "https://accounts.google.com/RotateCookies"
+_ROTATE_BODY_LITERAL = '[000,"-0000000000000000000"]'
+
+
+def _iter_src_modules() -> list[Path]:
+    return sorted(_SRC_ROOT.rglob("*.py"))
+
+
+def _files_with_constant(value: str) -> list[Path]:
+    hits: list[Path] = []
+    for path in _iter_src_modules():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and node.value == value:
+                hits.append(path)
+                break
+    return hits
+
+
+def test_rotate_url_literal_defined_once() -> None:
+    """The RotateCookies URL string exists only in the wire-owner module."""
+    assert _files_with_constant(_ROTATE_URL_LITERAL) == [_WIRE_OWNER], (
+        "The RotateCookies URL literal must appear only in _auth/keepalive.py "
+        "(as KEEPALIVE_ROTATE_URL). Other modules reference the constant, "
+        "never the string."
+    )
+
+
+def test_rotate_body_literal_defined_once() -> None:
+    """The RotateCookies request-body sentinel exists only in the wire owner."""
+    assert _files_with_constant(_ROTATE_BODY_LITERAL) == [_WIRE_OWNER], (
+        "The RotateCookies body sentinel must appear only in _auth/keepalive.py "
+        "(as _KEEPALIVE_ROTATE_BODY)."
+    )
+
+
+def _references_rotate_url(node: ast.expr) -> bool:
+    """True for ``KEEPALIVE_ROTATE_URL`` / ``<mod>.KEEPALIVE_ROTATE_URL``."""
+    if isinstance(node, ast.Name):
+        return node.id == "KEEPALIVE_ROTATE_URL"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "KEEPALIVE_ROTATE_URL"
+    return False
+
+
+def test_no_bespoke_rotate_post_outside_wire_owner() -> None:
+    """No ``.post(KEEPALIVE_ROTATE_URL, ...)`` call outside keepalive.
+
+    Rotation callers go through ``_rotate_post`` / ``_rotate_post_sync`` so the
+    full request policy (headers, body, redirects, timeout, raise_for_status)
+    rides along; re-assembling the POST from the imported URL constant is
+    exactly the drift this gate exists to stop.
+    """
+    violations: list[str] = []
+    for path in _iter_src_modules():
+        if path == _WIRE_OWNER:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "post"
+                and node.args
+                and _references_rotate_url(node.args[0])
+            ):
+                violations.append(f"{path.relative_to(_SRC_ROOT.parent.parent)}:{node.lineno}")
+    assert not violations, (
+        "Bespoke RotateCookies POST outside _auth/keepalive.py — route through "
+        f"_rotate_post/_rotate_post_sync instead: {violations}"
+    )

--- a/tests/_guardrails/test_rotate_wire_contract.py
+++ b/tests/_guardrails/test_rotate_wire_contract.py
@@ -19,9 +19,12 @@ entry points. This gate keeps a fifth bespoke assembly from creeping back:
 1. the URL literal may appear in exactly one ``src/`` module (keepalive);
 2. the request-body sentinel literal likewise;
 3. no ``.post(...)`` call outside keepalive may take ``KEEPALIVE_ROTATE_URL``
-   as its target (constructing a *non-sending* ``httpx.Request`` for the
-   routability computation in ``psidts_recovery._psidts_routes_to_rotate``
-   remains allowed — the gate matches ``.post`` calls, not the constant).
+   as its target — whether passed positionally (``client.post(URL, ...)``) or
+   by keyword (``client.post(url=URL, ...)``, which httpx also accepts.
+   Checking only the positional form would leave a one-keyword bypass).
+   Constructing a *non-sending* ``httpx.Request`` for the routability
+   computation in ``psidts_recovery._psidts_routes_to_rotate`` remains allowed
+   — the gate matches ``.post`` calls, not every use of the constant.
 """
 
 from __future__ import annotations
@@ -81,6 +84,27 @@ def _references_rotate_url(node: ast.expr) -> bool:
     return False
 
 
+def _is_bespoke_rotate_post(node: ast.AST) -> bool:
+    """True for a ``.post(...)`` call whose target is the rotate URL constant.
+
+    THE detector — the repo scan and the shape self-tests below both call this,
+    so the property the self-tests assert is the property the scan enforces. A
+    second copy of this logic could drift out of sync with the gate it claims
+    to cover, which is the same failure mode this whole module exists to stop.
+
+    httpx accepts the target as ``post(url)`` or ``post(url=url)``; matching
+    only the positional form would leave a one-keyword bypass.
+    """
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "post"
+    ):
+        return False
+    targets = list(node.args[:1]) + [kw.value for kw in node.keywords if kw.arg == "url"]
+    return any(_references_rotate_url(target) for target in targets)
+
+
 def test_no_bespoke_rotate_post_outside_wire_owner() -> None:
     """No ``.post(KEEPALIVE_ROTATE_URL, ...)`` call outside keepalive.
 
@@ -94,16 +118,53 @@ def test_no_bespoke_rotate_post_outside_wire_owner() -> None:
         if path == _WIRE_OWNER:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "post"
-                and node.args
-                and _references_rotate_url(node.args[0])
-            ):
-                violations.append(f"{path.relative_to(_SRC_ROOT.parent.parent)}:{node.lineno}")
+        violations.extend(
+            f"{path.relative_to(_SRC_ROOT.parent.parent)}:{node.lineno}"
+            for node in ast.walk(tree)
+            if _is_bespoke_rotate_post(node)
+        )
     assert not violations, (
         "Bespoke RotateCookies POST outside _auth/keepalive.py — route through "
         f"_rotate_post/_rotate_post_sync instead: {violations}"
     )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "client.post(KEEPALIVE_ROTATE_URL, headers=h, content=b)",
+        "client.post(url=KEEPALIVE_ROTATE_URL, headers=h, content=b)",
+        "await client.post(_keepalive.KEEPALIVE_ROTATE_URL)",
+        "await client.post(url=_keepalive.KEEPALIVE_ROTATE_URL)",
+        "self._client.post(mod.KEEPALIVE_ROTATE_URL)",
+    ],
+)
+def test_gate_detects_every_bespoke_post_shape(source: str) -> None:
+    """The detector must catch positional AND keyword target forms.
+
+    A gate that only matched ``post(URL)`` would wave through the one-keyword
+    ``post(url=URL)`` rewrite — the AST-bypass failure mode that bit the
+    master-token minting denylist twice (#2108). Pinned here so the detector's
+    coverage is asserted rather than assumed.
+    """
+    assert any(_is_bespoke_rotate_post(node) for node in ast.walk(ast.parse(source))), (
+        f"detector missed a bespoke-POST shape: {source!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # The routability probe: builds a Request to ask httpx which cookies
+        # WOULD be sent. Never goes on the wire — flagging it would leave
+        # deleting a correct check as the only way to green the gate.
+        'httpx.Request("POST", KEEPALIVE_ROTATE_URL)',
+        # An unrelated POST to some other endpoint.
+        "client.post(SOME_OTHER_URL, content=b)",
+        # The sanctioned indirection every caller is supposed to use.
+        "await _rotate_post(client)",
+    ],
+)
+def test_gate_ignores_legitimate_shapes(source: str) -> None:
+    """No false positives on the non-sending probe or unrelated POSTs."""
+    assert not any(_is_bespoke_rotate_post(node) for node in ast.walk(ast.parse(source)))


### PR DESCRIPTION
## Summary

Follow-up to the #2139 boundary audit, which traced the auth subsystem's coupling to a missing domain model. This PR lands the first, most urgent slice plus the design record:

**Stage 0 — one RotateCookies wire contract.** The POST to `accounts.google.com/RotateCookies` was independently assembled at **four** sites (`keepalive._rotate_cookies`, `psidts_recovery._attempt_rotation`, `psidts_recovery.recover_psidts_in_memory`, and the mint leg in `master_token.mint_cookies`), each re-listing the URL/headers/body/redirect/timeout quintet — and the mint leg alone omitted `raise_for_status`, so a 429/5xx there passed silently. Protocol drift in the credential-rotation path with nothing keeping the copies in sync. The contract now lives only in `_auth/keepalive.py` (`_ROTATE_POST_KWARGS` + `_rotate_post`/`_rotate_post_sync`/`_rotation_http_client`); the four sites are thin policy wrappers keeping their distinct guards (throttle claims, flocks, persistence, best-effort swallowing) byte-identical.

Intentional behavior deltas, **mint leg only**:
- a rejected rotation (4xx/5xx) is now logged and skipped instead of silently ignored — the `raise_for_status` rationale documented in keepalive since #345 now applies uniformly;
- the leg uses the canonical 15 s rotation timeout instead of inheriting the mint client's incidental 30 s.

**Guardrail**: `tests/_guardrails/test_rotate_wire_contract.py` pins the URL and body literals to `keepalive.py` and rejects any `.post(KEEPALIVE_ROTATE_URL, ...)` outside it (the non-sending `httpx.Request` used for routability computation stays allowed). Verified red against the pre-change code before landing the fix.

**ADR-0031 — credential-tier domain model** (`Proposed`). Names the model the audit surfaced — a three-tier credential system (durable → session → request) whose operations are mint / rotate / validate-heal / persist / identify — and records the staged follow-up plan (CookieJar, validate/heal split, ProfileStore, `AuthTokens` collapse, mode packages), the unattended-vs-interactive boundary principle, and the evidence-based rejections (case-by-case ledger shrinking, wholesale boundary moves, big rewrite).

## Test plan

- [x] Full suite: 13156 passed, 81 skipped, 3 xfailed
- [x] All four rotation sites' test files green (216 tests: keepalive, psidts_recovery, master_token, refresh, login_cookie_recovery, client_keepalive) — these mock at the network level (`httpx_mock` by URL), so they directly verify the wire request is unchanged
- [x] New guardrail verified to fail against the pre-change quadruplicated code
- [x] `ruff check` / `ruff format --check` / `mypy src/notebooklm --ignore-missing-imports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaeZfcxWvV3AuogrsiswrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie rotation error handling so failures are reported instead of silently ignored.
  * Standardized cookie rotation requests with consistent validation, redirect handling, and a 15-second timeout.

* **Documentation**
  * Added a proposed credential-tier authentication model and documented the staged rollout.
  * Updated the architecture decision index and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->