### PR TITLE
test(research): cover empty-report early return in extract_report_urls

### DIFF
--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -106,6 +106,9 @@ class TestCitedSourceSelection:
 
         assert urls == {"https://example.com/a"}
 
+    def test_extract_report_urls_empty_report_returns_empty_set(self):
+        assert extract_report_urls("") == set()
+
     def test_select_cited_sources_filters_urls_and_preserves_report_entry(self):
         sources = [
             {


### PR DESCRIPTION
## Summary
- `extract_report_urls()` in `src/notebooklm/research.py` has an early-return guard clause (`if not report: return set()`) that had no direct test coverage.
- Adds a small unit test following the existing sibling test pattern in `tests/unit/test_research.py`.

## Test plan
- [x] `uv run pytest tests/unit/test_research.py -k extract_report_urls -v` — 4 passed (including the new test)
- [x] `uv run ruff format --check` / `ruff check` — clean
- [x] Full `tests/unit tests/integration` suite run locally — no new failures introduced (pre-existing unrelated symlink-permission failures on this Windows machine, unrelated to this change)

This is my first contribution to this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage confirming that processing an empty report returns no report URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->