### PR TITLE
docs: commit web-RPC/gRPC and PR-2102 audit notes

### DIFF
--- a/docs/notes/pr-2102-quota-source-state-review-2026-08-07.md
+++ b/docs/notes/pr-2102-quota-source-state-review-2026-08-07.md
@@ -1,0 +1,623 @@
+# PR #2102 review + source-add failure-mode research (2026-08-07)
+
+**Subject:** PR [#2102](https://github.com/teng-lin/notebooklm-py/pull/2102) "fix(source): align
+quota and source-state accounting" (closes #1962), head commit `5439e333`.
+
+**Method:** Six-lens review (four native Claude specialists + agy/Antigravity + Codex, which failed
+on a usage-limit error and produced nothing), followed by live empirical probing against the real
+NotebookLM backend (two waves, ~24 distinct `source_add` failure modes) to verify claims that static
+review alone couldn't settle. This document consolidates both.
+
+---
+
+## 1. Six-lens review synthesis
+
+Lenses: `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `type-design-analyzer` (native
+Claude, parallel dispatch), `agy` (independent full pass), `codex` (no output — usage cap). Three
+earlier bot rounds (chatgpt-codex-connector, claude[bot] via GitHub Action) had already landed fixes
+for: ID-only-row state inference, `SourceCounts` public-module rebinding, and an empty-roster race in
+`get_metadata()`. All three verified still-correct on this head.
+
+### 🔴 Should fix before merge
+
+1. **Quota enforcement silently goes fully inert on any settings-RPC failure.**
+   `get_source_limit_or_none` (`_app/source_capacity.py:101-111`) catches bare `Exception` around
+   `client.settings.get_account_limits()` and returns `None` on *any* failure. `require_available`
+   (`source_capacity.py:65`) treats `limit is None` as "unlimited" — a no-op guard. `None` already
+   means "account has no configured cap" elsewhere, so there's no way for a caller to distinguish
+   "unlimited" from "we couldn't check." No doc mentions the collapsed sentinel.
+
+2. **`_extract_notebook_source_counts` still fabricates confident zeros — the "no fabricated states"
+   fix is incomplete.** `_types/notebooks.py:56-57,71-72`: when the sources block is absent/malformed,
+   *or* present but every row is an id-less ghost, the function returns `SourceCounts()` (all zeros)
+   instead of `None`. Serializes as a confident "0 active, 0 failed, 0 total" — contradicts the
+   CHANGELOG's claim that compact rows "leave `source_counts` null rather than fabricating states."
+   Only a genuinely empty `[]` should get real zeros.
+
+Both verified directly against the code (not just reported by a lens).
+
+### 🟡 Consensus findings (≥2 lenses independently)
+
+3. **Quota preflight is bypassed at several call sites** (agy + pr-test-analyzer): MCP file uploads
+   (check deferred until the actual byte POST), research bulk-import (zero capacity-check references
+   anywhere in that path). Both are in the PR's own "Deferred polish findings," but nothing in-code
+   marks them as known-accepted gaps (no comment/xfail/tracking issue).
+
+4. **CLI is left out of the new capacity surface** (agy + type-design-analyzer + code-reviewer):
+   `cli/services/source_listing.py:73` still calls bare `fetch_sources`; MCP/REST both moved to
+   `fetch_sources_with_capacity`. `source list --json` never emits `source_counts`/`source_limit`/
+   `remaining_capacity`, despite this repo having an explicit `test_cli_mcp_parity.py`.
+
+### 🟢 Single-lens, worth a look
+
+- Public SDK bypass (agy) — `client.sources.add_url/add_text/add_file/add_drive*` skip
+  `ensure_source_capacity` entirely; only CLI/REST/MCP adapter paths got wired up.
+- REST `add_file` spools up to 200MiB to disk before the capacity check runs (agy).
+- Positional wire read hard-blocks legit adds with no override (code-reviewer) — `source_limit` comes
+  from an undocumented positional descent (`_settings.py` `limits[2]` under path `(0,1)`).
+- New RPC amplification on hot paths (code-reviewer) — every non-batch `source add` costs +2 POSTs
+  (`sources.list` + `get_account_limits`, run concurrently via `asyncio.gather`); label-filtered
+  `source_list` double-lists. See §3 below for the follow-up analysis.
+- `quota_counted` is a permanent tautology of `active` (code-reviewer) — two fields that can never
+  differ, documented as distinct in `docs/python-api.md`.
+- Type invariants are convention-only (type-design-analyzer) — `SourceCounts`/`SourceCapacity` are
+  frozen dataclasses with no `__post_init__`; nothing stops constructing an inconsistent instance.
+- Unknown-status handling is inconsistent between `has_explicit_status` (→ `None`, "not explicit") and
+  `SourceCounts.from_statuses` (documents degrading unknown statuses to `READY`) — same input shape,
+  different outcome depending on which path parses it (agy).
+- Test gaps: CLI's own tests never exercise the quota-rejection path; both Drive-add executors are
+  untested for rejection (pr-test-analyzer).
+- Minor (code-reviewer): truncated (not fully-empty) roster still overwrites `sources_count`;
+  `SourceAddError.url` gets a notebook id instead of a URL (cosmetic); `asyncio.gather` without
+  `return_exceptions` can orphan a settings POST; two independent `SourceCounts` serializers could
+  drift; an autouse VCR fixture masks capacity regressions across the whole integration suite.
+
+### ✅ Verified clean
+
+Batch capacity-snapshot threading is race-free within a batch (dedup-by-id, no double-counting);
+quota rejection correctly isolates per-item in a batch rather than aborting it (no wasted RPCs — a
+pure local check); label-filtered listing computes capacity against the unfiltered roster correctly;
+`_app`/MCP/REST layering stays clean; `mypy` clean; 441 touched tests pass.
+
+---
+
+## 2. Should we chase every finding, or even close the PR?
+
+Two follow-up questions came up: (a) is the RPC-amplification finding worth fixing, and (b) given the
+quota preflight is fundamentally racy across processes, should the PR be scrapped and rethought?
+
+**(a) RPC amplification** — real, but a fast-follow not a blocker. *(Superseded: §4.7 found the limit
+is already present in the `GET_NOTEBOOK` response `ensure_source_capacity` fetches, which removes the
+extra POST outright rather than caching it. Read that first — the analysis below is retained for
+context.)* `execute_source_add` calls
+`ensure_source_capacity` unconditionally whenever no `capacity` snapshot is passed — i.e. every
+non-batch add. No caching exists anywhere in `_settings.py`/`source_capacity.py`. Cheapest fix:
+memoize `get_account_limits()` per client session (tier is effectively static) — cuts 2 extra RPCs to
+1. The `sources.list()` half is not cheap to remove (the count must be fresh to be meaningful; no
+lighter count-only RPC is known). A free bonus win in the same area: `source_listing.py:92-101`
+double-lists (once for the label-filtered display, once inside `get_source_capacity` for the
+unfiltered count) — should share one fetch.
+
+**(b) The cross-process race** — real and structurally irreducible from the client side, but *not* a
+reason to redesign. No CAS primitive exists in the captured RPC surface, and even a perfect same-host
+lock (this codebase already has `filelock`-based cross-process coordination for auth/storage state)
+couldn't help here, because the NotebookLM **web UI** is an independent writer to the same backend
+resource that no client-side mechanism can ever reach. Any redesign implementing "prevent before
+create" inherits the identical ceiling — the limitation is a property of the problem domain, not this
+PR's implementation. This is honestly documented in `source_capacity.py`'s module docstring already.
+
+**Verified against the original issue.** #1962's body (from a live Codex stress-test round, not
+speculation) already establishes: *"Adding a source that fails... can still create a persistent
+backend row discoverable via `source_list(status="error")`. It's not garbage-collected; the caller
+must delete it,"* and its proposed fix direction — *"validate quota/preconditions before creating a
+backend row"* — is exactly what this PR implements. Its proposed `source_counts` shape
+(`active`/`ready`/`processing`/`failed`/`quota_counted`/`total_records`) is a near-verbatim match to
+what `SourceCounts` ships. The `SourceAddError` message (`source_capacity.py:61-74`) verbatim
+satisfies the issue's Part A acceptance criterion ("name the exact limit + current active count").
+**Conclusion: don't close it.** Fix findings 1–2 above, ship the accounting layer (it's genuinely
+complete and faithful to the bug report), treat findings 3–4 as tracked fast-follows.
+
+Since prevention can never be airtight, accurate *after-the-fact* accounting is the real backstop —
+which is what makes finding #2 (fabricated zeros) more load-bearing than its "IMPORTANT, not
+CRITICAL" label suggests: it's the safety net for exactly the failure mode prevention can't close.
+
+---
+
+## 3. Live RPC probing — what the backend actually does on a failed add
+
+Two probe waves against the real API (scratch notebooks, created and torn down each time), using a
+patched response decoder (`notebooklm._client_seams._default_decode_response`) to dump raw wire
+payloads. Scripts live in the session scratchpad, not committed.
+
+### Wave 1 — single-cause probes (12 cases)
+
+| Probe | RPC path | rpc_code | Client-visible result | Ghost row? | Final status |
+|---|---|---|---|---|---|
+| dead domain | `ADD_SOURCE` (`izAoDd`) | 9 | `SourceAddError` (sync) | yes | `ERROR` |
+| 404 / 403 / 500 / empty-204 body | `ADD_SOURCE` | 9 (all four, identical) | `SourceAddError` (sync) | yes | `ERROR` |
+| bad YouTube ID | `ADD_SOURCE` | 9 | `SourceAddError` (sync) | yes | `ERROR` |
+| good URL (control) | `ADD_SOURCE` | — | success | — | `READY` |
+| empty file (0B) / corrupt "PDF" / mismatched MIME | `ADD_SOURCE_FILE` (`o4cbdc`) | — | **success, no exception** | yes | `ERROR` (async, ~3s later) |
+| unsupported `.exe` | `o4cbdc` register → upload POST | — | `ValidationError` (HTTP 400, **different exception class**) | yes | **`PREPARING` forever** |
+| empty text | `ADD_SOURCE` | **3** (INVALID_ARGUMENT) | `SourceAddError` (sync) | **no** | — |
+
+Findings:
+
+- **`rpc_code` does not discriminate cause for URLs.** Dead domain, 404, 403, 500, and an empty body
+  all return the identical `9`/"Failed precondition." No signal distinguishes "permanently dead" from
+  "blocked/paywalled" from "transient 5xx."
+- **File-content failures are a worse gap than URL failures.** `add_file` returns *successfully, with
+  no exception*, for empty/corrupt/mismatched-MIME files — the register RPC always succeeds before
+  content is inspected; validation happens async afterward. A caller without `wait=True` gets zero
+  synchronous signal that the file actually failed.
+- **Unsupported file types leave a permanent quota-consuming zombie.** The `.exe` case: registration
+  succeeds, the upload body itself gets HTTP-400-rejected (`ValidationError`, not `SourceAddError`/
+  `RPCError` — any future cleanup logic keyed only on `SourceAddError` would miss this), and the row
+  is stuck in `PREPARING` — never resolves to `ERROR`. `SourceCounts.from_statuses` counts `PREPARING`
+  toward `active`/`quota_counted`. This row silently and permanently eats a real quota slot and
+  doesn't even show up under `source_list(status="error")`. Not covered by #2102 or #1962 — both are
+  scoped around the `ERROR`-status ghost pattern specifically.
+- **The one clean case (empty text) proves the backend *can* reject with zero side effects** when the
+  failure is knowable without I/O (no fetch/parse attempt needed). It just doesn't do that for
+  anything requiring a fetch or content-parse — those need a row to exist first as an attachment point
+  for the eventual result.
+- **Ghost-row creation is immediate, not a delayed/probabilistic artifact.** Verified present on the
+  first `source_list` check and stable through 15s of polling — confirming this is deterministic
+  backend behavior, not a rare timing quirk.
+
+### Wave 2 — structural probes (batch, duplicates, Drive, schemes, timeout, content-type, concurrency)
+
+- **Batching contaminates good sources with bad ones.** Sent a single raw `ADD_SOURCE` RPC with two
+  entries (one good URL, one 404) by bypassing the client's one-source-per-call policy (the RPC method
+  is documented as "batch-capable" in `rpc/types.py`, this client just doesn't use that). The whole
+  RPC failed, and **both** sources — including the one that should have succeeded standalone — landed
+  as `ERROR`. This is the most consequential wave-2 finding: it retroactively validates, with real
+  evidence, why this codebase's batch adapters (`mcp/tools/sources.py::_add_url_batch`,
+  `server/routes/sources.py::add_batch`) loop one RPC per source instead of using the wire protocol's
+  real batch capability — a true batch call fails atomically at the row level and punishes unrelated
+  good sources caught in the same call. **Worth a code comment on `RPCMethod.ADD_SOURCE` or in
+  `source_capacity.py`'s docstring so a future "let's batch for efficiency" change doesn't reintroduce
+  this.**
+- **Idempotent retry self-healed under a genuine transport timeout.** A slow-URL probe (artificial
+  10s server delay) tripped an actual 30s transport timeout → `RPCTimeoutError` → the existing
+  probe-before-retry path in `idempotent_create` → the retry succeeded cleanly (`PREPARING`, no
+  duplicate, no exception surfaced). Real-world validation of that machinery, not just unit tests.
+- **URL-add supports PDFs, not raw images.** A direct PDF URL succeeded and was correctly imported
+  (`READY`, title auto-derived). A direct PNG URL got the same generic code-9 rejection as a dead
+  link. A previously-undocumented content-type boundary specific to the URL-add path (distinct from
+  file upload) — worth a line in `docs/python-api.md` or `docs/troubleshooting.md`.
+- **No client-side URL scheme validation.** `javascript:`, `ftp://`, `file:///etc/passwd`, and a
+  `data:` URL all passed through untouched to the RPC (which correctly rejected all four with code 9).
+  No local dereferencing happens — notebooklm-py never opens `file://` locally, so no SSRF/LFI risk on
+  this client's own host — but each one wastes a round trip and creates a nonsense-titled ghost row.
+  A cheap `urlparse(url).scheme in ("http", "https")` pre-check would skip both costs.
+- **No dedup on repeated failures.** The same bad URL added twice created two independent ghost rows.
+  Unlike the successful-add idempotency path (probes before retrying), a failing add has no equivalent
+  safety net — repeated retries of a still-bad URL pile up ghosts without bound.
+- **Drive-source errors don't propagate `rpc_code` consistently.** The invalid-Drive-file-id probe hit
+  the same code-9 at the RPC layer (visible in the raw capture), but `SourceAddError.cause.rpc_code`
+  came back `None` — the Drive add path's exception handling doesn't carry the code through `.cause`
+  the way URL/text paths do. Relevant if `rpc_code` passthrough (see §5) is ever built.
+- **Burst of 5 concurrent bad adds** all got the same code 9 — no distinct rate-limit signal (code
+  8/RESOURCE_EXHAUSTED) appeared at this scale. Inconclusive; deliberately didn't push higher to avoid
+  stress-testing the live service.
+
+---
+
+## 4. Android binary cross-check — what the first-party client knows
+
+Third investigation wave: rather than probe the backend, ask Google's own mobile client what the
+backend's contract *is*. Sources: the recovered mobile schema (`docs/mobile/schema.proto`, 282
+messages / 767 fields, produced by the blutter port documented in `docs/mobile/endpoints.md`) and
+string/symbol mining of `libNotebookLM_prod_android_library_flutter_artifacts.so` from
+`notebooklm.apk/split_config.arm64_v8a.apk` (app v1.46.7). Dart AOT symbol names carry a per-library
+id suffix (`@1877180633`), so grouping on it reconstructs each file's method surface without a full
+decompile.
+
+### 4.1 The ghost row is the documented protocol, not a leak
+
+Mobile has an RPC the web client doesn't: **`AddTentativeSources`**, and the schema makes the two-phase
+binding explicit:
+
+```protobuf
+message AddTentativeSourcesRequest {
+  repeated TentativeSourceMetadata tentativeSourcesMetadata = 1;  // just { string name }
+  string projectId = 2; ...
+}
+message AddTentativeSourcesResponse { repeated Source tentativeSources = 1; }
+
+message UserContent {                    // the AddSources (phase 2) payload
+  ...
+  SourceId tentativeSourceId = 9;        // ← rebinds phase 2 to the phase-1 row
+}
+```
+
+The row is created **before any content is inspected**, and `tentativeSourceId` re-attaches the real
+content afterward. This confirms wave-1's inference (§3, "those need a row to exist first as an
+attachment point") as the backend's actual design. Our web file path is the same shape:
+`_source/upload.py:400-432` — `_register_file_source_for_upload` → `start_resumable_upload` → body
+stream → `wait_until_registered`.
+
+### 4.2 `PREPARING` is really `TENTATIVE` — this rewrites the wave-1 `.exe` finding
+
+The binary's `SourceStatus` enum has six values; `rpc/types.py:437-440` models four. **Numbering read
+directly out of the decompiled object pool** (`out/full/pp.txt` — each `ProtobufEnum` instance carries
+its literal value at `off_8`), so this is measured, not inferred:
+
+| # | Backend name | `rpc/types.py` |
+|---|---|---|
+| 0 | `SOURCE_STATUS_UNSPECIFIED` | — |
+| 1 | `SOURCE_STATUS_PENDING` | `PROCESSING` |
+| 2 | `SOURCE_STATUS_COMPLETE` | `READY` |
+| 3 | `SOURCE_STATUS_ERROR` | `ERROR` |
+| 4 | `SOURCE_STATUS_PENDING_DELETION` | **unmapped → `"unknown"`** |
+| 5 | `SOURCE_STATUS_TENTATIVE` | `PREPARING` |
+
+Independently corroborated positionally: `rpc/types.py` documents status at `source[3][1]`, and the
+wire proto is `Source.settings` (tag 4 → index 3) → `SourceSettings.status` (tag 2 → index 1). Exact
+match — the web JSON array and the mobile protobuf are the same message, so mobile field tags are a
+reliable decoder for web positional indices generally.
+
+**Mobile collapses these six wire states into four UI states.** A second, client-side `SourceStatus`
+Dart enum exists (`unknown=0, loading=1, complete=2, failed=3`), and the mapping function
+`_extension#23.toSourceStatus` (`persistence_proto_util.dart`, `0x10b8b58`) disassembles to:
+
+| Wire | UI |
+|---|---|
+| `PENDING` (1), `PENDING_DELETION` (4), `TENTATIVE` (5) | `loading` |
+| `COMPLETE` (2) | `complete` |
+| `ERROR` (3) | `failed` |
+| `UNSPECIFIED` (0), anything else | `unknown` |
+
+So the first-party client deliberately shows a stuck `TENTATIVE` row as an indefinite spinner. It has
+no notion that the row is dead — which is exactly the `.exe` symptom, and confirms there is no
+server-side signal we're failing to read.
+
+Consequences:
+
+- **The `.exe` zombie is not "stuck in a processing stage" — it is a row still in phase 1 that was
+  never committed.** Registration created the tentative row, the upload body was rejected at HTTP 400,
+  and the phase-2 commit never ran. Strictly sharper than §3 could state, and it predicts the row is
+  permanently inert (nothing exists to advance it), which matches the observed behaviour. It also means
+  `PREPARING` is *structurally* ambiguous in our model: it conflates "upload in flight, will resolve"
+  with "half-finished transaction, will never resolve" — the two cannot be told apart by status alone.
+- **Status `4`/`PENDING_DELETION` is a real state we don't model**, and `source_status_to_str`
+  (`rpc/types.py:465`) degrades it to `"unknown"`. A source observed mid-deletion falls through every
+  status branch. Separate from #2102's scope; worth its own small issue.
+
+### 4.3 There is no per-source failure reason anywhere in the schema
+
+Across all 282 recovered messages, `Source`, `SourceMetadata`, and `SourceSettings` carry **no error,
+reason, or failure-detail field**; `AddSourcesResponse` returns bare `Source` objects. This settles
+§3's `rpc_code` finding from the opposite direction: it isn't that the code is a coarse bucket, it's
+that the backend has **no per-source failure channel to expose**.
+
+The mobile UI's entire add-failure vocabulary corroborates it:
+
+| l10n key | Cause |
+|---|---|
+| `ProjectL10n\|maxSourcesReached{SnackbarMessage,DasherUserMessage,NonDasherPlusMessage,NonDasherNonPlus{Owner,Writer}Message}` | quota (4 tier/role variants) |
+| `ProjectL10n\|get#fileTooLargeSnackbarMessage` | file size |
+| `ContentPickerL10n\|get#invalidYoutubeUrlSnackbarMessage` | **client-side** pre-check |
+| `ContentPickerL10n\|get#unsupportedDriveFileTypeMessage` | **client-side** pre-check |
+| `ProjectL10n\|get#couldNotAddSourceSnackbarMessage` | generic catch-all |
+
+There is no "couldn't fetch that URL" string. Google's own first-party client cannot distinguish a
+paywall from a dead domain either — this is a hard ceiling on any `rpc_code` passthrough design, not a
+gap in this client. Note also that two of the five are *client-side* validations, which supports the
+cheap-pre-check idea in §5.
+
+### 4.4 Quota is signalled by a short response, not by an error
+
+A log string recovered verbatim from the binary:
+
+> `Server returned fewer tentative IDs than requested. This will happen when user reach the source upload limits. In this case, intentionally to skip id updates for sources.`
+
+`AddTentativeSources` **silently returns fewer rows than requested** when the cap is hit — no error
+code, no `RESOURCE_EXHAUSTED`. That is very likely why §3's 5-concurrent-bad-add burst never surfaced
+code 8: that isn't the channel quota uses.
+
+Additionally, the limit is **discoverable rather than empirical**: `Project.projectTierLimits` is a
+`TierLimits` message returned on *every* `GetProject`. Exact tags, from the decompiled `BuilderInfo`:
+
+```protobuf
+message TierLimits {          // google.internal.labs.tailwind.orchestration.v1 (wire)
+  int32 maxProjects          = 2;
+  int32 maxSourcesPerProject = 3;
+  int32 maxWordsPerSource    = 4;
+}
+```
+
+There is no tag 1 — the builder starts at 2, so no field is missing. (The app's *local persistence*
+copy of `TierLimits` uses identical tags but renames tag 2 to `maxProjectsOfProjectOwner`.) Note
+`maxWordsPerSource` is a limit we don't model or surface anywhere.
+
+We don't read this at all today — `_settings.py` instead derives `source_limit` from a separate
+undocumented positional descent (`limits[2]` under path `(0,1)`), flagged as brittle in §1 — **which
+§4.7 confirms is this very `TierLimits` message**, reached from a different RPC.
+
+> **Parser bug found along the way.** `docs/mobile/schema.proto` renders all three of these as
+> `int32 fieldType = N`. That's an artifact of `scripts/parse_pbschema.py`: the Dart `BuilderInfo`
+> const list contains a literal placeholder string `"fieldType"`, and the parser picks that up instead
+> of the adjacent real name. Any `fieldType` in the committed schema is a **parse failure, not a real
+> field name** — the true names are recoverable from the `asm/` output as shown above. Bounded:
+> **11 occurrences out of 767 fields** (~1.4%), so the rest of the schema is unaffected.
+
+### 4.5 Mobile doesn't *delete* ghost rows either — it reconciles around them
+
+The add-source helper library (`@1877180633`) is **eight symbols total**: `_addDriveSourcesToProject`,
+`_addFileSourcesToProject`, `_addTextSourcesToProject`, `_addPlayBooksSourcesToProject`,
+`_handleAddSourceError`, `_quotaExceededSnackbarContent`, `_logger`, `init:_logger`. The entire error
+path is log + snackbar. The only `DeleteSources` caller in the whole binary is `_handleDeleteSource`
+(`@1880355218`) — the user tapping delete.
+
+Instead, mobile leans on `_reconcileOptimisticSources` + `_startPeriodicRefresh`/`_stopPeriodicRefresh`
+(notebook-detail view model, `@1880355218`): tentative rows are treated as optimistic UI — the app even
+synthesizes client-side placeholder titles (`UserContent|get#{pdfFile,imageFile,driveFile,audioFile,
+youtubeVideo}OptimisticSourceName`) — and reconciled against polled server truth. **Google's answer to
+the ghost-row problem is display reconciliation, not deletion.** The debris stays. This doesn't
+invalidate the §5 `cleanup_on_failure` idea, but it does confirm no server-side GC exists to wait for,
+and that opt-in (not default) is the right posture. §4.6 pins down the exact mechanism — the cleanup
+that does happen is purely local.
+
+### 4.6 What the failure path actually does (disassembled)
+
+The first pass could only list symbol names. With the analysis build, the two relevant functions
+decompile to concrete call sequences.
+
+**`_handleAddSourceError`** (`project_list_util.dart:631`) — in order:
+
+1. `SafeLogger::atWarning` — log only.
+2. `TailwindService::getProject` — **re-fetch the project from the server** (with a
+   `RequestExecutionMode`), i.e. go get ground truth rather than trust local state.
+3. `ProjectBuilder::sourceItems` → `ListBuilder::removeWhere` (+ `ListBase::contains`) — **drop the
+   optimistic rows from the local model.**
+4. `SnackbarDisplayController::showInfoSnackbar` — note **info**, not an error toast.
+
+This meaningfully refines §4.5. Mobile *does* clean up after a failed add — but **only the client-side
+copy**. There is no `DeleteSources` call anywhere on this path; the backend row is left exactly where
+it is. So the mobile behaviour is "re-sync from server, discard my optimistic guesses, tell the user
+mildly" — the ghost row survives, and the user is never told a row leaked. The whole failure path is
+also *unconditional*: it does not branch on error type at all, which is consistent with §4.3 (there's
+no per-source reason to branch on).
+
+**`_registerTentativeSources`** (`project_component.dart:7406`) — calls
+`SourceService::addTentativeSources`, then on the short-response quota case (§4.4) does
+`SafeLogger::atWarning` + `showInfoSnackbar` + `Store::upsertProject` / `_onProjectUpdated`. No retry,
+no error raised, no distinction from a normal partial result — it simply persists whatever came back.
+
+**Quota copy confirms role/tier-aware remediation.** The four `maxSourcesReached*` variants resolve to
+distinct user guidance, which is a genuine product decision worth mirroring if we ever improve
+`SourceAddError`'s message:
+
+| Audience | Copy |
+|---|---|
+| Enterprise/Dasher | `…source limit.` (no remediation offered) |
+| Writer, not owner | `…source limit. Contact the owner of the notebook to upgrade.` |
+| Owner, upgradeable | `…source limit. For more, <upgrade-link>upgrade</upgrade-link>.` |
+
+Separately, a distinct `You've reached the usage limit. Please try again later.` string exists — a
+rate-limit message, not a source-count one. Relevant to §6's open question about whether a true
+RESOURCE_EXHAUSTED path exists: the app clearly has copy for one, even though the 5-add burst in §3
+never triggered it.
+
+### 4.7 Confirmed on the web wire: `GET_NOTEBOOK` carries the same `TierLimits`
+
+Checked against the committed VCR cassettes (`tests/cassettes/*.yaml`, 35 contain `rLM1Ne`), decoding
+the batchexecute envelope directly. **Answer: yes.**
+
+`GET_NOTEBOOK` (`rLM1Ne` → `GetProject`) returns the tier block at **top-level index 10 = proto tag 11**
+— exactly where mobile's `Project.projectTierLimits = 11` says it should be:
+
+```
+[10] (tag 11) → [6, 500, 300, 500000, 2]
+[9]  (tag 10) → [true, true, true]        # PremiumFeatureInfo's 3 bools, also as predicted
+```
+
+Decoded with the mobile field names (§4.4), against a Pro account:
+
+| idx | tag | mobile name | value |
+|---|---|---|---|
+| 0 | 1 | *(not in mobile schema)* | `6` |
+| 1 | 2 | `maxProjects` | `500` |
+| 2 | 3 | `maxSourcesPerProject` | `300` |
+| 3 | 4 | `maxWordsPerSource` | `500000` |
+| 4 | 5 | *(not in mobile schema)* | `2` — matches `AccountLimits.tier` 2 = Pro |
+
+These are exactly Google's published Pro limits (500 notebooks / 300 sources / 500k words), so the
+mapping is externally corroborated, not just internally consistent.
+
+**It is the same block `_settings.py` already parses.** `GET_USER_SETTINGS` (`ZwVcOc`) at path `(0,1)`
+returns `[6, 500, 300, 500000]` — identical values, and `_NOTEBOOK_LIMIT_INDEX=1` /
+`_SOURCE_LIMIT_INDEX=2` / `_TIER_INDEX=4` line up with `maxProjects` / `maxSourcesPerProject` /
+tier. So the "undocumented positional descent" flagged in §1 isn't a mystery shape — **it is
+`TierLimits`, and mobile just gave us its field names.** That alone de-risks the §1 finding without
+changing any code: the indices can be documented and named instead of left as magic numbers.
+
+**Two bugs this surfaces:**
+
+1. `_settings.py:17` comments index 3 as `max_characters_per_source`. Mobile names it
+   **`maxWordsPerSource`**, and Google documents 500,000 **words** per source. The comment is wrong;
+   the field is words, not characters.
+2. ~~In both captured `GET_USER_SETTINGS` responses the limits list has only 4 elements, so `tier`
+   comes back `None`.~~ **REFUTED by live probing (§4.8).** Live `get_account_limits()` returns a
+   **5-element** list with `tier` populated (`raw_limits=(1, 100, 50, 500000, 1)`, `tier=1`). The
+   4-element responses are an artifact of those specific older cassettes, not current backend
+   behaviour, and `_TIER_INDEX` is not dead code. Only the `maxWordsPerSource` mislabel (item 1) is a
+   real bug.
+
+**Caveat before acting on this.** Presence is not guaranteed — but it is far more reliable than a
+first, buggy pass suggested. Across **all 42** captured `GET_NOTEBOOK` frames, **41 carry the block**.
+The sole absence is `notebooks_create.yaml`, a fetch immediately after creating a notebook, which
+returned `null` at **both** index 9 and index 10. Request params are byte-identical across cassettes
+(only the notebook id differs), so this is server-side lazy population on a fresh notebook, not a
+request-shape artifact. A switch to reading limits from `GET_NOTEBOOK` still needs a **fallback to
+`get_account_limits()` when index 10 is null** — but that fallback fires on ~2% of calls, not ~17%.
+
+The block also appears in **two shapes**: `[6, 500, 300, 500000]` (24 frames) and
+`[6, 500, 300, 500000, 2]` (17 frames). So the trailing `tier` element is genuinely **optional on the
+same account**, and `_settings.py`'s `len(limits) > _TIER_INDEX` guard is correct and load-bearing —
+not dead code.
+
+> **Numbers corrected 2026-08-07.** An earlier pass reported "5 of 6 frames" here. That was wrong: the
+> cassette frame-splitter treated batchexecute's **byte** length prefix as a character count, so any
+> response containing non-ASCII was silently dropped. `rLM1Ne` actually has **42** frames, not 6, and
+> `hizoJc` decoded as "empty" when it was not. Tooling fixed; every count in §4.7 is from the full set.
+> Flagged by the source-domain audit — a good catch against my own tooling.
+
+**Impact on §1 and §2a.** With that fallback, the §2a RPC-amplification finding largely dissolves:
+`ensure_source_capacity` already calls `sources.list()`, which *is* `GET_NOTEBOOK` (`listing.py:46`),
+so the limit arrives in a response we are already paying for — the extra `get_account_limits()` POST
+becomes a rare fallback rather than a per-add cost. That is a better fix than the memoization proposed
+in §2a, and it composes with it (memoize the fallback too). This is now the recommended direction for
+both findings.
+
+### 4.8 Live cross-transport check: web and mobile gRPC agree exactly
+
+Ran the same account against **both** transports live (not cassettes), using a mobile gRPC harness
+built for this (see §4.10):
+
+| | tag 1 | `maxProjects` | `maxSourcesPerProject` | `maxWordsPerSource` | tier |
+|---|---|---|---|---|---|
+| Web `get_account_limits()` — live | 1 | 100 | 50 | 500000 | 1 |
+| Mobile gRPC `GetOrCreateAccount` `[1.2]` — live | 1 | 100 | 50 | 500000 | 1 |
+
+**Field-for-field identical.** This is the strongest available confirmation that the block
+`_settings.py` parses positionally IS the `TierLimits` message, and that our index constants are
+correct — the same values arrive tag-addressed over gRPC, where there is no positional ambiguity to
+get wrong.
+
+Three consequences:
+
+1. **`tier` is populated and `_TIER_INDEX` works.** Live returns 5 elements with `tier=1`. The
+   4-element cassette responses were stale samples, not current behaviour — correcting §4.7 item 2.
+2. **The Pro figures `[6, 500, 300, 500000, 2]` in the cassettes come from a different, Pro-tier
+   account**, not from a transport difference. Both live profiles here are free tier
+   (100 notebooks / 50 sources / tier 1), matching Google's published free limits, exactly as the Pro
+   cassette values match the published Pro limits. Two tiers, two transports, all four consistent.
+3. **`maxWordsPerSource = 500000` is tier-independent** — identical on free and Pro. Reinforces that
+   it is a per-source content limit, and that `_settings.py:17` calling it "characters" is wrong
+   (§4.7 item 1).
+
+### 4.9 Confidence
+
+Everything in §4 is now **measured**, not inferred. The two open items from the first pass (enum
+numbering, `TierLimits` tags) were closed by rebuilding blutter *with* code analysis and reading the
+object pool and `BuilderInfo` disassembly directly, and the failure path in §4.6 is read off real
+disassembly rather than guessed from symbol names.
+
+The rebuild is preserved at **`~/src/blutter-nblm/`** with a `README.md` recording the full build
+identity and a from-scratch reproduction recipe. Verified build inputs:
+
+| | |
+|---|---|
+| App | NotebookLM `1.46.7.940945420`, `.so` sha256 `082d75e3…b8e6f81f` |
+| Dart SDK | `3.13.0-256.0.dev` @ `bf06ec43d9f241a04072fc97ed3f2501ce935d7d` |
+| Snapshot hash | `80d3c83b83e625573b88d3775debfe7d` |
+| blutter base | `528acbe83ba35a3a53fb97b231cb5f968c7068d1` + `docs/mobile/blutter-dart3.13.patch` |
+
+Two corrections to the prior reversing notes: the patch **applies cleanly to current blutter HEAD**
+(no rebase needed), and the build is **~3 minutes, not multi-hour** — the Dart SDK sparse clone is only
+71 MB. `docs/mobile/endpoints.md` and the `mobile-binary-reversing` memory should be corrected.
+The one analysis error emitted (`handleArgumentsDescriptorTypeArguments`, `insn.IsBranch()`) is
+non-fatal and did not affect any output used here.
+
+Nothing here contradicts §3's batch-contamination finding — the mobile schema is batch-shaped
+throughout (`repeated UserContent`, `repeated TentativeSourceMetadata`), so atomic per-batch failure
+remains the backend's real semantics and the one-RPC-per-source architecture note stands.
+
+### 4.10 Live mobile-gRPC probing — how, and one very costly gotcha
+
+The mobile gRPC API can be called directly from Python, which makes the mobile surface testable
+rather than merely readable. This closes the loop on §4: claims can now be confirmed against the live
+backend on **both** transports.
+
+**Auth** — exactly as `docs/mobile/auth-research.md` documents, and it is still
+accurate. `gpsoauth.perform_oauth()` with the NotebookLM Android identity
+(`app=com.google.android.apps.labs.language.tailwind`,
+`client_sig=a3382adf91991e6ef1e7e7de309c1febfedf3283`) and the **full 10-scope Android bundle** yields
+a 432-char `ya29` bearer. The `labs-tailwind` scope alone mints fine but then fails the actual call
+with `grpc-status 7 PERMISSION_DENIED` — a failure that only shows up at request time, not at mint
+time.
+
+**The gotcha, which cost an hour:** the request `content-type` must be plain **`application/grpc`**.
+Sending `application/grpc+proto` makes Google's ESF frontend return an **HTML 404** — which reads
+exactly like a wrong host or an unregistered method path, and sends you hunting through hostnames and
+API keys. Ruled out along the way (all irrelevant): 4 candidate hosts, and all 4 `AIza…` keys embedded
+in `base.apk` as `x-goog-api-key`. Diagnostic tell: a *correct* request to a *wrong* service returns
+`HTTP 200` with `grpc-status: 12` (UNIMPLEMENTED) — as `notebook-pa.googleapis.com` does — whereas a
+content-type mismatch returns an HTML 404. **A 404 here means content-type, not routing.**
+
+```
+POST https://notebooklm-pa.googleapis.com/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/<Method>
+authorization: Bearer <ya29…>
+content-type: application/grpc          # NOT application/grpc+proto
+te: trailers
+body: b"\x00" + uint32be(len(msg)) + msg
+```
+
+No `x-goog-api-key` is required. The host `notebooklm-pa.googleapis.com` is confirmed correct by real
+intercepted app traffic (`scripts/capture_mobile_grpc.js:15`), so the earlier suspicion of endpoint
+drift was unfounded — the documented endpoint works unchanged.
+
+Harness used for §4.8 lives in the session scratchpad (`mgrpc.py`: protobuf encode/decode, gRPC
+framing, bearer minting, `NB_PROFILE` selection). Not committed — it handles credentials, and it
+should stay out of the repo unless it is reworked to reuse `_auth/` rather than read
+`master_token.json` directly.
+
+---
+
+## 5. Design implications for follow-up work
+
+None of this has been implemented yet — captured here as scoped ideas for later, informed by what the
+probing actually showed (several of these are weaker than they looked before probing; noted below).
+
+- **`cleanup_on_failure` option for `source_add`.** Buildable: `ensure_source_capacity` already
+  lists sources before a create attempt (for the quota check), so a "before" snapshot is often already
+  in scope for free. On failure, diff against a fresh `list(status=ERROR)` and delete only what's new
+  (never blind-delete-all-ERROR — that would nuke a stub the user left there on purpose to inspect).
+  Needs to be **three different mechanisms**, not one, per the probing: (1) hook off `SourceAddError`
+  for the URL path (synchronous, works as designed), (2) needs `wait`-style polling for the
+  file-content-failure path (no synchronous exception exists to hook there), (3) needs to also catch
+  `ValidationError` (not just `SourceAddError`) for the unsupported-file-type path — the one that
+  actually matters most, since it's the only ghost shape that silently inflates quota. Recommend
+  opt-in (not default), to preserve today's debuggability.
+- **`rpc_code` passthrough on `SourceAddError`.** Cheap (data already flows onto `.cause`, mostly
+  needs a forwarding property + message line) but weaker than first proposed: probing showed code 9 is
+  a single bucket for *all* URL-fetch-failure causes (dead domain, 404, 403, 500, empty body) — it
+  won't power a smart "worth retrying as text" decision for URLs. Still useful as a coarse
+  "input rejected outright (3) vs fetch/parse attempted and failed (9)" signal, and for programmatic
+  handling instead of string-matching the generic message. Needs fixing in the Drive path too (see
+  above) to be consistent across source types.
+- **`text_fallback` param for `add_url`** (pairs with the cleanup option): try the URL, and on
+  `SourceAddError`, clean up the ghost stub and add caller-supplied pre-fetched text as the
+  replacement in one call, instead of two manual steps. Deliberately *not* proposing the library
+  auto-fetch content itself as a fallback — if a CDN/anti-bot layer blocked Google's own fetcher,
+  there's no strong reason to expect this client fetching from a different IP/UA would fare better,
+  and it adds a new failure/security surface for uncertain benefit.
+- **Doc note on the URL/PDF content-type boundary** (PDF via URL: yes; image via URL: no).
+- **Doc/comment note on batch-RPC contamination**, so a future contributor doesn't "optimize" the
+  sequential-loop batch adapters into a single multi-entry RPC call and reintroduce failure
+  contamination of good sources.
+- **Optional: cheap scheme pre-validation** on `add_url` to skip obviously-non-http(s) input before
+  spending an RPC round trip and creating a ghost row.
+
+## 6. Open / unresolved
+
+- Whether an actual quota-boundary rejection (the 51st source against a real limit) produces the same
+  `rpc_code=9` as the generic fetch-failure cases, or something distinguishable — not tested (would
+  require filling a real notebook to its limit; judged not worth the cost/waste for this pass).
+  §4.4 makes a concrete prediction to test against: on mobile the cap manifests as a *short response*
+  (fewer rows than requested) rather than any error code, so the web path may likewise return success
+  with nothing created rather than an `rpc_code` at all.
+- Whether higher-volume concurrent bursts would surface a distinct RESOURCE_EXHAUSTED (8) code — burst
+  of 5 didn't trigger it; not pushed further to avoid stress-testing the live service. §4.4 suggests
+  this may be a dead end: quota doesn't appear to use an error code on this surface.
+- ~~Whether the web `GET_NOTEBOOK` response carries the `TierLimits` block~~ — **resolved: it does**,
+  at index 10 (§4.7). Remaining sub-question: how broadly the null-on-freshly-created case applies, and
+  whether `GET_USER_SETTINGS` ever returns the 5th (tier) element in real traffic — both captures had
+  only 4, the unit tests assume 5.
+- ~~Exact `SourceStatus` numbering and `TierLimits` field↔tag pairing~~ — **resolved** by the blutter
+  rebuild (§4.2, §4.4, §4.8).
+- How many other `fieldType` entries in `docs/mobile/schema.proto` are parser failures rather than
+  real names (§4.4) — `scripts/parse_pbschema.py` needs a fix, and the committed schema a re-run.

--- a/docs/notes/web-rpc-vs-mobile-grpc-audit-2026-08-07.md
+++ b/docs/notes/web-rpc-vs-mobile-grpc-audit-2026-08-07.md
@@ -1,0 +1,640 @@
+# Web RPC ⇄ mobile gRPC audit — gaps and bugs (2026-08-07)
+
+**Question:** does `notebooklm-py`'s web `batchexecute` client discard information the backend
+actually sends, and does it misread any field?
+
+**Method:** a five-agent parallel audit (enums, sources, notebooks/sharing, artifacts, chat/research)
+diffing our client against ground truth recovered from Google's official NotebookLM Android app,
+then **confirming every claim live against the real backend on both transports**. Ground truth:
+`docs/mobile/schema.proto`, the blutter analysis build (object pool + `BuilderInfo` disassembly —
+see [pr-2102 review §4.10](pr-2102-quota-source-state-review-2026-08-07.md)), and live probing.
+
+**Why both transports.** Web `batchexecute` is positional JSON — index `i` carries protobuf tag
+`i + 1`, and nothing on the wire says what a field means. Mobile gRPC returns the *same backend
+messages* tag-addressed. So gRPC is an oracle that removes positional guesswork, and any
+web-vs-gRPC disagreement is a real finding.
+
+> **Precondition every cross-transport finding here rests on: same account on both transports —
+> which means the same profile, and "both unset" does NOT give you that.** The two credential stores
+> resolve an unspecified profile *differently*: `NotebookLMClient.from_storage()` honours
+> `~/.notebooklm/config.json`'s `default_profile`, while a probe harness
+> defaulting to the literal `profiles/default/` directory selects a **different account** on this
+> machine. That mismatch produces `PERMISSION_DENIED` and a web-created notebook missing from the
+> gRPC listing — which reads exactly like a transport difference and briefly produced a wrong
+> "the accounts differ" conclusion during this audit. Within a profile, `master_token.json` (gRPC)
+> and `storage_state.json` (web) do match. **Set the profile explicitly on both sides and verify by
+> comparing the two emails before trusting any cross-transport claim.** The findings below were
+> confirmed under a matched profile.
+
+**Evidence labels:** **CONFIRMED-LIVE** (observed against the live backend), **CONFIRMED-STATIC**
+(disassembly/schema only), **PLAUSIBLE**, **REFUTED**.
+
+---
+
+## 1. Confirmed bugs
+
+### 1.1 CRITICAL — `is_owner` is an inverted public-visibility flag
+
+`_types/notebooks.py:145-151` computes `is_owner = (meta[1] is False)`. Proto tag 2 is **not**
+ownership.
+
+> **Corrected 2026-08-07 by a live two-account probe.** Tag 2 does not track *public* — it tracks
+> **"this notebook has any sharing at all."** A scratch notebook that was never public (tag 13 stayed
+> `false` throughout) flipped tag 2 `false → true` the moment a collaborator was added, and back on
+> revoke. This *subsumes* the earlier `set_public()` observation: making a notebook public is one way
+> to share it, which is why tag 2 and tag 13 moved together in that test.
+>
+> So `is_owner` actually evaluates to **`not (shared with anyone)`**, and the headline repro is much
+> more common than the public-link case: **an owner shares their notebook with a colleague, and their
+> own CLI then labels it "Shared."**
+
+Verified on three independent protocols. gRPC, tag-addressed, same account:
+
+```
+PRIVATE  "Heavy Chain Engineering"   tag1 userRole=1  tag2=0  tag13 isPublic=0
+PUBLIC   "JSON: The Standard…"       tag1 userRole=1  tag2=1  tag13 isPublic=1
+```
+
+`userRole` stays `OWNER` for both; tag 2 tracks public exactly. A web causal test agrees —
+`set_public(True)` flipped `meta[1]` and `meta[12]` together and reverted on `set_public(False)`,
+with `meta[0]` pinned at `1` throughout.
+
+Independently re-verified by the lead before acceptance — our own two APIs contradict each other on
+the same live notebook:
+
+```
+notebooks.list()     → is_owner=False
+sharing.get_status() → is_public=True,
+                       shared_users=[<account-email>, permission=OWNER]
+```
+
+**Impact:** every notebook a user owns *and has shared* is mislabelled (CLI renders "Shared").
+`_notebooks.py:653` `owned_count` undercounts by exactly the number the user has shared, biasing
+`NotebookLimitError`. **Fix:** read `meta[0] == 1` (`userRole == OWNER`).
+
+**Live two-account matrix** (account A owns; B is the collaborator; `userRole` agreed between web
+`meta[0]` and gRPC tag 1 at every stage):
+
+| stage | A `userRole` | A tag 2 | A `is_owner` → CLI | B `userRole` | B `is_owner` → CLI |
+|---|---|---|---|---|---|
+| created, unshared | 1 OWNER | false | True → "Owner" | (no access) | — |
+| shared → B **editor** | 1 OWNER | **true** | **False → "Shared"** | **2 WRITER** | False → "Shared" |
+| shared → B **viewer** | 1 OWNER | true | False → "Shared" | **3 READER** | False → "Shared" |
+| revoked | 1 OWNER | false | True → "Owner" | `PERMISSION_DENIED` | error |
+
+**Three distinct roles collapse onto one string.** An owner-who-shared, a WRITER, and a READER are
+all rendered "Shared" and all report `is_owner=False` — so the boolean cannot be repaired by
+inverting it; it has to become the role. `WRITER=2` / `READER=3` are now **observed live**, closing a
+gap §5 previously recorded as unreachable. `SharePermission` (OWNER=1/EDITOR=2/VIEWER=3) is
+value-identical to `ProjectRole` — the same wire enum under two names.
+
+**The correct data is already parsed elsewhere.** `sharing.get_status()` returned the exact
+permission from B's side; it does not contradict `notebooks.list()`, it simply carries strictly more
+information that `list()` discards. `userRole` is on every `GET_NOTEBOOK` **and** `LIST_NOTEBOOKS`
+row, so the fix costs no extra RPC.
+
+Of all `ProjectMetadata` tags, **only tag 1 (userRole) and tag 2 (has-sharing) varied with permission
+state** across both accounts and every stage — so there is no second candidate field and no ambiguity
+about the fix. `NOT_SHARED=4` is still unobserved: revocation removes access outright rather than
+reporting role 4, so it presumably belongs to the access-request flow.
+
+Related: **`isPublic` (tag 13) is 100% populated on every row and never read anywhere in
+`src/notebooklm`** — we derive the wrong thing from a neighbouring slot while the correct field sits
+two positions away. *(CONFIRMED-LIVE)*
+
+### 1.2 CRITICAL — flashcards send quantity and difficulty transposed
+
+Two sibling call sites disagree with each other:
+
+```
+_artifact/payloads.py:289  quiz:       [quantity_code, difficulty_code]   ← correct
+_artifact/payloads.py:331  flashcards: [difficulty_code, quantity_code]   ← reversed
+```
+
+The backend's `FlashcardsGenerationOptions` is `{1: cardQuantity, 2: flashcardsDifficulty}` (from the
+Dart `BuilderInfo`). Live scratch test: sent `quantity=FEWER(1)`, `difficulty=HARD(3)`; the server
+echoed `[3, 1]` — i.e. it stored `cardQuantity=MORE(3)`, `difficulty=EASY(1)`. **A user asking for
+the fewest, hardest cards gets the most, easiest.** The identical rig run against quiz echoed `[1,3]`
+correctly, so this is flashcards-specific, not a systematic misunderstanding.
+
+Verified independently in-code by the lead: the transposition between the two call sites is plain in
+the source, and the live control establishes which one is right. *(CONFIRMED-LIVE + code-verified)*
+
+### 1.3 CRITICAL — `QuizQuantity.MORE = 2` is wrong; the backend uses 3
+
+`rpc/types.py:288-290`:
+
+```python
+FEWER = 1
+STANDARD = 2
+MORE = 2  # Alias for STANDARD - API limitation
+```
+
+The docstring's claim that "Google's API only distinguishes FEWER and STANDARD" is **refuted live** —
+the backend accepted and persisted `cardQuantity=3`. Our enum can never emit 3, so `--quantity more`
+silently produces a standard-sized set. Affects quiz and flashcards across CLI, MCP and REST.
+*(CONFIRMED-LIVE + code-verified)*
+
+### 1.4 HIGH — `ArtifactStatus` 1/2 are swapped, and three values are missing entirely
+
+The backend enum (merged `pp.txt` + `objs.txt`) versus ours (`rpc/types.py:204-213`):
+
+| code | backend | ours |
+|---|---|---|
+| 0 | `ARTIFACT_STATUS_UNKNOWN` | **absent** → `"unknown"` |
+| 1 | `ARTIFACT_STATUS_INITIALIZED` | `PROCESSING` → `"in_progress"` ❌ |
+| 2 | `ARTIFACT_STATUS_PROCESSING` | `PENDING` → `"pending"` ❌ |
+| 3 | `ARTIFACT_STATUS_READY` | `COMPLETED` ✓ |
+| 4 | `ARTIFACT_STATUS_FAILED` | `FAILED` ✓ |
+| 5 | `ARTIFACT_STATUS_SUGGESTED` | **absent** → `"unknown"` |
+| 6 | `ARTIFACT_PENDING_REVIEW` | **absent** → `"unknown"` |
+
+**The two transitional states are inverted.** A live trace of a fresh artifact showed **t+4s → code
+2**, t+20s → code 3 — so code 2 is what an artifact reports *while generating*. We report
+`"in_progress"` for a merely-initialized artifact and `"pending"` for one actively generating;
+`Artifact.is_processing` and `is_pending` are backwards with them. Terminal states 3/4 are correct,
+which is why this went unnoticed.
+
+**`6 = ARTIFACT_PENDING_REVIEW` is a state nobody knew existed** — note it breaks the naming pattern
+(no `ARTIFACT_STATUS_` prefix), which is why it appears only in `objs.txt` and was missed on the
+first pass. Callers keyed on "done vs still working" would misclassify it entirely.
+
+**The mislabel is visible at our own public API.** A live generation returned
+`GenerationStatus(status='pending')` while the backend artifact was at `PROCESSING` 180 ms later. A
+caller polling "queued vs running" gets the wrong answer from the first response onward, and
+`Artifact.is_pending` returns `True` for an artifact that is mid-generation while `is_processing`
+returns `False`.
+
+Code 2 = actively generating is **CONFIRMED-LIVE twice, independently** (two separate traces, both
+`2 → 3`). Code 1 was chased with 250 ms sampling starting 180 ms after `CreateArtifact` returned and
+never caught — it is already past by then.
+
+Code 1 is nonetheless **real**: across 301 cassette artifact rows there are **25 at status 1 and zero
+at status 2** — the exact inverse of the live runs. Both codes exist and are distinct; they occupy
+very short, differently-sampled windows, consistent with `1 = INITIALIZED` meaning "row created,
+worker not yet started". Its *semantics* stay CONFIRMED-STATIC (name from the merged dump, existence
+from recorded traffic) rather than claiming a live confirmation nobody obtained.
+
+Independent corroboration that this is the right enum: our own `_artifact/listing.py:99` already
+sends the literal string `'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"'`.
+
+**Code 6 `PENDING_REVIEW` was searched in three places and found in none** — 42 live artifacts across
+16 notebooks, 301 cassette rows, and a fresh generation. It exists in `objs.txt` alone. Best read is a
+review/moderation flow this account never triggers (plausibly Workspace/EDU or shared-notebook
+publishing), but that is a guess and is left flagged as an unknown state our enum cannot name.
+
+*(1/2 swap: CONFIRMED-LIVE. Codes 0/5/6 and the semantics of 1: CONFIRMED-STATIC.)*
+
+### 1.5 MEDIUM — `ArtifactTypeCode` has two wrong comments and two missing types
+
+Backend: `0=UNKNOWN, 1=AUDIO_OVERVIEW, 2=TAILORED_REPORT, 3=EXPLAINER_VIDEO, 4=APP, 5=MINDMAP,
+6=FANTASY_MAP, 7=INFOGRAPHIC, 8=SLIDES, 9=TABLE, 10=FILE`.
+
+- `rpc/types.py:189` says `# Note: Type 6 appears unused in current API`. It is
+  `ARTIFACT_TYPE_FANTASY_MAP` — a named backend type, not an unused code.
+- The `ArtifactTypeCode` docstring calls `MIND_MAP = 5` "the library's synthetic code".
+  `5 = ARTIFACT_TYPE_MINDMAP` is a genuine backend code, so the "synthetic" framing is wrong even
+  though our note-backed handling is legitimately separate.
+- **`10 = ARTIFACT_TYPE_FILE` is absent from both our enums** (`ArtifactTypeCode` and the public
+  `ArtifactType`, `_types/artifacts.py:41-50`). The proto backs it: `Artifact.file = 25` →
+  `FileArtifact{fileName, mimeType, filePreviewUrl, fileDownloadUrl}`. **A whole artifact type we
+  cannot represent or download.** Type 6 is likewise absent.
+
+*(CONFIRMED-STATIC — no type-6 or type-10 artifact existed among the 42 swept.)*
+
+### 1.6 CRITICAL — `userDriveSourceStatus` is populated and silently dropped
+
+`SourceSettings.userDriveSourceStatus` (tag 4 → settings index 3) is read by nothing in our client;
+`_row_adapters/sources.py:152-153` reads index 1 only, and no `Source` field could hold it.
+
+Across 409 live source rows:
+
+```
+settings shapes:  402x [null,2]  ·  4x [null,2,null,3]  ·  3x [null,2,[null,null,null,[]]]
+[3][3]  proto 4>4  n=4  null=0  int: 3   (= DRIVE_SOURCE_STATUS_ACTIVE)
+```
+
+All four populated rows are Drive-backed and all parse to `status=READY, is_ready=True, url=None`.
+
+**Impact:** the enum's other values are `INACCESSIBLE`, `SYNCING`, `DELETED`,
+`GEN_AI_ACCESS_DENIED`. When a Drive file is unshared, deleted, or still syncing, index 3 changes
+while index 1 stays `COMPLETE(2)` — because *ingestion* did complete. So `is_ready` stays `True`,
+`wait_until_ready` returns instantly, and chat is grounded on a stale snapshot with no signal
+anywhere. *(Population CONFIRMED-LIVE; degraded-value behaviour inferred from the enum — not staged,
+as that would mutate real user data.)*
+
+### 1.7 HIGH — `modified_at` is really *last-viewed*, and our own reads mutate it
+
+`meta[5]` (tag 6) is `lastViewedTime`, not a modification time, and it is the sort key for
+`ListRecentlyViewedProjects`. Three pure reads with no mutations advanced it
+(`1786105463 → 467 → 471`), and a single bare `GET_NOTEBOOK` moved that notebook to index 0 of the
+recency list.
+
+**Impact:** `modified_at` is misnamed and misleading, and merely listing/reading notebooks through
+this client silently reorders the user's "recent" ordering in the real NotebookLM UI.
+
+The other half of the same original probe note is correct: `created_at` = tag 9, pinned across
+create/share/rename/read and byte-identical over gRPC. *(CONFIRMED-LIVE)*
+
+### 1.8 HIGH — `Source` tags 6/7/8 dropped on 41 of 409 rows
+
+`_row_adapters/sources.py:149-153` reads indices 0–3 only. Mobile's `BuilderInfo` registers four
+named fields then six `addUnused()` slots — which are populated live:
+
+```
+Source[5] tag6 = "https://contribution.usercontent.google.com/download?c=…&filename=…"
+Source[6] tag7 = "https://drive.google.com/viewer/upload?ds=…"
+Source[7] tag8 = ["/contrib_service/blobrefs/notebooklm/nos_files/MediaDataBlobref/global::…",
+                  null, "text/markdown", [["AIP70BkAAAGk…"]]]
+```
+
+**Impact:** we cannot offer download of the user's originally-uploaded file, and we lose the true
+content MIME at `Source[7][2]` — independent of the Drive-only MIME slot we do read. Largest single
+discarded block found.
+
+Independently re-verified by the lead on a separate sample: 27 of 305 rows across 12 notebooks carry
+all three tags — the same ~9% rate, with the same download URL / viewer URL / blobref+MIME shapes.
+*(CONFIRMED-LIVE, two independent samples)*
+
+### 1.9 HIGH — `add_drive` idempotency probe can never match
+
+`_source/add.py:347-368` probes by URL, but all four live Drive sources parse to `url=None`
+(`metadata[7]` null; `[0]`/`[9]` are lists). With `disable_internal_retries=True`, a 5xx after commit
+means the probe returns `None`, the create is re-issued, and the user gets **two copies** of the file.
+
+Our own `_types/sources.py:83-86` already documents "Drive sources carry no URL", contradicting the
+probe docstring at `add.py:268-271`. The usable key is on the wire and unread:
+`metadata[0][0]` / `metadata[9][0]` = Drive `documentId` (live values match the requested file ids
+exactly). *(CONFIRMED-LIVE)*
+
+### 1.10 MEDIUM — five `SourceMetadata` slots populated on all 409 rows, none read
+
+`metadata[1]` (tag 2, size metric), `[3]` (tag 4, `[uuid,[s,ns]]` revision handle), `[8]` (tag 9,
+second size metric), `[14]` (tag 15, timestamp — **409/409**, likely last-modified; we expose only
+`created_at`), plus `[11]` (tag 12, second title string, 8 rows) and `metadata[5][1]/[5][2]`
+(YouTube video id + channel name, 3 rows).
+
+**We read 3 of the 9–11 populated slots.** Mobile marks these `addUnused()`, so population counts are
+CONFIRMED-LIVE but the *names* are unrecovered and the semantics are PLAUSIBLE.
+
+### 1.11 MEDIUM — `GET_SHARE_STATUS` drops 4 of 6 populated fields
+
+Unread: `maxIndividualsShareLimit` (1000), `isPublicSharingAllowed` (true), tags 7 and 8. If
+`isPublicSharingAllowed` is ever `false`, a "make public" call would presumably no-op silently while
+we report success — but that branch could not be exercised (no tenant with public sharing disabled).
+*(Population CONFIRMED-LIVE; silent-no-op PLAUSIBLE.)*
+
+### 1.12 MEDIUM — `LoadSource` discards all document structure
+
+`extract_all_text` throws away 100% of the `TailwindDoc` tree — `Citation`,
+`AnnotationMapEntry{objectId,startIndex,endIndex}`, headings, lists — so **citation anchors are
+lost**. Note the fix is "parse the doc", not "request a different field": `plainText` and
+`markdownString` are null under all five selectors on web. *(CONFIRMED-LIVE)*
+
+### 1.13 HIGH — every no-answer response is misclassified and emits a false "API changed" warning
+
+The backend's normal no-answer response is a canned prose apology with **no `TailwindDoc`**, so
+`AnswerRow.is_answer` evaluates `False`, and the parser falls through to its emergency path:
+
+```
+AnswerRow.is_answer -> False
+WARNING "No marked answer found; falling back to longest unmarked text (159 chars).
+         The API response format may have changed."
+```
+
+The format has **not** changed — this is the backend's standard no-answer shape. Callers still get
+the apology text (not an empty string), so this is misclassification plus a misleading diagnostic,
+not data loss. *(CONFIRMED-LIVE)*
+
+### 1.14 HIGH — `NextStepSuggestions` dropped, and cassettes could never have revealed it
+
+Populated on **every** live answer, e.g.
+`[5]=[[["What happens if the ratio is used above 18 degrees?", 9], …]]` where `9` =
+`MagicArtifactType.CONVERSATIONAL_TEXT_CHIP`. We discard it entirely.
+
+Notably **0 of 26 cassette frames carry it** — only live probing surfaced it. This is the clearest
+demonstration in the audit that cassette replay cannot answer "what does the backend actually send".
+*(CONFIRMED-LIVE)*
+
+### 1.15 MEDIUM — chat and research metadata dropped
+
+- `isFinalResponse` (inner[4]) is `true` on exactly the last chunk of every stream; we ignore it and
+  use a longest-wins heuristic instead.
+- `ConversationTurnKey[1]` (conversationId) and `[2]` (conversationTurnId) populated in all 9 live
+  asks, never read.
+- Research drops five always-populated paths: `DiscoveryMode` (task_info[2]), created and updated
+  timestamps (task[2]/[3], 8s apart on a live run), account id, and `DiscoveredSource.hint`.
+*(CONFIRMED-LIVE)*
+
+### 1.16 HIGH — the citation→answer linkage is discarded, and the offsets we substitute are wrong
+
+The complete citation→answer linkage appears to be present in every live response and discarded.
+`inner[2]` is an annotation map of `[[Range{start,end},[citation ordinals]], …]`, live:
+`[[[null,112,112],[0]], [[null,231,231],[1]]]` — zero-width anchors at exactly the `[1]`/`[2]` marker
+insertion points, matched by doc-body entries like `[107,112,["3:2:2",[true]]]`. That the map exists
+and is unread is **CONFIRMED-LIVE**.
+
+Two further claims were **challenged by the lead and then substantiated with raw wire values.** Both
+were reframed in the process — the original descriptions were right about impact and wrong about
+mechanism.
+
+**(a) `Citation` tag 4 is the fragment's source-side *union* range, not an answer-text range.**
+Our index is correct; the meaning we document is not. Raw, from a live `must_cite` capture where the
+answer is **256 chars**:
+
+```
+cite_inner[3]  (tag 4 → answer_start/end_char) = [[null, 0, 561]]
+cite_inner[4]  (tag 5 = TailwindDocFragment)   → 7 elements spanning [0,43] … [473,561]
+union of element ranges = [0, 561]   ==  cite_inner[3][0]   → True
+exceeds the 256-char answer?                                 → True
+```
+
+So `_types/chat.py:83-88` documenting `answer_start_char`/`answer_end_char` as *answer* positions is
+wrong — they are source-side. This also dissolves the coincidence that made the claim look shaky:
+`answer_start_char == start_char` because element 0 begins the fragment (both are 0), while the *end*
+values genuinely differ (43 vs 561). Two independent paths over the **same coordinate space**.
+
+The real answer-side data is `inner[2]`, the annotation map (above) — which we don't read at all.
+
+**(b) `cited_text`/`end_char` return only the first fragment element — because the descent stops one
+level short.** `CitationDetail.passages` returns `cite_inner[4]`, which has **length 1**: it is the
+fragment *message*, not a list of passages. So the `extract_text_passages` loop runs exactly once. It
+is not skipping elements and `PassageRow.is_well_formed` is not rejecting them.
+
+> **The fix must be two-level, or it regresses.** If `CitationDetail.passages` alone is changed to
+> descend to `cite_inner[4][0]` (the 7 elements) while `PassageRow` is left as-is, `PassageRow`
+> unwraps `element[0]` again — which is an **int** (`0`, `43`, `129`…), not a list — so
+> `is_well_formed` becomes `False` for *every* element, all are skipped, and `cited_text` becomes
+> `None`. Verified on elements 0/1/2. Both `CitationDetail.passages` (descend to `[4][0]`) and
+> `PassageRow` (stop unwrapping `[0]`; treat each element as `[start, end, paragraph]`) must change
+> together.
+
+Correct output for this citation would be `start=0, end=561`, 7 elements, `cited_text` **560 chars** —
+against the 42 chars we return today.
+
+*(Both CONFIRMED-LIVE from raw wire values, not derived output.)*
+
+### 1.17 HIGH — we invented two phantom artifact error fields, and the tests encode the fiction
+
+`_row_adapters/artifacts.py:117,119` documents index 3 as "failed-artifact plain error text" and
+index 5 as "failed-artifact nested error payload". **Both are wrong.** Index 3 is `Artifact.sources`
+(tag 4, repeated `ArtifactSource`) and index 5 is `isPubliclyReadable` (tag 6) — confirmed by the
+mobile proto and by gRPC (`tag 4: <42 sources>`, each `{1:{1:'<uuid>'}}`).
+
+Run against three **real** failed artifacts, `ArtifactRow.failed_error_text` (`:553`) returns `None`
+every time, with `raw[3]` holding the source-id list and `raw[5]` null. It is dead code that can
+never fire, and it is wired into `_artifact/polling.py:490` — so every failed generation surfaces
+`None` where the API promises an explanation. It is saved from emitting a source UUID *as* an error
+message only because index 3 happens to be a list rather than a string.
+
+Its unit tests (`tests/unit/test_row_adapters.py:393-404`) construct synthetic rows with strings at
+index 3 — **they pass while encoding a schema that does not exist.**
+
+Lead verification: the docstring and the `_ERROR_TEXT_POS=3` / `_ERROR_PAYLOAD_POS=5` constants are
+confirmed in-source, and they contradict the mobile tag map directly. *(CONFIRMED-LIVE by the
+artifact sweep; static contradiction independently verified.)*
+
+**Recommendation:** delete `failed_error_text` and both docstring lines. If a failure reason is
+wanted, it must be captured from the `CreateArtifact` RPC status at generation time —
+`QuotaFailure`/`ErrorInfo`/`PreconditionFailure` exist in the binary as standard `google.rpc.Status`
+detail types, delivered on the RPC, not persisted on the artifact resource. `Rytqqe`
+(RETRY_ARTIFACT) existing fits that: retry is offered precisely because the resource remembers
+nothing.
+
+### 1.18 MEDIUM — `is_answer` reads a negative index into a positional wire message
+
+`_row_adapters/chat.py:682,739-751` sets `_ANSWER_MARKER_POS = -1`, reading `first[4][-1]`.
+`first[4]` is `AnswerResponse.responseDoc` = `TailwindDoc`, whose `BuilderInfo` is `body=1`,
+(2,3 unused), `objects=4`, `type=5`. So `[-1]` lands on `TailwindDoc.type` **only because tag 5
+happens to be the last registered field today.**
+
+The moment the backend adds tag 6 — this repo's documented #1 breakage class — `[-1]` silently reads
+the new field, `is_answer` goes false for every chunk, and the parser falls through to its
+"No marked answer found" path. Should be an explicit `4` with a length guard. *(CONFIRMED-STATIC)*
+
+### 1.19 MEDIUM — `get_source_ids` cries schema-drift on every empty notebook
+
+`_notebooks.py:328-333`, observed live on a freshly created, genuinely empty notebook:
+
+```
+WARNING get_source_ids: notebook_info[1] not list for b6e4e936-… (schema drift?). len=11
+```
+
+An empty notebook **elides** the sources slot (`None`, not `[]`). The sibling path documents and
+handles exactly this (`_source/listing.py:134-140`: *"a valid empty state, NOT a malformed
+response"*); `get_source_ids` lacks the carve-out. `len=11` shows the envelope is perfectly healthy.
+
+Because genuine RPC drift **is** this project's top breakage class, a false positive that fires
+routinely on that exact log string trains operators to ignore the real signal. *(CONFIRMED-LIVE)*
+
+### 1.20 MEDIUM — chat persona/config returned free and discarded
+
+`Project` tag 8 (`[7]`) = `[[1, 'You are a helpful science tutor'], [1]]` — the chat config / custom
+persona, written by `ChatAPI.configure` via `MutateProject`. `GET_NOTEBOOK` returns it for free and we
+never read it back. Also `Project` tag 9 (`[8]`) = `[False]`, populated on 14/42 frames, unread.
+*(CONFIRMED-LIVE — only visible after the frame-splitter fix.)*
+
+### 1.21 HIGH — `artifactUserState` carries the user's study/playback progress, read by nothing
+
+`Artifact` index 17 = `artifactUserState`. **Null in every frozen cassette, populated live** — which
+is why it was initially ranked LOW on static evidence and then self-corrected upward.
+
+```
+audio:      [[[872, 489796000]]]   = audioOverviewState.playbackPosition   (6/9 audio artifacts)
+flashcards: appArtifactState.appState with
+            cardAcquisitionsMapping {"0":"acquired", "2":"not_acquired"},
+            currentCardIndex: 11, hiddenCardIndices: […]
+```
+
+This is the user's resume position and their per-card study progress, returned on the **primary
+listing RPC**, and nothing in our client reads it. Recall that `GetArtifactUserState` /
+`UpsertArtifactUserState` are mobile-only in the method cross-reference — so this is the web surface
+already handing us the same state for free. *(CONFIRMED-LIVE; invisible in cassettes.)*
+
+### 1.22 MEDIUM — artifact content fields dropped across every row
+
+All CONFIRMED-LIVE, from a 267-row artifact sweep:
+
+- **`duration`** on audio/video (872s–3436s), present on every row, unread.
+- **3 of 4 media URLs** dropped (HLS + DASH variants unreachable through our API).
+- **Slide and infographic alt-text and full text transcripts** — 131/131 live slides, 14/14 live
+  infographics. A caller wanting slide text must currently parse the exported PDF.
+- **Report kind** at `[7][1][0]` — live values include `'Concept Explanation'`, which is **not in our
+  `ReportFormat` enum**.
+- `sources`, `lastModifiedTimestamp`, `etag` populated on 112/112 rows, unread.
+
+### 1.23 Lower
+
+*(The `SourceStatus` fallback was promoted out of this list — see §1.24.)*
+- `Project.emoji` (tag 4, live `📖`/`🧬`) is unparsed and unsettable.
+- `premiumFeatureInfo` is `[true,true,false]` on free vs `[true,true,true]` on Pro, so
+  `canViewAnalytics` is real tier-dependent state we drop.
+- `chatSessions` (tag 12) appears **only** in the CREATE response, never in `GET_NOTEBOOK` — we
+  discard it there and then spend an `hPTbtc` round-trip to re-fetch it later.
+- `notebooks.get_or_none()` raises `ClientError` (rpc_code=5) instead of returning `None`, breaking
+  the ADR-0019 contract; the docstring at `_notebooks.py:684-687` is now false. *(CONFIRMED-LIVE,
+  out of original scope.)*
+- `add_url` never sends `WebContent.sourceName` *(PLAUSIBLE — may be intentional)*.
+
+---
+
+### 1.24 HIGH — an unmapped `SourceStatus` doesn't degrade to "unknown", it asserts *healthy*
+
+`_row_adapters/sources.py:662-673` catches `ValueError` from `SourceStatus(code)` and returns
+**`SourceStatus.READY`**. Verified by executing our own adapter directly:
+
+```
+raw status 0  -> SourceStatus.READY
+raw status 4  -> SourceStatus.READY
+raw status 99 -> SourceStatus.READY
+```
+
+Our enum lacks `0 = UNSPECIFIED` and `4 = PENDING_DELETION` (§1.6's sibling gap), so both become
+`READY` and `is_ready` reports `True`. **A source queued for deletion reads as ready to use.**
+
+This is the failure mode worth naming precisely: not "we're missing an enum value" but "an unmapped
+value silently lands in a *wrong* branch instead of an explicit unknown". The docstring at `:657-660`
+defends the design as automatically accepting "any new values added to `SourceStatus`" — but the
+fallback is `READY`, so every future backend state is asserted healthy by default. The safe default is
+the opposite. *(CONFIRMED by direct execution; lead-verified independently.)*
+
+Not observable live: the delete path goes `status 2 → GONE` inside a 0.6s poll interval, so
+`PENDING_DELETION` has no client-visible window on this transport. The degrade consequence above is
+proven regardless, and is the part that matters.
+
+---
+
+## 2. Refuted — claims that did not survive live testing
+
+Recorded so they are not re-raised.
+
+| Claim | Verdict |
+|---|---|
+| `metadata[0][1]` is a `mimeType` | **REFUTED.** Live it is an opaque token; the cassette's `SCRUBBED_AONS` was a VCR scrubber artifact. `metadata[0][0]` *is* the Drive documentId — that half stands. |
+| Markdown slot is wrong | **REFUTED.** Live `[3],[3]` returns len=5 with `markdownString` null and HTML at `result[4][1]` — exactly where we read it. **Our code is correct.** |
+| `TierLimits` null because notebook is freshly created | **REFUTED.** Not an age effect — it is per-RPC. `CCqFvf` (create) has tags 10/11 null, but the *first* `GET_NOTEBOOK` already carries them, unchanged at T+0/3/10/30s. No fallback needed. |
+| `AccountLimits.tier` is dead code | **REFUTED.** Live returns 5 elements with `tier=1` extracting correctly and agreeing with `premiumUserInfo[3]`. |
+| Mobile gRPC endpoint has drifted | **REFUTED.** The endpoint is unchanged; the failure was a `content-type` bug in the probe harness. See pr-2102 §4.10. |
+| Junk-token rate ~17.7% | **REVISED.** 17.7% on a nav-heavy recorded page, **0.0%** (0/447) on a live prose page. Data-dependent, not universal. |
+| `EmptyAnswerReason` is populated and we swallow it | **REFUTED on both transports.** The enum is fully defined in the merged dump (`0 UNKNOWN, 1 UNANSWERABLE, 2 FILTERED`) and we genuinely have no reader for it — but the backend never emits it. **12 live probes across two transports and two accounts with tag 4 never populated**: 9 web asks (off-topic, nonsense-topic, wholly empty notebook, PII, mild-abusive, control) all null/absent, plus 3 gRPC `ActOnSources` where tag 4 is read *directly* and only tags 1 and 3 are ever set; plus 72 cassette rows → zero. The "can't answer" path returns *prose*. Ranked CRITICAL twice, by two agents on two routes, before live probing killed it. |
+| Artifacts carry a failure reason we discard | **REFUTED.** 42 artifacts across 16 notebooks (3 genuinely FAILED), read on both transports: tag sets are identical and contain **no** reason/detail/message field. The per-type sub-message on a failed artifact holds only `generationOptions` — the request echo. Our model handles FAILED correctly (`status=4`, `is_failed=True`). |
+| Citation→source linkage is lost on the chat path | **REFUTED.** `_CITATIONS_POS=3` indexes *inside* `first[4]`, not top-level, so it correctly reads `TailwindDoc.objects` (tag 4) — populated in 54/72 rows and parsed into `ChatReference`. What *is* lost is citation-to-**fulltext alignment** (§1.12), a different and narrower problem. |
+| SourceType 14 mislabels content as spreadsheet | **DOWNGRADED** HIGH → MEDIUM/latent. Mechanism confirmed, but all 3 live type-14 sources labelled correctly across 65 notebooks; predicted harm did not occur. |
+
+---
+
+## 3. Verified clean
+
+Checked and correct — do not re-audit: `_META_YOUTUBE_POS=5`; `_META_MIME_POS=19` (no collision with
+`expertIntelligence` at 18); `metadata[9]` descriptor; `type_code==14` disambiguation (both
+directions); `_HTML_BLOCK_POS=4`; all six source request builders match their mobile messages; the
+full `RPCMethod` surface (47 rpcids, every captured id maps to a known method, every method exercised
+by ≥1 cassette, zero orphans).
+
+**Cross-transport confirmation of the index↔tag rule**, from a `Source` decoded off mobile gRPC:
+`[3.3]`↔`metadata[2]`, `[3.5]`↔`metadata[4]`, `[3.15]`↔`metadata[14]`, `[4.2]`↔`settings[1]`.
+
+---
+
+## 4. Method notes and one tooling defect
+
+**`pp.txt` alone is an incomplete enum source.** The object pool yields **74 enums / 273 values**;
+merging it with `objs.txt` yields **77 enums / ~1900 values**. Auditing from `pp.txt` alone
+manufactures false positives (it would wrongly flag `SourceType` 16/17 as invented) and hides real
+values (`SlideDeckLength.MEDIUM=3`). The lead's original guidance named only `pp.txt` and was wrong;
+use the merged dump. Extraction script and merged output live in the session scratchpad.
+
+**Two rpcids were mis-briefed by the lead.** `cFji9` is `GET_NOTES_AND_MIND_MAPS` and `I3xc3c` is
+`LIST_LABELS` — neither is chat, despite being handed to the chat audit as chat rpcids. Only `khqZz`
+(`GET_CONVERSATION_TURNS`) is. More importantly, **chat answers never traverse batchexecute at all** —
+they arrive on the streamed `GenerateFreeFormStreamed` endpoint, so cassette-based field coverage
+cannot see them under any circumstances and a separate stream-frame walker is required.
+
+**"Same account" holds only within a profile.** `master_token.json` (gRPC) and `storage_state.json`
+(web) match inside each profile, but differ across them — `default`/`ng-master` are one account,
+a second profile another. A cross-profile comparison yields `PERMISSION_DENIED` and looks like a
+transport difference. Any cross-transport claim must hold the profile fixed.
+
+**The gRPC probe harness silently hid every error.** `httpx` cannot read HTTP/2 **trailers**, and ESF
+returns `grpc-status` there — so a failed call arrives as HTTP 200, zero-length body, no status, which
+is indistinguishable from an empty result. Reproduced directly:
+
+```
+GetProject(empty)                -> (None, None, None)   # actually INVALID_ARGUMENT
+ListRecentlyViewed(empty)        -> (None, None, None)   # actually an error
+ListRecentlyViewed({2:1, 3:1})   -> 48 projects          # success
+```
+
+The lead's earlier "`ListRecentlyViewedProjects`/`GetLabels` return empty — possibly empty accounts"
+report to the team was therefore **wrong**: those were hidden errors, and the real fix was the missing
+`includeOwnProjects` (tag 2). Harness patched to return an explicit `INDETERMINATE`; a `grpcio`-based
+caller gives true statuses. **Never read "empty" from an httpx gRPC probe as a real empty result.**
+
+**`addUnused()` does not mean "not sent".** `ActOnSourcesResponse` populates tags 2, 4 and 7 which
+mobile's own `BuilderInfo` marks unused — the first-party client ignores fields its own backend
+sends. This qualifies every "mobile doesn't model it" inference in this audit.
+
+**A byte/char bug in the audit tooling produced false negatives.** The cassette frame-splitter treated
+batchexecute's length prefix as a character count when it is a **byte** count, so any response
+containing non-ASCII was silently dropped. `rLM1Ne` reported 6 frames when it has **42**; `hizoJc`
+decoded as empty when it was not. Fixed mid-audit, but it means **any "field is never populated"
+conclusion drawn before the fix is unsafe** — free-text-heavy responses (chat answers, citations,
+artifact titles with emoji) were the most affected. Re-run before trusting a negative.
+
+**`ProjectMetadata` field names cannot be recovered, and were not invented.** gRPC confirms the tag
+set exactly matches the web mapping (1,2,3,6,7,8,9,13,14,15,18,19,23), but a wire dump carries no
+names, and mobile's `BuilderInfo` names only four (`userRole`, `createTime`, `isPublic`,
+`audioOverviewArtifactIds`) — the rest are `addUnused()`.
+
+> **Derivation corrected 2026-08-07.** An earlier version claimed that counting `addUnused()` calls
+> "reconstructs the tag space and correctly predicts that tags 4 and 5 do not exist." It proves less
+> than that. `addUnused()` reserves one **field slot**, not one **tag number**, and the reserved slots
+> take the next real tags — which are not consecutive. Proof: `ProjectMetadata` has `userRole` = 1,
+> then five `addUnused()`, then `createTime` = **9**. Naive counting predicts tag 7; the true set is
+> {2,3,6,7,8}. So counting yields *how many* tags live in a gap, not *which* — it is a cardinality
+> argument. The conclusion (tags 4 and 5 are absent) still holds, but it is the **observed web tag
+> set** that establishes it, not the count.
+
+Of the unnamed tags, **19 and 20 vary
+with notebook state** (real discarded state); 3, 7, 8, 14, 15, 16, 18, 23 were constant across 16
+notebooks, two accounts, all cassettes and every transition — almost certainly feature flags.
+
+---
+
+## 5. Coverage gaps
+
+Stated explicitly rather than omitted.
+
+- **`EmptyAnswerReason.FILTERED` (value 2) untested — deliberately.** Inducing it requires authoring a
+  prompt engineered to trip the safety filter, which both auditors declined and the lead endorses
+  declining. Residual PLAUSIBLE risk: if `FILTERED` ever fires, a caller gets a bare empty string with
+  no reason. Reading `first[3]` is a cheap defensive fix regardless, and is worth doing on its own
+  merits — but it is not a confirmed live bug and should be ranked below the confirmed ones.
+- `ArtifactStatus` 1/2/5 not observed live — the swap is CONFIRMED-STATIC from two independent
+  derivations (the mobile enum, plus our own `_artifact/listing.py:99` already sending the literal
+  string `ARTIFACT_STATUS_SUGGESTED`, which proves we speak the same enum). Confirming live costs one
+  generation.
+- Enum values never observed live, so CONFIRMED-STATIC only: `SourceType` 2,6,7,10,11,12,15,18,19,20;
+  `SourceStatus` 0,1,4,5; `ArtifactStatus` 1,5,6; `ArtifactType` 5,6,10; `AppType` 3,5;
+  `SlideDeckLength` MEDIUM/LONG; `InfographicStyle` ACADEMIC; `VideoFormat` WHITEBOARD_ANIMATION;
+  `DiscoveryMode` 2,3,4,6.
+- ~~gRPC `GetProject` / `LoadSource` return a 0-byte payload for every request shape tried.~~
+  **RESOLVED — the finding was an artifact of the broken harness.** Re-run with a `grpcio` caller that
+  reads trailers: `GetProject {}` was `INVALID_ARGUMENT`, `LoadSource {1: "<uuid>"}` likewise.
+  `RequestContext` was never the culprit and is optional — `LoadSourceRequest.sourceId` is a
+  `SourceId` **message**, so tag 1 must be `{1: {1: uuid}}`. Both RPCs work.
+  **And the open question is answered:** across **17 sources spanning 10 `OriginalSourceContentType`
+  values**, `LoadSourceResponse` carried tags `[1, 4]` every time — `plainText` (tag 2) and
+  `markdownString` (tag 3) absent on 17/17, `tailwindDoc` present on 17/17. So §1.12's "the fix is
+  parse the doc, not request another field" is confirmed on **both** transports; the first-party
+  Android client parses the same tree we do.
+  Same re-check refuted the "`GetLabels` returns empty" reading (it was `INVALID_ARGUMENT`; with
+  `{2: projectId}` it returns 20 labels across the account) and independently corroborated §1.21's
+  `artifactUserState` on the tag-addressed transport (tag 18 populated on 7/42 artifacts, e.g.
+  `playbackPosition` 1412.562 s).
+- Not observable with available credentials: `userRole ∈ {WRITER, READER, NOT_SHARED}` (no
+  shared-with-me notebook), `PremiumTier` 2–6 (both accounts free tier), a tenant with public sharing
+  disabled, `SourceStatus` 0/4, and degraded `UserDriveSourceStatus` values.
+- `src/notebooklm/_source/_upload_decode.py` (525 lines) not deeply audited.
+- `MutateSource` / `RefreshSource` / `CheckSourceFreshness` are absent from the mobile binary, so they
+  are web-only and have no gRPC cross-check.


### PR DESCRIPTION
## Summary

Commits two audit notes that were sitting untracked in the working tree, so their evidence was invisible to anyone reviewing on GitHub.

- `docs/notes/web-rpc-vs-mobile-grpc-audit-2026-08-07.md`
- `docs/notes/pr-2102-quota-source-state-review-2026-08-07.md`

## Why now

#2118 cites the web-RPC/gRPC audit as its source, and section 2 of that note is what settles the open codex thread on #2168: `EmptyAnswerReason` is fully defined in the schema but the backend **never emits it** (12 live probes across two transports and two accounts, plus 72 cassette rows, all zero). A reviewer asked for exactly that evidence and neither they nor the PR author could read it, because it only existed locally. Ten fresh live probes today reproduced the same result — 128 raw `AnswerResponse` rows, slot 3 null in every one.

`docs/scratch/` is the gitignored process-scratch location; `docs/notes/` is not ignored, these files were simply never added.

## Safety

Scanned for credentials and account identifiers before committing: no live tokens, emails, or notebook ids. The `AIza…` / `ya29…` mentions are redacted placeholders in prose.

## Test plan

- [x] `scripts/check_docs_module_refs.py` — all doc links into `src/notebooklm` resolve, inline module refs fresh or allowlisted
- [x] `pytest tests/_guardrails` — 1908 passed, 3 xfailed (up from 1848 on `main`; the new files are picked up and scanned)
- [ ] CI green on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a research note documenting NotebookLM source-add behavior, quota accounting, mobile validation results, observed limitations, and recommended follow-up areas.
  * Added an audit comparing web and mobile interfaces, including verified behavior for notebook access, generated content, source handling, metadata, status reporting, and response data.
  * Documented confirmed issues, corrected earlier findings, methodological constraints, and remaining coverage gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->