### PR TITLE
refactor(auth): CookieJar canonical cookie type + conversion ratchet (ADR-0031 Stage 1)

### DIFF
--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -75,11 +75,28 @@ introduce its objects and operations in independently shippable stages:
   `_rotate_post_sync` / `_rotation_http_client`); the four former sites are
   thin policy wrappers. Enforced by
   `tests/_guardrails/test_rotate_wire_contract.py`.
-- **Stage 1: `CookieJar`** — one canonical cookie type with constructors
-  (`from_storage_state` / `from_rookiepy` / `from_flat`) and converters
-  (`to_httpx` / `to_storage_state`), introduced as a non-breaking wrapper
-  delegating to today's free functions. New code uses jar methods; a ratchet
-  blocks new imports of the legacy conversion functions.
+- **Stage 1: `CookieJar`** — one canonical cookie type
+  (`_auth/cookie_types.py`, completing the `cookie_semantics` /
+  `cookie_policy` family) with constructors (`from_storage_state` /
+  `from_rookiepy` / `from_domain_map`), converters (`to_httpx` /
+  `to_storage_state` / `to_domain_map`), and the policy questions as methods
+  (`names` / `validate_required` / `has_secondary_binding` / `is_rotatable` /
+  `missing_hint`). A non-breaking wrapper: every decision still delegates to
+  the free function that owns it, pinned by equivalence tests. A shrink-only
+  ratchet (`tests/_guardrails/test_cookie_conversion_ratchet.py`) blocks *new*
+  bespoke conversion call sites; the five existing ones are grandfathered with
+  the stage that retires each, and the allowlist may only shrink.
+
+  **The flat `name -> value` shape is deliberately not on the type.** It
+  collapses the path component (#369) and picks an arbitrary winner among
+  same-tier domains, so the survivor changes when `storage_state` is reordered
+  (#2054) — `AuthTokens.flat_cookies` documents itself as "lossy, and not
+  correct for building a request". Every remaining caller is back-compat (the
+  public property, and `_update_cookie_input`'s write-back into a
+  legacy-shaped caller dict). Carrying it onto the canonical type would import
+  the footgun into the model meant to retire it, so it stays reachable only
+  through the legacy free function, and `to_httpx()` is the path- and
+  domain-correct route for cookies on the wire.
 - **Stage 2: `validate` / `heal` split** — `validate(jar) → ValidationResult`
   is pure (extends the closed-enum reason
   `RequiredCookieValidationError` grew in #2061); `heal` is the explicit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -531,6 +531,7 @@ the default dependency.
 | [`_auth/cookies.py`](../src/notebooklm/_auth/cookies.py) | Cookie maps + `_update_cookie_input` helper. |
 | [`_auth/cookie_policy.py`](../src/notebooklm/_auth/cookie_policy.py) | Domain allowlist, cookie-domain builder (`build_cookie_domain_allowlist`), and cookie policy decisions. |
 | [`_auth/cookie_semantics.py`](../src/notebooklm/_auth/cookie_semantics.py) | Shared cookie-shape and expiry semantics used by sanitized auth loaders and persistence boundaries. |
+| [`_auth/cookie_types.py`](../src/notebooklm/_auth/cookie_types.py) | The canonical `Cookie` / `CookieJar` types (ADR-0031 Stage 1): constructors from every input shape, converters to httpx/storage-state, and the cookie-set policy questions as methods. A delegating wrapper — policy still lives in `cookie_policy`/`cookies`. |
 | [`_auth/browser_cookie_recovery.py`](../src/notebooklm/_auth/browser_cookie_recovery.py) | Leaf bridge that validates captured browser cookies and retries in-memory PSIDTS recovery. |
 | [`_auth/browser_state_validation.py`](../src/notebooklm/_auth/browser_state_validation.py) | Best-effort in-memory PSIDTS heal for Playwright-captured state, preserving cookie attributes. Returns `(state, error)` and never raises, so a failed heal cannot discard a completed sign-in. |
 | [`_auth/browser_capture.py`](../src/notebooklm/_auth/browser_capture.py) | Transport-neutral browser launch→navigate→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter and the layer-3 headless re-auth layer (ADR-0021). The headless arm classifies the landing URL (authenticated→capture, redirected-to-login→`HeadlessLoginRequiredError`). `run_cdp_capture` is an alternative credential source: attach to an operator-pointed already-running Chrome over CDP (`connect_over_cdp`, disconnect-only teardown) using the SAME landing classification + cookie-domain allowlist. |
@@ -1001,6 +1002,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_auth/cookies.py` | Cookie map manipulation + `_update_cookie_input` |
 | `_auth/cookie_policy.py` | Cookie-domain allowlist, `build_cookie_domain_allowlist` builder, and policy decisions |
 | `_auth/cookie_semantics.py` | Shared cookie-shape and expiry semantics at loader/persistence boundaries |
+| `_auth/cookie_types.py` | Canonical `Cookie`/`CookieJar` domain types (ADR-0031 Stage 1); delegating wrapper over the cookie conversions + policy |
 | `_auth/browser_cookie_recovery.py` | Captured-cookie validation and in-memory PSIDTS recovery bridge |
 | `_auth/browser_state_validation.py` | Best-effort PSIDTS heal for captured state; returns `(state, error)`, never raises |
 | `_auth/browser_capture.py` | Transport-neutral browser launch→capture→filter→persist core (lazy `playwright`); shared by the interactive CLI login adapter (`cli/services/playwright_login.py`) and the layer-3 headless re-auth layer (ADR-0021) |
@@ -1184,6 +1186,7 @@ src/notebooklm/
 │   ├── cookies.py               # Cookie maps + _update_cookie_input
 │   ├── cookie_policy.py         # Domain allowlist + cookie-domain builder and policy
 │   ├── cookie_semantics.py      # Shared cookie-shape and expiry semantics
+│   ├── cookie_types.py          # Canonical Cookie/CookieJar types (ADR-0031 Stage 1)
 │   ├── browser_cookie_recovery.py # Captured-cookie validation + in-memory PSIDTS recovery bridge
 │   ├── browser_state_validation.py # Best-effort PSIDTS heal for captured state (never raises)
 │   ├── browser_capture.py       # Transport-neutral browser launch→capture→filter→persist core (lazy playwright)

--- a/src/notebooklm/_auth/cookie_types.py
+++ b/src/notebooklm/_auth/cookie_types.py
@@ -1,0 +1,254 @@
+"""The canonical cookie types: :class:`Cookie` and :class:`CookieJar`.
+
+ADR-0031 Stage 1. A cookie currently exists in the auth layer in six shapes —
+the raw Playwright storage-state row, the rookiepy row, ``DomainCookieMap``
+(``(name, domain, path) -> value``), ``FlatCookieMap`` (``name -> value``),
+the legacy 2-tuple ``LegacyDomainCookieMap``, and the "sanitized entries"
+list — and the conversions between them are free functions scattered across
+:mod:`notebooklm._auth.cookies` and :mod:`notebooklm._auth.cookie_policy`.
+Because no type owns "a set of auth cookies", the questions callers ask about
+one ("which names are here?", "is this set usable?", "does it still bind?")
+have no method to be, so every flow reaches independently for the same
+scattered private helpers. That fan-out is what makes the auth layer hard to
+move: see ADR-0031's Context.
+
+This module introduces the types those questions belong to. It completes the
+``cookie_*`` family: :mod:`~notebooklm._auth.cookie_semantics` owns row
+validation/normalization, :mod:`~notebooklm._auth.cookie_policy` owns which
+cookies are required and allowed, and this module owns the shape callers
+hold. (Not named ``cookie_jar`` — ``cli/services/login/cookie_jar.py`` is a
+different thing: the CLI's browser-account enumeration service.) It is deliberately
+a **wrapper, not a replacement**: every policy decision still delegates to the
+existing free function that owns it, so this stage changes no behavior and no
+public shape. ``AuthTokens`` keeps its ``cookies`` / ``cookie_jar`` field pair
+until ADR-0031 Stage 4.
+
+Round-tripping is lossy in one direction, by design:
+:meth:`CookieJar.from_storage_state` applies the same allowlist +
+row-sanitization filter the rest of the auth layer applies
+(:func:`notebooklm._auth.cookies._sanitized_auth_entries`), so a jar built
+from a storage state holds only routable, structurally valid auth rows.
+:meth:`CookieJar.to_storage_state` therefore reproduces *that filtered view*,
+not the original file. Callers persisting cookies must keep using the
+canonical storage writer (ADR-0029), which owns merge semantics this type
+deliberately does not.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from . import cookie_policy as _cookie_policy
+from . import cookies as _auth_cookies
+
+
+@dataclass(frozen=True)
+class Cookie:
+    """One auth cookie, keyed by its RFC 6265 §5.3 identity.
+
+    ``(name, domain, path)`` is the identity: two cookies sharing a name at
+    distinct domains or paths are independent entries, never one shadowing the
+    other (issue #369). ``expires`` is the Playwright epoch-seconds convention
+    where ``-1`` means a session cookie.
+    """
+
+    name: str
+    domain: str
+    path: str
+    value: str
+    expires: float | int | None = None
+    http_only: bool = False
+    secure: bool = False
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        """The RFC 6265 §5.3 ``(name, domain, path)`` identity."""
+        return (self.name, self.domain, self.path)
+
+
+class CookieJar:
+    """An ordered, immutable set of auth cookies.
+
+    Construct through the ``from_*`` classmethods rather than ``__init__`` —
+    each one routes through the conversion the auth layer already trusts for
+    that input shape, so a jar can never hold rows the rest of the layer would
+    have filtered out.
+    """
+
+    __slots__ = ("_cookies",)
+
+    def __init__(self, cookies: tuple[Cookie, ...] = ()) -> None:
+        self._cookies = tuple(cookies)
+
+    # -- constructors ------------------------------------------------------
+
+    @classmethod
+    def from_storage_state(cls, storage_state: Mapping[str, Any]) -> CookieJar:
+        """Build from a parsed Playwright ``storage_state`` mapping.
+
+        Rows are filtered and normalized by
+        :func:`notebooklm._auth.cookies._sanitized_auth_entries` — the same
+        allowlist + row-sanitization gate every other reader applies — so
+        malformed rows and non-auth domains are dropped here exactly as they
+        are everywhere else.
+        """
+        entries = _auth_cookies._sanitized_auth_entries(dict(storage_state))
+        return cls(tuple(_cookie_from_entry(entry) for entry in entries))
+
+    @classmethod
+    def from_rookiepy(cls, rows: list[dict[str, Any]]) -> CookieJar:
+        """Build from rookiepy's browser-extraction rows.
+
+        Delegates the snake_case → camelCase field mapping and the
+        session-cookie expiry convention to
+        :func:`notebooklm._auth.cookies.convert_rookiepy_cookies_to_storage_state`.
+        """
+        return cls.from_storage_state(_auth_cookies.convert_rookiepy_cookies_to_storage_state(rows))
+
+    @classmethod
+    def from_domain_map(cls, cookies: Any) -> CookieJar:
+        """Build from any legacy cookie-map shape.
+
+        Accepts all three shapes :func:`notebooklm._auth.cookies.normalize_cookie_map`
+        accepts (path-aware 3-tuple keys, legacy 2-tuple keys, and flat
+        ``name -> value``), widening the shorter forms exactly as that function
+        does. The map shapes carry no expiry/flags, so those default.
+        """
+        normalized = _auth_cookies.normalize_cookie_map(cookies)
+        return cls(
+            tuple(
+                Cookie(name=name, domain=domain, path=path, value=value)
+                for (name, domain, path), value in normalized.items()
+            )
+        )
+
+    # -- converters --------------------------------------------------------
+
+    def to_domain_map(self) -> dict[tuple[str, str, str], str]:
+        """Return the path-aware ``(name, domain, path) -> value`` map.
+
+        First occurrence wins for a repeated identity, matching
+        :func:`notebooklm._auth.cookies.extract_cookies_with_domains`.
+        """
+        result: dict[tuple[str, str, str], str] = {}
+        for cookie in self._cookies:
+            result.setdefault(cookie.identity, cookie.value)
+        return result
+
+    # NOTE: there is deliberately no ``to_flat_map`` / ``FlatCookieMap`` export.
+    # Flattening to ``name -> value`` collapses the path component (#369) and
+    # picks an arbitrary winner among same-tier domains — ``AuthTokens.flat_cookies``
+    # documents itself as "lossy, and not correct for building a request", with a
+    # survivor that changes when ``storage_state`` is reordered (#2054). Every
+    # remaining caller of ``flatten_cookie_map`` is back-compat: the public
+    # ``flat_cookies`` property and ``_update_cookie_input``'s write-back into a
+    # legacy-shaped caller dict. Giving the canonical type a method for it would
+    # carry that footgun into the model meant to retire it, so the legacy shape
+    # stays reachable only through the legacy free function. Callers that want
+    # bytes on the wire use :meth:`to_httpx`, which is path- and domain-correct.
+
+    def to_httpx(self) -> httpx.Cookies:
+        """Return a domain-preserving ``httpx.Cookies`` jar.
+
+        Delegates to :func:`notebooklm._auth.cookies.build_cookie_jar`, the
+        single authoritative jar constructor.
+        """
+        return _auth_cookies.build_cookie_jar(cookies=self.to_domain_map())
+
+    def to_storage_state(self) -> dict[str, Any]:
+        """Return a Playwright-shaped ``storage_state`` dict for these cookies.
+
+        Reproduces the jar's *filtered* view, not any original file — see the
+        module docstring. ``origins`` is empty: this type models cookies only.
+        """
+        return {
+            "cookies": [
+                {
+                    "name": c.name,
+                    "value": c.value,
+                    "domain": c.domain,
+                    "path": c.path,
+                    "expires": -1 if c.expires is None else c.expires,
+                    "httpOnly": c.http_only,
+                    "secure": c.secure,
+                }
+                for c in self._cookies
+            ],
+            "origins": [],
+        }
+
+    # -- queries -----------------------------------------------------------
+
+    def names(self) -> set[str]:
+        """Return the set of cookie names present, on any domain."""
+        return {c.name for c in self._cookies}
+
+    def has_secondary_binding(self) -> bool:
+        """Whether the Tier-2 binding (``OSID``, or ``APISID`` + ``SAPISID`` +
+        ``LSID``) is intact — see
+        :func:`notebooklm._auth.cookie_policy._has_valid_secondary_binding`."""
+        return _cookie_policy._has_valid_secondary_binding(self.names())
+
+    def is_rotatable(self) -> bool:
+        """Whether a ``RotateCookies`` attempt is worth making.
+
+        Deliberately weaker than :meth:`has_secondary_binding` — see
+        :func:`notebooklm._auth.cookie_policy._has_rotatable_secondary_binding`.
+        """
+        return _cookie_policy._has_rotatable_secondary_binding(self.names())
+
+    def validate_required(self, *, context: str = "") -> None:
+        """Raise unless the Tier-1 required cookies are present.
+
+        Delegates the policy — including the Tier-2 warning — to
+        :func:`notebooklm._auth.cookie_policy._validate_required_cookies`,
+        raising its ``RequiredCookieValidationError`` (a ``ValueError``) with
+        the same closed-enum ``reason`` every other caller sees.
+        """
+        _cookie_policy._validate_required_cookies(self.names(), context=context)
+
+    def missing_hint(self, *, browser_label: str | None = None) -> str:
+        """Return the actionable recovery hint for this jar's missing cookies."""
+        return _cookie_policy.missing_cookies_hint(self.names(), browser_label=browser_label)
+
+    # -- container protocol ------------------------------------------------
+
+    def __iter__(self) -> Iterator[Cookie]:
+        return iter(self._cookies)
+
+    def __len__(self) -> int:
+        return len(self._cookies)
+
+    def __bool__(self) -> bool:
+        return bool(self._cookies)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CookieJar):
+            return NotImplemented
+        return self._cookies == other._cookies
+
+    def __repr__(self) -> str:
+        """Redacted: names and count only — values are credential-equivalent."""
+        return f"CookieJar({len(self._cookies)} cookies: {sorted(self.names())})"
+
+
+def _cookie_from_entry(entry: Mapping[str, Any]) -> Cookie:
+    """Build a :class:`Cookie` from an already-sanitized storage-state row.
+
+    Callers must pass rows that have been through
+    ``_sanitized_auth_entries`` / ``sanitize_cookie_entry``: identity and value
+    fields are trusted here, and ``path`` has already been defaulted to ``/``.
+    """
+    return Cookie(
+        name=entry["name"],
+        domain=entry["domain"],
+        path=entry.get("path") or "/",
+        value=entry["value"],
+        expires=entry.get("expires"),
+        http_only=bool(entry.get("httpOnly", entry.get("http_only", False))),
+        secure=bool(entry.get("secure", False)),
+    )

--- a/tests/_guardrails/test_cookie_conversion_ratchet.py
+++ b/tests/_guardrails/test_cookie_conversion_ratchet.py
@@ -1,0 +1,143 @@
+"""Shrink-only ratchet on the scattered cookie-conversion free functions.
+
+ADR-0031 Stage 1. A cookie has lived in six shapes in this layer, with the
+conversions between them as free functions any module could reach for. That is
+what let "which cookies are here / is this set usable" get re-derived
+independently at a dozen call sites, and it is why the auth layer resisted the
+#2139 boundary moves: the coupling had no owner.
+
+:class:`notebooklm._auth.cookie_types.CookieJar` is now that owner. This gate
+does **not** force a migration — per this repo's ratchet convention, existing
+call sites migrate opportunistically, not in an eager burndown. It blocks the
+*next* one: new code converts through ``CookieJar`` instead of adding a
+thirteenth bespoke call.
+
+Sanctioned homes (never flagged):
+
+* ``_auth/cookies.py`` — where these functions are defined and compose.
+* ``_auth/cookie_types.py`` — the wrapper whose whole job is delegating to them.
+
+Everything else is in :data:`_GRANDFATHERED`, which is **shrink-only**: an entry
+whose call has since moved to ``CookieJar`` must be deleted (asserted by
+``test_grandfathered_entries_are_all_live``), so the list can only get shorter.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+
+#: The conversions ``CookieJar`` now owns a typed route for.
+_RATCHETED = frozenset(
+    {
+        "normalize_cookie_map",
+        "flatten_cookie_map",
+        "extract_cookies_with_domains",
+        "convert_rookiepy_cookies_to_storage_state",
+    }
+)
+
+#: Modules that legitimately call these directly.
+_SANCTIONED = frozenset({"_auth/cookies.py", "_auth/cookie_types.py"})
+
+#: (module path relative to ``src/notebooklm``, function) pairs predating the
+#: ratchet. SHRINK-ONLY — never add. Each is a candidate for a later stage.
+_GRANDFATHERED: frozenset[tuple[str, str]] = frozenset(
+    {
+        # AuthTokens.__post_init__ widens legacy caller-supplied maps, and the
+        # back-compat flat-map property flattens them back. Both retire in
+        # ADR-0031 Stage 4, when the dual cookies/cookie_jar fields collapse
+        # into a single CookieJar and these become jar methods.
+        ("_auth/tokens.py", "normalize_cookie_map"),
+        ("_auth/tokens.py", "flatten_cookie_map"),
+        # The L3 heal converts rookiepy rows twice (before and after recovery).
+        # Retires with the Stage 2 validate/heal split.
+        ("_auth/browser_cookie_recovery.py", "convert_rookiepy_cookies_to_storage_state"),
+        # The CLI browser-extraction probe path. Its converter choice is pinned
+        # to the routability predicates by design (see the module docstring in
+        # _auth/psidts_recovery.py), so it moves only with Stage 5's mode split.
+        ("cli/services/login/cookie_jar.py", "convert_rookiepy_cookies_to_storage_state"),
+        ("cli/services/login/cookie_jar.py", "extract_cookies_with_domains"),
+    }
+)
+
+
+def _call_sites() -> set[tuple[str, str]]:
+    """Return every ``(module, ratcheted function)`` call site under ``src/``."""
+    found: set[tuple[str, str]] = set()
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        if rel in _SANCTIONED:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Matches both ``f(...)`` and ``mod.f(...)`` so aliasing a module
+            # (the ``_auth_cookies.f(...)`` idiom used throughout _auth) does
+            # not slip past the gate.
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr
+                if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name in _RATCHETED:
+                found.add((rel, name))
+    return found
+
+
+def test_no_new_bespoke_cookie_conversions() -> None:
+    """New code converts through ``CookieJar``, not the raw free functions."""
+    new = _call_sites() - _GRANDFATHERED
+    assert not new, (
+        "New direct call(s) to a ratcheted cookie conversion:\n"
+        + "\n".join(f"  {module}: {func}()" for module, func in sorted(new))
+        + "\n\nUse notebooklm._auth.cookie_types.CookieJar instead — e.g.\n"
+        "  CookieJar.from_storage_state(state).to_domain_map()\n"
+        "  CookieJar.from_rookiepy(rows).to_httpx()\n"
+        "flatten_cookie_map has NO jar equivalent on purpose: the flat shape is\n"
+        "lossy (path collapsed, arbitrary same-tier winner — #369/#2054) and\n"
+        "legacy-only. For cookies on the wire use CookieJar.to_httpx().\n"
+        "If the call genuinely cannot route through the jar, say why in the PR "
+        "and add it to _GRANDFATHERED with that reason."
+    )
+
+
+def test_grandfathered_entries_are_all_live() -> None:
+    """The allowlist is shrink-only: a migrated entry must be deleted.
+
+    Without this, the list silently becomes a graveyard and stops describing
+    the real remaining debt — the failure mode that makes ratchets rot.
+    """
+    stale = _GRANDFATHERED - _call_sites()
+    assert not stale, (
+        "Grandfathered entries whose call no longer exists — delete them:\n"
+        + "\n".join(f"  {module}: {func}()" for module, func in sorted(stale))
+    )
+
+
+def test_cookie_jar_is_the_sanctioned_wrapper() -> None:
+    """``cookie_types`` really does delegate — the premise of the whole gate.
+
+    If a future edit reimplemented a conversion inline instead of delegating,
+    the ratchet would be pointing callers at a second implementation rather
+    than at the single owner.
+    """
+    source = (_SRC_ROOT / "_auth" / "cookie_types.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    delegated = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    missing = {"normalize_cookie_map", "build_cookie_jar"} - delegated
+    assert not missing, f"cookie_types.py stopped delegating to: {sorted(missing)}"

--- a/tests/unit/test_auth_cookie_types.py
+++ b/tests/unit/test_auth_cookie_types.py
@@ -1,0 +1,263 @@
+"""Unit + equivalence tests for the ADR-0031 Stage 1 ``CookieJar`` wrapper.
+
+The point of this stage is that ``CookieJar`` changes **nothing** — it gives
+the scattered cookie conversions and policy questions a type to hang off,
+while every decision still delegates to the free function that owns it. So the
+load-bearing tests here are the *equivalence* ones: for each method, assert the
+jar's answer is identical to the legacy call it wraps. If a future edit makes
+the jar diverge (e.g. reimplements a filter instead of delegating), these fail
+even though the jar's own behavior might look self-consistent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._auth import cookie_policy as _cookie_policy
+from notebooklm._auth import cookies as _auth_cookies
+from notebooklm._auth.cookie_types import Cookie, CookieJar
+
+
+def _storage_state() -> dict:
+    """A realistic multi-domain storage state, including rows that must drop."""
+    return {
+        "cookies": [
+            {"name": "SID", "value": "sid-base", "domain": ".google.com", "path": "/"},
+            # Same name, regional domain — lower priority tier than .google.com.
+            {"name": "SID", "value": "sid-regional", "domain": ".google.com.sg", "path": "/"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": 1800000000,
+                "httpOnly": True,
+                "secure": True,
+            },
+            {"name": "APISID", "value": "apisid", "domain": ".google.com", "path": "/"},
+            {"name": "SAPISID", "value": "sapisid", "domain": ".google.com", "path": "/"},
+            {"name": "LSID", "value": "lsid", "domain": "accounts.google.com", "path": "/"},
+            {"name": "OSID", "value": "osid", "domain": "notebook.google.com", "path": "/"},
+            # Must be dropped: not an allowlisted auth domain.
+            {"name": "TRACKER", "value": "nope", "domain": ".evil.example", "path": "/"},
+            # Must be dropped: malformed (no domain).
+            {"name": "BROKEN", "value": "x", "path": "/"},
+        ],
+        "origins": [],
+    }
+
+
+class TestConstructorEquivalence:
+    """Each constructor must agree with the legacy conversion it wraps."""
+
+    def test_from_storage_state_matches_extract_cookies_with_domains(self) -> None:
+        state = _storage_state()
+        jar = CookieJar.from_storage_state(state)
+        assert jar.to_domain_map() == _auth_cookies.extract_cookies_with_domains(
+            state, validate_required=False
+        )
+
+    def test_from_storage_state_applies_the_allowlist_filter(self) -> None:
+        """Non-auth domains and malformed rows drop, exactly as elsewhere."""
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert "TRACKER" not in jar.names()
+        assert "BROKEN" not in jar.names()
+
+    def test_from_rookiepy_matches_convert_then_extract(self) -> None:
+        rows = [
+            {
+                "name": "SID",
+                "value": "sid",
+                "domain": ".google.com",
+                "path": "/",
+                "http_only": True,
+                "secure": True,
+                "expires": None,
+            },
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "http_only": True,
+                "secure": True,
+                "expires": 1800000000,
+            },
+        ]
+        jar = CookieJar.from_rookiepy(rows)
+        legacy_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rows)
+        assert jar.to_domain_map() == _auth_cookies.extract_cookies_with_domains(
+            legacy_state, validate_required=False
+        )
+
+    def test_session_cookie_expiry_uses_the_canonical_internal_form(self) -> None:
+        """A session cookie is ``expires=None`` *in* the jar, ``-1`` *on the wire*.
+
+        Two representations, deliberately: ``normalize_cookie_expiry`` collapses
+        both ``None`` and the exact non-boolean int ``-1`` to ``None`` (see
+        ``_auth/cookie_semantics.py``), so ``None`` is the canonical in-memory
+        session form the whole auth layer already uses. Playwright's file format
+        spells the same thing ``-1``, which is what ``to_storage_state`` emits.
+        Pinning both halves keeps a future edit from "simplifying" one into the
+        other and silently turning session cookies into dated ones.
+        """
+        jar = CookieJar.from_rookiepy(
+            [{"name": "SID", "value": "s", "domain": ".google.com", "path": "/", "expires": None}]
+        )
+        assert next(iter(jar)).expires is None
+        assert jar.to_storage_state()["cookies"][0]["expires"] == -1
+
+    def test_dated_minus_one_is_not_a_session_cookie(self) -> None:
+        """``-1.0`` / ``"-1"`` are dated values, not the session sentinel.
+
+        The distinction is load-bearing enough that ``normalize_cookie_expiry``
+        calls it out explicitly; assert the jar inherits it rather than
+        flattening every -1-ish input to the sentinel.
+        """
+        jar = CookieJar.from_storage_state(
+            {"cookies": [{"name": "SID", "value": "s", "domain": ".google.com", "expires": -1.0}]}
+        )
+        assert next(iter(jar)).expires == -1.0
+        assert next(iter(jar)).expires is not None
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            pytest.param({("SID", ".google.com", "/"): "v"}, id="path-aware-3-tuple"),
+            pytest.param({("SID", ".google.com"): "v"}, id="legacy-2-tuple"),
+            pytest.param({"SID": "v"}, id="flat"),
+        ],
+    )
+    def test_from_domain_map_widens_every_legacy_shape(self, shape: dict) -> None:
+        """All three legacy map shapes widen exactly as normalize_cookie_map does."""
+        assert CookieJar.from_domain_map(shape).to_domain_map() == (
+            _auth_cookies.normalize_cookie_map(shape)
+        )
+
+
+class TestConverterEquivalence:
+    def test_no_flat_map_method_is_exposed(self) -> None:
+        """Flattening is legacy-only and must NOT be on the canonical type.
+
+        ``name -> value`` collapses the path component (#369) and picks an
+        arbitrary winner among same-tier domains, so the survivor changes when
+        storage_state is reordered (#2054) — ``AuthTokens.flat_cookies`` says as
+        much in its own docstring. Every remaining caller is back-compat. Pinned
+        as a test because "add a convenience to_flat_map()" is the obvious,
+        wrong-looking-right change for a future contributor to make.
+        """
+        assert not hasattr(CookieJar, "to_flat_map")
+
+    def test_to_httpx_matches_build_cookie_jar(self) -> None:
+        jar = CookieJar.from_storage_state(_storage_state())
+        expected = _auth_cookies.build_cookie_jar(cookies=jar.to_domain_map())
+        actual = jar.to_httpx()
+        as_identity = lambda j: sorted(  # noqa: E731
+            (c.name, c.domain, c.path, c.value) for c in j.jar
+        )
+        assert as_identity(actual) == as_identity(expected)
+
+    def test_storage_state_round_trip_is_stable(self) -> None:
+        """Re-reading a jar's own storage_state yields the same jar.
+
+        Not a claim that the ORIGINAL file round-trips — the allowlist filter
+        drops rows on the way in (documented in the module docstring). What
+        must hold is idempotence from the filtered view onward, so a jar that
+        is written and re-read is unchanged.
+        """
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert CookieJar.from_storage_state(jar.to_storage_state()) == jar
+
+    def test_to_storage_state_preserves_flags_and_expiry(self) -> None:
+        jar = CookieJar.from_storage_state(_storage_state())
+        row = next(c for c in jar.to_storage_state()["cookies"] if c["name"] == "__Secure-1PSIDTS")
+        assert row["expires"] == 1800000000
+        assert row["httpOnly"] is True
+        assert row["secure"] is True
+
+
+class TestQueryEquivalence:
+    def test_names_matches_cookie_names_from_storage(self) -> None:
+        """The jar's name set equals the legacy reader's — on the FILTERED view.
+
+        ``cookie_names_from_storage`` reads raw rows (no allowlist), so it is
+        compared against the jar's own storage_state, which is the filtered
+        view both then share.
+        """
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert jar.names() == _cookie_policy.cookie_names_from_storage(jar.to_storage_state())
+
+    def test_has_secondary_binding_matches_policy(self) -> None:
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert jar.has_secondary_binding() == _cookie_policy._has_valid_secondary_binding(
+            jar.names()
+        )
+        assert jar.has_secondary_binding() is True
+
+    def test_is_rotatable_matches_policy(self) -> None:
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert jar.is_rotatable() == _cookie_policy._has_rotatable_secondary_binding(jar.names())
+
+    def test_validate_required_passes_on_a_complete_jar(self) -> None:
+        CookieJar.from_storage_state(_storage_state()).validate_required()
+
+    def test_validate_required_raises_the_canonical_error(self) -> None:
+        """The raise is the policy's own error type, not a lookalike."""
+        state = _storage_state()
+        state["cookies"] = [c for c in state["cookies"] if c["name"] != "__Secure-1PSIDTS"]
+        jar = CookieJar.from_storage_state(state)
+        with pytest.raises(_cookie_policy.RequiredCookieValidationError) as excinfo:
+            jar.validate_required()
+        assert "__Secure-1PSIDTS" in str(excinfo.value)
+
+    def test_missing_hint_matches_policy(self) -> None:
+        state = _storage_state()
+        state["cookies"] = [c for c in state["cookies"] if c["name"] != "SID"]
+        jar = CookieJar.from_storage_state(state)
+        assert jar.missing_hint(browser_label="chrome") == _cookie_policy.missing_cookies_hint(
+            jar.names(), browser_label="chrome"
+        )
+
+
+class TestContainerAndSafety:
+    def test_empty_jar_is_falsy_and_empty(self) -> None:
+        jar = CookieJar()
+        assert not jar
+        assert len(jar) == 0
+        assert jar.names() == set()
+
+    def test_iteration_yields_cookie_objects(self) -> None:
+        jar = CookieJar.from_storage_state(_storage_state())
+        assert all(isinstance(c, Cookie) for c in jar)
+        assert len(jar) == len(jar.to_storage_state()["cookies"])
+
+    def test_cookie_identity_is_rfc6265_triple(self) -> None:
+        c = Cookie(name="SID", domain=".google.com", path="/x", value="v")
+        assert c.identity == ("SID", ".google.com", "/x")
+
+    def test_same_name_different_path_are_independent(self) -> None:
+        """#369: a path-distinct twin must not shadow its sibling."""
+        jar = CookieJar.from_storage_state(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "root", "domain": ".google.com", "path": "/"},
+                    {"name": "SID", "value": "scoped", "domain": ".google.com", "path": "/app"},
+                ]
+            }
+        )
+        assert len(jar.to_domain_map()) == 2
+
+    def test_repr_redacts_cookie_values(self) -> None:
+        """Values are credential-equivalent and must never reach logs/diffs."""
+        jar = CookieJar.from_storage_state(_storage_state())
+        rendered = repr(jar)
+        assert "sid-base" not in rendered
+        assert "psidts" not in rendered
+        assert "SID" in rendered  # names are safe and useful
+
+    def test_jar_is_immutable_from_the_outside(self) -> None:
+        """Mutating a derived map must not write through to the jar."""
+        jar = CookieJar.from_storage_state(_storage_state())
+        before = jar.names()
+        jar.to_domain_map()[("INJECTED", "x", "/")] = "v"
+        assert jar.names() == before


### PR DESCRIPTION
## Summary

ADR-0031 Stage 1, following #2146 (Stage 0).

A cookie currently lives in **six shapes** in the auth layer — raw Playwright row, rookiepy row, `DomainCookieMap`, `FlatCookieMap`, the legacy 2-tuple map, and the "sanitized entries" list — with the conversions between them as free functions any module can reach for. Because no type owns *"a set of auth cookies"*, the questions callers ask about one ("which names are here?", "is this usable?", "does it still bind?") have no method to be, so every flow re-derives them from the same scattered private helpers.

That ownerless fan-out is not cosmetic: it's precisely why #2139's boundary moves kept turning out unsafe. Three names that looked adapter-local (`build_cookie_jar`, `validate_with_recovery`, `extract_cookies_from_storage`) proved core-coupled through hidden helper sharing that a facade-level audit can't see.

**Adds `_auth/cookie_types.py`** with `Cookie` + `CookieJar` — completing the `cookie_semantics` / `cookie_policy` family. (Not named `cookie_jar`: `cli/services/login/cookie_jar.py` already exists and is a different thing.) Strictly a **wrapper**: every policy decision still delegates to the free function that owns it, so this stage changes no behavior and no public shape. `AuthTokens` keeps its dual `cookies`/`cookie_jar` fields until Stage 4.

### Deliberately no flat `name -> value` method

The flat shape collapses the path component (#369) and picks an arbitrary winner among same-tier domains, so the survivor changes when `storage_state` is reordered (#2054) — `AuthTokens.flat_cookies` calls itself *"lossy, and not correct for building a request"* in its own docstring. Every remaining `flatten_cookie_map` caller is back-compat (that public property, and `_update_cookie_input`'s write-back into a legacy-shaped caller dict). Putting it on the canonical type would import the footgun into the model meant to retire it, so it stays reachable only via the legacy free function; `to_httpx()` is the path- and domain-correct route for cookies on the wire. Pinned as a test, since "add a convenience `to_flat_map()`" is the plausible-looking wrong change for a future contributor.

### Tests are equivalence-first

Each method is asserted **equal to the legacy call it wraps**, so an edit that reimplements instead of delegating fails even if the jar stays self-consistent. Also pins the two-form expiry contract (`None` in memory, `-1` on the wire; `-1.0`/`"-1"` are *dated*, not session — a distinction `normalize_cookie_expiry` calls out explicitly) and the redacted `repr`.

### Ratchet

`tests/_guardrails/test_cookie_conversion_ratchet.py` blocks **new** bespoke conversion call sites, per this repo's block-new-debt convention — it does not force a migration. The five existing sites are grandfathered, each annotated with the stage that retires it, and the allowlist is shrink-only (a migrated entry *must* be deleted, asserted by its own test, so it can't rot into a graveyard). Verified to bite by injecting a new call into `_app/doctor.py`. It also found a call site my initial grep had missed (`_auth/tokens.py: flatten_cookie_map`).

## Test plan

- [x] Full suite green (13190 passed) — the one failure was the CLAUDE.md-freshness gate correctly demanding the new module be documented; fixed in its own commit across all three places `docs/architecture.md` tracks modules
- [x] `tests/_guardrails` green post-rebase (1288 passed)
- [x] Ratchet verified to catch a genuinely new call site, then restored
- [x] `ruff check .` / `ruff format --check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaeZfcxWvV3AuogrsiswrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical cookie and cookie-collection handling with support for storage-state, browser-cookie, and domain-based formats.
  * Added conversion to HTTP clients, domain maps, and filtered browser storage state.
  * Added cookie inspection and policy checks, including required-cookie validation, binding detection, rotation status, and recovery hints.
  * Added safe iteration, comparison, and redacted display of cookie collections.

* **Documentation**
  * Updated authentication architecture documentation to describe the new cookie types and capabilities.

* **Tests**
  * Added comprehensive coverage for conversions, filtering, validation, security, round trips, and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->