### PR TITLE
fix(research): identify the deep report by content kind, and expose the per-task source ordinal (#2140, #2141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Deep-research reports are identified by their typed content block instead
+  of row order.** Report markdown is extracted only from a kind-`3` content
+  block, so reordered web snippets can no longer be mistaken for the report
+  ([#2140](https://github.com/teng-lin/notebooklm-py/issues/2140)).
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,10 +263,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Deep-research reports are identified by their typed content block instead
-  of row order.** Report markdown is extracted only from a kind-`3` content
-  block, so reordered web snippets can no longer be mistaken for the report
-  ([#2140](https://github.com/teng-lin/notebooklm-py/issues/2140)).
 - **An empty notebook no longer logs `schema drift?` on every
   `get_source_ids` call.** A genuinely empty notebook returns a healthy
   envelope whose sources slot is present but explicitly null — the backend
@@ -292,6 +288,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while using the same server count for their ordinal, and stale local cache
   entries no longer control the result
   ([#1976](https://github.com/teng-lin/notebooklm-py/issues/1976)).
+- **Deep-research reports are identified by their typed content block instead
+  of row order.** Report markdown is extracted only from a kind-`3` content
+  block, so reordered web snippets can no longer be mistaken for the report
+  ([#2140](https://github.com/teng-lin/notebooklm-py/issues/2140)).
 - **Research that finds nothing is no longer an undifferentiated `failed`.** A
   Google Drive research run whose query matched no file came back as
   `status: failed` with no sources, no code, no message and no remediation —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Deep-research sources expose observed citation ordinals.**
+  `ResearchSource.citation_number` and its serializers preserve integer
+  `src[8]` values from kind-`1` web-source rows, allowing callers to align
+  those sources with report `[cite: N]` markers
+  ([#2141](https://github.com/teng-lin/notebooklm-py/issues/2141)).
 - **Mid-session `NOTEBOOKLM_REFRESH_CMD` (opt-in for one release).** The external
   refresh command (the L2.5 rung of the unified recovery ladder) previously fired
   only at cold start; it can now also run **mid-session** — e.g. inside a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Deep-research sources expose observed citation ordinals.**
-  `ResearchSource.citation_number` and its serializers preserve integer
-  `src[8]` values from kind-`1` web-source rows, allowing callers to align
-  those sources with report `[cite: N]` markers
+- **Deep-research sources expose the backend's per-task source ordinal.**
+  `ResearchSource.source_ordinal` and its serializers preserve an integer
+  `src[8]` when the row carries one — in the captures a 1-based bijection over
+  a task's discovered sources, which the client previously decoded and threw
+  away. It is **not** established to resolve the report's own citation
+  markers; see the field docs before using it that way
   ([#2141](https://github.com/teng-lin/notebooklm-py/issues/2141)).
 - **Mid-session `NOTEBOOKLM_REFRESH_CMD` (opt-in for one release).** The external
   refresh command (the L2.5 rung of the unified recovery ladder) previously fired

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1616,7 +1616,11 @@ async def poll(notebook_id: str, task_id: str | None = None) -> ResearchTask:
       - result_type:        int — 1=web, 2=drive, 5=deep-research report entry
       - research_task_id:   str — task/report ID that produced this source
       - report_markdown:    str — deep-research report markdown (for type-5 entries)
-      - citation_number:    int | None — deep-report `[cite: N]` number from `src[8]`
+      - source_ordinal:     int | None — the backend's 1-based ordinal for this
+                            discovered source within its research task (`src[8]`).
+                            NOT verified to resolve the report's citation markers:
+                            research_deep_poll_long.yaml carries 24 ordinals and
+                            its report has no `[cite: N]` markers at all.
     """
 
 async def wait_for_completion(

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1616,6 +1616,7 @@ async def poll(notebook_id: str, task_id: str | None = None) -> ResearchTask:
       - result_type:        int — 1=web, 2=drive, 5=deep-research report entry
       - research_task_id:   str — task/report ID that produced this source
       - report_markdown:    str — deep-research report markdown (for type-5 entries)
+      - citation_number:    int | None — deep-report `[cite: N]` number from `src[8]`
     """
 
 async def wait_for_completion(

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2171,8 +2171,10 @@ await rpc_call(
 #
 # Deep research web source content blocks use kind 1 or 2 and carry their
 # snippet at position 2; they are not report rows. In the observed deep payload,
-# kind-1 web-source rows carry an integer citation ordinal at source position 8;
-# those ordinals align with the report's [cite: N] markers.
+# kind-1 web-source rows carry an integer ordinal at source position 8, a 1-based
+# bijection over the task's discovered sources. Whether that ordinal equals the
+# report's own citation numbering is NOT established: research_deep_poll_long.yaml
+# carries 24 such ordinals against a report containing no [cite: N] markers at all.
 #
 # Compatibility shape accepted by the parser (not seen in captures):
 # [None, [title, report_markdown], None, type, ...]

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2230,9 +2230,14 @@ Import selected research sources into the notebook.
 ```python
 # Build source array from selected sources
 # Deep research imports prepend a special report entry before regular web sources.
+#
+# NOTE: this is the REQUEST the client sends. It is a different shape from the
+# POLL_RESEARCH *response* row documented above — the report body rides at index 1
+# here, whereas a response row carries it in the src[6] kind-3 content block. Built
+# by `_research.py::_build_report_import_entry` / `_build_web_import_entry`.
 source_array = []
 
-# Deep research report entry:
+# Deep research report entry (outgoing import request):
 source_array.append([
     None,                 # 0
     [title, markdown],    # 1: Report title and full markdown body

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2170,8 +2170,9 @@ await rpc_call(
 #  [report_markdown, 3, None, None, None, structured_document]]
 #
 # Deep research web source content blocks use kind 1 or 2 and carry their
-# snippet at position 2; they are not report rows. Cited web-source rows carry
-# the report's 1-based [cite: N] citation_number at source position 8.
+# snippet at position 2; they are not report rows. In the observed deep payload,
+# kind-1 web-source rows carry an integer citation ordinal at source position 8;
+# those ordinals align with the report's [cite: N] markers.
 #
 # Compatibility shape accepted by the parser (not seen in captures):
 # [None, [title, report_markdown], None, type, ...]

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2170,7 +2170,8 @@ await rpc_call(
 #  [report_markdown, 3, None, None, None, structured_document]]
 #
 # Deep research web source content blocks use kind 1 or 2 and carry their
-# snippet at position 2; they are not report rows.
+# snippet at position 2; they are not report rows. Cited web-source rows carry
+# the report's 1-based [cite: N] citation_number at source position 8.
 #
 # Compatibility shape accepted by the parser (not seen in captures):
 # [None, [title, report_markdown], None, type, ...]

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2165,11 +2165,15 @@ await rpc_call(
 # Fast research web source:
 # [url, title, desc, type, ...]
 #
-# Deep research report source (current shape):
-# [None, [title, report_markdown], None, type, ...]
+# Deep research report source (captured shape):
+# [None, title, None, type, None, None,
+#  [report_markdown, 3, None, None, None, structured_document]]
 #
-# Deep research report source (legacy shape):
-# [None, title, None, type, None, None, [chunk1, chunk2, ...]]
+# Deep research web source content blocks use kind 1 or 2 and carry their
+# snippet at position 2; they are not report rows.
+#
+# Compatibility shape accepted by the parser (not seen in captures):
+# [None, [title, report_markdown], None, type, ...]
 #
 # Notes:
 # - The RPC returns all research tasks for the notebook, not just the latest one.

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -397,7 +397,8 @@ class ResearchAPI:
               ``NOT_FOUND``); equals the historical strings
             - ``task.query``: original research query text
             - ``task.sources``: tuple of ``ResearchSource`` (each exposes ``url``,
-              ``title``, ``result_type``, ``research_task_id``, ``report_markdown``)
+              ``title``, ``result_type``, ``research_task_id``, ``report_markdown``,
+              ``citation_number``)
             - ``task.summary``: summary text when present
             - ``task.report``: extracted deep-research report markdown, if present
             - ``task.tasks``: all parsed research tasks visible at this poll

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -398,7 +398,7 @@ class ResearchAPI:
             - ``task.query``: original research query text
             - ``task.sources``: tuple of ``ResearchSource`` (each exposes ``url``,
               ``title``, ``result_type``, ``research_task_id``, ``report_markdown``,
-              ``citation_number``)
+              ``source_ordinal``)
             - ``task.summary``: summary text when present
             - ``task.report``: extracted deep-research report markdown, if present
             - ``task.tasks``: all parsed research tasks visible at this poll

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -256,6 +256,7 @@ def _parse_source_row(
             title=title,
             result_type=result_type,
             research_task_id=task_id,
+            citation_number=row.citation_number,
         )
 
     report = source_report

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -256,7 +256,7 @@ def _parse_source_row(
             title=title,
             result_type=result_type,
             research_task_id=task_id,
-            citation_number=row.citation_number,
+            source_ordinal=row.source_ordinal,
         )
 
     report = source_report

--- a/src/notebooklm/_research_task_parser.py
+++ b/src/notebooklm/_research_task_parser.py
@@ -49,14 +49,9 @@ _POLL_SOURCE = "_research.poll"
 _POLL_METHOD_ID = RPCMethod.POLL_RESEARCH.value
 
 
-def extract_legacy_report_chunks(src: list[Any]) -> str:
-    """Join legacy deep-research report chunks stored in ``src[6]``."""
-    chunks = [
-        chunk
-        for chunk in ResearchResultRow(src).legacy_report_chunks
-        if isinstance(chunk, str) and chunk
-    ]
-    return "\n\n".join(chunks)
+def extract_report_markdown(src: list[Any]) -> str:
+    """Return markdown from the kind-3 content block stored in ``src[6]``."""
+    return ResearchResultRow(src).report_markdown
 
 
 def _extract_task_id(task_data: Any) -> str | None:
@@ -226,14 +221,14 @@ def _parse_source_row(
     source_report = ""
 
     # Fast research: [url, title, desc, type, ...]
-    # Deep research (legacy): [None, title, None, type, ..., [report_markdown]]
-    # Deep research (current): [None, [title, report_markdown], None, type, ...]
+    # Deep research (captured): [None, title, None, type, ..., content_block]
+    # Deep research (compat): [None, [title, report_markdown], None, type, ...]
     # src[3] is the authoritative result_type when present.
     result_type = (
         parse_result_type(row.result_type_slot) if row.has_result_type else RESEARCH_RESULT_TYPE_WEB
     )
     if row.url_slot is None and row.length > 1:
-        # Deep-research (current) packs ``[title, report_markdown]`` at ``src[1]``;
+        # A compatibility shape packs ``[title, report_markdown]`` at ``src[1]``;
         # ``ResearchResultRow.deep_payload`` unpacks that exact shape (a 2+-length
         # list of two strings) and returns ``None`` for the legitimate
         # alternatives (bare-string title, or neither), which fall through to the
@@ -265,7 +260,7 @@ def _parse_source_row(
 
     report = source_report
     if not report and not report_found:
-        report = extract_legacy_report_chunks(src)
+        report = extract_report_markdown(src)
     if report and parsed_source is not None:
         parsed_source = parsed_source.with_report_markdown(report)
 

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -51,6 +51,7 @@ Position contracts (pinned by ``tests/unit/test_research_row_adapter.py``):
   1      title (str) — or, for current deep research, ``[title, report]``
   3      authoritative result-type tag
   6      typed content block; kind 3 carries report markdown at position 0
+  8      deep-research citation number (int)
   =====  ============================================================
 """
 
@@ -240,6 +241,7 @@ class ResearchResultRow:
     _TITLE_POS: ClassVar[int] = 1
     _RESULT_TYPE_POS: ClassVar[int] = 3
     _CONTENT_BLOCK_POS: ClassVar[int] = 6
+    _CITATION_NUMBER_POS: ClassVar[int] = 8
     # A source row must carry at least ``[url/sentinel, title]`` to be usable —
     # mirrors the historical ``len(src) < 2`` early return.
     _MIN_LEN: ClassVar[int] = 2
@@ -323,6 +325,14 @@ class ResearchResultRow:
             return ""
         text = block[self._CONTENT_TEXT_POS]
         return text if isinstance(text, str) and text else ""
+
+    @property
+    def citation_number(self) -> int | None:
+        """Citation number at ``src[8]``, or ``None`` when absent or malformed."""
+        if self.length <= self._CITATION_NUMBER_POS:
+            return None
+        value = self._raw[self._CITATION_NUMBER_POS]
+        return value if type(value) is int else None
 
     @staticmethod
     def deep_payload(payload: Any) -> tuple[str, str] | None:

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -316,10 +316,10 @@ class ResearchResultRow:
     def report_markdown(self) -> str:
         """Report markdown from a kind-3 content block, otherwise ``""``."""
         block = self.content_block
-        if (
-            len(block) < self._CONTENT_MIN_LEN
-            or block[self._CONTENT_KIND_POS] != self._REPORT_CONTENT_KIND
-        ):
+        if len(block) < self._CONTENT_MIN_LEN:
+            return ""
+        kind = block[self._CONTENT_KIND_POS]
+        if type(kind) is not int or kind != self._REPORT_CONTENT_KIND:
             return ""
         text = block[self._CONTENT_TEXT_POS]
         return text if isinstance(text, str) and text else ""

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -48,10 +48,10 @@ Position contracts (pinned by ``tests/unit/test_research_row_adapter.py``):
   Index  Meaning
   =====  ============================================================
   0      URL (str) for fast research; ``None`` sentinel for deep research
-  1      title (str) — or, for current deep research, ``[title, report]``
+  1      title (str) — or, for the compat shape, ``[title, report]``
   3      authoritative result-type tag
   6      typed content block; kind 3 carries report markdown at position 0
-  8      deep-research citation number (int)
+  8      deep-research per-task source ordinal (int)
   =====  ============================================================
 """
 
@@ -225,7 +225,8 @@ class ResearchResultRow:
 
     * fast research — ``[url, title, desc, type, ...]``
     * deep research (captured) — ``[None, title, None, type, ..., content_block]``
-    * deep research (current) — ``[None, [title, report_md], None, type, ...]``
+    * deep research (compat, never observed in a capture) —
+      ``[None, [title, report_md], None, type, ...]``
 
     Every field is routinely-optional (a deep-research row omits its URL; a
     fast-research row omits the report), so the adapter length-guards each read
@@ -241,13 +242,13 @@ class ResearchResultRow:
     _TITLE_POS: ClassVar[int] = 1
     _RESULT_TYPE_POS: ClassVar[int] = 3
     _CONTENT_BLOCK_POS: ClassVar[int] = 6
-    _CITATION_NUMBER_POS: ClassVar[int] = 8
+    _SOURCE_ORDINAL_POS: ClassVar[int] = 8
     # A source row must carry at least ``[url/sentinel, title]`` to be usable —
     # mirrors the historical ``len(src) < 2`` early return.
     _MIN_LEN: ClassVar[int] = 2
 
-    # Layout of the current-deep-research ``[title, report_markdown]`` payload
-    # packed at ``src[1]``.
+    # Layout of the compat ``[title, report_markdown]`` payload packed at
+    # ``src[1]`` — accepted but never observed in a capture (#2140).
     _PAYLOAD_TITLE_POS: ClassVar[int] = 0
     _PAYLOAD_REPORT_POS: ClassVar[int] = 1
     _PAYLOAD_MIN_LEN: ClassVar[int] = 2
@@ -283,8 +284,8 @@ class ResearchResultRow:
 
     @property
     def title_slot(self) -> Any:
-        """Raw value at ``src[1]`` — a title ``str`` or, for current deep
-        research, the ``[title, report_markdown]`` payload. ``None`` when absent."""
+        """Raw value at ``src[1]`` — a title ``str`` or, for the compat shape,
+        the ``[title, report_markdown]`` payload. ``None`` when absent."""
         if self.length <= self._TITLE_POS:
             return None
         return self._raw[self._TITLE_POS]
@@ -327,21 +328,41 @@ class ResearchResultRow:
         return text if isinstance(text, str) and text else ""
 
     @property
-    def citation_number(self) -> int | None:
-        """Citation number at ``src[8]``, or ``None`` when absent or malformed."""
-        if self.length <= self._CITATION_NUMBER_POS:
+    def source_ordinal(self) -> int | None:
+        """The backend's per-task ordinal at ``src[8]`` — ``None`` when absent.
+
+        In the captures this is a 1-based bijection onto ``1..N`` over the
+        discovered (kind-1) rows of one research task. It is **not** established
+        to be the report's own citation numbering: #2141's evidence is a
+        range/count coincidence, and ``tests/cassettes/research_deep_poll_long.yaml``
+        carries 24 such ordinals against a report with no ``[cite: N]`` markers at
+        all. Do not resolve report markers through this without new evidence.
+
+        ``type(value) is int`` rather than ``isinstance``: ``bool`` is an ``int``
+        subclass, so a wire ``true`` would otherwise read as ordinal ``1``.
+        """
+        if self.length <= self._SOURCE_ORDINAL_POS:
             return None
-        value = self._raw[self._CITATION_NUMBER_POS]
+        value = self._raw[self._SOURCE_ORDINAL_POS]
         return value if type(value) is int else None
 
     @staticmethod
     def deep_payload(payload: Any) -> tuple[str, str] | None:
-        """Unpack a current-deep-research ``[title, report_markdown]`` payload.
+        """Unpack the compat ``[title, report_markdown]`` payload.
 
         Returns ``(title, report_markdown)`` only when ``payload`` is a list of
         at least two strings (the exact shape the historical parser required at
         ``src[1]``); otherwise ``None`` so the caller falls through to the
         bare-string-title / fast-research branches.
+
+        This shape has **never appeared in a captured payload** — both real deep
+        captures put a bare title here and carry the report in the ``src[6]``
+        content block instead. #2140 asked for a deliberate decision, and it is
+        kept rather than deleted: it costs one guarded branch, cannot mis-fire on
+        the captured shapes (the guard above rejects them), and removing a
+        never-observed *reader* would be a bet against payloads we have not
+        captured — the wrong side of the bet for a wire whose drift is this
+        project's #1 breakage class.
         """
         if (
             isinstance(payload, list)

--- a/src/notebooklm/_row_adapters/research.py
+++ b/src/notebooklm/_row_adapters/research.py
@@ -50,7 +50,7 @@ Position contracts (pinned by ``tests/unit/test_research_row_adapter.py``):
   0      URL (str) for fast research; ``None`` sentinel for deep research
   1      title (str) — or, for current deep research, ``[title, report]``
   3      authoritative result-type tag
-  6      legacy deep-research report chunks (list of str)
+  6      typed content block; kind 3 carries report markdown at position 0
   =====  ============================================================
 """
 
@@ -223,7 +223,7 @@ class ResearchResultRow:
     The source row carries three shapes the historical parser handled inline:
 
     * fast research — ``[url, title, desc, type, ...]``
-    * deep research (legacy) — ``[None, title, None, type, ..., [report_md]]``
+    * deep research (captured) — ``[None, title, None, type, ..., content_block]``
     * deep research (current) — ``[None, [title, report_md], None, type, ...]``
 
     Every field is routinely-optional (a deep-research row omits its URL; a
@@ -239,7 +239,7 @@ class ResearchResultRow:
     _URL_POS: ClassVar[int] = 0
     _TITLE_POS: ClassVar[int] = 1
     _RESULT_TYPE_POS: ClassVar[int] = 3
-    _LEGACY_CHUNKS_POS: ClassVar[int] = 6
+    _CONTENT_BLOCK_POS: ClassVar[int] = 6
     # A source row must carry at least ``[url/sentinel, title]`` to be usable —
     # mirrors the historical ``len(src) < 2`` early return.
     _MIN_LEN: ClassVar[int] = 2
@@ -249,6 +249,13 @@ class ResearchResultRow:
     _PAYLOAD_TITLE_POS: ClassVar[int] = 0
     _PAYLOAD_REPORT_POS: ClassVar[int] = 1
     _PAYLOAD_MIN_LEN: ClassVar[int] = 2
+
+    # Captured ``src[6]`` content block:
+    # [text | None, kind, snippet | None, ..., structured_document | None]
+    _CONTENT_TEXT_POS: ClassVar[int] = 0
+    _CONTENT_KIND_POS: ClassVar[int] = 1
+    _CONTENT_MIN_LEN: ClassVar[int] = 2
+    _REPORT_CONTENT_KIND: ClassVar[int] = 3
 
     @property
     def is_well_formed(self) -> bool:
@@ -298,12 +305,24 @@ class ResearchResultRow:
         return self.length > self._RESULT_TYPE_POS
 
     @property
-    def legacy_report_chunks(self) -> list[Any]:
-        """Legacy deep-research report chunks at ``src[6]`` — ``[]`` when absent/non-list."""
-        if self.length <= self._LEGACY_CHUNKS_POS:
+    def content_block(self) -> list[Any]:
+        """Typed content block at ``src[6]`` — ``[]`` when absent or malformed."""
+        if self.length <= self._CONTENT_BLOCK_POS:
             return []
-        value = self._raw[self._LEGACY_CHUNKS_POS]
+        value = self._raw[self._CONTENT_BLOCK_POS]
         return value if isinstance(value, list) else []
+
+    @property
+    def report_markdown(self) -> str:
+        """Report markdown from a kind-3 content block, otherwise ``""``."""
+        block = self.content_block
+        if (
+            len(block) < self._CONTENT_MIN_LEN
+            or block[self._CONTENT_KIND_POS] != self._REPORT_CONTENT_KIND
+        ):
+            return ""
+        text = block[self._CONTENT_TEXT_POS]
+        return text if isinstance(text, str) and text else ""
 
     @staticmethod
     def deep_payload(payload: Any) -> tuple[str, str] | None:

--- a/src/notebooklm/_types/research.py
+++ b/src/notebooklm/_types/research.py
@@ -209,7 +209,7 @@ class ResearchSource:
     result_type: ResearchResultType = RESEARCH_RESULT_TYPE_WEB
     research_task_id: str | None = None
     report_markdown: str = ""
-    citation_number: int | None = None
+    source_ordinal: int | None = None
 
     @classmethod
     def from_public_dict(cls, source: Mapping[str, Any]) -> ResearchSource:
@@ -218,7 +218,7 @@ class ResearchSource:
         title_raw = source.get("title", "Untitled")
         research_task_id_raw = source.get("research_task_id")
         report_markdown_raw = source.get("report_markdown", "")
-        citation_number_raw = source.get("citation_number")
+        source_ordinal_raw = source.get("source_ordinal")
 
         return cls(
             url=url_raw if isinstance(url_raw, str) else "",
@@ -228,7 +228,7 @@ class ResearchSource:
             if isinstance(research_task_id_raw, str)
             else None,
             report_markdown=report_markdown_raw if isinstance(report_markdown_raw, str) else "",
-            citation_number=citation_number_raw if type(citation_number_raw) is int else None,
+            source_ordinal=source_ordinal_raw if type(source_ordinal_raw) is int else None,
         )
 
     @property
@@ -250,8 +250,8 @@ class ResearchSource:
             public["research_task_id"] = self.research_task_id
         if self.report_markdown:
             public["report_markdown"] = self.report_markdown
-        if self.citation_number is not None:
-            public["citation_number"] = self.citation_number
+        if self.source_ordinal is not None:
+            public["source_ordinal"] = self.source_ordinal
         return public
 
 

--- a/src/notebooklm/_types/research.py
+++ b/src/notebooklm/_types/research.py
@@ -209,6 +209,7 @@ class ResearchSource:
     result_type: ResearchResultType = RESEARCH_RESULT_TYPE_WEB
     research_task_id: str | None = None
     report_markdown: str = ""
+    citation_number: int | None = None
 
     @classmethod
     def from_public_dict(cls, source: Mapping[str, Any]) -> ResearchSource:
@@ -217,6 +218,7 @@ class ResearchSource:
         title_raw = source.get("title", "Untitled")
         research_task_id_raw = source.get("research_task_id")
         report_markdown_raw = source.get("report_markdown", "")
+        citation_number_raw = source.get("citation_number")
 
         return cls(
             url=url_raw if isinstance(url_raw, str) else "",
@@ -226,6 +228,7 @@ class ResearchSource:
             if isinstance(research_task_id_raw, str)
             else None,
             report_markdown=report_markdown_raw if isinstance(report_markdown_raw, str) else "",
+            citation_number=citation_number_raw if type(citation_number_raw) is int else None,
         )
 
     @property
@@ -247,6 +250,8 @@ class ResearchSource:
             public["research_task_id"] = self.research_task_id
         if self.report_markdown:
             public["report_markdown"] = self.report_markdown
+        if self.citation_number is not None:
+            public["citation_number"] = self.citation_number
         return public
 
 

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -486,6 +486,15 @@ PINNED: tuple[Pinned, ...] = (
         "Two deep-research captures 14 months apart: report rows carry kind 3 with "
         "markdown at block[0]; 62/62 web rows carry kind 1/2 snippets at block[2]",
     ),
+    Pinned(
+        "research",
+        "ResearchResultRow",
+        "_CITATION_NUMBER_POS",
+        8,
+        "DiscoveredSource tag 9 — deep-report citation number",
+        "Issue #2141 live capture: 41/63 rows carried integer values 1-41; these "
+        "mapped one-to-one to the report's [cite: N] markers",
+    ),
 )
 
 

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -489,11 +489,15 @@ PINNED: tuple[Pinned, ...] = (
     Pinned(
         "research",
         "ResearchResultRow",
-        "_CITATION_NUMBER_POS",
+        "_SOURCE_ORDINAL_POS",
         8,
-        "DiscoveredSource tag 9 — deep-report citation number",
-        "Issue #2141 live capture: 41/63 rows carried integer values 1-41; these "
-        "mapped one-to-one to the report's [cite: N] markers",
+        "DiscoveredSource tag 9 — per-task ordinal for a discovered source",
+        "Issue #2141 live capture: 41/63 rows (all kind-1) carried integer values "
+        "1-41, i.e. a bijection onto 1..N. Whether that ordinal equals the "
+        "report's own citation numbering is NOT established: "
+        "tests/cassettes/research_deep_poll_long.yaml carries 24 such ordinals "
+        "and its report contains no [cite: N] markers at all, so the mapping "
+        "recorded here is the ordinal itself, not a marker resolution table",
     ),
 )
 

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -407,25 +407,8 @@ UNMAPPED: tuple[Unmapped, ...] = (
     Unmapped("research", "ResearchTaskInfoRow", "_QUERY_SOURCE_TYPE_POS", _SHAPE_UNKNOWN),
     Unmapped("research", "ResearchTaskInfoRow", "_SOURCES_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchTaskInfoRow", "_SUMMARY_POS", _NESTED_LOCAL),
-    Unmapped(
-        "research",
-        "ResearchResultRow",
-        "_LEGACY_CHUNKS_POS",
-        "MAPPED AND MIS-MODELLED, not merely unverified. src[6] is a structured "
-        "content block with a FIXED schema shared by both row types:\n"
-        "    [ text|None, kind:int, text|None, None, int|None, structured_doc|None ]\n"
-        "  report row: ['# ...', 3, None, None, None, [doc tree]]   (len 6)\n"
-        "  web row:    [None,     1, 'snippet...', None, 13]        (len 5)\n"
-        "src[6][1] is the discriminator: 3 = report, 1/2 = web snippet (live "
-        "distribution over 63 rows: {1:41, 2:21, 3:1}). Stable across two captures "
-        "14 months apart. But `extract_legacy_report_chunks` never reads chunks — it "
-        "harvests EVERY string in the block and joins them, working only because each "
-        "row type happens to hold exactly one (report at [0], snippet at [2]). "
-        "Correct today only because the report row arrives at index 0 and shields the "
-        "rest; 62/62 web rows carry a populated src[6]. Reordering the live payload "
-        "drops a 35,773-char report for a 4,020-char tardigrade blurb, silently. "
-        "FIX: gate on src[6][1] == 3 and read src[6][0].",
-    ),
+    Unmapped("research", "ResearchResultRow", "_CONTENT_TEXT_POS", _NESTED_LOCAL),
+    Unmapped("research", "ResearchResultRow", "_CONTENT_KIND_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchResultRow", "_PAYLOAD_TITLE_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchResultRow", "_PAYLOAD_REPORT_POS", _NESTED_LOCAL),
     Unmapped("research", "ResearchStartRow", "_TASK_ID_POS", _SHAPE_UNKNOWN),
@@ -493,6 +476,15 @@ PINNED: tuple[Pinned, ...] = (
         "ChatHistoryMessage tag 3 — role, values {1, 2}",
         "56/56 turns populated; role 1 rows carry userQueryText (tag 4) and role 2 "
         "rows carry actOnSourcesResponse (tag 5), 28/28 each",
+    ),
+    Pinned(
+        "research",
+        "ResearchResultRow",
+        "_CONTENT_BLOCK_POS",
+        6,
+        "DiscoveredSource tag 7 — typed content block",
+        "Two deep-research captures 14 months apart: report rows carry kind 3 with "
+        "markdown at block[0]; 62/62 web rows carry kind 1/2 snippets at block[2]",
     ),
 )
 

--- a/tests/integration/test_research_deep_poll_vcr.py
+++ b/tests/integration/test_research_deep_poll_vcr.py
@@ -566,6 +566,16 @@ class TestDeepResearchPollReplay:
             "state. Re-record with NOTEBOOKLM_VCR_RECORD=1."
         )
 
+        # The recorded terminal payload carries the report in src[6]'s typed
+        # content block (kind 3), followed by web rows whose kind-1/2 blocks
+        # contain snippets. Only the report row may supply report markdown.
+        final_task = tasks[0]
+        report_sources = [source for source in final_task.sources if source.report_markdown]
+        assert final_task.report
+        assert len(report_sources) == 1
+        assert report_sources[0].is_report
+        assert report_sources[0].report_markdown == final_task.report
+
 
 @pytest.mark.allow_no_vcr
 def test_cassette_under_size_cap() -> None:

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -830,7 +830,17 @@ class TestResearch:
     @pytest.mark.asyncio
     async def test_poll_deep_research_sources(self, auth_tokens, httpx_mock, build_rpc_response):
         """Test poll parses deep research sources (title only, no URL)."""
-        sources = [[None, "Deep Research Finding", None, 5, None, None, ["# Report markdown"]]]
+        sources = [
+            [
+                None,
+                "Deep Research Finding",
+                None,
+                5,
+                None,
+                None,
+                ["# Report markdown", 3, None, None, None, ["structured doc"]],
+            ]
+        ]
         task_info = [None, ["deep query", 1], 1, [sources, "Deep summary"], 2]
         response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
         httpx_mock.add_response(content=response_body.encode(), method="POST")
@@ -878,11 +888,14 @@ class TestResearch:
         assert "task_id" in str(err)
 
     @pytest.mark.asyncio
-    async def test_poll_joins_legacy_report_chunks(
+    async def test_poll_ignores_web_snippet_before_report(
         self, auth_tokens, httpx_mock, build_rpc_response
     ):
-        """Test poll joins multiple legacy report chunks instead of truncating to the first one."""
-        sources = [[None, "Deep Research Finding", None, 5, None, None, ["chunk one", "chunk two"]]]
+        """A web content block cannot win report extraction by arriving first."""
+        sources = [
+            ["https://example.com", "Web result", "desc", 1, None, None, [None, 1, "snippet"]],
+            [None, "Deep Research Finding", None, 5, None, None, ["# Report", 3]],
+        ]
         task_info = [None, ["deep query", 1], 1, [sources, "Deep summary"], 2]
         response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
         httpx_mock.add_response(content=response_body.encode(), method="POST")
@@ -890,8 +903,10 @@ class TestResearch:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.research.poll("nb_123")
 
-        assert result.report == "chunk one\n\nchunk two"
-        assert result.tasks[0].report == "chunk one\n\nchunk two"
+        assert result.report == "# Report"
+        assert result.sources[0].report_markdown == ""
+        assert result.sources[1].report_markdown == "# Report"
+        assert result.tasks[0].report == "# Report"
 
     @pytest.mark.asyncio
     async def test_poll_deep_research_current_report_shape(
@@ -1556,21 +1571,6 @@ class TestResearch:
             result = await client.research.poll("nb_123")
 
         assert result.sources[0].result_type == "video"
-
-    @pytest.mark.asyncio
-    async def test_poll_legacy_report_mixed_chunks(
-        self, auth_tokens, httpx_mock, build_rpc_response
-    ):
-        """Legacy report chunks filter out non-string and empty values."""
-        sources = [[None, "Report Title", None, 5, None, None, ["chunk1", None, "", "chunk2"]]]
-        task_info = [None, ["query", 1], 1, [sources, ""], 2]
-        response_body = build_rpc_response(RPCMethod.POLL_RESEARCH, [[["task_123", task_info]]])
-        httpx_mock.add_response(content=response_body.encode(), method="POST")
-
-        async with NotebookLMClient(auth_tokens) as client:
-            result = await client.research.poll("nb_123")
-
-        assert result.report == "chunk1\n\nchunk2"
 
     @pytest.mark.asyncio
     async def test_poll_source_single_element_list_title_dropped(

--- a/tests/unit/test_research_api.py
+++ b/tests/unit/test_research_api.py
@@ -421,7 +421,7 @@ class TestPollEdgeCases:
                                     5,
                                     None,
                                     None,
-                                    ["# Deep Report\nContent here"],
+                                    ["# Deep Report\nContent here", 3],
                                 ],
                             ],
                             "Deep summary",

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -207,11 +207,9 @@ class TestResearchResultRow:
         row = ResearchResultRow([None, "t", None, 5, None, None, block])
         assert row.report_markdown == ""
 
-    @pytest.mark.parametrize("kind", [1, 2])
-    def test_web_content_block_is_not_report(self, kind) -> None:
-        row = ResearchResultRow(
-            ["https://example.com", "t", None, 1, None, None, [None, kind, "s"]]
-        )
+    @pytest.mark.parametrize("kind", [1, 2, 3.0, True])
+    def test_non_report_content_kind_is_not_report(self, kind) -> None:
+        row = ResearchResultRow(["https://example.com", "t", None, 1, None, None, ["# Fake", kind]])
         assert row.report_markdown == ""
 
 

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -55,9 +55,17 @@ class TestResearchResultRowPositionContract:
             ResearchResultRow._URL_POS,
             ResearchResultRow._TITLE_POS,
             ResearchResultRow._RESULT_TYPE_POS,
-            ResearchResultRow._LEGACY_CHUNKS_POS,
+            ResearchResultRow._CONTENT_BLOCK_POS,
             ResearchResultRow._MIN_LEN,
         ) == (0, 1, 3, 6, 2)
+
+    def test_content_block_positions_pinned(self) -> None:
+        assert (
+            ResearchResultRow._CONTENT_TEXT_POS,
+            ResearchResultRow._CONTENT_KIND_POS,
+            ResearchResultRow._CONTENT_MIN_LEN,
+            ResearchResultRow._REPORT_CONTENT_KIND,
+        ) == (0, 1, 2, 3)
 
     def test_deep_payload_positions_pinned(self) -> None:
         assert (
@@ -165,7 +173,8 @@ class TestResearchResultRow:
         assert row.title_slot is None
         assert row.result_type_slot is None
         assert row.has_result_type is False
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
 
     def test_result_type_absent_short_circuits(self) -> None:
         row = ResearchResultRow([None, "title"])
@@ -177,17 +186,33 @@ class TestResearchResultRow:
         assert row.url_slot is None
         assert row.title_slot == ["Deep Report", "# Report"]
 
-    def test_legacy_chunks_present(self) -> None:
-        row = ResearchResultRow([None, "Legacy", None, "report", None, None, ["a", "b"]])
-        assert row.legacy_report_chunks == ["a", "b"]
+    def test_report_content_block_present(self) -> None:
+        block = ["# Report", 3, None, None, None, ["document"]]
+        row = ResearchResultRow([None, "Report", None, 5, None, None, block])
+        assert row.content_block is block
+        assert row.report_markdown == "# Report"
 
-    def test_legacy_chunks_non_list_returns_empty(self) -> None:
+    def test_content_block_non_list_returns_empty(self) -> None:
         row = ResearchResultRow([None, "t", None, 5, None, None, "str"])
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
 
-    def test_legacy_chunks_absent_returns_empty(self) -> None:
+    def test_content_block_absent_returns_empty(self) -> None:
         row = ResearchResultRow([None, "t", None, 5, None, None])
-        assert row.legacy_report_chunks == []
+        assert row.content_block == []
+        assert row.report_markdown == ""
+
+    @pytest.mark.parametrize("block", [[], ["# Report"], [None, 3], [42, 3]])
+    def test_malformed_report_content_block_returns_empty(self, block) -> None:
+        row = ResearchResultRow([None, "t", None, 5, None, None, block])
+        assert row.report_markdown == ""
+
+    @pytest.mark.parametrize("kind", [1, 2])
+    def test_web_content_block_is_not_report(self, kind) -> None:
+        row = ResearchResultRow(
+            ["https://example.com", "t", None, 1, None, None, [None, kind, "s"]]
+        )
+        assert row.report_markdown == ""
 
 
 class TestResearchResultRowDeepPayload:

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -56,7 +56,7 @@ class TestResearchResultRowPositionContract:
             ResearchResultRow._TITLE_POS,
             ResearchResultRow._RESULT_TYPE_POS,
             ResearchResultRow._CONTENT_BLOCK_POS,
-            ResearchResultRow._CITATION_NUMBER_POS,
+            ResearchResultRow._SOURCE_ORDINAL_POS,
             ResearchResultRow._MIN_LEN,
         ) == (0, 1, 3, 6, 8, 2)
 
@@ -161,7 +161,7 @@ class TestResearchResultRow:
         assert row.title_slot == "Example"
         assert row.has_result_type is True
         assert row.result_type_slot == "web"
-        assert row.citation_number is None
+        assert row.source_ordinal is None
 
     def test_short_row_not_well_formed(self) -> None:
         row = ResearchResultRow(["only_one"])
@@ -204,18 +204,18 @@ class TestResearchResultRow:
         assert row.content_block == []
         assert row.report_markdown == ""
 
-    def test_citation_number_reads_captured_ordinal(self) -> None:
+    def test_source_ordinal_reads_captured_ordinal(self) -> None:
         row = ResearchResultRow(
             ["https://example.com", "t", None, 1, None, None, [None, 1], None, 17]
         )
-        assert row.citation_number == 17
+        assert row.source_ordinal == 17
 
     @pytest.mark.parametrize("value", [None, True, 3.0, "3", []])
-    def test_citation_number_absent_or_non_integer_returns_none(self, value) -> None:
+    def test_source_ordinal_absent_or_non_integer_returns_none(self, value) -> None:
         row = ResearchResultRow(
             ["https://example.com", "t", None, 1, None, None, [None, 1], None, value]
         )
-        assert row.citation_number is None
+        assert row.source_ordinal is None
 
     @pytest.mark.parametrize("block", [[], ["# Report"], [None, 3], [42, 3]])
     def test_malformed_report_content_block_returns_empty(self, block) -> None:

--- a/tests/unit/test_research_row_adapter.py
+++ b/tests/unit/test_research_row_adapter.py
@@ -56,8 +56,9 @@ class TestResearchResultRowPositionContract:
             ResearchResultRow._TITLE_POS,
             ResearchResultRow._RESULT_TYPE_POS,
             ResearchResultRow._CONTENT_BLOCK_POS,
+            ResearchResultRow._CITATION_NUMBER_POS,
             ResearchResultRow._MIN_LEN,
-        ) == (0, 1, 3, 6, 2)
+        ) == (0, 1, 3, 6, 8, 2)
 
     def test_content_block_positions_pinned(self) -> None:
         assert (
@@ -160,6 +161,7 @@ class TestResearchResultRow:
         assert row.title_slot == "Example"
         assert row.has_result_type is True
         assert row.result_type_slot == "web"
+        assert row.citation_number is None
 
     def test_short_row_not_well_formed(self) -> None:
         row = ResearchResultRow(["only_one"])
@@ -201,6 +203,19 @@ class TestResearchResultRow:
         row = ResearchResultRow([None, "t", None, 5, None, None])
         assert row.content_block == []
         assert row.report_markdown == ""
+
+    def test_citation_number_reads_captured_ordinal(self) -> None:
+        row = ResearchResultRow(
+            ["https://example.com", "t", None, 1, None, None, [None, 1], None, 17]
+        )
+        assert row.citation_number == 17
+
+    @pytest.mark.parametrize("value", [None, True, 3.0, "3", []])
+    def test_citation_number_absent_or_non_integer_returns_none(self, value) -> None:
+        row = ResearchResultRow(
+            ["https://example.com", "t", None, 1, None, None, [None, 1], None, value]
+        )
+        assert row.citation_number is None
 
     @pytest.mark.parametrize("block", [[], ["# Report"], [None, 3], [42, 3]])
     def test_malformed_report_content_block_returns_empty(self, block) -> None:

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -67,9 +67,9 @@ class TestExtractReportMarkdown:
         src = [None, "t", None, 5, None, None, ["# Report", 3, None, None, None, []]]
         assert extract_report_markdown(src) == "# Report"
 
-    @pytest.mark.parametrize("kind", [1, 2])
-    def test_web_snippet_content_blocks_are_not_reports(self, kind):
-        src = [None, "t", None, 5, None, None, [None, kind, "web snippet", None, 13]]
+    @pytest.mark.parametrize("kind", [1, 2, 3.0, True])
+    def test_non_report_content_kinds_are_not_reports(self, kind):
+        src = [None, "t", None, 5, None, None, ["# Fake", kind, "web snippet", None, 13]]
         assert extract_report_markdown(src) == ""
 
     @pytest.mark.parametrize("text", [None, 42, ""])
@@ -337,6 +337,8 @@ class TestParseResearchTasks:
         sources = [
             ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
             ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+            ["https://float.example", "Float", "desc", 1, None, None, ["# Fake", 3.0]],
+            ["https://bool.example", "Bool", "desc", 1, None, None, ["# Fake", True]],
             [None, "Deep Report", None, 5, None, None, ["# Actual report", 3]],
         ]
         task_info = [None, ["deep query"], None, [sources], 6]
@@ -344,9 +346,8 @@ class TestParseResearchTasks:
         tasks = parse_research_tasks([[["task_reordered", task_info]]])
 
         assert tasks[0]["report"] == "# Actual report"
-        assert "report_markdown" not in tasks[0]["sources"][0]
-        assert "report_markdown" not in tasks[0]["sources"][1]
-        assert tasks[0]["sources"][2]["report_markdown"] == "# Actual report"
+        assert all("report_markdown" not in source for source in tasks[0]["sources"][:-1])
+        assert tasks[0]["sources"][-1]["report_markdown"] == "# Actual report"
 
     def test_web_rows_without_report_do_not_fabricate_one(self):
         sources = [

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -14,7 +14,7 @@ from notebooklm._research_task_parser import (
     _extract_task_id,
     _extract_task_info,
     _status_from_code,
-    extract_legacy_report_chunks,
+    extract_report_markdown,
     parse_research_task_models,
     parse_research_tasks,
     parse_result_type,
@@ -51,30 +51,31 @@ class TestParseResultType:
         assert parse_result_type([]) == 1
 
 
-class TestExtractLegacyReportChunks:
-    """Tests for legacy deep-research report chunk extraction."""
+class TestExtractReportMarkdown:
+    """Tests for typed deep-research content-block extraction."""
 
     def test_missing_index_6(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None]) == ""
+        assert extract_report_markdown([None, "t", None, 5, None, None]) == ""
 
     def test_index_6_not_list(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, "str"]) == ""
+        assert extract_report_markdown([None, "t", None, 5, None, None, "str"]) == ""
 
-    def test_single_chunk(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, ["chunk"]]) == (
-            "chunk"
-        )
+    def test_short_content_block(self):
+        assert extract_report_markdown([None, "t", None, 5, None, None, ["# Report"]]) == ""
 
-    def test_multiple_chunks_joined(self):
-        src = [None, "t", None, 5, None, None, ["a", "b", "c"]]
-        assert extract_legacy_report_chunks(src) == "a\n\nb\n\nc"
+    def test_current_captured_report_content_block(self):
+        src = [None, "t", None, 5, None, None, ["# Report", 3, None, None, None, []]]
+        assert extract_report_markdown(src) == "# Report"
 
-    def test_filters_non_string_and_empty(self):
-        src = [None, "t", None, 5, None, None, ["real", None, "", 42, "also_real"]]
-        assert extract_legacy_report_chunks(src) == "real\n\nalso_real"
+    @pytest.mark.parametrize("kind", [1, 2])
+    def test_web_snippet_content_blocks_are_not_reports(self, kind):
+        src = [None, "t", None, 5, None, None, [None, kind, "web snippet", None, 13]]
+        assert extract_report_markdown(src) == ""
 
-    def test_all_empty_returns_empty(self):
-        assert extract_legacy_report_chunks([None, "t", None, 5, None, None, ["", None]]) == ""
+    @pytest.mark.parametrize("text", [None, 42, ""])
+    def test_report_content_requires_non_empty_text(self, text):
+        src = [None, "t", None, 5, None, None, [text, 3]]
+        assert extract_report_markdown(src) == ""
 
 
 class TestExtractTaskId:
@@ -313,27 +314,51 @@ class TestParseResearchTasks:
             }
         ]
 
-    def test_legacy_deep_research_report_source(self):
-        sources = [[None, "Legacy Report", None, "report", None, None, ["a", "b"]]]
-        task_info = [None, ["deep query"], None, [sources], 6]
-
-        tasks = parse_research_tasks([[["task_legacy", task_info]]])
-
-        assert tasks[0]["report"] == "a\n\nb"
-        assert tasks[0]["sources"][0]["report_markdown"] == "a\n\nb"
-
-    def test_legacy_report_chunks_after_current_report_are_not_attached(self):
+    def test_captured_deep_research_report_source(self):
         sources = [
-            [None, ["Current Report", "# Current"], None, 1],
-            [None, "Legacy Later", None, "report", None, None, ["legacy"]],
+            [
+                None,
+                "Deep Report",
+                None,
+                5,
+                None,
+                None,
+                ["# Report markdown", 3, None, None, None, ["structured doc"]],
+            ]
         ]
         task_info = [None, ["deep query"], None, [sources], 6]
 
-        tasks = parse_research_tasks([[["task_mixed", task_info]]])
+        tasks = parse_research_tasks([[["task_deep", task_info]]])
 
-        assert tasks[0]["report"] == "# Current"
-        assert tasks[0]["sources"][0]["report_markdown"] == "# Current"
+        assert tasks[0]["report"] == "# Report markdown"
+        assert tasks[0]["sources"][0]["report_markdown"] == "# Report markdown"
+
+    def test_web_rows_before_report_do_not_win(self):
+        sources = [
+            ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
+            ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+            [None, "Deep Report", None, 5, None, None, ["# Actual report", 3]],
+        ]
+        task_info = [None, ["deep query"], None, [sources], 6]
+
+        tasks = parse_research_tasks([[["task_reordered", task_info]]])
+
+        assert tasks[0]["report"] == "# Actual report"
+        assert "report_markdown" not in tasks[0]["sources"][0]
         assert "report_markdown" not in tasks[0]["sources"][1]
+        assert tasks[0]["sources"][2]["report_markdown"] == "# Actual report"
+
+    def test_web_rows_without_report_do_not_fabricate_one(self):
+        sources = [
+            ["https://one.example", "One", "desc", 1, None, None, [None, 1, "snippet"]],
+            ["https://two.example", "Two", "desc", 1, None, None, [None, 2, "snippet"]],
+        ]
+        task_info = [None, ["deep query"], None, [sources], 6]
+
+        task = parse_research_tasks([[["task_no_report", task_info]]])[0]
+
+        assert task["report"] == ""
+        assert all("report_markdown" not in source for source in task["sources"])
 
 
 class TestExtractSourceType:

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -287,7 +287,7 @@ class TestParseResearchTasks:
             title="Video",
             result_type="video",
             research_task_id="task_123",
-            citation_number=9,
+            source_ordinal=9,
         )
 
         assert source.to_public_dict() == {
@@ -295,12 +295,12 @@ class TestParseResearchTasks:
             "title": "Video",
             "result_type": "video",
             "research_task_id": "task_123",
-            "citation_number": 9,
+            "source_ordinal": 9,
         }
 
         assert ResearchSource.from_public_dict(source.to_public_dict()) == source
 
-    def test_citation_numbers_stay_attached_across_reordered_duplicate_urls(self):
+    def test_source_ordinals_stay_attached_across_reordered_duplicate_urls(self):
         sources = [
             ["https://same.example", "Second", None, 1, None, None, [None, 1], None, 2],
             ["https://same.example", "First", None, 1, None, None, [None, 1], None, 1],
@@ -310,7 +310,7 @@ class TestParseResearchTasks:
 
         task = parse_research_task_models([[["task_deep", task_info]]])[0]
 
-        assert [(source.title, source.citation_number) for source in task.sources] == [
+        assert [(source.title, source.source_ordinal) for source in task.sources] == [
             ("Second", 2),
             ("First", 1),
             ("Deep Report", None),

--- a/tests/unit/test_research_task_parser.py
+++ b/tests/unit/test_research_task_parser.py
@@ -287,6 +287,7 @@ class TestParseResearchTasks:
             title="Video",
             result_type="video",
             research_task_id="task_123",
+            citation_number=9,
         )
 
         assert source.to_public_dict() == {
@@ -294,7 +295,26 @@ class TestParseResearchTasks:
             "title": "Video",
             "result_type": "video",
             "research_task_id": "task_123",
+            "citation_number": 9,
         }
+
+        assert ResearchSource.from_public_dict(source.to_public_dict()) == source
+
+    def test_citation_numbers_stay_attached_across_reordered_duplicate_urls(self):
+        sources = [
+            ["https://same.example", "Second", None, 1, None, None, [None, 1], None, 2],
+            ["https://same.example", "First", None, 1, None, None, [None, 1], None, 1],
+            [None, "Deep Report", None, 5, None, None, ["# Report", 3]],
+        ]
+        task_info = [None, ["deep query"], None, [sources], 6]
+
+        task = parse_research_task_models([[["task_deep", task_info]]])[0]
+
+        assert [(source.title, source.citation_number) for source in task.sources] == [
+            ("Second", 2),
+            ("First", 1),
+            ("Deep Report", None),
+        ]
 
     def test_current_deep_research_report_source(self):
         sources = [[None, ["Deep Report", "# Report"], None, 1]]


### PR DESCRIPTION
## Summary

Two defects on the same deep-research source row, one slot apart, so they ship together:

1. **#2140 — report extraction was order-dependent.** `src[6]` was modelled as "legacy report chunks",
   and `extract_legacy_report_chunks` harvested *every string* in the slot and joined them. It is
   actually a **typed content block present on every row**, whose `[1]` is a discriminator
   (`3` = report, `1`/`2` = web snippet). The old code worked only because each row type happens to
   hold exactly one string (report at `[0]`, snippet at `[2]`) **and** the report row happens to
   arrive first. Reorder the same 63 live rows so the report row is last and `task.report` becomes a
   4,020-char tardigrade blurb from the first web result while the genuine 35,773-char report is
   silently dropped — and one web source is handed a fabricated `report_markdown`.
2. **#2141 — an ordinal was decoded and thrown away.** Every discovered (kind-1) row carries an
   integer at `src[8]`, a 1-based bijection over the task's sources. `ResearchResultRow` declared
   positions only up to 6, so nothing read it. It is now exposed as
   `ResearchSource.source_ordinal` — see the Notes on what it is **not**.

The #2140 failure is the worse one: a deep run returning **no** report row does not degrade to "no
report" — it fabricates one from a web snippet and feeds it to `select_cited_sources`, which finds no
URLs and falls back to importing everything, so `--cited-only` silently stops meaning anything.

## Related Issue

Closes #2140
Closes #2141

## Root cause

The real `src[6]` shape, recovered from two live captures 14 months apart:

```
src[6] = [ text|None, kind:int, text|None, None, int|None, structured_doc|None ]

report row : ["# Biophysical and Molecular…", 3, None, None, None, [doc tree]]   len 6
web row    : [None,                           1, "Tardigrades can survive…", None, 13]  len 5
```

Live distribution of `src[6][1]` across 63 rows: `{1: 41, 2: 21, 3: 1}`. The 2026-06 cassette's report
row carries the byte-identical 6-slot shape, so this is stable, not a one-off.

Two accidents were stacked: "join whatever strings are in slot 6" (which only works because each row
type has exactly one string), then `report_found` shielding later rows (which only works because the
report arrives first).

## Changes

- `src/notebooklm/_row_adapters/research.py`
  - `_LEGACY_CHUNKS_POS` → `_CONTENT_BLOCK_POS` (same index 6, honest name), plus
    `_SOURCE_ORDINAL_POS = 8` and the content-block sub-positions
    (`_CONTENT_TEXT_POS = 0`, `_CONTENT_KIND_POS = 1`, `_REPORT_CONTENT_KIND = 3`).
  - `legacy_report_chunks` → `content_block` (raw slot, `[]` when absent/non-list).
  - New `report_markdown`: returns `block[0]` **only** when `block[1] == 3`, else `""`. This is the fix
    — it addresses the report by kind instead of by "first row with any string".
  - New `source_ordinal`: `src[8]` when it is an `int`, else `None`.
  - The module's position-contract docstring is corrected: index 6 is documented as the typed content
    block and index 8 as the per-task source ordinal.
- `src/notebooklm/_research_task_parser.py`
  - `extract_legacy_report_chunks` → `extract_report_markdown`, now a one-line delegation to
    `ResearchResultRow.report_markdown`. Fully internal rename — no doc or public reference exists.
  - `_parse_source_row` threads `source_ordinal=row.source_ordinal` onto the built `ResearchSource`,
    and the shape comments are corrected (see Notes on `deep_payload`).
- `src/notebooklm/_types/research.py` — `ResearchSource.source_ordinal: int | None = None`, round-tripped
  through `from_public_dict` (guarded with `type(x) is int`, so a wire `True` cannot become ordinal `1`)
  and emitted from the public dict only when set, keeping existing payloads byte-identical.
- `src/notebooklm/_research.py` — the `poll` docstring lists `source_ordinal` among the `ResearchSource`
  fields.
- `docs/rpc-reference.md` — corrects the `src[6]` documentation, which described it as
  `[chunk1, chunk2, ...]`, a list of report chunks. #2143 tracks the other wrong claims on this path;
  this PR fixes only the one it touches.
- `docs/python-api.md` — `source_ordinal` on the `ResearchSource` reference, with the "not verified to
  resolve citation markers" caveat inline.
- `tests/_guardrails/_wire_contract.py` — index 6 remapped to the content block, and index 8 added as a
  `Pinned` entry whose evidence string states exactly what the capture shows and what it does not
  establish (that file's own rule: "a wrong mapping here is worse than no mapping").
- Tests: `tests/unit/test_research_row_adapter.py` (kind-3 gating, non-report kinds, malformed blocks,
  ordinal presence/absence/bool-rejection), `tests/unit/test_research_task_parser.py` (the
  renamed helper across the shapes, incl. a bare string and a `["# Report"]` list at slot 6 both
  yielding `""`), `tests/unit/test_research.py`, `tests/unit/test_research_api.py`, and
  `tests/integration/test_research_deep_poll_vcr.py` for the cassette-backed path.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated — N/A, no shape change

Run against the canonical contributor install **plus the extras the CI test matrix adds**
(`--extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate`).
The lean `browser+dev+markdown` install alone skips ~1,500 tests and lands at 83% coverage, i.e.
under the gate — so the suite below is the full-extras run that matches CI:

```console
$ uv run mypy src/notebooklm --ignore-missing-imports
Success: no issues found in 351 source files

$ uv run pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed

$ uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90 -q
TOTAL                                                    30956    828   8132    507    96%
Required test coverage of 90% reached. Total coverage: 96.41%
15244 passed, 65 skipped, 3 xfailed, 116 warnings in 586.88s (0:09:46)
```

I also ran every remaining gate from the `Code Quality` job of `.github/workflows/test.yml`, all green:
`check_workflow_permissions`, `check_workflow_secret_gates`, `check_action_pinning`,
`check_deprecation_targets`, `check_coverage_thresholds`, `check_ci_install_parity`,
`check_claude_md_freshness`, `check_docs_module_refs`,
`audit_public_api_compat.py --check-stale`, `tests/scripts/check_method_coverage.py`,
`pytest tests/e2e --collect-only`, and the lean-install core-import assertion
(`import notebooklm, notebooklm.notebooklm_cli, notebooklm.client, notebooklm.artifacts`).

## Notes

**Why one PR for two issues.** Both read the same source row in the same adapter; #2141's ordinal is
the slot two positions after the one #2140 re-models, and both correct the same position-contract
docstring and the same guardrail entries. Shipping them apart would mean two conflicting edits to
`_row_adapters/research.py`, `_wire_contract.py`, and `rpc-reference.md` for no review benefit.

**The field is `source_ordinal`, not `citation_number` — #2141's framing does not survive the repo's
own cassette, and this is the one thing I'd most like you to check.** #2141 proposes `src[8]` as the
table that resolves the report's `[cite: N]` markers, on the strength of a range/count coincidence:
111 markers spanning 1–41, and 41 rows carrying integers 1–41. That is a count match, not a
per-marker mapping. Decoding `tests/cassettes/research_deep_poll_long.yaml` (terminal
`POLL_RESEARCH`, 25,095-char report, 24 rows with `src[8]` = 1..24) shows:

- the report contains **zero** occurrences of `[cite:` — its markers are plain `[N]` plus a numbered
  reference list, so the `[cite: N]` form #2141 describes is absent from the recorded payload entirely;
- the `src[8]` ordinals are a per-**task** discovery sequence. The rows carrying 1..6 in that cassette
  are about "comparing literary texts with similar themes" while the report is about the bitter
  lesson / JEPA — i.e. the ordinals and the report belong to different tasks in the same poll reply
  (`poll` returns every task visible at that poll).

Shipping this as `citation_number` with docs saying it aligns with report markers would hand callers a
resolver that silently mis-attributes. So this PR keeps the **read** (the slot and the `int` guard are
right, and the data was being discarded) and drops the **meaning**: the field is
`ResearchSource.source_ordinal`, documented as the backend's 1-based per-task ordinal with an explicit
"not verified to resolve the report's citation markers" caveat in the field docstring,
`docs/python-api.md`, `docs/rpc-reference.md`, the CHANGELOG, and the guardrail's evidence string. The
name also no longer collides with the established, genuinely-citation-shaped
`ChatReference.citation_number` on the chat path.

**That makes #2141 a partial close.** The slot is now exposed and no longer discarded, but the
marker-resolution use case #2141 actually wants is *not* delivered — that needs a live capture that
establishes the mapping per marker, on a run whose report uses the `[cite: N]` form. Happy to close
#2141 outright or leave it open for that follow-up; your call.

**`deep_payload` is kept as a compatibility shape — the deliberate decision #2140 asked for.**
#2140 notes that `src[1] == [title, report_md]` "has never appeared in any captured payload" and that
every test of that branch is hand-written, and asks that we decide deliberately rather than leave it.
This PR **keeps** it, relabelled from "deep research (current)" to "deep research (compat)" in both the
adapter and the parser. Reasoning: it costs one guarded branch, `deep_payload` already returns `None`
for the legitimate alternatives so it cannot mis-fire on the captured shapes, and removing a
never-observed *reader* is a behaviour bet against payloads we have not captured, which is the wrong
direction for a client whose #1 breakage class is undocumented wire change. If you would rather see it
deleted, say so and I will drop the branch and its tests in this PR.

**`src[6][5]` remains unread, per #2141.** The report row's structured document tree
(`[start, end, [...]]` spans) is named in the content-block comment but not consumed — #2141 explicitly
flags it as present rather than proposing we read it.

**`select_cited_sources` still regex-scrapes URLs — and deliberately so, now.** #2141 frames the
regex-scrape as a heuristic standing in for an authoritative linkage. Given the above, `src[8]` is not
established to *be* that linkage, so rewiring `select_cited_sources` onto it would trade a working
heuristic for an unverified one. Left alone.

**Scope of verification.** Offline: unit tests, the guardrail suite, and the deep-poll cassette. The
live evidence for #2140 — 63 rows, the `{1: 41, 2: 21, 3: 1}` kind distribution, and the reordering
reproduction — is the maintainer's, not an independent run; I have no account positioned to execute a
350-second deep research task. What I did verify independently is the `research_deep_poll_long.yaml`
decode above (zero `[cite:`, 24 ordinals, cross-task titles), that the code now addresses the report by
`kind == 3` and reads `src[8]`, and that the tests fail without each change.

**Not verified locally:** the Python 3.10–3.14 matrix. No version-sensitive syntax is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Research results now expose each source’s optional ordinal.
  * Deep-research reports are identified from typed report content, including when web sources appear first.
  * Report markdown and source metadata are captured more reliably.

* **Bug Fixes**
  * Prevented web snippets from being mistaken for the final research report.
  * Improved handling of malformed, empty, and legacy-compatible report data.

* **Documentation**
  * Updated API and RPC references to describe source ordinals, report content formats, and citation uncertainty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->