### PR TITLE
test(auth): pin the mint leg's rejected-rotation contract

### DIFF
--- a/tests/unit/test_auth_master_token.py
+++ b/tests/unit/test_auth_master_token.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import sys
 import types
@@ -115,6 +116,41 @@ async def test_mint_cookies_missing_required_cookie(fake_gpsoauth, httpx_mock):
     # answers it, so the required-cookie check is what raises.
     with pytest.raises(MasterTokenError, match="missing required cookies"):
         await mt.mint_cookies("e@x.com", "aas_et/MASTER", "abc")
+
+
+@pytest.mark.no_default_keepalive_mock  # own the RotateCookies response (simulate rejection)
+@pytest.mark.parametrize("status_code", [429, 503])
+@pytest.mark.asyncio
+async def test_mint_cookies_survives_a_rejected_rotation(
+    fake_gpsoauth, httpx_mock, caplog, status_code
+):
+    """The RotateCookies leg is best-effort inside the mint. It now runs through
+    ``keepalive._rotate_post``, which adds the ``raise_for_status`` the old
+    inline POST lacked, so a 429/5xx becomes an ``httpx.HTTPStatusError``
+    instead of a 200-shaped no-op. The contract that pins: it is logged and
+    skipped — neither silently ignored (the pre-existing bug) nor escalated
+    into a failed mint by the *outer* ``except httpx.HTTPError``. The jar comes
+    back without ``__Secure-1PSIDTS``, leaving the standard inline recovery to
+    mint it on first load."""
+    httpx_mock.add_response(url=_OAUTHLOGIN_RE, text="APh-UBERAUTH")
+    httpx_mock.add_response(
+        url=_MERGESESSION_RE,
+        headers=_merge_session_cookies("SID", "APISID", "SAPISID", "HSID"),
+    )
+    httpx_mock.add_response(url=_ROTATE_RE, status_code=status_code)
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm.auth.master_token"):
+        jar = await mt.mint_cookies("e@x.com", "aas_et/MASTER", "abc")
+
+    names = {c.name for c in jar.jar}
+    assert {"SID", "APISID", "SAPISID"} <= names  # the mint itself still succeeded
+    assert "__Secure-1PSIDTS" not in names  # withheld: inline recovery's job now
+    assert any("RotateCookies during mint failed" in r.getMessage() for r in caplog.records), (
+        "a rejected rotation must be logged, not silently swallowed"
+    )
+    # The rotation really was attempted (and really was the rejected response).
+    rotate_reqs = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
+    assert len(rotate_reqs) == 1 and rotate_reqs[0].method == "POST"
 
 
 # --- remint_from_stored_token (kernel, #2103 PR-2 D1) ----------------------


### PR DESCRIPTION
Closes a test gap `claude[bot]` identified while reviewing #2146. It raced that PR's merge rather than being an afterthought: the commit was pushed while #2146 was still open, but the squash merge landed ~4 minutes earlier and captured only up to `2c2f4da0`, so the test never made it to `main`. This is that commit, rebuilt on `main`.

## The gap

#2146 consolidated the quadruple-implemented `RotateCookies` POST into one wire contract. Its **only** production behavior delta is in the mint leg: `master_token.mint_cookies` now routes through `keepalive._rotate_post`, which adds the `raise_for_status` the old inline POST lacked. A 429/5xx that previously passed silently as a 200-shaped no-op is now an `httpx.HTTPStatusError` that gets logged and skipped.

Nothing pinned that. The adjacent `test_remint_from_stored_token_wraps_reload_failure_when_psidts_withheld` covers the *neighbouring* case — a 200 with no `Set-Cookie` — not a rejected status.

## What the test pins

`test_mint_cookies_survives_a_rejected_rotation`, parameterized over 429 and 503, asserts the contract the #2146 description claims:

- the mint still **succeeds** — the rotation is best-effort, so the inner handler logs and skips, and the failure must not escalate through the *outer* `except httpx.HTTPError` that wraps the whole mint;
- the jar comes back without `__Secure-1PSIDTS`, leaving the standard inline recovery to mint it on first load;
- the debug line actually fires.

## Why the log assertion is load-bearing

It is doing the real work here, and it is the reason this test is worth having rather than merely present. Under the *old* code a silently-swallowed 429 **also** yields a jar with no `__Secure-1PSIDTS` — so the cookie-set assertions alone would pass against the bug the PR fixed.

Verified by mutation rather than by watching it go green: deleting `raise_for_status` from `keepalive._rotate_post` makes both parameterizations fail, and fail specifically on the missing log line. That confirms the test pins the delta and not ambient behavior.

## Verification

Test-only — no production code touched (single file, +36 lines).

- `tests/unit/test_auth_master_token.py` + `tests/_guardrails/test_rotate_wire_contract.py`: 40 passed, run against the **merged** `main`, not the old branch.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC4GLbcdJx6UTb5mjsp6HY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for cookie rotation failures caused by HTTP 429 and 503 responses.
  * Verified cookie minting continues successfully, the appropriate cookie is omitted, failures are logged, and the rotation request is attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->