### PR TITLE
fix(notebooks): stop reporting an empty notebook as schema drift (#2131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An empty notebook no longer logs `schema drift?` on every
+  `get_source_ids` call.** A genuinely empty notebook returns a healthy
+  envelope whose sources slot is present but explicitly null — the backend
+  sends `None` there, not `[]` — and the guard tested only
+  `isinstance(sources, list)`, so a valid empty state landed in the branch
+  reserved for a malformed response. Obfuscated method ids and positional
+  payload shapes changing underneath us is this project's #1 breakage class
+  and `schema drift?` is how an operator finds out, so a warning that fires on
+  every empty notebook erodes the one signal that has to stay trustworthy. The
+  walk now separates the three shapes the single `isinstance` test conflated:
+  an envelope too short to carry a sources slot still warns (a truncated shape,
+  as before), a present-and-null slot returns quietly, and a present-but-wrong
+  type still warns. That is the same split the sibling walk over this slot
+  already makes in `_source/listing.py`
+  ([#2131](https://github.com/teng-lin/notebooklm-py/issues/2131)).
 - **Chat turn numbers now come from server history instead of the client-local
   cache.** Stateless remote MCP requests create a fresh client for each call, so
   a real continuation could previously report the contradictory pair

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -319,13 +319,32 @@ class NotebooksAPI:
                 )
                 return source_ids
 
-            sources = (
-                safe_index(
-                    notebook_info, 1, method_id=method_id, source="NotebooksAPI.get_source_ids"
+            if len(notebook_info) <= 1:
+                # The sources slot is *absent*, which is not the same thing as
+                # present-and-null below: a healthy envelope carries the slot
+                # (the #2131 report shows ``len=11`` on an empty notebook), so a
+                # response too short to hold one is a truncated shape worth
+                # surfacing.
+                logger.warning(
+                    "get_source_ids: notebook_info has no sources slot for %s "
+                    "(schema drift?). len=%d",
+                    notebook_id,
+                    len(notebook_info),
                 )
-                if len(notebook_info) > 1
-                else None
+                return source_ids
+
+            sources = safe_index(
+                notebook_info, 1, method_id=method_id, source="NotebooksAPI.get_source_ids"
             )
+            if sources is None:
+                # Slot present, explicitly null: a genuinely empty notebook
+                # elides its sources as ``None`` rather than ``[]``. A valid
+                # empty state, not a malformed response, so it must not reach
+                # the drift warning below (#2131). This is the same split the
+                # sibling walk over this slot already makes — reject the short
+                # envelope first, then accept a present ``None``
+                # (``_source/listing.py``, issue #1159).
+                return source_ids
             if not isinstance(sources, list):
                 logger.warning(
                     "get_source_ids: notebook_info[1] not list for %s (schema drift?). len=%d",

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -77,6 +77,52 @@ async def test_get_source_ids_happy_path_no_warning(caplog):
     assert warnings == []
 
 
+@pytest.mark.asyncio
+async def test_get_source_ids_empty_notebook_emits_no_drift_warning(caplog):
+    """An empty notebook elides the sources slot — a valid empty state, not drift (#2131).
+
+    Live shape on a freshly created, genuinely empty notebook: the envelope is
+    healthy (the observed report was ``len=11``) but ``notebook_info[1]`` is
+    ``None`` rather than ``[]``. Warning here fires on every empty notebook and
+    erodes the one signal that must stay trustworthy — ``schema drift?`` is how
+    an operator learns the positional payload shape really did change.
+    """
+    from notebooklm._notebooks import NotebooksAPI
+    from tests._fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[[None] * 11]))
+    api = NotebooksAPI(core)
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+        result = await api.get_source_ids("nb_empty")
+
+    assert result == []
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+@pytest.mark.asyncio
+async def test_get_source_ids_warns_when_the_sources_slot_is_absent(caplog):
+    """An *absent* sources slot is drift; only a present-and-null one is empty (#2131).
+
+    Pins the boundary the carve-out must not cross. ``[[None]]`` is too short to
+    hold slot 1 at all — a truncated envelope, not an empty notebook, whose
+    reported shape carries a full ``len=11``. Written because the obvious
+    implementation ("return quietly whenever the slot expression is ``None``")
+    folds this case in and silently drops the warning it used to emit.
+    """
+    from notebooklm._notebooks import NotebooksAPI
+    from tests._fixtures.fake_core import make_fake_core
+
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[[None]]))
+    api = NotebooksAPI(core)
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+        result = await api.get_source_ids("nb_short")
+
+    assert result == []
+    assert any("schema drift" in r.message and "nb_short" in r.message for r in caplog.records)
+
+
 def test_qa_pairs_raises_on_unguarded_shape():
     """_chat/api.py: QA-pair parser raises when next_turn[4] is not indexable.
 


### PR DESCRIPTION
## Summary

`NotebooksAPI.get_source_ids` logs `schema drift?` at WARNING on **every** call against a genuinely empty notebook. Per the live-verified evidence in #2131, an empty notebook returns a healthy envelope (the reported `len=11`) whose sources slot is present but explicitly null — the backend sends `None` there, not `[]` — and the existing guard tested only `isinstance(sources, list)`, so a valid empty state landed in the branch reserved for a malformed response.

This matters more than the noise itself. Obfuscated method ids and positional payload shapes changing underneath us is this project's #1 breakage class, and `schema drift?` in the logs is how an operator finds out. A warning that fires on every empty notebook trains that operator to scroll past the line that will one day be real.

## Related Issue

Closes #2131

## Root cause

One `isinstance` test was standing in for three distinct shapes, only one of which is drift:

| `notebook_info` shape | Meaning | Old behaviour | New behaviour |
|---|---|---|---|
| too short to carry slot 1 | truncated envelope | warns | **warns** (unchanged) |
| slot present, explicitly `None` | genuinely empty notebook | warns ❌ | **returns quietly** |
| slot present, wrong type | shape changed under us | warns | **warns** (unchanged) |

The sibling walk over this same slot of this same response already makes exactly this split: `_source/listing.py` rejects a short `nb_info` first, and only then accepts a present `None` without raising, even under strict-decode (issue #1159). `get_source_ids` collapsed the first two cases together.

## Changes

- `src/notebooklm/_notebooks.py` — split the single `not isinstance(sources, list)` guard into the three cases above. The short-envelope branch keeps warning (with a message naming the actual condition rather than reusing the slot-type wording); the present-and-null branch returns quietly; the wrong-type branch is untouched.
- `tests/unit/test_swallow_observability.py` — two tests alongside the existing drift cases:
  - `test_get_source_ids_empty_notebook_emits_no_drift_warning` — the fix itself (`[[None] * 11]`, mirroring the reported envelope).
  - `test_get_source_ids_warns_when_the_sources_slot_is_absent` — the boundary (`[[None]]`), pinning that the carve-out did not widen into "return quietly whenever the slot expression is `None`".

No public API, exception type, or return type changes; no architectural shape change, so no ADR.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated — N/A, no shape change

Run against the canonical contributor install plus the extras the CI test matrix adds (`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`):

```console
$ uv run mypy src/notebooklm --ignore-missing-imports
Success: no issues found in 334 source files

$ uv run pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed

$ uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90 -q
TOTAL                                                    28159    740   7634    450    97%
Required test coverage of 90% reached. Total coverage: 96.51%
13749 passed, 64 skipped, 3 xfailed, 18 warnings in 1601.22s (0:26:41)
```

Both new tests were confirmed non-vacuous by reverting only the source change and re-running: the empty-notebook test fails with the exact line from the issue —

```text
get_source_ids: notebook_info[1] not list for nb_empty (schema drift?). len=11
```

— and the absent-slot test fails against the naive carve-out described in Notes.

## Notes

**The obvious fix is wrong, and this is the second attempt.** The first version simply returned quietly whenever the slot expression evaluated to `None`. That expression also yields `None` when `len(notebook_info) <= 1`, so a truncated envelope — which *did* warn before — silently became "empty notebook", defeating the observability rationale that motivates this issue in the first place. `["title-only"]` went from a drift warning to `{"result": [], "warnings": []}`. The absent-slot test exists specifically to keep that regression from coming back.

**Scope of my verification.** Everything here was verified offline: unit tests, plus `tests/cassettes/notebook_zero_sources.yaml`, which carries the same present-null slot. The claim about *current* live backend behaviour is the maintainer's from #2131, not an independent live run — I do not have an account positioned to re-verify it.

**Not verified locally:** the Python 3.10–3.14 matrix. The change uses no version-sensitive syntax, but I can only exercise one interpreter here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty notebooks when retrieving source IDs.
  * Prevented unnecessary schema-drift warnings for valid notebooks with no sources.
  * Continued reporting truncated notebook responses where source information is missing.
  * Preserved warnings for notebook responses with invalid source data.

* **Tests**
  * Added coverage for valid empty notebooks, incomplete responses, and invalid source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->