### PR TITLE
refactor(auth): split validate from heal (ADR-0031 Stage 2)

### DIFF
--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -114,6 +114,16 @@ introduce its objects and operations in independently shippable stages:
   so a successful rotation already established what the preflight would
   re-litigate) but it was previously invisible. It is now documented and pinned
   by a test that fails on the naive "just re-run `validate()`" refactor.
+
+  **Stage 2 does not adopt the Stage-1 `CookieJar` at this seam.** `validate`
+  and `heal` still take the raw rookiepy `list[dict[str, Any]]` rows. The
+  routing preflight deliberately reads those rows rather than the converted
+  state — the two shapes spell the http-only flag differently (`http_only` vs
+  `httpOnly`) — and the in-place mutation contract
+  `cli/services/login/refresh.py` depends on *is* a mutation of the caller's
+  row list. Moving this seam onto `CookieJar` is deferred to a later stage
+  rather than folded in here, so that the "identical behavior" claim this
+  stage rests on stays checkable.
 - **Stage 3: `ProfileStore`** — the eight free functions in
   `storage_writer.py` become transactions on one object owning the
   lock-acquire → read → mutate → atomic-write template they each hand-roll

--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -99,11 +99,21 @@ introduce its objects and operations in independently shippable stages:
   the footgun into the model meant to retire it, so it stays reachable only
   through the legacy free function, and `to_httpx()` is the path- and
   domain-correct route for cookies on the wire.
-- **Stage 2: `validate` / `heal` split** — `validate(jar) → ValidationResult`
-  is pure (extends the closed-enum reason
-  `RequiredCookieValidationError` grew in #2061); `heal` is the explicit
-  composition point whose only strategy today is the Stage-0 rotate.
-  `validate_with_recovery` survives as a compatibility wrapper.
+- **Stage 2: `validate` / `heal` split** — `validate(...) → ValidationResult`
+  is pure (no network, no mutation; wraps the closed-enum
+  `RequiredCookieValidationError` #2061 introduced rather than replacing it),
+  and `heal(...)` is the named seam whose only strategy today is the Stage-0
+  rotate. `validate_with_recovery` survives unchanged as the compatibility
+  wrapper — it has four first-party callers, a `RefreshDeps` injection seam,
+  an entry in the cross-boundary ledger, and an in-place mutation contract
+  `cli/services/login/refresh.py` depends on.
+
+  Splitting it surfaced an asymmetry the fused control flow hid: the post-heal
+  re-check runs the Tier-1 **presence** check only, never the RFC 6265 routing
+  preflight. That is intentional (the heal exists to mint a PSIDTS that routes,
+  so a successful rotation already established what the preflight would
+  re-litigate) but it was previously invisible. It is now documented and pinned
+  by a test that fails on the naive "just re-run `validate()`" refactor.
 - **Stage 3: `ProfileStore`** — the eight free functions in
   `storage_writer.py` become transactions on one object owning the
   lock-acquire → read → mutate → atomic-write template they each hand-roll

--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -99,10 +99,14 @@ introduce its objects and operations in independently shippable stages:
   the footgun into the model meant to retire it, so it stays reachable only
   through the legacy free function, and `to_httpx()` is the path- and
   domain-correct route for cookies on the wire.
-- **Stage 2: `validate` / `heal` split** — `validate(...) → ValidationResult`
-  is pure (no network, no mutation; wraps the closed-enum
-  `RequiredCookieValidationError` #2061 introduced rather than replacing it),
-  and `heal(...)` is the named seam whose only strategy today is the Stage-0
+- **Stage 2: `validate` / `heal` split** —
+  `validate(rows) → tuple[dict[str, Any], ValidationResult]` is pure (no
+  network, no mutation; wraps the closed-enum
+  `RequiredCookieValidationError` #2061 introduced rather than replacing it).
+  It returns the **converted storage state alongside** the result, not the
+  result alone, so a caller that needs the converted form — as every caller of
+  the wrapper does — does not pay for a second conversion. `heal(rows) → bool`
+  is the named seam whose only strategy today is the Stage-0
   rotate. `validate_with_recovery` survives unchanged as the compatibility
   wrapper — it has four first-party callers, a `RefreshDeps` injection seam,
   an entry in the cross-boundary ledger, and an in-place mutation contract

--- a/src/notebooklm/_auth/browser_cookie_recovery.py
+++ b/src/notebooklm/_auth/browser_cookie_recovery.py
@@ -49,9 +49,9 @@ class ValidationResult:
     error: _cookie_policy.RequiredCookieValidationError | None = None
 
     @property
-    def reason(self) -> Any:
+    def reason(self) -> _cookie_policy.RequiredCookieReason | None:
         """The closed-enum failure reason, or ``None`` when valid."""
-        return getattr(self.error, "reason", None)
+        return self.error.reason if self.error is not None else None
 
 
 def _check_required_present(storage_state: dict[str, Any]) -> ValidationResult:

--- a/src/notebooklm/_auth/browser_cookie_recovery.py
+++ b/src/notebooklm/_auth/browser_cookie_recovery.py
@@ -1,7 +1,32 @@
-"""In-memory browser-cookie validation and PSIDTS recovery bridge."""
+"""In-memory browser-cookie validation and PSIDTS recovery bridge.
+
+ADR-0031 Stage 2 splits the two verbs this module fuses. ``validate_with_recovery``
+did three things behind one name — check, then try to fix, then check again —
+with the outcome threaded through an ``initial`` variable across nested
+try/except/else. The name says the quiet part out loud: a function called
+"validate WITH RECOVERY" is two operations, and callers who want only the
+question ("is this set usable?") had no way to ask it without also triggering a
+network POST and an in-place mutation of their rows.
+
+The verbs are now separable:
+
+* :func:`validate` — **pure**. Converts, runs both checks, returns a
+  :class:`ValidationResult`. No network, no mutation.
+* :func:`heal` — the fix. Fires one in-memory ``RotateCookies`` rotation and
+  mutates ``rookiepy_cookies`` in place on success.
+* :func:`validate_with_recovery` — unchanged compat wrapper composing
+  ``validate → heal → re-check``, byte-identical in behavior to before.
+
+The wrapper keeps its exact signature, its in-place mutation contract (which
+``cli/services/login/refresh.py`` depends on and documents), and its
+``(storage_state, error_or_None)`` return shape. It has four first-party
+callers plus a ``RefreshDeps`` injection seam and an entry in the auth
+cross-boundary ledger, so it is not going anywhere.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from . import cookie_policy as _cookie_policy
@@ -9,34 +34,109 @@ from . import cookies as _auth_cookies
 from . import psidts_recovery as _recovery
 
 
-def validate_with_recovery(
-    rookiepy_cookies: list[dict[str, Any]],
-) -> tuple[dict[str, Any], ValueError | None]:
-    """Convert and validate rookiepy cookies, attempting one in-memory heal."""
-    storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
-    initial: _cookie_policy.RequiredCookieValidationError
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of a pure cookie-set validation.
+
+    ``error`` carries the policy's own
+    :class:`~notebooklm._auth.cookie_policy.RequiredCookieValidationError`
+    (a ``ValueError``) with the closed-enum ``reason`` it grew in #2061 — the
+    result object wraps that error rather than replacing it, so callers keep
+    the machine-readable reason and the exact message they had before.
+    """
+
+    ok: bool
+    error: _cookie_policy.RequiredCookieValidationError | None = None
+
+    @property
+    def reason(self) -> Any:
+        """The closed-enum failure reason, or ``None`` when valid."""
+        return getattr(self.error, "reason", None)
+
+
+def _check_required_present(storage_state: dict[str, Any]) -> ValidationResult:
+    """Tier-1 presence check against a converted storage state."""
     try:
         _auth_cookies.extract_cookies_from_storage(storage_state)
     except _cookie_policy.RequiredCookieValidationError as exc:
-        initial = exc
-    else:
-        entries = _auth_cookies._sanitized_auth_entries({"cookies": rookiepy_cookies})
-        try:
-            _auth_cookies._validate_routable_entries(
-                entries,
-                to_cookie=_recovery._rookiepy_entry_to_cookie,
-                require_routable=True,
-            )
-        except _cookie_policy.RequiredCookieValidationError as exc:
-            initial = exc
-        else:
-            return storage_state, None
+        return ValidationResult(ok=False, error=exc)
+    return ValidationResult(ok=True)
 
-    if not _recovery.recover_psidts_in_memory(rookiepy_cookies):
-        return storage_state, initial
-    storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
+
+def _check_routable(rookiepy_cookies: list[dict[str, Any]]) -> ValidationResult:
+    """RFC 6265 routing preflight against the RAW rookiepy rows.
+
+    Deliberately reads the raw rows, not the converted state: the two shapes
+    spell the http-only flag differently (``http_only`` vs ``httpOnly``), and
+    this check needs the rookiepy converter
+    (:func:`notebooklm._auth.psidts_recovery._rookiepy_entry_to_cookie`) so the
+    cookies it reasons about are the ones a request would actually send.
+    """
+    entries = _auth_cookies._sanitized_auth_entries({"cookies": rookiepy_cookies})
     try:
-        _auth_cookies.extract_cookies_from_storage(storage_state)
+        _auth_cookies._validate_routable_entries(
+            entries,
+            to_cookie=_recovery._rookiepy_entry_to_cookie,
+            require_routable=True,
+        )
+    except _cookie_policy.RequiredCookieValidationError as exc:
+        return ValidationResult(ok=False, error=exc)
+    return ValidationResult(ok=True)
+
+
+def validate(
+    rookiepy_cookies: list[dict[str, Any]],
+) -> tuple[dict[str, Any], ValidationResult]:
+    """Convert and validate browser rows. **Pure** — no network, no mutation.
+
+    Runs the presence check first and the routing preflight second, returning
+    the first failure. Returns the converted storage state alongside the result
+    so callers that need the converted form do not convert twice.
+    """
+    storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
+    present = _check_required_present(storage_state)
+    if not present.ok:
+        return storage_state, present
+    return storage_state, _check_routable(rookiepy_cookies)
+
+
+def heal(rookiepy_cookies: list[dict[str, Any]]) -> bool:
+    """Attempt one in-memory ``RotateCookies`` rotation to mint PSIDTS.
+
+    **Mutates ``rookiepy_cookies`` in place** on success, replacing rotated
+    rows by RFC 6265 identity — the contract
+    ``cli/services/login/refresh.py`` relies on. Returns whether the rotation
+    landed a usable ``__Secure-1PSIDTS``.
+
+    The only heal strategy that exists today. Naming it makes the recovery
+    ladder's shape (try cheap, escalate) extendable here rather than stopping
+    at one bespoke arm baked into a validator's name.
+    """
+    return _recovery.recover_psidts_in_memory(rookiepy_cookies)
+
+
+def validate_with_recovery(
+    rookiepy_cookies: list[dict[str, Any]],
+) -> tuple[dict[str, Any], ValueError | None]:
+    """Convert and validate rookiepy cookies, attempting one in-memory heal.
+
+    Compat wrapper over :func:`validate` + :func:`heal`, preserving the exact
+    prior behavior for its four first-party callers and the ``RefreshDeps``
+    injection seam.
+
+    One asymmetry is worth stating because the pre-split control flow hid it:
+    the post-heal re-check runs the **presence** check only, not the routing
+    preflight. That is intentional and unchanged — the heal exists precisely to
+    mint a PSIDTS that routes, so its success is what the rotation already
+    proved; re-running the preflight here would re-litigate the thing the heal
+    just established.
+    """
+    storage_state, result = validate(rookiepy_cookies)
+    if result.ok:
         return storage_state, None
-    except _cookie_policy.RequiredCookieValidationError as final:
-        return storage_state, final
+
+    if not heal(rookiepy_cookies):
+        return storage_state, result.error
+
+    healed_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rookiepy_cookies)
+    return healed_state, _check_required_present(healed_state).error

--- a/tests/unit/test_auth_validate_heal_split.py
+++ b/tests/unit/test_auth_validate_heal_split.py
@@ -1,0 +1,222 @@
+"""ADR-0031 Stage 2: the validate/heal split preserves the fused behavior.
+
+``validate_with_recovery`` fused three operations behind one name — check, try
+to fix, check again — with the outcome threaded through an ``initial`` variable
+across nested try/except/else. Stage 2 separates the verbs so a caller can ask
+the pure question ("is this set usable?") without also firing a network POST
+and mutating its rows.
+
+The wrapper has four first-party callers, a ``RefreshDeps`` injection seam, and
+an entry in the auth cross-boundary ledger, so "identical behavior" is the
+whole contract. These tests pin each arm of the composition — including the
+in-place mutation that ``cli/services/login/refresh.py`` depends on, and the
+deliberate post-heal asymmetry the pre-split control flow hid.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from notebooklm._auth import browser_cookie_recovery as bcr
+from notebooklm._auth import cookie_policy as _cookie_policy
+
+
+def _rows(*names: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": n,
+            "value": f"v-{n}",
+            "domain": ".google.com",
+            "path": "/",
+            "http_only": True,
+            "secure": True,
+            "expires": None,
+        }
+        for n in names
+    ]
+
+
+_COMPLETE = ("SID", "__Secure-1PSIDTS", "APISID", "SAPISID", "LSID")
+_NO_PSIDTS = ("SID", "APISID", "SAPISID", "LSID")
+
+
+class TestValidateIsPure:
+    """``validate`` answers the question without fixing or mutating anything."""
+
+    def test_valid_set_passes(self) -> None:
+        _, result = bcr.validate(_rows(*_COMPLETE))
+        assert result.ok is True
+        assert result.error is None
+        assert result.reason is None
+
+    @pytest.mark.parametrize(
+        "names",
+        [
+            pytest.param(_NO_PSIDTS, id="missing-psidts"),
+            pytest.param(("__Secure-1PSIDTS", "APISID", "SAPISID"), id="missing-sid"),
+            pytest.param((), id="empty"),
+        ],
+    )
+    def test_invalid_sets_carry_the_policy_error(self, names: tuple[str, ...]) -> None:
+        """The result wraps the policy's own error, keeping its closed-enum reason."""
+        _, result = bcr.validate(_rows(*names))
+        assert result.ok is False
+        assert isinstance(result.error, _cookie_policy.RequiredCookieValidationError)
+        assert result.reason is not None
+
+    def test_validate_never_mutates_the_caller_rows(self) -> None:
+        """The whole point of the split: asking must not change the answer.
+
+        ``validate_with_recovery`` mutates rows in place when it heals, which
+        is why callers could not previously ask a read-only question.
+        """
+        rows = _rows(*_NO_PSIDTS)
+        before = copy.deepcopy(rows)
+        bcr.validate(rows)
+        assert rows == before
+
+    def test_validate_never_fires_a_heal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No network from the pure path, even on a heal-eligible failure."""
+        called = False
+
+        def _boom(_rows: list[dict[str, Any]]) -> bool:
+            nonlocal called
+            called = True
+            return False
+
+        monkeypatch.setattr(bcr._recovery, "recover_psidts_in_memory", _boom)
+        bcr.validate(_rows(*_NO_PSIDTS))
+        assert called is False
+
+
+class TestWrapperComposition:
+    """``validate_with_recovery`` == validate → heal → re-check, unchanged."""
+
+    @staticmethod
+    def _stub_heal(succeed: bool, adds: tuple[str, ...] = ()):
+        def _heal(rows: list[dict[str, Any]]) -> bool:
+            if succeed:
+                rows.extend(_rows(*adds))
+            return succeed
+
+        return _heal
+
+    def test_valid_set_short_circuits_before_healing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(bcr._recovery, "recover_psidts_in_memory", self._stub_heal(False))
+        rows = _rows(*_COMPLETE)
+        _, error = bcr.validate_with_recovery(rows)
+        assert error is None
+
+    def test_successful_heal_clears_the_error_and_mutates_in_place(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The in-place mutation is a contract, not an implementation detail.
+
+        ``cli/services/login/refresh.py`` documents and depends on the healed
+        rows being visible to the caller afterward.
+        """
+        monkeypatch.setattr(
+            bcr._recovery,
+            "recover_psidts_in_memory",
+            self._stub_heal(True, ("__Secure-1PSIDTS",)),
+        )
+        rows = _rows(*_NO_PSIDTS)
+        state, error = bcr.validate_with_recovery(rows)
+        assert error is None
+        assert "__Secure-1PSIDTS" in {c["name"] for c in rows}
+        assert "__Secure-1PSIDTS" in {c["name"] for c in state["cookies"]}
+
+    def test_heal_that_supplies_nothing_useful_still_reports_invalid(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A heal returning True is not proof the set became usable."""
+        monkeypatch.setattr(
+            bcr._recovery, "recover_psidts_in_memory", self._stub_heal(True, ("NID",))
+        )
+        _, error = bcr.validate_with_recovery(_rows(*_NO_PSIDTS))
+        assert isinstance(error, _cookie_policy.RequiredCookieValidationError)
+
+    def test_declined_heal_preserves_the_original_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(bcr._recovery, "recover_psidts_in_memory", self._stub_heal(False))
+        rows = _rows(*_NO_PSIDTS)
+        before = copy.deepcopy(rows)
+        _, error = bcr.validate_with_recovery(rows)
+        assert isinstance(error, _cookie_policy.RequiredCookieValidationError)
+        assert rows == before  # a declined heal leaves the rows untouched
+
+    def test_post_heal_recheck_is_presence_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pins the asymmetry the pre-split control flow hid.
+
+        After a successful heal the wrapper re-runs the Tier-1 **presence**
+        check only — never the RFC 6265 routing preflight. That is intentional
+        and unchanged: the heal exists to mint a PSIDTS that routes, so a
+        successful rotation already established what the preflight would
+        re-litigate.
+
+        The scenario has to reach the routing check to prove anything, so it
+        uses a host-scoped ``__Secure-1PSIDTS``: present (Tier-1 passes) but
+        unroutable to ``accounts.google.com`` (``psidts_unroutable``). The
+        routing check therefore runs exactly once, pre-heal — and must NOT run
+        again afterward. A naive "just re-run validate()" refactor would make
+        this two and fail here.
+        """
+        rows = _rows("SID", "APISID", "SAPISID", "LSID")
+        rows.append(
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "v-psidts",
+                "domain": "notebook.google.com",  # host-scoped => unroutable
+                "path": "/",
+                "http_only": True,
+                "secure": True,
+                "expires": None,
+            }
+        )
+        _, pre = bcr.validate(list(rows))
+        assert pre.ok is False and pre.reason == "psidts_unroutable", (
+            "fixture no longer reaches the routing check; the test would be vacuous"
+        )
+
+        # The heal supplies a properly-scoped PSIDTS, as a real rotation would.
+        monkeypatch.setattr(
+            bcr._recovery,
+            "recover_psidts_in_memory",
+            self._stub_heal(True, ("__Secure-1PSIDTS",)),
+        )
+        calls = {"n": 0}
+        real_check = bcr._check_routable
+
+        def _counting(rows_: list[dict[str, Any]]) -> bcr.ValidationResult:
+            calls["n"] += 1
+            return real_check(rows_)
+
+        monkeypatch.setattr(bcr, "_check_routable", _counting)
+        _, error = bcr.validate_with_recovery(rows)
+
+        assert error is None, "the heal supplied a routable PSIDTS; the set is usable"
+        assert calls["n"] == 1, (
+            f"routing preflight ran {calls['n']}x — it must run once pre-heal and "
+            "never again post-heal (see the wrapper's asymmetry note)"
+        )
+
+
+class TestHealIsSeparable:
+    def test_heal_delegates_to_the_single_rotation_implementation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``heal`` is a named seam over the one in-memory rotation (Stage 0)."""
+        seen: list[list[dict[str, Any]]] = []
+
+        def _spy(rows: list[dict[str, Any]]) -> bool:
+            seen.append(rows)
+            return True
+
+        monkeypatch.setattr(bcr._recovery, "recover_psidts_in_memory", _spy)
+        rows = _rows(*_NO_PSIDTS)
+        assert bcr.heal(rows) is True
+        assert seen == [rows]


### PR DESCRIPTION
## Summary

ADR-0031 Stage 2. **Stacked on #2148** (Stage 1) — base is `refactor/cookiejar-stage1`, so this diff shows only the Stage 2 change. Will retarget to `main` once #2148 merges.

`validate_with_recovery` fused three operations behind one name — check, try to fix, check again — threading the outcome through an `initial` variable across nested try/except/else. The name says the quiet part out loud: *"validate WITH RECOVERY"* is two verbs, and a caller who wanted only the question ("is this cookie set usable?") had no way to ask it without also firing a network POST and mutating their rows in place.

```
validate(rows) -> (state, ValidationResult)   pure — no network, no mutation
heal(rows)     -> bool                        the fix — mutates in place
validate_with_recovery(rows)                  unchanged compat wrapper
```

The wrapper keeps its **exact** signature, return shape, and in-place mutation contract. It has four first-party callers, a `RefreshDeps` injection seam, and an entry in `AUTH_CROSS_BOUNDARY_NAMES`, so identical behavior is the whole contract.

## The asymmetry this surfaced

Splitting the verbs exposed something the fused control flow hid: **the post-heal re-check runs the Tier-1 presence check only, never the RFC 6265 routing preflight.**

That's intentional — the heal exists to mint a PSIDTS that *routes*, so a successful rotation already established what the preflight would re-litigate — but it was previously invisible, discoverable only by tracing which `except` arm you landed in. It's now stated in the wrapper's docstring and pinned by a test.

Pinning it required care: the obvious test scenario never reaches the routing check at all (the presence check fails first), so a naive version passes vacuously. The test uses a **host-scoped `__Secure-1PSIDTS`** — present, so Tier-1 passes, but unroutable to `accounts.google.com` (`psidts_unroutable`) — and asserts the routing check runs exactly once. Mutation-tested: the naive "just re-run `validate()`" refactor fails it with `routing preflight ran 2x`.

## Verification

**Differential-tested against `origin/main`** — every arm, comparing storage state, error type, error message, closed-enum reason, *and* row mutation:

| case | result |
|---|---|
| complete / missing-PSIDTS / missing-SID / no-binding / empty | identical |
| heal-succeeds / heal-supplies-junk / heal-declines | identical |

- [x] Full suite: 13203 passed, 81 skipped, 3 xfailed
- [x] `tests/_guardrails` green (1250)
- [x] Asymmetry test mutation-verified against the naive refactor
- [x] `ruff check` / `ruff format --check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaeZfcxWvV3AuogrsiswrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer authentication validation results with explicit success status and failure reasons.
  * Added separate recovery handling for invalid browser cookies.
  * Preserved compatibility with the existing recovery workflow and return behavior.

* **Bug Fixes**
  * Improved recovery flow so successful repairs clear previous validation errors.
  * Added safer post-recovery checks to confirm required cookie presence.

* **Documentation**
  * Updated authentication architecture guidance covering validation, recovery, compatibility, and routing checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->