### PR TITLE
fix(chat): pin the answer marker wire position

### DIFF
--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -660,7 +660,7 @@ class AnswerRow:
     whose ``inner_data`` is a populated list (heartbeats decode to ``[]``
     and never reach this adapter). Position knowledge is centralised here;
     consumer sites should NEVER open-code ``first[0]`` / ``first[2][0]`` /
-    ``first[4][-1]`` / ``first[4][3]``.
+    ``first[4][4]`` / ``first[4][3]``.
 
     The dataclass is frozen so the wrapped row can't be mutated through the
     adapter; the adapter never copies the raw row, so it is cheap to build.
@@ -679,7 +679,7 @@ class AnswerRow:
     _TEXT_POS: ClassVar[int] = 0
     _CONV_BLOCK_POS: ClassVar[int] = 2
     _TYPE_BLOCK_POS: ClassVar[int] = 4
-    _ANSWER_MARKER_POS: ClassVar[int] = -1
+    _ANSWER_MARKER_POS: ClassVar[int] = 4
     _CITATIONS_POS: ClassVar[int] = 3
     _ANSWER_MARKER_VALUE: ClassVar[int] = 1
 
@@ -738,16 +738,16 @@ class AnswerRow:
 
     @property
     def is_answer(self) -> bool:
-        """Whether the type block marks this record as an answer (``[4][-1] == 1``).
+        """Whether the type block marks this record as an answer (``[4][4] == 1``).
 
         An absent / empty type block legitimately means "not an answer", so the
-        flag read is a single-level ``type_block[-1]`` index on a bound local
-        rather than a chained ``first[4][-1]`` descent.
+        flag read is a single-level ``type_block[4]`` index on a bound local
+        rather than a chained ``first[4][4]`` descent.
         """
         type_block = self._type_block
         return (
             type_block is not None
-            and len(type_block) > 0
+            and len(type_block) > self._ANSWER_MARKER_POS
             and type_block[self._ANSWER_MARKER_POS] == self._ANSWER_MARKER_VALUE
         )
 

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -216,6 +216,15 @@ MAPPINGS: tuple[Mapping, ...] = (
         section=DOC,
         note="nested inside responseDoc, not a top-level AnswerResponse index",
     ),
+    Mapping(
+        "chat",
+        "AnswerRow",
+        "_ANSWER_MARKER_POS",
+        "TailwindDoc",
+        "type",
+        section=DOC,
+        note="nested inside responseDoc, not a top-level AnswerResponse index",
+    ),
     # ---- Notes: ProjectNote ------------------------------------------------
     Mapping("notes", "NoteRow", "_ID_POS", "ProjectNote", "id"),
     Mapping("notes", "NoteRow", "_CONTENT_POS", "ProjectNote", "content"),
@@ -342,13 +351,6 @@ UNMAPPED: tuple[Unmapped, ...] = (
     Unmapped("artifacts", "ReportSuggestionRow", "_PROMPT_POS", _SHAPE_UNKNOWN),
     Unmapped("artifacts", "ReportSuggestionRow", "_AUDIENCE_LEVEL_POS", _SHAPE_UNKNOWN),
     # chat.py
-    Unmapped(
-        "chat",
-        "AnswerRow",
-        "_ANSWER_MARKER_POS",
-        "negative index (-1) into a positional message; only lands on "
-        "TailwindDoc.type because tag 5 is currently last — see #2121",
-    ),
     Unmapped("chat", "SavedChatNoteRow", "_OUTER_NOTE_POS", _NESTED_LOCAL),
     Unmapped("chat", "SavedChatNoteRow", "_ID_POS", _SHAPE_UNKNOWN),
     Unmapped("chat", "SavedChatNoteRow", "_SERVER_TITLE_POS", _SHAPE_UNKNOWN),

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -50,7 +50,7 @@ class TestAnswerRowPositionContract:
             AnswerRow._ANSWER_MARKER_POS,
             AnswerRow._CITATIONS_POS,
             AnswerRow._ANSWER_MARKER_VALUE,
-        ) == (0, 2, 4, -1, 3, 1)
+        ) == (0, 2, 4, 4, 3, 1)
 
 
 class TestCitationPositionContract:
@@ -143,6 +143,11 @@ class TestAnswerRow:
 
     def test_non_answer_marker_is_false(self) -> None:
         assert AnswerRow(_answer_record(marker=0)).is_answer is False
+
+    def test_trailing_type_field_does_not_change_answer_marker(self) -> None:
+        rec = _answer_record()
+        rec[4].append(0)
+        assert AnswerRow(rec).is_answer is True
 
     def test_absent_type_block_means_not_answer_and_no_citations(self) -> None:
         row = AnswerRow(_answer_record(marker=None))


### PR DESCRIPTION
## Summary

- read the TailwindDoc answer marker from explicit position 4 instead of the last field
- keep malformed and short blocks safely classified as non-answers
- promote the recovered TailwindDoc.type position into the wire-contract guardrail
- prove trailing backend fields cannot change answer classification

Closes #2121

## Test plan

- focused trailing-field regression (red before fix, 2 passed after)
- row adapter and wire contract suites (189 passed, 2 xfailed)
- broad chat suite (490 passed, 1 skipped)
- full guardrails (1276 passed, 4 skipped, 3 xfailed)
- Ruff check and format check (passed)
- `git diff --check` (passed)

## Notes

This PR intentionally does not alter the no-answer fallback or warning behavior from #2118. Mypy is currently blocked by three base-existing unused-ignore diagnostics in `_source/markdown.py`; that file is unchanged by this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer detection by using the correct fixed record position.
  * Prevented trailing data from incorrectly changing answer recognition.

* **Tests**
  * Added regression coverage to verify answer detection remains stable when extra trailing fields are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->