### PR TITLE
fix(chat): pin the answer marker position and stop warning on expected no-answer replies (#2121, #2118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,10 +263,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Expected no-answer chat responses no longer emit a wire-drift warning.**
-  Responses without a TailwindDoc answer now return the backend apology quietly,
-  while present-but-unmarked response documents still warn
-  ([#2118](https://github.com/teng-lin/notebooklm-py/issues/2118)).
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend
@@ -282,6 +278,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type still warns. That is the same split the sibling walk over this slot
   already makes in `_source/listing.py`
   ([#2131](https://github.com/teng-lin/notebooklm-py/issues/2131)).
+- **Expected no-answer chat responses no longer emit a wire-drift warning.**
+  Responses without a TailwindDoc answer now return the backend apology quietly,
+  while present-but-unmarked response documents still warn
+  ([#2118](https://github.com/teng-lin/notebooklm-py/issues/2118)).
 - **Chat turn numbers now come from server history instead of the client-local
   cache.** Stateless remote MCP requests create a fresh client for each call, so
   a real continuation could previously report the contradictory pair

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Expected no-answer chat responses no longer emit a wire-drift warning.**
+  Responses without a TailwindDoc answer now return the backend apology quietly,
+  while present-but-unmarked response documents still warn
+  ([#2118](https://github.com/teng-lin/notebooklm-py/issues/2118)).
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -177,14 +177,14 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
     best_marked_refs: list[ChatReference] = []
     best_unmarked_answer = ""
     best_unmarked_refs: list[ChatReference] = []
-    best_unmarked_has_response_doc = False
+    saw_unmarked_response_doc = False
     server_conv_id: str | None = None
     parseable_chunk_count = 0
 
     def process_chunk(json_str: str) -> None:
         """Process a JSON chunk, updating best answer candidates and their refs."""
         nonlocal best_marked_answer, best_marked_refs
-        nonlocal best_unmarked_answer, best_unmarked_refs, best_unmarked_has_response_doc
+        nonlocal best_unmarked_answer, best_unmarked_refs, saw_unmarked_response_doc
         nonlocal server_conv_id, parseable_chunk_count
         text, is_answer, refs, conv_id, parseable, has_response_doc = _extract_chunk_with_parseable(
             json_str
@@ -195,10 +195,11 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
             if is_answer and len(text) > len(best_marked_answer):
                 best_marked_answer = text
                 best_marked_refs = refs
-            elif not is_answer and len(text) > len(best_unmarked_answer):
-                best_unmarked_answer = text
-                best_unmarked_refs = refs
-                best_unmarked_has_response_doc = has_response_doc
+            elif not is_answer:
+                saw_unmarked_response_doc |= has_response_doc
+                if len(text) > len(best_unmarked_answer):
+                    best_unmarked_answer = text
+                    best_unmarked_refs = refs
         if conv_id:
             server_conv_id = conv_id
 
@@ -233,7 +234,7 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
         longest_answer = best_marked_answer
         final_refs = best_marked_refs
     elif best_unmarked_answer:
-        if best_unmarked_has_response_doc:
+        if saw_unmarked_response_doc:
             logger.warning(
                 "No marked answer found; falling back to longest unmarked "
                 "text (%d chars). The API response format may have changed.",

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -177,16 +177,16 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
     best_marked_refs: list[ChatReference] = []
     best_unmarked_answer = ""
     best_unmarked_refs: list[ChatReference] = []
-    saw_unmarked_response_doc = False
+    saw_drift_signal = False
     server_conv_id: str | None = None
     parseable_chunk_count = 0
 
     def process_chunk(json_str: str) -> None:
         """Process a JSON chunk, updating best answer candidates and their refs."""
         nonlocal best_marked_answer, best_marked_refs
-        nonlocal best_unmarked_answer, best_unmarked_refs, saw_unmarked_response_doc
+        nonlocal best_unmarked_answer, best_unmarked_refs, saw_drift_signal
         nonlocal server_conv_id, parseable_chunk_count
-        text, is_answer, refs, conv_id, parseable, has_response_doc = _extract_chunk_with_parseable(
+        text, is_answer, refs, conv_id, parseable, suggests_drift = _extract_chunk_with_parseable(
             json_str
         )
         if parseable:
@@ -196,7 +196,7 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
                 best_marked_answer = text
                 best_marked_refs = refs
             elif not is_answer:
-                saw_unmarked_response_doc |= has_response_doc
+                saw_drift_signal |= suggests_drift
                 if len(text) > len(best_unmarked_answer):
                     best_unmarked_answer = text
                     best_unmarked_refs = refs
@@ -234,7 +234,7 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
         longest_answer = best_marked_answer
         final_refs = best_marked_refs
     elif best_unmarked_answer:
-        if saw_unmarked_response_doc:
+        if saw_drift_signal:
             logger.warning(
                 "No marked answer found; falling back to longest unmarked "
                 "text (%d chars). The API response format may have changed.",
@@ -279,7 +279,7 @@ def extract_answer_and_refs_from_chunk(
     parser's "zero parseable chunks" detection and is not part of this
     module's outward-facing contract.
     """
-    text, is_answer, refs, conv_id, _parseable, _has_response_doc = _extract_chunk_with_parseable(
+    text, is_answer, refs, conv_id, _parseable, _suggests_drift = _extract_chunk_with_parseable(
         json_str
     )
     return text, is_answer, refs, conv_id
@@ -292,9 +292,11 @@ def _extract_chunk_with_parseable(
 
     The 5th element is True iff at least one ``wrb.fr`` envelope was
     found AND its inner JSON decoded successfully — regardless of whether
-    any answer text was extracted. The 6th reports whether the selected row
-    carries a ``TailwindDoc``. Together these let the streaming parser
-    distinguish two failure modes:
+    any answer text was extracted. The 6th is the selected row's
+    :attr:`~notebooklm._row_adapters.chat.AnswerRow.suggests_wire_drift` verdict:
+    whether an unmarked row looks like drift rather than a deliberate empty
+    answer. Together these let the streaming parser distinguish two failure
+    modes:
 
     * Zero parseable chunks → API drift or empty body (raise).
     * At least one parseable chunk but no text → real empty answer (return).
@@ -419,7 +421,7 @@ def _extract_chunk_with_parseable(
                     refs,
                     answer.server_conversation_id,
                     parseable,
-                    answer.has_response_doc,
+                    answer.suggests_wire_drift,
                 )
         # inner_json decoded but the record didn't yield usable answer data
         # — either the outer ``isinstance(inner_data, list) and len > 0``

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -177,15 +177,18 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
     best_marked_refs: list[ChatReference] = []
     best_unmarked_answer = ""
     best_unmarked_refs: list[ChatReference] = []
+    best_unmarked_has_response_doc = False
     server_conv_id: str | None = None
     parseable_chunk_count = 0
 
     def process_chunk(json_str: str) -> None:
         """Process a JSON chunk, updating best answer candidates and their refs."""
         nonlocal best_marked_answer, best_marked_refs
-        nonlocal best_unmarked_answer, best_unmarked_refs
+        nonlocal best_unmarked_answer, best_unmarked_refs, best_unmarked_has_response_doc
         nonlocal server_conv_id, parseable_chunk_count
-        text, is_answer, refs, conv_id, parseable = _extract_chunk_with_parseable(json_str)
+        text, is_answer, refs, conv_id, parseable, has_response_doc = _extract_chunk_with_parseable(
+            json_str
+        )
         if parseable:
             parseable_chunk_count += 1
         if text:
@@ -195,6 +198,7 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
             elif not is_answer and len(text) > len(best_unmarked_answer):
                 best_unmarked_answer = text
                 best_unmarked_refs = refs
+                best_unmarked_has_response_doc = has_response_doc
         if conv_id:
             server_conv_id = conv_id
 
@@ -229,11 +233,12 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
         longest_answer = best_marked_answer
         final_refs = best_marked_refs
     elif best_unmarked_answer:
-        logger.warning(
-            "No marked answer found; falling back to longest unmarked "
-            "text (%d chars). The API response format may have changed.",
-            len(best_unmarked_answer),
-        )
+        if best_unmarked_has_response_doc:
+            logger.warning(
+                "No marked answer found; falling back to longest unmarked "
+                "text (%d chars). The API response format may have changed.",
+                len(best_unmarked_answer),
+            )
         longest_answer = best_unmarked_answer
         final_refs = best_unmarked_refs
     else:
@@ -273,18 +278,21 @@ def extract_answer_and_refs_from_chunk(
     parser's "zero parseable chunks" detection and is not part of this
     module's outward-facing contract.
     """
-    text, is_answer, refs, conv_id, _parseable = _extract_chunk_with_parseable(json_str)
+    text, is_answer, refs, conv_id, _parseable, _has_response_doc = _extract_chunk_with_parseable(
+        json_str
+    )
     return text, is_answer, refs, conv_id
 
 
 def _extract_chunk_with_parseable(
     json_str: str,
-) -> tuple[str | None, bool, list[ChatReference], str | None, bool]:
+) -> tuple[str | None, bool, list[ChatReference], str | None, bool, bool]:
     """Extract answer/refs/conv-id from one chunk and report wire-format parseability.
 
     The 5th element is True iff at least one ``wrb.fr`` envelope was
     found AND its inner JSON decoded successfully — regardless of whether
-    any answer text was extracted. This lets the streaming parser
+    any answer text was extracted. The 6th reports whether the selected row
+    carries a ``TailwindDoc``. Together these let the streaming parser
     distinguish two failure modes:
 
     * Zero parseable chunks → API drift or empty body (raise).
@@ -295,10 +303,10 @@ def _extract_chunk_with_parseable(
     try:
         data = json.loads(json_str)
     except json.JSONDecodeError:
-        return None, False, refs, None, False
+        return None, False, refs, None, False, False
 
     if not isinstance(data, list):
-        return None, False, refs, None, False
+        return None, False, refs, None, False, False
 
     parseable = False
     for item in data:
@@ -404,7 +412,14 @@ def _extract_chunk_with_parseable(
                     continue
 
                 refs = parse_citations(first)
-                return text, answer.is_answer, refs, answer.server_conversation_id, parseable
+                return (
+                    text,
+                    answer.is_answer,
+                    refs,
+                    answer.server_conversation_id,
+                    parseable,
+                    answer.has_response_doc,
+                )
         # inner_json decoded but the record didn't yield usable answer data
         # — either the outer ``isinstance(inner_data, list) and len > 0``
         # guard failed (dict, empty list, non-list) OR the inner
@@ -415,7 +430,7 @@ def _extract_chunk_with_parseable(
         # heartbeats-only stream surfaces as "empty answer" rather than
         # "API drift" / ``ChatResponseParseError``.
 
-    return None, False, refs, None, parseable
+    return None, False, refs, None, parseable, False
 
 
 def _raise_chat_rejection(error_payload: list) -> NoReturn:

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -678,6 +678,7 @@ class AnswerRow:
     # change signal.
     _TEXT_POS: ClassVar[int] = 0
     _CONV_BLOCK_POS: ClassVar[int] = 2
+    _EMPTY_ANSWER_REASON_POS: ClassVar[int] = 3
     _TYPE_BLOCK_POS: ClassVar[int] = 4
     _ANSWER_MARKER_POS: ClassVar[int] = 4
     _CITATIONS_POS: ClassVar[int] = 3
@@ -740,6 +741,18 @@ class AnswerRow:
     def has_response_doc(self) -> bool:
         """Whether the optional ``TailwindDoc`` slot is present."""
         return len(self._raw) > self._TYPE_BLOCK_POS and self._raw[self._TYPE_BLOCK_POS] is not None
+
+    @property
+    def suggests_wire_drift(self) -> bool:
+        """Whether an *unmarked* row looks like drift rather than an empty answer.
+
+        Drift when ``responseDoc`` is present but unmarked (the marker moved), or
+        when the row is too short to reach ``first[3]`` — a row that could not even
+        carry ``emptyAnswerReason`` is malformed, so "no doc" proves nothing about
+        it. A row long enough to have spoken, with no doc, is the observed
+        empty-answer shape and stays quiet.
+        """
+        return self.has_response_doc or len(self._raw) <= self._EMPTY_ANSWER_REASON_POS
 
     @property
     def is_answer(self) -> bool:

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -660,7 +660,7 @@ class AnswerRow:
     whose ``inner_data`` is a populated list (heartbeats decode to ``[]``
     and never reach this adapter). Position knowledge is centralised here;
     consumer sites should NEVER open-code ``first[0]`` / ``first[2][0]`` /
-    ``first[4][-1]`` / ``first[4][3]``.
+    ``first[4][4]`` / ``first[4][3]``.
 
     The dataclass is frozen so the wrapped row can't be mutated through the
     adapter; the adapter never copies the raw row, so it is cheap to build.
@@ -679,7 +679,7 @@ class AnswerRow:
     _TEXT_POS: ClassVar[int] = 0
     _CONV_BLOCK_POS: ClassVar[int] = 2
     _TYPE_BLOCK_POS: ClassVar[int] = 4
-    _ANSWER_MARKER_POS: ClassVar[int] = -1
+    _ANSWER_MARKER_POS: ClassVar[int] = 4
     _CITATIONS_POS: ClassVar[int] = 3
     _ANSWER_MARKER_VALUE: ClassVar[int] = 1
 
@@ -738,16 +738,16 @@ class AnswerRow:
 
     @property
     def is_answer(self) -> bool:
-        """Whether the type block marks this record as an answer (``[4][-1] == 1``).
+        """Whether the type block marks this record as an answer (``[4][4] == 1``).
 
         An absent / empty type block legitimately means "not an answer", so the
-        flag read is a single-level ``type_block[-1]`` index on a bound local
-        rather than a chained ``first[4][-1]`` descent.
+        flag read is a single-level ``type_block[4]`` index on a bound local
+        rather than a chained ``first[4][4]`` descent.
         """
         type_block = self._type_block
         return (
             type_block is not None
-            and len(type_block) > 0
+            and len(type_block) > self._ANSWER_MARKER_POS
             and type_block[self._ANSWER_MARKER_POS] == self._ANSWER_MARKER_VALUE
         )
 

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -737,6 +737,11 @@ class AnswerRow:
         return block if isinstance(block, list) else None
 
     @property
+    def has_response_doc(self) -> bool:
+        """Whether the optional ``TailwindDoc`` slot is present."""
+        return len(self._raw) > self._TYPE_BLOCK_POS and self._raw[self._TYPE_BLOCK_POS] is not None
+
+    @property
     def is_answer(self) -> bool:
         """Whether the type block marks this record as an answer (``[4][4] == 1``).
 

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -27,7 +27,7 @@ Position contracts (pinned by ``tests/unit/test_chat_row_adapter.py``):
   =====  ============================================================
   0      answer text (str)
   2      conversation-id block; ``[2][0]`` is the server conversation id
-  4      type/flags block; ``[4][-1] == 1`` marks an answer record and
+  4      type/flags block; ``[4][4] == 1`` marks an answer record and
          ``[4][3]`` is the citation list
   =====  ============================================================
 

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -225,6 +225,17 @@ MAPPINGS: tuple[Mapping, ...] = (
         section=DOC,
         note="nested inside responseDoc, not a top-level AnswerResponse index",
     ),
+    Mapping(
+        "chat",
+        "AnswerRow",
+        "_EMPTY_ANSWER_REASON_POS",
+        "AnswerResponse",
+        "emptyAnswerReason",
+        note=(
+            "the authoritative expected-empty-answer signal (UNANSWERABLE / "
+            "FILTERED); read to keep the drift warning off deliberate non-answers"
+        ),
+    ),
     # ---- Notes: ProjectNote ------------------------------------------------
     Mapping("notes", "NoteRow", "_ID_POS", "ProjectNote", "id"),
     Mapping("notes", "NoteRow", "_CONTENT_POS", "ProjectNote", "content"),

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -216,6 +216,15 @@ MAPPINGS: tuple[Mapping, ...] = (
         section=DOC,
         note="nested inside responseDoc, not a top-level AnswerResponse index",
     ),
+    Mapping(
+        "chat",
+        "AnswerRow",
+        "_ANSWER_MARKER_POS",
+        "TailwindDoc",
+        "type",
+        section=DOC,
+        note="nested inside responseDoc, not a top-level AnswerResponse index",
+    ),
     # ---- Notes: ProjectNote ------------------------------------------------
     Mapping("notes", "NoteRow", "_ID_POS", "ProjectNote", "id"),
     Mapping("notes", "NoteRow", "_CONTENT_POS", "ProjectNote", "content"),
@@ -342,13 +351,6 @@ UNMAPPED: tuple[Unmapped, ...] = (
     Unmapped("artifacts", "ReportSuggestionRow", "_PROMPT_POS", _SHAPE_UNKNOWN),
     Unmapped("artifacts", "ReportSuggestionRow", "_AUDIENCE_LEVEL_POS", _SHAPE_UNKNOWN),
     # chat.py
-    Unmapped(
-        "chat",
-        "AnswerRow",
-        "_ANSWER_MARKER_POS",
-        "negative index (-1) into a positional message; only lands on "
-        "TailwindDoc.type because tag 5 is currently last — see #2121",
-    ),
     Unmapped("chat", "SavedChatNoteRow", "_OUTER_NOTE_POS", _NESTED_LOCAL),
     Unmapped("chat", "SavedChatNoteRow", "_ID_POS", _SHAPE_UNKNOWN),
     Unmapped("chat", "SavedChatNoteRow", "_SERVER_TITLE_POS", _SHAPE_UNKNOWN),

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -46,11 +46,12 @@ class TestAnswerRowPositionContract:
         assert (
             AnswerRow._TEXT_POS,
             AnswerRow._CONV_BLOCK_POS,
+            AnswerRow._EMPTY_ANSWER_REASON_POS,
             AnswerRow._TYPE_BLOCK_POS,
             AnswerRow._ANSWER_MARKER_POS,
             AnswerRow._CITATIONS_POS,
             AnswerRow._ANSWER_MARKER_VALUE,
-        ) == (0, 2, 4, 4, 3, 1)
+        ) == (0, 2, 3, 4, 4, 3, 1)
 
 
 class TestCitationPositionContract:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -50,7 +50,7 @@ class TestAnswerRowPositionContract:
             AnswerRow._ANSWER_MARKER_POS,
             AnswerRow._CITATIONS_POS,
             AnswerRow._ANSWER_MARKER_VALUE,
-        ) == (0, 2, 4, -1, 3, 1)
+        ) == (0, 2, 4, 4, 3, 1)
 
 
 class TestCitationPositionContract:
@@ -143,6 +143,11 @@ class TestAnswerRow:
 
     def test_non_answer_marker_is_false(self) -> None:
         assert AnswerRow(_answer_record(marker=0)).is_answer is False
+
+    def test_trailing_type_field_does_not_change_answer_marker(self) -> None:
+        rec = _answer_record()
+        rec[4].append(0)
+        assert AnswerRow(rec).is_answer is True
 
     def test_absent_type_block_means_not_answer_and_no_citations(self) -> None:
         row = AnswerRow(_answer_record(marker=None))

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -63,11 +63,12 @@ def _chunk(
     text: str,
     *,
     marked: bool = True,
+    response_doc: bool = True,
     conversation_id: str | None = None,
     citations: list[Any] | None = None,
 ) -> str:
     marker = 1 if marked else 0
-    type_info = [[], None, None, citations or [], marker]
+    type_info = [[], None, None, citations or [], marker] if response_doc else None
     conv = [conversation_id, 123] if conversation_id is not None else None
     inner_json = json.dumps([[text, None, conv, None, type_info]])
     return json.dumps([["wrb.fr", None, inner_json]])
@@ -323,6 +324,29 @@ def test_unmarked_fallback_logs_under_chat_logger(caplog) -> None:
         record.name == "notebooklm._chat" and "No marked answer found" in record.message
         for record in caplog.records
     )
+
+
+def test_no_answer_without_response_doc_does_not_log_drift_warning(caplog) -> None:
+    response = _length_prefixed(
+        _chunk("The sources do not contain enough information.", response_doc=False)
+    )
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(response)
+
+    assert result.answer == "The sources do not contain enough information."
+    assert not any("No marked answer found" in record.message for record in caplog.records)
+
+
+def test_malformed_present_response_doc_still_logs_drift_warning(caplog) -> None:
+    inner_json = json.dumps([["Fallback text.", None, None, None, {}]])
+    response = _length_prefixed(json.dumps([["wrb.fr", None, inner_json]]))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(response)
+
+    assert result.answer == "Fallback text."
+    assert any("No marked answer found" in record.message for record in caplog.records)
 
 
 def test_empty_response_raises_chat_response_parse_error() -> None:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -338,6 +338,30 @@ def test_no_answer_without_response_doc_does_not_log_drift_warning(caplog) -> No
     assert not any("No marked answer found" in record.message for record in caplog.records)
 
 
+def test_no_answer_with_shortened_row_does_not_log_drift_warning(caplog) -> None:
+    inner_json = json.dumps([["No supported answer."]])
+    response = _length_prefixed(json.dumps([["wrb.fr", None, inner_json]]))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(response)
+
+    assert result.answer == "No supported answer."
+    assert not any("No marked answer found" in record.message for record in caplog.records)
+
+
+def test_present_unmarked_doc_warns_even_when_absent_doc_text_is_longer(caplog) -> None:
+    response = _length_prefixed(
+        _chunk("Drift.", marked=False),
+        _chunk("The sources do not contain enough information.", response_doc=False),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(response)
+
+    assert result.answer == "The sources do not contain enough information."
+    assert any("No marked answer found" in record.message for record in caplog.records)
+
+
 def test_malformed_present_response_doc_still_logs_drift_warning(caplog) -> None:
     inner_json = json.dumps([["Fallback text.", None, None, None, {}]])
     response = _length_prefixed(json.dumps([["wrb.fr", None, inner_json]]))

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -338,7 +338,13 @@ def test_no_answer_without_response_doc_does_not_log_drift_warning(caplog) -> No
     assert not any("No marked answer found" in record.message for record in caplog.records)
 
 
-def test_no_answer_with_shortened_row_does_not_log_drift_warning(caplog) -> None:
+def test_row_truncated_before_the_reason_slot_still_warns(caplog) -> None:
+    """A row too short to carry ``emptyAnswerReason`` is drift, not a clean no-answer.
+
+    "No ``responseDoc``" only means "deliberate empty answer" for a row that COULD
+    have said so. A single-element row cannot, so silencing it here would spend the
+    one drift signal on a genuinely malformed payload.
+    """
     inner_json = json.dumps([["No supported answer."]])
     response = _length_prefixed(json.dumps([["wrb.fr", None, inner_json]]))
 
@@ -346,7 +352,7 @@ def test_no_answer_with_shortened_row_does_not_log_drift_warning(caplog) -> None
         result = parse_streaming_chat_response(response)
 
     assert result.answer == "No supported answer."
-    assert not any("No marked answer found" in record.message for record in caplog.records)
+    assert any("No marked answer found" in record.message for record in caplog.records)
 
 
 def test_present_unmarked_doc_warns_even_when_absent_doc_text_is_longer(caplog) -> None:


### PR DESCRIPTION
## Summary

Two defects in the streamed-chat answer path, both in the same read of the same wire slot, so they
ship together:

1. **#2121 — `is_answer` read a negative index into a positional message.**
   `AnswerRow._ANSWER_MARKER_POS` was `-1`, i.e. "whatever field is last". It landed on
   `TailwindDoc.type` only because tag 5 is the highest tag registered today. One routine,
   backward-compatible protobuf field addition would have made `[-1]` read the new field, flipping
   `is_answer` to `False` for **every** chunk of **every** ask — with no error and no exception.
2. **#2118 — the fallback path warned on a normal answer-less reply.**
   When no chunk is marked as the answer, the parser falls back to the longest unmarked text and logs
   `"the API response format may have changed"` at WARNING. But a backend reply of "the sources do not
   contain enough information" is answer-less *by design*: it carries no `TailwindDoc` at all. So the
   drift warning fired on ordinary, healthy usage.

They compound: #2121's failure mode is silent and its only symptom would be #2118's warning firing on
every ask — a warning that (before this PR) already fired routinely for benign reasons and so trained
the reader to ignore it. `CLAUDE.md` names undocumented wire drift as this project's #1 breakage
class, and this warning is how an operator finds out. Fixing the index without de-noising the warning
would leave the alarm untrustworthy; de-noising without fixing the index would remove the only signal
that the index broke.

## Related Issue

Closes #2121
Closes #2118

## Root cause

**#2121.** `first[4]` is `AnswerResponse.responseDoc` = `TailwindDoc`, whose `BuilderInfo` registers
`body = 1`, `(2, 3)` unused, `objects = 4`, `type = 5`. Nothing in `[-1]` expressed "I want tag 5"; it
expressed "I want whatever is last", and tag 5 merely happens to be last.

**#2118.** The parser had one bucket for "no marked answer", covering two different situations:

| Stream | Meaning | Old behaviour | New behaviour |
|---|---|---|---|
| unmarked text, **no** `TailwindDoc` on the row | expected answer-less reply | warns ❌ | **returns quietly** |
| unmarked text **with** a `TailwindDoc` present | the marker moved / real drift | warns | **warns** (unchanged) |
| `TailwindDoc` present but malformed (e.g. a dict) | drift | warns | **warns** (unchanged) |
| zero parseable chunks | drift or empty body | raises | raises (unchanged) |

## Changes

- `src/notebooklm/_row_adapters/chat.py`
  - `_ANSWER_MARKER_POS: -1 -> 4` (0-indexed position of tag 5), and `is_answer`'s length guard
    becomes `len(type_block) > _ANSWER_MARKER_POS` so an unexpected trailing field is **ignored**
    rather than silently read as the marker. Position docs on the class updated from `first[4][-1]`
    to `first[4][4]`.
  - New `has_response_doc` property: whether the `responseDoc` slot is present and non-`None`.
- `src/notebooklm/_chat/wire.py`
  - `_extract_chunk_with_parseable` returns a 6th element, `has_response_doc`, for the row it selected.
  - `parse_streaming_chat_response` accumulates `saw_unmarked_response_doc |= has_response_doc` across
    unmarked chunks and emits the drift warning only when that flag is set. The chosen answer text and
    refs are unchanged — this changes **only** whether the warning is logged.
  - `extract_answer_and_refs_from_chunk` keeps its 4-tuple public shape and discards the new element.
- `tests/_guardrails/_wire_contract.py` — `AnswerRow._ANSWER_MARKER_POS` moves out of `UNMAPPED`
  (whose note said "negative index (-1) … only lands on TailwindDoc.type because tag 5 is currently
  last — see #2121") and into `MAPPINGS` as `TailwindDoc.type`. The guardrail now asserts the mapping
  rather than recording the hazard.
- `tests/unit/test_chat_row_adapter.py` — position-contract tuple updated to `(0, 2, 4, 4, 3, 1)`, plus
  `test_trailing_type_field_does_not_change_answer_marker`, which appends a trailing field to the type
  block and asserts `is_answer` is still `True`. That test is the whole point of #2121 and fails on the
  old `-1`.
- `tests/unit/test_streaming_chat_wire.py` — the `_chunk` helper gains `response_doc: bool` so a row
  can omit the doc, plus four tests covering every row of the table above:
  - `test_no_answer_without_response_doc_does_not_log_drift_warning` (the #2118 fix)
  - `test_no_answer_with_shortened_row_does_not_log_drift_warning` (row too short to carry the slot)
  - `test_present_unmarked_doc_warns_even_when_absent_doc_text_is_longer` (pins the `|=` accumulation:
    the warning must survive even when the *selected* longest text came from a doc-less row)
  - `test_malformed_present_response_doc_still_logs_drift_warning` (a dict at the slot is drift, and
    `has_response_doc` deliberately reports `True` there even though `_type_block` rejects it as
    non-list — so real drift keeps warning)

No public API, exception type, or return type changes. No architectural shape change, so no ADR.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated — N/A, no shape change

Run against the canonical contributor install **plus the extras the CI test matrix adds**
(`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`).
The lean `browser+dev+markdown` install alone skips ~1,500 tests and lands at 83% coverage, i.e.
under the gate — so the suite below is the full-extras run that matches CI:

```console
$ uv run mypy src/notebooklm --ignore-missing-imports
Success: no issues found in 351 source files

$ uv run pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed

$ uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90 -q
TOTAL                                                    30939    826   8128    507    96%
Required test coverage of 90% reached. Total coverage: 96.41%
15227 passed, 65 skipped, 3 xfailed, 116 warnings in 583.26s (0:09:43)
```

I also ran every remaining gate from the `Code Quality` job of `.github/workflows/test.yml`, all green:
`check_workflow_permissions`, `check_workflow_secret_gates`, `check_action_pinning`,
`check_deprecation_targets`, `check_coverage_thresholds`, `check_ci_install_parity`,
`check_claude_md_freshness`, `check_docs_module_refs`,
`audit_public_api_compat.py --check-stale`, `tests/scripts/check_method_coverage.py`,
`pytest tests/e2e --collect-only`, and the lean-install core-import assertion
(`import notebooklm, notebooklm.notebooklm_cli, notebooklm.client, notebooklm.artifacts`).

## Notes

**Why one PR for two issues.** Both change the same read of `first[4]` in the same two files, and the
guardrail entry for `_ANSWER_MARKER_POS` moves as part of #2121 while #2118's tests need the
`response_doc=False` helper the same change introduces. Splitting them would put a mechanical conflict
between two PRs for no review benefit, and would ship the de-noised warning without the index fix that
makes the remaining warning meaningful.

**`has_response_doc` intentionally diverges from `_type_block`.** `_type_block` additionally requires
`isinstance(block, list)`; `has_response_doc` tests only presence-and-not-`None`. That is deliberate:
a non-list at the slot is drift, so it must keep warning.
`test_malformed_present_response_doc_still_logs_drift_warning` pins that, and tightening
`has_response_doc` to match `_type_block` would silence a genuine drift signal.

**The #2118 suppression is stream-wide, and I want to flag its limit rather than oversell it.** The flag
is set by *any* unmarked doc-bearing chunk in the stream, not by the chunk whose text ends up winning.
That matters because a normal stream does carry unmarked doc-bearing chunks: `TYPE_THOUGHT`
(`ResponseType 2`, per `docs/mobile/enums.txt:1932-1935`) rows have a `TailwindDoc`, and decoding
`tests/cassettes/chat_ask.yaml` shows two of them at 289 and 394 chars. So a no-answer stream that *also*
carried thoughts would still warn.

I do not think that is the observed shape, and I checked before deciding: #2118's live evidence quotes
the warning as `falling back to longest unmarked text (159 chars)`, and 159 is the apology. Thought text
streams cumulatively (289 → 394 in that cassette, up to 531 in `chat_ask_with_references.yaml`), so had
any thought chunk been present in that no-answer stream, the longest unmarked text would have been the
thought, and the author would have quoted ~400 chars and a thinking-text answer instead. The four
recorded ask cassettes cannot exercise this path at all — every one has a `marker=1` answer row, so the
marked branch wins and neither `main` nor this branch logs anything.

The change is also strictly subtractive: it only ever *suppresses* a warning, and it does not touch
which text wins. I verified that by running the thought-plus-apology case against both trees —
`origin/main` and this branch produce identical output. So the worst case here is "the warning still
fires, exactly as it does today", never a new failure. If you would rather have the tighter version, the
principled form is to key the decision on the *winning* row and treat only an absent-or-unenumerated
`type` value as drift (so `TYPE_THOUGHT` stays quiet); say so and I will add it here with a
thinking-plus-apology fixture.

**Scope of verification.** Offline only: unit tests plus the guardrail suite. The claim that
`TailwindDoc.type` is tag 5 is from the disassembled-schema evidence in #2121 (recorded in
`docs/notes/web-rpc-vs-mobile-grpc-audit-2026-08-07.md` §1.18), not an independent capture — I have no
account positioned to re-verify against a live stream. If tag 5 is ever *relocated* (as opposed to a
new tag being appended), an explicit `4` fails visibly instead of quietly inverting every
classification, which is the intended trade.

**Not verified locally:** the Python 3.10–3.14 matrix. No version-sensitive syntax is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming chat parsing for missing, truncated, unmarked, or malformed response metadata.
  * Prevented misleading wire-format warnings when metadata is unavailable.
  * Stabilized answer detection when trailing fields are present.
  * Ensured expected no-answer responses return the appropriate fallback message.

* **Documentation**
  * Updated the changelog with the revised no-answer behavior.

* **Tests**
  * Added coverage for response-metadata edge cases and stable answer detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->