### PR TITLE
feat(sharing): add users in one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their default `notify`. Two backend preconditions the probe exposed are
   encoded here: a batch naming one email twice returns success while silently
   leaving that user unchanged, so duplicates now raise `ValueError` before the
-  request is issued (case-insensitive); and a batch removal silently drops the
+  request is issued (exact match — case variants are passed through, since
+  RFC 5321 keeps the local part case-sensitive); and a batch removal silently drops the
   *whole* request if any target is already absent, so plural removal is
   deliberately not offered — it needs a share-status preflight and
   post-verification rather than a wider entry list. Both are recorded in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`SharingAPI.add_users()` grants mixed user permissions in one request.**
+- **`SharingAPI.set_users()` sets several users' permissions in one request.**
   The client sends one `SHARE_NOTEBOOK` RPC for all email/permission pairs,
   then refreshes the returned sharing status once. Notification and welcome
-  message settings apply to the whole call
+  message settings apply to the whole call, not per grant; batching collapses N
+  RPC + status-refresh round trips into one, which is not the same as sending
+  fewer notification emails. The operation is an **upsert** — a live probe
+  confirmed the backend adds an absent email and replaces an existing one, in
+  both the plural and singular forms — so `add_user()` and `update_user()` are
+  now intent wrappers over it rather than distinct operations, differing only in
+  their default `notify`. Two backend preconditions the probe exposed are
+  encoded here: a batch naming one email twice returns success while silently
+  leaving that user unchanged, so duplicates now raise `ValueError` before the
+  request is issued (case-insensitive); and a batch removal silently drops the
+  *whole* request if any target is already absent, so plural removal is
+  deliberately not offered — it needs a share-status preflight and
+  post-verification rather than a wider entry list. Both are recorded in
+  [`docs/rpc-reference.md`](docs/rpc-reference.md)
   ([#2000](https://github.com/teng-lin/notebooklm-py/issues/2000)).
 - **Deep-research sources expose the backend's per-task source ordinal.**
   `ResearchSource.source_ordinal` and its serializers preserve an integer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`SharingAPI.add_users()` grants mixed user permissions in one request.**
+  The client sends one `SHARE_NOTEBOOK` RPC for all email/permission pairs,
+  then refreshes the returned sharing status once. Notification and welcome
+  message settings apply to the whole call
+  ([#2000](https://github.com/teng-lin/notebooklm-py/issues/2000)).
 - **Deep-research sources expose the backend's per-task source ordinal.**
   `ResearchSource.source_ordinal` and its serializers preserve an integer
   `src[8]` when the row carries one — in the captures a 1-based bijection over

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1892,6 +1892,7 @@ print(f"Language set to: {result}")
 | `set_public(notebook_id, public)` | `str, bool` | `ShareStatus` | Enable/disable public link sharing |
 | `set_view_level(notebook_id, level)` | `str, ShareViewLevel` | `ShareStatus` | Set what viewers can access |
 | `add_user(notebook_id, email, permission, notify, welcome_message)` | `str, str, SharePermission, bool, str` | `ShareStatus` | Share with a user |
+| `add_users(notebook_id, grants, notify, welcome_message)` | `str, list[tuple[str, SharePermission]], bool, str` | `ShareStatus` | Share with multiple users in one request |
 | `update_user(notebook_id, email, permission)` | `str, str, SharePermission` | `ShareStatus` | Update user's permission |
 | `remove_user(notebook_id, email)` | `str, str` | `ShareStatus` | Remove user's access |
 
@@ -1918,6 +1919,18 @@ status = await client.sharing.add_user(
     SharePermission.VIEWER,
     notify=True,
     welcome_message="Check out my research!"
+)
+
+# Share with multiple users in one RPC. Notifications and the welcome message
+# apply to every grant in the call.
+status = await client.sharing.add_users(
+    notebook_id,
+    [
+        ("viewer@example.com", SharePermission.VIEWER),
+        ("editor@example.com", SharePermission.EDITOR),
+    ],
+    notify=True,
+    welcome_message="Welcome, team!",
 )
 
 # Update user permission

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1907,7 +1907,9 @@ knowing before you build on this:
 - **Duplicate grantees are rejected client-side.** A batch that names one email twice
   comes back *successful* from the backend while that user's permission stays
   unchanged. There is no first-wins or last-wins rule to rely on, so `set_users()`
-  raises `ValueError` instead of sending the request. Comparison is case-insensitive.
+  raises `ValueError` instead of sending the request. The comparison is **exact**:
+  addresses differing only in case are passed through, because RFC 5321 makes the
+  local part case-sensitive and no probe has shown that NotebookLM collapses them.
 - **Removal stays singular.** A batch of removals only applies when *every* target is
   currently shared; if any requested address is already absent, the backend drops the
   whole request — including the users that are present — and reports no failure.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1891,10 +1891,28 @@ print(f"Language set to: {result}")
 | `get_status(notebook_id)` | `str` | `ShareStatus` | Get current sharing configuration |
 | `set_public(notebook_id, public)` | `str, bool` | `ShareStatus` | Enable/disable public link sharing |
 | `set_view_level(notebook_id, level)` | `str, ShareViewLevel` | `ShareStatus` | Set what viewers can access |
-| `add_user(notebook_id, email, permission, notify, welcome_message)` | `str, str, SharePermission, bool, str` | `ShareStatus` | Share with a user |
-| `add_users(notebook_id, grants, notify, welcome_message)` | `str, list[tuple[str, SharePermission]], bool, str` | `ShareStatus` | Share with multiple users in one request |
-| `update_user(notebook_id, email, permission)` | `str, str, SharePermission` | `ShareStatus` | Update user's permission |
+| `set_users(notebook_id, grants, notify, welcome_message)` | `str, list[tuple[str, SharePermission]], bool, str` | `ShareStatus` | Set several users' permissions in one request (upsert) |
+| `add_user(notebook_id, email, permission, notify, welcome_message)` | `str, str, SharePermission, bool, str` | `ShareStatus` | Share with a user (wrapper over `set_users`) |
+| `update_user(notebook_id, email, permission)` | `str, str, SharePermission` | `ShareStatus` | Update user's permission (wrapper over `set_users`) |
 | `remove_user(notebook_id, email)` | `str, str` | `ShareStatus` | Remove user's access |
+
+**User permissions are an upsert, not an add.** One `SHARE_NOTEBOOK` call sets the
+permission for each email in the batch: an address that is not shared yet is added,
+and one that already has access has its permission replaced. `add_user()` and
+`update_user()` are intent wrappers over the same `set_users()` operation and differ
+only in their default `notify` — `update_user()` will happily add an absent user, and
+`add_user()` will happily change an existing one. Two backend preconditions are worth
+knowing before you build on this:
+
+- **Duplicate grantees are rejected client-side.** A batch that names one email twice
+  comes back *successful* from the backend while that user's permission stays
+  unchanged. There is no first-wins or last-wins rule to rely on, so `set_users()`
+  raises `ValueError` instead of sending the request. Comparison is case-insensitive.
+- **Removal stays singular.** A batch of removals only applies when *every* target is
+  currently shared; if any requested address is already absent, the backend drops the
+  whole request — including the users that are present — and reports no failure.
+  A plural removal therefore needs a share-status preflight and post-verification,
+  not a wider entry list, so it is deliberately not offered as a one-liner.
 
 **Example:**
 ```python
@@ -1921,9 +1939,10 @@ status = await client.sharing.add_user(
     welcome_message="Check out my research!"
 )
 
-# Share with multiple users in one RPC. Notifications and the welcome message
-# apply to every grant in the call.
-status = await client.sharing.add_users(
+# Set several users' permissions in one RPC. Notifications and the welcome
+# message apply to the whole call, not per grant. Existing grantees are updated
+# rather than duplicated; repeating one email raises ValueError.
+status = await client.sharing.set_users(
     notebook_id,
     [
         ("viewer@example.com", SharePermission.VIEWER),

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -132,7 +132,7 @@ or local convenience that has no stable web-control equivalent in the capture.
 | `NotesAPI.list/get/create/update/delete` | UI covered/partial | Add note, note row, note view close/title input, and note menu delete are documented. Rich body editing uses NotebookLM's internal editor; keep selectors conservative. |
 | `MindMapsAPI.list/generate/rename/delete/get_tree` | UI covered/partial | Interactive mind map generation is the live Studio tile. Note-backed mind maps are a synthetic/library backing; tree extraction via `GET_INTERACTIVE_HTML` is programmatic. |
 | `ResearchAPI.start/poll/wait/import_sources` | UI covered for start only | Source discovery corpus/mode/submit selectors map to fast/deep web/Drive research. Polling and import verification are backend workflow helpers. |
-| `SettingsAPI.get/set_output_language`, `SharingAPI.get_status/set_public/set_view_level/add_user/update_user/remove_user` | UI covered/partial | Settings and Share dialogs are covered at entry/save/copy selectors. Programmatic user-permission mutations go beyond the captured UI selectors. |
+| `SettingsAPI.get/set_output_language`, `SharingAPI.get_status/set_public/set_view_level/add_user/add_users/update_user/remove_user` | UI covered/partial | Settings and Share dialogs are covered at entry/save/copy selectors. Programmatic user-permission mutations go beyond the captured UI selectors. |
 | UI-only note operations | UI-only | Note menus expose `Convert to source`, `Convert all notes to source`, `Export to Docs`, and `Export to Sheets`; keep them documented as selectors unless/until a public library method owns those flows. |
 
 ---
@@ -1876,7 +1876,8 @@ await rpc_call(
 
 ### RPC: SHARE_NOTEBOOK (QDyure)
 
-**Source:** `_sharing.py::set_public()`, `_sharing.py::add_user()`, `_sharing.py::remove_user()`
+**Source:** `_sharing.py::set_public()`, `_sharing.py::add_user()`,
+`_sharing.py::add_users()`, `_sharing.py::remove_user()`
 
 Multi-purpose RPC for managing notebook sharing: toggle public access, add/update users, or remove users.
 
@@ -1900,17 +1901,22 @@ params = [
 # Response: [] (empty on success)
 ```
 
-**Add/update user:**
+**Add/update users:**
 ```python
 # permission: 2=editor, 3=viewer, 4=remove
 # notify_flag: 0=no email, 1=send notification
 # message_flag: 0=has message, 1=no message
+# entries may mix editor and viewer grants in one request
+entries = [
+    ["viewer@example.com", None, 3],
+    ["editor@example.com", None, 2],
+]
 params = [
     [
         [
             notebook_id,
-            [[email, None, permission]],  # user to add/update
-            None,                          # None = no public access change
+            entries,                       # users to add/update
+            None,                          # no public access change
             [message_flag, welcome_message]
         ]
     ],
@@ -1920,6 +1926,10 @@ params = [
 ]
 
 # Response: [] (empty on success)
+
+# SharingAPI.add_users() sends the SHARE_NOTEBOOK call above once, then calls
+# GET_SHARE_STATUS once and returns the refreshed ShareStatus. notify_flag and
+# welcome_message apply to every entry in this call.
 ```
 
 **Remove user:**
@@ -1993,6 +2003,15 @@ status = await client.sharing.get_status(notebook_id)
 await client.sharing.set_public(notebook_id, True)
 await client.sharing.set_view_level(notebook_id, ShareViewLevel.CHAT_ONLY)
 await client.sharing.add_user(notebook_id, "user@example.com", SharePermission.VIEWER)
+await client.sharing.add_users(
+    notebook_id,
+    [
+        ("viewer@example.com", SharePermission.VIEWER),
+        ("editor@example.com", SharePermission.EDITOR),
+    ],
+    notify=True,
+    welcome_message="Welcome, team!",
+)
 ```
 
 **Share URLs:**

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -132,7 +132,7 @@ or local convenience that has no stable web-control equivalent in the capture.
 | `NotesAPI.list/get/create/update/delete` | UI covered/partial | Add note, note row, note view close/title input, and note menu delete are documented. Rich body editing uses NotebookLM's internal editor; keep selectors conservative. |
 | `MindMapsAPI.list/generate/rename/delete/get_tree` | UI covered/partial | Interactive mind map generation is the live Studio tile. Note-backed mind maps are a synthetic/library backing; tree extraction via `GET_INTERACTIVE_HTML` is programmatic. |
 | `ResearchAPI.start/poll/wait/import_sources` | UI covered for start only | Source discovery corpus/mode/submit selectors map to fast/deep web/Drive research. Polling and import verification are backend workflow helpers. |
-| `SettingsAPI.get/set_output_language`, `SharingAPI.get_status/set_public/set_view_level/add_user/add_users/update_user/remove_user` | UI covered/partial | Settings and Share dialogs are covered at entry/save/copy selectors. Programmatic user-permission mutations go beyond the captured UI selectors. |
+| `SettingsAPI.get/set_output_language`, `SharingAPI.get_status/set_public/set_view_level/add_user/set_users/update_user/remove_user` | UI covered/partial | Settings and Share dialogs are covered at entry/save/copy selectors. Programmatic user-permission mutations go beyond the captured UI selectors. |
 | UI-only note operations | UI-only | Note menus expose `Convert to source`, `Convert all notes to source`, `Export to Docs`, and `Export to Sheets`; keep them documented as selectors unless/until a public library method owns those flows. |
 
 ---
@@ -1877,7 +1877,7 @@ await rpc_call(
 ### RPC: SHARE_NOTEBOOK (QDyure)
 
 **Source:** `_sharing.py::set_public()`, `_sharing.py::add_user()`,
-`_sharing.py::add_users()`, `_sharing.py::remove_user()`
+`_sharing.py::set_users()`, `_sharing.py::remove_user()`
 
 Multi-purpose RPC for managing notebook sharing: toggle public access, add/update users, or remove users.
 
@@ -1927,10 +1927,31 @@ params = [
 
 # Response: [] (empty on success)
 
-# SharingAPI.add_users() sends the SHARE_NOTEBOOK call above once, then calls
+# SharingAPI.set_users() sends the SHARE_NOTEBOOK call above once, then calls
 # GET_SHARE_STATUS once and returns the refreshed ShareStatus. notify_flag and
-# welcome_message apply to every entry in this call.
+# welcome_message apply to every entry in this call. Batching collapses N
+# RPC + status-refresh round trips into one; it is NOT established to change
+# how many notification emails recipients receive.
 ```
+
+**Entry-list semantics (live-probed 2026-08-11, two scratch notebooks, `notify=False`).**
+The entry list is a general batch **set/upsert** keyed by email, not an add:
+
+| Sent | Observed |
+|---|---|
+| Two distinct users, mixed VIEWER/EDITOR | Both granted; both grantees could open the notebook |
+| Two existing users with flipped permissions | Both permissions changed |
+| One existing update batched with one absent add | Both applied |
+| Singular update for an absent user | User was added |
+| The same email twice, conflicting permissions | RPC returned success, permission **unchanged** — a silent no-op |
+| Remove two users, both present | Both removed |
+| Remove several where any target is absent | **Whole request silently did nothing**, even with the present user listed first |
+| Remove one user and update another in one request | Both applied |
+
+Two consequences the client encodes: `set_users()` rejects duplicate emails before
+issuing the RPC (there is no first/last-wins rule to honour), and plural removal is
+not offered — it would need a `GET_SHARE_STATUS` preflight, an intersection with the
+currently-shared set, and post-verification to avoid the silent all-or-nothing trap.
 
 **Remove user:**
 ```python
@@ -2003,7 +2024,7 @@ status = await client.sharing.get_status(notebook_id)
 await client.sharing.set_public(notebook_id, True)
 await client.sharing.set_view_level(notebook_id, ShareViewLevel.CHAT_ONLY)
 await client.sharing.add_user(notebook_id, "user@example.com", SharePermission.VIEWER)
-await client.sharing.add_users(
+await client.sharing.set_users(
     notebook_id,
     [
         ("viewer@example.com", SharePermission.VIEWER),

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1953,6 +1953,12 @@ issuing the RPC (there is no first/last-wins rule to honour), and plural removal
 not offered — it would need a `GET_SHARE_STATUS` preflight, an intersection with the
 currently-shared set, and post-verification to avoid the silent all-or-nothing trap.
 
+The duplicate check compares addresses **exactly**, because that is what the probe
+covered. Whether two addresses differing only in case resolve to one account is
+**not established** — RFC 5321 keeps the local part case-sensitive — so the client
+passes them through rather than raising on an unobserved rule. Worth a probe row if
+anyone runs this again.
+
 **Remove user:**
 ```python
 params = [

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -137,6 +137,44 @@ class SharingAPI:
             share_url=status.share_url,
         )
 
+    @staticmethod
+    def _share_params(
+        notebook_id: str,
+        entries: list[tuple[str, SharePermission]],
+        *,
+        notify: bool,
+        message_block: list,
+    ) -> list:
+        """Build the ``SHARE_NOTEBOOK`` envelope for a batch of permission entries.
+
+        The single wire-shape site for every permission mutation — grants and
+        removals alike, since a removal is just ``_REMOVE`` in the same entry
+        slot. Position-sensitive: see ``docs/rpc-reference.md``.
+
+        ``message_block`` is passed in rather than derived from a welcome message,
+        because the two callers do not agree on it: the grant path sends
+        ``[0, msg]`` with a message and ``[1, ""]`` without, while removal has
+        always sent ``[0, ""]``. Deriving it here would silently rewrite the
+        removal payload that ``test_remove_user`` pins.
+
+        Policy (which permissions a caller may send, and whether the batch is
+        coherent) lives with the callers, not here, so a future ``remove_users()``
+        can reuse the encoder without inheriting grant-side validation.
+        """
+        return [
+            [
+                [
+                    notebook_id,
+                    [[email, None, permission.value] for email, permission in entries],
+                    None,
+                    message_block,
+                ]
+            ],
+            1 if notify else 0,
+            None,
+            [2],
+        ]
+
     async def add_user(
         self,
         notebook_id: str,
@@ -146,6 +184,9 @@ class SharingAPI:
         welcome_message: str = "",
     ) -> ShareStatus:
         """Share notebook with a user.
+
+        Intent wrapper over :meth:`set_users`. The underlying operation is an
+        upsert, so this also updates a user who already has access.
 
         Args:
             notebook_id: The notebook ID.
@@ -160,23 +201,36 @@ class SharingAPI:
         Raises:
             ValueError: If permission is OWNER or _REMOVE.
         """
-        return await self.add_users(
+        return await self.set_users(
             notebook_id,
             [(email, permission)],
             notify=notify,
             welcome_message=welcome_message,
         )
 
-    async def add_users(
+    async def set_users(
         self,
         notebook_id: str,
         grants: list[tuple[str, SharePermission]],
         notify: bool = True,
         welcome_message: str = "",
     ) -> ShareStatus:
-        """Share a notebook with multiple users in one request.
+        """Set several users' permissions on a notebook in one request.
 
-        ``notify`` and ``welcome_message`` apply to every grant in this call.
+        This is an **upsert**, not an add: an email that is not shared yet is
+        added, and an email that already has access has its permission replaced.
+        That is the backend's own behaviour — confirmed live — and it is why the
+        singular :meth:`add_user` and :meth:`update_user` are both wrappers over
+        this method rather than distinct operations.
+
+        ``notify`` and ``welcome_message`` apply to the whole call, not per grant.
+
+        Duplicate emails are rejected before the request is issued. The backend
+        answers a batch containing the same grantee twice with success while
+        silently leaving that user's permission unchanged, so there is no
+        first-wins or last-wins rule to honour — sending one would be a lie.
+        Comparison is case-insensitive, because two entries differing only in
+        case reach the same account and hit exactly that silent no-op.
 
         Args:
             notebook_id: The notebook ID.
@@ -188,44 +242,43 @@ class SharingAPI:
             Updated ShareStatus.
 
         Raises:
-            ValueError: If grants is empty or a permission is OWNER or _REMOVE.
+            ValueError: If grants is empty, contains a duplicate email, or a
+                permission is OWNER or _REMOVE.
         """
         if not grants:
             raise ValueError("Must provide at least one user grant")
-        for _email, permission in grants:
+        seen: set[str] = set()
+        for email, permission in grants:
             if permission == SharePermission.OWNER:
                 raise ValueError("Cannot assign OWNER permission")
             if permission == SharePermission._REMOVE:
                 raise ValueError("Use remove_user() instead")
+            key = email.casefold()
+            if key in seen:
+                raise ValueError(
+                    f"Duplicate email in grants: {email!r}. The backend silently "
+                    "ignores a repeated grantee instead of applying either entry; "
+                    "send one grant per user."
+                )
+            seen.add(key)
 
         # Keep the grantee detail the single-user path used to log: a typoed
         # address is exactly what this line gets read for.
         logger.debug(
-            "Adding %d user(s) to notebook %s: %s",
+            "Setting %d user permission(s) on notebook %s: %s",
             len(grants),
             notebook_id,
             [(email, permission.name) for email, permission in grants],
         )
 
-        message_flag = 0 if welcome_message else 1
-        notify_flag = 1 if notify else 0
-
-        params = [
-            [
-                [
-                    notebook_id,
-                    [[email, None, permission.value] for email, permission in grants],
-                    None,
-                    [message_flag, welcome_message],
-                ]
-            ],
-            notify_flag,
-            None,
-            [2],
-        ]
         await self._rpc.rpc_call(
             RPCMethod.SHARE_NOTEBOOK,
-            params,
+            self._share_params(
+                notebook_id,
+                grants,
+                notify=notify,
+                message_block=[0 if welcome_message else 1, welcome_message],
+            ),
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
@@ -238,6 +291,9 @@ class SharingAPI:
         permission: SharePermission,
     ) -> ShareStatus:
         """Update a user's permission level.
+
+        Intent wrapper over :meth:`set_users`. The underlying operation is an
+        upsert, so this adds a user who does not have access yet.
 
         Args:
             notebook_id: The notebook ID.
@@ -253,8 +309,7 @@ class SharingAPI:
             permission.name,
             notebook_id,
         )
-        # Same RPC as add_user, just updates existing user
-        return await self.add_user(notebook_id, email, permission, notify=False)
+        return await self.set_users(notebook_id, [(email, permission)], notify=False)
 
     async def remove_user(
         self,
@@ -262,6 +317,13 @@ class SharingAPI:
         email: str,
     ) -> ShareStatus:
         """Remove a user's access to the notebook.
+
+        Singular by design. A batch of ``_REMOVE`` entries only works when every
+        target is currently shared: if any requested email is already absent the
+        backend silently drops the whole request — including the users that *are*
+        present — and reports no failure. A plural removal therefore needs a
+        share-status preflight and post-verification rather than a wider entry
+        list; see ``docs/rpc-reference.md``.
 
         Args:
             notebook_id: The notebook ID.
@@ -271,12 +333,14 @@ class SharingAPI:
             Updated ShareStatus.
         """
         logger.debug("Removing user %s from notebook %s", email, notebook_id)
-        params = [
-            [[notebook_id, [[email, None, SharePermission._REMOVE.value]], None, [0, ""]]],
-            0,
-            None,
-            [2],
-        ]
+        # ``[0, ""]``, not the grant path's ``[1, ""]`` — the captured removal
+        # payload has always sent flag 0 with an empty message.
+        params = self._share_params(
+            notebook_id,
+            [(email, SharePermission._REMOVE)],
+            notify=False,
+            message_block=[0, ""],
+        )
         await self._rpc.rpc_call(
             RPCMethod.SHARE_NOTEBOOK,
             params,

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -198,7 +198,14 @@ class SharingAPI:
             if permission == SharePermission._REMOVE:
                 raise ValueError("Use remove_user() instead")
 
-        logger.debug("Adding %d users to notebook %s", len(grants), notebook_id)
+        # Keep the grantee detail the single-user path used to log: a typoed
+        # address is exactly what this line gets read for.
+        logger.debug(
+            "Adding %d user(s) to notebook %s: %s",
+            len(grants),
+            notebook_id,
+            [(email, permission.name) for email, permission in grants],
+        )
 
         message_flag = 0 if welcome_message else 1
         notify_flag = 1 if notify else 0

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -229,8 +229,14 @@ class SharingAPI:
         answers a batch containing the same grantee twice with success while
         silently leaving that user's permission unchanged, so there is no
         first-wins or last-wins rule to honour — sending one would be a lie.
-        Comparison is case-insensitive, because two entries differing only in
-        case reach the same account and hit exactly that silent no-op.
+
+        The comparison is **exact**, matching what was actually probed (the same
+        address twice). Addresses differing only in case are left alone: RFC 5321
+        makes the local part case-sensitive, only the domain is not, so folding
+        case here would reject two addresses the server may well treat as
+        distinct identities. If they do resolve to one account they hit the same
+        silent no-op the backend already has; establishing that needs a live
+        probe, not a guess in the client.
 
         Args:
             notebook_id: The notebook ID.
@@ -253,14 +259,13 @@ class SharingAPI:
                 raise ValueError("Cannot assign OWNER permission")
             if permission == SharePermission._REMOVE:
                 raise ValueError("Use remove_user() instead")
-            key = email.casefold()
-            if key in seen:
+            if email in seen:
                 raise ValueError(
                     f"Duplicate email in grants: {email!r}. The backend silently "
                     "ignores a repeated grantee instead of applying either entry; "
                     "send one grant per user."
                 )
-            seen.add(key)
+            seen.add(email)
 
         # Keep the grantee detail the single-user path used to log: a typoed
         # address is exactly what this line gets read for.

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -160,17 +160,45 @@ class SharingAPI:
         Raises:
             ValueError: If permission is OWNER or _REMOVE.
         """
-        if permission == SharePermission.OWNER:
-            raise ValueError("Cannot assign OWNER permission")
-        if permission == SharePermission._REMOVE:
-            raise ValueError("Use remove_user() instead")
-
-        logger.debug(
-            "Adding user %s to notebook %s with permission %s",
-            email,
+        return await self.add_users(
             notebook_id,
-            permission.name,
+            [(email, permission)],
+            notify=notify,
+            welcome_message=welcome_message,
         )
+
+    async def add_users(
+        self,
+        notebook_id: str,
+        grants: list[tuple[str, SharePermission]],
+        notify: bool = True,
+        welcome_message: str = "",
+    ) -> ShareStatus:
+        """Share a notebook with multiple users in one request.
+
+        ``notify`` and ``welcome_message`` apply to every grant in this call.
+
+        Args:
+            notebook_id: The notebook ID.
+            grants: Email and permission pairs. Permissions must be EDITOR or VIEWER.
+            notify: Send email notifications to all users.
+            welcome_message: Optional welcome message sent to all users.
+
+        Returns:
+            Updated ShareStatus.
+
+        Raises:
+            ValueError: If grants is empty or a permission is OWNER or _REMOVE.
+        """
+        if not grants:
+            raise ValueError("Must provide at least one user grant")
+        for _email, permission in grants:
+            if permission == SharePermission.OWNER:
+                raise ValueError("Cannot assign OWNER permission")
+            if permission == SharePermission._REMOVE:
+                raise ValueError("Use remove_user() instead")
+
+        logger.debug("Adding %d users to notebook %s", len(grants), notebook_id)
 
         message_flag = 0 if welcome_message else 1
         notify_flag = 1 if notify else 0
@@ -179,7 +207,7 @@ class SharingAPI:
             [
                 [
                     notebook_id,
-                    [[email, None, permission.value]],
+                    [[email, None, permission.value] for email, permission in grants],
                     None,
                     [message_flag, welcome_message],
                 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import re
+from urllib.parse import parse_qs
 
 import pytest
 
@@ -533,6 +534,24 @@ def build_rpc_response():
         return f")]}}'\n{len(chunk)}\n{chunk}\n"
 
     return _build
+
+
+@pytest.fixture
+def rpc_request_params():
+    """Decode the positional params out of an outgoing ``batchexecute`` request.
+
+    The inverse of :func:`build_rpc_response` for assertions on request shape:
+    unwraps the ``f.req`` form body and returns the params list the client sent.
+    Shared here rather than duplicated per test module, since both tiers assert on
+    wire shape and ``tests/_guardrails/test_no_cross_test_imports.py`` forbids one
+    test module importing another.
+    """
+
+    def _params(request) -> list:
+        outer = json.loads(parse_qs(request.content.decode())["f.req"][0])
+        return json.loads(outer[0][0][1])
+
+    return _params
 
 
 @pytest.fixture

--- a/tests/integration/test_sharing_integration.py
+++ b/tests/integration/test_sharing_integration.py
@@ -6,6 +6,9 @@ integration-tree VCR enforcement hook in ``tests/integration/conftest.py``.
 Cassette-backed coverage lives in ``tests/integration/test_vcr_comprehensive.py``.
 """
 
+import json
+from urllib.parse import parse_qs
+
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -13,6 +16,12 @@ from notebooklm import NotebookLMClient, SharePermission, ShareViewLevel
 from notebooklm.rpc import RPCMethod
 
 pytestmark = pytest.mark.allow_no_vcr
+
+
+def _request_params(request) -> list:
+    """Decode the positional params from an RPC request."""
+    outer = json.loads(parse_qs(request.content.decode())["f.req"][0])
+    return json.loads(outer[0][0][1])
 
 
 class TestGetShareStatus:
@@ -253,6 +262,21 @@ class TestAddUser:
         assert status.shared_users[1].email == "new@example.com"
         assert status.shared_users[1].permission == SharePermission.VIEWER
 
+        requests = httpx_mock.get_requests()
+        assert _request_params(requests[0]) == [
+            [
+                [
+                    "nb_123",
+                    [["new@example.com", None, SharePermission.VIEWER.value]],
+                    None,
+                    [1, ""],
+                ]
+            ],
+            1,
+            None,
+            [2],
+        ]
+
     @pytest.mark.asyncio
     async def test_add_user_as_editor(
         self,
@@ -318,6 +342,100 @@ class TestAddUser:
             )
 
         assert len(status.shared_users) == 2
+
+
+class TestAddUsers:
+    """Tests for SharingAPI.add_users()."""
+
+    @pytest.mark.asyncio
+    async def test_add_users_sends_mixed_grants_in_one_request(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """A bulk grant shares per-call notification settings and refreshes once."""
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.GET_SHARE_STATUS,
+                [
+                    [
+                        ["owner@example.com", 1, [], ["Owner", "https://avatar"]],
+                        ["viewer@example.com", 3, [], ["Viewer", "https://viewer"]],
+                        ["editor@example.com", 2, [], ["Editor", "https://editor"]],
+                    ],
+                    [False],
+                    1000,
+                ],
+            ).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            status = await client.sharing.add_users(
+                "nb_123",
+                [
+                    ("viewer@example.com", SharePermission.VIEWER),
+                    ("editor@example.com", SharePermission.EDITOR),
+                ],
+                notify=False,
+                welcome_message="Welcome, team!",
+            )
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+        assert requests[0].url.params["rpcids"] == RPCMethod.SHARE_NOTEBOOK.value
+        assert requests[1].url.params["rpcids"] == RPCMethod.GET_SHARE_STATUS.value
+        assert _request_params(requests[0]) == [
+            [
+                [
+                    "nb_123",
+                    [
+                        ["viewer@example.com", None, SharePermission.VIEWER.value],
+                        ["editor@example.com", None, SharePermission.EDITOR.value],
+                    ],
+                    None,
+                    [0, "Welcome, team!"],
+                ]
+            ],
+            0,
+            None,
+            [2],
+        ]
+        assert [user.email for user in status.shared_users] == [
+            "owner@example.com",
+            "viewer@example.com",
+            "editor@example.com",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("grants", "message"),
+        [
+            ([], "at least one user"),
+            (
+                [("owner@example.com", SharePermission.OWNER)],
+                "Cannot assign OWNER permission",
+            ),
+            (
+                [("removed@example.com", SharePermission._REMOVE)],
+                r"Use remove_user\(\) instead",
+            ),
+        ],
+    )
+    async def test_add_users_rejects_invalid_grants(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        grants,
+        message,
+    ):
+        """Empty, owner, and remove grants fail before an RPC is sent."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValueError, match=message):
+                await client.sharing.add_users("nb_123", grants)
+
+        assert httpx_mock.get_requests() == []
 
 
 class TestUpdateUser:
@@ -388,6 +506,22 @@ class TestRemoveUser:
         assert len(status.shared_users) == 1
         assert status.shared_users[0].email == "owner@example.com"
 
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+        assert _request_params(requests[0]) == [
+            [
+                [
+                    "nb_123",
+                    [["removed@example.com", None, SharePermission._REMOVE.value]],
+                    None,
+                    [0, ""],
+                ]
+            ],
+            0,
+            None,
+            [2],
+        ]
+
 
 class TestSharingAPIIntegration:
     """Additional integration tests for SharingAPI."""
@@ -405,5 +539,6 @@ class TestSharingAPIIntegration:
             assert hasattr(client.sharing, "set_public")
             assert hasattr(client.sharing, "set_view_level")
             assert hasattr(client.sharing, "add_user")
+            assert hasattr(client.sharing, "add_users")
             assert hasattr(client.sharing, "update_user")
             assert hasattr(client.sharing, "remove_user")

--- a/tests/integration/test_sharing_integration.py
+++ b/tests/integration/test_sharing_integration.py
@@ -438,6 +438,6 @@ class TestSharingAPIIntegration:
             assert hasattr(client.sharing, "set_public")
             assert hasattr(client.sharing, "set_view_level")
             assert hasattr(client.sharing, "add_user")
-            assert hasattr(client.sharing, "add_users")
+            assert hasattr(client.sharing, "set_users")
             assert hasattr(client.sharing, "update_user")
             assert hasattr(client.sharing, "remove_user")

--- a/tests/integration/test_sharing_integration.py
+++ b/tests/integration/test_sharing_integration.py
@@ -6,9 +6,6 @@ integration-tree VCR enforcement hook in ``tests/integration/conftest.py``.
 Cassette-backed coverage lives in ``tests/integration/test_vcr_comprehensive.py``.
 """
 
-import json
-from urllib.parse import parse_qs
-
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -16,12 +13,6 @@ from notebooklm import NotebookLMClient, SharePermission, ShareViewLevel
 from notebooklm.rpc import RPCMethod
 
 pytestmark = pytest.mark.allow_no_vcr
-
-
-def _request_params(request) -> list:
-    """Decode the positional params from an RPC request."""
-    outer = json.loads(parse_qs(request.content.decode())["f.req"][0])
-    return json.loads(outer[0][0][1])
 
 
 class TestGetShareStatus:
@@ -232,6 +223,7 @@ class TestAddUser:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        rpc_request_params,
     ):
         """Test adding a user as viewer."""
         share_response = build_rpc_response(RPCMethod.SHARE_NOTEBOOK, [])
@@ -263,7 +255,7 @@ class TestAddUser:
         assert status.shared_users[1].permission == SharePermission.VIEWER
 
         requests = httpx_mock.get_requests()
-        assert _request_params(requests[0]) == [
+        assert rpc_request_params(requests[0]) == [
             [
                 [
                     "nb_123",
@@ -344,100 +336,6 @@ class TestAddUser:
         assert len(status.shared_users) == 2
 
 
-class TestAddUsers:
-    """Tests for SharingAPI.add_users()."""
-
-    @pytest.mark.asyncio
-    async def test_add_users_sends_mixed_grants_in_one_request(
-        self,
-        auth_tokens,
-        httpx_mock: HTTPXMock,
-        build_rpc_response,
-    ):
-        """A bulk grant shares per-call notification settings and refreshes once."""
-        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
-        httpx_mock.add_response(
-            content=build_rpc_response(
-                RPCMethod.GET_SHARE_STATUS,
-                [
-                    [
-                        ["owner@example.com", 1, [], ["Owner", "https://avatar"]],
-                        ["viewer@example.com", 3, [], ["Viewer", "https://viewer"]],
-                        ["editor@example.com", 2, [], ["Editor", "https://editor"]],
-                    ],
-                    [False],
-                    1000,
-                ],
-            ).encode()
-        )
-
-        async with NotebookLMClient(auth_tokens) as client:
-            status = await client.sharing.add_users(
-                "nb_123",
-                [
-                    ("viewer@example.com", SharePermission.VIEWER),
-                    ("editor@example.com", SharePermission.EDITOR),
-                ],
-                notify=False,
-                welcome_message="Welcome, team!",
-            )
-
-        requests = httpx_mock.get_requests()
-        assert len(requests) == 2
-        assert requests[0].url.params["rpcids"] == RPCMethod.SHARE_NOTEBOOK.value
-        assert requests[1].url.params["rpcids"] == RPCMethod.GET_SHARE_STATUS.value
-        assert _request_params(requests[0]) == [
-            [
-                [
-                    "nb_123",
-                    [
-                        ["viewer@example.com", None, SharePermission.VIEWER.value],
-                        ["editor@example.com", None, SharePermission.EDITOR.value],
-                    ],
-                    None,
-                    [0, "Welcome, team!"],
-                ]
-            ],
-            0,
-            None,
-            [2],
-        ]
-        assert [user.email for user in status.shared_users] == [
-            "owner@example.com",
-            "viewer@example.com",
-            "editor@example.com",
-        ]
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("grants", "message"),
-        [
-            ([], "at least one user"),
-            (
-                [("owner@example.com", SharePermission.OWNER)],
-                "Cannot assign OWNER permission",
-            ),
-            (
-                [("removed@example.com", SharePermission._REMOVE)],
-                r"Use remove_user\(\) instead",
-            ),
-        ],
-    )
-    async def test_add_users_rejects_invalid_grants(
-        self,
-        auth_tokens,
-        httpx_mock: HTTPXMock,
-        grants,
-        message,
-    ):
-        """Empty, owner, and remove grants fail before an RPC is sent."""
-        async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(ValueError, match=message):
-                await client.sharing.add_users("nb_123", grants)
-
-        assert httpx_mock.get_requests() == []
-
-
 class TestUpdateUser:
     """Tests for SharingAPI.update_user()."""
 
@@ -484,6 +382,7 @@ class TestRemoveUser:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        rpc_request_params,
     ):
         """Test removing a user."""
         share_response = build_rpc_response(RPCMethod.SHARE_NOTEBOOK, [])
@@ -508,7 +407,7 @@ class TestRemoveUser:
 
         requests = httpx_mock.get_requests()
         assert len(requests) == 2
-        assert _request_params(requests[0]) == [
+        assert rpc_request_params(requests[0]) == [
             [
                 [
                     "nb_123",

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -3,7 +3,10 @@
 from typing import Any
 
 import pytest
+from pytest_httpx import HTTPXMock
 
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
 from notebooklm.rpc.types import ShareAccess, SharePermission, ShareViewLevel
 from notebooklm.types import SharedUser, ShareStatus
 
@@ -453,3 +456,98 @@ class TestShareStatusDefaultValues:
         )
         assert len(status1.shared_users) == 1
         assert len(status2.shared_users) == 0
+
+
+class TestAddUsers:
+    """Tests for SharingAPI.add_users()."""
+
+    @pytest.mark.asyncio
+    async def test_add_users_sends_mixed_grants_in_one_request(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """A bulk grant shares per-call notification settings and refreshes once."""
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.GET_SHARE_STATUS,
+                [
+                    [
+                        ["owner@example.com", 1, [], ["Owner", "https://avatar"]],
+                        ["viewer@example.com", 3, [], ["Viewer", "https://viewer"]],
+                        ["editor@example.com", 2, [], ["Editor", "https://editor"]],
+                    ],
+                    [False],
+                    1000,
+                ],
+            ).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            status = await client.sharing.add_users(
+                "nb_123",
+                [
+                    ("viewer@example.com", SharePermission.VIEWER),
+                    ("editor@example.com", SharePermission.EDITOR),
+                ],
+                notify=False,
+                welcome_message="Welcome, team!",
+            )
+
+        requests = httpx_mock.get_requests()
+        assert len(requests) == 2
+        assert requests[0].url.params["rpcids"] == RPCMethod.SHARE_NOTEBOOK.value
+        assert requests[1].url.params["rpcids"] == RPCMethod.GET_SHARE_STATUS.value
+        assert rpc_request_params(requests[0]) == [
+            [
+                [
+                    "nb_123",
+                    [
+                        ["viewer@example.com", None, SharePermission.VIEWER.value],
+                        ["editor@example.com", None, SharePermission.EDITOR.value],
+                    ],
+                    None,
+                    [0, "Welcome, team!"],
+                ]
+            ],
+            0,
+            None,
+            [2],
+        ]
+        assert [user.email for user in status.shared_users] == [
+            "owner@example.com",
+            "viewer@example.com",
+            "editor@example.com",
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("grants", "message"),
+        [
+            ([], "at least one user"),
+            (
+                [("owner@example.com", SharePermission.OWNER)],
+                "Cannot assign OWNER permission",
+            ),
+            (
+                [("removed@example.com", SharePermission._REMOVE)],
+                r"Use remove_user\(\) instead",
+            ),
+        ],
+    )
+    async def test_add_users_rejects_invalid_grants(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        grants,
+        message,
+    ):
+        """Empty, owner, and remove grants fail before an RPC is sent."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValueError, match=message):
+                await client.sharing.add_users("nb_123", grants)
+
+        assert httpx_mock.get_requests() == []

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -458,11 +458,11 @@ class TestShareStatusDefaultValues:
         assert len(status2.shared_users) == 0
 
 
-class TestAddUsers:
-    """Tests for SharingAPI.add_users()."""
+class TestSetUsers:
+    """Tests for SharingAPI.set_users()."""
 
     @pytest.mark.asyncio
-    async def test_add_users_sends_mixed_grants_in_one_request(
+    async def test_set_users_sends_mixed_grants_in_one_request(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
@@ -487,7 +487,7 @@ class TestAddUsers:
         )
 
         async with NotebookLMClient(auth_tokens) as client:
-            status = await client.sharing.add_users(
+            status = await client.sharing.set_users(
                 "nb_123",
                 [
                     ("viewer@example.com", SharePermission.VIEWER),
@@ -536,18 +536,153 @@ class TestAddUsers:
                 [("removed@example.com", SharePermission._REMOVE)],
                 r"Use remove_user\(\) instead",
             ),
+            (
+                [
+                    ("dup@example.com", SharePermission.VIEWER),
+                    ("dup@example.com", SharePermission.EDITOR),
+                ],
+                "Duplicate email in grants",
+            ),
+            # Case-only difference reaches the same account, so it hits the same
+            # silent no-op and must be rejected too.
+            (
+                [
+                    ("Dup@Example.com", SharePermission.VIEWER),
+                    ("dup@example.com", SharePermission.EDITOR),
+                ],
+                "Duplicate email in grants",
+            ),
         ],
     )
-    async def test_add_users_rejects_invalid_grants(
+    async def test_set_users_rejects_invalid_grants(
         self,
         auth_tokens,
         httpx_mock: HTTPXMock,
         grants,
         message,
     ):
-        """Empty, owner, and remove grants fail before an RPC is sent."""
+        """Empty, owner, remove, and duplicate grants fail before an RPC is sent.
+
+        The duplicate cases are not cosmetic: a batch repeating one grantee comes
+        back **successful** from the backend while that user's permission stays
+        unchanged (confirmed live), so there is no first-wins or last-wins rule to
+        implement — only a request worth refusing to send.
+        """
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ValueError, match=message):
-                await client.sharing.add_users("nb_123", grants)
+                await client.sharing.set_users("nb_123", grants)
 
         assert httpx_mock.get_requests() == []
+
+    @pytest.mark.asyncio
+    async def test_set_users_upserts_an_existing_grantee(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """Re-sending an email that already has access replaces its permission.
+
+        This is the naming contract: the operation is an upsert, so ``set_users``
+        sends the same entry shape whether the grantee is new or existing, and
+        the caller gets the changed permission back.
+        """
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.GET_SHARE_STATUS,
+                [
+                    [
+                        ["owner@example.com", 1, [], ["Owner", "https://avatar"]],
+                        ["existing@example.com", 2, [], ["Existing", "https://e"]],
+                    ],
+                    [False],
+                    1000,
+                ],
+            ).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            status = await client.sharing.set_users(
+                "nb_123",
+                [("existing@example.com", SharePermission.EDITOR)],
+                notify=False,
+            )
+
+        assert rpc_request_params(httpx_mock.get_requests()[0])[0][0][1] == [
+            ["existing@example.com", None, SharePermission.EDITOR.value]
+        ]
+        promoted = next(u for u in status.shared_users if u.email == "existing@example.com")
+        assert promoted.permission == SharePermission.EDITOR
+
+    @pytest.mark.asyncio
+    async def test_add_user_and_update_user_send_the_same_wire_shape(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """The singular wrappers differ only in ``notify``, not in the operation.
+
+        ``update_user`` adds an absent user and ``add_user`` updates a present one
+        — both are the same upsert — so pinning their entry blocks equal is what
+        stops a future change from re-splitting them into distinct operations.
+        """
+        for _ in range(2):
+            httpx_mock.add_response(
+                content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode()
+            )
+            httpx_mock.add_response(
+                content=build_rpc_response(RPCMethod.GET_SHARE_STATUS, [[], [False], 1000]).encode()
+            )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sharing.add_user(
+                "nb_123", "u@example.com", SharePermission.EDITOR, notify=False
+            )
+            await client.sharing.update_user("nb_123", "u@example.com", SharePermission.EDITOR)
+
+        added, updated = (
+            rpc_request_params(r)
+            for r in httpx_mock.get_requests()
+            if r.url.params["rpcids"] == RPCMethod.SHARE_NOTEBOOK.value
+        )
+        assert added == updated
+
+    @pytest.mark.asyncio
+    async def test_removal_keeps_its_own_message_block(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """Grants and removals disagree on the message flag; both shapes are pinned.
+
+        A grant with no welcome message sends ``[1, ""]``; a removal sends
+        ``[0, ""]``. They share ``_share_params``, so without this test the next
+        person to "unify" the flag would silently rewrite the removal payload.
+        """
+        for _ in range(2):
+            httpx_mock.add_response(
+                content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode()
+            )
+            httpx_mock.add_response(
+                content=build_rpc_response(RPCMethod.GET_SHARE_STATUS, [[], [False], 1000]).encode()
+            )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sharing.set_users(
+                "nb_123", [("u@example.com", SharePermission.VIEWER)], notify=False
+            )
+            await client.sharing.remove_user("nb_123", "u@example.com")
+
+        grant, removal = (
+            rpc_request_params(r)
+            for r in httpx_mock.get_requests()
+            if r.url.params["rpcids"] == RPCMethod.SHARE_NOTEBOOK.value
+        )
+        assert grant[0][0][3] == [1, ""]
+        assert removal[0][0][3] == [0, ""]

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -543,15 +543,6 @@ class TestSetUsers:
                 ],
                 "Duplicate email in grants",
             ),
-            # Case-only difference reaches the same account, so it hits the same
-            # silent no-op and must be rejected too.
-            (
-                [
-                    ("Dup@Example.com", SharePermission.VIEWER),
-                    ("dup@example.com", SharePermission.EDITOR),
-                ],
-                "Duplicate email in grants",
-            ),
         ],
     )
     async def test_set_users_rejects_invalid_grants(
@@ -563,7 +554,7 @@ class TestSetUsers:
     ):
         """Empty, owner, remove, and duplicate grants fail before an RPC is sent.
 
-        The duplicate cases are not cosmetic: a batch repeating one grantee comes
+        The duplicate case is not cosmetic: a batch repeating one grantee comes
         back **successful** from the backend while that user's permission stays
         unchanged (confirmed live), so there is no first-wins or last-wins rule to
         implement — only a request worth refusing to send.
@@ -573,6 +564,98 @@ class TestSetUsers:
                 await client.sharing.set_users("nb_123", grants)
 
         assert httpx_mock.get_requests() == []
+
+    @pytest.mark.asyncio
+    async def test_case_variant_emails_are_not_treated_as_duplicates(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """Duplicate detection is exact, and deliberately so.
+
+        The live probe covered the *same* address twice, not case variants. RFC 5321
+        makes the local part case-sensitive (only the domain is not), so folding case
+        here could reject two addresses the server may treat as distinct identities —
+        a client-side hard error standing in for a backend rule nobody has observed.
+        This pins the narrower behaviour so a future "improvement" to `casefold()`
+        has to argue with evidence.
+        """
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_SHARE_STATUS, [[], [False], 1000]).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sharing.set_users(
+                "nb_123",
+                [
+                    ("Dup@example.com", SharePermission.VIEWER),
+                    ("dup@example.com", SharePermission.EDITOR),
+                ],
+                notify=False,
+            )
+
+        assert rpc_request_params(httpx_mock.get_requests()[0])[0][0][1] == [
+            ["Dup@example.com", None, SharePermission.VIEWER.value],
+            ["dup@example.com", None, SharePermission.EDITOR.value],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_set_users_notifies_by_default(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """``notify`` defaults to True — every other test passes it explicitly.
+
+        Without this, flipping the new method's default to False would go unnoticed:
+        a brand-new method's default is not covered by the stable-API baseline.
+        """
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_SHARE_STATUS, [[], [False], 1000]).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sharing.set_users("nb_123", [("u@example.com", SharePermission.VIEWER)])
+
+        assert rpc_request_params(httpx_mock.get_requests()[0])[1] == 1
+
+    @pytest.mark.asyncio
+    async def test_add_user_forwards_its_welcome_message(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        rpc_request_params,
+    ):
+        """The singular wrapper must not drop the caller's welcome message.
+
+        ``add_user`` now delegates to ``set_users``; nothing else asserts that the
+        message survives the hop, so dropping it would have been silent.
+        """
+        httpx_mock.add_response(content=build_rpc_response(RPCMethod.SHARE_NOTEBOOK, []).encode())
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_SHARE_STATUS, [[], [False], 1000]).encode()
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sharing.add_user(
+                "nb_123",
+                "u@example.com",
+                SharePermission.VIEWER,
+                notify=False,
+                welcome_message="Come look at this",
+            )
+
+        assert rpc_request_params(httpx_mock.get_requests()[0])[0][0][3] == [
+            0,
+            "Come look at this",
+        ]
 
     @pytest.mark.asyncio
     async def test_set_users_upserts_an_existing_grantee(


### PR DESCRIPTION
## Summary

`SHARE_NOTEBOOK` already accepts many user entries in one call — the wire slot at index 1 of the
first param is a **list** of `[email, None, permission]` triples. `SharingAPI.add_user()` has always
put exactly one entry in it, so sharing a notebook with a team costs N RPC + status-refresh round
trips for what the backend will do in one. #2000 live-verified the plural shape on a scratch
notebook, including **mixed** permissions in a single call.

What batching saves is those round trips. It is **not** established to reduce how many notification
emails recipients receive: `notify` and `welcome_message` are per call, but nothing observed says
the backend sends fewer messages per grantee. An earlier revision of this description claimed "N
notification emails" — that claim was unfounded and has been removed.

This adds `SharingAPI.set_users()` for that case and re-expresses `add_user()` and `update_user()`
as 1-element calls of it, so there is a single validation path and a single wire-shape site rather
than several that can drift apart.

## Related Issue

Refs #2000 — **client half only**, so deliberately not a closing keyword. #2000 asks for plural
support in the MCP tool as well; `mcp/tools/sharing.py` is still singular and this PR does not touch
it (see Notes). Merging on `Closes` would auto-close the issue with that acceptance work untracked.

## Changes

- `src/notebooklm/_sharing.py`
  - New `set_users(notebook_id, grants, notify=True, welcome_message="")` where `grants` is a list of
    `(email, SharePermission)` pairs. It builds the entry list as
    `[[email, None, permission.value] for email, permission in grants]` — the shape #2000 recorded —
    sends one `SHARE_NOTEBOOK`, then refreshes `ShareStatus` once.
  - `add_user()` and `update_user()` now delegate to `set_users(notebook_id, [(email, permission)], ...)`. Their behaviour,
    signature, and its two `ValueError` messages are unchanged, and they are now raised from one
    place instead of two.
  - Validation runs before any RPC: empty `grants` raises `ValueError`, and `OWNER` / `_REMOVE`
    are rejected per grant with the pre-existing messages.
  - The DEBUG log keeps the grantee detail the single-user path used to carry. Delegating naively
    reduced `"Adding user %s … with permission %s"` to `"Adding 1 users to notebook nb_x"`, which drops
    *who* was granted *what* on the most common path — and that line's whole purpose is confirming a
    typoed address. It now logs the `(email, permission.name)` pairs for both the single and bulk
    callers.
- `docs/python-api.md` — `set_users` row in the `SharingAPI` table plus a worked mixed-permission
  example next to the existing `add_user` one.
- `docs/rpc-reference.md` — corrects the `SHARE_NOTEBOOK` section, which documented the entry slot as
  a single `[[email, None, permission]]`. It now shows a multi-entry `entries` list, states that
  `notify_flag` / `welcome_message` are **per call, not per user**, and records that `set_users()`
  issues one `SHARE_NOTEBOOK` + one `GET_SHARE_STATUS`. The web-control coverage table gains
  `set_users` alongside `add_user`.
- `tests/unit/test_sharing_types.py`
  - `TestSetUsers::test_set_users_sends_mixed_grants_in_one_request` decodes the outgoing `f.req`
    body and asserts the exact params, including both grants in one entry list, `notify_flag=0`, and
    `[message_flag=0, "Welcome, team!"]` — plus that exactly **two** requests are made
    (`SHARE_NOTEBOOK` then `GET_SHARE_STATUS`), which is the whole point of the method.
  - `test_set_users_rejects_invalid_grants` parametrises the `ValueError` cases (empty, OWNER,
    `_REMOVE`, duplicate) and asserts `httpx_mock.get_requests() == []`, so validation is pinned as
    pre-flight.
  - `test_set_users_upserts_an_existing_grantee`, `test_add_user_and_update_user_send_the_same_wire_shape`,
    `test_removal_keeps_its_own_message_block`, `test_case_variant_emails_are_not_treated_as_duplicates`,
    `test_set_users_notifies_by_default`, and `test_add_user_forwards_its_welcome_message`.
  - These are `httpx_mock` request-shape assertions, which `CONTRIBUTING.md` assigns to the **Unit**
    tier; they live there. (An earlier revision put them in `tests/integration/`; that was the
    subject of the now-resolved review thread.)
- `tests/integration/test_sharing_integration.py`
  - The existing `add_user` and `remove_user` tests gain a params assertion via the shared
    `rpc_request_params` fixture, so the single-entry wire shape is now pinned too — it previously
    was not, which is what let this slot's real arity go unnoticed. No new node IDs are added to the
    integration `allow_no_vcr` set.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated — N/A, no shape change

Run against the canonical contributor install **plus the extras the CI test matrix adds**
(`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`).
The lean `browser+dev+markdown` install alone skips ~1,500 tests and lands at 83% coverage, i.e.
under the gate — so the suite below is the full-extras run that matches CI:

```console
$ uv run mypy src/notebooklm --ignore-missing-imports
Success: no issues found in 351 source files

$ uv run pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed

$ uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90 -q
TOTAL                                                    30937    826   8128    507    96%
Required test coverage of 90% reached. Total coverage: 96.41%
15384 passed, 64 skipped, 3 xfailed, 253 warnings in 565.52s (0:09:25)
```

I also ran every remaining gate from the `Code Quality` job of `.github/workflows/test.yml`, all green:
`check_workflow_permissions`, `check_workflow_secret_gates`, `check_action_pinning`,
`check_deprecation_targets`, `check_coverage_thresholds`, `check_ci_install_parity`,
`check_claude_md_freshness`, `check_docs_module_refs`,
`audit_public_api_compat.py --check-stale`, `tests/scripts/check_method_coverage.py`,
`pytest tests/e2e --collect-only`, and the lean-install core-import assertion
(`import notebooklm, notebooklm.notebooklm_cli, notebooklm.client, notebooklm.artifacts`).

## Notes

**Scope: this is the client half of #2000, not the MCP half.** #2000 also proposes a plural mode for
the MCP `share_set_user` tool (keeping its `confirm=true` gate, with the preview listing every
grantee). That is a separate surface with its own ADR-0025 schema-character budget and its own
confirmation-preview semantics, so it is left for a follow-up rather than bundled here. Nothing in
this PR blocks it — the MCP tool can adopt `set_users()` unchanged.

**No new idempotency-policy slot is needed.** #2000 mentions one, but `_idempotency_policy.py` is
keyed by `RPCMethod`, not by client method, and `RPCMethod.SHARE_NOTEBOOK` is already registered
(`NON_IDEMPOTENT_*` with the `GET_SHARE_STATUS` probe note). `set_users()` sends that same RPC, so it
inherits the existing classification rather than needing a new one.

**`notify` / `welcome_message` are per call.** The wire has one `notify_flag` and one
`[message_flag, message]` pair for the whole request, so a bulk call cannot vary them per grantee.
That is now stated in the docstring, in `docs/python-api.md`, and in `docs/rpc-reference.md` rather
than left for a caller to discover.

**Not verified live.** The multi-entry acceptance and the mixed-permission behaviour are from the
maintainer's live capture in #2000, not an independent run — I have no account positioned to
re-verify. My verification is offline: the params assertions above pin that we send exactly the shape
#2000 recorded. The Python 3.10–3.14 matrix is also unverified locally; the change uses no
version-sensitive syntax.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bulk notebook sharing for multiple recipients with mixed viewer and editor permissions in one operation.
  - Added notification and welcome-message options that apply to the whole call.
  - Single-recipient sharing now uses the same bulk-sharing capability.

- **Bug Fixes**
  - Added validation for empty recipient lists and unsupported permissions before requests are sent.

- **Documentation**
  - Documented the bulk-sharing API with usage examples and behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Revision after the maintainer's live probe (2026-08-12)

@teng-lin probed this exact head against real accounts, and the results changed the public contract,
not just the wording. All six requested revisions are in.

**1. The operation is an upsert, so it is named one.** `add_users()` -> **`set_users()`**. The probe
showed a batch replaces an existing grantee's permission and adds an absent one, in both the plural
and singular forms. "Add" and "update" were never distinct operations, only distinct intents, so
`add_user()` and `update_user()` are now wrappers over `set_users()` differing only in their default
`notify`. No `update_users()` was added, per your note.

**2. Duplicate emails are rejected before any RPC.** A repeated grantee returns success while leaving
the permission unchanged, so there is no first-wins or last-wins rule to honour. `set_users()` raises
`ValueError` naming the offending address, and the test asserts `httpx_mock.get_requests() == []`.

The comparison is **exact**. I first made it case-insensitive and have reverted that: the probe
covered the same address twice, not case variants, and RFC 5321 keeps the mailbox local part
case-sensitive (only the domain is not), so folding case would have let the client hard-reject two
addresses the server may treat as distinct identities — a rule nobody has observed. `casefold()` also
collapses more than case (`straße@` and `strasse@` become one). Exact matching satisfies what was
actually probed; `test_case_variant_emails_are_not_treated_as_duplicates` pins the narrower behaviour,
and `docs/rpc-reference.md` flags the open question as worth a probe row if you run one again.

**3. No `remove_users()`.** Not added. `remove_user()`'s docstring now records *why* — the
all-or-nothing silent drop when any target is already absent — so the next reader does not take the
singular form for an oversight.

**4. Wire construction centralised, with one correction worth flagging.** A private `_share_params()`
now owns the `SHARE_NOTEBOOK` envelope for grants and removals alike; validation, logging, and the
status refresh live in `set_users()`; removal keeps its own explicit call site.

Doing this surfaced that the two paths **disagree on the message block**: the grant path sends
`[0, msg]` with a welcome message and `[1, ""]` without, while removal has always sent `[0, ""]`.
My first version derived that flag inside the encoder, which silently rewrote the removal payload
`test_remove_user` pins. `_share_params()` therefore takes `message_block` explicitly, and
`test_removal_keeps_its_own_message_block` pins **both** shapes so the discrepancy cannot be tidied
into a wire change later. It was previously invisible; it is now stated in the encoder's docstring.

**5. Contract and test language updated.**
- `docs/python-api.md`: upsert semantics, absent emails added, duplicate rejection, the per-call
  notify/welcome caveat, and why plural removal is absent.
- `docs/rpc-reference.md`: your eight probe rows recorded as an entry-list semantics table, plus the
  two consequences the client encodes.
- `CHANGELOG.md`: rewritten around upsert plus both preconditions.
- This description: the "N notification emails" claim is gone (see Summary).
- New tests: `test_set_users_upserts_an_existing_grantee` and
  `test_add_user_and_update_user_send_the_same_wire_shape`, which pins the two wrappers as one
  operation.

**6. Rebased** onto current `main`; the outdated test-tier thread is resolved.
