### PR TITLE
fix(research): identify report rows by content kind

### DIFF
--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2165,11 +2165,15 @@ await rpc_call(
 # Fast research web source:
 # [url, title, desc, type, ...]
 #
-# Deep research report source (current shape):
-# [None, [title, report_markdown], None, type, ...]
+# Deep research report source (captured shape):
+# [None, title, None, type, None, None,
+#  [report_markdown, 3, None, None, None, structured_document]]
 #
-# Deep research report source (legacy shape):
-# [None, title, None, type, None, None, [chunk1, chunk2, ...]]
+# Deep research web source content blocks use kind 1 or 2 and carry their
+# snippet at position 2; they are not report rows.
+#
+# Compatibility shape accepted by the parser (not seen in captures):
+# [None, [title, report_markdown], None, type, ...]
 #
 # Notes:
 # - The RPC returns all research tasks for the notebook, not just the latest one.

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -49,14 +49,9 @@ _POLL_SOURCE = "_research.poll"
 _POLL_METHOD_ID = RPCMethod.POLL_RESEARCH.value
 
 
-def extract_legacy_report_chunks(src: list[Any]) -> str:
-    """Join legacy deep-research report chunks stored in ``src[6]``."""
-    chunks = [
-        chunk
-        for chunk in ResearchResultRow(src).legacy_report_chunks
-        if isinstance(chunk, str) and chunk
-    ]
-    return "\n\n".join(chunks)
+def extract_report_markdown(src: list[Any]) -> str:
+    """Return markdown from the kind-3 content block stored in ``src[6]``."""
+    return ResearchResultRow(src).report_markdown
 
 
 def _extract_task_id(task_data: Any) -> str | None:
@@ -226,14 +221,14 @@ def _parse_source_row(
     source_report = ""
 
     # Fast research: [url, title, desc, type, ...]
-    # Deep research (legacy): [None, title, None, type, ..., [report_markdown]]
-    # Deep research (current): [None, [title, report_markdown], None, type, ...]
+    # Deep research (captured): [None, title, None, type, ..., content_block]
+    # Deep research (compat): [None, [title, report_markdown], None, type, ...]
     # src[3] is the authoritative result_type when present.
     result_type = (
         parse_result_type(row.result_type_slot) if row.has_result_type else RESEARCH_RESULT_TYPE_WEB
     )
     if row.url_slot is None and row.length > 1:
-        # Deep-research (current) packs ``[title, report_markdown]`` at ``src[1]``;
+        # A compatibility shape packs ``[title, report_markdown]`` at ``src[1]``;
         # ``ResearchResultRow.deep_payload`` unpacks that exact shape (a 2+-length
         # list of two strings) and returns ``None`` for the legitimate
         # alternatives (bare-string title, or neither), which fall through to the
@@ -265,7 +260,7 @@ def _parse_source_row(
 
     report = source_report
     if not report and not report_found:
-        report = extract_legacy_report_chunks(src)
+        report = extract_report_markdown(src)
     if report and parsed_source is not None:
         parsed_source = parsed_source.with_report_markdown(report)
 

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -316,10 +316,10 @@ class ResearchResultRow:
     def report_markdown(self) -> str:
         """Report markdown from a kind-3 content block, otherwise ``""``."""
         block = self.content_block
-        if (
-            len(block) < self._CONTENT_MIN_LEN
-            or block[self._CONTENT_KIND_POS] != self._REPORT_CONTENT_KIND
-        ):
+        if len(block) < self._CONTENT_MIN_LEN:
+            return ""
+        kind = block[self._CONTENT_KIND_POS]
+        if type(kind) is not int or kind != self._REPORT_CONTENT_KIND:
             return ""
         text = block[self._CONTENT_TEXT_POS]
         return text if isinstance(text, str) and text else ""

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -50,7 +50,7 @@ Position contracts (pinned by ``tests/unit/test_research_row_adapter.py``):
   0      URL (str) for fast research; ``None`` sentinel for deep research
   1      title (str) — or, for current deep research, ``[title, report]``
   3      authoritative result-type tag
-  6      legacy deep-research report chunks (list of str)
+  6      typed content block; kind 3 carries report markdown at position 0
   =====  ============================================================
 """
 
@@ -223,7 +223,7 @@ class ResearchResultRow:
     The source row carries three shapes the historical parser handled inline:
 
     * fast research — ``[url, title, desc, type, ...]``
-    * deep research (legacy) — ``[None, title, None, type, ..., [report_md]]``
+    * deep research (captured) — ``[None, title, None, type, ..., content_block]``
     * deep research (current) — ``[None, [title, report_md], None, type, ...]``
 
     Every field is routinely-optional (a deep-research row omits its URL; a
@@ -239,7 +239,7 @@ class ResearchResultRow:
     _URL_POS: ClassVar[int] = 0
     _TITLE_POS: ClassVar[int] = 1
     _RESULT_TYPE_POS: ClassVar[int] = 3
-    _LEGACY_CHUNKS_POS: ClassVar[int] = 6
+    _CONTENT_BLOCK_POS: ClassVar[int] = 6
     # A source row must carry at least ``[url/sentinel, title]`` to be usable —
     # mirrors the historical ``len(src) < 2`` early return.
     _MIN_LEN: ClassVar[int] = 2
@@ -249,6 +249,13 @@ class ResearchResultRow:
     _PAYLOAD_TITLE_POS: ClassVar[int] = 0
     _PAYLOAD_REPORT_POS: ClassVar[int] = 1
     _PAYLOAD_MIN_LEN: ClassVar[int] = 2
+
+    # Captured ``src[6]`` content block:
+    # [text | None, kind, snippet | None, ..., structured_document | None]
+    _CONTENT_TEXT_POS: ClassVar[int] = 0
+    _CONTENT_KIND_POS: ClassVar[int] = 1
+    _CONTENT_MIN_LEN: ClassVar[int] = 2
+    _REPORT_CONTENT_KIND: ClassVar[int] = 3
 
     @property
     def is_well_formed(self) -> bool:
@@ -298,12 +305,24 @@ class ResearchResultRow:
         return self.length > self._RESULT_TYPE_POS
 
     @property
-    def legacy_report_chunks(self) -> list[Any]:
-        """Legacy deep-research report chunks at ``src[6]`` — ``[]`` when absent/non-list."""
-        if self.length <= self._LEGACY_CHUNKS_POS:
+    def content_block(self) -> list[Any]:
+        """Typed content block at ``src[6]`` — ``[]`` when absent or malformed."""
+        if self.length <= self._CONTENT_BLOCK_POS:
             return []
-        value = self._raw[self._LEGACY_CHUNKS_POS]
+        value = self._raw[self._CONTENT_BLOCK_POS]
         return value if isinstance(value, list) else []
+
+    @property
+    def report_markdown(self) -> str:
+        """Report markdown from a kind-3 content block, otherwise ``""``."""
+        block = self.content_block
+        if (
+            len(block) < self._CONTENT_MIN_LEN
+            or block[self._CONTENT_KIND_POS] != self._REPORT_CONTENT_KIND
+        ):
+            return ""
+        text = block[self._CONTENT_TEXT_POS]
+        return text if isinstance(text, str) and text else ""
 
     @staticmethod
     def deep_payload(payload: Any) -> tuple[str, str] | None:

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -407,25 +407,8 @@ UNMAPPED: tuple[Unmapped, ...] = (
     Unmapped("research", "ResearchTaskInfoRow", "_QUERY_SOURCE_TYPE_POS", _SHAPE_UNKNOWN),
     Unmapped("research", "ResearchTaskInfoRow", "_SOURCES_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchTaskInfoRow", "_SUMMARY_POS", _NESTED_LOCAL),
-    Unmapped(
-        "research",
-        "ResearchResultRow",
-        "_LEGACY_CHUNKS_POS",
-        "MAPPED AND MIS-MODELLED, not merely unverified. src[6] is a structured "
-        "content block with a FIXED schema shared by both row types:\n"
-        "    [ text|None, kind:int, text|None, None, int|None, structured_doc|None ]\n"
-        "  report row: ['# ...', 3, None, None, None, [doc tree]]   (len 6)\n"
-        "  web row:    [None,     1, 'snippet...', None, 13]        (len 5)\n"
-        "src[6][1] is the discriminator: 3 = report, 1/2 = web snippet (live "
-        "distribution over 63 rows: {1:41, 2:21, 3:1}). Stable across two captures "
-        "14 months apart. But `extract_legacy_report_chunks` never reads chunks — it "
-        "harvests EVERY string in the block and joins them, working only because each "
-        "row type happens to hold exactly one (report at [0], snippet at [2]). "
-        "Correct today only because the report row arrives at index 0 and shields the "
-        "rest; 62/62 web rows carry a populated src[6]. Reordering the live payload "
-        "drops a 35,773-char report for a 4,020-char tardigrade blurb, silently. "
-        "FIX: gate on src[6][1] == 3 and read src[6][0].",
-    ),
+    Unmapped("research", "ResearchResultRow", "_CONTENT_TEXT_POS", _NESTED_LOCAL),
+    Unmapped("research", "ResearchResultRow", "_CONTENT_KIND_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchResultRow", "_PAYLOAD_TITLE_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchResultRow", "_PAYLOAD_REPORT_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchStartRow", "_TASK_ID_POS", _SHAPE_UNKNOWN),
@@ -493,6 +476,15 @@ PINNED: tuple[Pinned, ...] = (
         "ChatHistoryMessage tag 3 — role, values {1, 2}",
         "56/56 turns populated; role 1 rows carry userQueryText (tag 4) and role 2 "
         "rows carry actOnSourcesResponse (tag 5), 28/28 each",
+    ),
+    Pinned(
+        "research",
+        "ResearchResultRow",
+        "_CONTENT_BLOCK_POS",
+        6,
+        "DiscoveredSource tag 7 — typed content block",
+        "Two deep-research captures 14 months apart: report rows carry kind 3 with "
+        "markdown at block[0]; 62/62 web rows carry kind 1/2 snippets at block[2]",
     ),
 )
 

--- a/tests/integration/test_research_deep_poll_vcr.py
+++ b/tests/integration/test_research_deep_poll_vcr.py
@@ -566,6 +566,16 @@ class TestDeepResearchPollReplay:
             "state. Re-record with NOTEBOOKLM_VCR_RECORD=1."
         )
 
+        # The recorded terminal payload carries the report in src[6]'s typed
+        # content block (kind 3), followed by web rows whose kind-1/2 blocks
+        # contain snippets. Only the report row may supply report markdown.
+        final_task = tasks[0]
+        report_sources = [source for source in final_task.sources if source.report_markdown]
+        assert final_task.report
+        assert len(report_sources) == 1
+        assert report_sources[0].is_report
+        assert report_sources[0].report_markdown == final_task.report
+
 
 @pytest.mark.allow_no_vcr
 def test_cassette_under_size_cap() -> None:

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -830,7 +830,17 @@ class TestResearch:
     @pytest.mark.asyncio
     async def test_poll_deep_research_sources(self, auth_tokens, httpx_mock, build_rpc_response):
         """Test poll parses deep research sources (title only, no URL)."""
-        sources = [[None, "Deep Research Finding", None, 5, None, None, ["# Report markdown"]]]
+        sources = [
+            [
+                None,
+                "Deep Research Finding",
+                None,
+                5,
+                None,
+                None,
+                ["# Report markdown", 3, None, None, None, ["structured doc"]],
+            ]
+        ]
         task_info = [None, ["deep query", 1], 1, [sources, "Deep summary"], 2]
         response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
         httpx_mock.add_response(content=response_body.encode(), method="POST")
@@ -878,11 +888,14 @@ class TestResearch:
         assert "task_id" in str(err)
 
     @pytest.mark.asyncio
-    async def test_poll_joins_legacy_report_chunks(
+    async def test_poll_ignores_web_snippet_before_report(
         self, auth_tokens, httpx_mock, build_rpc_response
     ):
-        """Test poll joins multiple legacy report chunks instead of truncating to the first one."""
-        sources = [[None, "Deep Research Finding", None, 5, None, None, ["chunk one", "chunk two"]]]
+        """A web content block cannot win report extraction by arriving first."""
+        sources = [
+            ["https://example.com", "Web result", "desc", 1, None, None, [None, 1, "snippet"]],
+            [None, "Deep Research Finding", None, 5, None, None, ["# Report", 3]],
+        ]
         task_info = [None, ["deep query", 1], 1, [sources, "Deep summary"], 2]
         response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
         httpx_mock.add_response(content=response_body.encode(), method="POST")
@@ -890,8 +903,10 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result.report == "chunk one\n\nchunk two"
-        assert result.tasks[0].report == "chunk one\n\nchunk two"
+        assert result.report == "# Report"
+        assert result.sources[0].report_markdown == ""
+        assert result.sources[1].report_markdown == "# Report"
+        assert result.tasks[0].report == "# Report"
 
     @pytest.mark.asyncio
     async def test_poll_deep_research_current_report_shape(
@@ -1556,21 +1571,6 @@ class TestResearch:
             result = await client.research.poll("nb_123")
 
         assert result.sources[0].result_type == "video"
-
-    @pytest.mark.asyncio
-    async def test_poll_legacy_report_mixed_chunks(
-        self, auth_tokens, httpx_mock, build_rpc_response
-    ):
-        """Legacy report chunks filter out non-string and empty values."""
-        sources = [[None, "Report Title", None, 5, None, None, ["chunk1", None, "", "chunk2"]]]
-        task_info = [None, ["query", 1], 1, [sources, ""], 2]
-        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
-        httpx_mock.add_response(content=response_body.encode(), method="POST")
-
-        async with NotebookLMClient(auth_tokens) as client:
-            result = await client.research.poll("nb_123")
-
-        assert result.report == "chunk1\n\nchunk2"
 
     @pytest.mark.asyncio
     async def test_poll_source_single_element_list_title_dropped(

--- a/tests/unit/test_research_api.py
+++ b/tests/unit/test_research_api.py
@@ -421,7 +421,7 @@ class TestPollEdgeCases:
                                     5,
                                     None,
                                     None,
-                                    ["# Deep Report\nContent here"],
+                                    ["# Deep Report\nContent here", 3],
                                 ],
                             ],
                             "Deep summary",

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -207,11 +207,9 @@ class TestResearchResultRow:
         row = ResearchResultRow([None, "t", None, 5, None, None, block])
         assert row.report_markdown == ""
 
-    @pytest.mark.parametrize("kind", [1, 2])
-    def test_web_content_block_is_not_report(self, kind) -> None:
-        row = ResearchResultRow(
-            ["https://example.com", "t", None, 1, None, None, [None, kind, "s"]]
-        )
+    @pytest.mark.parametrize("kind", [1, 2, 3.0, True])
+    def test_non_report_content_kind_is_not_report(self, kind) -> None:
+        row = ResearchResultRow(["https://example.com", "t", None, 1, None, None, ["# Fake", kind]])
         assert row.report_markdown == ""
 
 

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -55,9 +55,17 @@ class TestResearchResultRowPositionContract:
             ResearchResultRow._URL_POS,
             ResearchResultRow._TITLE_POS,
             ResearchResultRow._RESULT_TYPE_POS,
-            ResearchResultRow._LEGACY_CHUNKS_POS,
+            ResearchResultRow._CONTENT_BLOCK_POS,
             ResearchResultRow._MIN_LEN,
         ) == (0, 1, 3, 6, 2)
+
+    def test_content_block_positions_pinned(self) -> None:
+        assert (
+            ResearchResultRow._CONTENT_TEXT_POS,
+            ResearchResultRow._CONTENT_KIND_POS,
+            ResearchResultRow._CONTENT_MIN_LEN,
+            ResearchResultRow._REPORT_CONTENT_KIND,
+        ) == (0, 1, 2, 3)
 
     def test_deep_payload_positions_pinned(self) -> None:
         assert (
@@ -165,7 +173,8 @@ class TestResearchResultRow:
         assert row.title_slot is None
         assert row.result_type_slot is None
         assert row.has_result_type is False
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
 
     def test_result_type_absent_short_circuits(self) -> None:
         row = ResearchResultRow([None, "title"])
@@ -177,17 +186,33 @@ class TestResearchResultRow:
         assert row.url_slot is None
         assert row.title_slot == ["Deep Report", "# Report"]
 
-    def test_legacy_chunks_present(self) -> None:
-        row = ResearchResultRow([None, "Legacy", None, "report", None, None, ["a", "b"]])
-        assert row.legacy_report_chunks == ["a", "b"]
+    def test_report_content_block_present(self) -> None:
+        block = ["# Report", 3, None, None, None, ["document"]]
+        row = ResearchResultRow([None, "Report", None, 5, None, None, block])
+        assert row.content_block is block
+        assert row.report_markdown == "# Report"
 
-    def test_legacy_chunks_non_list_returns_empty(self) -> None:
+    def test_content_block_non_list_returns_empty(self) -> None:
         row = ResearchResultRow([None, "t", None, 5, None, None, "str"])
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
 
-    def test_legacy_chunks_absent_returns_empty(self) -> None:
+    def test_content_block_absent_returns_empty(self) -> None:
         row = ResearchResultRow([None, "t", None, 5, None, None])
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
+
+    @pytest.mark.parametrize("block", [[], ["# Report"], [None, 3], [42, 3]])
+    def test_malformed_report_content_block_returns_empty(self, block) -> None:
+        row = ResearchResultRow([None, "t", None, 5, None, None, block])
+        assert row.report_markdown == ""
+
+    @pytest.mark.parametrize("kind", [1, 2])
+    def test_web_content_block_is_not_report(self, kind) -> None:
+        row = ResearchResultRow(
+            ["https://example.com", "t", None, 1, None, None, [None, kind, "s"]]
+        )
+        assert row.report_markdown == ""
 
 
 class TestResearchResultRowDeepPayload:

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -67,9 +67,9 @@ class TestExtractReportMarkdown:
         src = [None, "t", None, 5, None, None, ["# Report", 3, None, None, None, []]]
         assert extract_report_markdown(src) == "# Report"
 
-    @pytest.mark.parametrize("kind", [1, 2])
-    def test_web_snippet_content_blocks_are_not_reports(self, kind):
-        src = [None, "t", None, 5, None, None, [None, kind, "web snippet", None, 13]]
+    @pytest.mark.parametrize("kind", [1, 2, 3.0, True])
+    def test_non_report_content_kinds_are_not_reports(self, kind):
+        src = [None, "t", None, 5, None, None, ["# Fake", kind, "web snippet", None, 13]]
         assert extract_report_markdown(src) == ""
 
     @pytest.mark.parametrize("text", [None, 42, ""])
@@ -337,6 +337,8 @@ class TestParseResearchTasks:
         sources = [
             ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
             ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+            ["https://float.example", "Float", "desc", 1, None, None, ["# Fake", 3.0]],
+            ["https://bool.example", "Bool", "desc", 1, None, None, ["# Fake", True]],
             [None, "Deep Report", None, 5, None, None, ["# Actual report", 3]],
         ]
         task_info = [None, ["deep query"], None, [sources], 6]
@@ -344,9 +346,8 @@ class TestParseResearchTasks:
         tasks = parse_research_tasks([[["task_reordered", task_info]]])
 
         assert tasks[0]["report"] == "# Actual report"
-        assert "report_markdown" not in tasks[0]["sources"][0]
-        assert "report_markdown" not in tasks[0]["sources"][1]
-        assert tasks[0]["sources"][2]["report_markdown"] == "# Actual report"
+        assert all("report_markdown" not in source for source in tasks[0]["sources"][:-1])
+        assert tasks[0]["sources"][-1]["report_markdown"] == "# Actual report"
 
     def test_web_rows_without_report_do_not_fabricate_one(self):
         sources = [

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -14,7 +14,7 @@ from notebooklm._research_task_parser import (
     _extract_task_id,
     _extract_task_info,
     _status_from_code,
-    extract_legacy_report_chunks,
+    extract_report_markdown,
     parse_research_task_models,
     parse_research_tasks,
     parse_result_type,
@@ -51,30 +51,31 @@ class TestParseResultType:
         assert parse_result_type([]) == 1
 
 
-class TestExtractLegacyReportChunks:
-    """Tests for legacy deep-research report chunk extraction."""
+class TestExtractReportMarkdown:
+    """Tests for typed deep-research content-block extraction."""
 
     def test_missing_index_6(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None]) == ""
+        assert extract_report_markdown([None, "t", None, 5, None, None]) == ""
 
     def test_index_6_not_list(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, "str"]) == ""
+        assert extract_report_markdown([None, "t", None, 5, None, None, "str"]) == ""
 
-    def test_single_chunk(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, ["chunk"]]) == (
-            "chunk"
-        )
+    def test_short_content_block(self):
+        assert extract_report_markdown([None, "t", None, 5, None, None, ["# Report"]]) == ""
 
-    def test_multiple_chunks_joined(self):
-        src = [None, "t", None, 5, None, None, ["a", "b", "c"]]
-        assert extract_legacy_report_chunks(src) == "a\n\nb\n\nc"
+    def test_current_captured_report_content_block(self):
+        src = [None, "t", None, 5, None, None, ["# Report", 3, None, None, None, []]]
+        assert extract_report_markdown(src) == "# Report"
 
-    def test_filters_non_string_and_empty(self):
-        src = [None, "t", None, 5, None, None, ["real", None, "", 42, "also_real"]]
-        assert extract_legacy_report_chunks(src) == "real\n\nalso_real"
+    @pytest.mark.parametrize("kind", [1, 2])
+    def test_web_snippet_content_blocks_are_not_reports(self, kind):
+        src = [None, "t", None, 5, None, None, [None, kind, "web snippet", None, 13]]
+        assert extract_report_markdown(src) == ""
 
-    def test_all_empty_returns_empty(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, ["", None]]) == ""
+    @pytest.mark.parametrize("text", [None, 42, ""])
+    def test_report_content_requires_non_empty_text(self, text):
+        src = [None, "t", None, 5, None, None, [text, 3]]
+        assert extract_report_markdown(src) == ""
 
 
 class TestExtractTaskId:
@@ -313,27 +314,51 @@ class TestParseResearchTasks:
             }
         ]
 
-    def test_legacy_deep_research_report_source(self):
-        sources = [[None, "Legacy Report", None, "report", None, None, ["a", "b"]]]
-        task_info = [None, ["deep query"], None, [sources], 6]
-
-        tasks = parse_research_tasks([[["task_legacy", task_info]]])
-
-        assert tasks[0]["report"] == "a\n\nb"
-        assert tasks[0]["sources"][0]["report_markdown"] == "a\n\nb"
-
-    def test_legacy_report_chunks_after_current_report_are_not_attached(self):
+    def test_captured_deep_research_report_source(self):
         sources = [
-            [None, ["Current Report", "# Current"], None, 1],
-            [None, "Legacy Later", None, "report", None, None, ["legacy"]],
+            [
+                None,
+                "Deep Report",
+                None,
+                5,
+                None,
+                None,
+                ["# Report markdown", 3, None, None, None, ["structured doc"]],
+            ]
         ]
         task_info = [None, ["deep query"], None, [sources], 6]
 
-        tasks = parse_research_tasks([[["task_mixed", task_info]]])
+        tasks = parse_research_tasks([[["task_deep", task_info]]])
 
-        assert tasks[0]["report"] == "# Current"
-        assert tasks[0]["sources"][0]["report_markdown"] == "# Current"
+        assert tasks[0]["report"] == "# Report markdown"
+        assert tasks[0]["sources"][0]["report_markdown"] == "# Report markdown"
+
+    def test_web_rows_before_report_do_not_win(self):
+        sources = [
+            ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
+            ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+            [None, "Deep Report", None, 5, None, None, ["# Actual report", 3]],
+        ]
+        task_info = [None, ["deep query"], None, [sources], 6]
+
+        tasks = parse_research_tasks([[["task_reordered", task_info]]])
+
+        assert tasks[0]["report"] == "# Actual report"
+        assert "report_markdown" not in tasks[0]["sources"][0]
         assert "report_markdown" not in tasks[0]["sources"][1]
+        assert tasks[0]["sources"][2]["report_markdown"] == "# Actual report"
+
+    def test_web_rows_without_report_do_not_fabricate_one(self):
+        sources = [
+            ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
+            ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+        ]
+        task_info = [None, ["deep query"], None, [sources], 6]
+
+        task = parse_research_tasks([[["task_no_report", task_info]]])[0]
+
+        assert task["report"] == ""
+        assert all("report_markdown" not in source for source in task["sources"])
 
 
 class TestExtractSourceType:


### PR DESCRIPTION
## Summary

- model `src[6]` as a typed content block instead of a list of report chunks
- extract report markdown only from exact integer kind 3 at position 1 and text at position 0
- prevent web snippets, malformed kinds, and row ordering from fabricating or suppressing reports
- preserve the existing `src[1]` compatibility path and leave citation ordinals for #2141

Closes #2140

## Test plan

- focused parser, adapter, and wire-contract suites (203 passed, 2 xfailed)
- broader research, CLI, MCP, server, and deep cassette suites (497 passed, 2 xfailed)
- full pytest (13718 passed, 77 skipped, 3 xfailed)
- post-review malformed-kind focused suite (263 passed)
- mypy over 334 source files (passed)
- Ruff changed-file check and format check (passed)
- `git diff --check` (passed)

## Evidence scope

The discriminator is backed by the two captures described in #2140. This fixes a latent order dependency; it does not claim row reordering has been observed. No `src[8]` citation work is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-research report extraction from current captured response formats.
  * Ensured report content is selected correctly when web results appear first.
  * Prevented non-report content or malformed data from being treated as reports.
  * Improved handling when no valid report is available.

* **Documentation**
  * Updated deep-research source documentation to reflect current report and web-content formats.

* **Tests**
  * Added coverage for report identification, markdown extraction, malformed content, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->