### PR TITLE
fix(artifacts): delete the phantom failure-reason read on indices 3/5 (#2134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `artifact_status_to_str` helpers.
   ([#2125](https://github.com/teng-lin/notebooklm-py/issues/2125))
 
+### Changed
+
+- **Failed artifact polling no longer derives `GenerationStatus.error` from
+  nonexistent artifact-row fields.** `poll_status()` treated row index 3 as
+  "failure text" and index 5 as a "nested error payload"; those slots are
+  `Artifact.sources` and `Artifact.isPubliclyReadable`, so the read could only
+  ever produce a wrong answer. For schema-conformant rows the observed output is
+  unchanged — #2134 reports `error=None` for 3/3 real failed artifacts — but a
+  nonconforming row carrying a string in either slot no longer populates the
+  public field. `wait_for_completion()` still sets its own client-authored
+  message for `REMOVED`, and `generate_*(retry=...)` still synthesizes
+  `error=str(exc)` for retry callbacks; neither reads the wire for it. Capturing
+  a genuine provider failure reason (delivered on the `CreateArtifact` RPC
+  status, not persisted on the artifact) is not implemented.
+  ([#2134](https://github.com/teng-lin/notebooklm-py/issues/2134))
+
 ### Fixed
 
 - **`Notebook.is_owner` no longer inverts on shared notebooks, and the notebook's

--- a/src/notebooklm/_artifact/polling.py
+++ b/src/notebooklm/_artifact/polling.py
@@ -38,7 +38,6 @@ ListRawCallback = Callable[[str], Awaitable[builtins.list[Any]]]
 PollStatusCallback = Callable[[str, str], Awaitable[GenerationStatus]]
 MediaReadyCallback = Callable[[builtins.list[Any], int], bool]
 ArtifactTypeNameCallback = Callable[[int], str]
-ArtifactErrorCallback = Callable[[builtins.list[Any]], str | None]
 StatusChangeCallback = Callable[[GenerationStatus], object]
 
 
@@ -103,7 +102,6 @@ class ArtifactPollingService:
         list_raw: ListRawCallback,
         is_media_ready: MediaReadyCallback,
         get_artifact_type_name: ArtifactTypeNameCallback,
-        extract_artifact_error: ArtifactErrorCallback,
     ) -> GenerationStatus:
         """Poll the status of a generation task."""
         # List all artifacts and find by ID (no poll-by-ID RPC exists).
@@ -136,18 +134,12 @@ class ArtifactPollingService:
                     # Downgrade to PROCESSING to continue polling.
                     status_code = ArtifactStatus.PROCESSING
 
-            status = artifact_status_to_str(status_code)
-
-            error_msg: str | None = None
-            if status == "failed":
-                error_msg = extract_artifact_error(row.raw)
             url = row.artifact_url(artifact_type, suppress_drift=True)
 
             return GenerationStatus(
                 task_id=task_id,
                 status=_status_from_code(status_code),
                 url=url,
-                error=error_msg,
                 metadata=metadata,
             )
 
@@ -480,22 +472,6 @@ def _artifact_timeout_error(
         status_history=history,
         status_transitions=transitions,
     )
-
-
-def _extract_artifact_error(art: builtins.list[Any]) -> str | None:
-    """Try to extract a human-readable error from a failed artifact."""
-    try:
-        if not isinstance(art, list):
-            return None
-        return ArtifactRow(art).failed_error_text
-    except Exception:
-        preview = art[:6] if isinstance(art, list) else art
-        logger.warning(
-            "Failed to extract error from artifact data: %r",
-            preview,
-            exc_info=True,
-        )
-        return None
 
 
 def _get_artifact_type_name(artifact_type: int) -> str:

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -734,7 +734,6 @@ class ArtifactsAPI:
             list_raw=self._list_raw,
             is_media_ready=self._is_media_ready,
             get_artifact_type_name=self._get_artifact_type_name,
-            extract_artifact_error=self._extract_artifact_error,
         )
 
     async def wait_for_completion(
@@ -969,17 +968,6 @@ class ArtifactsAPI:
         the implementation lives on :class:`ArtifactGenerationService`.
         """
         return self._generation._parse_generation_result(result, method_id=method_id, source=source)
-
-    @staticmethod
-    def _extract_artifact_error(art: builtins.list[Any]) -> str | None:
-        """Extract a human-readable error from a failed artifact, or ``None``.
-
-        Google's batchexecute responses embed error info in varying positions;
-        this walks known (reverse-engineered) locations and returns the first
-        non-empty string. ``art[3]`` sometimes holds an error reason string;
-        ``art[5]`` may hold a nested UserDisplayableError-style payload.
-        """
-        return _artifact_polling._extract_artifact_error(art)
 
     def _get_artifact_type_name(self, artifact_type: int) -> str:
         """Human-readable name for an ``ArtifactTypeCode``, else the raw int as str."""

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -114,9 +114,9 @@ class ArtifactRow:
     0      artifact id (str)
     1      artifact title (str)
     2      type code (int — see :class:`notebooklm.rpc.ArtifactTypeCode`)
-    3      failed-artifact plain error text (when present)
+    3      sources (repeated message — unread; see #2134)
     4      processing status (int — see :class:`notebooklm.rpc.ArtifactStatus`)
-    5      failed-artifact nested error payload (when present)
+    5      isPubliclyReadable (bool — unread; see #2134)
     6      audio metadata; ``[6][5]`` is the audio media list
     7      report markdown payload (string or one-element wrapper)
     8      video metadata; nested media variants
@@ -168,9 +168,7 @@ class ArtifactRow:
     _ID_POS: ClassVar[int] = 0
     _TITLE_POS: ClassVar[int] = 1
     _TYPE_POS: ClassVar[int] = 2
-    _ERROR_TEXT_POS: ClassVar[int] = 3
     _STATUS_POS: ClassVar[int] = 4
-    _ERROR_PAYLOAD_POS: ClassVar[int] = 5
     _AUDIO_METADATA_POS: ClassVar[int] = 6
     _REPORT_MARKDOWN_POS: ClassVar[int] = 7
     _VIDEO_METADATA_POS: ClassVar[int] = 8
@@ -548,28 +546,6 @@ class ArtifactRow:
             source="ArtifactRow.generation_prompt",
         )
         return value if isinstance(value, str) else None
-
-    @property
-    def failed_error_text(self) -> str | None:
-        """Human-readable error text from a failed artifact row, when present."""
-        if len(self._raw) > self._ERROR_TEXT_POS:
-            direct = self._raw[self._ERROR_TEXT_POS]
-            if isinstance(direct, str) and direct.strip():
-                return direct.strip()
-
-        if len(self._raw) <= self._ERROR_PAYLOAD_POS:
-            return None
-        nested = self._raw[self._ERROR_PAYLOAD_POS]
-        if not isinstance(nested, list):
-            return None
-        for item in nested:
-            if isinstance(item, str) and item.strip():
-                return item.strip()
-            if isinstance(item, list):
-                for sub_item in item:
-                    if isinstance(sub_item, str) and sub_item.strip():
-                        return sub_item.strip()
-        return None
 
     def artifact_url(
         self,

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -182,27 +182,6 @@ MAPPINGS: tuple[Mapping, ...] = (
     ),
     Mapping("artifacts", "ArtifactRow", "_INFOGRAPHIC_METADATA_POS", "Artifact", "infographic"),
     Mapping("artifacts", "ArtifactRow", "_SLIDE_DECK_METADATA_POS", "Artifact", "slides"),
-    # Known-wrong: these two name fields that do not exist. Index 3 is
-    # `sources` (repeated message) and index 5 is `isPubliclyReadable` (bool).
-    # `failed_error_text` is consequently dead code that always returns None.
-    Mapping(
-        "artifacts",
-        "ArtifactRow",
-        "_ERROR_TEXT_POS",
-        "Artifact",
-        "sources",
-        known_bad="#2134",
-        note="constant claims 'failed-artifact error text'; the field is `sources`",
-    ),
-    Mapping(
-        "artifacts",
-        "ArtifactRow",
-        "_ERROR_PAYLOAD_POS",
-        "Artifact",
-        "isPubliclyReadable",
-        known_bad="#2134",
-        note="constant claims 'nested error payload'; the field is `isPubliclyReadable`",
-    ),
     # ---- Answer row: AnswerResponse / TailwindDoc -------------------------
     Mapping("chat", "AnswerRow", "_TEXT_POS", "AnswerResponse", "response"),
     Mapping("chat", "AnswerRow", "_CONV_BLOCK_POS", "AnswerResponse", "conversationTurnKey"),

--- a/tests/unit/test_generation_state.py
+++ b/tests/unit/test_generation_state.py
@@ -27,7 +27,7 @@ from notebooklm._artifact.polling import ArtifactPollingService
 from notebooklm._types.artifacts import _status_from_code
 from notebooklm.cli.error_handler import _generation_status_extra
 from notebooklm.exceptions import ArtifactTimeoutError
-from notebooklm.rpc.types import _ARTIFACT_STATUS_MAP, ArtifactStatus
+from notebooklm.rpc.types import _ARTIFACT_STATUS_MAP, ArtifactStatus, ArtifactTypeCode
 from notebooklm.types import GenerationState, GenerationStatus
 
 # ---------------------------------------------------------------------------
@@ -269,7 +269,7 @@ def _make_polling_service() -> ArtifactPollingService:
 
 async def _poll_with_status_code(code: int | None) -> GenerationStatus:
     service = _make_polling_service()
-    # Minimal LIST_ARTIFACTS row: [id, title, type_code, error, status_code].
+    # Minimal LIST_ARTIFACTS row: [id, title, type_code, sources, status_code].
     row = ["task1", "Title", 7, None, code]
 
     async def list_raw(_notebook_id: str) -> list:
@@ -281,7 +281,6 @@ async def _poll_with_status_code(code: int | None) -> GenerationStatus:
         list_raw=list_raw,
         is_media_ready=lambda *_: True,
         get_artifact_type_name=lambda _code: "report",
-        extract_artifact_error=lambda _raw: "err",
     )
 
 
@@ -290,6 +289,62 @@ async def _poll_with_status_code(code: int | None) -> GenerationStatus:
 async def test_poll_status_never_returns_removed(code: int):
     status = await _poll_with_status_code(code)
     assert status.status is not GenerationState.REMOVED
+
+
+class _RecordingRow(list):
+    """A LIST_ARTIFACTS row that records which top-level indices are read."""
+
+    def __init__(self, values: list) -> None:
+        super().__init__(values)
+        self.read_indices: list[int] = []
+
+    def __getitem__(self, index):  # type: ignore[no-untyped-def]
+        if isinstance(index, int):
+            self.read_indices.append(index)
+        return super().__getitem__(index)
+
+
+@pytest.mark.asyncio
+async def test_poll_status_never_reads_the_non_error_slots():
+    """Polling a FAILED artifact must not touch row indices 3 or 5 (#2134).
+
+    Those slots are ``Artifact.sources`` and ``Artifact.isPubliclyReadable``,
+    not the "error text" / "nested error payload" the adapter used to claim, so
+    reading them can only produce a wrong answer. Asserting on ``error is None``
+    alone would be a tautology — the deleted read also returned ``None`` for a
+    list-at-3 / bool-at-5 row — so this records the indices actually read and
+    pins their absence, which does fail against the pre-removal code.
+
+    Evidence for "the resource carries no reason" is external: live, reported in
+    #2134 as 3/3 failed artifacts returning ``None``. This row is constructed.
+    """
+    service = _make_polling_service()
+    row = _RecordingRow(
+        [
+            "task1",
+            "Title",
+            ArtifactTypeCode.REPORT.value,
+            [[["src-1"]]],  # [3] sources
+            ArtifactStatus.FAILED,
+            False,  # [5] isPubliclyReadable
+        ]
+    )
+
+    async def list_raw(_notebook_id: str) -> list:
+        return [row]
+
+    status = await service.poll_status(
+        "nb1",
+        "task1",
+        list_raw=list_raw,
+        is_media_ready=lambda *_: True,
+        get_artifact_type_name=lambda _code: "report",
+    )
+
+    assert status.status is GenerationState.FAILED
+    assert status.error is None
+    assert 3 not in row.read_indices
+    assert 5 not in row.read_indices
 
 
 @pytest.mark.asyncio
@@ -311,7 +366,6 @@ async def test_poll_status_missing_artifact_is_not_found_not_removed():
         list_raw=list_raw,
         is_media_ready=lambda *_: True,
         get_artifact_type_name=lambda _code: "report",
-        extract_artifact_error=lambda _raw: "err",
     )
     assert status.status is GenerationState.NOT_FOUND
     assert status.status is not GenerationState.REMOVED

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -57,10 +57,9 @@ async def _noop_operation_scope():
     yield None
 
 
-def _art(artifact_id: str, status: int, artifact_type: int = 1, error_at_3: str | None = None):
-    """Build a minimal raw artifact list entry."""
-    entry = [artifact_id, "Title", artifact_type, error_at_3, status]
-    return entry
+def _art(artifact_id: str, status: int, artifact_type: int = 1, sources: list | None = None):
+    """Build a constructed artifact row; index 3 models ``Artifact.sources`` (#2134)."""
+    return [artifact_id, "Title", artifact_type, sources, status]
 
 
 # ---------------------------------------------------------------------------
@@ -129,66 +128,6 @@ class TestPollStatusNotFound:
 
         assert result.status == "failed"
         assert result.is_failed is True
-
-
-# ---------------------------------------------------------------------------
-# poll_status: extracts error message from failed artifacts
-# ---------------------------------------------------------------------------
-
-
-class TestPollStatusErrorExtraction:
-    """poll_status surfaces error details from failed artifacts."""
-
-    @pytest.mark.asyncio
-    async def test_error_string_at_index_3_is_surfaced(self):
-        """When art[3] is a non-empty string, it becomes error in GenerationStatus."""
-        api = _make_api()
-        api._list_raw = AsyncMock(
-            return_value=[_art("task_abc", ArtifactStatus.FAILED, error_at_3="Daily limit reached")]
-        )
-
-        result = await api.poll_status("nb1", "task_abc")
-
-        assert result.status == "failed"
-        assert result.error == "Daily limit reached"
-
-    @pytest.mark.asyncio
-    async def test_no_error_at_index_3_error_is_none(self):
-        """When art[3] is None, error field remains None."""
-        api = _make_api()
-        api._list_raw = AsyncMock(return_value=[_art("task_abc", ArtifactStatus.FAILED)])
-
-        result = await api.poll_status("nb1", "task_abc")
-
-        assert result.status == "failed"
-        assert result.error is None
-
-    @pytest.mark.asyncio
-    async def test_art5_fallback_end_to_end(self):
-        """Error in art[5] is surfaced through poll_status (end-to-end, not just helper)."""
-        api = _make_api()
-        # art[3] is None, error is in art[5] nested list
-        art = ["task_abc", "Title", 1, None, ArtifactStatus.FAILED, ["Veo daily limit hit"]]
-        api._list_raw = AsyncMock(return_value=[art])
-
-        result = await api.poll_status("nb1", "task_abc")
-
-        assert result.status == "failed"
-        assert result.error == "Veo daily limit hit"
-
-    @pytest.mark.asyncio
-    async def test_error_extraction_only_for_failed_status(self):
-        """Error extraction is skipped for non-failed statuses."""
-        api = _make_api()
-        # art[3] has content, but status is PROCESSING — should not surface error
-        art = _art("task_abc", ArtifactStatus.PROCESSING, error_at_3="some stray text")
-        api._list_raw = AsyncMock(return_value=[art])
-
-        result = await api.poll_status("nb1", "task_abc")
-
-        # Status is in_progress; error should not be set
-        assert result.status == "in_progress"
-        assert result.error is None
 
 
 # ---------------------------------------------------------------------------
@@ -583,50 +522,3 @@ class TestGenerationStatusIsRemoved:
     def test_removed_without_quota_wording_is_not_rate_limited(self):
         status = GenerationStatus(task_id="x", status="removed", error="just gone")
         assert status.is_rate_limited is False
-
-
-# ---------------------------------------------------------------------------
-# _extract_artifact_error helper
-# ---------------------------------------------------------------------------
-
-
-class TestExtractArtifactError:
-    """Unit tests for the static _extract_artifact_error helper."""
-
-    def test_string_at_index_3_is_returned(self):
-        art = ["id", "title", 1, "Quota exceeded", 4]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result == "Quota exceeded"
-
-    def test_none_at_index_3_returns_none(self):
-        art = ["id", "title", 1, None, 4]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result is None
-
-    def test_empty_string_at_index_3_returns_none(self):
-        art = ["id", "title", 1, "   ", 4]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result is None
-
-    def test_short_artifact_no_index_3_returns_none(self):
-        art = ["id", "title"]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result is None
-
-    def test_nested_string_at_index_5_is_returned(self):
-        """Error text in art[5] as nested list is extracted."""
-        art = ["id", "title", 1, None, 4, ["Daily cinematic limit reached"]]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result == "Daily cinematic limit reached"
-
-    def test_deeply_nested_string_at_index_5(self):
-        """Error text in art[5] as doubly nested list is extracted."""
-        art = ["id", "title", 1, None, 4, [["Veo quota exhausted"]]]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result == "Veo quota exhausted"
-
-    def test_index_3_takes_priority_over_index_5(self):
-        """When both art[3] and art[5] contain strings, art[3] wins."""
-        art = ["id", "title", 1, "Primary error", 4, ["Secondary error"]]
-        result = ArtifactsAPI._extract_artifact_error(art)
-        assert result == "Primary error"

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -66,14 +66,8 @@ class TestPositionContract:
     def test_type_position_is_2(self) -> None:
         assert ArtifactRow._TYPE_POS == 2
 
-    def test_error_text_position_is_3(self) -> None:
-        assert ArtifactRow._ERROR_TEXT_POS == 3
-
     def test_status_position_is_4(self) -> None:
         assert ArtifactRow._STATUS_POS == 4
-
-    def test_error_payload_position_is_5(self) -> None:
-        assert ArtifactRow._ERROR_PAYLOAD_POS == 5
 
     def test_audio_metadata_position_is_6(self) -> None:
         assert ArtifactRow._AUDIO_METADATA_POS == 6
@@ -107,9 +101,7 @@ class TestPositionContract:
             ArtifactRow._ID_POS,
             ArtifactRow._TITLE_POS,
             ArtifactRow._TYPE_POS,
-            ArtifactRow._ERROR_TEXT_POS,
             ArtifactRow._STATUS_POS,
-            ArtifactRow._ERROR_PAYLOAD_POS,
             ArtifactRow._AUDIO_METADATA_POS,
             ArtifactRow._REPORT_MARKDOWN_POS,
             ArtifactRow._VIDEO_METADATA_POS,
@@ -118,7 +110,10 @@ class TestPositionContract:
             ArtifactRow._TIMESTAMP_POS,
             ArtifactRow._SLIDE_DECK_METADATA_POS,
             ArtifactRow._DATA_TABLE_PAYLOAD_POS,
-        ) == (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 18)
+        ) == (0, 1, 2, 4, 6, 7, 8, 9, 14, 15, 16, 18)
+        # 3 and 5 are absent on purpose: they are `sources` and
+        # `isPubliclyReadable`, not the error slots the adapter used to claim
+        # (#2134). Nothing reads them, so nothing pins them.
 
 
 # ---------------------------------------------------------------------------
@@ -391,19 +386,6 @@ class TestArtifactPayloadAccessors:
 
         assert ArtifactRow(raw).data_table_raw_payload is payload
 
-    def test_failed_error_text_prefers_plain_error_over_nested_payload(self) -> None:
-        raw = _full_row(status=ArtifactStatus.FAILED)
-        raw[ArtifactRow._ERROR_TEXT_POS] = " Primary "
-        raw[ArtifactRow._ERROR_PAYLOAD_POS] = ["Secondary"]
-
-        assert ArtifactRow(raw).failed_error_text == "Primary"
-
-    def test_failed_error_text_falls_back_to_nested_payload(self) -> None:
-        raw = _full_row(status=ArtifactStatus.FAILED)
-        raw[ArtifactRow._ERROR_PAYLOAD_POS] = [["Nested quota limit"]]
-
-        assert ArtifactRow(raw).failed_error_text == "Nested quota limit"
-
     def test_artifact_url_dispatches_by_type(self) -> None:
         raw = _full_row(type_code=ArtifactTypeCode.AUDIO)
         raw[ArtifactRow._AUDIO_METADATA_POS] = [
@@ -436,7 +418,6 @@ class TestArtifactPayloadAccessors:
         assert row.slide_deck_pptx_url is None
         assert row.report_markdown is None
         assert row.data_table_raw_payload is None
-        assert row.failed_error_text is None
         assert row.artifact_url(ArtifactTypeCode.AUDIO.value, suppress_drift=True) is None
 
 


### PR DESCRIPTION
## Summary

Delete the artifact row's failure-reason read. `_ERROR_TEXT_POS = 3` and `_ERROR_PAYLOAD_POS = 5` named fields that do not exist, so `failed_error_text` could not answer for any schema-conformant row while its docstring promised a human-readable explanation.

Refs #2134.

## Evidence

| Claim | Provenance |
|---|---|
| Index 3 is `Artifact.sources` (repeated message), index 5 is `isPubliclyReadable` (bool) | **Recovered schema** (`docs/mobile/schema.proto`), cross-checked in #2134 against gRPC on the same artifact |
| `failed_error_text` returned `None` on real failed artifacts | **Live, reported in #2134**: 3/3 |
| The pre-removal poll path really did read those slots | **Measured on this branch**: replayed against `e55de0af`, the same row reports `read_indices [0, 4, 2, 3, 5]` |
| `GenerationStatus.error` has other producers | **In-source**: `wait_for_completion`'s `REMOVED` message and the retry-callback status in `artifacts.py` — both client-authored, neither reads the wire |

## What changed

Removed: the property, both constants, the module-level `_extract_artifact_error`, its `ArtifactsAPI` static hop, the injected `extract_artifact_error` seam on the *private* `ArtifactPollingService.poll_status` (`ArtifactsAPI.poll_status`'s own signature is unchanged), the two `known_bad` wire-contract entries that recorded the gap, and the row-index table lines that mislabelled 3/5.

**Why `Changed` and not `Fixed`:** for conforming rows the output is identical, but a *nonconforming* row carrying a string in slot 3 or 5 no longer populates the public `GenerationStatus.error`. That is a behaviour change, small as it is, so it is priced into the CHANGELOG as one.

## On the tests

The unit tests that kept the wrong model green are **gone rather than adjusted** — they constructed rows with error text at index 3/5, a shape the backend has never emitted, and would have failed a correct implementation.

Their replacement deliberately does **not** just assert `error is None`: the deleted read also returned `None` for a list-at-3 / bool-at-5 row, so that assertion would have been a tautology dressed as evidence. Instead the row records which top-level indices the poll path reads and the test pins that 3 and 5 are not among them — which does fail against the pre-removal code (`read_indices [0, 4, 2, 3, 5]`).

## Scope boundary / Not done

- **No provider failure reason is captured.** A real one would have to come from the `CreateArtifact` RPC status at generation time (`QuotaFailure` / `ErrorInfo` / `PreconditionFailure` are delivered on the RPC, not persisted on the artifact resource). That is a separate change, and this PR supplies no captured status detail for it.
- `docs/notes/web-rpc-vs-mobile-grpc-audit-2026-08-07.md` §1.17 still carries the original recommendation; I left the audit note as the dated record it is.

## Verification

```
uv run ruff format --check <changed files>   # clean
uv run ruff check .                          # clean
uv run mypy src/notebooklm --ignore-missing-imports   # clean, 351 files
uv run pytest                                # 15413 passed, 64 skipped, 1 xfailed
```

Wire contract: mappings 38 → 36, with zero `known_bad` entries remaining.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected failed-artifact status handling so nonexistent artifact fields no longer produce misleading error messages.
  * Preserved client-provided and retry-generated errors.
  * Failed artifacts now correctly report their status without incorrectly reading unrelated artifact metadata.
  * Artifact source and visibility information is no longer mistaken for an error message.
  * Status and artifact URL handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->