### PR TITLE
fix(auth): preserve sameSite through CookieJar + close ratchet bypasses

### DIFF
--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -85,7 +85,9 @@ introduce its objects and operations in independently shippable stages:
   the free function that owns it, pinned by equivalence tests. A shrink-only
   ratchet (`tests/_guardrails/test_cookie_conversion_ratchet.py`) blocks *new*
   bespoke conversion call sites; the five existing ones are grandfathered with
-  the stage that retires each, and the allowlist may only shrink.
+  the stage that retires each, pinned at their measured call counts so a module
+  already on the list cannot grow a second one for free, and the allowlist may
+  only shrink.
 
   **The flat `name -> value` shape is deliberately not on the type.** It
   collapses the path component (#369) and picks an arbitrary winner among

--- a/src/notebooklm/_auth/cookie_types.py
+++ b/src/notebooklm/_auth/cookie_types.py
@@ -54,6 +54,10 @@ class Cookie:
     distinct domains or paths are independent entries, never one shadowing the
     other (issue #369). ``expires`` is the Playwright epoch-seconds convention
     where ``-1`` means a session cookie.
+
+    ``same_site`` is carried rather than defaulted: dropping a stored value is
+    the exact regression ``storage._preserved_same_site`` exists to prevent, so
+    ``None`` here means "the row carried none", never "assume ``None``".
     """
 
     name: str
@@ -63,6 +67,7 @@ class Cookie:
     expires: float | int | None = None
     http_only: bool = False
     secure: bool = False
+    same_site: str | None = None
 
     @property
     def identity(self) -> tuple[str, str, str]:
@@ -165,21 +170,23 @@ class CookieJar:
         Reproduces the jar's *filtered* view, not any original file — see the
         module docstring. ``origins`` is empty: this type models cookies only.
         """
-        return {
-            "cookies": [
-                {
-                    "name": c.name,
-                    "value": c.value,
-                    "domain": c.domain,
-                    "path": c.path,
-                    "expires": -1 if c.expires is None else c.expires,
-                    "httpOnly": c.http_only,
-                    "secure": c.secure,
-                }
-                for c in self._cookies
-            ],
-            "origins": [],
-        }
+        rows: list[dict[str, Any]] = []
+        for c in self._cookies:
+            row: dict[str, Any] = {
+                "name": c.name,
+                "value": c.value,
+                "domain": c.domain,
+                "path": c.path,
+                "expires": -1 if c.expires is None else c.expires,
+                "httpOnly": c.http_only,
+                "secure": c.secure,
+            }
+            # Emitted only when the source row carried one, so this never
+            # invents a value the way a bare default would.
+            if c.same_site is not None:
+                row["sameSite"] = c.same_site
+            rows.append(row)
+        return {"cookies": rows, "origins": []}
 
     # -- queries -----------------------------------------------------------
 
@@ -243,6 +250,7 @@ def _cookie_from_entry(entry: Mapping[str, Any]) -> Cookie:
     ``_sanitized_auth_entries`` / ``sanitize_cookie_entry``: identity and value
     fields are trusted here, and ``path`` has already been defaulted to ``/``.
     """
+    same_site = entry.get("sameSite", entry.get("same_site"))
     return Cookie(
         name=entry["name"],
         domain=entry["domain"],
@@ -251,4 +259,5 @@ def _cookie_from_entry(entry: Mapping[str, Any]) -> Cookie:
         expires=entry.get("expires"),
         http_only=bool(entry.get("httpOnly", entry.get("http_only", False))),
         secure=bool(entry.get("secure", False)),
+        same_site=same_site if isinstance(same_site, str) else None,
     )

--- a/tests/_guardrails/test_cookie_conversion_ratchet.py
+++ b/tests/_guardrails/test_cookie_conversion_ratchet.py
@@ -17,14 +17,20 @@ Sanctioned homes (never flagged):
 * ``_auth/cookies.py`` — where these functions are defined and compose.
 * ``_auth/cookie_types.py`` — the wrapper whose whole job is delegating to them.
 
-Everything else is in :data:`_GRANDFATHERED`, which is **shrink-only**: an entry
-whose call has since moved to ``CookieJar`` must be deleted (asserted by
-``test_grandfathered_entries_are_all_live``), so the list can only get shorter.
+Everything else is in :data:`_GRANDFATHERED`, which pins each surviving call
+site at its **measured call count** and is **shrink-only** in both directions:
+a count may never rise (``test_no_new_bespoke_cookie_conversions``), and one
+that no longer matches reality must be lowered or deleted
+(``test_grandfathered_entries_are_all_live``). Counting, rather than merely
+listing the pairs, is what stops a module already on the list from growing a
+second bespoke call for free.
 """
 
 from __future__ import annotations
 
 import ast
+from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -46,61 +52,121 @@ _RATCHETED = frozenset(
 #: Modules that legitimately call these directly.
 _SANCTIONED = frozenset({"_auth/cookies.py", "_auth/cookie_types.py"})
 
-#: (module path relative to ``src/notebooklm``, function) pairs predating the
-#: ratchet. SHRINK-ONLY — never add. Each is a candidate for a later stage.
-_GRANDFATHERED: frozenset[tuple[str, str]] = frozenset(
-    {
-        # AuthTokens.__post_init__ widens legacy caller-supplied maps, and the
-        # back-compat flat-map property flattens them back. Both retire in
-        # ADR-0031 Stage 4, when the dual cookies/cookie_jar fields collapse
-        # into a single CookieJar and these become jar methods.
-        ("_auth/tokens.py", "normalize_cookie_map"),
-        ("_auth/tokens.py", "flatten_cookie_map"),
-        # The L3 heal converts rookiepy rows twice (before and after recovery).
-        # Retires with the Stage 2 validate/heal split.
-        ("_auth/browser_cookie_recovery.py", "convert_rookiepy_cookies_to_storage_state"),
-        # The CLI browser-extraction probe path. Its converter choice is pinned
-        # to the routability predicates by design (see the module docstring in
-        # _auth/psidts_recovery.py), so it moves only with Stage 5's mode split.
-        ("cli/services/login/cookie_jar.py", "convert_rookiepy_cookies_to_storage_state"),
-        ("cli/services/login/cookie_jar.py", "extract_cookies_with_domains"),
+#: (module path relative to ``src/notebooklm``, function) -> the number of calls
+#: measured when the ratchet landed. SHRINK-ONLY — never add a pair, never raise
+#: a count. Pinning the *count* rather than just the pair matters: a bare pair
+#: would let an already-listed module grow a second, third … bespoke call for
+#: free, which is the same debt the gate exists to stop. Each entry is a
+#: candidate for a later stage.
+_GRANDFATHERED: dict[tuple[str, str], int] = {
+    # AuthTokens.__post_init__ widens legacy caller-supplied maps, and the
+    # back-compat flat-map property flattens them back. Both retire in
+    # ADR-0031 Stage 4, when the dual cookies/cookie_jar fields collapse
+    # into a single CookieJar and these become jar methods.
+    ("_auth/tokens.py", "normalize_cookie_map"): 1,
+    ("_auth/tokens.py", "flatten_cookie_map"): 1,
+    # The L3 heal converts rookiepy rows twice (before and after recovery).
+    # Retires with the Stage 2 validate/heal split.
+    ("_auth/browser_cookie_recovery.py", "convert_rookiepy_cookies_to_storage_state"): 2,
+    # The CLI browser-extraction probe path. Its converter choice is pinned
+    # to the routability predicates by design (see the module docstring in
+    # _auth/psidts_recovery.py), so it moves only with Stage 5's mode split.
+    ("cli/services/login/cookie_jar.py", "convert_rookiepy_cookies_to_storage_state"): 1,
+    ("cli/services/login/cookie_jar.py", "extract_cookies_with_domains"): 1,
+}
+
+
+def _renamed_imports(tree: ast.AST) -> dict[str, str]:
+    """Map local binding -> ratcheted function for ``from … import f as g``.
+
+    Rename-on-import is a live idiom in this package (``_auth/storage_writer.py``
+    imports ``_atomic_write_json_unchecked as atomic_write_json``), so without
+    this the gate would have a real bypass, not a theoretical one: bind the
+    function to any other name and the call node no longer carries a ratcheted
+    one. Resolved back to the canonical name so ``_GRANDFATHERED`` stays keyed
+    on the real function regardless of what a caller called it.
+    """
+    return {
+        alias.asname: alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+        if alias.name in _RATCHETED and alias.asname
     }
-)
 
 
-def _call_sites() -> set[tuple[str, str]]:
-    """Return every ``(module, ratcheted function)`` call site under ``src/``."""
-    found: set[tuple[str, str]] = set()
+def _module_call_sites(rel: str, tree: ast.AST) -> Counter[tuple[str, str]]:
+    """Count the ``(module, ratcheted function)`` calls in one module."""
+    renamed = _renamed_imports(tree)
+    found: Counter[tuple[str, str]] = Counter()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Matches both ``f(...)`` and ``mod.f(...)`` so aliasing a module
+        # (the ``_auth_cookies.f(...)`` idiom used throughout _auth) does
+        # not slip past the gate.
+        name = (
+            func.id
+            if isinstance(func, ast.Name)
+            else func.attr
+            if isinstance(func, ast.Attribute)
+            else None
+        )
+        if name is None:
+            continue
+        resolved = renamed.get(name, name)
+        if resolved in _RATCHETED:
+            found[(rel, resolved)] += 1
+    return found
+
+
+def _call_sites() -> Counter[tuple[str, str]]:
+    """Count every ``(module, ratcheted function)`` call under ``src/``."""
+    found: Counter[tuple[str, str]] = Counter()
     for path in sorted(_SRC_ROOT.rglob("*.py")):
         rel = path.relative_to(_SRC_ROOT).as_posix()
         if rel in _SANCTIONED:
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            # Matches both ``f(...)`` and ``mod.f(...)`` so aliasing a module
-            # (the ``_auth_cookies.f(...)`` idiom used throughout _auth) does
-            # not slip past the gate.
-            name = (
-                func.id
-                if isinstance(func, ast.Name)
-                else func.attr
-                if isinstance(func, ast.Attribute)
-                else None
-            )
-            if name in _RATCHETED:
-                found.add((rel, name))
+        found += _module_call_sites(rel, ast.parse(path.read_text(encoding="utf-8")))
     return found
+
+
+def _grown(measured: Mapping[tuple[str, str], int]) -> dict[tuple[str, str], tuple[int, int]]:
+    """Sites over their pinned count → ``{site: (measured, ceiling)}``.
+
+    A site absent from :data:`_GRANDFATHERED` has a ceiling of 0, so a brand-new
+    call site and an extra call in an already-listed module fail the same way.
+    """
+    return {
+        site: (count, _GRANDFATHERED.get(site, 0))
+        for site, count in measured.items()
+        if count > _GRANDFATHERED.get(site, 0)
+    }
+
+
+def _slack(measured: Mapping[tuple[str, str], int]) -> dict[tuple[str, str], tuple[int, int]]:
+    """Entries pinned above reality → ``{site: (measured, ceiling)}``.
+
+    Covers both a fully migrated entry (measured 0) and a partially migrated
+    one, so the pin always describes the debt that is actually there.
+    """
+    return {
+        site: (measured.get(site, 0), ceiling)
+        for site, ceiling in _GRANDFATHERED.items()
+        if measured.get(site, 0) < ceiling
+    }
 
 
 def test_no_new_bespoke_cookie_conversions() -> None:
     """New code converts through ``CookieJar``, not the raw free functions."""
-    new = _call_sites() - _GRANDFATHERED
-    assert not new, (
+    grown = _grown(_call_sites())
+    assert not grown, (
         "New direct call(s) to a ratcheted cookie conversion:\n"
-        + "\n".join(f"  {module}: {func}()" for module, func in sorted(new))
+        + "\n".join(
+            f"  {module}: {func}() — {count} call(s), pinned at {ceiling}"
+            for (module, func), (count, ceiling) in sorted(grown.items())
+        )
         + "\n\nUse notebooklm._auth.cookie_types.CookieJar instead — e.g.\n"
         "  CookieJar.from_storage_state(state).to_domain_map()\n"
         "  CookieJar.from_rookiepy(rows).to_httpx()\n"
@@ -112,17 +178,60 @@ def test_no_new_bespoke_cookie_conversions() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("from x import normalize_cookie_map\nnormalize_cookie_map({})\n", id="bare"),
+        pytest.param("import x\nx.normalize_cookie_map({})\n", id="module-attr"),
+        pytest.param(
+            "from x import normalize_cookie_map as _n\n_n({})\n",
+            id="renamed-on-import",
+        ),
+    ],
+)
+def test_every_call_spelling_is_caught(source: str) -> None:
+    """A ratcheted call counts however it is spelled, including renamed.
+
+    The rename form is the one a name-only scan misses, and it is the spelling
+    this package already uses elsewhere — so it is checked here rather than
+    assumed impossible.
+    """
+    assert _module_call_sites("_auth/probe.py", ast.parse(source)) == Counter(
+        {("_auth/probe.py", "normalize_cookie_map"): 1}
+    )
+
+
 def test_grandfathered_entries_are_all_live() -> None:
-    """The allowlist is shrink-only: a migrated entry must be deleted.
+    """The allowlist is shrink-only: a migrated call must lower its pin.
 
     Without this, the list silently becomes a graveyard and stops describing
-    the real remaining debt — the failure mode that makes ratchets rot.
+    the real remaining debt — the failure mode that makes ratchets rot. Slack
+    is as bad as staleness: a pin of 2 against 1 remaining call is headroom for
+    a future call to reappear for free.
     """
-    stale = _GRANDFATHERED - _call_sites()
-    assert not stale, (
-        "Grandfathered entries whose call no longer exists — delete them:\n"
-        + "\n".join(f"  {module}: {func}()" for module, func in sorted(stale))
+    slack = _slack(_call_sites())
+    assert not slack, (
+        "Grandfathered entries pinned above the calls that remain — lower the "
+        "count, or delete the entry if it reached 0:\n"
+        + "\n".join(
+            f"  {module}: {func}() — {count} call(s) left, pinned at {ceiling}"
+            for (module, func), (count, ceiling) in sorted(slack.items())
+        )
     )
+
+
+def test_an_extra_call_in_a_grandfathered_module_is_caught() -> None:
+    """Being on the list buys the measured calls, not unlimited ones."""
+    site = ("_auth/tokens.py", "normalize_cookie_map")
+    assert _grown({site: _GRANDFATHERED[site] + 1})
+    assert not _grown({site: _GRANDFATHERED[site]})
+
+
+def test_a_migrated_call_must_lower_its_pin() -> None:
+    """Shrink-only in the other direction: reality drops, the pin must follow."""
+    site = ("_auth/browser_cookie_recovery.py", "convert_rookiepy_cookies_to_storage_state")
+    assert _slack({site: _GRANDFATHERED[site] - 1})
+    assert not _slack(dict(_GRANDFATHERED))
 
 
 def test_cookie_jar_is_the_sanctioned_wrapper() -> None:

--- a/tests/unit/test_auth_cookie_types.py
+++ b/tests/unit/test_auth_cookie_types.py
@@ -175,6 +175,57 @@ class TestConverterEquivalence:
         assert row["httpOnly"] is True
         assert row["secure"] is True
 
+    def test_to_storage_state_preserves_same_site(self) -> None:
+        """A stored ``sameSite`` survives the jar.
+
+        Losing one is the regression ``storage._preserved_same_site`` exists to
+        prevent, and ``convert_rookiepy_cookies_to_storage_state`` documents
+        preserving it — so a jar that silently dropped it would reintroduce the
+        bug through the type meant to become canonical.
+        """
+        jar = CookieJar.from_storage_state(
+            {
+                "cookies": [
+                    {
+                        "name": "SID",
+                        "value": "s",
+                        "domain": ".google.com",
+                        "path": "/",
+                        "sameSite": "Lax",
+                    }
+                ]
+            }
+        )
+        assert next(iter(jar)).same_site == "Lax"
+        assert jar.to_storage_state()["cookies"][0]["sameSite"] == "Lax"
+
+    def test_to_storage_state_omits_same_site_when_the_row_had_none(self) -> None:
+        """Absent stays absent: the jar must not invent a default.
+
+        ``_preserved_same_site`` treats a missing value as "nothing to keep";
+        emitting an invented ``"None"`` here would turn that into a real
+        downgrade on the next merge.
+        """
+        jar = CookieJar.from_storage_state(
+            {"cookies": [{"name": "SID", "value": "s", "domain": ".google.com", "path": "/"}]}
+        )
+        assert next(iter(jar)).same_site is None
+        assert "sameSite" not in jar.to_storage_state()["cookies"][0]
+
+    def test_from_rookiepy_matches_the_converters_same_site(self) -> None:
+        """The jar route and the legacy converter agree on ``sameSite``."""
+        rows = [
+            {
+                "name": "SID",
+                "value": "s",
+                "domain": ".google.com",
+                "path": "/",
+                "sameSite": "Strict",
+            }
+        ]
+        legacy = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rows)
+        assert CookieJar.from_rookiepy(rows).to_storage_state() == legacy
+
 
 class TestQueryEquivalence:
     def test_names_matches_cookie_names_from_storage(self) -> None:


### PR DESCRIPTION
## Summary

Two review fixes for #2148 (ADR-0031 Stage 1) that were **lost to a merge race** — #2148 was merged at its old head `caf1f4fa` while these were still in CI, so main currently carries both defects. Same race that cost #2146 a test (rescued as #2147).

Neither is speculative; both were found by review on #2148 and verified by injection.

### 1. `CookieJar` silently dropped `sameSite` (data loss)

`Cookie` had no `same_site` field, so `to_storage_state()` erased it:

```python
convert_rookiepy_cookies_to_storage_state(rows)      # {..., 'sameSite': 'Strict'}
CookieJar.from_rookiepy(rows).to_storage_state()     # sameSite gone
```

The sanitized row *does* carry `sameSite` (`validate_cookie_shape` does `dict(entry)`); it was dropped specifically by `_cookie_from_entry`. This is precisely the regression `storage._preserved_same_site` exists to prevent, and the converter documents preserving it. Latent today because no production caller uses `to_storage_state()` — but this type is slated to become canonical in ADR-0031 Stage 4, and the existing test already pinned `httpOnly`/`secure`/`expires`, so `sameSite` was the one flag with a dedicated protection mechanism that went unpinned.

`to_storage_state()` emits `sameSite` **only when not None**, so it never invents a value — an invented one would read as a real downgrade to the next `_preserved_same_site` merge. Now `CookieJar.from_rookiepy(rows).to_storage_state() == convert_rookiepy_cookies_to_storage_state(rows)` exactly, pinned by a jar-vs-converter equality test.

### 2. The conversion ratchet was bypassable two ways

- **Rename-on-import**: the AST scan matched `ast.Name.id`/`ast.Attribute.attr` against the literal name, so `from .cookies import normalize_cookie_map as _n; _n(x)` was invisible. Not theoretical — this package already uses that idiom (`storage_writer.py`, `browser_capture.py`). Renamed imports are now resolved back to the canonical name.
- **Per-module pair keying**: `_GRANDFATHERED` held `(module, function)` pairs, so a listed module could grow a second bespoke call for free. Also not theoretical — `browser_cookie_recovery.py` already had **two** `convert_rookiepy_cookies_to_storage_state` calls, and the entry's own comment said "converts rookiepy rows twice" while the gate pinned nothing. It now pins **measured counts**, shrink-only in both directions (counts may never rise; a pin above reality must be lowered or deleted), mirroring `test_string_patch_ratchet.py`'s ceiling/anti-slack/anti-stale shape.

## Test plan

- [x] Ratchet + cookie_types tests: 35 passed against main
- [x] `sameSite` preserved through the jar and equal to the legacy converter
- [x] Injection-tested both bypasses: an extra `normalize_cookie_map` call in `tokens.py` reds with `2 call(s), pinned at 1`; an aliased import in a new module reds with `1 call(s), pinned at 0`
- [x] Full suite / `tests/_guardrails` / mypy / ruff clean (verified on the source branch before the race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaeZfcxWvV3AuogrsiswrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved cookie `SameSite` settings during authentication state storage and restoration.
  * Continued omitting `SameSite` when no value is provided, preventing unintended cookie changes.
  * Improved compatibility when reading cookie data that uses different field naming conventions.
  * Ensured cookie conversions consistently retain existing values across supported authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->