### PR TITLE
fix(notebooks): honour the documented not-found contract on a status-5 reply (#2132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,49 +229,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`notebooks.get_or_none()` returns `None` again for a notebook that does
-  not exist.** ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, but it
-  raised `ClientError` on exactly that input, so every caller of the safe
-  lookup was holding an unsafe one — visible only against the live backend,
-  not in the docstring or the type signature. The cause sits one layer up:
-  `get()` documents that it raises `NotebookNotFoundError` on a miss, and its
-  post-validation rests on the premise that the backend answers an unknown id
-  with a degenerate payload rather than a proper RPC error. It now answers with
-  gRPC status 5, which the decoder surfaces as `ClientError` — a *sibling* of
-  `NotebookNotFoundError` under `RPCError`, not an ancestor, so
-  `except NotebookNotFoundError` never saw it. `get()` now translates a
-  status-5 rejection into `NotebookNotFoundError` and keeps the
-  degenerate-payload post-validation as the belt-and-braces path. The match is
-  deliberately narrow to status 5: the decoder routes status 7
-  (`PERMISSION_DENIED`) through the same `ClientError` branch, and a notebook
-  the caller may not read is not a notebook that does not exist. Callers
-  wanting the untranslated failure still have `get_raw()`
-  ([#2132](https://github.com/teng-lin/notebooklm-py/issues/2132)).
-
-  The **whole diagnostic survives the translation**, not just the chained
-  cause: status 5 also covers "the notebook belongs to a different signed-in
-  Google account", and `server/_errors.py` documents that the 404 body
-  preserves that account-routing guidance verbatim. Since every adapter renders
-  `str(exc)` and never `__cause__`, `NotebookNotFoundError` gained optional
-  `detail` / `rpc_code` / `found_ids` arguments (all keyword-only with
-  defaults, so existing construction is unaffected) and the translation passes
-  the decoder's message through. A plain absence with no diagnostic still reads
-  exactly `Notebook not found: <id>`. `get_or_none()` folds both meanings of
-  status 5 into `None` by construction — its docstring now says so, and points
-  at `get()` for callers who need to tell them apart.
-
-- **Canonical gRPC status codes replace scattered magic numbers.** The wire
-  statuses at index 5 of a `wrb.fr` entry were spelled as bare literals at
-  three layers — the decoder's `(5, 7)` routing, the neutral error classifier's
-  `== 5`, and the new notebook not-found translation — with nothing naming the
-  namespace, while `RPCErrorCode.NOT_FOUND` is `404` in a *different*
-  (HTTP-style) namespace that shares member names. `GrpcStatusCode` in
-  `rpc/types.py` is now the single source of truth for those numbers, paired
-  with two coercion helpers for the `str | int | None` shape `rpc_code` takes:
-  `normalize_rpc_code` (to `int`, keeping HTTP 5xx intact for the transient
-  check) and `normalize_grpc_status` (to the enum, for semantic comparisons).
-  Both reject `bool` explicitly, since `True` would otherwise coerce to
-  `CANCELLED`. `RPCErrorCode` is unchanged.
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend
@@ -563,6 +520,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The `login` path marker (which subsumes the old `servicelogin` entry) closes it
   ([#2073](https://github.com/teng-lin/notebooklm-py/issues/2073)).
 
+- **`notebooks.get_or_none()` returns `None` again for a notebook that does
+  not exist.** ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, but it
+  raised `ClientError` on exactly that input, so every caller of the safe
+  lookup was holding an unsafe one — visible only against the live backend,
+  not in the docstring or the type signature. The cause sits one layer up:
+  `get()` documents that it raises `NotebookNotFoundError` on a miss, and its
+  post-validation rests on the premise that the backend answers an unknown id
+  with a degenerate payload rather than a proper RPC error. It now answers with
+  gRPC status 5, which the decoder surfaces as `ClientError` — a *sibling* of
+  `NotebookNotFoundError` under `RPCError`, not an ancestor, so
+  `except NotebookNotFoundError` never saw it. `get()` now translates a
+  status-5 rejection into `NotebookNotFoundError` and keeps the
+  degenerate-payload post-validation as the belt-and-braces path. The match is
+  deliberately narrow to status 5: the decoder routes status 7
+  (`PERMISSION_DENIED`) through the same `ClientError` branch, and a notebook
+  the caller may not read is not a notebook that does not exist. Callers
+  wanting the untranslated failure still have `get_raw()`
+  ([#2132](https://github.com/teng-lin/notebooklm-py/issues/2132)).
+
+  The **whole diagnostic survives the translation**, not just the chained
+  cause: status 5 also covers "the notebook belongs to a different signed-in
+  Google account", and `server/_errors.py` documents that the 404 body
+  preserves that account-routing guidance verbatim. Since every adapter renders
+  `str(exc)` and never `__cause__`, `NotebookNotFoundError` gained optional
+  `detail` / `rpc_code` / `found_ids` arguments (all keyword-only with
+  defaults, so existing construction is unaffected) and the translation passes
+  the decoder's message through. A plain absence with no diagnostic still reads
+  exactly `Notebook not found: <id>`. `get_or_none()` folds both meanings of
+  status 5 into `None` by construction — its docstring now says so, and points
+  at `get()` for callers who need to tell them apart.
+
+- **Canonical gRPC status codes replace scattered magic numbers.** The wire
+  statuses at index 5 of a `wrb.fr` entry were spelled as bare literals at
+  three layers — the decoder's `(5, 7)` routing, the neutral error classifier's
+  `== 5`, and the new notebook not-found translation — with nothing naming the
+  namespace, while `RPCErrorCode.NOT_FOUND` is `404` in a *different*
+  (HTTP-style) namespace that shares member names. `GrpcStatusCode` in
+  `rpc/types.py` is now the single source of truth for those numbers, paired
+  with two coercion helpers for the `str | int | None` shape `rpc_code` takes:
+  `normalize_rpc_code` (to `int`, keeping HTTP 5xx intact for the transient
+  check) and `normalize_grpc_status` (to the enum, for semantic comparisons).
+  Both reject `bool` explicitly, since `True` would otherwise coerce to
+  `CANCELLED`. `RPCErrorCode` is unchanged.
 - **RPC errors now name the host, not just the method.** Google serves the
   personal app from two hosts — `notebooklm.google.com` and, since the Gemini
   Notebook rebrand, `notebook.google.com` (ADR-0028) — and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,49 +520,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The `login` path marker (which subsumes the old `servicelogin` entry) closes it
   ([#2073](https://github.com/teng-lin/notebooklm-py/issues/2073)).
 
-- **`notebooks.get_or_none()` returns `None` again for a notebook that does
-  not exist.** ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, but it
-  raised `ClientError` on exactly that input, so every caller of the safe
-  lookup was holding an unsafe one — visible only against the live backend,
-  not in the docstring or the type signature. The cause sits one layer up:
-  `get()` documents that it raises `NotebookNotFoundError` on a miss, and its
-  post-validation rests on the premise that the backend answers an unknown id
-  with a degenerate payload rather than a proper RPC error. It now answers with
-  gRPC status 5, which the decoder surfaces as `ClientError` — a *sibling* of
-  `NotebookNotFoundError` under `RPCError`, not an ancestor, so
-  `except NotebookNotFoundError` never saw it. `get()` now translates a
-  status-5 rejection into `NotebookNotFoundError` and keeps the
-  degenerate-payload post-validation as the belt-and-braces path. The match is
-  deliberately narrow to status 5: the decoder routes status 7
-  (`PERMISSION_DENIED`) through the same `ClientError` branch, and a notebook
-  the caller may not read is not a notebook that does not exist. Callers
-  wanting the untranslated failure still have `get_raw()`
-  ([#2132](https://github.com/teng-lin/notebooklm-py/issues/2132)).
-
-  The **whole diagnostic survives the translation**, not just the chained
-  cause: status 5 also covers "the notebook belongs to a different signed-in
-  Google account", and `server/_errors.py` documents that the 404 body
-  preserves that account-routing guidance verbatim. Since every adapter renders
-  `str(exc)` and never `__cause__`, `NotebookNotFoundError` gained optional
-  `detail` / `rpc_code` / `found_ids` arguments (all keyword-only with
-  defaults, so existing construction is unaffected) and the translation passes
-  the decoder's message through. A plain absence with no diagnostic still reads
-  exactly `Notebook not found: <id>`. `get_or_none()` folds both meanings of
-  status 5 into `None` by construction — its docstring now says so, and points
-  at `get()` for callers who need to tell them apart.
-
-- **Canonical gRPC status codes replace scattered magic numbers.** The wire
-  statuses at index 5 of a `wrb.fr` entry were spelled as bare literals at
-  three layers — the decoder's `(5, 7)` routing, the neutral error classifier's
-  `== 5`, and the new notebook not-found translation — with nothing naming the
-  namespace, while `RPCErrorCode.NOT_FOUND` is `404` in a *different*
-  (HTTP-style) namespace that shares member names. `GrpcStatusCode` in
-  `rpc/types.py` is now the single source of truth for those numbers, paired
-  with two coercion helpers for the `str | int | None` shape `rpc_code` takes:
-  `normalize_rpc_code` (to `int`, keeping HTTP 5xx intact for the transient
-  check) and `normalize_grpc_status` (to the enum, for semantic comparisons).
-  Both reject `bool` explicitly, since `True` would otherwise coerce to
-  `CANCELLED`. `RPCErrorCode` is unchanged.
 - **RPC errors now name the host, not just the method.** Google serves the
   personal app from two hosts — `notebooklm.google.com` and, since the Gemini
   Notebook rebrand, `notebook.google.com` (ADR-0028) — and
@@ -708,6 +665,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / [#2018](https://github.com/teng-lin/notebooklm-py/issues/2018), which fixed
   the script's *auth* path and left its *request* path untouched
   ([#2054](https://github.com/teng-lin/notebooklm-py/issues/2054)).
+
+- **`notebooks.get_or_none()` returns `None` again for a notebook that does
+  not exist.** ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, but it
+  raised `ClientError` on exactly that input, so every caller of the safe
+  lookup was holding an unsafe one — visible only against the live backend,
+  not in the docstring or the type signature. The cause sits one layer up:
+  `get()` documents that it raises `NotebookNotFoundError` on a miss, and its
+  post-validation rests on the premise that the backend answers an unknown id
+  with a degenerate payload rather than a proper RPC error. It now answers with
+  gRPC status 5, which the decoder surfaces as `ClientError` — a *sibling* of
+  `NotebookNotFoundError` under `RPCError`, not an ancestor, so
+  `except NotebookNotFoundError` never saw it. `get()` now translates a
+  status-5 rejection into `NotebookNotFoundError` and keeps the
+  degenerate-payload post-validation as the belt-and-braces path. The match is
+  deliberately narrow to status 5: the decoder routes status 7
+  (`PERMISSION_DENIED`) through the same `ClientError` branch, and a notebook
+  the caller may not read is not a notebook that does not exist. Callers
+  wanting the untranslated failure still have `get_raw()`
+  ([#2132](https://github.com/teng-lin/notebooklm-py/issues/2132)).
+
+  The **whole diagnostic survives the translation**, not just the chained
+  cause: status 5 also covers "the notebook belongs to a different signed-in
+  Google account", and `server/_errors.py` documents that the 404 body
+  preserves that account-routing guidance verbatim. Since every adapter renders
+  `str(exc)` and never `__cause__`, `NotebookNotFoundError` gained optional
+  `detail` / `rpc_code` / `found_ids` arguments (all keyword-only with
+  defaults, so existing construction is unaffected) and the translation passes
+  the decoder's message through. A plain absence with no diagnostic still reads
+  exactly `Notebook not found: <id>`. `get_or_none()` folds both meanings of
+  status 5 into `None` by construction — its docstring now says so, and points
+  at `get()` for callers who need to tell them apart.
+
+- **Canonical gRPC status codes replace scattered magic numbers.** The wire
+  statuses at index 5 of a `wrb.fr` entry were spelled as bare literals at
+  three layers — the decoder's `(5, 7)` routing, the neutral error classifier's
+  `== 5`, and the new notebook not-found translation — with nothing naming the
+  namespace, while `RPCErrorCode.NOT_FOUND` is `404` in a *different*
+  (HTTP-style) namespace that shares member names. `GrpcStatusCode` in
+  `rpc/types.py` is now the single source of truth for those numbers, paired
+  with two coercion helpers for the `str | int | None` shape `rpc_code` takes:
+  `normalize_rpc_code` (to `int`, keeping HTTP 5xx intact for the transient
+  check) and `normalize_grpc_status` (to the enum, for semantic comparisons).
+  Both reject `bool` explicitly, since `True` would otherwise coerce to
+  `CANCELLED`. `RPCErrorCode` is unchanged.
 
 - **`scripts/diagnose_get_notebook.py` can authenticate again, and honours
   `NOTEBOOKLM_BASE_URL`.** Two independent defects in the same ~40 lines: it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`notebooks.get_or_none()` returns `None` again for a notebook that does
+  not exist.** ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, but it
+  raised `ClientError` on exactly that input, so every caller of the safe
+  lookup was holding an unsafe one — visible only against the live backend,
+  not in the docstring or the type signature. The cause sits one layer up:
+  `get()` documents that it raises `NotebookNotFoundError` on a miss, and its
+  post-validation rests on the premise that the backend answers an unknown id
+  with a degenerate payload rather than a proper RPC error. It now answers with
+  gRPC status 5, which the decoder surfaces as `ClientError` — a *sibling* of
+  `NotebookNotFoundError` under `RPCError`, not an ancestor, so
+  `except NotebookNotFoundError` never saw it. `get()` now translates a
+  status-5 rejection into `NotebookNotFoundError` and keeps the
+  degenerate-payload post-validation as the belt-and-braces path. The match is
+  deliberately narrow to status 5: the decoder routes status 7
+  (`PERMISSION_DENIED`) through the same `ClientError` branch, and a notebook
+  the caller may not read is not a notebook that does not exist. Callers
+  wanting the untranslated failure still have `get_raw()`
+  ([#2132](https://github.com/teng-lin/notebooklm-py/issues/2132)).
+
+  The **whole diagnostic survives the translation**, not just the chained
+  cause: status 5 also covers "the notebook belongs to a different signed-in
+  Google account", and `server/_errors.py` documents that the 404 body
+  preserves that account-routing guidance verbatim. Since every adapter renders
+  `str(exc)` and never `__cause__`, `NotebookNotFoundError` gained optional
+  `detail` / `rpc_code` / `found_ids` arguments (all keyword-only with
+  defaults, so existing construction is unaffected) and the translation passes
+  the decoder's message through. A plain absence with no diagnostic still reads
+  exactly `Notebook not found: <id>`. `get_or_none()` folds both meanings of
+  status 5 into `None` by construction — its docstring now says so, and points
+  at `get()` for callers who need to tell them apart.
+
+- **Canonical gRPC status codes replace scattered magic numbers.** The wire
+  statuses at index 5 of a `wrb.fr` entry were spelled as bare literals at
+  three layers — the decoder's `(5, 7)` routing, the neutral error classifier's
+  `== 5`, and the new notebook not-found translation — with nothing naming the
+  namespace, while `RPCErrorCode.NOT_FOUND` is `404` in a *different*
+  (HTTP-style) namespace that shares member names. `GrpcStatusCode` in
+  `rpc/types.py` is now the single source of truth for those numbers, paired
+  with two coercion helpers for the `str | int | None` shape `rpc_code` takes:
+  `normalize_rpc_code` (to `int`, keeping HTTP 5xx intact for the transient
+  check) and `normalize_grpc_status` (to the enum, for semantic comparisons).
+  Both reject `bool` explicitly, since `True` would otherwise coerce to
+  `CANCELLED`. `RPCErrorCode` is unchanged.
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -292,7 +292,17 @@ decode faults rather than swallowing them. (The one documented carve-out is
 `artifacts`, which inherits `client.artifacts.list(...)`'s deliberate
 partial-availability behavior: a transport failure of the mind-map sub-fetch is
 logged and the studio artifacts that loaded are still returned — see ADR-0019
-Rule 3.) The workflows that
+Rule 3.)
+
+For `notebooks` specifically, gRPC status `5` reaches `None` under **both** its
+meanings: the notebook is genuinely absent, or it exists under a different
+signed-in Google account (the account-routing case behind issues #114 / #294).
+The backend sends the same status either way, so `get_or_none()` cannot
+distinguish them and the routing guidance is unobservable there. Use
+`client.notebooks.get(...)` when that matters — it raises
+`NotebookNotFoundError` carrying the guidance in its message, the originating
+`rpc_code`, and the original rejection as `__cause__`. `PERMISSION_DENIED`
+(status `7`) is never folded into `None` and always propagates. The workflows that
 *already* raise `SourceNotFoundError` are `client.sources.get_fulltext(...)` and
 `client.sources.wait_until_ready(...)`. Artifact-download workflows raise
 `ArtifactNotFoundError` when a requested artifact ID is not in the listing.

--- a/src/notebooklm/_app/errors.py
+++ b/src/notebooklm/_app/errors.py
@@ -72,6 +72,11 @@ from ..exceptions import (
     ValidationError,
     WaitTimeoutError,
 )
+
+# Via the public ``notebooklm.types`` facade, not ``notebooklm.rpc.*`` — the
+# _app boundary lint (tests/_guardrails/test_app_boundary.py) requires RPC
+# enums to be consumed through their public re-export.
+from ..types import GrpcStatusCode, normalize_grpc_status, normalize_rpc_code
 from .source_mutations import SourceMutationError
 
 
@@ -232,19 +237,20 @@ def is_retriable(category: ErrorCategory) -> bool:
 
 
 def _normalized_rpc_code(exc: RPCError) -> int | None:
-    """Return ``exc.rpc_code`` normalized to an ``int``, or ``None`` if absent/non-numeric.
+    """Return ``exc.rpc_code`` coerced to an ``int``, or ``None``.
 
-    ``rpc_code`` is typed ``str | int | None``; a string ``"5"`` must compare
-    equal to the integer status, so this coerces before comparison and tolerates
-    a non-numeric value (returns ``None`` rather than raising).
+    Thin adapter over the canonical
+    :func:`~notebooklm.types.normalize_rpc_code` so this module keeps taking an
+    exception rather than a raw code. The coercion rules live in that one
+    helper, shared with the decoder and the notebook not-found translation.
+
+    Stays an ``int`` rather than a :class:`GrpcStatusCode` because
+    :func:`_is_transient_rpc_code` range-checks HTTP statuses (``500 <= code <
+    600``) through the same value; narrowing here would silently drop every
+    5xx to ``None``. Semantic gRPC comparisons use
+    :func:`~notebooklm.types.normalize_grpc_status` instead.
     """
-    code = getattr(exc, "rpc_code", None)
-    if code is None:
-        return None
-    try:
-        return int(code)
-    except (TypeError, ValueError):
-        return None
+    return normalize_rpc_code(getattr(exc, "rpc_code", None))
 
 
 #: rpc_codes that mean a *transient / server-side* failure (not specific to the one
@@ -253,7 +259,14 @@ def _normalized_rpc_code(exc: RPCError) -> int | None:
 #: whose bare-RPCError cause carries one of these FATAL in a batch add — the per-source
 #: rejection codes (e.g. 3 INVALID_ARGUMENT / 9 FAILED_PRECONDITION) fall through to
 #: the non-fatal SOURCE_ADD instead.
-_TRANSIENT_GRPC_CODES = frozenset({4, 8, 13, 14})
+_TRANSIENT_GRPC_CODES = frozenset(
+    {
+        GrpcStatusCode.DEADLINE_EXCEEDED,
+        GrpcStatusCode.RESOURCE_EXHAUSTED,
+        GrpcStatusCode.INTERNAL,
+        GrpcStatusCode.UNAVAILABLE,
+    }
+)
 
 
 def _is_transient_rpc_code(code: int | None) -> bool:
@@ -325,7 +338,9 @@ def _category_for(exc: BaseException) -> ErrorCategory:
     # ``"5"`` is not missed. Purely additive (no exception-type change), so the
     # ``RPC`` exemplar (a bare ``RPCError`` with no ``rpc_code``) is unaffected
     # and the consistency gate stays green.
-    if isinstance(exc, ClientError) and _normalized_rpc_code(exc) == 5:
+    if isinstance(exc, ClientError) and (
+        normalize_grpc_status(getattr(exc, "rpc_code", None)) is GrpcStatusCode.NOT_FOUND
+    ):
         return ErrorCategory.NOT_FOUND
 
     # --- Remaining RPC failures (decoding, unknown-method, client 4xx, ...) ---

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -394,6 +394,42 @@ def scrub_secrets(text: object) -> str:
     return text
 
 
+_PREVIEW_LIMIT = 80
+# Pre-slice cap for the truncated path: scrub at most this many chars before
+# cutting to ``_PREVIEW_LIMIT``. The 10x window gives a boundary-straddling
+# secret ample room to be neutralized before the 80-char cut, while bounding
+# the regex sweep at O(800 chars) instead of O(len(raw)) for multi-MB bodies.
+_PREVIEW_SCRUB_CAP = _PREVIEW_LIMIT * 10
+
+
+def _truncate_response_preview(raw: str | None) -> str | None:
+    """Truncate a raw RPC response preview for safe display in error contexts.
+
+    Default behavior keeps the preview compact (80 chars + ``"..."`` suffix) so
+    error logs and CLI output stay readable. Set ``NOTEBOOKLM_DEBUG=1`` to opt
+    into the full untruncated body for deep debugging.
+
+    Credential-shaped substrings (CSRF tokens, session cookies, etc.) are
+    scrubbed *before* truncation in both modes. ``raw_response`` is a public
+    attribute spliced into ``str()``/``repr()`` of RPC errors, so it escapes the
+    logging pipeline's ``RedactingFilter`` and must be sanitized at the source.
+
+    In the default (truncated) path the input is pre-sliced to
+    ``_PREVIEW_SCRUB_CAP`` before scrubbing so a multi-MB error body does not
+    pay for a full regex sweep just to discard all but the first 80 chars. The
+    ``NOTEBOOKLM_DEBUG=1`` path keeps the whole body, so it scrubs the full
+    string.
+    """
+    if raw is None:
+        return None
+    if os.environ.get("NOTEBOOKLM_DEBUG") == "1":
+        return scrub_secrets(raw)
+    scrubbed = scrub_secrets(raw[:_PREVIEW_SCRUB_CAP])
+    if len(scrubbed) > _PREVIEW_LIMIT:
+        return scrubbed[:_PREVIEW_LIMIT] + "..."
+    return scrubbed
+
+
 # Backwards-compat alias for any in-package code that imported the historical
 # private name. New code should use ``scrub_secrets`` directly.
 _scrub = scrub_secrets

--- a/src/notebooklm/_notebook_payloads.py
+++ b/src/notebooklm/_notebook_payloads.py
@@ -1,17 +1,40 @@
 """Stable ``batchexecute`` notebook RPC request payload builders.
 
-Currently the ``SUGGEST_PROMPTS`` (``otmP3b`` / ``GeneratePromptSuggestions``)
-request builder backing :meth:`NotebooksAPI.suggest_prompts`. Kept in a sibling
-module (rather than inline in ``_notebooks.py``) so the notebook RPC façade stays
-under the ADR-0008 module-size budget; mirrors the ``_settings`` /
-``_source.upload_payloads`` split.
+Kept in a sibling module (rather than inline in ``_notebooks.py``) so the
+notebook RPC façade stays under the ADR-0008 module-size budget; mirrors the
+``_settings`` / ``_source.upload_payloads`` split.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from ._source.upload_payloads import build_template_block
 from .rpc import nest_source_ids
+
+
+def build_create_notebook_params(title: str) -> list[Any]:
+    """Return the canonical CREATE_NOTEBOOK RPC payload.
+
+    The trailing :func:`build_template_block` replaced the old flat ``[2], [1]``
+    tail that migrated backends now reject with ``status=3`` (#1546).
+    """
+    return [title, None, None, build_template_block()]
+
+
+def build_get_notebook_params(notebook_id: str) -> list[Any]:
+    """Return the canonical GET_NOTEBOOK (``rLM1Ne``) RPC payload.
+
+    The Gemini-3.5 rollout migrated the read path's trailing template block from
+    the flat ``[2]`` to the same nested :func:`build_template_block` wrapper the
+    write path adopted in #1548 (issue #1549). Live-verified forward-compatible:
+    the nested shape returns a byte-identical decoded notebook (notebook id /
+    title and every ``SourceRow``) as the flat ``[2]`` on an un-migrated account,
+    so it is safe across cohorts. The trailing ``None, 0`` is unchanged — only
+    the template block at position 2 is migrated (the narrow scope #1549 tracks).
+    """
+    return [notebook_id, None, build_template_block(), None, 0]
+
 
 # The required ``C0`` "mode/surface" enum (field 4 of the SUGGEST_PROMPTS request).
 # ``0`` / omitted -> gRPC INTERNAL; ``1..10`` return a populated suggestion list;

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -12,6 +12,8 @@ from ._notebook_metadata import (
 )
 from ._notebook_payloads import (
     _PROMPT_SUGGESTIONS_DEFAULT_MODE,
+    build_create_notebook_params,
+    build_get_notebook_params,
     build_prompt_suggestions_params,
 )
 from ._row_adapters.notebooks import PromptSuggestionRow, unwrap_prompt_suggestions
@@ -19,7 +21,6 @@ from ._row_adapters.sources import SourceRow
 from ._runtime.contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
-from ._source.upload_payloads import build_template_block
 from .exceptions import (
     AuthError,
     ClientError,
@@ -46,29 +47,6 @@ logger = logging.getLogger(__name__)
 
 
 CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
-
-
-def build_create_notebook_params(title: str) -> list[Any]:
-    """Return the canonical CREATE_NOTEBOOK RPC payload.
-
-    The trailing :func:`build_template_block` replaced the old flat ``[2], [1]``
-    tail that migrated backends now reject with ``status=3`` (#1546).
-    """
-    return [title, None, None, build_template_block()]
-
-
-def build_get_notebook_params(notebook_id: str) -> list[Any]:
-    """Return the canonical GET_NOTEBOOK (``rLM1Ne``) RPC payload.
-
-    The Gemini-3.5 rollout migrated the read path's trailing template block from
-    the flat ``[2]`` to the same nested :func:`build_template_block` wrapper the
-    write path adopted in #1548 (issue #1549). Live-verified forward-compatible:
-    the nested shape returns a byte-identical decoded notebook (notebook id /
-    title and every ``SourceRow``) as the flat ``[2]`` on an un-migrated account,
-    so it is safe across cohorts. The trailing ``None, 0`` is unchanged — only
-    the template block at position 2 is migrated (the narrow scope #1549 tracks).
-    """
-    return [notebook_id, None, build_template_block(), None, 0]
 
 
 def _extract_summary(outer: Any) -> str:

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -22,6 +22,7 @@ from ._sharing_manager import ShareManager
 from ._source.upload_payloads import build_template_block
 from .exceptions import (
     AuthError,
+    ClientError,
     DecodingError,
     NetworkError,
     NotebookLimitError,
@@ -31,7 +32,7 @@ from .exceptions import (
     ServerError,
     ValidationError,
 )
-from .rpc import RPCMethod, safe_index
+from .rpc import GrpcStatusCode, RPCMethod, normalize_grpc_status, safe_index
 from .types import (
     AccountLimits,
     Notebook,
@@ -700,17 +701,43 @@ class NotebooksAPI:
             Notebook object with details.
 
         Raises:
-            NotebookNotFoundError: If the notebook does not exist. The backend
-                returns an empty / degenerate payload (missing ``id`` and
-                ``title``) for unknown IDs rather than a proper RPC error, so
-                this method post-validates the parsed response.
+            NotebookNotFoundError: If the notebook does not exist. Both backend
+                signals are handled, so the ADR-0019 contract holds either way:
+                a proper RPC error (gRPC status ``5``, surfaced by the decoder
+                as ``ClientError`` and translated below), or the historical
+                empty / degenerate payload with no RPC error at all, which the
+                post-validation further down still catches.
         """
         params = build_get_notebook_params(notebook_id)
-        result = await self._rpc.rpc_call(
-            RPCMethod.GET_NOTEBOOK,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-        )
+        try:
+            result = await self._rpc.rpc_call(
+                RPCMethod.GET_NOTEBOOK,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+            )
+        except ClientError as exc:
+            # Translate the status-5 rejection into this method's documented
+            # miss signal: ``ClientError`` and ``NotebookNotFoundError`` are
+            # siblings under ``RPCError``, not ancestor/descendant, so
+            # ``get_or_none``'s ``except`` never sees it (#2132, ADR-0019).
+            # Narrow on purpose -- ``PERMISSION_DENIED`` comes through this
+            # same branch and must keep propagating.
+            #
+            # ``detail`` carries the decoder's guidance onto the typed error
+            # rather than leaving it on ``__cause__``: status 5 also means
+            # "belongs to a different signed-in account" (#114 / #294),
+            # ``server/_errors.py`` promises the 404 body keeps that verbatim,
+            # and every adapter renders ``str(exc)``.
+            if normalize_grpc_status(exc.rpc_code) is GrpcStatusCode.NOT_FOUND:
+                raise NotebookNotFoundError(
+                    notebook_id,
+                    method_id=RPCMethod.GET_NOTEBOOK.value,
+                    raw_response=exc.raw_response,
+                    rpc_code=exc.rpc_code,
+                    found_ids=exc.found_ids,
+                    detail=str(exc),
+                ) from exc
+            raise
         # get_notebook returns [nb_info, ...] where nb_info contains the notebook
         # data. The ``[0]`` read is fully guarded (truthy + list + non-empty), so
         # ``safe_index`` cannot raise here; it keeps the envelope-unwrap position
@@ -750,6 +777,14 @@ class NotebooksAPI:
         ``None``; transport, auth, and decode faults — including the broader
         :class:`~notebooklm.exceptions.RPCError` subtree
         :class:`NotebookNotFoundError` also inherits — propagate unchanged.
+
+        Status-5 policy: **both** its meanings collapse to ``None`` here. The
+        backend sends that one status whether the notebook is absent or lives
+        under a *different* signed-in account (#114 / #294), so the
+        account-routing guidance is unobservable on this API by construction.
+        Use :meth:`get` when that matters — it raises with the guidance in the
+        message, the ``rpc_code``, and the original rejection as ``__cause__``.
+        ``PERMISSION_DENIED`` is folded in neither place.
 
         Args:
             notebook_id: The notebook ID.

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -493,10 +493,10 @@ def register_session_commands(cli):
             if isinstance(exc, click.ClickException):
                 raise exc
             if isinstance(exc, NotebookNotFoundError):
+                # ``str(exc)`` keeps a status-5 account-routing hint (#2132).
                 _output_error(
-                    f"Error: Notebook {notebook_id!r} not found. "
-                    "Run 'notebooklm list' to see available notebooks, "
-                    "or pass --force to bypass verification.",
+                    f"Error: {exc}. Run 'notebooklm list' to see available "
+                    "notebooks, or pass --force to bypass verification.",
                     "NOT_FOUND",
                     json_output,
                     1,

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -14,56 +14,21 @@ Example:
 
 from __future__ import annotations
 
-import os
 import re
 import reprlib
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
+from . import _logging
 from ._env import DEFAULT_BASE_URL, get_base_url
-from ._logging import scrub_secrets
+from ._logging import _truncate_response_preview, scrub_secrets
 
 if TYPE_CHECKING:
     from ._types.artifacts import GenerationStatus
 
 ArtifactStalledPhase = Literal["pending", "in_progress"]
-
-
-_PREVIEW_LIMIT = 80
-# Pre-slice cap for the truncated path: scrub at most this many chars before
-# cutting to ``_PREVIEW_LIMIT``. The 10x window gives a boundary-straddling
-# secret ample room to be neutralized before the 80-char cut (mirrors the
-# two-stage slice in ``AuthExtractionError`` below), while bounding the regex
-# sweep at O(800 chars) instead of O(len(raw)) for multi-MB error bodies.
-_PREVIEW_SCRUB_CAP = _PREVIEW_LIMIT * 10
-
-
-def _truncate_response_preview(raw: str | None) -> str | None:
-    """Truncate a raw RPC response preview for safe display in error contexts.
-
-    Default behavior keeps the preview compact (80 chars + ``"..."`` suffix) so
-    error logs and CLI output stay readable. Set ``NOTEBOOKLM_DEBUG=1`` to opt
-    into the full untruncated body for deep debugging.
-
-    Credential-shaped substrings (CSRF tokens, session cookies, etc.) are
-    scrubbed *before* truncation in both modes. ``raw_response`` is a public
-    attribute spliced into ``str()``/``repr()`` of RPC errors, so it escapes the
-    logging pipeline's ``RedactingFilter`` and must be sanitized at the source.
-
-    In the default (truncated) path the input is pre-sliced to
-    ``_PREVIEW_SCRUB_CAP`` before scrubbing so a multi-MB error body does not
-    pay for a full regex sweep just to discard all but the first 80 chars. The
-    ``NOTEBOOKLM_DEBUG=1`` path keeps the whole body, so it scrubs the full
-    string.
-    """
-    if raw is None:
-        return None
-    if os.environ.get("NOTEBOOKLM_DEBUG") == "1":
-        return scrub_secrets(raw)
-    scrubbed = scrub_secrets(raw[:_PREVIEW_SCRUB_CAP])
-    if len(scrubbed) > _PREVIEW_LIMIT:
-        return scrubbed[:_PREVIEW_LIMIT] + "..."
-    return scrubbed
+_PREVIEW_LIMIT = _logging._PREVIEW_LIMIT
+_PREVIEW_SCRUB_CAP = _logging._PREVIEW_SCRUB_CAP
 
 
 __all__ = [

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -786,6 +786,12 @@ class NotebookNotFoundError(NotFoundError, RPCError, NotebookError):
         method_id: The RPC method ID (inherited from :class:`RPCError`).
         raw_response: First 80 chars of the raw response, if any
             (``NOTEBOOKLM_DEBUG=1`` preserves the full body).
+        rpc_code / found_ids: Wire diagnostics, when the absence came from a
+            typed rejection rather than a degenerate payload (both inherited
+            from :class:`RPCError`).
+        detail: Appended to the message. A status-5 miss can mean "belongs to
+            another signed-in account" and adapters render only ``str(exc)``
+            (#114 / #294); callers pass text their layer already scrubbed.
     """
 
     def __init__(
@@ -794,12 +800,17 @@ class NotebookNotFoundError(NotFoundError, RPCError, NotebookError):
         *,
         method_id: str | None = None,
         raw_response: str | None = None,
+        rpc_code: str | int | None = None,
+        found_ids: list[str] | None = None,
+        detail: str | None = None,
     ):
         self.notebook_id = notebook_id
         super().__init__(
-            f"Notebook not found: {notebook_id}",
+            f"Notebook not found: {notebook_id}" + (f" — {detail}" if detail else ""),
             method_id=method_id,
             raw_response=raw_response,
+            rpc_code=rpc_code,
+            found_ids=found_ids,
         )
 
 

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -46,6 +46,7 @@ from .types import (  # noqa: F401
     ChatResponseLength,
     DriveMimeType,
     ExportType,
+    GrpcStatusCode,
     InfographicDetail,
     InfographicOrientation,
     InfographicStyle,
@@ -61,6 +62,7 @@ from .types import (  # noqa: F401
     get_batchexecute_url,
     get_query_url,
     get_upload_url,
+    normalize_grpc_status,
 )
 
 # Blessed public power-user surface only; see the banner comment above for why

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -20,6 +20,7 @@ from ..exceptions import (
     _truncate_response_preview,
 )
 from ._safe_index import safe_index
+from .types import GrpcStatusCode
 
 # Re-export for backward compatibility (imports from notebooklm.rpc.decoder still work)
 __all__ = [
@@ -99,29 +100,40 @@ class RPCErrorCode(IntEnum):
     SERVER_ERROR = 500  # Internal server error
 
 
-# gRPC canonical status codes (google.rpc.Code) embedded by the batchexecute
-# backend at index 5 of a `wrb.fr` response when the RPC returns null result
-# data. The bare single-element form `[code]` is what issues #114 and #294
-# observed on the wire.
+# Human-readable labels for the gRPC canonical status codes the batchexecute
+# backend embeds at index 5 of a `wrb.fr` response when the RPC returns null
+# result data. The bare single-element form `[code]` is what issues #114 and
+# #294 observed on the wire.
+#
+# The codes themselves live in `GrpcStatusCode` (rpc/types.py) — the single
+# source of truth shared with the neutral error classifier and the notebook
+# not-found translation. This table only supplies the wording, and is keyed by
+# the enum so a member added there without a label fails the guardrail test
+# rather than silently degrading to an unlabelled status.
 _GRPC_STATUS_MESSAGES: dict[int, str] = {
-    0: "OK",
-    1: "Cancelled",
-    2: "Unknown",
-    3: "Invalid argument",
-    4: "Deadline exceeded",
-    5: "Not found",
-    6: "Already exists",
-    7: "Permission denied",
-    8: "Resource exhausted",
-    9: "Failed precondition",
-    10: "Aborted",
-    11: "Out of range",
-    12: "Not implemented",
-    13: "Internal",
-    14: "Unavailable",
-    15: "Data loss",
-    16: "Unauthenticated",
+    GrpcStatusCode.OK: "OK",
+    GrpcStatusCode.CANCELLED: "Cancelled",
+    GrpcStatusCode.UNKNOWN: "Unknown",
+    GrpcStatusCode.INVALID_ARGUMENT: "Invalid argument",
+    GrpcStatusCode.DEADLINE_EXCEEDED: "Deadline exceeded",
+    GrpcStatusCode.NOT_FOUND: "Not found",
+    GrpcStatusCode.ALREADY_EXISTS: "Already exists",
+    GrpcStatusCode.PERMISSION_DENIED: "Permission denied",
+    GrpcStatusCode.RESOURCE_EXHAUSTED: "Resource exhausted",
+    GrpcStatusCode.FAILED_PRECONDITION: "Failed precondition",
+    GrpcStatusCode.ABORTED: "Aborted",
+    GrpcStatusCode.OUT_OF_RANGE: "Out of range",
+    GrpcStatusCode.UNIMPLEMENTED: "Not implemented",
+    GrpcStatusCode.INTERNAL: "Internal",
+    GrpcStatusCode.UNAVAILABLE: "Unavailable",
+    GrpcStatusCode.DATA_LOSS: "Data loss",
+    GrpcStatusCode.UNAUTHENTICATED: "Unauthenticated",
 }
+
+#: Statuses the decoder routes through ``ClientError`` rather than the generic
+#: ``RPCError``, so ``is_auth_error`` cannot misclassify them and fire a
+#: spurious token refresh. Both also carry the account-routing hint below.
+_ACCOUNT_ROUTED_STATUSES = (GrpcStatusCode.NOT_FOUND, GrpcStatusCode.PERMISSION_DENIED)
 
 # Hint appended to NOT_FOUND / PERMISSION_DENIED messages. Deliberately avoids
 # the substrings checked by AUTH_ERROR_PATTERNS in _runtime/helpers.py so these errors
@@ -749,12 +761,12 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
         if status is not None:
             code, label = status
             message = f"The server rejected this request ({label.lower()})."
-            # Route NOT_FOUND (5) / PERMISSION_DENIED (7) through ClientError
-            # so is_auth_error does not misclassify them as auth
-            # failures and trigger a spurious token-refresh retry. The
-            # account-routing hint is only relevant for these two codes —
-            # other codes (e.g. INTERNAL 13) get a plain message.
-            if code in (5, 7):
+            # Route NOT_FOUND / PERMISSION_DENIED through ClientError so
+            # is_auth_error does not misclassify them as auth failures and
+            # trigger a spurious token-refresh retry. The account-routing hint
+            # is only relevant for these two codes — other codes (e.g.
+            # INTERNAL 13) get a plain message.
+            if code in _ACCOUNT_ROUTED_STATUSES:
                 raise ClientError(
                     message + _ACCOUNT_MISMATCH_HINT,
                     method_id=rpc_id,

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -7,6 +7,8 @@ import threading
 from enum import IntEnum
 from typing import Any
 
+from .._logging import _truncate_response_preview
+
 # Import exceptions from centralized module
 from ..exceptions import (
     AuthError,
@@ -17,7 +19,6 @@ from ..exceptions import (
     RPCTimeoutError,
     ServerError,
     UnknownRPCMethodError,
-    _truncate_response_preview,
 )
 from ._safe_index import safe_index
 from .types import GrpcStatusCode

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -166,6 +166,95 @@ class RPCMethod(str, Enum):
     SET_USER_SETTINGS = "hT54vc"
 
 
+class GrpcStatusCode(int, Enum):
+    """Canonical gRPC status codes (``google.rpc.Code``) seen on the wire.
+
+    The batchexecute backend embeds one of these at index 5 of a ``wrb.fr``
+    entry when an RPC returns null result data — the bare single-element form
+    ``[code]`` observed in issues #114 and #294.
+
+    Deliberately distinct from :class:`notebooklm.rpc.decoder.RPCErrorCode`,
+    which is an HTTP-style namespace (``NOT_FOUND = 404``). The two share
+    member names but not values, so code that compares a wire status must say
+    which namespace it means: ``GrpcStatusCode.NOT_FOUND`` is ``5``.
+
+    This is the single source of truth for those numbers. Before it existed the
+    literals were spelled inline at three layers — the decoder's ``(5, 7)``
+    routing, the neutral error classifier's ``== 5``, and the notebook
+    not-found translation — so a reader had to know from context whether a bare
+    ``5`` meant gRPC NOT_FOUND or something else.
+    """
+
+    OK = 0
+    CANCELLED = 1
+    UNKNOWN = 2
+    INVALID_ARGUMENT = 3
+    DEADLINE_EXCEEDED = 4
+    NOT_FOUND = 5
+    ALREADY_EXISTS = 6
+    PERMISSION_DENIED = 7
+    RESOURCE_EXHAUSTED = 8
+    FAILED_PRECONDITION = 9
+    ABORTED = 10
+    OUT_OF_RANGE = 11
+    UNIMPLEMENTED = 12
+    INTERNAL = 13
+    UNAVAILABLE = 14
+    DATA_LOSS = 15
+    UNAUTHENTICATED = 16
+
+
+def normalize_rpc_code(code: str | int | None) -> int | None:
+    """Coerce an ``RPCError.rpc_code`` to an ``int``, or ``None``.
+
+    ``rpc_code`` is typed ``str | int | None`` and carries three different
+    kinds of value: a numeric status (gRPC on the decoder's wire path, or an
+    HTTP status on the transport path), a non-numeric label such as
+    ``"USER_DISPLAYABLE_ERROR"``, or ``None`` when the error came from a layer
+    that never saw a status. A string ``"5"`` has to compare equal to the
+    integer status, and a non-numeric label has to answer ``None`` rather than
+    raise.
+
+    Deliberately *not* restricted to :class:`GrpcStatusCode`: callers that
+    range-check HTTP statuses (``500 <= code < 600``) need the raw integer
+    through. Use :func:`normalize_grpc_status` when the question is
+    specifically "which gRPC status is this?".
+
+    ``bool`` is rejected explicitly: it is a subclass of ``int``, so ``True``
+    would otherwise coerce to ``1``.
+    """
+    if code is None or isinstance(code, bool):
+        return None
+    try:
+        return int(code)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_grpc_status(code: str | int | None) -> GrpcStatusCode | None:
+    """Normalize an ``RPCError.rpc_code`` to a :class:`GrpcStatusCode`.
+
+    The narrower companion to :func:`normalize_rpc_code`: it answers "is this
+    gRPC status X?" for callers that want the semantic comparison, and returns
+    ``None`` for anything outside the canonical table — including HTTP statuses
+    such as ``500``, which are numeric but are not gRPC codes.
+
+    Args:
+        code: The raw ``rpc_code`` off an :class:`~notebooklm.exceptions.RPCError`.
+
+    Returns:
+        The matching :class:`GrpcStatusCode`, or ``None`` when the value is
+        absent, non-numeric, or not a code this table knows.
+    """
+    as_int = normalize_rpc_code(code)
+    if as_int is None:
+        return None
+    try:
+        return GrpcStatusCode(as_int)
+    except ValueError:
+        return None
+
+
 class ArtifactTypeCode(int, Enum):
     """Integer codes for artifact types used in RPC calls.
 

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -115,6 +115,15 @@ from .rpc.types import (
 from .rpc.types import (
     ArtifactTypeCode as _ArtifactTypeCode,
 )
+from .rpc.types import (
+    GrpcStatusCode as _GrpcStatusCode,
+)
+from .rpc.types import (
+    normalize_grpc_status as _normalize_grpc_status,
+)
+from .rpc.types import (
+    normalize_rpc_code as _normalize_rpc_code,
+)
 
 # Keep private facade names that first-party tests and external callers have
 # historically imported while the implementation moves into _types modules.
@@ -134,6 +143,15 @@ _warned_source_types = _source_types._warned_source_types
 # Imported for the historical ``notebooklm.types.ArtifactTypeCode`` attribute,
 # but intentionally absent from ``__all__``.
 ArtifactTypeCode = _ArtifactTypeCode
+
+# The canonical gRPC status table and its two coercion helpers, routed through
+# this facade for the ``_app`` layer: the boundary lint
+# (``tests/_guardrails/test_app_boundary.py``) forbids ``_app`` from importing
+# ``notebooklm.rpc.*`` directly, and the neutral error classifier needs both.
+# Internal plumbing, so intentionally absent from ``__all__``.
+GrpcStatusCode = _GrpcStatusCode
+normalize_grpc_status = _normalize_grpc_status
+normalize_rpc_code = _normalize_rpc_code
 
 # Guards the ``ResearchSourceInput`` import from being removed as unused:
 # ``typing.get_type_hints(CitedSourceSelection)`` needs it in this facade's

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -132,8 +132,9 @@ ALLOWLISTED_CEILINGS: dict[str, int] = {
     # ``CollectionNotFoundError`` (the Collections domain; #2006), then
     # 1577 -> 1599 for ``LockUnavailableError`` (the canonical-storage-writer
     # fail-closed lock exception; ADR-0029 — replaces ``filelock.Timeout`` and
-    # must be public so callers catch it) — all irreducible additions to this home.
-    "exceptions.py": 1599,
+    # must be public so callers catch it), then 1599 -> 1575 after the private
+    # response-preview helper moved to its credential-redaction home (#2132).
+    "exceptions.py": 1575,
     # sanctioned merge (ADR-0033) — the `_auth` persistence merge: the seam that
     # was spelled as three cap-split files becomes one deep module.
     # ``_auth/storage_writer.py`` (981) and ``_auth/storage_transaction.py``

--- a/tests/_guardrails/test_studio_enum_manifest.py
+++ b/tests/_guardrails/test_studio_enum_manifest.py
@@ -44,6 +44,28 @@ pytestmark = pytest.mark.repo_lint
 
 _RPC_ENUM_SNAPSHOT: dict[str, dict[str, int]] = {
     "ArtifactStatus": {"PROCESSING": 1, "PENDING": 2, "COMPLETED": 3, "FAILED": 4},
+    # google.rpc.Code, as embedded at index 5 of a wrb.fr entry. Not our
+    # numbering to choose — these are the canonical gRPC statuses, so a diff
+    # here means either a typo or that the backend stopped speaking gRPC codes.
+    "GrpcStatusCode": {
+        "OK": 0,
+        "CANCELLED": 1,
+        "UNKNOWN": 2,
+        "INVALID_ARGUMENT": 3,
+        "DEADLINE_EXCEEDED": 4,
+        "NOT_FOUND": 5,
+        "ALREADY_EXISTS": 6,
+        "PERMISSION_DENIED": 7,
+        "RESOURCE_EXHAUSTED": 8,
+        "FAILED_PRECONDITION": 9,
+        "ABORTED": 10,
+        "OUT_OF_RANGE": 11,
+        "UNIMPLEMENTED": 12,
+        "INTERNAL": 13,
+        "UNAVAILABLE": 14,
+        "DATA_LOSS": 15,
+        "UNAUTHENTICATED": 16,
+    },
     "ArtifactTypeCode": {
         "AUDIO": 1,
         "REPORT": 2,

--- a/tests/server/test_errors.py
+++ b/tests/server/test_errors.py
@@ -89,6 +89,77 @@ def test_status_7_is_not_routed_to_404() -> None:
     assert resp.json()["error"]["category"] == "rpc"
 
 
+def _client_with_real_notebooks(error: BaseException) -> TestClient:
+    """REST app whose ``notebooks`` namespace is the **real** ``NotebooksAPI``.
+
+    The tests above inject a bare ``ClientError`` in place of the whole
+    namespace, so they project ``classify`` faithfully but never execute
+    ``NotebooksAPI.get()``. Only the ``rpc_call`` seam raises here, so the GET
+    route runs the real translation from a status-5 rejection to
+    ``NotebookNotFoundError`` — the path an actual missing notebook takes.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from notebooklm._notebooks import NotebooksAPI
+    from tests._fixtures.fake_core import make_fake_core
+
+    fake = FakeClient()
+    core = make_fake_core(rpc_call=AsyncMock(side_effect=error))
+    fake.notebooks = NotebooksAPI(core.rpc_executor, sources_api=MagicMock())  # type: ignore[assignment]
+
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[FakeClient]:
+        yield fake
+
+    app = create_app(client_factory=factory)
+    headers = {"Authorization": f"Bearer {TEST_TOKEN}", "Host": "127.0.0.1"}
+    client = TestClient(
+        app, headers=headers, client=("127.0.0.1", 5555), raise_server_exceptions=False
+    )
+    client.__enter__()
+    return client
+
+
+def test_get_route_status_5_keeps_the_routing_hint_through_the_translation() -> None:
+    """GET /v1/notebooks/{id} preserves the hint *after* the typed translation.
+
+    ``server/_errors.py`` documents that the status-5 account-routing hint is
+    preserved verbatim in the 404 body. Once ``NotebooksAPI.get()`` converts
+    that rejection into ``NotebookNotFoundError``, keeping the promise depends
+    on the translation carrying the diagnostic onto the typed error — the
+    renderers print ``str(exc)``, never ``__cause__``.
+    """
+    hint = "commonly an account-routing mismatch"
+    client = _client_with_real_notebooks(
+        exc.ClientError(f"The server rejected this request (not found). {hint}", rpc_code=5)
+    )
+    try:
+        resp = client.get("/v1/notebooks/nb-missing")
+    finally:
+        client.__exit__(None, None, None)
+
+    assert resp.status_code == 404
+    body = resp.json()["error"]
+    assert body["category"] == "not_found"
+    assert hint in body["message"], f"routing hint dropped from the 404 body: {body['message']!r}"
+
+
+def test_get_route_status_7_is_not_reported_as_a_missing_notebook() -> None:
+    """A notebook the caller may not read must not project as 404 through GET.
+
+    The decoder routes PERMISSION_DENIED through the same ``ClientError``
+    branch as NOT_FOUND, so this pins that the translation did not widen.
+    """
+    client = _client_with_real_notebooks(exc.ClientError("denied", rpc_code=7))
+    try:
+        resp = client.get("/v1/notebooks/nb-forbidden")
+    finally:
+        client.__exit__(None, None, None)
+
+    assert resp.status_code == 502
+    assert resp.json()["error"]["category"] == "rpc"
+
+
 def _error_body(exc_obj: BaseException) -> dict[str, object]:
     import json
 

--- a/tests/unit/test_get_or_none.py
+++ b/tests/unit/test_get_or_none.py
@@ -27,7 +27,7 @@ from notebooklm._note_service import NoteService
 from notebooklm._notebooks import NotebooksAPI
 from notebooklm._notes import NotesAPI
 from notebooklm._sources import SourcesAPI
-from notebooklm.exceptions import RPCError
+from notebooklm.exceptions import ClientError, NotebookNotFoundError, RPCError
 from notebooklm.types import MindMap, MindMapKind, Source
 
 # ---------------------------------------------------------------------------
@@ -145,6 +145,89 @@ class TestNotebooksGetOrNone:
         api = _make_notebooks_api(AsyncMock(side_effect=RPCError("boom")))
         with pytest.raises(RPCError):
             await api.get_or_none("nb_1")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_grpc_not_found(self):
+        # The live backend answers an unknown id with a proper RPC error (gRPC
+        # status 5), which the decoder raises as ClientError — a *sibling* of
+        # NotebookNotFoundError under RPCError, not an ancestor. Before #2132
+        # this propagated straight out of the sanctioned None-on-miss lookup.
+        api = _make_notebooks_api(
+            AsyncMock(side_effect=ClientError("The server rejected this request.", rpc_code=5))
+        )
+        assert await api.get_or_none("nb_missing") is None
+
+    @pytest.mark.asyncio
+    async def test_grpc_not_found_as_string_code_also_returns_none(self):
+        # ``rpc_code`` is typed ``str | int | None`` — a string "5" is the same
+        # status and must not slip past the comparison.
+        api = _make_notebooks_api(AsyncMock(side_effect=ClientError("rejected", rpc_code="5")))
+        assert await api.get_or_none("nb_missing") is None
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_is_not_a_miss(self):
+        # The decoder routes status 7 (PERMISSION_DENIED) through the SAME
+        # ClientError branch as status 5. A notebook the caller may not read is
+        # not a notebook that does not exist: collapsing it to None would tell
+        # the caller the resource is absent and hide the access failure.
+        api = _make_notebooks_api(AsyncMock(side_effect=ClientError("denied", rpc_code=7)))
+        with pytest.raises(ClientError):
+            await api.get_or_none("nb_forbidden")
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_rpc_code_is_not_a_miss(self):
+        # The decoder also puts non-numeric labels in ``rpc_code``; the
+        # comparison must answer "not a miss" rather than raise on int().
+        api = _make_notebooks_api(
+            AsyncMock(side_effect=ClientError("boom", rpc_code="USER_DISPLAYABLE_ERROR"))
+        )
+        with pytest.raises(ClientError):
+            await api.get_or_none("nb_1")
+
+    @pytest.mark.asyncio
+    async def test_get_raises_typed_not_found_on_grpc_not_found(self):
+        # get_or_none only works because get() honours its documented contract.
+        # Pin the translation at the source, not just its downstream effect.
+        api = _make_notebooks_api(AsyncMock(side_effect=ClientError("rejected", rpc_code=5)))
+        with pytest.raises(NotebookNotFoundError):
+            await api.get("nb_missing")
+
+    @pytest.mark.asyncio
+    async def test_translation_carries_the_diagnostic_onto_the_typed_error(self):
+        # Status 5 also means "the notebook is under another signed-in
+        # account", and the decoder synthesises that guidance into its message.
+        # Every adapter renders str(exc), never __cause__, so the guidance has
+        # to survive on the raised exception itself — not only in the chain.
+        original = ClientError(
+            "The server rejected this request (not found). "
+            "If you have multiple Google accounts signed in, "
+            "this is commonly an account-routing mismatch.",
+            rpc_code=5,
+            raw_response="wire-bytes",
+        )
+        api = _make_notebooks_api(AsyncMock(side_effect=original))
+
+        with pytest.raises(NotebookNotFoundError) as caught:
+            await api.get("nb_missing")
+
+        raised = caught.value
+        assert "nb_missing" in str(raised)
+        assert "account-routing mismatch" in str(raised)
+        # The wire status and debugging context ride along too, so a caller can
+        # branch on the code without re-reading the chained cause.
+        assert raised.rpc_code == 5
+        assert raised.raw_response == "wire-bytes"
+        assert raised.__cause__ is original
+
+    @pytest.mark.asyncio
+    async def test_plain_absence_message_has_no_trailing_separator(self):
+        # The degenerate-payload path supplies no diagnostic, so the message
+        # must stay exactly as it always read — the detail separator is only
+        # appended when there is something to append.
+        api = _make_notebooks_api(AsyncMock(return_value=[[]]))
+        with pytest.raises(NotebookNotFoundError) as caught:
+            await api.get("nb_missing")
+        assert str(caught.value) == "Notebook not found: nb_missing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -7,6 +7,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from notebooklm._notebook_payloads import (
+    build_create_notebook_params as canonical_build_create_notebook_params,
+)
+from notebooklm._notebook_payloads import (
+    build_get_notebook_params as canonical_build_get_notebook_params,
+)
 from notebooklm._notebooks import (
     NotebooksAPI,
     build_create_notebook_params,
@@ -98,6 +104,11 @@ def test_build_get_notebook_params_matches_live_payload() -> None:
         None,
         0,
     ]
+
+
+def test_notebook_payload_builders_keep_their_compatibility_import_path() -> None:
+    assert build_create_notebook_params is canonical_build_create_notebook_params
+    assert build_get_notebook_params is canonical_build_get_notebook_params
 
 
 def test_direct_notebooks_api_construction_remains_supported() -> None:

--- a/tests/unit/test_response_preview.py
+++ b/tests/unit/test_response_preview.py
@@ -9,7 +9,27 @@ from __future__ import annotations
 
 import pytest
 
-from notebooklm.exceptions import RPCError, _truncate_response_preview
+from notebooklm._logging import (
+    _PREVIEW_LIMIT as canonical_preview_limit,
+)
+from notebooklm._logging import (
+    _PREVIEW_SCRUB_CAP as canonical_preview_scrub_cap,
+)
+from notebooklm._logging import (
+    _truncate_response_preview as canonical_response_preview,
+)
+from notebooklm.exceptions import (
+    _PREVIEW_LIMIT,
+    _PREVIEW_SCRUB_CAP,
+    RPCError,
+    _truncate_response_preview,
+)
+
+
+def test_response_preview_keeps_its_exceptions_compatibility_import_path() -> None:
+    assert _truncate_response_preview is canonical_response_preview
+    assert canonical_preview_limit == _PREVIEW_LIMIT
+    assert canonical_preview_scrub_cap == _PREVIEW_SCRUB_CAP
 
 
 class TestTruncateResponsePreview:

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -11,11 +11,14 @@ from notebooklm.rpc.types import (
     QUERY_URL,
     ArtifactStatus,
     ArtifactTypeCode,
+    GrpcStatusCode,
     RPCMethod,
     SourceStatus,
     artifact_status_to_str,
     get_batchexecute_url,
     get_query_url,
+    normalize_grpc_status,
+    normalize_rpc_code,
     source_status_to_str,
 )
 
@@ -232,3 +235,64 @@ class TestSourceStatusToStr:
         assert source_status_to_str(6) == "unknown"
         assert source_status_to_str(99) == "unknown"
         assert source_status_to_str(-1) == "unknown"
+
+
+class TestGrpcStatusCode:
+    """The canonical gRPC status table and its two coercion helpers."""
+
+    def test_values_match_the_google_rpc_code_table(self):
+        # Wire contract: these numbers come from google.rpc.Code and are what
+        # the backend embeds at index 5 of a wrb.fr entry.
+        assert GrpcStatusCode.NOT_FOUND == 5
+        assert GrpcStatusCode.PERMISSION_DENIED == 7
+        assert GrpcStatusCode.OK == 0
+        assert GrpcStatusCode.UNAUTHENTICATED == 16
+
+    def test_is_a_separate_namespace_from_rpc_error_code(self):
+        """``NOT_FOUND`` means 5 here and 404 in the HTTP-style enum.
+
+        The two enums share member names, so anything comparing a wire status
+        has to say which namespace it means. Pins that they did not get merged.
+        """
+        from notebooklm.rpc.decoder import RPCErrorCode
+
+        assert RPCErrorCode.NOT_FOUND == 404
+        assert GrpcStatusCode.NOT_FOUND == 5
+
+    def test_decoder_status_labels_cover_every_member(self):
+        """Every status has wording; a new member cannot go unlabelled."""
+        from notebooklm.rpc.decoder import _GRPC_STATUS_MESSAGES
+
+        assert set(_GRPC_STATUS_MESSAGES) == {int(code) for code in GrpcStatusCode}
+
+    def test_normalize_grpc_status_accepts_both_wire_forms(self):
+        assert normalize_grpc_status(5) is GrpcStatusCode.NOT_FOUND
+        assert normalize_grpc_status("5") is GrpcStatusCode.NOT_FOUND
+        assert normalize_grpc_status(7) is GrpcStatusCode.PERMISSION_DENIED
+
+    def test_normalize_grpc_status_rejects_non_statuses(self):
+        # rpc_code also carries non-numeric labels and may be absent entirely;
+        # neither may raise, and neither is a status.
+        assert normalize_grpc_status(None) is None
+        assert normalize_grpc_status("USER_DISPLAYABLE_ERROR") is None
+        assert normalize_grpc_status(999) is None
+        # An HTTP status is numeric but is not a gRPC code.
+        assert normalize_grpc_status(500) is None
+
+    def test_bool_is_not_a_status(self):
+        """``True`` must not normalize to CANCELLED (1) via the int subclass."""
+        assert normalize_grpc_status(True) is None
+        assert normalize_rpc_code(True) is None
+
+    def test_normalize_rpc_code_keeps_http_statuses(self):
+        """The wider helper passes 5xx through — the transient check needs it.
+
+        Narrowing this one to the gRPC table would silently drop every HTTP
+        status to ``None`` and disable the ``500 <= code < 600`` branch in the
+        neutral error classifier.
+        """
+        assert normalize_rpc_code(500) == 500
+        assert normalize_rpc_code("503") == 503
+        assert normalize_rpc_code(5) == 5
+        assert normalize_rpc_code(None) is None
+        assert normalize_rpc_code("USER_DISPLAYABLE_ERROR") is None


### PR DESCRIPTION
## Summary

`notebooks.get_or_none()` raises `ClientError` for a notebook that does not exist — on the exact input the method exists to absorb. ADR-0019 makes it *the* sanctioned `None`-on-miss lookup, so every caller of the safe lookup is holding an unsafe one, and the failure only shows up against the live backend: neither the docstring nor the type signature reveals it.

## Related Issue

Closes #2132

## Root cause

The bug is one layer above where it surfaces. `get_or_none` catches `NotebookNotFoundError`, which is correct only while `get()` raises that on a miss. `get()`'s post-validation rests on a premise its own docstring states — the backend "returns an empty / degenerate payload (missing `id` and `title`) for unknown IDs rather than a proper RPC error".

Per the live-verified evidence in #2132 it now returns a proper one: `GET_NOTEBOOK` on an unknown id comes back with gRPC status 5, which the decoder surfaces as `ClientError`. That is a *sibling* of `NotebookNotFoundError` under `RPCError`, not an ancestor:

```text
ClientError            → RPCError → NotebookLMError → Exception
NotebookNotFoundError  → NotFoundError → RPCError → NotebookError → NotebookLMError
```

so `except NotebookNotFoundError` never sees it.

## Changes

- `src/notebooklm/_notebooks.py` — `get()` now translates a status-5 `ClientError` into `NotebookNotFoundError`, chaining the original and carrying `raw_response` across. The degenerate-payload post-validation stays as the belt-and-braces path (it is the historical behaviour and may still be what other or older backends do), and the docstring now documents both signals.
- `tests/unit/test_get_or_none.py` — five cases in `TestNotebooksGetOrNone`: int `5` and string `"5"` both yield `None`; status `7` and a non-numeric `rpc_code` both propagate; `get()` itself raises the typed error; plus one pinning that the translation keeps the original reachable.

Fixed in `get()` rather than in `get_or_none`, as the issue recommends. One translation at the source fixes every caller of both methods and restores the contract `get()` already documents, instead of teaching one caller to work around it. Callers who want the untranslated RPC failure still have `get_raw()`.

No public API or signature changes; no architectural shape change, so no ADR.

### Why the match is narrow to status 5

`rpc/decoder.py` routes status 5 (`NOT_FOUND`) **and** status 7 (`PERMISSION_DENIED`) through the identical `ClientError` branch. A notebook the caller may not read is not a notebook that does not exist — collapsing 7 into `None` would report the resource absent and hide the access failure. `rpc_code` is typed `str | int | None` and also carries non-numeric labels such as `USER_DISPLAYABLE_ERROR`, hence the two-form match rather than a bare `== 5`. All four boundaries have tests.

### REST projection is unchanged

`_app.errors.classify` already maps `NotFoundError` to `NOT_FOUND` on an earlier branch than its `ClientError`-with-code-5 rule, so the 404 still happens; it now arrives through the typed path rather than by sniffing `rpc_code`. `tests/server` passes unchanged.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated — N/A, no shape change

Run against the canonical contributor install plus the extras the CI test matrix adds (`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`):

```console
$ uv run mypy src/notebooklm --ignore-missing-imports
Success: no issues found in 334 source files

$ uv run pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed

$ uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90 -q
TOTAL                                                    28159    739   7632    450    97%
Required test coverage of 90% reached. Total coverage: 96.52%
13753 passed, 64 skipped, 3 xfailed, 18 warnings in 1567.50s (0:26:07)
```

Non-vacuity was confirmed per test by reverting only the source change: the int-5, string-5 and direct-`get()` cases fail; the status-7 and non-numeric cases pass either way (they are boundary assertions, not regressions). The chaining test was separately confirmed by dropping `from exc`, which fails it.

## Notes

**Known trade-off — flagged for your decision, not silently accepted.**

`rpc/decoder.py` appends an account-routing hint to the status-5 message (#114 / #294) precisely because that status can also mean "this notebook belongs to another signed-in Google account". After the translation the raised message is `Notebook not found: <id>`, and the hint survives only on `__cause__` — which the CLI (`cli/error_handler.py`), REST (`server/_errors.py`) and MCP (`mcp/_errors.py`) renderers do not print, since all three render `str(exc)`.

Observed directly:

```text
outer: "Notebook not found: nb_missing"
cause: "The server rejected this request (not found). ... check authuser."
```

`raw_response` is carried across and a test pins both it and the chaining, but `raw_response` does **not** contain the hint — the decoder synthesises it into the message.

I did not fix this here on purpose. Preserving the hint means giving `NotebookNotFoundError` optional diagnostic text, which changes a public exception's constructor and sits behind the API-compat gate — that is your API's shape to decide, and it would turn a contract fix into an API proposal. Happy to follow up with it as a separate PR if you want it, or to change the approach here if you would rather not ship the message regression at all.

**Scope of my verification.** Offline: unit tests, the existing cassettes, and the `_app` / server error-projection suites. The live premise — that unknown ids now return status 5 — is yours from #2132, not independently re-verified; I do not have an account positioned to re-check it.

**Not verified locally:** the Python 3.10–3.14 matrix. The change uses no version-sensitive syntax, but I can only exercise one interpreter here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook lookups now consistently report missing notebooks as not found, including relevant account-routing cases.
  * Permission errors and other client errors continue to be surfaced correctly.
  * Original error details, response information, and troubleshooting context are preserved.
  * Command-line error messages now retain helpful details about why a notebook could not be found.

* **Documentation**
  * Clarified notebook lookup behavior and error handling for missing and inaccessible notebooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->