### PR TITLE
refactor(auth): storage-write transaction template (ADR-0031 Stage 3)

### DIFF
--- a/docs/adr/0031-credential-tier-auth-model.md
+++ b/docs/adr/0031-credential-tier-auth-model.md
@@ -128,11 +128,47 @@ introduce its objects and operations in independently shippable stages:
   row list. Moving this seam onto `CookieJar` is deferred to a later stage
   rather than folded in here, so that the "identical behavior" claim this
   stage rests on stays checkable.
-- **Stage 3: `ProfileStore`** — the eight free functions in
-  `storage_writer.py` become transactions on one object owning the
-  lock-acquire → read → mutate → atomic-write template they each hand-roll
-  today. Method names stay initially; `persist_minted_jar`'s #2108
-  ownership-guard and write-ordering semantics are preserved bit-for-bit.
+- **Stage 3: the storage-write transaction template** — the writers in
+  `storage_writer.py` each hand-roll the same preamble (secure the parent dir,
+  derive the lock path, take the bounded lock, branch on held).
+  `storage_transaction.in_storage_transaction` owns it; method names and
+  `persist_minted_jar`'s #2108 ownership-guard and write-ordering are preserved
+  bit-for-bit.
+
+  **Investigation corrected this stage's premise.** The writers are not uniform,
+  and the plan above ("one object") would have flattened a real distinction.
+  On lock-unavailable there are **two intents**:
+
+  - *must-know* — the write mattered and a caller proceeding as though it
+    happened is wrong (five writers);
+  - *tolerable* — the write was cleanup and a miss degrades gracefully (one).
+
+  Must-know has **two mechanisms**, and the split is forced by the writers'
+  return channels rather than by intent: `-> None` has nowhere to report, and
+  `update_account_metadata`'s `-> bool` already spends `False` on "deliberately
+  skipped (`only_if_absent`)", so both raise; the two full-replace writers have
+  rich outcome enums with room for a distinct `LOCK_UNAVAILABLE`, so they
+  report. Each choice is locally forced; the inconsistency is one level up, in
+  writers doing morally identical things having different return types.
+
+  `merge_cookie_delta` is exempt by design, not oversight — it takes the
+  *blocking* `_file_lock_exclusive` and skips the parent-dir prep (it only
+  updates a file that already exists). Different operation, not a variant.
+
+  Two follow-ups this surfaced, deliberately **not** taken here:
+
+  1. *Unify the must-know channel.* Giving every must-know writer a rich outcome
+     type would collapse raise-vs-report to one mechanism, but it is a breaking
+     change for callers that today catch `OSError`/`TimeoutError` around
+     `persist_minted_jar` and `update_account_metadata` — it needs the
+     deprecation runway, not a refactor stage.
+  2. *Revisit the tolerable case.* `clear_in_band_account`'s swallow is
+     justified functionally (the legacy reader still resolves the record), but
+     the operation is **privacy**-motivated — "a stale key must not leave the
+     account email at rest". A swallowed failure leaves exactly that email on
+     disk. The swallow is defended on a different axis than the one that
+     matters most; promoting it to must-know would let a best-effort cleanup
+     fail a caller, so it wants its own decision rather than a silent change.
 - **Stage 4: `AuthTokens.cookies: CookieJar`** — the dual
   `cookies`/`cookie_jar` fields collapse. The only stage touching documented
   public API; requires a `Mapping`-compatible shim or a deprecation runway

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -526,6 +526,7 @@ the default dependency.
 | [`_auth/paths.py`](../src/notebooklm/_auth/paths.py) | Storage paths and filesystem helpers. |
 | [`_auth/storage.py`](../src/notebooklm/_auth/storage.py) | Profile/state persistence on disk: cookie snapshot/delta CAS math + the file-lock primitive; `save_cookies_to_storage` is the monkeypatchable delegate seam onto `storage_writer`. |
 | [`_auth/storage_writer.py`](../src/notebooklm/_auth/storage_writer.py) | Canonical `storage_state.json` writer (ADR-0029): the only `_auth` module that performs the atomic write; intent-shaped API (CAS merge, account metadata, master-token persist) on the unified bounded storage lock. |
+| [`_auth/storage_transaction.py`](../src/notebooklm/_auth/storage_transaction.py) | The storage-write transaction template (ADR-0031 Stage 3): `in_storage_transaction` owns the secure-parent-dir / lock-path / bounded-acquire / not-held preamble the writers each hand-rolled, with the lock-failure policy (`raise_` / `skip_` / `report_on_lock_unavailable`) supplied by the caller because the six writers genuinely differ there. Split out of `storage_writer.py` for the ADR-0008 size budget; never imports the `_atomic_io` primitives, so the single-writer boundary holds. |
 | [`_auth/extraction.py`](../src/notebooklm/_auth/extraction.py) | Cookie/token extraction from browser sessions. |
 | [`_auth/headers.py`](../src/notebooklm/_auth/headers.py) | HTTP header construction. |
 | [`_auth/cookies.py`](../src/notebooklm/_auth/cookies.py) | Cookie maps + `_update_cookie_input` helper. |
@@ -1198,6 +1199,7 @@ src/notebooklm/
 │   ├── session.py               # Auth-session refresh implementation via `refresh_auth_session()` and explicit collaborators
 │   ├── storage.py               # Profile/state persistence: CAS merge math + file-lock primitive + save_cookies_to_storage delegate seam
 │   ├── storage_writer.py        # Canonical storage_state.json writer (ADR-0029): sole atomic-write owner, unified bounded lock
+│   ├── storage_transaction.py   # Storage-write transaction template + lock-failure policies (ADR-0031 Stage 3)
 │   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
 │   ├── psidts_recovery.py       # Inline PSIDTS recovery for cold-start (issue #865)
 │   ├── master_token.py          # Headless master-token auth: minting primitives + the audited bootstrap/re-mint transaction (ADR-0023)

--- a/src/notebooklm/_auth/storage_transaction.py
+++ b/src/notebooklm/_auth/storage_transaction.py
@@ -2,10 +2,13 @@
 
 Six writers in :mod:`notebooklm._auth.storage_writer` each hand-rolled the same
 four-step preamble — secure the parent dir, derive the sentinel lock path, take
-the bounded lock, and branch on whether it was held. Only the last step differs,
-and it differs in three genuinely incompatible ways, so the policy is a
-parameter rather than a decision baked into the template: a version that picked
-one behavior would be a silent semantic change in a credential-write path.
+the bounded lock, and branch on whether it was held. **Three of those six route
+through this template today**; the remaining three are pinned in the shrink-only
+ratchet ``tests/_guardrails/test_storage_transaction_ratchet.py`` and convert in
+a later pass. Only the last step differs, and it differs in three genuinely
+incompatible ways, so the policy is a parameter rather than a decision baked
+into the template: a version that picked one behavior would be a silent
+semantic change in a credential-write path.
 
 ``merge_cookie_delta`` deliberately does NOT use this. It takes the BLOCKING
 ``storage._file_lock_exclusive`` rather than the bounded acquire, and skips the
@@ -92,6 +95,14 @@ def report_on_lock_unavailable(outcome: Any) -> _LockUnavailablePolicy:
     because the caller has somewhere unambiguous to put it. The two full-replace
     writers have their OWN outcome types (:class:`WriteOutcome` vs
     :class:`LoginWriteOutcome`), so the value comes from the caller.
+
+    .. note::
+       This has **no caller yet** — ``replace_from_login`` and
+       ``replace_from_remint`` are the only writers whose return type can carry
+       a distinct lock-unavailable status, and both are still unconverted. That
+       is pinned rather than merely noted: the ratchet asserts zero callers
+       while they are unconverted, and at least one once they are, so this
+       helper cannot quietly outlive its reason to exist.
     """
 
     def _policy(lock_path: Path) -> Any:
@@ -102,6 +113,13 @@ def report_on_lock_unavailable(outcome: Any) -> _LockUnavailablePolicy:
 
 def skip_on_lock_unavailable(message: str) -> _LockUnavailablePolicy:
     """TOLERABLE — log at DEBUG and do nothing.
+
+    Args:
+        message: a logging format string with **exactly one** ``%s``, which
+            receives the lock path. A message with no placeholder (or more than
+            one) raises inside ``logging``, which swallows it and prints to
+            stderr instead of logging — an unpleasant failure to trace back,
+            since it surfaces nowhere near this call.
 
     The only genuinely different intent, and it has exactly one user today:
     ``clear_in_band_account``. Its justification is functional — a missed clear

--- a/src/notebooklm/_auth/storage_transaction.py
+++ b/src/notebooklm/_auth/storage_transaction.py
@@ -32,6 +32,39 @@ from .storage import _LOCK_ACQUIRE_DEADLINE_SECONDS
 logger = logging.getLogger("notebooklm.auth")
 
 
+#
+# THE POLICIES — two intents, three constructors
+# ----------------------------------------------
+# There are only TWO intents here, and it is worth stating which is which,
+# because the surface count of three invites the wrong mental model:
+#
+#   MUST-KNOW  the write mattered; a caller that proceeds as though it happened
+#              is wrong. Five writers. A master token that was not persisted
+#              means the mint was wasted; account metadata that was not written
+#              means routing silently targets the wrong Google account; a login
+#              that was not persisted means the user believes they are signed in.
+#
+#   TOLERABLE  the write was cleanup; missing it degrades gracefully. One writer.
+#
+# MUST-KNOW has *two constructors* only because the writers' return channels
+# differ in what they can express — not because the intent differs:
+#
+#   ``-> None``            no channel at all                      -> raise
+#   ``-> bool``            ``False`` already means "deliberately   -> raise
+#                          skipped (only_if_absent)", so reusing
+#                          it would conflate *chose not to* with
+#                          *could not*
+#   ``-> WriteOutcome``    a rich enum with room for a distinct    -> report
+#   ``-> LoginWriteOutcome`` LOCK_UNAVAILABLE status
+#
+# Each choice is locally forced. The inconsistency lives one level up, in
+# writers that do morally identical things having different return types.
+# Unifying that means giving every MUST-KNOW writer a rich outcome type, which
+# is a breaking change for callers that today catch ``OSError``/``TimeoutError``
+# around ``persist_minted_jar`` and ``update_account_metadata`` — a deprecation
+# runway, not a refactor stage. Tracked in ADR-0031.
+
+
 class _LockUnavailablePolicy(Protocol):
     """What a writer does when the storage lock could not be acquired."""
 
@@ -39,11 +72,11 @@ class _LockUnavailablePolicy(Protocol):
 
 
 def raise_on_lock_unavailable(operation: str) -> _LockUnavailablePolicy:
-    """Fail closed: raise :class:`LockUnavailableError`.
+    """MUST-KNOW, via exception — for writers with no usable return channel.
 
-    For writers where proceeding without the lock risks losing a concurrent
-    writer's commit — the account-metadata write and both master-token
-    persists.
+    Used where the return type is ``None`` (``persist_minted_jar``,
+    ``write_master_token``) or a ``bool`` whose ``False`` already carries a
+    different meaning (``update_account_metadata``).
     """
 
     def _policy(lock_path: Path) -> Any:
@@ -52,31 +85,43 @@ def raise_on_lock_unavailable(operation: str) -> _LockUnavailablePolicy:
     return _policy
 
 
-def skip_on_lock_unavailable(message: str) -> _LockUnavailablePolicy:
-    """Best-effort: log at DEBUG and do nothing.
+def report_on_lock_unavailable(outcome: Any) -> _LockUnavailablePolicy:
+    """MUST-KNOW, via return value — for writers with a rich outcome type.
 
-    Only correct where skipping degrades gracefully rather than corrupting —
-    today just the in-band account clear, whose miss leaves the legacy reader
-    still able to resolve the record.
+    Same intent as :func:`raise_on_lock_unavailable`; different mechanism only
+    because the caller has somewhere unambiguous to put it. The two full-replace
+    writers have their OWN outcome types (:class:`WriteOutcome` vs
+    :class:`LoginWriteOutcome`), so the value comes from the caller.
+    """
+
+    def _policy(lock_path: Path) -> Any:
+        return outcome
+
+    return _policy
+
+
+def skip_on_lock_unavailable(message: str) -> _LockUnavailablePolicy:
+    """TOLERABLE — log at DEBUG and do nothing.
+
+    The only genuinely different intent, and it has exactly one user today:
+    ``clear_in_band_account``. Its justification is functional — a missed clear
+    leaves the legacy reader still able to resolve the account record.
+
+    .. note::
+       That justification is narrower than the operation's motive. Clearing the
+       in-band account is **privacy**-motivated ("a stale key must not leave the
+       account email at rest" — see ``auth.py``), and a swallowed failure leaves
+       precisely that email on disk until the next successful write. Functional
+       degradation is graceful; the privacy miss is silent. Rare — it needs 90 s
+       of lock contention or a lock-infrastructure failure — but the swallow is
+       justified on a different axis than the one that matters most here.
+       Flagged in ADR-0031 rather than changed unilaterally, since promoting it
+       to MUST-KNOW would make a best-effort cleanup able to fail a caller.
     """
 
     def _policy(lock_path: Path) -> Any:
         logger.debug(message, lock_path)
         return None
-
-    return _policy
-
-
-def report_on_lock_unavailable(outcome: Any) -> _LockUnavailablePolicy:
-    """Return a caller-supplied typed outcome describing the miss.
-
-    The two full-replace writers each have their OWN outcome type
-    (:class:`WriteOutcome` vs :class:`LoginWriteOutcome`), so the value is
-    supplied by the caller rather than constructed here.
-    """
-
-    def _policy(lock_path: Path) -> Any:
-        return outcome
 
     return _policy
 

--- a/src/notebooklm/_auth/storage_transaction.py
+++ b/src/notebooklm/_auth/storage_transaction.py
@@ -1,0 +1,112 @@
+"""The storage-write transaction template (ADR-0031 Stage 3).
+
+Six writers in :mod:`notebooklm._auth.storage_writer` each hand-rolled the same
+four-step preamble — secure the parent dir, derive the sentinel lock path, take
+the bounded lock, and branch on whether it was held. Only the last step differs,
+and it differs in three genuinely incompatible ways, so the policy is a
+parameter rather than a decision baked into the template: a version that picked
+one behavior would be a silent semantic change in a credential-write path.
+
+``merge_cookie_delta`` deliberately does NOT use this. It takes the BLOCKING
+``storage._file_lock_exclusive`` rather than the bounded acquire, and skips the
+parent-dir prep because it only ever updates a file that already exists. Its
+lock semantics are a different operation, not a variant of this one.
+
+Split out of ``storage_writer.py`` to stay under the ADR-0008 module-size
+budget. The atomic write itself stays in ``storage_writer`` — this module never
+imports the ``_atomic_io`` primitives, preserving the single-writer boundary
+``tests/_guardrails/test_storage_writer_boundary.py`` enforces.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..exceptions import LockUnavailableError
+from .paths import _storage_state_lock_path
+from .storage import _LOCK_ACQUIRE_DEADLINE_SECONDS
+
+logger = logging.getLogger("notebooklm.auth")
+
+
+class _LockUnavailablePolicy(Protocol):
+    """What a writer does when the storage lock could not be acquired."""
+
+    def __call__(self, lock_path: Path) -> Any: ...
+
+
+def raise_on_lock_unavailable(operation: str) -> _LockUnavailablePolicy:
+    """Fail closed: raise :class:`LockUnavailableError`.
+
+    For writers where proceeding without the lock risks losing a concurrent
+    writer's commit — the account-metadata write and both master-token
+    persists.
+    """
+
+    def _policy(lock_path: Path) -> Any:
+        raise LockUnavailableError(f"{operation}: storage lock unavailable at {lock_path}")
+
+    return _policy
+
+
+def skip_on_lock_unavailable(message: str) -> _LockUnavailablePolicy:
+    """Best-effort: log at DEBUG and do nothing.
+
+    Only correct where skipping degrades gracefully rather than corrupting —
+    today just the in-band account clear, whose miss leaves the legacy reader
+    still able to resolve the record.
+    """
+
+    def _policy(lock_path: Path) -> Any:
+        logger.debug(message, lock_path)
+        return None
+
+    return _policy
+
+
+def report_on_lock_unavailable(outcome: Any) -> _LockUnavailablePolicy:
+    """Return a caller-supplied typed outcome describing the miss.
+
+    The two full-replace writers each have their OWN outcome type
+    (:class:`WriteOutcome` vs :class:`LoginWriteOutcome`), so the value is
+    supplied by the caller rather than constructed here.
+    """
+
+    def _policy(lock_path: Path) -> Any:
+        return outcome
+
+    return _policy
+
+
+def in_storage_transaction(
+    path: Path,
+    body: Callable[[], Any],
+    *,
+    log_prefix: str,
+    on_unavailable: _LockUnavailablePolicy,
+    deadline_seconds: float = _LOCK_ACQUIRE_DEADLINE_SECONDS,
+) -> Any:
+    """Run ``body()`` under the bounded storage lock for ``path``.
+
+    Owns the four steps every writer repeated: secure-parent-dir prep, lock-path
+    derivation, the bounded acquire, and the not-held branch. ``body`` returns
+    the writer's own return value, so an early ``return`` inside it (the
+    ``only_if_absent`` short-circuit, for instance) propagates unchanged.
+
+    The lock is held for the whole of ``body``, including its ``atomic_write_json``
+    — the read-decide-write sequence must not be re-entered by a concurrent
+    writer partway through.
+    """
+    from .storage_writer import _acquire_storage_lock, _ensure_secure_parent_dir
+
+    _ensure_secure_parent_dir(path)
+    lock_path = _storage_state_lock_path(path)
+    with _acquire_storage_lock(
+        lock_path, log_prefix=log_prefix, deadline_seconds=deadline_seconds
+    ) as state:
+        if state != "held":
+            return on_unavailable(lock_path)
+        return body()

--- a/src/notebooklm/_auth/storage_writer.py
+++ b/src/notebooklm/_auth/storage_writer.py
@@ -111,6 +111,10 @@ from .storage import (
     _LOCK_ACQUIRE_DEADLINE_SECONDS,
     _LOCK_ACQUIRE_INITIAL_DELAY_SECONDS,
 )
+from .storage_transaction import (
+    in_storage_transaction,
+    raise_on_lock_unavailable,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -943,17 +947,22 @@ def write_master_token(path: Path, *, email: str, master_token: str, android_id:
     """
     from . import master_token as _master_token  # lazy: avoid import cycle
 
-    _ensure_secure_parent_dir(path)
     payload = {
         "version": _master_token._MASTER_TOKEN_VERSION,
         "email": email,
         "android_id": android_id,
         "master_token": master_token,
     }
-    # Sibling dotted lock for the credential file (distinct from the profile's
-    # storage-state lock — a different file).
-    lock_path = _storage_state_lock_path(path)
-    with _acquire_storage_lock(lock_path, log_prefix="write_master_token") as state:
-        if state != "held":
-            raise LockUnavailableError(f"write_master_token: lock unavailable at {lock_path}")
+
+    def _write() -> None:
         atomic_write_json(path, payload)
+
+    # The transaction template derives the sibling dotted lock for this
+    # credential file (distinct from the profile's storage-state lock — a
+    # different file) and ensures the parent dir is secure before taking it.
+    in_storage_transaction(
+        path,
+        _write,
+        log_prefix="write_master_token",
+        on_unavailable=raise_on_lock_unavailable("write_master_token"),
+    )

--- a/src/notebooklm/_auth/storage_writer.py
+++ b/src/notebooklm/_auth/storage_writer.py
@@ -114,6 +114,7 @@ from .storage import (
 from .storage_transaction import (
     in_storage_transaction,
     raise_on_lock_unavailable,
+    skip_on_lock_unavailable,
 )
 
 if TYPE_CHECKING:
@@ -485,15 +486,7 @@ def update_account_metadata(
     if email:
         account_payload["email"] = email
 
-    lock_path = _storage_state_lock_path(storage_path)
-    _ensure_secure_parent_dir(storage_path)
-    with _acquire_storage_lock(
-        lock_path, log_prefix="write_account_metadata", deadline_seconds=deadline_seconds
-    ) as state:
-        if state != "held":
-            raise LockUnavailableError(
-                f"write_account_metadata: storage lock unavailable at {lock_path}"
-            )
+    def _write() -> bool:
         data = _account._load_storage_state_for_write(storage_path)
         namespace = data.get(_account._STORAGE_NAMESPACE_KEY)
         if not isinstance(namespace, dict):
@@ -505,6 +498,19 @@ def update_account_metadata(
         data[_account._STORAGE_NAMESPACE_KEY] = namespace
         atomic_write_json(storage_path, data)
         return True
+
+    # MUST-KNOW via exception: the ``bool`` return already spends ``False`` on
+    # the ``only_if_absent`` no-op above, so it cannot also carry "could not
+    # acquire" without conflating *chose not to* with *could not*.
+    return bool(
+        in_storage_transaction(
+            storage_path,
+            _write,
+            log_prefix="write_account_metadata",
+            on_unavailable=raise_on_lock_unavailable("write_account_metadata"),
+            deadline_seconds=deadline_seconds,
+        )
+    )
 
 
 def clear_in_band_account(storage_path: Path) -> None:
@@ -519,14 +525,8 @@ def clear_in_band_account(storage_path: Path) -> None:
 
     if not storage_path.exists():
         return
-    lock_path = _storage_state_lock_path(storage_path)
-    _ensure_secure_parent_dir(storage_path)
-    with _acquire_storage_lock(lock_path, log_prefix="clear_account_metadata") as state:
-        if state != "held":
-            # Best-effort: the same failure mode the old filelock OSError arm
-            # swallowed. The legacy reader still resolves the account record.
-            logger.debug("in-band account clear skipped: storage lock unavailable at %s", lock_path)
-            return
+
+    def _clear() -> None:
         try:
             data = json.loads(storage_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as e:
@@ -543,6 +543,19 @@ def clear_in_band_account(storage_path: Path) -> None:
         else:
             data[_account._STORAGE_NAMESPACE_KEY] = namespace
         atomic_write_json(storage_path, data)
+
+    # TOLERABLE: the same failure mode the old filelock OSError arm swallowed.
+    # See the caveat on ``skip_on_lock_unavailable`` — the functional argument
+    # (the legacy reader still resolves the record) is narrower than this
+    # operation's privacy motive, and that tension is tracked in ADR-0031.
+    in_storage_transaction(
+        storage_path,
+        _clear,
+        log_prefix="clear_account_metadata",
+        on_unavailable=skip_on_lock_unavailable(
+            "in-band account clear skipped: storage lock unavailable at %s"
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/_guardrails/test_storage_transaction_ratchet.py
+++ b/tests/_guardrails/test_storage_transaction_ratchet.py
@@ -1,11 +1,13 @@
 """Shrink-only ratchet: storage writers take the lock via the transaction template.
 
-ADR-0031 Stage 3. Six writers in ``_auth/storage_writer.py`` each hand-rolled the
-same four-step preamble — secure the parent dir, derive the sentinel lock path,
-take the bounded lock, branch on whether it was held.
-:func:`~notebooklm._auth.storage_writer.in_storage_transaction` now owns those
-four steps, with the fourth (the not-held branch) supplied by the caller because
-it genuinely differs three ways:
+ADR-0031 Stage 3. Six writers in ``_auth/storage_writer.py`` USED TO each
+hand-roll the same four-step preamble — secure the parent dir, derive the
+sentinel lock path, take the bounded lock, branch on whether it was held.
+:func:`~notebooklm._auth.storage_transaction.in_storage_transaction` now owns
+those four steps. **Three of the six route through it today**; the other three
+are pinned in :data:`_UNCONVERTED` below and convert in a later pass. The fourth
+step (the not-held branch) is supplied by the caller because it genuinely
+differs three ways:
 
 * **raise** ``LockUnavailableError`` — fail closed, where proceeding without the
   lock could lose a concurrent writer's commit;
@@ -59,12 +61,49 @@ _UNCONVERTED: frozenset[str] = frozenset(
 )
 
 
+#: The three not-held policies the template exposes.
+_POLICIES: tuple[str, ...] = (
+    "raise_on_lock_unavailable",
+    "skip_on_lock_unavailable",
+    "report_on_lock_unavailable",
+)
+
+#: The writers that will use ``report_on_lock_unavailable`` when they convert —
+#: the only two whose return type (``WriteOutcome`` / ``LoginWriteOutcome``) has
+#: room for a distinct ``LOCK_UNAVAILABLE`` status. Every other writer returns
+#: ``None`` or a ``bool`` already spoken for, so it must raise instead.
+_REPORT_POLICY_WRITERS: frozenset[str] = frozenset({"replace_from_login", "replace_from_remint"})
+
+
+def _policy_call_counts() -> dict[str, int]:
+    """Count real call sites of each policy across ``_auth/``.
+
+    Definitions do not count — only ``<policy>(...)`` calls. Counting by AST
+    rather than substring keeps a mention inside a docstring or an error
+    message (this module puts the policy names in both) from reading as a use.
+    """
+    counts = dict.fromkeys(_POLICIES, 0)
+    for source_file in sorted(_AUTH.glob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in counts:
+                    counts[node.func.id] += 1
+    return counts
+
+
 def _functions_calling_directly() -> set[str]:
     """Return writer functions that call ``_acquire_storage_lock`` themselves."""
     tree = ast.parse(_WRITER.read_text(encoding="utf-8"))
     found: set[str] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef):
+        # ``AsyncFunctionDef`` is NOT a subclass of ``FunctionDef`` — matching
+        # only the latter would leave an ``async def`` writer free to hand-roll
+        # the acquire without ever tripping this gate. Every storage writer is
+        # sync today, so this closes a hole that is empty rather than one that
+        # leaks; a ratchet that only covers the shapes in use when it was
+        # written stops being a ratchet the moment someone adds a new shape.
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
         # The template itself lives in ``storage_transaction.py`` now, so
         # nothing in THIS module should be calling the primitive except the
@@ -117,18 +156,70 @@ def test_merge_cookie_delta_is_not_expected_to_convert() -> None:
     assert "merge_cookie_delta" not in _functions_calling_directly()
 
 
-def test_the_three_lock_policies_are_all_used() -> None:
-    """Each policy has a real caller — none is speculative API.
+def test_the_three_lock_policies_are_all_defined() -> None:
+    """Each policy still exists — deleting one silently is a semantic change."""
+    tree = ast.parse(_TEMPLATE.read_text(encoding="utf-8"))
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    missing = set(_POLICIES) - defined
+    assert not missing, f"lock policy/policies disappeared from {_TEMPLATE.name}: {sorted(missing)}"
 
-    If one drops to zero callers it should be deleted, not kept as a
-    just-in-case helper that nothing pins the semantics of.
+
+def test_in_use_policies_have_real_callers() -> None:
+    """``raise_`` and ``skip_`` are load-bearing, not decoration.
+
+    Counts real call sites across ``_auth/`` rather than asserting the
+    definition exists in the file that defines it — the latter is a tautology
+    that cannot fail while the function is present, and would stay green if
+    every caller in the repo were deleted.
     """
-    source = _TEMPLATE.read_text(encoding="utf-8")
-    for policy in (
-        "raise_on_lock_unavailable",
-        "skip_on_lock_unavailable",
-        "report_on_lock_unavailable",
-    ):
-        # One definition plus at least one call site once conversion completes;
-        # while writers remain unconverted, the definition alone is expected.
-        assert f"def {policy}(" in source, f"{policy} disappeared"
+    counts = _policy_call_counts()
+    for policy in ("raise_on_lock_unavailable", "skip_on_lock_unavailable"):
+        assert counts[policy] >= 1, (
+            f"{policy} has no callers left in _auth/. Either a writer regressed "
+            f"to hand-rolling its not-held branch, or the policy is now dead and "
+            f"should be deleted rather than kept as a just-in-case helper."
+        )
+
+
+def test_report_policy_is_pinned_until_its_writers_convert() -> None:
+    """``report_on_lock_unavailable`` is self-retiring, in both directions.
+
+    It has ZERO callers today, which is correct but only *while* the two
+    full-replace writers that will use it are unconverted — they are the only
+    writers with a rich enough outcome type to report into. So the expectation
+    is conditional on :data:`_UNCONVERTED`, not a fixed number:
+
+    * while they are pinned, a caller appearing means someone reached for the
+      report policy from a writer whose return channel cannot express it;
+    * the moment they convert, zero callers means the conversion quietly used a
+      different policy — silently changing fail-closed-by-return into
+      fail-closed-by-raise for callers — or that the helper is now dead and
+      should be deleted.
+
+    This is what the previous version of this gate *claimed* to check and did
+    not: it asserted ``"def <policy>(" in <the file defining it>``, which is a
+    tautology. It read as proof that all three policies were live, and that
+    reading was wrong — one of them never had a caller at all.
+    """
+    pending = _REPORT_POLICY_WRITERS & _UNCONVERTED
+    callers = _policy_call_counts()["report_on_lock_unavailable"]
+    if pending:
+        assert callers == 0, (
+            "report_on_lock_unavailable gained a caller while its intended "
+            f"writers are still unconverted: {sorted(pending)}. It exists for "
+            "writers returning a rich outcome enum; a writer returning None or "
+            "bool must use raise_on_lock_unavailable instead — reporting into a "
+            "channel that cannot express it drops the failure silently."
+        )
+    else:
+        assert callers >= 1, (
+            f"{sorted(_REPORT_POLICY_WRITERS)} converted but "
+            "report_on_lock_unavailable still has no callers. Either they were "
+            "converted to the wrong policy (changing fail-closed-by-return into "
+            "fail-closed-by-raise, a breaking change for their callers), or the "
+            "helper is dead and should be deleted."
+        )

--- a/tests/_guardrails/test_storage_transaction_ratchet.py
+++ b/tests/_guardrails/test_storage_transaction_ratchet.py
@@ -50,11 +50,8 @@ _TEMPLATE = _AUTH / "storage_transaction.py"
 #:     domain filter and required-cookie revalidation run inside the lock.
 #:   * ``replace_from_remint`` — the browser-capture re-mint, which carries or
 #:     drops the account namespace under the same lock.
-#: The two account writers are simpler and are next in line.
 _UNCONVERTED: frozenset[str] = frozenset(
     {
-        "update_account_metadata",
-        "clear_in_band_account",
         "replace_from_remint",
         "replace_from_login",
         "persist_minted_jar",

--- a/tests/_guardrails/test_storage_transaction_ratchet.py
+++ b/tests/_guardrails/test_storage_transaction_ratchet.py
@@ -1,0 +1,137 @@
+"""Shrink-only ratchet: storage writers take the lock via the transaction template.
+
+ADR-0031 Stage 3. Six writers in ``_auth/storage_writer.py`` each hand-rolled the
+same four-step preamble — secure the parent dir, derive the sentinel lock path,
+take the bounded lock, branch on whether it was held.
+:func:`~notebooklm._auth.storage_writer.in_storage_transaction` now owns those
+four steps, with the fourth (the not-held branch) supplied by the caller because
+it genuinely differs three ways:
+
+* **raise** ``LockUnavailableError`` — fail closed, where proceeding without the
+  lock could lose a concurrent writer's commit;
+* **skip** with a DEBUG log — best-effort, only where a miss degrades gracefully;
+* **report** a typed outcome — and the two full-replace writers have *different*
+  outcome types, so the value comes from the caller.
+
+A template that picked one of those would be a silent semantic change in a
+credential-write path, which is why the policy is a parameter and why this gate
+checks *routing through the template*, not uniformity of behavior.
+
+Migration is opportunistic per this repo's ratchet convention: the gate blocks a
+NEW hand-rolled acquire and pins the remaining ones so the list can only shrink.
+``merge_cookie_delta`` is exempt by design — it takes the BLOCKING
+``storage._file_lock_exclusive`` rather than the bounded acquire, which is a
+different operation, not a variant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+_AUTH = Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "_auth"
+_WRITER = _AUTH / "storage_writer.py"
+#: The template + its three policies were split out of ``storage_writer`` to
+#: stay under the ADR-0008 module-size budget.
+_TEMPLATE = _AUTH / "storage_transaction.py"
+
+#: Functions still calling ``_acquire_storage_lock`` directly. SHRINK-ONLY —
+#: never add. Each is a candidate for conversion; the three below are the
+#: delicate ones deliberately left for a focused pass rather than converted in
+#: bulk, because their bodies carry semantics worth converting under their own
+#: differential tests:
+#:   * ``persist_minted_jar`` — the #2108 cross-account ownership guard and the
+#:     write-ordering it depends on; sits on the client's own L4 recovery path.
+#:   * ``replace_from_login`` — the login/import full-replace, whose write-time
+#:     domain filter and required-cookie revalidation run inside the lock.
+#:   * ``replace_from_remint`` — the browser-capture re-mint, which carries or
+#:     drops the account namespace under the same lock.
+#: The two account writers are simpler and are next in line.
+_UNCONVERTED: frozenset[str] = frozenset(
+    {
+        "update_account_metadata",
+        "clear_in_band_account",
+        "replace_from_remint",
+        "replace_from_login",
+        "persist_minted_jar",
+    }
+)
+
+
+def _functions_calling_directly() -> set[str]:
+    """Return writer functions that call ``_acquire_storage_lock`` themselves."""
+    tree = ast.parse(_WRITER.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        # The template itself lives in ``storage_transaction.py`` now, so
+        # nothing in THIS module should be calling the primitive except the
+        # writers still awaiting conversion.
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id == "_acquire_storage_lock"
+            ):
+                found.add(node.name)
+    return found
+
+
+def test_no_new_hand_rolled_storage_lock() -> None:
+    """A new writer must route through ``in_storage_transaction``."""
+    new = _functions_calling_directly() - _UNCONVERTED
+    assert not new, (
+        "Writer(s) calling _acquire_storage_lock directly instead of routing "
+        f"through in_storage_transaction: {sorted(new)}\n\n"
+        "Use:\n"
+        "    in_storage_transaction(path, _body, log_prefix=..., \n"
+        "                           on_unavailable=raise_on_lock_unavailable(...))\n"
+        "picking the on_unavailable policy deliberately — raise_ / skip_ / "
+        "report_on_lock_unavailable are NOT interchangeable."
+    )
+
+
+def test_unconverted_list_is_shrink_only() -> None:
+    """A converted writer must be removed from the list.
+
+    Without this the list becomes a graveyard and stops describing the real
+    remaining work — the failure mode that makes ratchets rot.
+    """
+    stale = _UNCONVERTED - _functions_calling_directly()
+    assert not stale, (
+        f"These writers no longer hand-roll the lock — delete them from "
+        f"_UNCONVERTED: {sorted(stale)}"
+    )
+
+
+def test_merge_cookie_delta_is_not_expected_to_convert() -> None:
+    """The CAS merge is exempt by design, so it must not appear in the list.
+
+    It takes the blocking ``_file_lock_exclusive`` and skips the parent-dir prep
+    (it only updates a file that already exists). Listing it would imply a
+    conversion we do not intend and that would change its lock semantics.
+    """
+    assert "merge_cookie_delta" not in _UNCONVERTED
+    assert "merge_cookie_delta" not in _functions_calling_directly()
+
+
+def test_the_three_lock_policies_are_all_used() -> None:
+    """Each policy has a real caller — none is speculative API.
+
+    If one drops to zero callers it should be deleted, not kept as a
+    just-in-case helper that nothing pins the semantics of.
+    """
+    source = _TEMPLATE.read_text(encoding="utf-8")
+    for policy in (
+        "raise_on_lock_unavailable",
+        "skip_on_lock_unavailable",
+        "report_on_lock_unavailable",
+    ):
+        # One definition plus at least one call site once conversion completes;
+        # while writers remain unconverted, the definition alone is expected.
+        assert f"def {policy}(" in source, f"{policy} disappeared"

--- a/tests/_guardrails/test_storage_transaction_ratchet.py
+++ b/tests/_guardrails/test_storage_transaction_ratchet.py
@@ -205,21 +205,22 @@ def test_report_policy_is_pinned_until_its_writers_convert() -> None:
     tautology. It read as proof that all three policies were live, and that
     reading was wrong — one of them never had a caller at all.
     """
-    pending = _REPORT_POLICY_WRITERS & _UNCONVERTED
+    converted = _REPORT_POLICY_WRITERS - _UNCONVERTED
     callers = _policy_call_counts()["report_on_lock_unavailable"]
-    if pending:
-        assert callers == 0, (
-            "report_on_lock_unavailable gained a caller while its intended "
-            f"writers are still unconverted: {sorted(pending)}. It exists for "
-            "writers returning a rich outcome enum; a writer returning None or "
-            "bool must use raise_on_lock_unavailable instead — reporting into a "
-            "channel that cannot express it drops the failure silently."
-        )
-    else:
-        assert callers >= 1, (
-            f"{sorted(_REPORT_POLICY_WRITERS)} converted but "
-            "report_on_lock_unavailable still has no callers. Either they were "
-            "converted to the wrong policy (changing fail-closed-by-return into "
-            "fail-closed-by-raise, a breaking change for their callers), or the "
-            "helper is dead and should be deleted."
-        )
+    # Each CONVERTED designated writer must call the report policy exactly once;
+    # unconverted ones contribute zero. Pinning to the converted count (rather
+    # than branching all-or-nothing on ``pending``) is what permits a correct
+    # one-writer-at-a-time migration: with one of the two converted, the
+    # expectation is 1, not the impossible "zero callers while a converted
+    # writer must call it" (CodeRabbit finding on #2152).
+    assert callers == len(converted), (
+        "report_on_lock_unavailable caller count drifted from its converted "
+        f"writers.\n  converted report-policy writers: {sorted(converted) or '(none)'}\n"
+        f"  expected callers: {len(converted)}  actual: {callers}\n"
+        "If a caller appeared from a writer NOT in the designated set, that "
+        "writer's return channel cannot express the report — use "
+        "raise_on_lock_unavailable. If a designated writer converted without a "
+        "caller appearing, it was converted to the wrong policy (changing "
+        "fail-closed-by-return into fail-closed-by-raise, a breaking change "
+        "for its callers)."
+    )


### PR DESCRIPTION
## Summary

ADR-0031 Stage 3, following #2146 (Stage 0), #2148 (Stage 1), #2149 (Stage 2).

Writers in `storage_writer.py` each hand-rolled the same preamble: secure the parent dir, derive the sentinel lock path, take the bounded lock, branch on whether it was held. `storage_transaction.in_storage_transaction` now owns it.

## The investigation corrected the ADR's premise

The ADR sketched "one object owning the transaction". **The writers aren't uniform, and flattening them would have been a silent semantic change in credential-write paths.** On lock-unavailable there are **two intents**:

- **must-know** — the write mattered; a caller proceeding as though it happened is wrong. *Five writers.* An unpersisted master token means the mint was wasted; unwritten account metadata means routing silently targets the wrong Google account; an unpersisted login means the user believes they're signed in.
- **tolerable** — cleanup; a miss degrades gracefully. *One writer.*

Must-know has **two mechanisms**, and the split is forced by return-channel expressiveness rather than by intent:

| return type | can it carry "lock unavailable"? | so it… |
|---|---|---|
| `-> None` | no channel | raises |
| `-> bool` (`update_account_metadata`) | `False` is **already taken** — "deliberately skipped (`only_if_absent`)" | raises, since reusing it conflates *chose not to* with *could not* |
| `-> WriteOutcome` / `-> LoginWriteOutcome` | rich enums with room for a distinct status | reports |

Each choice is locally forced; the inconsistency lives one level up, in writers doing morally identical things having different return types. Unifying that is a **breaking change** for callers catching `OSError`/`TimeoutError` — recorded in the ADR as a follow-up needing a runway, not smuggled into a refactor.

`merge_cookie_delta` is **exempt by design**, not oversight: it takes the *blocking* `_file_lock_exclusive` and skips parent-dir prep (it only updates an existing file). Different operation, not a variant.

## A question the reframing surfaced

`clear_in_band_account`'s swallow is justified functionally — the legacy reader still resolves the record. But the operation is **privacy**-motivated (`auth.py`: *"a stale key must not leave the account email at rest"*), and a swallowed failure leaves exactly that email on disk. The swallow is defended on a different axis than the one that matters most. **Not changed here** — promoting it would let a best-effort cleanup fail a caller — but recorded in ADR-0031 as a decision to make rather than an assumption to inherit. The three-peer framing hid this; naming the intents exposed it.

## Scope

Converts **three** writers (`write_master_token`, `update_account_metadata`, `clear_in_band_account`). Three remain, pinned in a shrink-only ratchet and deliberately left for a focused pass with their own differential tests: `persist_minted_jar` (the #2108 cross-account ownership guard, on the client's L4 recovery path) and both full-replace writers (write-time domain filter + revalidation inside the lock).

Design note: the template takes a **body callable**, not a context manager, because `update_account_metadata`'s early `return False` inside the `only_if_absent` branch has to propagate as the function's return value — a `with` block couldn't express that.

Lives in a new `storage_transaction.py` because adding it to `storage_writer.py` breached the ADR-0008 1000-line budget. It never imports the `_atomic_io` primitives, so `storage_writer` remains the sole atomic-write owner its boundary guardrail asserts.

## Test plan

- [x] Full suite: 13205 passed, 81 skipped, 3 xfailed
- [x] `tests/_guardrails` green (1259)
- [x] Ratchet verified to bite (reverted a writer to a hand-rolled acquire → red; restored)
- [x] Behavior spot-checked: real write → `True` + persists; `only_if_absent` over an existing record → `False` + untouched; clear removes the namespace
- [x] `ruff check .` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaeZfcxWvV3AuogrsiswrP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved reliability when saving account information and authentication tokens.
  - Added consistent handling for temporary storage access conflicts to help prevent incomplete or unsafe writes.
  - Preserved existing behavior for successful saves and cleanup operations.

- **Documentation**
  - Expanded technical documentation covering protected storage updates and access-conflict handling.

- **Tests**
  - Added safeguards ensuring storage updates consistently follow protection and lock-failure handling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->