### PR TITLE
fix(notebooks): decode userRole so is_owner stops inverting on shared notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`notebooklm.types.share_permission_to_str`** — the single source of truth
+  for permission/role code to string (`"owner"` / `"editor"` / `"viewer"`,
+  `"unknown"` for unmapped codes), joining the existing `source_status_to_str`
+  and `artifact_status_to_str` helpers.
+  ([#2125](https://github.com/teng-lin/notebooklm-py/issues/2125))
+
 ### Fixed
+
+- **`Notebook.is_owner` no longer inverts on shared notebooks, and the notebook's
+  role is now surfaced.** `is_owner` was decoded from `meta[1]` (proto tag 2) on
+  the belief that the slot flagged ownership. A two-account live probe showed
+  tag 2 actually tracks *"this notebook has any sharing at all"*, so the flag
+  evaluated to `not (shared with anyone)`: **every notebook you own and have
+  shared reported `is_owner=False`** and rendered as "Shared" in your own CLI.
+  The same undercount reached `NotebookLimitError`, whose owned-notebook quota
+  check silently dropped each shared notebook.
+
+  The flag now derives from `meta[0]` (tag 1, `userRole`), which is present on
+  every `LIST_NOTEBOOKS` and `GET_NOTEBOOK` row, so the fix costs no extra RPC.
+
+  **Migration.** `is_owner` keeps working and keeps its type; it simply returns
+  the right answer now, so callers relying on the inverted value should drop
+  their workaround. Because one boolean cannot separate an owner-who-shared from
+  an editor or a viewer — all three previously collapsed onto `False` — a new
+  `Notebook.role` field carries the real level as a `SharePermission`
+  (`OWNER` / `EDITOR` / `VIEWER`, or `None` when the row states no level), and
+  `is_owner` is now the `role is SharePermission.OWNER` shorthand. Prefer `role`
+  when read-only access must be distinguished from edit access:
+
+  ```python
+  from notebooklm.types import SharePermission
+
+  for nb in await client.notebooks.list():
+      if nb.role is SharePermission.VIEWER:
+          print(f"{nb.title}: read-only")
+  ```
+
+  The CLI's `list` / `use` "Owner" column is renamed **"Access"** and now shows
+  Owner / Editor / Viewer, `metadata` and `status` follow, and `list --json`
+  gains a `role` string alongside `is_owner`. MCP and REST notebook payloads
+  gain `role` (the raw code) plus `role_label`, mirroring how sources already
+  ship `status` plus `status_label`.
+  ([#2125](https://github.com/teng-lin/notebooklm-py/issues/2125))
 
 - **RPC bundle monitoring no longer reports authentication/access failures as
   protocol drift.** The live registry capture now classifies login,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ Stores the current CLI context, such as the active notebook:
   "notebook_id": "abc123def456",
   "title": "Quarterly review notes",
   "is_owner": true,
+  "role": "owner",
   "created_at": "2026-05-01T17:43:21Z"
 }
 ```
@@ -107,7 +108,7 @@ Stores the current CLI context, such as the active notebook:
 Field summary:
 
 - `notebook_id` — currently selected notebook, written by `notebooklm use` and read by every command that takes `-n/--notebook`.
-- `title`, `is_owner`, `created_at` — optional notebook metadata captured at selection time so `status` / display commands don't need an extra round-trip. Omitted when the CLI didn't have the values to write (see `set_current_notebook` in `src/notebooklm/cli/context.py`).
+- `title`, `is_owner`, `role`, `created_at` — optional notebook metadata captured at selection time so `status` / display commands don't need an extra round-trip. Omitted when the CLI didn't have the values to write (see `set_current_notebook` in `src/notebooklm/cli/context.py`). `role` is `"owner"` / `"editor"` / `"viewer"`; `is_owner` is the `role == "owner"` shorthand and is retained for backward compatibility. Contexts written before `role` existed carry only `is_owner`, and `status` falls back to it.
 
 This file is managed automatically by `notebooklm use`, `notebooklm clear`, and the `auth` commands.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2158,8 +2158,28 @@ class Notebook:
     title: str
     created_at: Optional[datetime]   # creation time (tz-aware UTC)
     sources_count: int
-    is_owner: bool
+    is_owner: bool                   # role is SharePermission.OWNER
     modified_at: Optional[datetime]  # last-modified time (tz-aware UTC)
+    role: Optional[SharePermission]  # your own level: OWNER / EDITOR / VIEWER
+```
+
+`role` is the calling account's permission level on the notebook, decoded from
+the backend's `userRole` field. It is `None` only when the row does not state a
+level (an unexpectedly short or unmapped row), in which case `is_owner`
+defaults to `True`.
+
+`is_owner` is kept as the `role is SharePermission.OWNER` shorthand for
+backward compatibility. Prefer `role` when the distinction matters: a read-only
+collaborator (`VIEWER`) and a full editor (`EDITOR`) both report
+`is_owner=False`.
+
+```python
+from notebooklm.types import SharePermission, share_permission_to_str
+
+for nb in await client.notebooks.list():
+    if nb.role is SharePermission.VIEWER:
+        print(f"{nb.title}: read-only")
+    print(share_permission_to_str(nb.role))  # "owner" / "editor" / "viewer"
 ```
 
 ### Source

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2179,7 +2179,10 @@ from notebooklm.types import SharePermission, share_permission_to_str
 for nb in await client.notebooks.list():
     if nb.role is SharePermission.VIEWER:
         print(f"{nb.title}: read-only")
-    print(share_permission_to_str(nb.role))  # "owner" / "editor" / "viewer"
+    # Guard the None case: share_permission_to_str is typed int | SharePermission,
+    # and an unstated role is not a level to label.
+    label = share_permission_to_str(nb.role) if nb.role is not None else "unstated"
+    print(label)  # "owner" / "editor" / "viewer" / "unstated"
 ```
 
 ### Source

--- a/src/notebooklm/_app/session.py
+++ b/src/notebooklm/_app/session.py
@@ -117,6 +117,10 @@ class StatusContext:
     created_at: str | None = None
     conversation_id: str | None = None
     payload_readable: bool = True
+    #: Cached ``"owner"`` / ``"editor"`` / ``"viewer"`` label (#2125). Appended
+    #: last so positional construction stays unaffected. ``None`` for contexts
+    #: written before the role was recorded, which fall back to ``is_owner``.
+    role: str | None = None
 
 
 @dataclass(frozen=True)
@@ -210,6 +214,7 @@ def read_status(inputs: StatusInputs) -> StatusReport:
             is_owner=data.get("is_owner"),
             created_at=data.get("created_at"),
             conversation_id=data.get("conversation_id"),
+            role=data.get("role"),
         ),
         paths=inputs.path_info,
         has_env_auth=inputs.has_env_auth,

--- a/src/notebooklm/_app/session.py
+++ b/src/notebooklm/_app/session.py
@@ -102,6 +102,19 @@ async def verify_and_set_notebook(
 # ---------------------------------------------------------------------------
 
 
+#: Role labels the context file may legitimately carry — the same strings
+#: ``share_permission_to_str`` writes. The context file is user-editable, so the
+#: read side validates rather than trusting it: an unrecognized value would
+#: otherwise be title-cased straight onto the ``status`` table (a hand-edited
+#: ``"role": "wizard"`` printing ``Access: Wizard``).
+_ROLE_LABELS = frozenset({"owner", "editor", "viewer"})
+
+
+def _valid_role_label(raw: object) -> str | None:
+    """Return ``raw`` if it is a known role label, else ``None``."""
+    return raw if isinstance(raw, str) and raw in _ROLE_LABELS else None
+
+
 @dataclass(frozen=True)
 class StatusContext:
     """The context-file payload joined with the active notebook id.
@@ -214,7 +227,7 @@ def read_status(inputs: StatusInputs) -> StatusReport:
             is_owner=data.get("is_owner"),
             created_at=data.get("created_at"),
             conversation_id=data.get("conversation_id"),
-            role=data.get("role"),
+            role=_valid_role_label(data.get("role")),
         ),
         paths=inputs.path_info,
         has_env_auth=inputs.has_env_auth,

--- a/src/notebooklm/_app/views.py
+++ b/src/notebooklm/_app/views.py
@@ -11,6 +11,8 @@ projection into ``_app`` rather than copy it per adapter):
   ``access=1`` etc.).
 * :func:`source_view` — a ``Source`` with string ``kind`` / ``status_label``
   labels added alongside the raw ``status`` / ``_type_code`` integers.
+* :func:`notebook_view` — a ``Notebook`` with a string ``role_label`` added
+  alongside the raw ``role`` integer.
 * :func:`ask_result_view` — an ``AskResult`` serialized with the internal
   ``raw_response`` debugging blob stripped (it just burns agent context; the
   field stays on the dataclass, it is only omitted from the wire).
@@ -23,11 +25,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..types import source_status_to_str
+from ..types import share_permission_to_str, source_status_to_str
 from .serialize import to_jsonable
 
 if TYPE_CHECKING:
-    from ..types import AskResult, ShareStatus, Source
+    from ..types import AskResult, Notebook, ShareStatus, Source
 
 __all__ = [
     "ACCESS_LABELS",
@@ -35,6 +37,7 @@ __all__ = [
     "VIEW_LEVEL_LABELS",
     "ask_result_view",
     "label",
+    "notebook_view",
     "share_status_view",
     "source_view",
 ]
@@ -99,6 +102,23 @@ def source_view(source: Source) -> dict[str, Any]:
     view = to_jsonable(source)
     view["kind"] = source.kind.value
     view["status_label"] = source_status_to_str(source.status)
+    return view
+
+
+def notebook_view(notebook: Notebook) -> dict[str, Any]:
+    """Serialize a ``Notebook`` with an agent-readable ``role_label`` added.
+
+    ``role`` is the caller's own permission level on the notebook
+    (``SharePermission``), so a raw :func:`to_jsonable` pass would leak
+    ``role=3`` and force an agent to guess. ``role_label`` comes from
+    :func:`~notebooklm.rpc.types.share_permission_to_str` — the repo's single
+    source of truth for permission→string — and is one of ``owner``/``editor``/
+    ``viewer``, or ``None`` when the row did not state a role.
+    """
+    view = to_jsonable(notebook)
+    view["role_label"] = (
+        share_permission_to_str(notebook.role) if notebook.role is not None else None
+    )
     return view
 
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -648,6 +648,10 @@ class NotebooksAPI:
             )
             return
 
+        # ``is_owner`` is now ``role is SharePermission.OWNER``. It previously
+        # decoded a "has any sharing" slot, so this count silently dropped every
+        # notebook the user owned *and had shared* — biasing the quota check
+        # towards never raising ``NotebookLimitError`` (#2125).
         owned_count = sum(1 for notebook in notebooks if notebook.is_owner)
         # Allow one notebook of slack because list results can lag a failed
         # create or omit service-internal notebooks that still count.

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -56,12 +56,17 @@ def _extract_notebook_sources_count(data: list[Any]) -> int:
     return len(sources) if isinstance(sources, list) else 0
 
 
-#: Wire codes the ``userRole`` slot may legitimately carry. ``SharePermission``
-#: also owns ``_REMOVE = 4`` (proto ``NOT_SHARED``), but that is a write-only
-#: sentinel for the share-mutation call — a notebook row never reports it (a
-#: revoked account gets ``PERMISSION_DENIED``, not role 4), so it is excluded
-#: here rather than surfaced as a nonsensical role.
-_NOTEBOOK_ROLES = frozenset({SharePermission.OWNER, SharePermission.EDITOR, SharePermission.VIEWER})
+#: Wire codes the ``userRole`` slot may legitimately carry, as plain ints —
+#: comparing ints to ints rather than relying on ``SharePermission`` hashing as
+#: its value, so the check cannot quietly start rejecting everything if the enum
+#: ever stops mixing in ``int``. ``SharePermission`` also owns ``_REMOVE = 4``
+#: (proto ``NOT_SHARED``), but that is a write-only sentinel for the
+#: share-mutation call — a notebook row never reports it (a revoked account gets
+#: ``PERMISSION_DENIED``, not role 4), so it is excluded here rather than
+#: surfaced as a nonsensical role.
+_NOTEBOOK_ROLES = frozenset(
+    {SharePermission.OWNER.value, SharePermission.EDITOR.value, SharePermission.VIEWER.value}
+)
 
 
 def _role_from_wire(raw_role: Any, row: list[Any]) -> SharePermission | None:
@@ -79,9 +84,8 @@ def _role_from_wire(raw_role: Any, row: list[Any]) -> SharePermission | None:
     # of the neighbouring has-sharing slot, i.e. exactly the drift we would
     # most want to notice.
     if isinstance(raw_role, int) and not isinstance(raw_role, bool):
-        role = SharePermission(raw_role) if raw_role in _NOTEBOOK_ROLES else None
-        if role is not None:
-            return role
+        if raw_role in _NOTEBOOK_ROLES:
+            return SharePermission(raw_role)
     logger.warning(
         "Notebook row userRole slot unmapped — reporting unknown role "
         "(expected 1/2/3 at data[5][0], got %r; row=%s)",
@@ -111,18 +115,33 @@ class Notebook:
     #: carries an unmapped code.
     role: SharePermission | None = None
 
-    def __post_init__(self) -> None:
-        """Keep ``is_owner`` in lock-step with ``role``.
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Keep ``is_owner`` in lock-step with ``role``, at construction *and* after.
 
-        ``is_owner`` stays a *field* (not a property) so it keeps appearing in
-        ``dataclasses.fields`` — the MCP/REST serializer emits fields only, and
-        dropping it would be a breaking wire change. Deriving it here instead
-        makes ``Notebook(role=VIEWER, is_owner=True)`` unrepresentable rather
-        than merely discouraged. When ``role`` is ``None`` (unknown), the caller's
-        explicit ``is_owner`` is left untouched.
+        ``is_owner`` stays a *field* rather than becoming a property because the
+        MCP/REST serializer emits ``dataclasses.fields`` only — a property would
+        silently vanish from every adapter's response, a breaking wire change.
+        So the invariant is maintained on assignment instead.
+
+        Hooking ``__setattr__`` rather than ``__post_init__`` matters because
+        this dataclass is mutated in place after construction (see the
+        timestamp backfill in ``_app.notebooks._backfill_created_timestamps``);
+        a construction-only hook would let ``is_owner`` go stale the moment
+        anyone assigned ``role``.
+
+        A contradictory ``is_owner`` is *corrected*, not rejected. Raising is not
+        actually available here: ``is_owner`` has a plain ``True`` default, so
+        the ordinary ``Notebook(id=..., title=..., role=VIEWER)`` call is
+        indistinguishable from an explicit ``is_owner=True``, and rejecting the
+        contradiction would reject the most natural construction in the codebase.
+
+        When ``role`` is ``None`` (the row stated no level) the caller's
+        ``is_owner`` is left untouched, preserving the historical
+        optimistic-``True`` soft-degrade.
         """
-        if self.role is not None:
-            self.is_owner = self.role is SharePermission.OWNER
+        super().__setattr__(name, value)
+        if name == "role" and value is not None:
+            super().__setattr__("is_owner", value is SharePermission.OWNER)
 
     @classmethod
     def from_api_response(cls, data: list[Any]) -> Notebook:
@@ -156,7 +175,7 @@ class Notebook:
                 )
 
         # ``data[5]`` is the metadata block; bind it once so the timestamp and
-        # owner-flag descents read a single named local instead of re-chaining
+        # role descents read a single named local instead of re-chaining
         # ``data[5][...]`` (the legitimately-absent block defaults below). The
         # slot read goes through ``safe_index`` (length-guarded first, so it
         # cannot raise) and the result is only retained when it is a list.

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any
 
 from ..rpc import RPCMethod, safe_index
+from ..rpc.types import SharePermission, share_permission_to_str
 from .common import _datetime_from_timestamp
 from .sources import SourceType
 
@@ -55,6 +56,41 @@ def _extract_notebook_sources_count(data: list[Any]) -> int:
     return len(sources) if isinstance(sources, list) else 0
 
 
+#: Wire codes the ``userRole`` slot may legitimately carry. ``SharePermission``
+#: also owns ``_REMOVE = 4`` (proto ``NOT_SHARED``), but that is a write-only
+#: sentinel for the share-mutation call — a notebook row never reports it (a
+#: revoked account gets ``PERMISSION_DENIED``, not role 4), so it is excluded
+#: here rather than surfaced as a nonsensical role.
+_NOTEBOOK_ROLES = frozenset({SharePermission.OWNER, SharePermission.EDITOR, SharePermission.VIEWER})
+
+
+def _role_from_wire(raw_role: Any, row: list[Any]) -> SharePermission | None:
+    """Map a raw ``userRole`` slot to :class:`SharePermission`, or ``None``.
+
+    ``None`` means "not stated by this row" — an absent slot, or a value this
+    client does not recognize. Callers treat that as unknown rather than
+    guessing a level. An unmapped *present* value logs a WARNING because it is
+    the signature of protocol drift (#1485 absence-vs-malformed policy).
+    """
+    if raw_role is None:
+        return None
+    # ``bool`` is an ``int`` subclass, so ``SharePermission(True)`` would
+    # silently yield ``OWNER``. Reject booleans explicitly: they are the shape
+    # of the neighbouring has-sharing slot, i.e. exactly the drift we would
+    # most want to notice.
+    if isinstance(raw_role, int) and not isinstance(raw_role, bool):
+        role = SharePermission(raw_role) if raw_role in _NOTEBOOK_ROLES else None
+        if role is not None:
+            return role
+    logger.warning(
+        "Notebook row userRole slot unmapped — reporting unknown role "
+        "(expected 1/2/3 at data[5][0], got %r; row=%s)",
+        raw_role,
+        reprlib.repr(row),
+    )
+    return None
+
+
 @dataclass
 class Notebook:
     """Represents a NotebookLM notebook."""
@@ -63,10 +99,30 @@ class Notebook:
     title: str
     created_at: datetime | None = None
     sources_count: int = 0
+    #: ``True`` when :attr:`role` is :attr:`~notebooklm.types.SharePermission.OWNER`.
+    #: Kept as a convenience derivation of :attr:`role`; it can no longer
+    #: distinguish an editor from a viewer, so prefer :attr:`role` (#2125).
     is_owner: bool = True
-    # ``modified_at`` is appended at the END of the field list so positional
-    # construction stays unaffected (additive, defaults to ``None``).
+    # ``modified_at`` / ``role`` are appended at the END of the field list so
+    # positional construction stays unaffected (additive, default ``None``).
     modified_at: datetime | None = None
+    #: The calling account's permission level on this notebook, decoded from
+    #: ``ProjectMetadata.userRole``. ``None`` when the row omits the slot or
+    #: carries an unmapped code.
+    role: SharePermission | None = None
+
+    def __post_init__(self) -> None:
+        """Keep ``is_owner`` in lock-step with ``role``.
+
+        ``is_owner`` stays a *field* (not a property) so it keeps appearing in
+        ``dataclasses.fields`` — the MCP/REST serializer emits fields only, and
+        dropping it would be a breaking wire change. Deriving it here instead
+        makes ``Notebook(role=VIEWER, is_owner=True)`` unrepresentable rather
+        than merely discouraged. When ``role`` is ``None`` (unknown), the caller's
+        explicit ``is_owner`` is left untouched.
+        """
+        if self.role is not None:
+            self.is_owner = self.role is SharePermission.OWNER
 
     @classmethod
     def from_api_response(cls, data: list[Any]) -> Notebook:
@@ -142,21 +198,36 @@ class Notebook:
                     )
                 )
 
-        is_owner = True
-        if meta is not None and len(meta) > 1:
-            # The API sends False in this slot for owner notebooks; truthy values mean shared.
-            is_owner = (
-                safe_index(meta, 1, method_id=_NOTEBOOK_METHOD_ID, source="Notebook.is_owner")
-                is False
-            )
+        # ``meta[0]`` (``data[5][0]``) is ``ProjectMetadata.userRole`` — the
+        # CALLING account's permission level on this notebook (1 OWNER /
+        # 2 WRITER / 3 READER, value-identical to ``SharePermission``).
+        #
+        # This used to be read from ``meta[1]`` instead, on the belief that the
+        # slot was an owner flag. A two-account live probe (#2125) showed
+        # ``meta[1]`` actually tracks "this notebook has ANY sharing at all":
+        # it flipped ``False -> True`` the moment a collaborator was added to a
+        # notebook the account owned, and back on revoke. So the old expression
+        # evaluated to ``not (shared with anyone)`` and reported ``is_owner=False``
+        # for every notebook the user owned *and had shared*. ``meta[0]`` stayed
+        # pinned at ``1`` for the owner across every stage of that probe, and is
+        # present on 100% of ``LIST_NOTEBOOKS`` *and* ``GET_NOTEBOOK`` rows, so
+        # the correct read costs no extra RPC.
+        role = None
+        if meta is not None and len(meta) > 0:
+            raw_role = safe_index(meta, 0, method_id=_NOTEBOOK_METHOD_ID, source="Notebook.role")
+            role = _role_from_wire(raw_role, data)
 
+        # ``is_owner`` is derived from ``role`` in ``__post_init__``. An unknown
+        # / absent role leaves the field's default of ``True``: the
+        # overwhelmingly common case is the caller's own notebook, and a short
+        # or malformed row must soft-degrade rather than mislabel every entry.
         return cls(
             id=notebook_id,
             title=title,
             created_at=created_at,
             sources_count=sources_count,
-            is_owner=is_owner,
             modified_at=modified_at,
+            role=role,
         )
 
 
@@ -235,8 +306,13 @@ class NotebookMetadata:
 
     @property
     def is_owner(self) -> bool:
-        """Get owner status."""
+        """Get owner status (``role is SharePermission.OWNER``)."""
         return self.notebook.is_owner
+
+    @property
+    def role(self) -> SharePermission | None:
+        """Get the calling account's permission level on the notebook."""
+        return self.notebook.role
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -246,5 +322,6 @@ class NotebookMetadata:
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "modified_at": self.modified_at.isoformat() if self.modified_at else None,
             "is_owner": self.is_owner,
+            "role": share_permission_to_str(self.role) if self.role is not None else None,
             "sources": [s.to_dict() for s in self.sources],
         }

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -15,7 +15,12 @@ from rich.markup import render as render_markup
 from rich.table import Table
 
 from .error_handler import _output_error, exit_with_code
-from .rendering import console, json_error_response, json_output_response
+from .rendering import (
+    console,
+    get_notebook_access_display,
+    json_error_response,
+    json_output_response,
+)
 from .services.auth_diagnostics import AuthCheckResult
 from .services.auth_source import AUTH_JSON_ENV_NAME
 from .services.login.outcomes import BrowserCookieOutcome
@@ -31,6 +36,19 @@ def _use_notebook_table() -> Table:
     t.add_column("Access")
     t.add_column("Created", style="dim")
     return t
+
+
+def _render_use_notebook(notebook: Any, *, notebook_id: str, created: str) -> None:
+    """Print the one-row table ``use`` shows after selecting a notebook.
+
+    Lives here rather than inline in ``session_cmd`` so the Access-column
+    label lookup sits next to ``_use_notebook_table`` and the sibling
+    ``status`` renderer that formats the same role (ADR-0008 also keeps
+    ``session_cmd`` under its module-size budget).
+    """
+    table = _use_notebook_table()
+    table.add_row(notebook_id, notebook.title, get_notebook_access_display(notebook.role), created)
+    console.print(table)
 
 
 def _render_status(report: StatusReport, *, json_output: bool) -> None:

--- a/src/notebooklm/cli/_session_render.py
+++ b/src/notebooklm/cli/_session_render.py
@@ -26,7 +26,9 @@ def _use_notebook_table() -> Table:
     t = Table()
     t.add_column("ID", style="cyan")
     t.add_column("Title", style="green")
-    t.add_column("Owner")
+    # "Access" (not "Owner") because the column reports the caller's actual
+    # role — Owner / Editor / Viewer (#2125).
+    t.add_column("Access")
     t.add_column("Created", style="dim")
     return t
 
@@ -92,6 +94,7 @@ def _render_status(report: StatusReport, *, json_output: bool) -> None:
                         "id": ctx_view.notebook_id,
                         "title": None,
                         "is_owner": None,
+                        "role": None,
                     },
                     "conversation_id": None,
                 }
@@ -103,7 +106,7 @@ def _render_status(report: StatusReport, *, json_output: bool) -> None:
         table.add_column("Value", style="cyan")
         table.add_row("Notebook ID", ctx_view.notebook_id or "")
         table.add_row("Title", "-")
-        table.add_row("Ownership", "-")
+        table.add_row("Access", "-")
         table.add_row("Created", "-")
         table.add_row("Conversation", "[dim]None[/dim]")
         console.print(table)
@@ -117,6 +120,7 @@ def _render_status(report: StatusReport, *, json_output: bool) -> None:
                     "id": ctx_view.notebook_id,
                     "title": ctx_view.title if ctx_view.title and ctx_view.title != "-" else None,
                     "is_owner": ctx_view.is_owner if ctx_view.is_owner is not None else True,
+                    "role": ctx_view.role,
                 },
                 "conversation_id": ctx_view.conversation_id,
             }
@@ -129,9 +133,14 @@ def _render_status(report: StatusReport, *, json_output: bool) -> None:
 
     table.add_row("Notebook ID", ctx_view.notebook_id or "")
     table.add_row("Title", str(ctx_view.title or "-"))
-    is_owner = ctx_view.is_owner if ctx_view.is_owner is not None else True
-    owner_status = "Owner" if is_owner else "Shared"
-    table.add_row("Ownership", owner_status)
+    # Contexts written before the role was recorded (#2125) carry only the
+    # boolean, so fall back to it rather than showing nothing.
+    if ctx_view.role:
+        access = ctx_view.role.capitalize()
+    else:
+        is_owner = ctx_view.is_owner if ctx_view.is_owner is not None else True
+        access = "Owner" if is_owner else "Shared"
+    table.add_row("Access", access)
     table.add_row("Created", ctx_view.created_at or "-")
     if ctx_view.conversation_id:
         table.add_row("Conversation", ctx_view.conversation_id)

--- a/src/notebooklm/cli/context.py
+++ b/src/notebooklm/cli/context.py
@@ -113,6 +113,7 @@ def set_current_notebook(
     is_owner: bool | None = None,
     created_at: str | None = None,
     *,
+    role: str | None = None,
     context_path_fn: ContextPathFn | None = None,
 ) -> None:
     """Set the current notebook context."""
@@ -128,6 +129,8 @@ def set_current_notebook(
             data["title"] = title
         if is_owner is not None:
             data["is_owner"] = is_owner
+        if role:
+            data["role"] = role
         if created_at:
             data["created_at"] = created_at
         return data

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -223,6 +223,8 @@ def set_current_notebook(
     title: str | None = None,
     is_owner: bool | None = None,
     created_at: str | None = None,
+    *,
+    role: str | None = None,
 ):
     """Set the current notebook context."""
     context_helpers.set_current_notebook(
@@ -230,6 +232,7 @@ def set_current_notebook(
         title=title,
         is_owner=is_owner,
         created_at=created_at,
+        role=role,
         context_path_fn=get_context_path,
     )
 

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -28,7 +28,7 @@ from .options import json_option, list_options, notebook_option
 from .rendering import (
     cli_print,
     console,
-    get_permission_display,
+    get_notebook_access_display,
     json_output_response,
     render_list,
 )
@@ -73,7 +73,7 @@ def register_notebook_commands(cli):
                     row=lambda nb: [
                         nb.id,
                         nb.title,
-                        get_permission_display(nb.role),
+                        get_notebook_access_display(nb.role),
                         nb.created_at.strftime("%Y-%m-%d") if nb.created_at else "-",
                     ],
                 )
@@ -392,7 +392,9 @@ def register_notebook_commands(cli):
                         console.print(
                             f"[dim]Created:[/dim] {metadata.created_at.strftime('%Y-%m-%d %H:%M')}"
                         )
-                    console.print(f"[dim]Access:[/dim] {get_permission_display(metadata.role)}")
+                    console.print(
+                        f"[dim]Access:[/dim] {get_notebook_access_display(metadata.role)}"
+                    )
 
                     console.print(f"\n[bold]Sources ({len(metadata.sources)}):[/bold]")
                     if not metadata.sources:

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -20,11 +20,18 @@ from .._app.notebooks import (
     execute_notebook_metadata,
     execute_notebook_rename,
 )
+from ..types import share_permission_to_str
 from .auth_runtime import resolve_client_factory, with_client
 from .context import clear_context, get_current_notebook, set_current_notebook
 from .error_handler import _output_error
 from .options import json_option, list_options, notebook_option
-from .rendering import cli_print, console, json_output_response, render_list
+from .rendering import (
+    cli_print,
+    console,
+    get_permission_display,
+    json_output_response,
+    render_list,
+)
 from .resolve import require_notebook, resolve_notebook_id
 from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, prepare_list
@@ -56,14 +63,17 @@ def register_notebook_commands(cli):
                         "id": nb.id,
                         "title": nb.title,
                         "is_owner": nb.is_owner,
+                        "role": share_permission_to_str(nb.role) if nb.role is not None else None,
                         "created_at": nb.created_at.isoformat() if nb.created_at else None,
                         "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                     },
-                    columns=["ID", "Title", "Owner", "Created"],
+                    # "Access" (not "Owner") because the column now reports the
+                    # caller's actual role — Owner / Editor / Viewer (#2125).
+                    columns=["ID", "Title", "Access", "Created"],
                     row=lambda nb: [
                         nb.id,
                         nb.title,
-                        "Owner" if nb.is_owner else "Shared",
+                        get_permission_display(nb.role),
                         nb.created_at.strftime("%Y-%m-%d") if nb.created_at else "-",
                     ],
                 )
@@ -105,7 +115,13 @@ def register_notebook_commands(cli):
 
                 if switch_context:
                     created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
-                    set_current_notebook(nb.id, nb.title, nb.is_owner, created_str)
+                    set_current_notebook(
+                        nb.id,
+                        nb.title,
+                        nb.is_owner,
+                        created_str,
+                        role=share_permission_to_str(nb.role) if nb.role is not None else None,
+                    )
 
                 if json_output:
                     data: dict = {
@@ -376,8 +392,7 @@ def register_notebook_commands(cli):
                         console.print(
                             f"[dim]Created:[/dim] {metadata.created_at.strftime('%Y-%m-%d %H:%M')}"
                         )
-                    owner_status = "Owner" if metadata.is_owner else "Shared"
-                    console.print(f"[dim]Access:[/dim] {owner_status}")
+                    console.print(f"[dim]Access:[/dim] {get_permission_display(metadata.role)}")
 
                     console.print(f"\n[bold]Sources ({len(metadata.sources)}):[/bold]")
                     if not metadata.sources:

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -128,6 +128,11 @@ def register_notebook_commands(cli):
                         "notebook": {
                             "id": nb.id,
                             "title": nb.title,
+                            # Kept in step with `list --json` / `use --json` so
+                            # automation sees one notebook shape (#2125).
+                            "role": (
+                                share_permission_to_str(nb.role) if nb.role is not None else None
+                            ),
                             "created_at": nb.created_at.isoformat() if nb.created_at else None,
                             "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                         }

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -314,17 +314,35 @@ def get_source_type_display(source_type: str) -> str:
     return type_map.get(type_str, f"❓ {type_str}")
 
 
-def get_permission_display(permission: SharePermission | None) -> str:
+def get_permission_display(
+    permission: SharePermission | None, *, unknown_label: str = "Unknown"
+) -> str:
     """Get display string for a share permission / notebook role.
 
-    ``None`` means the backend did not state a level for this row, which the
-    notebook decoder treats as "assume the caller owns it" — so it renders the
-    same as ``OWNER`` rather than inventing a fourth label. Unmapped codes
-    render as ``"Unknown"``.
+    The label for an unstated / unmapped level is the caller's choice, because
+    the two consumers legitimately disagree and silently sharing one default
+    would mislabel the other. The sharing UI keeps the conservative
+    ``"Unknown"``; the notebook columns pass ``"Owner"`` via
+    :func:`get_notebook_access_display`.
     """
     if permission is None:
-        return "Owner"
-    return share_permission_to_str(permission).capitalize()
+        return unknown_label
+    label = share_permission_to_str(permission)
+    return unknown_label if label == "unknown" else label.capitalize()
+
+
+def get_notebook_access_display(role: SharePermission | None) -> str:
+    """Get the "Access" column label for a notebook's own-role field.
+
+    An unstated role renders as ``"Owner"`` because that is exactly what
+    ``Notebook.is_owner`` degrades to for the same row — the human-facing
+    column stays consistent with the boolean beside it rather than introducing
+    a fourth state the rest of the CLI does not have. Machine-readable surfaces
+    deliberately do NOT share this optimism: ``role`` / ``role_label`` stay
+    ``null`` in JSON, MCP and REST output so an agent is never told "owner"
+    on the strength of a guess.
+    """
+    return get_permission_display(role, unknown_label="Owner")
 
 
 def _list_column_options(header: str, *, no_truncate: bool) -> dict[str, Any]:

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -15,10 +15,10 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from ..types import ArtifactType
+from ..types import ArtifactType, share_permission_to_str
 
 if TYPE_CHECKING:
-    from ..types import Artifact
+    from ..types import Artifact, SharePermission
     from .services.listing import ListRender
 
 
@@ -312,6 +312,19 @@ def get_source_type_display(source_type: str) -> str:
         "unknown": "❓ Unknown",
     }
     return type_map.get(type_str, f"❓ {type_str}")
+
+
+def get_permission_display(permission: SharePermission | None) -> str:
+    """Get display string for a share permission / notebook role.
+
+    ``None`` means the backend did not state a level for this row, which the
+    notebook decoder treats as "assume the caller owns it" — so it renders the
+    same as ``OWNER`` rather than inventing a fourth label. Unmapped codes
+    render as ``"Unknown"``.
+    """
+    if permission is None:
+        return "Owner"
+    return share_permission_to_str(permission).capitalize()
 
 
 def _list_column_options(header: str, *, no_truncate: bool) -> dict[str, Any]:

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -18,6 +18,7 @@ import httpx
 from ..auth import MasterTokenError as _MasterTokenError
 from ..exceptions import AuthError, NotebookNotFoundError
 from ..paths import get_storage_path
+from ..types import share_permission_to_str
 
 # Cookie-JSON import helpers (split out to keep this module under the size budget).
 from ._cookie_import import _import_cookie_json, _read_auth_json_input
@@ -49,7 +50,12 @@ from .playwright_login_io import (
 from .playwright_login_io import (
     repair_after_refresh as repair_after_refresh,
 )
-from .rendering import console, json_error_response, json_output_response
+from .rendering import (
+    console,
+    get_permission_display,
+    json_error_response,
+    json_output_response,
+)
 from .resolve import resolve_notebook_id
 from .runtime import run_async
 from .services.auth_diagnostics import (
@@ -525,7 +531,8 @@ def register_session_commands(cli):
         nb = result.notebook
         resolved_id = result.resolved_id
         created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
-        set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
+        role_label = share_permission_to_str(nb.role) if nb.role is not None else None
+        set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str, role=role_label)
 
         if json_output:
             json_output_response(
@@ -537,6 +544,7 @@ def register_session_commands(cli):
                         "id": resolved_id,
                         "title": nb.title,
                         "is_owner": nb.is_owner,
+                        "role": role_label,
                         "created_at": nb.created_at.isoformat() if nb.created_at else None,
                         "modified_at": nb.modified_at.isoformat() if nb.modified_at else None,
                     },
@@ -546,8 +554,7 @@ def register_session_commands(cli):
 
         table = _use_notebook_table()
         created = created_str or "-"
-        owner_status = "Owner" if nb.is_owner else "Shared"
-        table.add_row(nb.id, nb.title, owner_status, created)
+        table.add_row(nb.id, nb.title, get_permission_display(nb.role), created)
         console.print(table)
 
     @cli.command("status")

--- a/src/notebooklm/cli/session_cmd.py
+++ b/src/notebooklm/cli/session_cmd.py
@@ -30,6 +30,7 @@ from ._session_render import (
     _render_auth_inspect_error,
     _render_logout_outcome,
     _render_status,
+    _render_use_notebook,
     _use_notebook_table,
 )
 from .auth_runtime import (
@@ -50,12 +51,7 @@ from .playwright_login_io import (
 from .playwright_login_io import (
     repair_after_refresh as repair_after_refresh,
 )
-from .rendering import (
-    console,
-    get_permission_display,
-    json_error_response,
-    json_output_response,
-)
+from .rendering import console, json_error_response, json_output_response
 from .resolve import resolve_notebook_id
 from .runtime import run_async
 from .services.auth_diagnostics import (
@@ -552,10 +548,7 @@ def register_session_commands(cli):
             )
             return
 
-        table = _use_notebook_table()
-        created = created_str or "-"
-        table.add_row(nb.id, nb.title, get_permission_display(nb.role), created)
-        console.print(table)
+        _render_use_notebook(nb, notebook_id=nb.id, created=created_str or "-")
 
     @cli.command("status")
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")

--- a/src/notebooklm/cli/share_cmd.py
+++ b/src/notebooklm/cli/share_cmd.py
@@ -23,18 +23,14 @@ from .._app.sharing import (
 from ..types import SharePermission, ShareViewLevel
 from .auth_runtime import resolve_client_factory, with_client
 from .options import notebook_option
-from .rendering import console, json_output_response
+from .rendering import console, get_permission_display, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
 from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 
 
 def _permission_name(perm: SharePermission) -> str:
     """Convert permission enum to display name."""
-    return {
-        SharePermission.OWNER: "Owner",
-        SharePermission.EDITOR: "Editor",
-        SharePermission.VIEWER: "Viewer",
-    }.get(perm, "Unknown")
+    return get_permission_display(perm)
 
 
 def _view_level_display(view_level: ShareViewLevel) -> str:

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -23,6 +23,7 @@ from fastmcp import Context
 
 from ..._app import notebooks as core
 from ..._app.serialize import to_jsonable
+from ..._app.views import notebook_view as _notebook_view
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client
 from .._errors import mcp_errors
@@ -48,7 +49,7 @@ def register(mcp: Any) -> None:
         client = get_client(ctx)
         with mcp_errors():
             notebooks = await client.notebooks.list()
-            page, meta = paginate(to_jsonable(notebooks), limit, offset)
+            page, meta = paginate([_notebook_view(nb) for nb in notebooks], limit, offset)
             return {"notebooks": page, **meta}
 
     @mcp.tool
@@ -67,7 +68,7 @@ def register(mcp: Any) -> None:
             # transport-neutral core (``execute_notebook_create``), so CLI / REST
             # / MCP all get populated timestamps from one place (#1705) — no
             # adapter-level re-read here.
-            record = to_jsonable(result.notebook)
+            record = _notebook_view(result.notebook)
             notebook_id = record.pop("id")
             return {"status": "created", "notebook_id": notebook_id, **record}
 
@@ -123,6 +124,7 @@ def register(mcp: Any) -> None:
                 # untouched elsewhere (e.g. ``notebook_list`` list rows).
                 # ``NotebookMetadata.notebook`` is a non-optional ``Notebook``
                 # dataclass, so ``to_jsonable`` always emits it as a dict here.
+                metadata_block["notebook"] = _notebook_view(meta_result.metadata.notebook)
                 metadata_block["notebook"]["sources_count"] = len(meta_result.metadata.sources)
                 output["metadata"] = metadata_block
                 return output

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -62,7 +62,8 @@ def register(mcp: Any) -> None:
             # the sibling create tool (``note_create``) and ``notebook_delete``,
             # which key the notebook by ``notebook_id`` rather than nesting the
             # record under a ``notebook`` key (#1540). The remaining Notebook
-            # fields (title, created_at, sources_count, is_owner, modified_at)
+            # fields (title, created_at, sources_count, is_owner, modified_at,
+            # role) — plus the ``role_label`` projection —
             # stay at the top level so no metadata is dropped. The
             # created_at/modified_at backfill (#1699) now lives in the
             # transport-neutral core (``execute_notebook_create``), so CLI / REST

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -506,12 +506,51 @@ class ShareViewLevel(int, Enum):
 
 
 class SharePermission(int, Enum):
-    """User permission level for sharing."""
+    """User permission level on a notebook.
+
+    This is the wire enum the backend uses for *both* halves of the sharing
+    story, under two different proto names:
+
+    * ``SharedUser.permission`` — a collaborator's level, from
+      ``GET_SHARE_STATUS`` (``SharePermission``).
+    * ``Notebook.role`` — the *calling account's own* level, from
+      ``ProjectMetadata.userRole`` (tag 1, ``meta[0]``) on every
+      ``LIST_NOTEBOOKS`` / ``GET_NOTEBOOK`` row. The proto names its members
+      ``OWNER``/``WRITER``/``READER``, but the integers are identical, so this
+      one enum covers both rather than shipping a value-identical twin (#2125).
+    """
 
     OWNER = 1  # Full control (read-only, cannot assign)
-    EDITOR = 2  # Can edit notebook
-    VIEWER = 3  # Read-only access
-    _REMOVE = 4  # Internal: remove user from share list
+    EDITOR = 2  # Can edit notebook (proto: WRITER)
+    VIEWER = 3  # Read-only access (proto: READER)
+    _REMOVE = 4  # Internal: remove user from share list (proto: NOT_SHARED)
+
+
+# Share permission code to string mapping (uses int keys for mypy compatibility).
+# ``_REMOVE`` is deliberately absent: it is a write-only sentinel with no
+# display meaning, so it degrades to "unknown" like any unmapped code.
+_SHARE_PERMISSION_MAP: dict[int, str] = {
+    SharePermission.OWNER: "owner",
+    SharePermission.EDITOR: "editor",
+    SharePermission.VIEWER: "viewer",
+}
+
+
+def share_permission_to_str(permission: int | SharePermission) -> str:
+    """Convert a share permission / notebook role code to a human-readable string.
+
+    This is the single source of truth for permission code to string mapping
+    (the sibling of :func:`source_status_to_str`). Use this helper instead of
+    inline conditionals so every adapter's label stays in lock-step.
+
+    Args:
+        permission: Permission code as int or SharePermission enum.
+
+    Returns:
+        String permission: ``"owner"``, ``"editor"``, or ``"viewer"``.
+        Returns ``"unknown"`` for unrecognized codes (future-proofing).
+    """
+    return _SHARE_PERMISSION_MAP.get(permission, "unknown")
 
 
 class SourceStatus(int, Enum):

--- a/src/notebooklm/server/routes/notebooks.py
+++ b/src/notebooklm/server/routes/notebooks.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 from ..._app import notebooks as core
 from ..._app.notebooks import SUGGEST_SURFACE_MAP, SuggestSurface
 from ..._app.serialize import to_jsonable
+from ..._app.views import notebook_view
 from ...client import NotebookLMClient
 from .._context import get_client
 from .._pagination import MAX_LIMIT, paginate_envelope
@@ -59,21 +60,23 @@ async def list_notebooks(
     ``?limit=`` to slice and add a ``meta`` block; ``?offset=`` pages forward.
     """
     notebooks = await client.notebooks.list()
-    return paginate_envelope(to_jsonable(notebooks), key="notebooks", limit=limit, offset=offset)
+    return paginate_envelope(
+        [notebook_view(nb) for nb in notebooks], key="notebooks", limit=limit, offset=offset
+    )
 
 
 @router.get("/{notebook_id}")
 async def get_notebook(notebook_id: str, client: ClientDep) -> dict[str, Any]:
     """Fetch one notebook (raises ``NotebookNotFoundError`` → 404 on a miss)."""
     notebook = await client.notebooks.get(notebook_id)
-    return to_jsonable(notebook)
+    return notebook_view(notebook)
 
 
 @router.post("", status_code=201)
 async def create_notebook(body: NotebookCreate, client: ClientDep) -> dict[str, Any]:
     """Create a notebook with the given title."""
     result = await core.execute_notebook_create(client, body.title)
-    return to_jsonable(result.notebook)
+    return notebook_view(result.notebook)
 
 
 @router.patch("/{notebook_id}")

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -110,6 +110,7 @@ from .rpc.types import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
+    share_permission_to_str,
     source_status_to_str,
 )
 from .rpc.types import (
@@ -249,6 +250,7 @@ __all__ = [
     "SharePermission",
     # Helper functions
     "artifact_status_to_str",
+    "share_permission_to_str",
     "source_status_to_str",
 ]
 

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -509,6 +509,7 @@ def test_rpc_helper_reexports_are_canonical_identities() -> None:
 
     assert public_types.artifact_status_to_str is rpc_types.artifact_status_to_str
     assert public_types.source_status_to_str is rpc_types.source_status_to_str
+    assert public_types.share_permission_to_str is rpc_types.share_permission_to_str
 
 
 def test_types_non_all_facade_attributes_are_frozen() -> None:

--- a/tests/fixtures/baselines/types_all.json
+++ b/tests/fixtures/baselines/types_all.json
@@ -79,5 +79,6 @@
   "ShareViewLevel",
   "SharePermission",
   "artifact_status_to_str",
+  "share_permission_to_str",
   "source_status_to_str"
 ]

--- a/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
+++ b/tests/fixtures/rpc_golden/GET_NOTEBOOK.json
@@ -29,7 +29,7 @@
         [
           "wrb.fr",
           "rLM1Ne",
-          "[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]]]",
+          "[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[1,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]]]",
           null,
           null,
           null,
@@ -50,7 +50,7 @@
         "📓",
         null,
         [
-          null,
+          1,
           false,
           null,
           null,
@@ -76,6 +76,7 @@
     "created_at": "2024-01-01T00:00:00+00:00",
     "sources_count": 1,
     "is_owner": true,
-    "modified_at": "2024-01-02T00:00:00+00:00"
+    "modified_at": "2024-01-02T00:00:00+00:00",
+    "role": 1
   }
 }

--- a/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
+++ b/tests/fixtures/rpc_golden/LIST_NOTEBOOKS.json
@@ -28,7 +28,7 @@
         [
           "wrb.fr",
           "wXbhsf",
-          "[[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[null,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]],[\"Scrubbed Notebook Two\",[],\"SCRUBBED_NB_002\",\"\\ud83d\\udcd8\",null,[null,true,null,null,null,[1704240000,0],null,null,[1704067200,0]]]]]",
+          "[[[\"Scrubbed Notebook One\",[[\"SCRUBBED_SRC_001\"]],\"SCRUBBED_NB_001\",\"\\ud83d\\udcd3\",null,[1,false,null,null,null,[1704153600,0],null,null,[1704067200,0]]],[\"Scrubbed Notebook Two\",[],\"SCRUBBED_NB_002\",\"\\ud83d\\udcd8\",null,[3,true,null,null,null,[1704240000,0],null,null,[1704067200,0]]]]]",
           null,
           null,
           null,
@@ -50,7 +50,7 @@
           "📓",
           null,
           [
-            null,
+            1,
             false,
             null,
             null,
@@ -74,7 +74,7 @@
           "📘",
           null,
           [
-            null,
+            3,
             true,
             null,
             null,
@@ -221,7 +221,8 @@
       "created_at": "2024-01-01T00:00:00+00:00",
       "sources_count": 1,
       "is_owner": true,
-      "modified_at": "2024-01-02T00:00:00+00:00"
+      "modified_at": "2024-01-02T00:00:00+00:00",
+      "role": 1
     },
     {
       "id": "SCRUBBED_NB_002",
@@ -229,7 +230,8 @@
       "created_at": "2024-01-01T00:00:00+00:00",
       "sources_count": 0,
       "is_owner": false,
-      "modified_at": "2024-01-03T00:00:00+00:00"
+      "modified_at": "2024-01-03T00:00:00+00:00",
+      "role": 3
     }
   ]
 }

--- a/tests/integration/mcp_vcr/test_notebooks.py
+++ b/tests/integration/mcp_vcr/test_notebooks.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import pytest
 
+from notebooklm.types import SharePermission
 from tests.integration.conftest import skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 
@@ -104,6 +105,10 @@ async def test_mcp_notebook_create_over_vcr() -> None:
         "sources_count",
         "is_owner",
         "modified_at",
+        "role",
+        # ``role_label`` is not a dataclass field — it is the agent-readable
+        # projection ``_app.views.notebook_view`` adds next to the raw code.
+        "role_label",
     }
     # #1699: CREATE_NOTEBOOK returns null created_at/modified_at; the tool's
     # GET_NOTEBOOK re-read populates them. Asserting NON-null is the load-bearing
@@ -111,6 +116,9 @@ async def test_mcp_notebook_create_over_vcr() -> None:
     # (or a silent fallback) would leave these null and fail here.
     assert structured["created_at"] is not None, "created_at should be populated by the re-read"
     assert structured["modified_at"] is not None, "modified_at should be populated by the re-read"
+    # The creating account owns what it just created (#2125).
+    assert structured["role"] == SharePermission.OWNER.value
+    assert structured["role_label"] == "owner"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -97,28 +97,47 @@ _WIKIPEDIA_SOURCE_ID = "466b9ee3-c1ce-45ef-861c-1d4bfcd939ad"
 
 
 # Per-row golden for the first three recorded notebooks:
-# (id, title, sources_count, is_owner). The (id <-> title <-> count <-> owner)
-# tuple is the positional canary for the notebook-list decoder.
+# (id, title, sources_count, role, is_owner). The tuple is the positional canary
+# for the notebook-list decoder.
+#
+# Row 2 is the #2125 regression witness: the recorded row carries
+# ``meta[0] == 1`` (userRole OWNER) alongside ``meta[1] is True`` (the notebook
+# has been shared). The pre-fix decoder read ``meta[1]`` and reported
+# ``is_owner=False`` for this row — the recorded account's own notebook,
+# labelled "Shared" by its own CLI.
 _NOTEBOOKS_LIST_GOLDEN_HEAD = [
     (
         "f66923f0-1df4-4ffe-9822-3ed63c558b1c",
         "GENERATION: Claude Code Deep Dive: Skills, Agents, Commands & Plugins",
         42,
+        SharePermission.OWNER,
         True,
     ),
     (
         "167481cd-23a3-4331-9a45-c8948900bf91",
         "READ ONLY: Learn Claude Code & AI Agents for High School Students",
         8,
-        False,
+        SharePermission.OWNER,
+        True,
     ),
     (
         "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e",
         "TypeScript Fundamentals: A Handbook of Type Systems and Rules",
         2,
+        SharePermission.OWNER,
         True,
     ),
 ]
+
+#: The one recorded row the account does NOT own — ``meta[0] == 3`` (READER).
+#: Pinned separately so the list golden covers a genuine non-owner role rather
+#: than only the owner path.
+_NOTEBOOKS_LIST_GOLDEN_VIEWER_ROW = (
+    "40b0bb3f-afa6-49b2-959f-d91fb0a91a3b",
+    "Jane Austen: The Complete Works",
+    SharePermission.VIEWER,
+    False,
+)
 
 
 class TestNotebooksGoldenDecoded:
@@ -128,14 +147,20 @@ class TestNotebooksGoldenDecoded:
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("notebooks_list.yaml")
     async def test_list_decoded_golden(self):
-        """``notebooks.list`` decodes id/title/sources_count/is_owner per row."""
+        """``notebooks.list`` decodes id/title/sources_count/role/is_owner per row."""
         async with vcr_client() as client:
             notebooks = await client.notebooks.list()
 
         assert_decoded_equals(len(notebooks), 12, field="notebooks_list length")
-        actual_head = [(n.id, n.title, n.sources_count, n.is_owner) for n in notebooks[:3]]
+        actual_head = [(n.id, n.title, n.sources_count, n.role, n.is_owner) for n in notebooks[:3]]
         assert_decoded_equals(
             actual_head, _NOTEBOOKS_LIST_GOLDEN_HEAD, field="notebooks_list[:3] rows"
+        )
+        viewer = next(nb for nb in notebooks if nb.id == _NOTEBOOKS_LIST_GOLDEN_VIEWER_ROW[0])
+        assert_decoded_equals(
+            (viewer.id, viewer.title, viewer.role, viewer.is_owner),
+            _NOTEBOOKS_LIST_GOLDEN_VIEWER_ROW,
+            field="notebooks_list viewer row",
         )
         # The created_at / modified_at slots decode to real timestamps (not
         # fabricated defaults) — pin the first row's to catch a timestamp-column
@@ -181,6 +206,7 @@ class TestNotebooksGoldenDecoded:
             field="notebooks_get.title",
         )
         assert_decoded_equals(notebook.sources_count, 2, field="notebooks_get.sources_count")
+        assert_decoded_equals(notebook.role, SharePermission.OWNER, field="notebooks_get.role")
         assert_decoded_equals(notebook.is_owner, True, field="notebooks_get.is_owner")
         # created_at is the CREATION instant (``data[5][8][0]``); modified_at is
         # the LAST-MODIFIED instant (``data[5][5][0]``). Pin both epochs (TZ-

--- a/tests/server/test_notebooks.py
+++ b/tests/server/test_notebooks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from notebooklm._types.notebooks import Notebook
+from notebooklm.types import SharePermission
 
 from .fakes import FakeClient
 
@@ -15,6 +16,57 @@ def test_list_returns_notebooks(authed_client: TestClient, fake_client: FakeClie
     assert resp.status_code == 200
     titles = [n["title"] for n in resp.json()["notebooks"]]
     assert titles == ["First"]
+
+
+def test_list_projects_role_and_role_label(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """REST rows carry the caller's role plus its agent-readable label (#2125).
+
+    A bare ``to_jsonable`` pass would ship ``role: 3`` with nothing to decode
+    it against, so the routes go through ``_app.views.notebook_view``.
+    """
+    fake_client.notebooks_store["nb-v"] = Notebook(
+        id="nb-v", title="Read only", role=SharePermission.VIEWER
+    )
+    fake_client.notebooks_store["nb-o"] = Notebook(
+        id="nb-o", title="Mine", role=SharePermission.OWNER
+    )
+    rows = {n["id"]: n for n in authed_client.get("/v1/notebooks").json()["notebooks"]}
+
+    assert rows["nb-v"]["role"] == SharePermission.VIEWER.value
+    assert rows["nb-v"]["role_label"] == "viewer"
+    assert rows["nb-v"]["is_owner"] is False
+    assert rows["nb-o"]["role_label"] == "owner"
+    assert rows["nb-o"]["is_owner"] is True
+
+
+def test_list_unstated_role_stays_null_for_machines(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """An unstated role must NOT be optimistically reported as "owner" on the wire.
+
+    The CLI's Access column deliberately degrades to "Owner" to match
+    ``is_owner``; machine-readable surfaces stay honest and emit ``null`` so an
+    agent is never told a role the backend did not state.
+    """
+    fake_client.notebooks_store["nb-?"] = Notebook(id="nb-?", title="No role stated")
+    row = authed_client.get("/v1/notebooks").json()["notebooks"][0]
+
+    assert row["role"] is None
+    assert row["role_label"] is None
+    assert row["is_owner"] is True
+
+
+def test_get_projects_role_label(authed_client: TestClient, fake_client: FakeClient) -> None:
+    fake_client.notebooks_store["nb-e"] = Notebook(
+        id="nb-e", title="Editable", role=SharePermission.EDITOR
+    )
+    body = authed_client.get("/v1/notebooks/nb-e").json()
+
+    assert body["role"] == SharePermission.EDITOR.value
+    assert body["role_label"] == "editor"
+    assert body["is_owner"] is False
 
 
 def test_list_default_is_unbounded_no_meta(

--- a/tests/unit/app/test_app_serialize.py
+++ b/tests/unit/app/test_app_serialize.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timezone
 from enum import Enum, IntEnum
 
 from notebooklm._app.serialize import to_jsonable
-from notebooklm.types import Notebook
+from notebooklm.types import Notebook, SharePermission
 
 
 class Color(str, Enum):
@@ -125,10 +125,13 @@ def test_real_notebooklm_type_round_trips() -> None:
         created_at=datetime(2026, 6, 8, 0, 0, 0, tzinfo=timezone.utc),
         sources_count=3,
         is_owner=True,
+        role=SharePermission.OWNER,
     )
 
     result = to_jsonable(nb)
 
+    # ``role`` is an ``int`` enum, so ``to_jsonable`` unwraps it to its wire
+    # value; adapters add the ``role_label`` string via ``_app.views``.
     assert result == {
         "id": "nb-1",
         "title": "My Notebook",
@@ -136,8 +139,34 @@ def test_real_notebooklm_type_round_trips() -> None:
         "sources_count": 3,
         "is_owner": True,
         "modified_at": None,
+        "role": 1,
     }
     json.dumps(result)
+
+
+def test_notebook_view_adds_role_label() -> None:
+    """``notebook_view`` labels the raw role code for agent consumers (#2125)."""
+    from notebooklm._app.views import notebook_view
+
+    view = notebook_view(Notebook(id="nb-1", title="N", role=SharePermission.VIEWER))
+
+    assert view["role"] == SharePermission.VIEWER.value
+    assert view["role_label"] == "viewer"
+    # The projection is additive — every dataclass field still ships.
+    assert view["is_owner"] is False
+    assert view["id"] == "nb-1"
+
+
+def test_notebook_view_role_label_is_none_for_unknown_role() -> None:
+    """An unstated role stays ``None`` rather than becoming the "unknown" label."""
+    from notebooklm._app.views import notebook_view
+
+    view = notebook_view(Notebook(id="nb-1", title="N"))
+
+    assert view["role"] is None
+    assert view["role_label"] is None
+    # ``role`` is unknown, so the historical optimistic default holds.
+    assert view["is_owner"] is True
 
 
 def test_unknown_object_falls_back_to_str() -> None:

--- a/tests/unit/app/test_app_session.py
+++ b/tests/unit/app/test_app_session.py
@@ -479,3 +479,20 @@ def test_logout_failure_is_frozen_and_typed() -> None:
     # Frozen dataclass: assignment is rejected.
     with pytest.raises(FrozenInstanceError):
         failure.kind = "context"  # type: ignore[misc]
+
+
+def test_status_rejects_unknown_role_label_from_context_file(tmp_path, monkeypatch):
+    """The context file is user-editable, so an unknown role label is dropped.
+
+    Without validation a hand-edited ``"role": "wizard"`` would be title-cased
+    straight onto the ``status`` table (#2125).
+    """
+    from notebooklm._app.session import _valid_role_label
+
+    assert _valid_role_label("owner") == "owner"
+    assert _valid_role_label("editor") == "editor"
+    assert _valid_role_label("viewer") == "viewer"
+    assert _valid_role_label("wizard") is None
+    assert _valid_role_label("Owner") is None
+    assert _valid_role_label(1) is None
+    assert _valid_role_label(None) is None

--- a/tests/unit/cli/test_cli_rendering_permissions.py
+++ b/tests/unit/cli/test_cli_rendering_permissions.py
@@ -1,0 +1,36 @@
+"""Display-label policy for share permissions vs. notebook roles (#2125)."""
+
+from __future__ import annotations
+
+from notebooklm.cli.rendering import get_notebook_access_display, get_permission_display
+from notebooklm.types import SharePermission
+
+
+class TestGetPermissionDisplay:
+    def test_known_permissions(self):
+        assert get_permission_display(SharePermission.OWNER) == "Owner"
+        assert get_permission_display(SharePermission.EDITOR) == "Editor"
+        assert get_permission_display(SharePermission.VIEWER) == "Viewer"
+
+    def test_unknown_defaults_to_unknown_not_owner(self):
+        """The sharing UI must never upgrade an unknown level to "Owner".
+
+        ``get_notebook_access_display`` deliberately degrades to "Owner"; that
+        policy belongs to the notebook column alone and must not leak into the
+        share list, where mislabelling a permission is security-adjacent.
+        """
+        assert get_permission_display(None) == "Unknown"
+        assert get_permission_display(SharePermission._REMOVE) == "Unknown"
+
+    def test_unknown_label_is_caller_chosen(self):
+        assert get_permission_display(None, unknown_label="Owner") == "Owner"
+
+
+class TestGetNotebookAccessDisplay:
+    def test_known_roles(self):
+        assert get_notebook_access_display(SharePermission.OWNER) == "Owner"
+        assert get_notebook_access_display(SharePermission.EDITOR) == "Editor"
+        assert get_notebook_access_display(SharePermission.VIEWER) == "Viewer"
+
+    def test_unstated_role_matches_is_owner_soft_degrade(self):
+        assert get_notebook_access_display(None) == "Owner"

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -93,7 +93,7 @@ class TestStatusCommand:
         assert "Demo NB" in result.output
 
     def test_status_with_context_json(self, runner: CliRunner, isolated_home: Path) -> None:
-        """``--json`` envelope echoes notebook id/title/is_owner + conversation_id."""
+        """``--json`` envelope echoes notebook id/title/is_owner/role + conversation_id."""
         _seed_context(
             isolated_home,
             notebook_id="abc123",
@@ -107,7 +107,14 @@ class TestStatusCommand:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert data["has_context"] is True
-        assert data["notebook"] == {"id": "abc123", "title": "Demo NB", "is_owner": True}
+        # ``role`` is ``None`` for a context written before the role was
+        # recorded (#2125); the renderer then falls back to ``is_owner``.
+        assert data["notebook"] == {
+            "id": "abc123",
+            "title": "Demo NB",
+            "is_owner": True,
+            "role": None,
+        }
         assert data["conversation_id"] == "conv-99"
 
     def test_status_paths_json(self, runner: CliRunner, isolated_home: Path) -> None:

--- a/tests/unit/cli/test_cli_session_local.py
+++ b/tests/unit/cli/test_cli_session_local.py
@@ -92,6 +92,48 @@ class TestStatusCommand:
         assert "abc123" in result.output
         assert "Demo NB" in result.output
 
+    def test_status_text_renders_recorded_role(
+        self, runner: CliRunner, isolated_home: Path
+    ) -> None:
+        """The Access row shows the recorded role, not just Owner/Shared (#2125)."""
+        _seed_context(
+            isolated_home, notebook_id="abc123", title="Demo NB", is_owner=False, role="viewer"
+        )
+
+        result = runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Access" in result.output
+        assert "Viewer" in result.output
+
+    def test_status_text_falls_back_to_is_owner_for_legacy_context(
+        self, runner: CliRunner, isolated_home: Path
+    ) -> None:
+        """A context written before ``role`` existed still renders (compat promise).
+
+        ``docs/configuration.md`` documents this fallback, so it is pinned here.
+        """
+        _seed_context(isolated_home, notebook_id="abc123", title="Demo NB", is_owner=False)
+
+        result = runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Shared" in result.output
+
+    def test_status_text_ignores_unknown_role_label(
+        self, runner: CliRunner, isolated_home: Path
+    ) -> None:
+        """context.json is hand-editable, so a bogus role must not reach the table."""
+        _seed_context(
+            isolated_home, notebook_id="abc123", title="Demo NB", is_owner=True, role="wizard"
+        )
+
+        result = runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Wizard" not in result.output
+        assert "Owner" in result.output
+
     def test_status_with_context_json(self, runner: CliRunner, isolated_home: Path) -> None:
         """``--json`` envelope echoes notebook id/title/is_owner/role + conversation_id."""
         _seed_context(

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -334,13 +334,18 @@ class TestContextManagement:
         context_file = tmp_path / "context.json"
         with patch.object(helpers_module, "get_context_path", return_value=context_file):
             set_current_notebook(
-                "nb_test123", title="Test Notebook", is_owner=True, created_at="2024-01-01T00:00:00"
+                "nb_test123",
+                title="Test Notebook",
+                is_owner=True,
+                created_at="2024-01-01T00:00:00",
+                role="owner",
             )
             data = json.loads(context_file.read_text())
             assert data["notebook_id"] == "nb_test123"
             assert data["title"] == "Test Notebook"
             assert data["is_owner"] is True
             assert data["created_at"] == "2024-01-01T00:00:00"
+            assert data["role"] == "owner"
 
     def test_clear_context(self, tmp_path):
         context_file = tmp_path / "context.json"

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -16,7 +16,7 @@ import notebooklm.cli.resolve as resolve_module
 from notebooklm.exceptions import NotebookLimitError, RPCError
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc import RPCMethod
-from notebooklm.types import AskResult, Notebook
+from notebooklm.types import AskResult, Notebook, SharePermission
 
 from .conftest import (
     create_mock_client,
@@ -94,6 +94,33 @@ class TestNotebookList:
         assert "First Notebook" in result.output
         assert "Second Notebook" in result.output
 
+    def test_notebook_list_renders_each_role_distinctly(self, runner, mock_auth):
+        """#2125: owner / editor / viewer must be distinguishable in the table.
+
+        Pre-fix, all three collapsed onto "Owner" vs "Shared", so a read-only
+        collaborator looked identical to a full editor.
+        """
+        mock_client = create_mock_client()
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(id="nb_own", title="Mine", role=SharePermission.OWNER),
+                Notebook(id="nb_edit", title="Theirs (edit)", role=SharePermission.EDITOR),
+                Notebook(id="nb_view", title="Theirs (read)", role=SharePermission.VIEWER),
+            ]
+        )
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(cli, ["list", "--no-truncate"], obj=inject_client(mock_client))
+
+        assert result.exit_code == 0
+        assert "Access" in result.output
+        for label in ("Owner", "Editor", "Viewer"):
+            assert label in result.output, f"{label!r} missing from:\n{result.output}"
+        assert "Shared" not in result.output
+
     def test_notebook_list_json_output(self, runner, mock_auth):
         mock_client = create_mock_client()
         mock_client.notebooks.list = AsyncMock(
@@ -103,6 +130,7 @@ class TestNotebookList:
                     title="Test Notebook",
                     created_at=datetime(2024, 1, 1),
                     is_owner=True,
+                    role=SharePermission.OWNER,
                 ),
             ]
         )
@@ -123,10 +151,12 @@ class TestNotebookList:
             "id",
             "title",
             "is_owner",
+            "role",
             "created_at",
             "modified_at",
         ]
         assert data["notebooks"][0]["id"] == "nb_1"
+        assert data["notebooks"][0]["role"] == "owner"
 
     def test_notebook_list_limit_caps_rows(self, runner, mock_auth):
         """`--limit N` returns at most N data rows in text output."""

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -348,7 +348,10 @@ class TestNotebookCreate:
         mock_client = create_mock_client()
         mock_client.notebooks.create = AsyncMock(
             return_value=Notebook(
-                id="new_nb_id", title="Test Notebook", created_at=datetime(2024, 1, 1)
+                id="new_nb_id",
+                title="Test Notebook",
+                created_at=datetime(2024, 1, 1),
+                role=SharePermission.OWNER,
             )
         )
 
@@ -363,6 +366,8 @@ class TestNotebookCreate:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["notebook"]["id"] == "new_nb_id"
+        # One notebook shape across `create` / `list` / `use` --json (#2125).
+        assert data["notebook"]["role"] == "owner"
         assert not mock_context_file.exists()
 
     def test_notebook_create_with_use_flag(self, runner, mock_auth, mock_context_file):

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -121,6 +121,22 @@ class TestNotebookList:
             assert label in result.output, f"{label!r} missing from:\n{result.output}"
         assert "Shared" not in result.output
 
+    def test_notebook_list_unknown_role_renders_as_owner(self, runner, mock_auth):
+        """An unstated role renders "Owner", matching ``is_owner``'s soft-degrade."""
+        mock_client = create_mock_client()
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[Notebook(id="nb_x", title="No Role Stated")]
+        )
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(cli, ["list"], obj=inject_client(mock_client))
+
+        assert result.exit_code == 0
+        assert "Owner" in result.output
+
     def test_notebook_list_json_output(self, runner, mock_auth):
         mock_client = create_mock_client()
         mock_client.notebooks.list = AsyncMock(
@@ -1289,6 +1305,7 @@ class TestNotebookMetadata:
             id="nb_1",
             title="Test Notebook",
             created_at=datetime(2024, 1, 1),
+            role=SharePermission.EDITOR,
         )
         # Override notebooks.list to return only our test notebook (avoid partial ID conflicts)
         mock_client.notebooks.list = AsyncMock(return_value=[notebook])
@@ -1324,6 +1341,9 @@ class TestNotebookMetadata:
         assert "Test Notebook" in result.output
         assert "[pdf]" in result.output
         assert "nb_1" in result.output
+        # The Access line reports the caller's real role, not Owner/Shared (#2125).
+        assert "Access:" in result.output
+        assert "Editor" in result.output
 
     def test_metadata_json_output(self, runner, mock_auth):
         """Test JSON output with --json flag."""
@@ -1339,6 +1359,7 @@ class TestNotebookMetadata:
             notebook=notebook,
             sources=[SourceSummary(kind=SourceType.PDF, title="test.pdf")],
         )
+        assert metadata.to_dict()["role"] is None  # unstated role stays null in JSON
 
         # Use side_effect to avoid potential pickling issues with enums
         async def return_metadata(nb_id):

--- a/tests/unit/cli/test_session_characterization.py
+++ b/tests/unit/cli/test_session_characterization.py
@@ -52,7 +52,7 @@ import notebooklm.cli.services.session_context as session_context_module
 import notebooklm.cli.session_cmd as session_cmd
 import notebooklm.paths as paths_module
 from notebooklm.notebooklm_cli import cli
-from notebooklm.types import Notebook
+from notebooklm.types import Notebook, SharePermission
 from tests._fixtures import patch_session_login_dual
 
 from .conftest import create_mock_client, inject_client
@@ -248,6 +248,7 @@ class TestUseCharacterization:
                 title="JSON Char Notebook",
                 created_at=datetime(2024, 2, 1),
                 is_owner=False,
+                role=SharePermission.VIEWER,
             )
         )
         with (
@@ -276,6 +277,7 @@ class TestUseCharacterization:
                 "id": "nb_json_001",
                 "title": "JSON Char Notebook",
                 "is_owner": False,
+                "role": "viewer",
                 "created_at": "2024-02-01T00:00:00",
                 "modified_at": None,
             },
@@ -351,6 +353,7 @@ class TestStatusCharacterization:
                     "notebook_id": "nb_status_2",
                     "title": "Status Notebook 2",
                     "is_owner": False,
+                    "role": "viewer",
                     "created_at": "2024-04-05",
                     "conversation_id": "conv_xyz",
                 }
@@ -365,6 +368,7 @@ class TestStatusCharacterization:
                 "id": "nb_status_2",
                 "title": "Status Notebook 2",
                 "is_owner": False,
+                "role": "viewer",
             },
             "conversation_id": "conv_xyz",
         }

--- a/tests/unit/cli/test_use.py
+++ b/tests/unit/cli/test_use.py
@@ -17,7 +17,7 @@ import notebooklm.auth as auth_module
 import notebooklm.cli.helpers as helpers_module
 import notebooklm.cli.session_cmd as session_cmd_module
 from notebooklm.notebooklm_cli import cli
-from notebooklm.types import Notebook
+from notebooklm.types import Notebook, SharePermission
 
 from .conftest import create_mock_client, inject_client
 
@@ -136,15 +136,21 @@ class TestUseCommand:
         data = json.loads(mock_context_file.read_text())
         assert data["notebook_id"] == "nb_forced"
 
-    def test_use_shows_owner_status(self, runner, mock_auth, mock_context_file):
-        """Test 'use' command displays ownership status correctly."""
+    def test_use_shows_role_and_persists_it(self, runner, mock_auth, mock_context_file):
+        """``use`` shows the caller's actual role and records it in the context.
+
+        The old assertion here (``"Shared" in output or "nb_shared" in output``)
+        could never fail — the right operand is the notebook id, which is always
+        printed. It now pins the Access cell itself, and the write half of the
+        context round-trip that ``status`` later reads back (#2125).
+        """
         mock_client = create_mock_client()
         mock_client.notebooks.get = AsyncMock(
             return_value=Notebook(
                 id="nb_shared",
                 title="Shared Notebook",
                 created_at=datetime(2024, 1, 15),
-                is_owner=False,  # Shared notebook
+                role=SharePermission.VIEWER,  # shared WITH us, read-only
             )
         )
 
@@ -162,7 +168,12 @@ class TestUseCommand:
                 result = runner.invoke(cli, ["use", "nb_shared"], obj=inject_client(mock_client))
 
         assert result.exit_code == 0
-        assert "Shared" in result.output or "nb_shared" in result.output
+        assert "Viewer" in result.output
+        assert "Access" in result.output
+
+        data = json.loads(mock_context_file.read_text())
+        assert data["role"] == "viewer"
+        assert data["is_owner"] is False
 
 
 # =============================================================================

--- a/tests/unit/mcp/test_notebooks.py
+++ b/tests/unit/mcp/test_notebooks.py
@@ -27,6 +27,7 @@ from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
 from notebooklm.types import (  # noqa: E402 - after importorskip guard
     Notebook,
     NotebookMetadata,
+    SharePermission,
     SourceSummary,
     SourceType,
 )
@@ -38,6 +39,9 @@ from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 class FakeNotebook:
     id: str
     title: str
+    # ``_app.views.notebook_view`` reads ``role`` to add the ``role_label``
+    # projection, so even the minimal fake carries the field (#2125).
+    role: SharePermission | None = None
 
 
 @dataclass
@@ -57,6 +61,7 @@ class FakeNotebookFull:
     sources_count: int = 0
     is_owner: bool = True
     modified_at: datetime | None = None
+    role: SharePermission | None = None
 
 
 @dataclass
@@ -71,10 +76,14 @@ MODIFIED_AT = datetime(2026, 1, 3, 4, 5, 6, tzinfo=timezone.utc)
 
 
 async def test_notebook_list(mcp_call, mock_client) -> None:
-    mock_client.notebooks.list = AsyncMock(return_value=[FakeNotebook(id=NB_ID, title="Research")])
+    mock_client.notebooks.list = AsyncMock(
+        return_value=[FakeNotebook(id=NB_ID, title="Research", role=SharePermission.VIEWER)]
+    )
     result = await mcp_call("notebook_list")
+    # ``role`` is the raw wire code; ``role_label`` is the agent-readable
+    # projection added by ``_app.views.notebook_view`` (#2125).
     assert result.structured_content == {
-        "notebooks": [{"id": NB_ID, "title": "Research"}],
+        "notebooks": [{"id": NB_ID, "title": "Research", "role": 3, "role_label": "viewer"}],
         "total": 1,
         "offset": 0,
         "has_more": False,
@@ -112,7 +121,13 @@ async def test_notebook_create_surfaces_backfilled_timestamps(mcp_call, mock_cli
     the populated ``created_at`` / ``modified_at`` and the id as ``notebook_id``.
     """
     mock_client.notebooks.create = AsyncMock(
-        return_value=FakeNotebookFull(id=NB_ID, title="New", sources_count=0, is_owner=True)
+        return_value=FakeNotebookFull(
+            id=NB_ID,
+            title="New",
+            sources_count=0,
+            is_owner=True,
+            role=SharePermission.OWNER,
+        )
     )
     # The core re-reads via GET to backfill the null create timestamps; the GET
     # diverges on the non-timestamp fields to prove the create stays authoritative.
@@ -135,6 +150,8 @@ async def test_notebook_create_surfaces_backfilled_timestamps(mcp_call, mock_cli
         "sources_count": 0,  # from create
         "is_owner": True,  # from create
         "modified_at": MODIFIED_AT.isoformat(),  # backfilled by the core
+        "role": SharePermission.OWNER.value,  # from create
+        "role_label": "owner",
     }
     mock_client.notebooks.create.assert_awaited_once_with("New")
     mock_client.notebooks.get.assert_awaited_once_with(NB_ID)
@@ -188,7 +205,7 @@ async def test_notebook_describe_include_metadata_adds_block(mcp_call, mock_clie
     )
     mock_client.notebooks.get_metadata = AsyncMock(
         return_value=NotebookMetadata(
-            notebook=Notebook(id=NB_ID, title="Research"),
+            notebook=Notebook(id=NB_ID, title="Research", role=SharePermission.EDITOR),
             sources=[SourceSummary(kind=SourceType.PDF, title="Doc", url=None)],
         )
     )
@@ -206,8 +223,11 @@ async def test_notebook_describe_include_metadata_adds_block(mcp_call, mock_clie
             "title": "Research",
             "created_at": None,
             "sources_count": 1,
-            "is_owner": True,
+            # An EDITOR is a collaborator, not the owner (#2125).
+            "is_owner": False,
             "modified_at": None,
+            "role": SharePermission.EDITOR.value,
+            "role_label": "editor",
         },
         "sources": [{"kind": "pdf", "title": "Doc", "url": None}],
     }

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -417,6 +417,26 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value.current_count == 500
 
     @pytest.mark.asyncio
+    async def test_quota_check_counts_rows_with_no_stated_role(self):
+        """An unstated role counts as owned — matching ``is_owner``'s soft-degrade.
+
+        Pinned deliberately: it means widespread protocol drift would inflate
+        ``owned_count`` rather than deflate it. That direction is the safe one
+        here — this path only runs to reclassify an already-failed create, so
+        the worst case is a more specific error message, never a blocked create.
+        """
+        api = _make_api(rpc_call=AsyncMock(side_effect=_create_invalid_argument_error()))
+        _set_account_limit(api, 500)
+        unstated = [Notebook(id=f"nb_{i}", title=f"N{i}") for i in range(500)]
+        assert all(nb.role is None for nb in unstated)
+        api.list = AsyncMock(return_value=unstated)
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("Unknown Roles")
+
+        assert exc_info.value.current_count == 500
+
+    @pytest.mark.asyncio
     async def test_quota_check_excludes_notebooks_shared_with_the_user(self):
         """Notebooks owned by *someone else* still must not count toward quota."""
         api = _make_api(rpc_call=AsyncMock(side_effect=_create_invalid_argument_error()))

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -28,7 +28,14 @@ from notebooklm.exceptions import (
     RPCError,
 )
 from notebooklm.rpc import RPCMethod
-from notebooklm.types import AccountLimits, Notebook, NotebookMetadata, Source, SourceType
+from notebooklm.types import (
+    AccountLimits,
+    Notebook,
+    NotebookMetadata,
+    SharePermission,
+    Source,
+    SourceType,
+)
 
 
 def _make_core(rpc_call: AsyncMock | None = None):
@@ -69,7 +76,33 @@ def _owned_notebooks(count: int) -> list[Notebook]:
 
 
 def _shared_notebooks(count: int) -> list[Notebook]:
-    return [Notebook(id=f"shared_{i}", title=f"Shared {i}", is_owner=False) for i in range(count)]
+    return [
+        Notebook(id=f"shared_{i}", title=f"Shared {i}", role=SharePermission.VIEWER)
+        for i in range(count)
+    ]
+
+
+def _owned_but_shared_notebooks(count: int) -> list[Notebook]:
+    """Notebooks the account OWNS and has shared with a collaborator.
+
+    Parsed from the live row shape rather than constructed with an explicit
+    ``is_owner``: ``meta[0] == 1`` (userRole OWNER) with ``meta[1] is True``
+    (the notebook has sharing) is exactly the combination the pre-#2125 decoder
+    mis-read as "not owned".
+    """
+    return [
+        Notebook.from_api_response(
+            [
+                f"Owned & Shared {i}",
+                [],
+                f"owned_shared_{i}",
+                "\U0001f4d3",
+                None,
+                [1, True, True, None, None, None, 1, False, None],
+            ]
+        )
+        for i in range(count)
+    ]
 
 
 def _create_invalid_argument_error(
@@ -361,6 +394,39 @@ class TestCreateNotebookQuotaDetection:
         # ``create`` calls ``list`` twice on an RPC failure path:
         # once for the baseline snapshot, once for the quota check.
         assert api.list.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_quota_check_counts_owned_notebooks_the_user_has_shared(self):
+        """#2125: sharing a notebook must not remove it from ``owned_count``.
+
+        The pre-fix decoder derived ``is_owner`` from the "has any sharing"
+        slot, so every notebook the account owned *and had shared* dropped out
+        of this count and ``NotebookLimitError`` was never raised. Here all 500
+        notebooks are owned-and-shared, so a correct count reaches the limit.
+        """
+        original = _create_invalid_argument_error()
+        api = _make_api(rpc_call=AsyncMock(side_effect=original))
+        _set_account_limit(api, 500)
+        owned_and_shared = _owned_but_shared_notebooks(500)
+        assert all(nb.role is SharePermission.OWNER for nb in owned_and_shared)
+        api.list = AsyncMock(return_value=owned_and_shared)
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("At Paid Limit")
+
+        assert exc_info.value.current_count == 500
+
+    @pytest.mark.asyncio
+    async def test_quota_check_excludes_notebooks_shared_with_the_user(self):
+        """Notebooks owned by *someone else* still must not count toward quota."""
+        api = _make_api(rpc_call=AsyncMock(side_effect=_create_invalid_argument_error()))
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(100) + _shared_notebooks(400))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Mostly Someone Else's")
+
+        assert not isinstance(exc_info.value, NotebookLimitError)
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_at_paid_limit_raises_limit_error(self):

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -13,12 +13,14 @@ from notebooklm.rpc.types import (
     ArtifactTypeCode,
     GrpcStatusCode,
     RPCMethod,
+    SharePermission,
     SourceStatus,
     artifact_status_to_str,
     get_batchexecute_url,
     get_query_url,
     normalize_grpc_status,
     normalize_rpc_code,
+    share_permission_to_str,
     source_status_to_str,
 )
 
@@ -233,6 +235,35 @@ class TestSourceStatusToStr:
         assert source_status_to_str(6) == "unknown"
         assert source_status_to_str(99) == "unknown"
         assert source_status_to_str(-1) == "unknown"
+
+
+class TestSharePermissionToStr:
+    """Tests for the share_permission_to_str helper function."""
+
+    def test_all_permission_codes(self):
+        """Every displayable SharePermission member maps to its label."""
+        assert share_permission_to_str(SharePermission.OWNER) == "owner"
+        assert share_permission_to_str(1) == "owner"
+        assert share_permission_to_str(SharePermission.EDITOR) == "editor"
+        assert share_permission_to_str(2) == "editor"
+        assert share_permission_to_str(SharePermission.VIEWER) == "viewer"
+        assert share_permission_to_str(3) == "viewer"
+
+    def test_remove_sentinel_is_not_a_label(self):
+        """``_REMOVE`` is a write-only share-mutation sentinel, not a role.
+
+        It must never surface as a displayable permission, so it degrades like
+        any other unmapped code rather than leaking a private enum name.
+        """
+        assert share_permission_to_str(SharePermission._REMOVE) == "unknown"
+        assert share_permission_to_str(4) == "unknown"
+
+    def test_unknown_permission_codes(self):
+        """Unrecognized codes return 'unknown' (future-proofing)."""
+        assert share_permission_to_str(0) == "unknown"
+        assert share_permission_to_str(5) == "unknown"
+        assert share_permission_to_str(99) == "unknown"
+        assert share_permission_to_str(-1) == "unknown"
 
 
 class TestGrpcStatusCode:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -21,6 +21,7 @@ from notebooklm.types import (
     Notebook,
     NotebookDescription,
     ReportSuggestion,
+    SharePermission,
     Source,
     SourceFulltext,
     SourceType,
@@ -322,6 +323,34 @@ def test_representative_public_dataclasses_pickle_round_trip():
         assert pickle.loads(pickle.dumps(enum_member)) is enum_member
 
 
+def _notebook_meta(*, user_role=1, has_sharing=False):
+    """Build a ``data[5]`` metadata block in the live 16-slot shape.
+
+    Copied from a real ``LIST_NOTEBOOKS`` response (see
+    ``tests/cassettes/notebooks_list.yaml``): slot 0 is ``userRole``, slot 1 is
+    the "has any sharing" flag, slot 5 is the last-modified instant, slot 8 the
+    creation instant and slot 12 ``isPublic``.
+    """
+    return [
+        user_role,
+        has_sharing,
+        True,
+        None,
+        None,
+        [1768311605, 661578000],
+        1,
+        False,
+        [1768174413, 819385000],
+        None,
+        None,
+        None,
+        has_sharing,
+        True,
+        1,
+        False,
+    ]
+
+
 class TestNotebook:
     def test_from_api_response_basic(self):
         """Test parsing basic notebook data."""
@@ -460,19 +489,118 @@ class TestNotebook:
 
         assert notebook.title == "Actual Title"
 
-    def test_from_api_response_shared_notebook(self):
-        """Test parsing shared notebook (is_owner=False)."""
+    @pytest.mark.parametrize(
+        ("user_role", "has_sharing", "expected_role", "expected_is_owner"),
+        [
+            # Owner of a private notebook — the pre-#2125 code got this right.
+            (1, False, SharePermission.OWNER, True),
+            # Owner who shared the notebook with a colleague. The old code read
+            # the has-sharing slot and reported is_owner=False here; this is the
+            # headline regression #2125 fixes.
+            (1, True, SharePermission.OWNER, True),
+            # Collaborator with edit rights (proto WRITER).
+            (2, True, SharePermission.EDITOR, False),
+            # Collaborator with read-only rights (proto READER). Observed live
+            # in tests/cassettes/notebooks_list.yaml ("Jane Austen").
+            (3, True, SharePermission.VIEWER, False),
+        ],
+    )
+    def test_from_api_response_decodes_user_role(
+        self, user_role, has_sharing, expected_role, expected_is_owner
+    ):
+        """``meta[0]`` (``userRole``) drives ``role`` and therefore ``is_owner``.
+
+        The metadata block is the full 16-slot shape captured from a live
+        ``LIST_NOTEBOOKS`` response, so the positional descents are exercised
+        against a realistic row rather than a hand-shortened one.
+        """
         data = [
-            "Shared Notebook",
+            "A Notebook",
             [],
-            "nb_shared",
+            "nb_role",
             "📓",
             None,
-            [None, True],  # data[5][1] = True means shared
+            _notebook_meta(user_role=user_role, has_sharing=has_sharing),
         ]
+
         notebook = Notebook.from_api_response(data)
 
-        assert notebook.is_owner is False
+        assert notebook.role is expected_role
+        assert notebook.is_owner is expected_is_owner
+
+    @pytest.mark.parametrize("raw_role", [None, 0, 4, 99, True, False, "1", []])
+    def test_from_api_response_unmapped_role_degrades_to_none(self, raw_role):
+        """Absent / unrecognized ``userRole`` codes report an unknown role.
+
+        ``is_owner`` keeps its historical optimistic default so a malformed row
+        soft-degrades instead of mislabelling every entry. ``True``/``False`` are
+        included because ``bool`` is an ``int`` subclass — the neighbouring
+        has-sharing slot's shape must not be misread as ``OWNER``.
+        """
+        data = [
+            "A Notebook",
+            [],
+            "nb_role",
+            "📓",
+            None,
+            _notebook_meta(user_role=raw_role),
+        ]
+
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.role is None
+        assert notebook.is_owner is True
+
+    def test_from_api_response_ignores_has_sharing_slot(self):
+        """``meta[1]`` no longer participates in the ownership decision.
+
+        Pre-#2125 this slot *was* the ownership signal, so pinning both
+        polarities against a fixed OWNER role is the regression guard.
+        """
+        roles = {
+            has_sharing: Notebook.from_api_response(
+                [
+                    "A Notebook",
+                    [],
+                    "nb_role",
+                    "📓",
+                    None,
+                    _notebook_meta(user_role=1, has_sharing=has_sharing),
+                ]
+            )
+            for has_sharing in (True, False)
+        }
+
+        assert roles[True].role is roles[False].role is SharePermission.OWNER
+        assert roles[True].is_owner is roles[False].is_owner is True
+
+    def test_is_owner_is_derived_from_role_on_construction(self):
+        """``Notebook(role=..., is_owner=...)`` cannot hold an inconsistent pair.
+
+        ``is_owner`` stays a dataclass *field* (the MCP/REST serializer emits
+        fields only), so the invariant is enforced in ``__post_init__`` rather
+        than by turning it into a property.
+        """
+        assert Notebook(id="a", title="t", role=SharePermission.OWNER).is_owner is True
+        assert Notebook(id="a", title="t", role=SharePermission.EDITOR).is_owner is False
+        assert Notebook(id="a", title="t", role=SharePermission.VIEWER).is_owner is False
+        # A contradictory explicit boolean is corrected, not preserved.
+        assert (
+            Notebook(id="a", title="t", role=SharePermission.VIEWER, is_owner=True).is_owner
+            is False
+        )
+
+    def test_is_owner_is_untouched_when_role_is_unknown(self):
+        """With no role stated, the caller's explicit ``is_owner`` still wins."""
+        assert Notebook(id="a", title="t").is_owner is True
+        assert Notebook(id="a", title="t", is_owner=False).is_owner is False
+
+    def test_from_api_response_missing_meta_block_reports_unknown_role(self):
+        """A row with no metadata block states no role, and stays is_owner=True."""
+        notebook = Notebook.from_api_response(["No Meta", [], "nb_nometa", "📓"])
+
+        assert notebook.role is None
+        assert notebook.is_owner is True
 
     def test_from_api_response_empty_data(self):
         """Test parsing with minimal data."""
@@ -2212,6 +2340,7 @@ class TestNotebookMetadata:
             created_at=datetime(2024, 1, 1, 12, 0),
             is_owner=True,
             modified_at=datetime(2024, 1, 2, 9, 30),
+            role=SharePermission.OWNER,
         )
         metadata = NotebookMetadata(
             notebook=notebook,
@@ -2228,6 +2357,7 @@ class TestNotebookMetadata:
             "created_at": "2024-01-01T12:00:00",
             "modified_at": "2024-01-02T09:30:00",
             "is_owner": True,
+            "role": "owner",
             "sources": [
                 {"type": "pdf", "title": "test.pdf", "url": None},
                 {"type": "web_page", "title": "Example", "url": "https://example.com"},
@@ -2246,6 +2376,7 @@ class TestNotebookMetadata:
             created_at=datetime(2024, 2, 1),
             is_owner=False,
             modified_at=datetime(2024, 3, 1),
+            role=SharePermission.VIEWER,
         )
         metadata = NotebookMetadata(notebook=notebook)
 
@@ -2254,6 +2385,7 @@ class TestNotebookMetadata:
         assert metadata.created_at == datetime(2024, 2, 1)
         assert metadata.modified_at == datetime(2024, 3, 1)
         assert metadata.is_owner is False
+        assert metadata.role is SharePermission.VIEWER
 
     def test_to_dict_with_none_created_at(self):
         """Test serialization when created_at is None."""
@@ -2264,6 +2396,8 @@ class TestNotebookMetadata:
 
         result = metadata.to_dict()
         assert result["created_at"] is None
+        # An unknown role serializes as ``null``, not the "unknown" label.
+        assert result["role"] is None
 
     def test_empty_sources_list(self):
         """Test metadata with empty sources list."""

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -551,6 +551,41 @@ class TestNotebook:
         assert notebook.role is None
         assert notebook.is_owner is True
 
+    @pytest.mark.parametrize("raw_role", [0, 4, 99, True, False, "1", []])
+    def test_from_api_response_unmapped_role_warns(self, caplog, raw_role):
+        """A present-but-unmapped ``userRole`` is drift, so it degrades LOUDLY.
+
+        This WARNING is the tripwire for the repo's #1 breakage class (Google
+        changing the wire shape). ``True``/``False`` matter most: ``bool`` is an
+        ``int`` subclass, so a slot slip onto the neighbouring has-sharing flag
+        would otherwise decode as a confident ``OWNER`` (#1485 policy).
+        """
+        import logging
+
+        data = ["A Notebook", [], "nb_role", "📓", None, _notebook_meta(user_role=raw_role)]
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            notebook = Notebook.from_api_response(data)
+
+        assert notebook.role is None
+        assert any(
+            r.levelno == logging.WARNING and "userRole slot unmapped" in r.message
+            for r in caplog.records
+        ), f"no drift WARNING for raw_role={raw_role!r}"
+
+    def test_from_api_response_absent_role_is_silent(self, caplog):
+        """A ``None`` slot / missing meta block is absence, not drift — no WARNING."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            null_slot = Notebook.from_api_response(
+                ["A Notebook", [], "nb_role", "📓", None, _notebook_meta(user_role=None)]
+            )
+            no_meta = Notebook.from_api_response(["No Meta", [], "nb_nometa", "📓"])
+
+        assert null_slot.role is None
+        assert no_meta.role is None
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
     def test_from_api_response_ignores_has_sharing_slot(self):
         """``meta[1]`` no longer participates in the ownership decision.
 
@@ -589,6 +624,26 @@ class TestNotebook:
             Notebook(id="a", title="t", role=SharePermission.VIEWER, is_owner=True).is_owner
             is False
         )
+
+    def test_is_owner_tracks_role_reassigned_after_construction(self):
+        """``Notebook`` is mutated in place elsewhere, so the invariant must survive it.
+
+        ``_app.notebooks._backfill_created_timestamps`` already assigns to a
+        live ``Notebook``, so a construction-only hook would let ``is_owner`` go
+        stale the moment anyone assigned ``role``.
+        """
+        notebook = Notebook(id="a", title="t", role=SharePermission.OWNER)
+        assert notebook.is_owner is True
+
+        notebook.role = SharePermission.VIEWER
+        assert notebook.is_owner is False
+
+        notebook.role = SharePermission.OWNER
+        assert notebook.is_owner is True
+
+        # Clearing the role leaves the last derived value rather than guessing.
+        notebook.role = None
+        assert notebook.is_owner is True
 
     def test_is_owner_is_untouched_when_role_is_unknown(self):
         """With no role stated, the caller's explicit ``is_owner`` still wins."""


### PR DESCRIPTION
## Corrected diagnosis — please read this before the issue body

The issue body (and the audit note it came from) says `meta[1]` / proto tag 2 is the notebook's **public** flag. **A follow-up two-account live probe refuted that**, and issue #2125 carries a correction comment. Tag 2 actually tracks **"this notebook has any sharing at all"**:

```
is_owner  ==  not (notebook is shared with anyone)
```

A scratch notebook that was *never* public (tag 13 `isPublic` stayed `false` throughout) flipped tag 2 `false → true` the instant a collaborator was added, and reverted on revoke. That subsumes the original `set_public()` observation — making a notebook public is simply one way to share it.

**So the headline repro is the ordinary collaboration case, not the public-link edge case: an owner shares their notebook with a colleague, and their own CLI immediately labels it "Shared."**

### Live matrix (account A owns, B collaborates; web `meta[0]` and gRPC `ProjectMetadata` tag 1 agreed at every stage)

| stage | A `userRole` | A tag 2 | A `is_owner` → CLI | B `userRole` | B `is_owner` → CLI |
|---|---|---|---|---|---|
| created, unshared | 1 OWNER | false | True → "Owner" | (no access) | — |
| shared → B **editor** | 1 OWNER | **true** | **False → "Shared"** | **2 WRITER** | False → "Shared" |
| shared → B **viewer** | 1 OWNER | true | False → "Shared" | **3 READER** | False → "Shared" |
| revoked | 1 OWNER | false | True → "Owner" | `PERMISSION_DENIED` | error |

## Why the boolean had to become a role

Three distinct roles collapsed onto one string. Owner-who-shared, WRITER, and READER all rendered "Shared" and all reported `is_owner=False`, so **a read-only collaborator was indistinguishable from a full editor**. Inverting the boolean would have fixed the owner case and left the editor/viewer conflation in place. The correct field is one slot earlier — `meta[0]` (tag 1, `userRole`) — and it is a three-valued enum, so that is what the type now carries.

## What changed

**1. `Notebook.role` — reusing `SharePermission`, not adding a twin.**
`SharePermission` (OWNER=1 / EDITOR=2 / VIEWER=3) is value-identical to the proto's `ProjectRole` (OWNER / WRITER / READER) — the same wire enum under two names, for the two halves of one sharing story: `SharedUser.permission` is *a collaborator's* level, `Notebook.role` is *your own*. Rather than ship a parallel `ProjectRole`, `meta[0]` decodes into the existing public enum, which also means `notebooklm list` and `notebooklm share list` now speak the same Owner/Editor/Viewer vocabulary.

`_REMOVE = 4` (proto `NOT_SHARED`) is explicitly excluded from the decodable set: it is a write-only sentinel for the share-mutation call, and a notebook row never reports it (a revoked account gets `PERMISSION_DENIED`, not role 4).

**2. `is_owner` stays, derived.**
`is_owner = (role is SharePermission.OWNER)`, computed in `__post_init__`. It remains a dataclass **field** rather than becoming a property because the MCP/REST serializer emits `dataclasses.fields` only — turning it into a property would silently drop it from every adapter's wire shape. Deriving it in `__post_init__` additionally makes `Notebook(role=VIEWER, is_owner=True)` unrepresentable rather than merely discouraged. When the row states no role, the caller's explicit `is_owner` is left untouched and the field's optimistic `True` default holds, preserving the historical soft-degrade contract.

**3. `owned_count` (`_notebooks.py`) is fixed as a consequence.**
It gates `NotebookLimitError` and was undercounting by exactly the number of notebooks the user had *shared* (16 of 17 on the reporter's test account), biasing the quota check towards never raising. Two regression tests now cover it: 500 owned-and-shared notebooks must reach the limit, and 400 notebooks shared *with* the user must not.

**4. `share_permission_to_str`** joins `source_status_to_str` / `artifact_status_to_str` in `rpc/types.py` as the single source of truth for permission→string, and `cli/share_cmd._permission_name` is re-pointed at it so the CLI has one label table instead of two.

**5. CLI rendering distinguishes the three roles.** The `list` / `use` "Owner" column becomes **"Access"** (Owner / Editor / Viewer), `metadata` and `status` follow, and `use` / `create --use` now record `role` in the CLI context file so `status` stays precise. Contexts written before this change carry only `is_owner` and fall back to it.

**6. `_app.views.notebook_view`** adds an agent-readable `role_label` next to the raw code for MCP/REST, exactly mirroring how `source_view` adds `status_label` — otherwise `notebook_list` would ship a bare `"role": 3` for an agent to guess at.

## No additional RPC

`userRole` is present on **507 of 507** notebook rows across every recorded cassette — both `LIST_NOTEBOOKS` (`wXbhsf`, 463 rows) and `GET_NOTEBOOK` (`rLM1Ne`, 42 rows), with zero rows missing `meta[0]`. Values observed in the recordings: `1` (OWNER) ×505 and `3` (READER) ×2.

## Tests

- **All three roles** are covered by a parametrized decoder test driven by the **full 16-slot metadata block captured from a live `LIST_NOTEBOOKS` response**, not a hand-shortened invention — including the `userRole=1 + hasSharing=true` combination that is the regression itself.
- **`tests/cassettes/notebooks_list.yaml` already contained the witness.** Row 2, *"READ ONLY: Learn Claude Code & AI Agents for High School Students"*, carries `meta[0] == 1` with `meta[1] is True` — the recorded account's own notebook, which the old decoder reported as `is_owner=False`. The integration golden previously **pinned that wrong value**; it now pins `OWNER` / `True`. The same cassette's *"Jane Austen: The Complete Works"* row carries a genuine `meta[0] == 3`, so the golden now covers a real non-owner role too.
- Degrade coverage: `None`, `0`, `4`, `99`, `True`, `False`, `"1"`, `[]` all report an unknown role. `True`/`False` are explicit cases because `bool` is an `int` subclass — `SharePermission(True)` would otherwise silently yield `OWNER`, and a bool is precisely the shape of the neighbouring slot this bug came from.
- The RPC golden fixtures for `LIST_NOTEBOOKS` / `GET_NOTEBOOK` had `meta[0] = null`; they now carry realistic `1` / `3` codes so the fixture exercises both paths.

`13149 passed, 77 skipped` (unit + integration, with the `mcp` and `server` extras installed so the MCP/REST tests actually run rather than skipping). `mypy` clean. `pre-commit run --all-files` clean.

## Deliberately not in this PR

**Surfacing `isPublic` (tag 13 / `meta[12]`).** It is 100% populated and read nowhere, and the issue notes it — but visibility is a different axis from role, `sharing.get_status()` already reports it, and adding a second new public field would widen this bugfix's surface. Worth a follow-up; called out here so it is a decision rather than an oversight.

## Live probe (read-only, run against three real accounts)

Run post-fix against the live backend, comparing each row's decoded `is_owner` with what the **pre-fix** expression (`meta[1] is False`) would have produced on the same row. Entirely read-only — no notebook was created, shared, modified or deleted.

```
profile=peopleconf      rows=27   owned_count BEFORE=25  AFTER=27   roles: {'owner': 27}
  FLIPPED (2):
    userRole=1 hasSharing=True isPublic=False  is_owner False->True  role=OWNER  'Multiple Sources Type -- notebooklm'
    userRole=1 hasSharing=True isPublic=True   is_owner False->True  role=OWNER  'Minneapolis Controversy Final Analysis'

profile=teng-lin-9414   rows=11   owned_count BEFORE=11  AFTER=11   roles: {'owner': 11}
  FLIPPED (0)

profile=teng-lin-9420   rows=16   owned_count BEFORE=15  AFTER=16   roles: {'owner': 16}
  FLIPPED (1):
    userRole=1 hasSharing=True isPublic=True   is_owner False->True  role=OWNER  'JSON: The Standard for Modern Data Interchange'
```

Three things this establishes:

1. **The reported symptom reproduces and is fixed.** Notebooks these accounts own were reporting `is_owner=False`; they now report `role=OWNER` / `is_owner=True`. `JSON: The Standard for Modern Data Interchange` is the very notebook named in the issue body.
2. **`owned_count` rises accordingly** — 25 → 27 and 15 → 16 — which is the `NotebookLimitError` quota input.
3. **Tag 2 is confirmed as has-sharing, not `isPublic`.** `Multiple Sources Type -- notebooklm` has `hasSharing=True` with **`isPublic=False`**. Under the issue body's original premise that slot could not have been set, so this row independently corroborates the correction comment from live data rather than from the earlier probe's notes.

Honest limitation: all three profiles belong to accounts that own every notebook they can see, so every live row decoded to `OWNER` and the **EDITOR / VIEWER paths were not exercised live in this session**. A second collaborator account was not available to me. Those two roles are covered by the recorded `meta[0] == 3` row in `tests/cassettes/notebooks_list.yaml` (asserted in the integration golden) and by the two-account matrix in the issue's correction comment.

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notebook access roles now display as Owner, Editor, or Viewer across CLI, API, server, and MCP outputs.
  - JSON responses and active notebook context include role values and readable labels.
  - Added public permission-to-label conversion support.

- **Bug Fixes**
  - Ownership status now reflects permission roles correctly.
  - Owned notebooks remain included in quota calculations when shared.
  - Unknown or missing roles safely fall back to legacy ownership behavior.

- **Documentation**
  - Documented notebook roles and backward-compatible ownership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->