### PR TITLE
fix(rpc): send flashcard options in [quantity, difficulty] order and unalias QuizQuantity.MORE (#2116, #2117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ship `status` plus `status_label`.
   ([#2125](https://github.com/teng-lin/notebooklm-py/issues/2125))
 
+- **Flashcard generation no longer swaps `quantity` and `difficulty`.** The
+  flashcards payload builder emitted the option pair as
+  `[difficulty, quantity]` while the backend's `FlashcardsGenerationOptions` —
+  and the quiz builder next to it — expect `[quantity, difficulty]`. Asking for
+  the fewest, hardest cards silently produced the most, easiest ones, with no
+  error at any layer (CLI, MCP, REST). The regression test meant to pin this
+  ordering used symmetric fixtures (`[2, 2]` and `[1, 1]`) and so passed under
+  either ordering; it is now asymmetric (`FEWER` + `HARD` → `[1, 3]`), and a new
+  test asserts the quiz and flashcards builders agree side by side
+  ([#2116](https://github.com/teng-lin/notebooklm-py/issues/2116)).
+- **`QuizQuantity.MORE` now emits its own wire value.** It was defined as a
+  value-alias of `STANDARD` (`2`), on the documented but incorrect belief that
+  Google's API could not distinguish the two, so `--quantity more` produced a
+  standard-sized quiz or flashcard set with no warning. The backend accepts and
+  persists `cardQuantity = 3`, matching both
+  `QuizGenerationOptions.QuestionQuantity` and
+  `FlashcardsGenerationOptions.CardQuantity`, so `MORE = 3`. **Behavior change
+  for existing callers:** `QuizQuantity.MORE == QuizQuantity.STANDARD` was
+  `True` and is now `False`, and unchanged code passing `--quantity more` /
+  `quantity=QuizQuantity.MORE` now receives a genuinely larger quiz or flashcard
+  set rather than the standard-sized one it silently got before — which is what
+  those callers were asking for all along
+  ([#2117](https://github.com/teng-lin/notebooklm-py/issues/2117)).
 - **RPC bundle monitoring no longer reports authentication/access failures as
   protocol drift.** The live registry capture now classifies login,
   CookieMismatch, region/anti-abuse, HTTP, and CDN failures as exit code 2 and
@@ -95,6 +118,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`QuizQuantity.MORE` no longer compares equal to `QuizQuantity.STANDARD`.**
+  `MORE` was a value-alias of `STANDARD` (`2`) and is now its own wire value
+  (`3`), so the identity and equality between the two members no longer hold.
+  Callers that branched on that collapse, or that relied on `--quantity more`
+  producing a standard-sized artifact, will see different behavior. See the
+  `### Fixed` entry above for the live evidence
+  ([#2117](https://github.com/teng-lin/notebooklm-py/issues/2117)).
 - **First-party profile replacements now use native typed results.** Browser capture consumes
   `ProfileStore.replace_from_remint()` directly, while cookie import/login/refresh use a narrow
   path-shaped login operation with primitive account modes. Existing v0.x storage wrapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gain `role` (the raw code) plus `role_label`, mirroring how sources already
   ship `status` plus `status_label`.
   ([#2125](https://github.com/teng-lin/notebooklm-py/issues/2125))
-
 - **Flashcard generation no longer swaps `quantity` and `difficulty`.** The
   flashcards payload builder emitted the option pair as
   `[difficulty, quantity]` while the backend's `FlashcardsGenerationOptions` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,12 +118,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`QuizQuantity.MORE` no longer compares equal to `QuizQuantity.STANDARD`.**
-  `MORE` was a value-alias of `STANDARD` (`2`) and is now its own wire value
-  (`3`), so the identity and equality between the two members no longer hold.
-  Callers that branched on that collapse, or that relied on `--quantity more`
-  producing a standard-sized artifact, will see different behavior. See the
-  `### Fixed` entry above for the live evidence
+- **BREAKING: `QuizQuantity.MORE` no longer compares equal to
+  `QuizQuantity.STANDARD`.** `MORE` was a value-alias of `STANDARD` (`2`) and is
+  now its own wire value (`3`), so the identity and equality between the two
+  members no longer hold. `QuizQuantity` is part of the documented-stable public
+  surface (`docs/stability.md`), so this is an intentional, allowlisted
+  wire-value correction rather than an incidental change — see
+  `scripts/api-compat-allowlist.json`. **Migration:** callers that branched on
+  `MORE == STANDARD` must drop that assumption; callers passing `--quantity
+  more` / `quantity=QuizQuantity.MORE` now receive a genuinely larger quiz or
+  flashcard set instead of a standard-sized one, which is what they were asking
+  for all along. Nothing needs to change to *get* the old output — pass
+  `standard` explicitly. See the `### Fixed` entry above for the live evidence
   ([#2117](https://github.com/teng-lin/notebooklm-py/issues/2117)).
 - **First-party profile replacements now use native typed results.** Browser capture consumes
   `ProfileStore.replace_from_remint()` directly, while cookie import/login/refresh use a narrow

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1453,7 +1453,7 @@ status = await client.artifacts.generate_quiz(
     notebook_id,
     source_ids=None,
     instructions="...",
-    quantity=QuizQuantity.MORE,        # FEWER, STANDARD, MORE (MORE aliases STANDARD)
+    quantity=QuizQuantity.MORE,        # FEWER, STANDARD, MORE
     difficulty=QuizDifficulty.MEDIUM,  # EASY, MEDIUM, HARD
 )
 ```
@@ -2610,7 +2610,7 @@ class VideoStyle(Enum):
 class QuizQuantity(Enum):
     FEWER = 1
     STANDARD = 2
-    MORE = 2  # Alias of STANDARD used by the CLI/web UI
+    MORE = 3
 
 class QuizDifficulty(Enum):
     EASY = 1

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1315,7 +1315,7 @@ params = [
 
 #### Quiz (Type 4, Variant 2)
 
-**Source:** `_artifacts.py::generate_quiz()`
+**Source:** `_artifact/payloads.py::build_quiz_artifact_params()`
 
 ```python
 params = [
@@ -1341,7 +1341,7 @@ params = [
                 None,
                 None,
                 None,
-                [quantity_code, difficulty_code],  # quantity: 1=FEWER, 2=STANDARD
+                [quantity_code, difficulty_code],  # quantity: 1=FEWER, 2=STANDARD, 3=MORE
             ],                                     # difficulty: 1=EASY, 2=MEDIUM, 3=HARD
         ],                            # [9]
     ],
@@ -1350,7 +1350,7 @@ params = [
 
 #### Flashcards (Type 4, Variant 1)
 
-**Source:** `_artifacts.py::generate_flashcards()`
+**Source:** `_artifact/payloads.py::build_flashcards_artifact_params()`
 
 ```python
 params = [
@@ -1375,9 +1375,9 @@ params = [
                 None,
                 None,
                 None,
-                [difficulty_code, quantity_code],  # Note: reversed order from quiz!
-            ],
-        ],                            # [9]
+                [quantity_code, difficulty_code],  # Same order as quiz (#2116).
+            ],                                     # quantity: 1=FEWER, 2=STANDARD, 3=MORE
+        ],                            # [9]         # difficulty: 1=EASY, 2=MEDIUM, 3=HARD
     ],
 ]
 ```

--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -144,6 +144,16 @@
       "code": "changed-constant-value",
       "object": "notebooklm.auth.REQUIRED_COOKIE_DOMAINS",
       "reason": "Gemini Notebook rebrand (#2013, shipped in #2020): notebook.google.com and .notebook.google.com joined the required cookie-domain tier because Google sets the per-product binding cookies (OSID / __Secure-OSID) on that host. Additive for the constant's documented use (an extractor allowlist); a narrower set would drop binding cookies and break login."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.QuizQuantity.MORE",
+      "reason": "QuizQuantity.MORE was a value-alias of STANDARD (2) with a docstring asserting Google's API could not distinguish the two. That is false: the backend accepts and persists cardQuantity = 3, and both QuizGenerationOptions.QuestionQuantity and FlashcardsGenerationOptions.CardQuantity declare MORE = 3 (docs/mobile/enums.txt). Live-confirmed: a flashcard set generated with quantity=MORE echoed back cardQuantity=3 from the server. Deliberate wire-value correction for #2117 -- '--quantity more' previously produced a standard-sized set with no warning. MORE no longer compares equal to STANDARD; see the ### Changed entry in CHANGELOG.md."
+    },
+    {
+      "code": "changed-enum-value",
+      "object": "notebooklm.types.QuizQuantity.MORE",
+      "reason": "QuizQuantity.MORE was a value-alias of STANDARD (2) with a docstring asserting Google's API could not distinguish the two. That is false: the backend accepts and persists cardQuantity = 3, and both QuizGenerationOptions.QuestionQuantity and FlashcardsGenerationOptions.CardQuantity declare MORE = 3 (docs/mobile/enums.txt). Live-confirmed: a flashcard set generated with quantity=MORE echoed back cardQuantity=3 from the server. Deliberate wire-value correction for #2117 -- '--quantity more' previously produced a standard-sized set with no warning. MORE no longer compares equal to STANDARD; see the ### Changed entry in CHANGELOG.md."
     }
   ],
   "extra_public_names": {

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -328,7 +328,10 @@ def build_flashcards_artifact_params(
                     None,
                     None,
                     None,
-                    [difficulty_code, quantity_code],
+                    # ``FlashcardsGenerationOptions`` is {1: cardQuantity,
+                    # 2: flashcardsDifficulty}, i.e. quantity first — the same
+                    # order the quiz builder above uses (#2116).
+                    [quantity_code, difficulty_code],
                 ],
             ],
         ],

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -370,14 +370,16 @@ class VideoStyle(int, Enum):
 class QuizQuantity(int, Enum):
     """Quiz/Flashcards quantity options.
 
-    Note: Google's API only distinguishes between FEWER (1) and STANDARD (2).
-    MORE is an alias for STANDARD - the API treats them identically.
-    This matches the observed behavior from NotebookLM's web interface.
+    Values match the backend ``QuizGenerationOptions.QuestionQuantity`` /
+    ``FlashcardsGenerationOptions.CardQuantity`` enums, both of which declare
+    FEWER (1), STANDARD (2) and MORE (3). ``MORE`` was previously an alias for
+    ``STANDARD`` on the (incorrect) belief that the API could not express the
+    distinction; the backend accepts and persists ``cardQuantity = 3`` (#2117).
     """
 
     FEWER = 1
     STANDARD = 2
-    MORE = 2  # Alias for STANDARD - API limitation
+    MORE = 3
 
 
 class QuizDifficulty(int, Enum):

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -538,6 +538,30 @@ ENUM_BINDINGS: dict[str, tuple[str, dict[int, str]]] = {
             4: "ARTIFACT_STATUS_FAILED",
         },
     ),
+    # rpc/types.py::QuizQuantity. Shared by quiz AND flashcards; the two backend
+    # enums (``QuizGenerationOptions.QuestionQuantity`` and
+    # ``FlashcardsGenerationOptions.CardQuantity``) declare identical values, so
+    # binding to either one gates both. #2117 landed precisely because these
+    # values were pinned to a snapshot without ever being bound to the backend:
+    # ``MORE`` sat at 2 as a documented "API limitation" while the backend has
+    # always declared it as 3.
+    "QuizQuantity": (
+        "QuizGenerationOptions_QuestionQuantity",
+        {
+            1: "QUESTION_QUANTITY_FEWER",
+            2: "QUESTION_QUANTITY_STANDARD",
+            3: "QUESTION_QUANTITY_MORE",
+        },
+    ),
+    # rpc/types.py::QuizDifficulty, the sibling of the pair above.
+    "QuizDifficulty": (
+        "QuizGenerationOptions_QuizDifficulty",
+        {
+            1: "QUIZ_DIFFICULTY_EASY",
+            2: "QUIZ_DIFFICULTY_MEDIUM",
+            3: "QUIZ_DIFFICULTY_HARD",
+        },
+    ),
     # _types/sources.py::_SOURCE_TYPE_CODE_MAP
     "SourceType": (
         "OriginalSourceContentType",

--- a/tests/_guardrails/test_studio_enum_manifest.py
+++ b/tests/_guardrails/test_studio_enum_manifest.py
@@ -34,9 +34,9 @@ pytestmark = pytest.mark.repo_lint
 #
 # Every ``int``-valued ``Enum`` defined in ``notebooklm.rpc.types`` is pinned to
 # its exact ``{member_name: value}`` map, INCLUDING value-aliases like
-# ``QuizQuantity.MORE`` and ``ArtifactTypeCode.QUIZ_FLASHCARD`` (the map is built
-# from ``__members__``, so aliases are frozen too — an alias whose wire value
-# drifted independently would otherwise slip past the gate).
+# ``ArtifactTypeCode.QUIZ_FLASHCARD`` (the map is built from ``__members__``, so
+# aliases are frozen too — an alias whose wire value drifted independently would
+# otherwise slip past the gate).
 #
 # To change a value here you MUST edit this snapshot in the SAME PR — that diff
 # line is the deliberate, reviewed acknowledgement that a wire contract moved.
@@ -98,7 +98,7 @@ _RPC_ENUM_SNAPSHOT: dict[str, dict[str, int]] = {
         "SCIENTIFIC": 11,
     },
     "QuizDifficulty": {"EASY": 1, "MEDIUM": 2, "HARD": 3},
-    "QuizQuantity": {"FEWER": 1, "STANDARD": 2, "MORE": 2},  # MORE = value-alias of STANDARD
+    "QuizQuantity": {"FEWER": 1, "STANDARD": 2, "MORE": 3},
     "ShareAccess": {"RESTRICTED": 0, "ANYONE_WITH_LINK": 1},
     "SharePermission": {"OWNER": 1, "EDITOR": 2, "VIEWER": 3, "_REMOVE": 4},
     "ShareViewLevel": {"FULL_NOTEBOOK": 0, "CHAT_ONLY": 1},

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -31,6 +31,7 @@ The reference data lives in ``docs/mobile/schema.proto`` and
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -276,18 +277,41 @@ _PARALLEL_BACKEND_ENUMS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _semantic_members(members: dict[int, str]) -> dict[int, str]:
+    """Strip an enum's shared name prefix, leaving the semantic member names.
+
+    ``QUESTION_QUANTITY_FEWER`` and ``CARD_QUANTITY_FEWER`` both reduce to
+    ``FEWER``, so two differently-named backend enums become comparable
+    value-for-value. The prefix is derived rather than hardcoded, and trimmed
+    back to a token boundary so a partial word is never cut.
+    """
+    prefix = os.path.commonprefix(list(members.values()))
+    prefix = prefix[: prefix.rfind("_") + 1]
+    return {value: name[len(prefix) :] for value, name in members.items()}
+
+
 @pytest.mark.parametrize(("quiz_enum", "flashcards_enum"), _PARALLEL_BACKEND_ENUMS)
 def test_quiz_and_flashcards_backend_enums_agree(quiz_enum: str, flashcards_enum: str) -> None:
-    """The quiz and flashcards option enums carry identical numeric values."""
+    """The quiz and flashcards option enums agree member-for-member.
+
+    Comparing only the numeric key sets would be too weak: if the flashcards
+    enum swapped FEWER and MORE while keeping ``{0, 1, 2, 3}``, the shared
+    ``QuizQuantity`` would encode flashcards backwards and a key-set assertion
+    would still pass — the exact divergence this guard exists to catch. So the
+    comparison is on ``{value: semantic_name}``.
+    """
     enums = load_enums()
     quiz, flashcards = enums.get(quiz_enum), enums.get(flashcards_enum)
     assert quiz, f"{quiz_enum} missing from docs/mobile/enums.txt"
     assert flashcards, f"{flashcards_enum} missing from docs/mobile/enums.txt"
 
-    assert sorted(quiz) == sorted(flashcards), (
-        f"{quiz_enum} and {flashcards_enum} no longer declare the same values "
-        f"({sorted(quiz)} vs {sorted(flashcards)}). The shared client enum can no "
-        "longer serve both -- split it, and bind each side separately."
+    quiz_semantic = _semantic_members(quiz)
+    flashcards_semantic = _semantic_members(flashcards)
+
+    assert quiz_semantic == flashcards_semantic, (
+        f"{quiz_enum} and {flashcards_enum} no longer agree member-for-member "
+        f"({quiz_semantic} vs {flashcards_semantic}). The shared client enum can "
+        "no longer serve both -- split it, and bind each side separately."
     )
 
 

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -36,6 +36,7 @@ from pathlib import Path
 
 import pytest
 
+import notebooklm.rpc.types as rpc_types
 from tests._guardrails._wire_contract import (
     ENUM_BINDINGS,
     ENUM_GAPS,
@@ -49,6 +50,27 @@ from tests._guardrails._wire_contract import (
 from tests._guardrails._wire_schema import load_enums, load_proto_schema
 
 pytestmark = pytest.mark.repo_lint
+
+#: Bindings whose client side is an ``int``-Enum in ``notebooklm.rpc.types``,
+#: so the table can be checked against the live members. Decode-map bindings
+#: like ``SourceType`` (a ``str``-Enum keyed by wire code in a separate dict)
+#: are excluded -- their values live in ``_SOURCE_TYPE_CODE_MAP``, not on the
+#: enum, so ``__members__`` has nothing to compare against.
+_LIVE_BOUND_ENUMS: tuple[str, ...] = tuple(
+    name
+    for name in sorted(ENUM_BINDINGS)
+    if isinstance(getattr(rpc_types, name, None), type)
+    and issubclass(getattr(rpc_types, name), int)
+)
+
+#: Client-only sentinel members that deliberately have no backend counterpart,
+#: so the "every live value is bound" half of the check must skip them. Keep
+#: this list short and justified — an undeclared unbound value is a real gap.
+_CLIENT_SYNTHETIC_VALUES: dict[str, dict[int, str]] = {
+    # Not a wire value: returned when source[3][1] is absent, malformed, or a
+    # code we do not map yet. See SourceStatus.UNKNOWN in rpc/types.py.
+    "SourceStatus": {-1: "UNKNOWN"},
+}
 
 _SRC = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 
@@ -186,6 +208,86 @@ def test_enum_values_match_backend(client_enum: str) -> None:
     ]
     assert not mismatches, f"{client_enum} disagrees with the backend enum:\n" + "\n".join(
         mismatches
+    )
+
+
+@pytest.mark.parametrize("client_enum", sorted(_LIVE_BOUND_ENUMS))
+def test_binding_covers_the_live_client_enum(client_enum: str) -> None:
+    """C (third leg). The binding table describes the *real* Python enum.
+
+    Without this, ``ENUM_BINDINGS`` only proves the hand-written table agrees
+    with the backend dump — it never imports the client, so setting
+    ``QuizQuantity.MORE = 4`` and updating the frozen snapshot to match would
+    leave both other gates green. That is exactly the shape of #2117, where a
+    wrong value survived for months behind a snapshot that faithfully preserved
+    it. Tying the table to ``__members__`` closes the loop:
+    code -> table -> backend.
+
+    Scoped to ``_LIVE_BOUND_ENUMS`` because several bindings describe decode
+    maps (e.g. ``SourceType``) whose client members are strings keyed by wire
+    code elsewhere, not ``int``-Enum values.
+    """
+    _, bindings = ENUM_BINDINGS[client_enum]
+    live = getattr(rpc_types, client_enum)
+    live_by_value = {member.value: member.name for member in live}
+
+    mismatches = [
+        f"  {client_enum} has no member with value {value} (table claims {member!r}); "
+        f"live members are {live_by_value}"
+        for value, member in bindings.items()
+        if value not in live_by_value
+    ]
+    assert not mismatches, (
+        f"{client_enum} in rpc/types.py disagrees with its _wire_contract binding:\n"
+        + "\n".join(mismatches)
+        + "\n\nUpdate whichever side is wrong -- but check a real captured "
+        "response first, not just the enum dump."
+    )
+
+    synthetic = _CLIENT_SYNTHETIC_VALUES.get(client_enum, {})
+    missing = sorted(set(live_by_value) - set(bindings) - set(synthetic))
+    assert not missing, (
+        f"{client_enum} declares value(s) {missing} that the _wire_contract binding "
+        "does not cover, so they are never checked against the backend enum. Add "
+        "them to ENUM_BINDINGS, to ENUM_GAPS with an honest reason, or — only if "
+        "the member is a client-side sentinel with no backend counterpart — to "
+        "_CLIENT_SYNTHETIC_VALUES."
+    )
+
+    stale_synthetic = sorted(
+        value for value, name in synthetic.items() if live_by_value.get(value) != name
+    )
+    assert not stale_synthetic, (
+        f"_CLIENT_SYNTHETIC_VALUES[{client_enum!r}] declares value(s) {stale_synthetic} "
+        "that no longer match a live member of that name. Remove the stale exemption."
+    )
+
+
+#: ``QuizQuantity`` / ``QuizDifficulty`` are single client enums serving two
+#: distinct backend messages. ``ENUM_BINDINGS`` is keyed by client enum, so only
+#: the quiz copy can be bound; these pairs assert the flashcards copy still
+#: agrees, turning "they declare identical values" from an assumption into a
+#: checked fact. If Google ever renumbers only the flashcards side, every
+#: flashcard request would go out wrong while the quiz binding stayed green --
+#: the same silent class as #2116/#2117.
+_PARALLEL_BACKEND_ENUMS: tuple[tuple[str, str], ...] = (
+    ("QuizGenerationOptions_QuestionQuantity", "FlashcardsGenerationOptions_CardQuantity"),
+    ("QuizGenerationOptions_QuizDifficulty", "FlashcardsGenerationOptions_FlashcardsDifficulty"),
+)
+
+
+@pytest.mark.parametrize(("quiz_enum", "flashcards_enum"), _PARALLEL_BACKEND_ENUMS)
+def test_quiz_and_flashcards_backend_enums_agree(quiz_enum: str, flashcards_enum: str) -> None:
+    """The quiz and flashcards option enums carry identical numeric values."""
+    enums = load_enums()
+    quiz, flashcards = enums.get(quiz_enum), enums.get(flashcards_enum)
+    assert quiz, f"{quiz_enum} missing from docs/mobile/enums.txt"
+    assert flashcards, f"{flashcards_enum} missing from docs/mobile/enums.txt"
+
+    assert sorted(quiz) == sorted(flashcards), (
+        f"{quiz_enum} and {flashcards_enum} no longer declare the same values "
+        f"({sorted(quiz)} vs {sorted(flashcards)}). The shared client enum can no "
+        "longer serve both -- split it, and bind each side separately."
     )
 
 

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -595,7 +595,16 @@ class TestArtifactsGenerateAPI:
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("artifacts_generate_flashcards.yaml")
     async def test_generate_flashcards(self):
-        """Generate flashcards."""
+        """Generate flashcards.
+
+        Note: this tier cannot pin the quantity/difficulty pair. The ``freq``
+        matcher compares request bodies *shape-only* (see ``_shape_only`` in
+        ``tests/vcr_config.py``), so ``[1, 3]``, ``[3, 1]`` and the ``[null,
+        null]`` this cassette actually recorded are indistinguishable to it.
+        The transposition in #2116 was therefore invisible here and would be
+        again — the ordering is pinned by the unit golden payloads in
+        ``tests/unit/test_rpc_golden_payloads.py`` instead.
+        """
         async with vcr_client() as client:
             result = await client.artifacts.generate_flashcards(MUTABLE_NOTEBOOK_ID)
         assert result is not None

--- a/tests/unit/app/test_app_generate_plans.py
+++ b/tests/unit/app/test_app_generate_plans.py
@@ -161,20 +161,23 @@ class TestPerKindEnumMapping:
     def test_quiz_enum_mapping(self):
         plan = build_generation_plan(
             "quiz",
-            {"notebook_id": "nb_1", "quantity": "more", "difficulty": "hard"},
+            # more(3) + easy(1): asymmetric. "hard" also encodes to 3 (#2117),
+            # so pairing it with "more" would hide a quantity/difficulty swap.
+            {"notebook_id": "nb_1", "quantity": "more", "difficulty": "easy"},
         )
         assert plan.params["quantity"] == QuizQuantity.MORE
-        assert plan.params["difficulty"] == QuizDifficulty.HARD
+        assert plan.params["difficulty"] == QuizDifficulty.EASY
         # Quiz does not accept a language.
         assert plan.language is None
 
     def test_flashcards_enum_mapping(self):
         plan = build_generation_plan(
             "flashcards",
-            {"notebook_id": "nb_1", "quantity": "fewer", "difficulty": "easy"},
+            # fewer(1) + hard(3): asymmetric. "fewer" + "easy" both encode to 1.
+            {"notebook_id": "nb_1", "quantity": "fewer", "difficulty": "hard"},
         )
         assert plan.params["quantity"] == QuizQuantity.FEWER
-        assert plan.params["difficulty"] == QuizDifficulty.EASY
+        assert plan.params["difficulty"] == QuizDifficulty.HARD
         assert plan.language is None
 
     def test_infographic_enum_mapping(self):

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -334,16 +334,21 @@ _OPTION_CASES = [
         "quiz",
         "quiz",
         "generate_quiz",
-        {"quantity": "more", "difficulty": "hard"},
-        ["--quantity", "more", "--difficulty", "hard"],
+        # Asymmetric on the wire: more(3) + easy(1). Avoid pairing "more" with
+        # "hard" -- both encode to 3 (#2117), which would hide a quantity /
+        # difficulty swap in the adapter.
+        {"quantity": "more", "difficulty": "easy"},
+        ["--quantity", "more", "--difficulty", "easy"],
     ),
     (
         "flashcards",
         "flashcards",
         "flashcards",
         "generate_flashcards",
-        {"quantity": "fewer", "difficulty": "easy"},
-        ["--quantity", "fewer", "--difficulty", "easy"],
+        # Asymmetric on the wire: fewer(1) + hard(3). "fewer" + "easy" both
+        # encode to 1 and could not detect a swap.
+        {"quantity": "fewer", "difficulty": "hard"},
+        ["--quantity", "fewer", "--difficulty", "hard"],
     ),
     (
         "report",

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -623,7 +623,8 @@ def _expected_rpc_envelope(method: RPCMethod, params: list[Any]) -> list[Any]:
                     None,
                     [
                         None,
-                        [1, None, "Use short prompts", None, None, None, [1, 2]],
+                        # [quantity, difficulty] — asymmetric on purpose (#2116).
+                        [1, None, "Use short prompts", None, None, None, [2, 1]],
                     ],
                 ],
             ],
@@ -825,6 +826,53 @@ def test_artifact_payload_builders_match_golden_rpc_envelopes(
 
     assert params == expected
     assert encode_rpc_request(method, params) == _expected_rpc_envelope(method, expected)
+
+
+def test_quiz_and_flashcards_agree_on_option_order() -> None:
+    """Both builders emit ``[quantity, difficulty]`` — they must not drift apart.
+
+    The two option pairs live at different slots (quiz ``[7]``, flashcards
+    ``[6]``) of otherwise near-identical payloads, which is exactly how the
+    flashcards builder came to be transposed (#2116) while the quiz one stayed
+    correct. Asserting them side by side with an asymmetric fixture makes any
+    future transposition of either builder fail.
+    """
+    kwargs: dict[str, Any] = {
+        "instructions": None,
+        "quantity": QuizQuantity.FEWER,
+        "difficulty": QuizDifficulty.HARD,
+    }
+    quiz = build_quiz_artifact_params("nb_payload", ["src_alpha"], **kwargs)
+    flashcards = build_flashcards_artifact_params("nb_payload", ["src_alpha"], **kwargs)
+
+    expected = [QuizQuantity.FEWER.value, QuizDifficulty.HARD.value]
+    assert expected == [1, 3]
+    assert quiz[2][9][1][7] == expected
+    assert flashcards[2][9][1][6] == expected
+
+
+def test_quiz_quantity_more_is_distinct_on_the_wire() -> None:
+    """``MORE`` emits 3, not the ``STANDARD`` value it used to alias (#2117)."""
+    assert QuizQuantity.MORE.value == 3
+    assert QuizQuantity.MORE is not QuizQuantity.STANDARD
+
+    quiz = build_quiz_artifact_params(
+        "nb_payload",
+        ["src_alpha"],
+        instructions=None,
+        quantity=QuizQuantity.MORE,
+        difficulty=QuizDifficulty.EASY,
+    )
+    flashcards = build_flashcards_artifact_params(
+        "nb_payload",
+        ["src_alpha"],
+        instructions=None,
+        quantity=QuizQuantity.MORE,
+        difficulty=QuizDifficulty.EASY,
+    )
+
+    assert quiz[2][9][1][7] == [3, 1]
+    assert flashcards[2][9][1][6] == [3, 1]
 
 
 def test_video_style_values_match_live_web_ui() -> None:

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -790,13 +790,20 @@ class TestArtifactsSourceSelection:
         flashcard_options = inner_params[9][1][6]
 
         assert source_ids_triple == [[["src_flash"]]]
-        assert flashcard_options == [QuizDifficulty.MEDIUM.value, QuizQuantity.STANDARD.value]
+        assert flashcard_options == [QuizQuantity.STANDARD.value, QuizDifficulty.MEDIUM.value]
 
     @pytest.mark.asyncio
     async def test_generate_flashcards_explicit_options_override_defaults(
         self, mock_core, mock_mind_map_service
     ):
-        """Explicit flashcard quantity and difficulty preserve flashcard option order."""
+        """Explicit flashcard quantity and difficulty preserve flashcard option order.
+
+        The fixture is deliberately **asymmetric** (#2116): the previous
+        ``FEWER``/``EASY`` pair encoded to ``[1, 1]``, which stayed green under
+        the transposed ``[difficulty, quantity]`` ordering this test exists to
+        pin. ``FEWER``/``HARD`` -> ``[1, 3]`` fails loudly if the pair is
+        reversed, mirroring the quiz sibling above.
+        """
         api = ArtifactsAPI(
             rpc=mock_core,
             drain=mock_core,
@@ -810,12 +817,13 @@ class TestArtifactsSourceSelection:
             notebook_id="nb_123",
             source_ids=["src_flash"],
             quantity=QuizQuantity.FEWER,
-            difficulty=QuizDifficulty.EASY,
+            difficulty=QuizDifficulty.HARD,
         )
 
         params = mock_core.rpc_executor.rpc_call.call_args.args[1]
         flashcard_options = params[2][9][1][6]
-        assert flashcard_options == [QuizDifficulty.EASY.value, QuizQuantity.FEWER.value]
+        assert flashcard_options == [QuizQuantity.FEWER.value, QuizDifficulty.HARD.value]
+        assert flashcard_options == [1, 3]
 
     @pytest.mark.asyncio
     async def test_generate_infographic_source_encoding(self, mock_core, mock_mind_map_service):


### PR DESCRIPTION
Two live-confirmed bugs in the option pair shared by quiz and flashcards generation.

Closes #2116
Closes #2117

> [!NOTE]
> Originally scoped to four issues. #2137 and #2142 were dropped when @audichuang independently opened #2191 and #2189 for them — this PR does not touch PowerPoint source types or the research-wait timeout.

## #2116 — flashcards sent `quantity` and `difficulty` transposed

`_artifact/payloads.py` emitted the pair as `[difficulty, quantity]` while `FlashcardsGenerationOptions` — and the quiz builder 40 lines above it — expect `[quantity, difficulty]`. Every flashcard generation through this client (CLI, MCP and REST alike) silently inverted **both** axes: asking for the fewest, hardest cards produced the most, easiest. No error, no warning; the artifact generated fine, just with the opposite settings.

Verified against `docs/mobile/schema.proto`: `FlashcardsGenerationOptions{cardQuantity=1, flashcardsDifficulty=2}`, and field N → JSON index N−1, so position 0 is quantity.

### Why the existing test could not catch this — and what changed

This is the important part for reviewers. The test that existed *specifically* to "preserve flashcard option order" was structurally incapable of checking order:

```python
assert flashcard_options == [QuizDifficulty.MEDIUM.value, QuizQuantity.STANDARD.value]  # [2, 2]
assert flashcard_options == [QuizDifficulty.EASY.value, QuizQuantity.FEWER.value]       # [1, 1]
```

**Both fixtures were symmetric pairs.** Reversing the builder left both assertions green. The tell is the sibling: the quiz test used an asymmetric `[1, 3]` — which is exactly why the quiz builder stayed correct while the flashcards one drifted.

So the fixture is now asymmetric — `FEWER(1)` + `HARD(3)` → `[1, 3]` — plus a new test asserting the two builders agree side by side. **Mutation-tested:** reverting `payloads.py` now fails 4 tests. On `main` today, that same revert fails zero.

## #2117 — `QuizQuantity.MORE` was an alias for `STANDARD`

`MORE = 2  # Alias for STANDARD - API limitation`, with a docstring asserting Google's API could not distinguish them. It can. Both `QuizGenerationOptions.QuestionQuantity` and `FlashcardsGenerationOptions.CardQuantity` declare `MORE = 3`, and the backend accepts and persists `cardQuantity = 3`. Since our enum could never emit 3, `--quantity more` silently produced a standard-sized set.

The docstring was the worst part — it stated as fact that the backend couldn't express the distinction, actively discouraging anyone from fixing it.

⚠️ **This is a public-API break** (`QuizQuantity` is documented-stable): `MORE == STANDARD` was `True`, now `False`. Allowlisted in `scripts/api-compat-allowlist.json` with a `BREAKING` CHANGELOG entry and migration note. Swept for reliance on the collapse — no reverse `QuizQuantity(2)` lookups, no enum iteration, no persisted ints; every CLI/MCP/REST surface is name-keyed on the string `"more"`, so none needed changes.

## Live probe

Confirmatory, against the real backend, in a scratch notebook created and deleted in the same run:

| request | server echo of stored options |
|---|---|
| `quantity=FEWER(1)`, `difficulty=HARD(3)` | `[1, 3]` — quantity first ✅ |
| `quantity=MORE(3)`, `difficulty=EASY(1)` | `[3, 1]` — `cardQuantity=3` persists ✅ |

## Guardrail gaps this closes

A review pass found the bug class could still hide, so the second commit fixes the mechanism, not just the values:

- **`ENUM_BINDINGS` never imported the client.** It only proved the hand-written table matched the backend dump. Setting `MORE = 4` and updating the frozen snapshot to match left every gate green — *exactly* #2117's shape. A new test ties the table to the live `__members__`, closing the loop code → table → backend. It immediately found a real unbound value (`SourceStatus.UNKNOWN = -1`), now declared explicitly as a client-side sentinel.
- **"Both backend enums declare identical values" was an unchecked assumption.** Now a test: if Google renumbers only the flashcards side, every flashcard request would go out wrong while the quiz binding stayed green.
- **`docs/rpc-reference.md` still documented the transposed order** — emphatically, as `# Note: reversed order from quiz!`. `CLAUDE.md` tells maintainers to copy the shape from that reference when re-deriving payloads, so it would have invited the bug straight back in with a citation behind it. Corrected.

### A regression this PR caused, and fixed

`MORE = 3` now collides with `QuizDifficulty.HARD = 3` under `int`-Enum comparison, so parity fixtures pairing `"more"` with `"hard"` became `(3, 3)` — blind to a quantity/difficulty swap, the same symmetric-fixture blindness this PR set out to fix. Re-asymmetrised in `test_cli_mcp_parity.py` and `test_app_generate_plans.py`. (The flashcards rows were already blind at `fewer(1)`+`easy(1)` and got the same treatment.)

### Known limit, now documented

The VCR tier **cannot** pin these values: the `freq` matcher compares request bodies shape-only, so `[1,3]`, `[3,1]` and the `[null,null]` the cassette actually recorded are indistinguishable to it. The ordering is pinned by the unit golden payloads alone — noted at the cassette-backed test so the next reader doesn't assume otherwise.

## Verification

- `pytest -n auto tests/unit tests/integration` — 12025 passed, 79 skipped
- full suite — 13897 passed, 84 skipped, 3 xfailed
- `mypy src/notebooklm --ignore-missing-imports` — clean, 351 files
- `pre-commit run --all-files` — clean
- `scripts/audit_public_api_compat.py` — exit 0 (fails without the allowlist rows)
- module-size ratchet (ADR-0008) — clean; touched src modules are 567 and 558 lines

## Follow-ups deliberately not in scope — filed, not dropped

- **#2195** — nothing reads the option pair *back*. `ArtifactRow` parses `[9]` but not `[9][1][6]`/`[7]`, so only unit fixtures stand between a wrong pair and the user. The backend *does* echo the stored options (that is how this PR's live probe worked), so an echo-asserting e2e test is possible — it just needs a new row accessor plus a wire-contract registry entry.
- **#2196** — both builders silently rewrite `None` → an explicit `STANDARD`/`MEDIUM`, so "let the server choose" (`*_UNSPECIFIED = 0`) is inexpressible.
- **#2197** — `cli/generate_cmd.py`'s `click.Choice` list is hardcoded, unlike the MCP/REST copies which are pinned to `_QUIZ_QUANTITY_MAP`. The mirror risk of #2117: a value in our enum that never reaches one of our surfaces.

Not filed, because it is fully handled here: the strengthened binding check surfaced `SourceStatus.UNKNOWN = -1` as an unbound value. It is a legitimate client-side sentinel with no backend counterpart, now declared explicitly in `_CLIENT_SYNTHETIC_VALUES` rather than silently skipped. `SourceStatus` is now completely accounted for — `1,2,3,5` bound to the backend, `0,4` declared as gaps, `-1` declared synthetic, nothing unaccounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flashcard generation option ordering to consistently use quantity followed by difficulty.
  * Assigned “More” quiz quantity a distinct value, improving accurate quiz generation and compatibility.

* **Documentation**
  * Updated API and RPC references with corrected quantity values and option ordering.
  * Added migration guidance for the changed quiz quantity behavior.

* **Tests**
  * Expanded coverage for quiz and flashcard payloads, enum values, and option mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
