### PR TITLE
refactor(auth): AuthTokens.jar projection + CookieJar.from_httpx (ADR-0032 Phase A)

### DIFF
--- a/src/notebooklm/_auth/cookie_types.py
+++ b/src/notebooklm/_auth/cookie_types.py
@@ -139,6 +139,13 @@ class CookieJar:
         underlying ``http.cookiejar.Cookie`` objects — only ``same_site`` is
         lost, and unavoidably so.
 
+        Applies the same allowed-auth-domain + non-``None`` value filter as
+        :func:`notebooklm._auth.cookies._cookie_map_from_jar` (the contract
+        that builds ``AuthTokens.cookies``), so this constructor cannot hold a
+        row the rest of the layer would have filtered out — a non-auth-domain
+        cookie named ``SID``/``OSID`` must not let ``.jar`` report a binding the
+        filtered ``cookies`` view correctly excludes.
+
         .. warning::
            **``same_site``-lossy — never for persistence or a save baseline.**
            ``http.cookiejar.Cookie`` cannot carry a SameSite attribute, so every
@@ -157,12 +164,16 @@ class CookieJar:
                     name=c.name,
                     domain=c.domain,
                     path=c.path or "/",
-                    value=c.value or "",
+                    value=c.value,
                     expires=c.expires,
                     secure=bool(c.secure),
                     http_only=_auth_cookies._cookie_is_http_only(c),
                 )
                 for c in jar.jar
+                if c.name
+                and c.domain
+                and c.value is not None
+                and _auth_cookies._is_allowed_auth_domain(c.domain)
             )
         )
 

--- a/src/notebooklm/_auth/cookie_types.py
+++ b/src/notebooklm/_auth/cookie_types.py
@@ -131,6 +131,41 @@ class CookieJar:
             )
         )
 
+    @classmethod
+    def from_httpx(cls, jar: httpx.Cookies) -> CookieJar:
+        """Snapshot a live ``httpx.Cookies`` jar into an immutable jar.
+
+        Preserves ``expires`` / ``secure`` / ``http_only`` straight off the
+        underlying ``http.cookiejar.Cookie`` objects — only ``same_site`` is
+        lost, and unavoidably so.
+
+        .. warning::
+           **``same_site``-lossy — never for persistence or a save baseline.**
+           ``http.cookiejar.Cookie`` cannot carry a SameSite attribute, so every
+           ``Cookie`` produced here has ``same_site=None`` regardless of the
+           cookie's actual SameSite. Round-tripping this jar through
+           :meth:`to_storage_state` would drop ``sameSite`` — the exact #2150
+           downgrade. Use this only to ask read-only questions of the live
+           session (``names`` / ``validate_required`` / ``has_secondary_binding``),
+           which do not depend on SameSite. The delta/baseline machinery keeps
+           SameSite out-of-band (``storage._preserved_same_site``) and must not be
+           fed a ``from_httpx`` jar.
+        """
+        return cls(
+            tuple(
+                Cookie(
+                    name=c.name,
+                    domain=c.domain,
+                    path=c.path or "/",
+                    value=c.value or "",
+                    expires=c.expires,
+                    secure=bool(c.secure),
+                    http_only=_auth_cookies._cookie_is_http_only(c),
+                )
+                for c in jar.jar
+            )
+        )
+
     # -- converters --------------------------------------------------------
 
     def to_domain_map(self) -> dict[tuple[str, str, str], str]:

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -87,6 +87,25 @@ class AuthTokens:
                 storage_path=self.storage_path,
             )
 
+    def replace_cookie_jar(self, cookie_jar: httpx.Cookies) -> None:
+        """Rebind the live jar **and** the derived map together (ADR-0031 Stage 4).
+
+        ``cookies`` and ``cookie_jar`` hold the same information in two shapes,
+        synced once at construction. Rebinding only the jar — which is what the
+        mid-session refresh does — leaves ``cookies`` describing the *previous*
+        session, and ``AuthTokens`` is public API, so a caller reading
+        ``auth.cookies`` after a refresh silently gets stale values. Nothing
+        inside the library noticed, because the one internal reader
+        (``_kernel.py``) prefers ``cookie_jar`` and only falls back to
+        ``cookies`` when the jar is ``None``, which construction makes
+        impossible.
+
+        Every rebind goes through here so the two cannot diverge. Enforced by
+        ``tests/_guardrails/test_authtokens_jar_sync.py``.
+        """
+        self.cookie_jar = cookie_jar
+        self.cookies = _auth_cookies._cookie_map_from_jar(cookie_jar)
+
     def __repr__(self) -> str:
         """Return a redacted representation safe for logs and pytest diffs.
 

--- a/src/notebooklm/_auth/tokens.py
+++ b/src/notebooklm/_auth/tokens.py
@@ -14,6 +14,7 @@ from . import cookies as _auth_cookies
 from . import psidts_recovery as _auth_psidts_recovery
 from . import refresh as _auth_refresh
 from . import storage as _auth_storage
+from .cookie_types import CookieJar
 
 DomainCookieMap: TypeAlias = _auth_cookies.DomainCookieMap
 FlatCookieMap: TypeAlias = _auth_cookies.FlatCookieMap
@@ -232,6 +233,24 @@ class AuthTokens:
     def account_route(self) -> str:
         """Return the value to send in NotebookLM ``authuser`` routing fields."""
         return _auth_account.format_authuser_value(self.authuser, self.account_email)
+
+    @property
+    def jar(self) -> CookieJar:
+        """Return a typed, read-only :class:`CookieJar` view of the current cookies.
+
+        The forward-looking accessor for new code (ADR-0032). Projected fresh
+        from the live ``cookie_jar`` each access, so it never goes stale — but it
+        is a **read-only question view** (``names`` / ``validate_required`` /
+        ``has_secondary_binding`` / ``missing_hint``), not the live jar. Mutating
+        the live session still goes through ``cookie_jar`` (the httpx jar the
+        transport owns); persistence still goes through the storage writer.
+
+        ``same_site``-lossy by construction (:meth:`CookieJar.from_httpx`), so it
+        must never be persisted — the SameSite the wire cookies carry is not
+        recoverable from ``http.cookiejar``. This is why ``jar`` answers
+        questions rather than replacing ``cookie_jar``.
+        """
+        return CookieJar.from_httpx(self.cookie_jar) if self.cookie_jar is not None else CookieJar()
 
     @property
     def flat_cookies(self) -> FlatCookieMap:

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -85,6 +85,11 @@ class Kernel:
         )
         self._timeout = timeout
         self._connect_timeout = connect_timeout
+        # Bootstrap seed only (ADR-0032): this is the ONE legitimate internal
+        # read of auth's cookie fields — it seeds the client's live jar at open,
+        # after which the client (kernel) owns the jar and auth's copy is a
+        # public-compat shadow. This read becomes ``auth.initial_cookies`` when
+        # the fields are removed (Phase B).
         cookies = (
             auth.cookie_jar
             if auth.cookie_jar is not None

--- a/src/notebooklm/_runtime/auth.py
+++ b/src/notebooklm/_runtime/auth.py
@@ -300,6 +300,14 @@ class AuthRefreshCoordinator(LoopBoundPrimitive):
     def update_auth_headers(self, *, auth: AuthTokens, kernel: Kernel) -> None:
         """Sync ``auth.cookie_jar`` with the live HTTP client's jar.
 
+        Compat-only (ADR-0032 Phase A): the kernel's jar is already the sole
+        internal live-cookie authority — persistence reads ``kernel.cookies``
+        and no internal code reads ``auth.cookie_jar`` after open. This
+        write-back exists solely so a PUBLIC holder of ``auth`` that reads
+        ``auth.cookies`` / ``auth.cookie_jar`` sees fresh values. When those
+        fields are removed (ADR-0032 Phase B, next major), this method and the
+        write-back go with them.
+
         Synchronous on purpose — no await — so callers can run this without
         any auth lock held. The httpx client's cookie jar is authoritative
         once the session is open; re-injecting startup cookies here would

--- a/src/notebooklm/_runtime/auth.py
+++ b/src/notebooklm/_runtime/auth.py
@@ -313,7 +313,10 @@ class AuthRefreshCoordinator(LoopBoundPrimitive):
             RuntimeError: If the kernel's HTTP client is not initialised (the
                 error originates from :meth:`Kernel.get_http_client`).
         """
-        auth.cookie_jar = kernel.get_http_client().cookies
+        # Rebinds the derived ``auth.cookies`` map alongside the jar. Assigning
+        # ``auth.cookie_jar`` directly here left the public ``auth.cookies``
+        # describing the pre-refresh session (ADR-0031 Stage 4).
+        auth.replace_cookie_jar(kernel.get_http_client().cookies)
 
     # ------------------------------------------------------------------
     # Single-flight refresh task.

--- a/tests/_guardrails/test_authtokens_jar_sync.py
+++ b/tests/_guardrails/test_authtokens_jar_sync.py
@@ -1,0 +1,97 @@
+"""Every ``cookie_jar`` rebind goes through ``AuthTokens.replace_cookie_jar``.
+
+ADR-0031 Stage 4. ``AuthTokens.cookies`` and ``AuthTokens.cookie_jar`` carry the
+same information in two shapes. Assigning the jar directly leaves the map
+describing the previous session, and ``AuthTokens`` is public API — so the stale
+value is readable by callers with nothing to signal it. The mid-session refresh
+did exactly that until this stage.
+
+``replace_cookie_jar`` rebinds both. This gate keeps a future rebind from
+reintroducing the divergence by assigning the field directly. It is scoped to
+assignments onto an ``AuthTokens``-shaped object (``<something>.cookie_jar = ...``)
+anywhere under ``src/``, excluding ``_auth/tokens.py`` itself, which legitimately
+sets the field inside ``__post_init__`` and ``replace_cookie_jar``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+#: The class's own module: it defines the field and the sanctioned rebind.
+_OWNER = "_auth/tokens.py"
+
+
+def _direct_assignments() -> list[str]:
+    """Return ``file:line`` for every ``<obj>.cookie_jar = ...`` outside the owner."""
+    hits: list[str] = []
+    for path in sorted(_SRC.rglob("*.py")):
+        rel = path.relative_to(_SRC).as_posix()
+        if rel == _OWNER:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Attribute) and target.attr == "cookie_jar":
+                    # ``self.cookie_jar = ...`` inside an unrelated class (e.g. a
+                    # transport wrapper owning its own jar) is not an AuthTokens
+                    # rebind; those live outside _auth and are matched by name
+                    # only, so keep the exclusion explicit rather than implicit.
+                    hits.append(f"{rel}:{node.lineno}")
+    return hits
+
+
+#: Assignments that are NOT ``AuthTokens`` rebinds. SHRINK-ONLY.
+_NON_AUTHTOKENS: frozenset[str] = frozenset()
+
+
+def test_no_direct_cookie_jar_rebind() -> None:
+    """A rebind must go through ``replace_cookie_jar`` so both views move."""
+    found = set(_direct_assignments()) - _NON_AUTHTOKENS
+    assert not found, (
+        "Direct ``.cookie_jar = ...`` assignment(s) outside _auth/tokens.py:\n"
+        + "\n".join(f"  {h}" for h in sorted(found))
+        + "\n\nUse ``auth.replace_cookie_jar(jar)`` — assigning the field alone "
+        "leaves the public ``auth.cookies`` describing the previous session.\n"
+        "If the target is not an AuthTokens (a transport owning its own jar, "
+        "say), add it to _NON_AUTHTOKENS with that reason."
+    )
+
+
+def test_the_sanctioned_rebind_exists_and_sets_both() -> None:
+    """The method the gate points callers at must actually set both views.
+
+    Without this the gate could keep redirecting people to a method that had
+    silently lost half its job — the failure mode where a guardrail's name
+    outlives what it verifies.
+    """
+    source = (_SRC / "_auth" / "tokens.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    fn = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "replace_cookie_jar"
+        ),
+        None,
+    )
+    assert fn is not None, "AuthTokens.replace_cookie_jar disappeared"
+
+    assigned = {
+        t.attr
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Assign)
+        for t in node.targets
+        if isinstance(t, ast.Attribute)
+    }
+    assert {"cookie_jar", "cookies"} <= assigned, (
+        f"replace_cookie_jar must set BOTH views; it sets {sorted(assigned)}"
+    )

--- a/tests/unit/test_auth_cookie_types.py
+++ b/tests/unit/test_auth_cookie_types.py
@@ -11,6 +11,7 @@ even though the jar's own behavior might look self-consistent.
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from notebooklm._auth import cookie_policy as _cookie_policy
@@ -312,3 +313,39 @@ class TestContainerAndSafety:
         before = jar.names()
         jar.to_domain_map()[("INJECTED", "x", "/")] = "v"
         assert jar.names() == before
+
+
+class TestFromHttpx:
+    """ADR-0032 Phase A: snapshot a live httpx jar for read-only questions."""
+
+    @staticmethod
+    def _httpx_jar(**cookies: str) -> httpx.Cookies:
+        jar = httpx.Cookies()
+        for name, value in cookies.items():
+            jar.set(name, value, domain=".google.com", path="/")
+        return jar
+
+    def test_from_httpx_preserves_names_and_values(self) -> None:
+        jar = CookieJar.from_httpx(self._httpx_jar(SID="s", HSID="h"))
+        assert jar.names() == {"SID", "HSID"}
+        assert jar.to_domain_map()[("SID", ".google.com", "/")] == "s"
+
+    def test_from_httpx_preserves_expires_and_secure(self) -> None:
+        import httpx
+
+        h = httpx.Cookies()
+        h.set("SID", "s", domain=".google.com", path="/")
+        for c in h.jar:
+            c.expires, c.secure = 1900000000, True
+        cookie = next(iter(CookieJar.from_httpx(h)))
+        assert cookie.expires == 1900000000
+        assert cookie.secure is True
+
+    def test_from_httpx_loses_same_site_by_construction(self) -> None:
+        """http.cookiejar can't carry SameSite — every Cookie gets None."""
+        cookie = next(iter(CookieJar.from_httpx(self._httpx_jar(SID="s"))))
+        assert cookie.same_site is None
+
+    def test_from_httpx_answers_binding_questions(self) -> None:
+        jar = CookieJar.from_httpx(self._httpx_jar(SID="s", APISID="a", SAPISID="sa", LSID="l"))
+        assert jar.has_secondary_binding() is True

--- a/tests/unit/test_auth_cookie_types.py
+++ b/tests/unit/test_auth_cookie_types.py
@@ -331,8 +331,6 @@ class TestFromHttpx:
         assert jar.to_domain_map()[("SID", ".google.com", "/")] == "s"
 
     def test_from_httpx_preserves_expires_and_secure(self) -> None:
-        import httpx
-
         h = httpx.Cookies()
         h.set("SID", "s", domain=".google.com", path="/")
         for c in h.jar:
@@ -349,3 +347,21 @@ class TestFromHttpx:
     def test_from_httpx_answers_binding_questions(self) -> None:
         jar = CookieJar.from_httpx(self._httpx_jar(SID="s", APISID="a", SAPISID="sa", LSID="l"))
         assert jar.has_secondary_binding() is True
+
+    def test_from_httpx_excludes_non_auth_domain_cookies(self) -> None:
+        """A non-auth-domain cookie with an auth name must not leak in.
+
+        ``from_httpx`` applies the same allowed-auth-domain filter as
+        ``_cookie_map_from_jar`` (which builds ``AuthTokens.cookies``). Without
+        it, an ``OSID`` on an unrelated domain would make ``.jar`` report a
+        secondary binding the filtered ``cookies`` view correctly excludes.
+        """
+        jar = httpx.Cookies()
+        jar.set("OSID", "impostor", domain=".evil.example", path="/")
+        result = CookieJar.from_httpx(jar)
+        assert "OSID" not in result.names()
+        assert result.has_secondary_binding() is False
+        # A legitimate auth-domain cookie in the same jar still projects through.
+        jar.set("SID", "real", domain=".google.com", path="/")
+        mixed = CookieJar.from_httpx(jar)
+        assert mixed.names() == {"SID"}

--- a/tests/unit/test_authtokens_jar_sync.py
+++ b/tests/unit/test_authtokens_jar_sync.py
@@ -102,3 +102,27 @@ def test_rebind_handles_edge_case_values(value: str) -> None:
     assert auth.cookie_jar is not None
     jar_names = {c.name for c in auth.cookie_jar.jar}
     assert (got is not None) == ("SID" in jar_names)
+
+
+class TestJarProjection:
+    """ADR-0032 Phase A: AuthTokens.jar is a fresh, never-stale question view."""
+
+    def test_jar_reflects_the_current_live_jar(self) -> None:
+        auth = _auth(SID="old")
+        assert auth.jar.names() == {"SID"}
+        auth.replace_cookie_jar(_jar(SID="new", HSID="h"))
+        # Fresh projection each access — no staleness, unlike the old .cookies bug.
+        assert auth.jar.names() == {"SID", "HSID"}
+        assert auth.jar.to_domain_map()[("SID", ".google.com", "/")] == "new"
+
+    def test_jar_is_a_cookiejar_not_the_live_httpx_jar(self) -> None:
+        from notebooklm._auth.cookie_types import CookieJar
+
+        auth = _auth(SID="s")
+        assert isinstance(auth.jar, CookieJar)
+        # Distinct object each access (a projection, not the live jar).
+        assert auth.jar is not auth.jar
+
+    def test_jar_answers_questions(self) -> None:
+        auth = _auth(SID="s", APISID="a", SAPISID="sa", LSID="l")
+        assert auth.jar.has_secondary_binding() is True

--- a/tests/unit/test_authtokens_jar_sync.py
+++ b/tests/unit/test_authtokens_jar_sync.py
@@ -1,0 +1,104 @@
+"""``AuthTokens.cookies`` must not go stale when the live jar is rebound.
+
+ADR-0031 Stage 4. ``cookies`` (a ``(name, domain, path) -> value`` map) and
+``cookie_jar`` (a live ``httpx.Cookies``) hold the same information in two
+shapes, synced once in ``__post_init__``. The mid-session refresh rebinds only
+the jar, which left ``cookies`` describing the *previous* session.
+
+That was invisible internally — the one reader, ``_kernel.py``, prefers
+``cookie_jar`` and only falls back to ``cookies`` when the jar is ``None``,
+which construction makes impossible. But ``AuthTokens`` is documented public
+API, so a caller reading ``auth.cookies`` after a refresh got stale values with
+nothing to signal it.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from notebooklm._auth.tokens import AuthTokens
+
+
+def _jar(**cookies: str) -> httpx.Cookies:
+    jar = httpx.Cookies()
+    for name, value in cookies.items():
+        jar.set(name, value, domain=".google.com", path="/")
+    return jar
+
+
+def _auth(**cookies: str) -> AuthTokens:
+    return AuthTokens(
+        cookies={(n, ".google.com", "/"): v for n, v in cookies.items()},
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+def test_replace_cookie_jar_updates_both_views() -> None:
+    """The regression: rebinding the jar must refresh the derived map too."""
+    auth = _auth(SID="old-sid")
+    assert auth.cookies[("SID", ".google.com", "/")] == "old-sid"
+
+    auth.replace_cookie_jar(_jar(SID="fresh-sid"))
+
+    assert auth.cookies[("SID", ".google.com", "/")] == "fresh-sid", (
+        "auth.cookies still describes the pre-refresh session"
+    )
+    assert auth.cookie_jar is not None
+    assert auth.cookie_jar.get("SID", domain=".google.com") == "fresh-sid"
+
+
+def test_the_two_views_agree_after_a_rebind() -> None:
+    """Stated as the invariant rather than as one example.
+
+    Whatever the jar holds, the map must describe the same cookies — that is
+    the property the dual storage kept breaking.
+    """
+    auth = _auth(SID="s0", HSID="h0")
+    auth.replace_cookie_jar(_jar(SID="s1", HSID="h1", APISID="a1"))
+
+    from_map = {name: value for (name, _domain, _path), value in auth.cookies.items()}
+    assert auth.cookie_jar is not None
+    from_jar = {c.name: c.value for c in auth.cookie_jar.jar}
+    assert from_map == from_jar
+
+
+def test_a_cookie_dropped_by_the_refresh_disappears_from_the_map() -> None:
+    """Rebinding replaces the view; it does not merge into the stale one.
+
+    A stale key surviving a refresh is the more dangerous half of the bug —
+    it would keep a retired cookie readable through the public surface.
+    """
+    auth = _auth(SID="s0", RETIRED="gone")
+    auth.replace_cookie_jar(_jar(SID="s1"))
+
+    assert ("RETIRED", ".google.com", "/") not in auth.cookies
+    assert auth.cookies[("SID", ".google.com", "/")] == "s1"
+
+
+def test_construction_still_syncs_the_two_views() -> None:
+    """The pre-existing ``__post_init__`` sync is unchanged."""
+    auth = _auth(SID="s")
+    assert auth.cookie_jar is not None
+    assert auth.cookie_jar.get("SID", domain=".google.com") == "s"
+
+
+def test_flat_cookies_reflects_the_refresh() -> None:
+    """The legacy flat read is derived from ``cookies``, so it inherits the fix."""
+    auth = _auth(SID="old")
+    auth.replace_cookie_jar(_jar(SID="new"))
+    assert auth.flat_cookies["SID"] == "new"
+
+
+@pytest.mark.parametrize("value", ["", "x" * 200])
+def test_rebind_handles_edge_case_values(value: str) -> None:
+    """Empty and long values round-trip through the jar->map conversion."""
+    auth = _auth(SID="seed")
+    auth.replace_cookie_jar(_jar(SID=value))
+    got = auth.cookies.get(("SID", ".google.com", "/"))
+    # httpx drops an empty-valued cookie rather than storing it; either way the
+    # two views must still agree, which is the invariant under test.
+    assert auth.cookie_jar is not None
+    jar_names = {c.name for c in auth.cookie_jar.jar}
+    assert (got is not None) == ("SID" in jar_names)


### PR DESCRIPTION
## ADR-0032 Phase A — the non-breaking compat surface

First slice of [ADR-0032](../blob/main/docs/adr/0032-auth-domain-types.md) (merged in #2153). Zero public change: adds the typed read-projection and the constructor the destination design needs, and folds in the stranded staleness fix. Sets up the runway; deletes nothing.

### What's here

- **`CookieJar.from_httpx(jar)`** — snapshot a live `httpx.Cookies` into an immutable `CookieJar`. Preserves `expires`/`secure`/`http_only`; **`same_site`-lossy by construction** (`http.cookiejar.Cookie` cannot carry SameSite), so it is documented and barred from persistence/baseline paths — question-only (`names` / `validate_required` / `has_secondary_binding`). Feeding it to `to_storage_state`/baseline would re-open the #2150 SameSite downgrade; the delta machinery keeps SameSite out-of-band (`storage._preserved_same_site`).
- **`AuthTokens.jar`** — a typed, read-only `CookieJar` **projection of the live jar**, materialized fresh on each read (never cached — a construction-time cache goes stale the instant `cookies` is reassigned on the mutable dataclass; projection-on-read cannot). Gives map-shaped readers a question-answering view without a new stored field.
- **Stranded staleness fix folded in** (`replace_cookie_jar`): keeps `AuthTokens.cookies` in sync when the live jar is rebound, so the two vestigial views can't diverge. Guardrail asserts every rebind routes through it and that it sets both views.
- **Bootstrap-seed + sync-back labels** (`_kernel.py`, `_runtime/auth.py:316`): mark the ONE legitimate internal read of auth's cookie fields (becomes `initial_cookies` at Phase B) and the compat-only write-back, so the deletion runway is legible in the code.

### Not in scope (per the ADR runway)

Next minor: `DeprecationWarning` on `flat_cookies`, docs-only deprecation of `cookies`/`cookie_jar`. Next major (Phase B): delete the fields, `AuthTokens` becomes the frozen bootstrap credential with `initial_cookies: CookieJar`.

### Verification

- Full guardrails 1266 passed / 3 skipped / 3 xfailed; mypy clean (335 files); ruff clean.
- Phase A + keepalive tests: 71 passed (the timing-sensitive `test_client_keepalive.py` persistence tests that flaked on windows-py3.10 during #2153 pass here).
- Live auth matrix run against a real master-token profile — results in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only authentication cookie views with expiry, security, HTTP-only, and policy metadata.
  * Added reliable synchronization when authentication cookies are replaced or updated.

* **Bug Fixes**
  * Improved consistency between live authentication cookies and their derived representations.
  * Preserved cookie values and metadata during authentication updates.

* **Tests**
  * Added coverage for cookie conversion, filtering, synchronization, replacement, policy queries, and edge-case values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->