### PR TITLE
fix(auth): separate RPC auth failures from drift

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -299,11 +299,46 @@ jobs:
       # redirect chain regardless of which auth source fed it — issue #2019.
       continue-on-error: true
       shell: bash
+      env:
+        HEALTH_EXIT_CODE: ${{ steps.health.outputs.exit_code }}
       run: |
         set +e
-        uv run python scripts/capture_rpc_registry.py --check --check-enums 2>&1 \
+        if [ "$HEALTH_EXIT_CODE" = "2" ]; then
+          cat > bundle-drift-report.txt <<'EOF'
+        AUTHENTICATION FAILURE: bundle drift monitor skipped because the RPC Health Check
+        already classified this run as an authentication or infrastructure failure.
+          No RPC or studio-enum drift conclusion was drawn.
+        EOF
+          echo "outcome=authentication" >> "$GITHUB_OUTPUT"
+          echo "exit_code=2" >> "$GITHUB_OUTPUT"
+          exit 2
+        fi
+        rm -f bundle-outcome.txt
+        uv run python scripts/capture_rpc_registry.py --check --check-enums \
+          --outcome-file bundle-outcome.txt 2>&1 \
           | tee bundle-drift-report.txt
-        exit_code=${PIPESTATUS[0]}
+        raw_exit_code=${PIPESTATUS[0]}
+        if [ -f bundle-outcome.txt ]; then
+          read -r outcome < bundle-outcome.txt || outcome=""
+        else
+          outcome=""
+        fi
+        case "$outcome" in
+          clean) exit_code=0 ;;
+          drift) exit_code=1 ;;
+          authentication|infrastructure) exit_code=2 ;;
+          *)
+            outcome="runner-error"
+            exit_code=2
+            {
+              echo
+              echo "INFRASTRUCTURE FAILURE: bundle monitor exited before classifying the run."
+              echo "Raw command exit: ${raw_exit_code}."
+              echo "No RPC or studio-enum drift conclusion was drawn."
+            } >> bundle-drift-report.txt
+            ;;
+        esac
+        echo "outcome=${outcome}" >> "$GITHUB_OUTPUT"
         echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
         exit "$exit_code"
 
@@ -334,7 +369,7 @@ jobs:
         PY
 
     - name: Check for existing bundle drift issue
-      if: steps.bundle.outputs.exit_code != '0'
+      if: steps.bundle.outputs.outcome == 'drift'
       id: dup_bundle
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -350,7 +385,7 @@ jobs:
 
     - name: Create Issue on bundle drift
       if: |
-        steps.bundle.outputs.exit_code != '0'
+        steps.bundle.outputs.outcome == 'drift'
         && steps.dup_bundle.outputs.open == '0'
       uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
       with:
@@ -396,8 +431,30 @@ jobs:
         content-filepath: health-report.txt
         labels: bug, rpc-breakage, automated
 
+    - name: Prepare authentication failure report
+      if: |
+        steps.health.outputs.exit_code == '2'
+        || steps.bundle.outputs.exit_code == '2'
+      shell: bash
+      run: |
+        {
+          echo "RPC health authentication/infrastructure failure"
+          echo
+          if [ "${{ steps.health.outputs.exit_code }}" = "2" ]; then
+            echo "--- RPC health check ---"
+            cat health-report.txt
+          fi
+          if [ "${{ steps.bundle.outputs.exit_code }}" = "2" ]; then
+            echo
+            echo "--- Bundle discovery ---"
+            cat bundle-drift-report.txt
+          fi
+        } > auth-failure-report.txt
+
     - name: Check for existing Auth Failure issue
-      if: steps.health.outputs.exit_code == '2'
+      if: |
+        steps.health.outputs.exit_code == '2'
+        || steps.bundle.outputs.exit_code == '2'
       id: dup_auth
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -413,12 +470,12 @@ jobs:
 
     - name: Create Issue on Auth Failure
       if: |
-        steps.health.outputs.exit_code == '2'
+        (steps.health.outputs.exit_code == '2' || steps.bundle.outputs.exit_code == '2')
         && steps.dup_auth.outputs.open == '0'
       uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
       with:
         title: "RPC Health Check: Authentication Failure"
-        content-filepath: health-report.txt
+        content-filepath: auth-failure-report.txt
         labels: bug, automated
 
     - name: Check for existing non-transient ERROR issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **RPC bundle monitoring no longer reports authentication/access failures as
+  protocol drift.** The live registry capture now classifies login,
+  CookieMismatch, region/anti-abuse, HTTP, and CDN failures as exit code 2 and
+  explicitly states that no drift conclusion was possible. The nightly workflow
+  opens its RPC/studio-drift issue only for the script's explicit `drift`
+  outcome; exit 2 and unclassified runner failures are routed into the existing
+  authentication/infrastructure report instead. The maintainer live-auth matrix
+  now runs the real RPC canary; always exercises fallback-disabled storage-only
+  mid-session recovery (#2161); tests a sibling-process re-mint under four
+  simultaneous RPCs and actual mid-session master-token fallback; drives both
+  REST (live recovery plus stale-start lazy rebind) and MCP (tool call
+  before/after live-jar invalidation) through their adapter lifespans; and
+  regression-tests the access-gate routing that caused
+  [#2174](https://github.com/teng-lin/notebooklm-py/issues/2174) alongside
+  [#2175](https://github.com/teng-lin/notebooklm-py/issues/2175).
 - **Long-lived MCP and REST servers now keep cookie sessions alive and recover
   from sibling profile refreshes.** Both server adapters enable the client's
   600-second background `RotateCookies` loop for their process-lifetime client.

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -502,6 +502,15 @@ error:
 - **RPC ID mismatch** issues (exit code 1): labeled `bug, rpc-breakage, automated`.
 - **Auth failure** issues (exit code 2): labeled `bug, automated` (no `rpc-breakage`
   label — auth is an operational concern, not a protocol break).
+- **Frontend bundle drift** is a separate live monitor. Its exit code 1 is
+  reserved for confirmed ABSENT RPC IDs or CHANGED/STALE studio enums. If its
+  authenticated homepage request instead lands on login, CookieMismatch, or the
+  region/anti-abuse gate—or the app/CDN cannot be read—it exits 2, says that no
+  drift conclusion was possible, and joins the authentication/infrastructure
+  issue lane. The script also writes a classified outcome file; the workflow
+  opens `Studio enum / RPC drift detected` only for the explicit `drift`
+  outcome. A Python, dependency, or runner failure that exits 1 before writing
+  that outcome is therefore treated as infrastructure, never as protocol drift.
 - **Non-transient ERROR detected** issues (exit code 3): labeled `rpc-error, bug,
   automated`. Opened when `check_rpc_health.py` surfaces failures that survive
   the rate-limit / `RESOURCE_EXHAUSTED` filter (timeouts, parse failures,

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -682,6 +682,8 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    if args.outcome_file is not None:
+        args.outcome_file.unlink(missing_ok=True)
 
     types_text = args.types.read_text(encoding="utf-8")
     ours = parse_ids_from_text(types_text)

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -58,6 +58,12 @@ Usage::
     python scripts/capture_rpc_registry.py --check-enums    # exit 1 on CHANGED/STALE studio enums
     python scripts/capture_rpc_registry.py --check --check-enums  # both gates (combine freely)
     python scripts/capture_rpc_registry.py --bundle-file bundle.js   # offline, no auth
+
+Exit codes are ``0`` for a clean/report-only run, ``1`` for confirmed RPC or
+studio-enum drift, and ``2`` when the authenticated homepage is diverted to a
+login, cookie-mismatch, or region/anti-abuse surface.  Auth/infrastructure
+failures are deliberately distinct from drift so automation never turns an
+unreadable app bundle into an "all RPC ids disappeared" alarm.
 """
 
 from __future__ import annotations
@@ -90,6 +96,23 @@ _ID_LOOKBACK = 160
 _RPC_ID_RE = re.compile(r"[A-Za-z0-9]{5,8}")
 
 _UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138 Safari/537.36"
+
+_AUTH_FAILURE_EXIT = 2
+
+
+class _BundleAuthenticationError(RuntimeError):
+    """The authenticated homepage did not reach the NotebookLM app surface."""
+
+
+class _BundleInfrastructureError(RuntimeError):
+    """The live app or CDN could not be inspected, so drift is unknowable."""
+
+
+def _write_outcome(path: Path | None, outcome: str) -> None:
+    """Publish a machine-readable result only after the script classified the run."""
+    if path is not None:
+        path.write_text(f"{outcome}\n", encoding="utf-8")
+
 
 # Resolved relative to this file (scripts/ -> repo root) so the script runs from
 # any working directory, not just the repo root.
@@ -409,6 +432,7 @@ def fetch_bundle() -> str:
     """
     import httpx
 
+    from notebooklm._auth.extraction import _safe_url, _url_only_extraction_failure
     from notebooklm._env import get_base_url
     from notebooklm.auth import authuser_query, build_httpx_cookies_from_storage
 
@@ -435,16 +459,45 @@ def fetch_bundle() -> str:
     # cookies (``OSID`` on the NotebookLM host, ``LSID`` on
     # ``accounts.google.com``) leaking across hosts dead-ends the post-cutover
     # sign-in chain on ``accounts.google.com/CookieMismatch`` — see issue #2019.
-    cookies = build_httpx_cookies_from_storage()
-    html = _fetch(
-        f"{get_base_url()}/?{authuser_query(0)}",
-        cookies=cookies,
-        follow_redirects=True,
-        timeout=30.0,
-    ).text
+    try:
+        cookies = build_httpx_cookies_from_storage()
+    except Exception as exc:
+        # This is a process-boundary diagnostic: malformed/missing storage,
+        # failed PSIDTS healing, and other credential-loader faults all mean
+        # "bundle unreadable", never "RPC ids disappeared". Keep the detail
+        # type-only so an exception cannot echo credential-shaped input.
+        raise _BundleAuthenticationError(
+            "Stored authentication could not be loaded "
+            f"({type(exc).__name__}). Run `notebooklm login` and retry."
+        ) from exc
+    try:
+        homepage = _fetch(
+            f"{get_base_url()}/?{authuser_query(0)}",
+            cookies=cookies,
+            follow_redirects=True,
+            timeout=30.0,
+        )
+    except httpx.HTTPStatusError as exc:
+        raise _BundleInfrastructureError(
+            "Authenticated homepage returned "
+            f"HTTP {exc.response.status_code} at {_safe_url(str(exc.request.url))}."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise _BundleInfrastructureError(
+            "Authenticated homepage request failed with "
+            f"{type(exc).__name__} at {_safe_url(str(exc.request.url))}."
+        ) from exc
+    failure = _url_only_extraction_failure(
+        str(homepage.url),
+        [str(response.url) for response in homepage.history],
+    )
+    if failure is not None:
+        raise _BundleAuthenticationError(str(failure)) from failure
+
+    html = homepage.text
     urls = sorted(set(_BUNDLE_URL_RE.findall(html)))
     if not urls:
-        raise SystemExit(
+        raise _BundleInfrastructureError(
             f"No {_APP} bundle URL found in the homepage — not authenticated for "
             "NotebookLM? Run `notebooklm login` (or pass --bundle-file)."
         )
@@ -453,12 +506,25 @@ def fetch_bundle() -> str:
     # page), which would otherwise be parsed as a bundle and make every id ABSENT.
     bodies: list[str] = []
     for url in urls:
-        response = _fetch(url)
+        try:
+            response = _fetch(url)
+        except httpx.HTTPStatusError as exc:
+            raise _BundleInfrastructureError(
+                f"Public bundle returned HTTP {exc.response.status_code} at "
+                f"{_safe_url(str(exc.request.url))}."
+            ) from exc
+        except httpx.RequestError as exc:
+            raise _BundleInfrastructureError(
+                "Public bundle request failed with "
+                f"{type(exc).__name__} at {_safe_url(str(exc.request.url))}."
+            ) from exc
         content_type = response.headers.get("content-type", "")
         if "javascript" in content_type or "text/plain" in content_type:
             bodies.append(response.text)
     if not bodies:
-        raise SystemExit(f"No readable JS bundle content fetched from the {_APP} URLs.")
+        raise _BundleInfrastructureError(
+            f"No readable JS bundle content fetched from the {_APP} URLs."
+        )
     return "\n".join(bodies)
 
 
@@ -583,12 +649,15 @@ def _print_enum_report(
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point: load/fetch the bundle, diff vs rpc/types.py, report.
 
-    Returns the process exit code: ``1`` when a gate fires —  ``--check`` with any
-    ABSENT id (id rotation), and/or ``--check-enums`` with any CHANGED/STALE
-    studio enum (a selectable format renumbered or retired). The two gates
-    combine (either firing exits ``1``); ``NEW``/``UNPARSED`` enum classes,
-    quota codes and proto assertions are report-only and never affect the exit
-    code. Without a gate flag the exit is always ``0`` (report mode).
+    Returns the process exit code: ``1`` when a drift gate fires — ``--check``
+    with any ABSENT id (id rotation), and/or ``--check-enums`` with any
+    CHANGED/STALE studio enum (a selectable format renumbered or retired).
+    ``2`` means the authenticated homepage hit a login, cookie-mismatch, or
+    region/anti-abuse surface, so no drift conclusion was possible. The two
+    drift gates combine (either firing exits ``1``); ``NEW``/``UNPARSED`` enum
+    classes, quota codes and proto assertions are report-only and never affect
+    the exit code. Without a gate flag the exit is ``0`` unless authentication
+    prevents the live bundle from being discovered.
     """
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
     parser.add_argument(
@@ -604,11 +673,63 @@ def main(argv: list[str] | None = None) -> int:
         "--bundle-file", type=Path, help="analyse a saved bundle file (no auth/network)"
     )
     parser.add_argument("--types", type=Path, default=_DEFAULT_TYPES, help="path to rpc/types.py")
+    parser.add_argument(
+        "--outcome-file",
+        type=Path,
+        help=(
+            "write clean, drift, authentication, or infrastructure after a classified run; "
+            "an absent file means the process failed before it could classify the result"
+        ),
+    )
     args = parser.parse_args(argv)
 
     types_text = args.types.read_text(encoding="utf-8")
     ours = parse_ids_from_text(types_text)
-    bundle = args.bundle_file.read_text(encoding="utf-8") if args.bundle_file else fetch_bundle()
+    try:
+        bundle = (
+            args.bundle_file.read_text(encoding="utf-8") if args.bundle_file else fetch_bundle()
+        )
+    except _BundleAuthenticationError as exc:
+        _write_outcome(args.outcome_file, "authentication")
+        if args.json:
+            print(
+                json.dumps(
+                    {"error": {"kind": "authentication", "message": str(exc)}},
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(
+                "AUTHENTICATION FAILURE: the live NotebookLM bundle could not be inspected.\n"
+                f"{exc}\n"
+                "No RPC or studio-enum drift conclusion was drawn.",
+                file=sys.stderr,
+            )
+        return _AUTH_FAILURE_EXIT
+    except _BundleInfrastructureError as exc:
+        _write_outcome(args.outcome_file, "infrastructure")
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "error": {
+                            "kind": "infrastructure",
+                            "message": str(exc),
+                        }
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(
+                "INFRASTRUCTURE FAILURE: the live NotebookLM bundle could not be inspected.\n"
+                f"{exc}\n"
+                "No RPC or studio-enum drift conclusion was drawn.",
+                file=sys.stderr,
+            )
+        return _AUTH_FAILURE_EXIT
     live = extract_registry(bundle)
     buckets = diff(ours, live, bundle)
     # Services any CONFIRMED id resolves to are, empirically, serving our cohort.
@@ -665,6 +786,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         exit_code = 1
+    _write_outcome(args.outcome_file, "drift" if exit_code == 1 else "clean")
     return exit_code
 
 

--- a/scripts/live_auth_matrix.py
+++ b/scripts/live_auth_matrix.py
@@ -401,6 +401,7 @@ class Matrix:
         proc = self._run(
             command,
             home,
+            timeout=max(self.args.timeout, 120),
             env_overrides={"NOTEBOOKLM_PROFILE": "rpc-bundle"},
         )
         self.record("rpc-bundle-health", proc, include_stdout_on_failure=True)
@@ -417,7 +418,13 @@ class Matrix:
             extra["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"] = self.args.read_only_notebook_id
         if self.args.generation_notebook_id:
             extra["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] = self.args.generation_notebook_id
-        proc = self._run(command, home, env_overrides=extra)
+        timeout_floor = 300 if self.args.rpc_health_full else 120
+        proc = self._run(
+            command,
+            home,
+            timeout=max(self.args.timeout, timeout_floor),
+            env_overrides=extra,
+        )
         self.record(
             "rpc-health-full" if self.args.rpc_health_full else "rpc-health-quick",
             proc,
@@ -879,6 +886,7 @@ class Matrix:
         proc = self._run(
             command,
             home,
+            timeout=max(self.args.timeout, 180),
             env_overrides={
                 "NOTEBOOKLM_PROFILE": "mid-session-browser",
                 "NOTEBOOKLM_REFRESH_CMD": (
@@ -973,7 +981,7 @@ class Matrix:
         self.record("transient-fault-injection-tests", proc)
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--profile", default=os.environ.get("NOTEBOOKLM_PROFILE", "default"))
     parser.add_argument("--account", required=True)
@@ -1014,7 +1022,7 @@ def parse_args() -> argparse.Namespace:
             "Storage-only mid-session recovery and RPC access-gate cells still run."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":

--- a/scripts/live_auth_matrix.py
+++ b/scripts/live_auth_matrix.py
@@ -7,7 +7,7 @@ browser profile are read-only inputs.
 
 Example::
 
-    uv run --extra browser --extra cookies --extra headless \
+    uv run --extra browser --extra cookies --extra headless --extra mcp --extra server \
       python scripts/live_auth_matrix.py \
       --profile teng-lin-9420 \
       --browser 'chromium::Profile 3' \
@@ -19,15 +19,20 @@ The JSON report is suitable for attaching to a release checklist. All writes
 go to a disposable ``NOTEBOOKLM_HOME`` and the temporary credential copies are
 removed when the run finishes. Covered cells include baseline/live token
 checks, browser-cookie login, master-token re-mint, cookie import filtering,
-both NotebookLM hosts, concurrent refresh, true mid-session recovery,
-transient-fault recovery (503, connection failure, and read timeout), and
-crash-safe canonical writes.
+both NotebookLM hosts, live RPC and frontend-bundle health, concurrent refresh,
+strict storage-only mid-session recovery (#2161), a real sibling-process re-mint
+followed by simultaneous failing RPCs, actual mid-session master-token fallback,
+optional browser-backed mid-session recovery, access-gate classification
+(#2175), transient-fault recovery (503, connection failure, and read timeout),
+and crash-safe canonical writes.
 
 The browser cookie extractor is host-sensitive: use the host where the browser
 profile currently has its NotebookLM binding. Interactive Playwright login,
 initial master-token bootstrap, CDP capture, Workspace/SSO, regional-account,
-long-duration expiry, and MCP transport checks remain separate/manual cells.
-MCP file-route coverage is available from ``scripts/mcp_live_smoke.py``.
+long-duration expiry, and remote MCP HTTP/bearer/file-side-channel checks remain
+separate/manual cells. The matrix's MCP auth-recovery cell uses FastMCP's real
+in-memory protocol transport; deployed file-route coverage is available from
+``scripts/mcp_live_smoke.py``.
 """
 
 from __future__ import annotations
@@ -41,12 +46,20 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_HOME = Path(os.environ.get("NOTEBOOKLM_HOME", Path.home() / ".notebooklm"))
+
+
+def _timeout_text(value: str | bytes | None) -> str:
+    """Normalize ``TimeoutExpired`` output despite subprocess stub variance."""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value or ""
 
 
 class Matrix:
@@ -70,6 +83,34 @@ class Matrix:
         env.update(extra)
         return env
 
+    def _run(
+        self,
+        command: list[str],
+        home: Path,
+        *,
+        timeout: int | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one isolated matrix subprocess with consistent timeout reporting."""
+        effective_timeout = self.args.timeout if timeout is None else timeout
+        try:
+            return subprocess.run(
+                command,
+                cwd=ROOT,
+                env=self.env(home, **(env_overrides or {})),
+                text=True,
+                capture_output=True,
+                timeout=effective_timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return subprocess.CompletedProcess(
+                command,
+                124,
+                _timeout_text(exc.stdout),
+                f"timed out after {effective_timeout}s",
+            )
+
     def cli(
         self, home: Path, *args: str, profile: str | None = None, **extra: str
     ) -> subprocess.CompletedProcess[str]:
@@ -77,26 +118,15 @@ class Matrix:
         if profile:
             command.extend(["--profile", profile])
         command.extend(args)
-        try:
-            return subprocess.run(
-                command,
-                cwd=ROOT,
-                env=self.env(home, **extra),
-                text=True,
-                capture_output=True,
-                timeout=self.args.timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            return subprocess.CompletedProcess(
-                command,
-                124,
-                exc.stdout or "",
-                f"timed out after {self.args.timeout}s",
-            )
+        return self._run(command, home, env_overrides=extra)
 
     def record(
-        self, name: str, proc: subprocess.CompletedProcess[str], *, expect_json: bool = False
+        self,
+        name: str,
+        proc: subprocess.CompletedProcess[str],
+        *,
+        expect_json: bool = False,
+        include_stdout_on_failure: bool = False,
     ) -> None:
         payload: dict[str, Any] = {
             "name": name,
@@ -111,6 +141,8 @@ class Matrix:
                 payload["status"] = "fail"
         if proc.returncode != 0:
             payload["stderr"] = proc.stderr[-2000:]
+            if include_stdout_on_failure:
+                payload["stdout_tail"] = proc.stdout[-4000:]
         self.results.append(payload)
 
     def copy_profile(self, source: str, home: Path, target: str) -> None:
@@ -139,9 +171,19 @@ class Matrix:
             self.phase_master_refresh()
             self.phase_import_filter()
             self.phase_hosts()
+            self.phase_rpc_bundle_health()
+            self.phase_rpc_health()
             self.phase_concurrency()
+            self.phase_storage_mid_session()
+            self.phase_sibling_concurrent_mid_session()
+            self.phase_master_token_mid_session()
+            if not self.args.skip_rest:
+                self.phase_rest_auth_recovery()
+            if not self.args.skip_mcp:
+                self.phase_mcp_auth_recovery()
             if not self.args.skip_browser:
-                self.phase_mid_session()
+                self.phase_browser_mid_session()
+            self.phase_rpc_access_gate_contract()
             self.phase_fault_injection()
             self.phase_crash_safety()
         finally:
@@ -153,6 +195,9 @@ class Matrix:
                     "browser": self.args.browser,
                     "base_url": self.args.base_url,
                     "browser_cells": "skipped" if self.args.skip_browser else "executed",
+                    "rest_cells": "skipped" if self.args.skip_rest else "executed",
+                    "mcp_cells": "skipped" if self.args.skip_mcp else "executed",
+                    "rpc_health_mode": "full" if self.args.rpc_health_full else "quick",
                     **self.worktree_info(),
                     "results": self.results,
                     "temporary_home": str(self.temp),
@@ -209,6 +254,11 @@ class Matrix:
         self.record("baseline-auth", proc, expect_json=True)
         proc = self.cli(home, "--quiet", "list", "--json", profile="baseline")
         self.record("baseline-list", proc, expect_json=True)
+        # The report is meant for release-checklist attachment. A notebook
+        # inventory contains private titles and stable ids; the cell needs only
+        # the count to prove the RPC succeeded.
+        if proc.returncode == 0 and isinstance(self.results[-1].get("json"), dict):
+            self.results[-1]["json"] = {"count": self.results[-1]["json"].get("count")}
 
     def phase_browser_discovery(self) -> None:
         proc = self.cli(DEFAULT_HOME, "auth", "inspect", "--browser", self.args.browser, "--json")
@@ -333,49 +383,529 @@ class Matrix:
                 err[-2000:] for status, err in zip(statuses, stderrs, strict=True) if status != 0
             ]
         self.results.append(entry)
-        proc = self.cli(home, "auth", "check", "--test", "--passive", "--json", profile="shared")
-        self.record("concurrent-refresh-final-check", proc, expect_json=True)
+        check_proc = self.cli(
+            home, "auth", "check", "--test", "--passive", "--json", profile="shared"
+        )
+        self.record("concurrent-refresh-final-check", check_proc, expect_json=True)
 
-    def phase_mid_session(self) -> None:
-        home = self.temp / "mid-session"
-        self.copy_profile(self.args.profile, home, "mid-session")
+    def phase_rpc_bundle_health(self) -> None:
+        """Exercise the authenticated bundle path and its typed exit codes live."""
+        home = self.temp / "rpc-bundle"
+        self.copy_profile(self.args.profile, home, "rpc-bundle")
+        command = [
+            sys.executable,
+            str(ROOT / "scripts" / "capture_rpc_registry.py"),
+            "--check",
+            "--check-enums",
+        ]
+        proc = self._run(
+            command,
+            home,
+            env_overrides={"NOTEBOOKLM_PROFILE": "rpc-bundle"},
+        )
+        self.record("rpc-bundle-health", proc, include_stdout_on_failure=True)
+
+    def phase_rpc_health(self) -> None:
+        """Run the real RPC canary, using configured stable notebooks when available."""
+        home = self.temp / "rpc-health"
+        self.copy_profile(self.args.profile, home, "rpc-health")
+        command = [sys.executable, str(ROOT / "scripts" / "check_rpc_health.py")]
+        if self.args.rpc_health_full:
+            command.append("--full")
+        extra = {"NOTEBOOKLM_PROFILE": "rpc-health"}
+        if self.args.read_only_notebook_id:
+            extra["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"] = self.args.read_only_notebook_id
+        if self.args.generation_notebook_id:
+            extra["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] = self.args.generation_notebook_id
+        proc = self._run(command, home, env_overrides=extra)
+        self.record(
+            "rpc-health-full" if self.args.rpc_health_full else "rpc-health-quick",
+            proc,
+            include_stdout_on_failure=True,
+        )
+
+    def phase_storage_mid_session(self) -> None:
+        """Prove #2161 recovery uses storage, without another rung masking it."""
+        home = self.temp / "mid-session-storage"
+        self.copy_profile(self.args.profile, home, "mid-session-storage")
+        (home / "profiles" / "mid-session-storage" / "master_token.json").unlink(missing_ok=True)
         script = (
-            "import asyncio\n"
+            "import asyncio, json\n"
             "from notebooklm import NotebookLMClient\n"
+            "from notebooklm._auth import session as auth_session\n"
             "async def main():\n"
-            "    async with NotebookLMClient.from_storage(profile='mid-session') as c:\n"
+            "    reload_calls = 0\n"
+            "    original_reload = getattr(auth_session, 'try_storage_cookie_reload', None)\n"
+            "    async def tracked_reload(*args, **kwargs):\n"
+            "        nonlocal reload_calls\n"
+            "        reload_calls += 1\n"
+            "        assert original_reload is not None\n"
+            "        return await original_reload(*args, **kwargs)\n"
+            "    async def forbidden(*args, **kwargs):\n"
+            "        raise AssertionError('external recovery rung reached')\n"
+            "    if original_reload is not None:\n"
+            "        auth_session.try_storage_cookie_reload = tracked_reload\n"
+            "    auth_session._try_refresh_cmd_reauth = forbidden\n"
+            "    auth_session._try_headless_reauth = forbidden\n"
+            "    auth_session._try_master_token_reauth = forbidden\n"
+            "    async with NotebookLMClient.from_storage(profile='mid-session-storage') as c:\n"
             "        before = await c.notebooks.list()\n"
-            "        c._collaborators.kernel.get_http_client().cookies.clear()\n"
+            "        live = c._collaborators.kernel.get_http_client().cookies\n"
+            "        live.clear()\n"
             "        after = await c.notebooks.list()\n"
-            "        print(f'{len(before)} {len(after)} {len(c._collaborators.kernel.get_http_client().cookies)}')\n"
+            "        assert reload_calls > 0, 'storage reload rung was not exercised'\n"
+            "        assert len(live) > 0, 'storage reload did not restore the live jar'\n"
+            "        assert len(before) == len(after), 'notebook result changed after recovery'\n"
+            "        print(json.dumps({'before': len(before), 'after': len(after), "
+            "'reload_calls': reload_calls, 'live_cookies': len(live)}))\n"
             "asyncio.run(main())\n"
         )
         command = [sys.executable, "-c", script]
-        try:
-            proc = subprocess.run(
-                command,
-                cwd=ROOT,
-                env=self.env(
-                    home,
-                    NOTEBOOKLM_REFRESH_CMD=(
-                        f"{shlex.quote(sys.executable)} "
-                        f"{shlex.quote(str(ROOT / 'examples' / 'refresh_browser_cookies.py'))}"
-                    ),
-                    NOTEBOOKLM_REFRESH_CMD_MIDSESSION="1",
+        proc = self._run(
+            command,
+            home,
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "mid-session-storage",
+                "NOTEBOOKLM_REFRESH_BROWSER": "",
+                "NOTEBOOKLM_REFRESH_CMD": "",
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "",
+            },
+        )
+        self.record("mid-session-storage-reload", proc, expect_json=True)
+
+    def phase_sibling_concurrent_mid_session(self) -> None:
+        """Consume a real sibling re-mint through one concurrent recovery wave."""
+        home = self.temp / "mid-session-sibling"
+        self.copy_profile(self.args.profile, home, "mid-session-sibling")
+        script = textwrap.dedent(
+            """\
+            import asyncio
+            import hashlib
+            import json
+            import os
+            import subprocess
+            import sys
+            from pathlib import Path
+
+            from notebooklm import NotebookLMClient
+            from notebooklm._auth import session as auth_session
+
+            async def main():
+                reload_calls = 0
+                original_reload = auth_session.try_storage_cookie_reload
+
+                async def tracked_reload(*args, **kwargs):
+                    nonlocal reload_calls
+                    reload_calls += 1
+                    return await original_reload(*args, **kwargs)
+
+                async def forbidden(*args, **kwargs):
+                    raise AssertionError("external recovery rung reached")
+
+                auth_session.try_storage_cookie_reload = tracked_reload
+                auth_session._try_refresh_cmd_reauth = forbidden
+                auth_session._try_headless_reauth = forbidden
+                auth_session._try_master_token_reauth = forbidden
+                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-sibling"
+                storage = profile_dir / "storage_state.json"
+                before_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
+
+                async with NotebookLMClient.from_storage(profile="mid-session-sibling") as client:
+                    before = await client.notebooks.list()
+                    sibling = subprocess.run(
+                        [
+                            sys.executable,
+                            "-m",
+                            "notebooklm.notebooklm_cli",
+                            "--profile",
+                            "mid-session-sibling",
+                            "login",
+                            "--master-token-refresh",
+                        ],
+                        env=os.environ.copy(),
+                        text=True,
+                        capture_output=True,
+                        timeout=90,
+                        check=False,
+                    )
+                    assert sibling.returncode == 0, sibling.stderr[-1000:]
+                    after_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
+                    assert after_hash != before_hash, "sibling re-mint did not replace profile state"
+                    (profile_dir / "master_token.json").unlink()
+                    live = client._collaborators.kernel.get_http_client().cookies
+                    live.clear()
+                    recovered = await asyncio.gather(*(client.notebooks.list() for _ in range(4)))
+                    counts = [len(items) for items in recovered]
+                    assert counts == [len(before)] * 4
+                    assert 0 < reload_calls <= 3, "concurrent RPCs did not share one recovery wave"
+                    assert len(live) > 0
+                    print(json.dumps({
+                        "before": len(before),
+                        "after": counts,
+                        "reload_calls": reload_calls,
+                        "live_cookies": len(live),
+                        "sibling_profile_changed": True,
+                    }))
+
+            asyncio.run(main())
+            """
+        )
+        command = [sys.executable, "-c", script]
+        proc = self._run(
+            command,
+            home,
+            timeout=max(self.args.timeout, 120),
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "mid-session-sibling",
+                "NOTEBOOKLM_REFRESH_BROWSER": "",
+                "NOTEBOOKLM_REFRESH_CMD": "",
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "",
+                "NOTEBOOKLM_HEADLESS_REAUTH": "",
+            },
+        )
+        self.record("mid-session-sibling-concurrent-reload", proc, expect_json=True)
+
+    def phase_master_token_mid_session(self) -> None:
+        """Force the real Layer-4 rung after both live and disk cookies become unusable."""
+        home = self.temp / "mid-session-master"
+        self.copy_profile(self.args.profile, home, "mid-session-master")
+        script = textwrap.dedent(
+            """\
+            import asyncio
+            import json
+            import os
+            from pathlib import Path
+
+            from notebooklm import NotebookLMClient
+            from notebooklm._auth import session as auth_session
+
+            async def main():
+                master_calls = 0
+                original_master = auth_session._try_master_token_reauth
+
+                async def tracked_master(*args, **kwargs):
+                    nonlocal master_calls
+                    master_calls += 1
+                    return await original_master(*args, **kwargs)
+
+                auth_session._try_master_token_reauth = tracked_master
+                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-master"
+                storage = profile_dir / "storage_state.json"
+
+                async with NotebookLMClient.from_storage(profile="mid-session-master") as client:
+                    before = await client.notebooks.list()
+                    state = json.loads(storage.read_text(encoding="utf-8"))
+                    state["cookies"] = []
+                    replacement = storage.with_suffix(".matrix-tmp")
+                    replacement.write_text(json.dumps(state), encoding="utf-8")
+                    os.replace(replacement, storage)
+                    live = client._collaborators.kernel.get_http_client().cookies
+                    live.clear()
+                    after = await client.notebooks.list()
+                    persisted = json.loads(storage.read_text(encoding="utf-8"))
+                    assert len(before) == len(after)
+                    assert master_calls == 1, "mid-session Layer-4 recovery was not exercised once"
+                    assert persisted.get("cookies"), "master-token recovery did not repair storage"
+                    assert len(live) > 0
+                    print(json.dumps({
+                        "before": len(before),
+                        "after": len(after),
+                        "master_token_calls": master_calls,
+                        "persisted_cookies": len(persisted["cookies"]),
+                        "live_cookies": len(live),
+                    }))
+
+            asyncio.run(main())
+            """
+        )
+        command = [sys.executable, "-c", script]
+        proc = self._run(
+            command,
+            home,
+            timeout=max(self.args.timeout, 120),
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "mid-session-master",
+                "NOTEBOOKLM_REFRESH_BROWSER": "",
+                "NOTEBOOKLM_REFRESH_CMD": "",
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "",
+                "NOTEBOOKLM_HEADLESS_REAUTH": "",
+            },
+        )
+        self.record("mid-session-master-token-recovery", proc, expect_json=True)
+
+    def phase_rest_auth_recovery(self) -> None:
+        """Drive REST through live-jar recovery and degraded-startup lazy binding."""
+        home = self.temp / "rest-auth"
+        self.copy_profile(self.args.profile, home, "rest-live")
+        self.copy_profile(self.args.profile, home, "rest-stale")
+        (home / "profiles" / "rest-live" / "master_token.json").unlink(missing_ok=True)
+        script = textwrap.dedent(
+            """\
+            import asyncio
+            import contextlib
+            import json
+            import os
+            import subprocess
+            import sys
+            from pathlib import Path
+
+            import httpx
+
+            from notebooklm import NotebookLMClient
+            from notebooklm.server.app import create_app
+
+            TOKEN = "matrix-rest-token"
+            HEADERS = {"Authorization": f"Bearer {TOKEN}", "Host": "127.0.0.1"}
+
+            async def mid_session():
+                holder = {}
+
+                @contextlib.asynccontextmanager
+                async def factory():
+                    async with NotebookLMClient.from_storage(
+                        profile="rest-live", keepalive=600.0
+                    ) as client:
+                        holder["client"] = client
+                        yield client
+
+                app = create_app(profile="rest-live", client_factory=factory)
+                async with app.router.lifespan_context(app):
+                    transport = httpx.ASGITransport(
+                        app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
+                    )
+                    async with httpx.AsyncClient(
+                        transport=transport, base_url="http://127.0.0.1"
+                    ) as http:
+                        before = await http.get("/v1/notebooks", headers=HEADERS)
+                        assert before.status_code == 200, before.text[-1000:]
+                        holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
+                        after = await http.get("/v1/notebooks", headers=HEADERS)
+                        assert after.status_code == 200, after.text[-1000:]
+                        return len(before.json()["notebooks"]), len(after.json()["notebooks"])
+
+            async def stale_startup():
+                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "rest-stale"
+                storage = profile_dir / "storage_state.json"
+                token = profile_dir / "master_token.json"
+                held_token = profile_dir / "master_token.matrix-held"
+                state = json.loads(storage.read_text(encoding="utf-8"))
+                state["cookies"] = []
+                replacement = storage.with_suffix(".matrix-tmp")
+                replacement.write_text(json.dumps(state), encoding="utf-8")
+                os.replace(replacement, storage)
+                token.replace(held_token)
+
+                app = create_app(profile="rest-stale")
+                async with app.router.lifespan_context(app):
+                    assert app.state.notebooklm.client is None
+                    held_token.replace(token)
+                    sibling = subprocess.run(
+                        [
+                            sys.executable,
+                            "-m",
+                            "notebooklm.notebooklm_cli",
+                            "--profile",
+                            "rest-stale",
+                            "login",
+                            "--master-token-refresh",
+                        ],
+                        env=os.environ.copy(),
+                        text=True,
+                        capture_output=True,
+                        timeout=90,
+                        check=False,
+                    )
+                    assert sibling.returncode == 0, sibling.stderr[-1000:]
+                    transport = httpx.ASGITransport(
+                        app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
+                    )
+                    async with httpx.AsyncClient(
+                        transport=transport, base_url="http://127.0.0.1"
+                    ) as http:
+                        response = await http.get("/v1/notebooks", headers=HEADERS)
+                    assert response.status_code == 200, response.text[-1000:]
+                    assert app.state.notebooklm.client is not None
+                    return len(response.json()["notebooks"])
+
+            async def main():
+                before, after = await mid_session()
+                rebound = await stale_startup()
+                assert before == after == rebound
+                print(json.dumps({
+                    "before": before,
+                    "after_live_reload": after,
+                    "after_stale_startup_rebind": rebound,
+                    "stale_startup_rebound": True,
+                }))
+
+            asyncio.run(main())
+            """
+        )
+        command = [sys.executable, "-c", script]
+        proc = self._run(
+            command,
+            home,
+            timeout=max(self.args.timeout, 150),
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "rest-live",
+                "NOTEBOOKLM_SERVER_TOKEN": "matrix-rest-token",
+                "NOTEBOOKLM_REFRESH_BROWSER": "",
+                "NOTEBOOKLM_REFRESH_CMD": "",
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "",
+                "NOTEBOOKLM_HEADLESS_REAUTH": "",
+            },
+        )
+        self.record("rest-auth-recovery", proc, expect_json=True)
+
+    def phase_mcp_auth_recovery(self) -> None:
+        """Drive a real FastMCP tool call across a live-jar invalidation."""
+        home = self.temp / "mcp-auth"
+        self.copy_profile(self.args.profile, home, "mcp-live")
+        (home / "profiles" / "mcp-live" / "master_token.json").unlink(missing_ok=True)
+        script = textwrap.dedent(
+            """\
+            import asyncio
+            import contextlib
+            import json
+
+            from fastmcp import Client
+
+            from notebooklm import NotebookLMClient
+            from notebooklm.mcp.server import create_server
+
+            async def main():
+                holder = {}
+
+                @contextlib.asynccontextmanager
+                async def factory():
+                    async with NotebookLMClient.from_storage(
+                        profile="mcp-live", keepalive=600.0
+                    ) as client:
+                        holder["client"] = client
+                        yield client
+
+                server = create_server(profile="mcp-live", client_factory=factory)
+                async with Client(server) as mcp:
+                    before_result = await mcp.call_tool("notebook_list", {"limit": 50})
+                    assert before_result.structured_content is not None
+                    before = before_result.structured_content
+                    assert "total" in before and "notebooks" in before
+                    holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
+                    after_result = await mcp.call_tool("notebook_list", {"limit": 50})
+                    assert after_result.structured_content is not None
+                    after = after_result.structured_content
+                    assert "total" in after and "notebooks" in after
+                    assert before.get("total") == after.get("total")
+                    assert before.get("notebooks") == after.get("notebooks")
+                    live = holder["client"]._collaborators.kernel.get_http_client().cookies
+                    assert len(live) > 0
+                    print(json.dumps({
+                        "before": before.get("total"),
+                        "after": after.get("total"),
+                        "live_cookies": len(live),
+                        "transport": "fastmcp-in-memory",
+                    }))
+
+            asyncio.run(main())
+            """
+        )
+        command = [sys.executable, "-c", script]
+        proc = self._run(
+            command,
+            home,
+            timeout=max(self.args.timeout, 120),
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "mcp-live",
+                "NOTEBOOKLM_REFRESH_BROWSER": "",
+                "NOTEBOOKLM_REFRESH_CMD": "",
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "",
+                "NOTEBOOKLM_HEADLESS_REAUTH": "",
+            },
+        )
+        self.record("mcp-auth-recovery", proc, expect_json=True)
+
+    def phase_browser_mid_session(self) -> None:
+        home = self.temp / "mid-session-browser"
+        self.copy_profile(self.args.profile, home, "mid-session-browser")
+        profile_dir = home / "profiles" / "mid-session-browser"
+        (profile_dir / "master_token.json").unlink(missing_ok=True)
+        script = textwrap.dedent(
+            """\
+            import asyncio
+            import json
+            import os
+            from pathlib import Path
+
+            from notebooklm import NotebookLMClient
+            from notebooklm._auth import session as auth_session
+
+            async def main():
+                refresh_calls = 0
+                original_refresh = auth_session._try_refresh_cmd_reauth
+
+                async def tracked_refresh(*args, **kwargs):
+                    nonlocal refresh_calls
+                    refresh_calls += 1
+                    return await original_refresh(*args, **kwargs)
+
+                auth_session._try_refresh_cmd_reauth = tracked_refresh
+                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-browser"
+                storage = profile_dir / "storage_state.json"
+
+                async with NotebookLMClient.from_storage(profile="mid-session-browser") as client:
+                    before = await client.notebooks.list()
+                    state = json.loads(storage.read_text(encoding="utf-8"))
+                    state["cookies"] = []
+                    replacement = storage.with_suffix(".matrix-tmp")
+                    replacement.write_text(json.dumps(state), encoding="utf-8")
+                    os.replace(replacement, storage)
+                    live = client._collaborators.kernel.get_http_client().cookies
+                    live.clear()
+                    after = await client.notebooks.list()
+                    assert len(before) == len(after)
+                    assert refresh_calls == 1, "browser refresh command rung was not exercised once"
+                    assert len(live) > 0
+                    print(json.dumps({
+                        "before": len(before),
+                        "after": len(after),
+                        "refresh_command_calls": refresh_calls,
+                        "live_cookies": len(live),
+                    }))
+
+            asyncio.run(main())
+            """
+        )
+        command = [sys.executable, "-c", script]
+        proc = self._run(
+            command,
+            home,
+            env_overrides={
+                "NOTEBOOKLM_PROFILE": "mid-session-browser",
+                "NOTEBOOKLM_REFRESH_CMD": (
+                    f"{shlex.quote(sys.executable)} "
+                    f"{shlex.quote(str(ROOT / 'examples' / 'refresh_browser_cookies.py'))}"
                 ),
-                text=True,
-                capture_output=True,
-                timeout=self.args.timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            proc = subprocess.CompletedProcess(
-                command,
-                124,
-                exc.stdout or "",
-                f"timed out after {self.args.timeout}s",
-            )
-        self.record("true-mid-session-recovery", proc)
+                "NOTEBOOKLM_REFRESH_CMD_MIDSESSION": "1",
+                "NOTEBOOKLM_HEADLESS_REAUTH": "",
+            },
+        )
+        self.record("mid-session-browser-refresh", proc, expect_json=True)
+
+    def phase_rpc_access_gate_contract(self) -> None:
+        """Run the deterministic #2175 classifier and workflow-routing regressions."""
+        home = self.temp / "rpc-access-gate"
+        home.mkdir(parents=True, exist_ok=True)
+        command = [
+            "uv",
+            "run",
+            "pytest",
+            "-q",
+            "tests/unit/test_scripts_auth_cookie_domains.py::test_capture_rpc_registry_classifies_access_gate_as_auth_failure",
+            "tests/unit/test_capture_rpc_registry.py::test_main_reports_bundle_auth_failure_without_drift",
+            "tests/unit/test_rpc_health_bundle_lane.py",
+        ]
+        proc = self._run(command, home)
+        self.record("rpc-access-gate-classification", proc)
 
     def phase_crash_safety(self) -> None:
         home = self.temp / "crash"
@@ -439,23 +969,7 @@ class Matrix:
             "tests/unit/test_retry_middleware.py",
             "tests/unit/test_auth_refresh_middleware.py",
         ]
-        try:
-            proc = subprocess.run(
-                command,
-                cwd=ROOT,
-                env=self.env(home),
-                text=True,
-                capture_output=True,
-                timeout=self.args.timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            proc = subprocess.CompletedProcess(
-                command,
-                124,
-                exc.stdout or "",
-                f"timed out after {self.args.timeout}s",
-            )
+        proc = self._run(command, home)
         self.record("transient-fault-injection-tests", proc)
 
 
@@ -468,9 +982,37 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--timeout", type=int, default=90)
     parser.add_argument("--output", type=Path)
     parser.add_argument(
+        "--rpc-health-full",
+        action="store_true",
+        help="Run the mutating full RPC canary (creates and deletes a temporary notebook).",
+    )
+    parser.add_argument(
+        "--read-only-notebook-id",
+        default=os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"),
+        help="Stable notebook used by the RPC health canary's read-only methods.",
+    )
+    parser.add_argument(
+        "--generation-notebook-id",
+        default=os.environ.get("NOTEBOOKLM_GENERATION_NOTEBOOK_ID"),
+        help="Stable notebook used by the RPC health canary's generation methods.",
+    )
+    parser.add_argument(
+        "--skip-rest",
+        action="store_true",
+        help="Skip REST adapter recovery cells when the server extra is unavailable.",
+    )
+    parser.add_argument(
+        "--skip-mcp",
+        action="store_true",
+        help="Skip MCP adapter recovery cells when the mcp extra is unavailable.",
+    )
+    parser.add_argument(
         "--skip-browser",
         action="store_true",
-        help="Skip rookiepy browser discovery/login cells when no fresh browser session is available.",
+        help=(
+            "Skip rookiepy browser discovery/login and browser-refresh cells. "
+            "Storage-only mid-session recovery and RPC access-gate cells still run."
+        ),
     )
     return parser.parse_args()
 

--- a/scripts/live_auth_matrix.py
+++ b/scripts/live_auth_matrix.py
@@ -43,6 +43,7 @@ import json
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -94,22 +95,64 @@ class Matrix:
         """Run one isolated matrix subprocess with consistent timeout reporting."""
         effective_timeout = self.args.timeout if timeout is None else timeout
         try:
-            return subprocess.run(
+            process = subprocess.Popen(
                 command,
                 cwd=ROOT,
                 env=self.env(home, **(env_overrides or {})),
                 text=True,
-                capture_output=True,
-                timeout=effective_timeout,
-                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                **self._process_group_options(),
             )
+        except OSError as exc:
+            return subprocess.CompletedProcess(
+                command,
+                127,
+                "",
+                f"unable to launch matrix phase: {type(exc).__name__}",
+            )
+
+        try:
+            stdout, stderr = process.communicate(timeout=effective_timeout)
         except subprocess.TimeoutExpired as exc:
+            self._terminate_process_tree(process)
+            stdout, _stderr = process.communicate()
             return subprocess.CompletedProcess(
                 command,
                 124,
-                _timeout_text(exc.stdout),
+                stdout or _timeout_text(exc.stdout),
                 f"timed out after {effective_timeout}s",
             )
+        return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
+
+    @staticmethod
+    def _process_group_options() -> dict[str, Any]:
+        """Return platform-specific options for isolating a phase process tree."""
+        if os.name == "nt":
+            return {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+        return {"start_new_session": True}
+
+    @staticmethod
+    def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
+        """Terminate a timed-out phase and every child that inherited its credentials."""
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        else:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        if process.poll() is None:
+            process.kill()
 
     def cli(
         self, home: Path, *args: str, profile: str | None = None, **extra: str
@@ -257,8 +300,15 @@ class Matrix:
         # The report is meant for release-checklist attachment. A notebook
         # inventory contains private titles and stable ids; the cell needs only
         # the count to prove the RPC succeeded.
-        if proc.returncode == 0 and isinstance(self.results[-1].get("json"), dict):
-            self.results[-1]["json"] = {"count": self.results[-1]["json"].get("count")}
+        result = self.results[-1]
+        payload = result.pop("json", None)
+        result.pop("json_error", None)
+        count = payload.get("count") if isinstance(payload, dict) else None
+        if proc.returncode == 0 and type(count) is int and count >= 0:
+            result["json"] = {"count": count}
+        elif proc.returncode == 0:
+            result["status"] = "fail"
+            result["json_error"] = "baseline response has no non-negative integer count"
 
     def phase_browser_discovery(self) -> None:
         proc = self.cli(DEFAULT_HOME, "auth", "inspect", "--browser", self.args.browser, "--json")
@@ -338,38 +388,65 @@ class Matrix:
     def phase_concurrency(self) -> None:
         home = self.temp / "concurrency"
         self.copy_profile(self.args.profile, home, "shared")
-        processes = [
-            subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "notebooklm.notebooklm_cli",
-                    "--profile",
-                    "shared",
-                    "auth",
-                    "refresh",
-                    "--verify",
-                    "--json",
-                ],
-                cwd=ROOT,
-                env=self.env(home),
-                text=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
-            for _ in range(4)
+        command = [
+            sys.executable,
+            "-m",
+            "notebooklm.notebooklm_cli",
+            "--profile",
+            "shared",
+            "auth",
+            "refresh",
+            "--verify",
+            "--json",
         ]
+        processes: list[subprocess.Popen[str]] = []
         statuses: list[int] = []
         stderrs: list[str] = []
-        for proc in processes:
-            try:
-                _out, err = proc.communicate(timeout=self.args.timeout)
-                statuses.append(proc.returncode)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                _out, err = proc.communicate()
-                statuses.append(-1)
-            stderrs.append(err or "")
+        launch_error: str | None = None
+        try:
+            for _ in range(4):
+                try:
+                    processes.append(
+                        subprocess.Popen(
+                            command,
+                            cwd=ROOT,
+                            env=self.env(home),
+                            text=True,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.PIPE,
+                            **self._process_group_options(),
+                        )
+                    )
+                except OSError as exc:
+                    launch_error = type(exc).__name__
+                    break
+
+            if launch_error is None:
+                for proc in processes:
+                    try:
+                        _out, err = proc.communicate(timeout=self.args.timeout)
+                        statuses.append(proc.returncode)
+                    except subprocess.TimeoutExpired:
+                        self._terminate_process_tree(proc)
+                        _out, err = proc.communicate()
+                        statuses.append(-1)
+                    stderrs.append(err or "")
+        finally:
+            for proc in processes:
+                if proc.poll() is None:
+                    self._terminate_process_tree(proc)
+                    proc.communicate()
+
+        if launch_error is not None:
+            self.results.append(
+                {
+                    "name": "concurrent-refresh",
+                    "status": "fail",
+                    "returncodes": [127],
+                    "error": f"unable to launch refresh worker: {launch_error}",
+                }
+            )
+            return
         entry: dict[str, Any] = {
             "name": "concurrent-refresh",
             "status": "pass" if statuses == [0] * 4 else "fail",
@@ -440,13 +517,16 @@ class Matrix:
             "import asyncio, json\n"
             "from notebooklm import NotebookLMClient\n"
             "from notebooklm._auth import session as auth_session\n"
+            "def require(condition, message):\n"
+            "    if not condition:\n"
+            "        raise RuntimeError(message)\n"
             "async def main():\n"
             "    reload_calls = 0\n"
             "    original_reload = getattr(auth_session, 'try_storage_cookie_reload', None)\n"
             "    async def tracked_reload(*args, **kwargs):\n"
             "        nonlocal reload_calls\n"
             "        reload_calls += 1\n"
-            "        assert original_reload is not None\n"
+            "        require(original_reload is not None, 'storage reload helper unavailable')\n"
             "        return await original_reload(*args, **kwargs)\n"
             "    async def forbidden(*args, **kwargs):\n"
             "        raise AssertionError('external recovery rung reached')\n"
@@ -457,12 +537,14 @@ class Matrix:
             "    auth_session._try_master_token_reauth = forbidden\n"
             "    async with NotebookLMClient.from_storage(profile='mid-session-storage') as c:\n"
             "        before = await c.notebooks.list()\n"
+            "        before_ids = tuple(sorted(item.id for item in before))\n"
             "        live = c._collaborators.kernel.get_http_client().cookies\n"
             "        live.clear()\n"
             "        after = await c.notebooks.list()\n"
-            "        assert reload_calls > 0, 'storage reload rung was not exercised'\n"
-            "        assert len(live) > 0, 'storage reload did not restore the live jar'\n"
-            "        assert len(before) == len(after), 'notebook result changed after recovery'\n"
+            "        after_ids = tuple(sorted(item.id for item in after))\n"
+            "        require(reload_calls > 0, 'storage reload rung was not exercised')\n"
+            "        require(len(live) > 0, 'storage reload did not restore the live jar')\n"
+            "        require(before_ids == after_ids, 'notebook identity changed after recovery')\n"
             "        print(json.dumps({'before': len(before), 'after': len(after), "
             "'reload_calls': reload_calls, 'live_cookies': len(live)}))\n"
             "asyncio.run(main())\n"
@@ -497,6 +579,10 @@ class Matrix:
             from notebooklm import NotebookLMClient
             from notebooklm._auth import session as auth_session
 
+            def require(condition, message):
+                if not condition:
+                    raise RuntimeError(message)
+
             async def main():
                 reload_calls = 0
                 original_reload = auth_session.try_storage_cookie_reload
@@ -519,6 +605,7 @@ class Matrix:
 
                 async with NotebookLMClient.from_storage(profile="mid-session-sibling") as client:
                     before = await client.notebooks.list()
+                    before_ids = tuple(sorted(item.id for item in before))
                     sibling = subprocess.run(
                         [
                             sys.executable,
@@ -535,17 +622,29 @@ class Matrix:
                         timeout=90,
                         check=False,
                     )
-                    assert sibling.returncode == 0, sibling.stderr[-1000:]
+                    require(sibling.returncode == 0, sibling.stderr[-1000:])
                     after_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
-                    assert after_hash != before_hash, "sibling re-mint did not replace profile state"
+                    require(
+                        after_hash != before_hash,
+                        "sibling re-mint did not replace profile state",
+                    )
                     (profile_dir / "master_token.json").unlink()
                     live = client._collaborators.kernel.get_http_client().cookies
                     live.clear()
                     recovered = await asyncio.gather(*(client.notebooks.list() for _ in range(4)))
                     counts = [len(items) for items in recovered]
-                    assert counts == [len(before)] * 4
-                    assert 0 < reload_calls <= 3, "concurrent RPCs did not share one recovery wave"
-                    assert len(live) > 0
+                    recovered_ids = [
+                        tuple(sorted(item.id for item in items)) for items in recovered
+                    ]
+                    require(
+                        recovered_ids == [before_ids] * 4,
+                        "notebook identity changed after sibling recovery",
+                    )
+                    require(
+                        0 < reload_calls <= 3,
+                        "concurrent RPCs did not share one recovery wave",
+                    )
+                    require(len(live) > 0, "sibling recovery did not restore the live jar")
                     print(json.dumps({
                         "before": len(before),
                         "after": counts,
@@ -586,6 +685,10 @@ class Matrix:
             from notebooklm import NotebookLMClient
             from notebooklm._auth import session as auth_session
 
+            def require(condition, message):
+                if not condition:
+                    raise RuntimeError(message)
+
             async def main():
                 master_calls = 0
                 original_master = auth_session._try_master_token_reauth
@@ -601,6 +704,7 @@ class Matrix:
 
                 async with NotebookLMClient.from_storage(profile="mid-session-master") as client:
                     before = await client.notebooks.list()
+                    before_ids = tuple(sorted(item.id for item in before))
                     state = json.loads(storage.read_text(encoding="utf-8"))
                     state["cookies"] = []
                     replacement = storage.with_suffix(".matrix-tmp")
@@ -609,11 +713,21 @@ class Matrix:
                     live = client._collaborators.kernel.get_http_client().cookies
                     live.clear()
                     after = await client.notebooks.list()
+                    after_ids = tuple(sorted(item.id for item in after))
                     persisted = json.loads(storage.read_text(encoding="utf-8"))
-                    assert len(before) == len(after)
-                    assert master_calls == 1, "mid-session Layer-4 recovery was not exercised once"
-                    assert persisted.get("cookies"), "master-token recovery did not repair storage"
-                    assert len(live) > 0
+                    require(
+                        before_ids == after_ids,
+                        "notebook identity changed after master-token recovery",
+                    )
+                    require(
+                        master_calls == 1,
+                        "mid-session Layer-4 recovery was not exercised once",
+                    )
+                    require(
+                        persisted.get("cookies"),
+                        "master-token recovery did not repair storage",
+                    )
+                    require(len(live) > 0, "master-token recovery did not restore live jar")
                     print(json.dumps({
                         "before": len(before),
                         "after": len(after),
@@ -664,6 +778,13 @@ class Matrix:
             TOKEN = "matrix-rest-token"
             HEADERS = {"Authorization": f"Bearer {TOKEN}", "Host": "127.0.0.1"}
 
+            def require(condition, message):
+                if not condition:
+                    raise RuntimeError(message)
+
+            def notebook_ids(response):
+                return tuple(sorted(item["id"] for item in response.json()["notebooks"]))
+
             async def mid_session():
                 holder = {}
 
@@ -684,11 +805,11 @@ class Matrix:
                         transport=transport, base_url="http://127.0.0.1"
                     ) as http:
                         before = await http.get("/v1/notebooks", headers=HEADERS)
-                        assert before.status_code == 200, before.text[-1000:]
+                        require(before.status_code == 200, before.text[-1000:])
                         holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
                         after = await http.get("/v1/notebooks", headers=HEADERS)
-                        assert after.status_code == 200, after.text[-1000:]
-                        return len(before.json()["notebooks"]), len(after.json()["notebooks"])
+                        require(after.status_code == 200, after.text[-1000:])
+                        return notebook_ids(before), notebook_ids(after)
 
             async def stale_startup():
                 profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "rest-stale"
@@ -704,7 +825,10 @@ class Matrix:
 
                 app = create_app(profile="rest-stale")
                 async with app.router.lifespan_context(app):
-                    assert app.state.notebooklm.client is None
+                    require(
+                        app.state.notebooklm.client is None,
+                        "REST server did not enter degraded startup",
+                    )
                     held_token.replace(token)
                     sibling = subprocess.run(
                         [
@@ -722,7 +846,7 @@ class Matrix:
                         timeout=90,
                         check=False,
                     )
-                    assert sibling.returncode == 0, sibling.stderr[-1000:]
+                    require(sibling.returncode == 0, sibling.stderr[-1000:])
                     transport = httpx.ASGITransport(
                         app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
                     )
@@ -730,18 +854,24 @@ class Matrix:
                         transport=transport, base_url="http://127.0.0.1"
                     ) as http:
                         response = await http.get("/v1/notebooks", headers=HEADERS)
-                    assert response.status_code == 200, response.text[-1000:]
-                    assert app.state.notebooklm.client is not None
-                    return len(response.json()["notebooks"])
+                    require(response.status_code == 200, response.text[-1000:])
+                    require(
+                        app.state.notebooklm.client is not None,
+                        "REST server did not bind a recovered client",
+                    )
+                    return notebook_ids(response)
 
             async def main():
-                before, after = await mid_session()
-                rebound = await stale_startup()
-                assert before == after == rebound
+                before_ids, after_ids = await mid_session()
+                rebound_ids = await stale_startup()
+                require(
+                    before_ids == after_ids == rebound_ids,
+                    "REST recovery changed notebook identity",
+                )
                 print(json.dumps({
-                    "before": before,
-                    "after_live_reload": after,
-                    "after_stale_startup_rebind": rebound,
+                    "before": len(before_ids),
+                    "after_live_reload": len(after_ids),
+                    "after_stale_startup_rebind": len(rebound_ids),
                     "stale_startup_rebound": True,
                 }))
 
@@ -780,6 +910,10 @@ class Matrix:
             from notebooklm import NotebookLMClient
             from notebooklm.mcp.server import create_server
 
+            def require(condition, message):
+                if not condition:
+                    raise RuntimeError(message)
+
             async def main():
                 holder = {}
 
@@ -794,18 +928,36 @@ class Matrix:
                 server = create_server(profile="mcp-live", client_factory=factory)
                 async with Client(server) as mcp:
                     before_result = await mcp.call_tool("notebook_list", {"limit": 50})
-                    assert before_result.structured_content is not None
+                    require(
+                        before_result.structured_content is not None,
+                        "MCP baseline returned no structured content",
+                    )
                     before = before_result.structured_content
-                    assert "total" in before and "notebooks" in before
+                    require(
+                        "total" in before and "notebooks" in before,
+                        "MCP baseline response is incomplete",
+                    )
                     holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
                     after_result = await mcp.call_tool("notebook_list", {"limit": 50})
-                    assert after_result.structured_content is not None
+                    require(
+                        after_result.structured_content is not None,
+                        "MCP recovery returned no structured content",
+                    )
                     after = after_result.structured_content
-                    assert "total" in after and "notebooks" in after
-                    assert before.get("total") == after.get("total")
-                    assert before.get("notebooks") == after.get("notebooks")
+                    require(
+                        "total" in after and "notebooks" in after,
+                        "MCP recovery response is incomplete",
+                    )
+                    require(
+                        before.get("total") == after.get("total"),
+                        "MCP recovery changed the notebook count",
+                    )
+                    require(
+                        before.get("notebooks") == after.get("notebooks"),
+                        "MCP recovery changed notebook identity",
+                    )
                     live = holder["client"]._collaborators.kernel.get_http_client().cookies
-                    assert len(live) > 0
+                    require(len(live) > 0, "MCP recovery did not restore the live jar")
                     print(json.dumps({
                         "before": before.get("total"),
                         "after": after.get("total"),
@@ -846,6 +998,10 @@ class Matrix:
             from notebooklm import NotebookLMClient
             from notebooklm._auth import session as auth_session
 
+            def require(condition, message):
+                if not condition:
+                    raise RuntimeError(message)
+
             async def main():
                 refresh_calls = 0
                 original_refresh = auth_session._try_refresh_cmd_reauth
@@ -861,6 +1017,7 @@ class Matrix:
 
                 async with NotebookLMClient.from_storage(profile="mid-session-browser") as client:
                     before = await client.notebooks.list()
+                    before_ids = tuple(sorted(item.id for item in before))
                     state = json.loads(storage.read_text(encoding="utf-8"))
                     state["cookies"] = []
                     replacement = storage.with_suffix(".matrix-tmp")
@@ -869,9 +1026,16 @@ class Matrix:
                     live = client._collaborators.kernel.get_http_client().cookies
                     live.clear()
                     after = await client.notebooks.list()
-                    assert len(before) == len(after)
-                    assert refresh_calls == 1, "browser refresh command rung was not exercised once"
-                    assert len(live) > 0
+                    after_ids = tuple(sorted(item.id for item in after))
+                    require(
+                        before_ids == after_ids,
+                        "notebook identity changed after browser recovery",
+                    )
+                    require(
+                        refresh_calls == 1,
+                        "browser refresh command rung was not exercised once",
+                    )
+                    require(len(live) > 0, "browser recovery did not restore live jar")
                     print(json.dumps({
                         "before": len(before),
                         "after": len(after),

--- a/scripts/live_auth_matrix.py
+++ b/scripts/live_auth_matrix.py
@@ -821,6 +821,7 @@ class Matrix:
                 replacement = storage.with_suffix(".matrix-tmp")
                 replacement.write_text(json.dumps(state), encoding="utf-8")
                 os.replace(replacement, storage)
+                require(token.is_file(), "rest-stale profile has no master_token.json")
                 token.replace(held_token)
 
                 app = create_app(profile="rest-stale")

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -125,6 +125,23 @@ def test_main_bundle_file_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str
     assert outcome.read_text(encoding="utf-8") == "drift\n"
 
 
+def test_main_clears_stale_outcome_before_unclassified_startup_failure(tmp_path: Path) -> None:
+    outcome = tmp_path / "outcome.txt"
+    outcome.write_text("drift\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError):
+        main(
+            [
+                "--types",
+                str(tmp_path / "missing-types.py"),
+                "--outcome-file",
+                str(outcome),
+            ]
+        )
+
+    assert not outcome.exists()
+
+
 def test_main_reports_bundle_auth_failure_without_drift(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 from scripts.capture_rpc_registry import (
+    _BundleAuthenticationError,
+    _BundleInfrastructureError,
     _normalize_label,
     _service_of,
     classify_service,
@@ -105,7 +107,139 @@ def test_main_bundle_file_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str
     assert "NewOne" in out  # an unmapped live RPC is listed
 
     # --check turns the ABSENT id (ZZxxYY/GONE) into a non-zero exit
-    assert main(["--bundle-file", str(bundle), "--types", str(types), "--check"]) == 1
+    outcome = tmp_path / "outcome.txt"
+    assert (
+        main(
+            [
+                "--bundle-file",
+                str(bundle),
+                "--types",
+                str(types),
+                "--check",
+                "--outcome-file",
+                str(outcome),
+            ]
+        )
+        == 1
+    )
+    assert outcome.read_text(encoding="utf-8") == "drift\n"
+
+
+def test_main_reports_bundle_auth_failure_without_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unreadable authenticated homepage is auth exit 2, never RPC drift."""
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    outcome = tmp_path / "outcome.txt"
+
+    def fail_auth() -> str:
+        raise _BundleAuthenticationError(
+            "NotebookLM redirected this request to its region / anti-abuse access gate: "
+            "https://notebooklm.google/ (location=unsupported)."
+        )
+
+    monkeypatch.setattr("scripts.capture_rpc_registry.fetch_bundle", fail_auth)
+
+    assert (
+        main(
+            [
+                "--types",
+                str(types),
+                "--check",
+                "--check-enums",
+                "--outcome-file",
+                str(outcome),
+            ]
+        )
+        == 2
+    )
+    assert outcome.read_text(encoding="utf-8") == "authentication\n"
+    captured = capsys.readouterr()
+    assert "AUTHENTICATION FAILURE" in captured.err
+    assert "location=unsupported" in captured.err
+    assert "No RPC or studio-enum drift conclusion was drawn" in captured.err
+    assert "ABSENT" not in captured.out
+    assert "FAIL:" not in captured.err
+
+
+def test_main_json_reports_typed_bundle_auth_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+
+    def fail_auth() -> str:
+        raise _BundleAuthenticationError("Authentication expired or invalid.")
+
+    monkeypatch.setattr("scripts.capture_rpc_registry.fetch_bundle", fail_auth)
+
+    assert main(["--types", str(types), "--json"]) == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "error": {
+            "kind": "authentication",
+            "message": "Authentication expired or invalid.",
+        }
+    }
+
+
+def test_main_reports_bundle_infrastructure_failure_without_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+
+    def fail_infrastructure() -> str:
+        raise _BundleInfrastructureError("No readable JS bundle content was available.")
+
+    monkeypatch.setattr("scripts.capture_rpc_registry.fetch_bundle", fail_infrastructure)
+
+    assert main(["--types", str(types), "--check", "--check-enums"]) == 2
+    captured = capsys.readouterr()
+    assert "INFRASTRUCTURE FAILURE" in captured.err
+    assert "No RPC or studio-enum drift conclusion was drawn" in captured.err
+    assert "ABSENT" not in captured.out
+
+
+def test_main_json_reports_typed_bundle_infrastructure_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    outcome = tmp_path / "outcome.txt"
+
+    def fail_infrastructure() -> str:
+        raise _BundleInfrastructureError("Bundle CDN was unavailable.")
+
+    monkeypatch.setattr("scripts.capture_rpc_registry.fetch_bundle", fail_infrastructure)
+
+    assert (
+        main(
+            [
+                "--types",
+                str(types),
+                "--json",
+                "--outcome-file",
+                str(outcome),
+            ]
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out) == {
+        "error": {
+            "kind": "infrastructure",
+            "message": "Bundle CDN was unavailable.",
+        }
+    }
+    assert outcome.read_text(encoding="utf-8") == "infrastructure\n"
 
 
 def test_service_of() -> None:

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -283,6 +283,7 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     assert 'http.get("/v1/notebooks"' in rest_script
     assert "app.state.notebooklm.client is None" in rest_script
     assert "--master-token-refresh" in rest_script
+    assert 'require(token.is_file(), "rest-stale profile has no master_token.json")' in rest_script
     assert "before_ids == after_ids == rebound_ids" in rest_script
 
     mcp_script = by_profile["mcp-live"][0][-1]

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -13,20 +13,19 @@ from scripts import live_auth_matrix
 
 
 def _args(*, skip_browser: bool) -> argparse.Namespace:
-    return argparse.Namespace(
-        profile="source",
-        account="maintainer@example.com",
-        browser="chromium::Profile 3",
-        base_url="https://notebooklm.google.com",
-        timeout=10,
-        output=None,
-        skip_browser=skip_browser,
-        rpc_health_full=False,
-        read_only_notebook_id=None,
-        generation_notebook_id=None,
-        skip_rest=False,
-        skip_mcp=False,
-    )
+    argv = [
+        "--profile",
+        "source",
+        "--account",
+        "maintainer@example.com",
+        "--base-url",
+        "https://notebooklm.google.com",
+        "--timeout",
+        "10",
+    ]
+    if skip_browser:
+        argv.append("--skip-browser")
+    return live_auth_matrix.parse_args(argv)
 
 
 def _source_profile(tmp_path: Path) -> Path:
@@ -200,34 +199,37 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     finally:
         live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
 
-    rpc_command, rpc_env = calls[0]
+    by_profile = {env["NOTEBOOKLM_PROFILE"]: (command, env) for command, env in calls}
+    assert len(by_profile) == len(calls), "a phase issued more than one subprocess call"
+
+    rpc_command, rpc_env = by_profile["rpc-health"]
     assert rpc_command[-1] == "--full"
     assert "check_rpc_health.py" in rpc_command[-2]
     assert rpc_env["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"] == "read-only-id"
     assert rpc_env["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] == "generation-id"
 
-    sibling_script = calls[1][0][-1]
+    sibling_script = by_profile["mid-session-sibling"][0][-1]
     assert "--master-token-refresh" in sibling_script
     assert "asyncio.gather" in sibling_script
     assert "reload_calls <= 3" in sibling_script
 
-    master_script = calls[2][0][-1]
+    master_script = by_profile["mid-session-master"][0][-1]
     assert 'state["cookies"] = []' in master_script
     assert "tracked_master" in master_script
     assert "master_calls == 1" in master_script
 
-    rest_script = calls[3][0][-1]
+    rest_script = by_profile["rest-live"][0][-1]
     assert 'http.get("/v1/notebooks"' in rest_script
     assert "app.state.notebooklm.client is None" in rest_script
     assert "--master-token-refresh" in rest_script
 
-    mcp_script = calls[4][0][-1]
+    mcp_script = by_profile["mcp-live"][0][-1]
     assert 'mcp.call_tool("notebook_list"' in mcp_script
     assert "keepalive=600.0" in mcp_script
     assert 'assert "total" in before and "notebooks" in before' in mcp_script
 
-    browser_script = calls[5][0][-1]
-    browser_env = calls[5][1]
+    browser_command, browser_env = by_profile["mid-session-browser"]
+    browser_script = browser_command[-1]
     assert 'state["cookies"] = []' in browser_script
     assert "tracked_refresh" in browser_script
     assert "refresh_calls == 1" in browser_script

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -1,0 +1,235 @@
+"""Behavioral wiring tests for the maintainer live-auth matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import live_auth_matrix
+
+
+def _args(*, skip_browser: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        profile="source",
+        account="maintainer@example.com",
+        browser="chromium::Profile 3",
+        base_url="https://notebooklm.google.com",
+        timeout=10,
+        output=None,
+        skip_browser=skip_browser,
+        rpc_health_full=False,
+        read_only_notebook_id=None,
+        generation_notebook_id=None,
+        skip_rest=False,
+        skip_mcp=False,
+    )
+
+
+def _source_profile(tmp_path: Path) -> Path:
+    source = tmp_path / "profiles" / "source"
+    source.mkdir(parents=True)
+    (source / "storage_state.json").write_text('{"cookies": []}', encoding="utf-8")
+    (source / "master_token.json").write_text('{"token": "test-only"}', encoding="utf-8")
+    return source
+
+
+def test_skip_browser_still_runs_storage_and_access_gate_cells(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    calls: list[str] = []
+
+    always = (
+        "phase_baseline",
+        "phase_master_refresh",
+        "phase_import_filter",
+        "phase_hosts",
+        "phase_rpc_bundle_health",
+        "phase_rpc_health",
+        "phase_concurrency",
+        "phase_storage_mid_session",
+        "phase_sibling_concurrent_mid_session",
+        "phase_master_token_mid_session",
+        "phase_rest_auth_recovery",
+        "phase_mcp_auth_recovery",
+        "phase_rpc_access_gate_contract",
+        "phase_fault_injection",
+        "phase_crash_safety",
+    )
+    for name in always:
+        monkeypatch.setattr(matrix, name, lambda name=name: calls.append(name))
+    monkeypatch.setattr(
+        matrix,
+        "phase_browser_discovery",
+        lambda: pytest.fail("browser discovery must be skipped"),
+    )
+    monkeypatch.setattr(
+        matrix,
+        "phase_browser_login",
+        lambda: pytest.fail("browser login must be skipped"),
+    )
+    monkeypatch.setattr(
+        matrix,
+        "phase_browser_mid_session",
+        lambda: pytest.fail("browser refresh must be skipped"),
+    )
+    monkeypatch.setattr(matrix, "revision", lambda: "test-revision")
+    monkeypatch.setattr(
+        matrix,
+        "worktree_info",
+        lambda: {"worktree_dirty": False, "worktree_diff_hash": "test"},
+    )
+
+    assert matrix.run() == 0
+    capsys.readouterr()
+    assert calls == list(always)
+
+
+def test_storage_mid_session_cell_disables_every_external_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        observed["command"] = command
+        observed["env"] = env
+        copied = matrix.temp / "mid-session-storage" / "profiles" / "mid-session-storage"
+        assert not (copied / "master_token.json").exists()
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            json.dumps({"before": 2, "after": 2, "reload_calls": 1, "live_cookies": 8}),
+            "",
+        )
+
+    monkeypatch.setattr(live_auth_matrix.subprocess, "run", fake_run)
+    try:
+        matrix.phase_storage_mid_session()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    env = observed["env"]
+    assert isinstance(env, dict)
+    assert env["NOTEBOOKLM_REFRESH_BROWSER"] == ""
+    assert env["NOTEBOOKLM_REFRESH_CMD"] == ""
+    assert env["NOTEBOOKLM_REFRESH_CMD_MIDSESSION"] == ""
+    assert env["NOTEBOOKLM_PROFILE"] == "mid-session-storage"
+    command = observed["command"]
+    assert isinstance(command, list)
+    child_script = command[-1]
+    assert "try_storage_cookie_reload = tracked_reload" in child_script
+    assert "external recovery rung reached" in child_script
+    assert matrix.results == [
+        {
+            "name": "mid-session-storage-reload",
+            "status": "pass",
+            "returncode": 0,
+            "json": {"before": 2, "after": 2, "reload_calls": 1, "live_cookies": 8},
+        }
+    ]
+
+
+def test_baseline_report_keeps_count_but_not_private_notebook_inventory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    responses = iter(
+        (
+            subprocess.CompletedProcess(["auth"], 0, '{"status": "ok"}', ""),
+            subprocess.CompletedProcess(
+                ["list"],
+                0,
+                '{"count": 1, "notebooks": [{"id": "private-id", "title": "Private"}]}',
+                "",
+            ),
+        )
+    )
+    monkeypatch.setattr(matrix, "cli", lambda *args, **kwargs: next(responses))
+    try:
+        matrix.phase_baseline()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert matrix.results[1]["json"] == {"count": 1}
+    assert "private-id" not in json.dumps(matrix.results)
+
+
+def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    matrix.args.rpc_health_full = True
+    matrix.args.read_only_notebook_id = "read-only-id"
+    matrix.args.generation_notebook_id = "generation-id"
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        if env.get("NOTEBOOKLM_PROFILE") == "mid-session-browser":
+            browser_profile = (
+                matrix.temp / "mid-session-browser" / "profiles" / "mid-session-browser"
+            )
+            assert not (browser_profile / "master_token.json").exists()
+        calls.append((command, env))
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    monkeypatch.setattr(live_auth_matrix.subprocess, "run", fake_run)
+    try:
+        matrix.phase_rpc_health()
+        matrix.phase_sibling_concurrent_mid_session()
+        matrix.phase_master_token_mid_session()
+        matrix.phase_rest_auth_recovery()
+        matrix.phase_mcp_auth_recovery()
+        matrix.phase_browser_mid_session()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    rpc_command, rpc_env = calls[0]
+    assert rpc_command[-1] == "--full"
+    assert "check_rpc_health.py" in rpc_command[-2]
+    assert rpc_env["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"] == "read-only-id"
+    assert rpc_env["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] == "generation-id"
+
+    sibling_script = calls[1][0][-1]
+    assert "--master-token-refresh" in sibling_script
+    assert "asyncio.gather" in sibling_script
+    assert "reload_calls <= 3" in sibling_script
+
+    master_script = calls[2][0][-1]
+    assert 'state["cookies"] = []' in master_script
+    assert "tracked_master" in master_script
+    assert "master_calls == 1" in master_script
+
+    rest_script = calls[3][0][-1]
+    assert 'http.get("/v1/notebooks"' in rest_script
+    assert "app.state.notebooklm.client is None" in rest_script
+    assert "--master-token-refresh" in rest_script
+
+    mcp_script = calls[4][0][-1]
+    assert 'mcp.call_tool("notebook_list"' in mcp_script
+    assert "keepalive=600.0" in mcp_script
+    assert 'assert "total" in before and "notebooks" in before' in mcp_script
+
+    browser_script = calls[5][0][-1]
+    browser_env = calls[5][1]
+    assert 'state["cookies"] = []' in browser_script
+    assert "tracked_refresh" in browser_script
+    assert "refresh_calls == 1" in browser_script
+    assert browser_env["NOTEBOOKLM_PROFILE"] == "mid-session-browser"
+    assert browser_env["NOTEBOOKLM_HEADLESS_REAUTH"] == ""

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -98,11 +101,19 @@ def test_storage_mid_session_cell_disables_every_external_fallback(
     matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
     observed: dict[str, object] = {}
 
-    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        env = kwargs["env"]
-        assert isinstance(env, dict)
+    def fake_run(
+        command: list[str],
+        home: Path,
+        *,
+        timeout: int | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = matrix.env(home, **(env_overrides or {}))
+        if len(command) >= 3 and command[-2] == "-c":
+            compile(command[-1], "<live-auth-matrix-cell>", "exec")
         observed["command"] = command
         observed["env"] = env
+        observed["timeout"] = timeout
         copied = matrix.temp / "mid-session-storage" / "profiles" / "mid-session-storage"
         assert not (copied / "master_token.json").exists()
         return subprocess.CompletedProcess(
@@ -112,7 +123,7 @@ def test_storage_mid_session_cell_disables_every_external_fallback(
             "",
         )
 
-    monkeypatch.setattr(live_auth_matrix.subprocess, "run", fake_run)
+    monkeypatch.setattr(matrix, "_run", fake_run)
     try:
         matrix.phase_storage_mid_session()
     finally:
@@ -129,6 +140,8 @@ def test_storage_mid_session_cell_disables_every_external_fallback(
     child_script = command[-1]
     assert "try_storage_cookie_reload = tracked_reload" in child_script
     assert "external recovery rung reached" in child_script
+    assert "before_ids == after_ids" in child_script
+    assert "assert " not in child_script
     assert matrix.results == [
         {
             "name": "mid-session-storage-reload",
@@ -166,6 +179,42 @@ def test_baseline_report_keeps_count_but_not_private_notebook_inventory(
     assert "private-id" not in json.dumps(matrix.results)
 
 
+@pytest.mark.parametrize(
+    ("returncode", "stdout"),
+    [
+        (0, '[{"id": "private-id", "title": "Private"}]'),
+        (0, '{"notebooks": [{"id": "private-id", "title": "Private"}]}'),
+        (0, "not-json-private-id"),
+        (1, '{"count": 1, "notebooks": [{"id": "private-id"}]}'),
+    ],
+)
+def test_baseline_report_fails_closed_without_private_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    returncode: int,
+    stdout: str,
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    responses = iter(
+        (
+            subprocess.CompletedProcess(["auth"], 0, '{"status": "ok"}', ""),
+            subprocess.CompletedProcess(["list"], returncode, stdout, "list failed"),
+        )
+    )
+    monkeypatch.setattr(matrix, "cli", lambda *args, **kwargs: next(responses))
+    try:
+        matrix.phase_baseline()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    result = matrix.results[1]
+    assert result["status"] == "fail"
+    assert "json" not in result
+    assert "private-id" not in json.dumps(result)
+
+
 def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -175,20 +224,27 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     matrix.args.rpc_health_full = True
     matrix.args.read_only_notebook_id = "read-only-id"
     matrix.args.generation_notebook_id = "generation-id"
-    calls: list[tuple[list[str], dict[str, str]]] = []
+    calls: list[tuple[list[str], dict[str, str], int | None]] = []
 
-    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        env = kwargs["env"]
-        assert isinstance(env, dict)
+    def fake_run(
+        command: list[str],
+        home: Path,
+        *,
+        timeout: int | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = matrix.env(home, **(env_overrides or {}))
+        if len(command) >= 3 and command[-2] == "-c":
+            compile(command[-1], "<live-auth-matrix-cell>", "exec")
         if env.get("NOTEBOOKLM_PROFILE") == "mid-session-browser":
             browser_profile = (
                 matrix.temp / "mid-session-browser" / "profiles" / "mid-session-browser"
             )
             assert not (browser_profile / "master_token.json").exists()
-        calls.append((command, env))
+        calls.append((command, env, timeout))
         return subprocess.CompletedProcess(command, 0, "{}", "")
 
-    monkeypatch.setattr(live_auth_matrix.subprocess, "run", fake_run)
+    monkeypatch.setattr(matrix, "_run", fake_run)
     try:
         matrix.phase_rpc_health()
         matrix.phase_sibling_concurrent_mid_session()
@@ -199,39 +255,161 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     finally:
         live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
 
-    by_profile = {env["NOTEBOOKLM_PROFILE"]: (command, env) for command, env in calls}
+    by_profile = {
+        env["NOTEBOOKLM_PROFILE"]: (command, env, timeout) for command, env, timeout in calls
+    }
     assert len(by_profile) == len(calls), "a phase issued more than one subprocess call"
 
-    rpc_command, rpc_env = by_profile["rpc-health"]
+    rpc_command, rpc_env, rpc_timeout = by_profile["rpc-health"]
     assert rpc_command[-1] == "--full"
     assert "check_rpc_health.py" in rpc_command[-2]
     assert rpc_env["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"] == "read-only-id"
     assert rpc_env["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] == "generation-id"
+    assert rpc_timeout == 300
 
     sibling_script = by_profile["mid-session-sibling"][0][-1]
     assert "--master-token-refresh" in sibling_script
     assert "asyncio.gather" in sibling_script
     assert "reload_calls <= 3" in sibling_script
+    assert "recovered_ids == [before_ids] * 4" in sibling_script
 
     master_script = by_profile["mid-session-master"][0][-1]
     assert 'state["cookies"] = []' in master_script
     assert "tracked_master" in master_script
     assert "master_calls == 1" in master_script
+    assert "before_ids == after_ids" in master_script
 
     rest_script = by_profile["rest-live"][0][-1]
     assert 'http.get("/v1/notebooks"' in rest_script
     assert "app.state.notebooklm.client is None" in rest_script
     assert "--master-token-refresh" in rest_script
+    assert "before_ids == after_ids == rebound_ids" in rest_script
 
     mcp_script = by_profile["mcp-live"][0][-1]
     assert 'mcp.call_tool("notebook_list"' in mcp_script
     assert "keepalive=600.0" in mcp_script
-    assert 'assert "total" in before and "notebooks" in before' in mcp_script
+    assert '"total" in before and "notebooks" in before' in mcp_script
 
-    browser_command, browser_env = by_profile["mid-session-browser"]
+    browser_command, browser_env, browser_timeout = by_profile["mid-session-browser"]
     browser_script = browser_command[-1]
     assert 'state["cookies"] = []' in browser_script
     assert "tracked_refresh" in browser_script
     assert "refresh_calls == 1" in browser_script
+    assert "before_ids == after_ids" in browser_script
     assert browser_env["NOTEBOOKLM_PROFILE"] == "mid-session-browser"
     assert browser_env["NOTEBOOKLM_HEADLESS_REAUTH"] == ""
+    assert browser_timeout == 180
+
+    child_scripts = [
+        sibling_script,
+        master_script,
+        rest_script,
+        mcp_script,
+        browser_script,
+    ]
+    assert all("assert " not in script for script in child_scripts)
+
+
+def test_run_normalizes_launch_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+
+    def fail_to_launch(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("private path must not be copied")
+
+    monkeypatch.setattr(live_auth_matrix.subprocess, "Popen", fail_to_launch)
+    try:
+        result = matrix._run(["missing-command"], tmp_path)
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert result.returncode == 127
+    assert result.stdout == ""
+    assert result.stderr == "unable to launch matrix phase: FileNotFoundError"
+    assert "private path" not in result.stderr
+
+
+def test_concurrent_refresh_reaps_started_worker_after_partial_launch_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+
+    class StartedProcess:
+        pid = 12345
+        returncode: int | None = None
+        terminated = False
+        communicated = False
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            self.communicated = True
+            self.returncode = -9
+            return "", ""
+
+    started = StartedProcess()
+    launch_calls = 0
+
+    def partial_launch(*args: object, **kwargs: object) -> StartedProcess:
+        nonlocal launch_calls
+        launch_calls += 1
+        if launch_calls == 1:
+            return started
+        raise OSError("private launch detail")
+
+    def terminate(process: object) -> None:
+        assert process is started
+        started.terminated = True
+
+    monkeypatch.setattr(live_auth_matrix.subprocess, "Popen", partial_launch)
+    monkeypatch.setattr(matrix, "_terminate_process_tree", terminate)
+    try:
+        matrix.phase_concurrency()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert started.terminated is True
+    assert started.communicated is True
+    assert matrix.results == [
+        {
+            "name": "concurrent-refresh",
+            "status": "fail",
+            "returncodes": [127],
+            "error": "unable to launch refresh worker: OSError",
+        }
+    ]
+    assert "private launch detail" not in json.dumps(matrix.results)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group regression")
+def test_run_terminates_descendant_processes_on_timeout(tmp_path: Path) -> None:
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    child_pid_path = tmp_path / "child.pid"
+    script = (
+        "import subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])\n"
+        "Path(sys.argv[1]).write_text(str(child.pid), encoding='utf-8')\n"
+        "time.sleep(60)\n"
+    )
+    try:
+        result = matrix._run(
+            [sys.executable, "-c", script, str(child_pid_path)],
+            tmp_path,
+            timeout=1,
+        )
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        for _ in range(40):
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("timed-out matrix phase left its descendant running")
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert result.returncode == 124

--- a/tests/unit/test_rpc_health_bundle_lane.py
+++ b/tests/unit/test_rpc_health_bundle_lane.py
@@ -1,0 +1,123 @@
+"""Regression guards for RPC bundle auth-vs-drift reporting (#2174/#2175)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rpc-health.yml"
+
+
+def _steps() -> list[dict[str, Any]]:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["health-check"]["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"step not found in rpc-health.yml: {name!r}")
+
+
+def test_bundle_lane_maps_health_auth_failure_to_typed_bundle_exit() -> None:
+    step = _step("Run bundle drift monitor")
+    assert step["env"]["HEALTH_EXIT_CODE"] == "${{ steps.health.outputs.exit_code }}"
+    script = step["run"]
+    assert 'if [ "$HEALTH_EXIT_CODE" = "2" ]' in script
+    assert 'echo "outcome=authentication" >> "$GITHUB_OUTPUT"' in script
+    assert 'echo "exit_code=2" >> "$GITHUB_OUTPUT"' in script
+    assert "No RPC or studio-enum drift conclusion was drawn" in script
+
+
+def test_bundle_issue_lanes_explicitly_exclude_auth_exit() -> None:
+    for name in ("Check for existing bundle drift issue", "Create Issue on bundle drift"):
+        condition = _step(name)["if"]
+        assert "steps.bundle.outputs.outcome == 'drift'" in condition
+        assert "steps.bundle.outputs.exit_code == '1'" not in condition
+        assert "steps.bundle.outputs.exit_code !=" not in condition
+
+
+def test_bundle_auth_failure_routes_to_auth_issue_report() -> None:
+    prepare = _step("Prepare authentication failure report")
+    assert "steps.health.outputs.exit_code == '2'" in prepare["if"]
+    assert "steps.bundle.outputs.exit_code == '2'" in prepare["if"]
+    assert "bundle-drift-report.txt" in prepare["run"]
+
+    dedup = _step("Check for existing Auth Failure issue")
+    create = _step("Create Issue on Auth Failure")
+    for step in (dedup, create):
+        assert "steps.health.outputs.exit_code == '2'" in step["if"]
+        assert "steps.bundle.outputs.exit_code == '2'" in step["if"]
+        assert "||" in step["if"]
+    assert create["with"]["content-filepath"] == "auth-failure-report.txt"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_bundle_command_skips_capture_after_health_auth_failure(tmp_path: Path) -> None:
+    """Execute the auth branch: capture is skipped and no drift claim is emitted."""
+    output = tmp_path / "github-output"
+    proc = subprocess.run(
+        ["bash", "-c", _step("Run bundle drift monitor")["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "HEALTH_EXIT_CODE": "2",
+            "GITHUB_OUTPUT": str(output),
+            # If the branch accidentally invokes uv, the restricted PATH makes
+            # that regression fail instead of touching the network.
+            "PATH": "/usr/bin:/bin",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert output.read_text(encoding="utf-8") == "outcome=authentication\nexit_code=2\n"
+    report = (tmp_path / "bundle-drift-report.txt").read_text(encoding="utf-8")
+    assert "AUTHENTICATION FAILURE" in report
+    assert "No RPC or studio-enum drift conclusion was drawn" in report
+    assert "ABSENT" not in report
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_bundle_command_maps_unclassified_process_exit_to_runner_error(tmp_path: Path) -> None:
+    """A raw Python/uv exit 1 cannot impersonate a classified drift result."""
+    output = tmp_path / "github-output"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text("#!/bin/sh\necho synthetic runner crash >&2\nexit 1\n", encoding="utf-8")
+    fake_uv.chmod(0o755)
+
+    proc = subprocess.run(
+        ["bash", "-c", _step("Run bundle drift monitor")["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "HEALTH_EXIT_CODE": "0",
+            "GITHUB_OUTPUT": str(output),
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 2
+    assert output.read_text(encoding="utf-8") == "outcome=runner-error\nexit_code=2\n"
+    report = (tmp_path / "bundle-drift-report.txt").read_text(encoding="utf-8")
+    assert "synthetic runner crash" in report
+    assert "No RPC or studio-enum drift conclusion was drawn" in report

--- a/tests/unit/test_rpc_health_bundle_lane.py
+++ b/tests/unit/test_rpc_health_bundle_lane.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.repo_lint
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rpc-health.yml"
+BASH = shutil.which("bash")
 
 
 def _steps() -> list[dict[str, Any]]:
@@ -64,17 +65,20 @@ def test_bundle_auth_failure_routes_to_auth_issue_report() -> None:
     assert create["with"]["content-filepath"] == "auth-failure-report.txt"
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+@pytest.mark.skipif(BASH is None, reason="needs bash")
 def test_bundle_command_skips_capture_after_health_auth_failure(tmp_path: Path) -> None:
     """Execute the auth branch: capture is skipped and no drift claim is emitted."""
     output = tmp_path / "github-output"
+    assert BASH is not None
     proc = subprocess.run(
-        ["bash", "-c", _step("Run bundle drift monitor")["run"]],
+        [BASH, "-c", _step("Run bundle drift monitor")["run"]],
         cwd=tmp_path,
         env={
             **os.environ,
             "HEALTH_EXIT_CODE": "2",
-            "GITHUB_OUTPUT": str(output),
+            # A cwd-relative path works in POSIX shells and Git Bash. Passing
+            # ``C:\\...`` directly makes Bash interpret the drive/path syntax.
+            "GITHUB_OUTPUT": output.name,
             # If the branch accidentally invokes uv, the restricted PATH makes
             # that regression fail instead of touching the network.
             "PATH": "/usr/bin:/bin",
@@ -92,24 +96,27 @@ def test_bundle_command_skips_capture_after_health_auth_failure(tmp_path: Path) 
     assert "ABSENT" not in report
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+@pytest.mark.skipif(BASH is None, reason="needs bash")
 def test_bundle_command_maps_unclassified_process_exit_to_runner_error(tmp_path: Path) -> None:
     """A raw Python/uv exit 1 cannot impersonate a classified drift result."""
     output = tmp_path / "github-output"
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     fake_uv = bin_dir / "uv"
-    fake_uv.write_text("#!/bin/sh\necho synthetic runner crash >&2\nexit 1\n", encoding="utf-8")
+    fake_uv.write_bytes(b"#!/bin/sh\necho synthetic runner crash >&2\nexit 1\n")
     fake_uv.chmod(0o755)
 
+    assert BASH is not None
     proc = subprocess.run(
-        ["bash", "-c", _step("Run bundle drift monitor")["run"]],
+        [BASH, "-c", _step("Run bundle drift monitor")["run"]],
         cwd=tmp_path,
         env={
             **os.environ,
             "HEALTH_EXIT_CODE": "0",
-            "GITHUB_OUTPUT": str(output),
-            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "GITHUB_OUTPUT": output.name,
+            # The shell runs with cwd=tmp_path, so a relative POSIX entry also
+            # addresses the shim correctly under Git Bash on Windows.
+            "PATH": "./bin:/usr/bin:/bin",
         },
         text=True,
         capture_output=True,

--- a/tests/unit/test_rpc_health_rebrand_lane.py
+++ b/tests/unit/test_rpc_health_rebrand_lane.py
@@ -169,11 +169,12 @@ def test_main_issue_lanes_are_untouched_by_the_rebrand_lane() -> None:
     """Every health-script lane still keys off ``steps.health.outputs.exit_code``.
 
     The bundle-drift lane is a different script (``steps.bundle``) and keeps its
-    own gate; everything else the health script drives must stay exit-coded.
+    own gate. Authentication is intentionally shared because either script can
+    prove the homepage is unavailable; all remaining health-script lanes stay
+    keyed only to their health exit code.
     """
     expected = {
         "RPC ID Mismatch Detected": "1",
-        "RPC Health Check: Authentication Failure": "2",
         MAIN_ERROR_TITLE: "3",
         "Studio customization cohort flipped — re-capture VideoStyle codes": "4",
     }
@@ -185,6 +186,15 @@ def test_main_issue_lanes_are_untouched_by_the_rebrand_lane() -> None:
         seen.add(title)
         assert f"steps.health.outputs.exit_code == '{expected[title]}'" in step["if"]
     assert seen == set(expected)
+
+    auth = next(
+        step
+        for step in _issue_steps()
+        if step["with"]["title"] == "RPC Health Check: Authentication Failure"
+    )
+    assert "steps.health.outputs.exit_code == '2'" in auth["if"]
+    assert "steps.bundle.outputs.exit_code == '2'" in auth["if"]
+    assert "||" in auth["if"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scripts_auth_cookie_domains.py
+++ b/tests/unit/test_scripts_auth_cookie_domains.py
@@ -43,6 +43,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+import notebooklm.auth as public_auth
 from notebooklm._auth.tokens import AuthTokens
 from notebooklm._env import get_base_url
 from scripts import capture_rpc_registry, check_rpc_health
@@ -326,6 +327,56 @@ def test_capture_rpc_registry_sends_domain_scoped_cookie_jar(
     cdn_requests = [r for r in httpx_mock.get_requests() if r.url.host == "www.gstatic.com"]
     assert cdn_requests
     assert all("cookie" not in r.headers for r in cdn_requests)
+
+
+def test_capture_rpc_registry_classifies_access_gate_as_auth_failure(
+    monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+) -> None:
+    """A #2175 access gate must stop before bundle parsing can allege RPC drift."""
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(_storage_state()))
+
+    start_url = f"{get_base_url()}/?authuser=0"
+    gate_url = "https://notebooklm.google/?location=unsupported"
+    fake_bundle_url = (
+        f"https://www.gstatic.com/_/mss/{capture_rpc_registry._APP}/_/js/k=boq.en.fake.js"
+    )
+    httpx_mock.add_response(url=start_url, status_code=302, headers={"location": gate_url})
+    # Even a gate page containing a bundle-shaped URL must be classified from
+    # the redirect URL before HTML discovery. Otherwise it can yield a blank or
+    # unrelated registry and recreate #2174.
+    httpx_mock.add_response(
+        url=gate_url,
+        status_code=200,
+        text=f'<html><script src="{fake_bundle_url}"></script></html>',
+    )
+
+    with pytest.raises(capture_rpc_registry._BundleAuthenticationError) as raised:
+        capture_rpc_registry.fetch_bundle()
+
+    message = str(raised.value)
+    assert "region / anti-abuse access gate" in message
+    assert "location=unsupported" in message
+    assert "not a library bug or an expired login" in message
+    assert not any(request.url.host == "www.gstatic.com" for request in httpx_mock.get_requests())
+
+
+def test_capture_rpc_registry_classifies_storage_load_failure_as_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed/missing profile cannot become a process exit-1 drift alarm."""
+
+    def fail_storage() -> httpx.Cookies:
+        raise ValueError("test credential detail must not be echoed")
+
+    monkeypatch.setattr(public_auth, "build_httpx_cookies_from_storage", fail_storage)
+
+    with pytest.raises(capture_rpc_registry._BundleAuthenticationError) as raised:
+        capture_rpc_registry.fetch_bundle()
+
+    message = str(raised.value)
+    assert "Stored authentication could not be loaded (ValueError)" in message
+    assert "notebooklm login" in message
+    assert "test credential detail" not in message
 
 
 def _auth_tokens_with_collision() -> AuthTokens:


### PR DESCRIPTION
## Summary

- classify live bundle capture as `clean`, `drift`, `authentication`, or `infrastructure`, and require the explicit `drift` outcome before the nightly workflow can open an RPC/studio drift issue
- route auth, access-gate, CDN, and unclassified runner failures into the authentication/infrastructure lane without drawing a protocol-drift conclusion
- expand `live_auth_matrix.py` with real RPC health, strict #2161 storage-only recovery, sibling re-mint under four concurrent RPCs, Layer-4 master-token recovery, REST live/stale-start recovery, MCP tool recovery, and deterministic #2175 access-gate coverage
- keep reports attachable and privacy-bounded by removing notebook inventories and retaining only bounded failure diagnostics

## Validation

- `uv run pytest -q`: 15,174 passed, 77 skipped, 3 xfailed
- final affected suite after polish/rebase: 313 passed
- committed live matrix: 19/19 executed cells passed (browser-cookie cells skipped; RPC, storage, master-token, REST, and MCP cells executed)
- pre-#2173 negative control failed the strict storage, REST, and MCP recovery cells as expected
- `uv run ruff check .`
- `uv run mypy src/notebooklm scripts/capture_rpc_registry.py scripts/live_auth_matrix.py`
- `uv run pre-commit run --all-files`
- Claude, Codex, and Antigravity polish/closure reviews: clean

Related to #2161, #2174, and #2175.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RPC monitoring to distinguish confirmed bundle drift from authentication, access, and infrastructure failures.
  - Prevented false drift alerts and unnecessary issue creation when checks or bundle retrieval fail.
  - Combined authentication diagnostics into a single sanitized report.

- **New Features**
  - Expanded live authentication checks across RPC, storage, REST, MCP, browser recovery, and access-gate scenarios.
  - Added configurable timeouts and options to skip selected checks.
  - Added clearer monitoring outcomes for clean, drift, authentication, and infrastructure results.

- **Documentation**
  - Documented RPC bundle-drift triage and failure classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->