### PR TITLE
fix(sources): probe add_drive idempotency by Drive documentId, not url (#2113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set rather than the standard-sized one it silently got before — which is what
   those callers were asking for all along
   ([#2117](https://github.com/teng-lin/notebooklm-py/issues/2117)).
+
+- **`sources.add_drive` no longer duplicates a Drive source when a create has to
+  be retried.** Its idempotency probe matched an existing source by looking for
+  a `/d/<file_id>` segment inside `source.url`, but Drive-backed sources carry no
+  URL at all, so the probe could never match. Since this variant runs with
+  internal retries disabled, a 5xx or network failure *after* the server had
+  committed the create left the probe reporting "not committed" and the add was
+  re-issued, producing two copies of the same Drive file
+  ([#2113](https://github.com/teng-lin/notebooklm-py/issues/2113)). The probe now
+  matches on the Drive `documentId` the backend echoes back — exposed as the new
+  `Source.drive_document_id` and decoded from either
+  `SourceMetadata.googleDocsMetadata` (Docs/Slides) or
+  `googleDriveSourceMetadata` (Drive-hosted files). Because a `documentId` is not
+  unique within a notebook, matches are filtered against a snapshot of source ids
+  taken before the create, so a pre-existing copy of the same file is never
+  handed back as if it were the one just created; an unavailable snapshot or an
+  ambiguous multi-match raises `SourceAddError` rather than guessing. `add_drive`
+  also now rejects a blank `file_id` with `ValidationError` instead of writing an
+  unmatchable source.
 - **RPC bundle monitoring no longer reports authentication/access failures as
   protocol drift.** The live registry capture now classifies login,
   CookieMismatch, region/anti-abuse, HTTP, and CDN failures as exit code 2 and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ambiguous multi-match raises `SourceAddError` rather than guessing. `add_drive`
   also now rejects a blank `file_id` with `ValidationError` instead of writing an
   unmatchable source.
+
+  **Behaviour change:** `add_drive` previously listed sources only inside its
+  retry probe (i.e. only after a transport failure); it now takes that snapshot
+  on *every* call, matching the shape `add_file` has always had. That is one
+  extra `GET_NOTEBOOK` per `add_drive`, and because the backend writes
+  `lastViewedTime` when answering one
+  ([#2126](https://github.com/teng-lin/notebooklm-py/issues/2126)), every
+  `add_drive` now bumps the notebook's position in the web UI's *Recent* list.
+  No cheaper probe exists — source ids are published only inside the
+  `GET_NOTEBOOK` payload — and the trade is deliberate: reporting a create that
+  never happened is far worse than a reordered Recent list.
+
 - **RPC bundle monitoring no longer reports authentication/access failures as
   protocol drift.** The live registry capture now classifies login,
   CookieMismatch, region/anti-abuse, HTTP, and CDN failures as exit code 2 and

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2245,6 +2245,7 @@ class Source:
     url: Optional[str]
     created_at: Optional[datetime]
     status: SourceStatus                 # UNKNOWN when the wire status is missing or unmapped
+    drive_document_id: Optional[str]     # Drive file id for Drive-backed sources; None otherwise
 
     @property
     def kind(self) -> SourceType:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2210,20 +2210,19 @@ effect of doing something else:
 | `notebooks.rename()` | Re-reads after the mutation to return the updated `Notebook`. |
 | `notebooks.create()` (CLI/MCP/REST path) | One best-effort re-read to backfill the timestamps `CREATE_NOTEBOOK` leaves null; skipped when both are already populated. |
 | `chat.get_settings()` | Chat config lives in the notebook payload. |
-| `sources.add_file()` | An **unconditional** pre-create baseline of existing source ids, on every call — the idempotency probe needs it to tell a source it created from one that was already there. |
-| `sources.add_url()` / `add_text()` / `add_drive()` | Only **on a retry**: their idempotency probe runs after a transport failure, not on the happy path. See the note below on `add_drive`. |
+| `sources.add_file()` / `add_drive()` | An **unconditional** pre-create baseline of existing source ids, on every call — the idempotency probe needs it to tell a source it created from one that was already there. |
+| `sources.add_url()` | Only **on a retry**: its idempotency probe runs after a transport failure, not on the happy path. (`add_text()` is `NON_IDEMPOTENT_NO_RETRY` and runs no probe at all, so it never bumps recency.) |
 | REST `POST /v1/notebooks/{id}/sources/batch` preflight | One shared existence/auth check before the per-URL loop. |
 
-> **Pending change — `sources.add_drive()`.**
-> [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113) moves `add_drive`
-> from a retry-only probe to an **unconditional** pre-create baseline, the same
-> shape `add_file` already uses, because a Drive `documentId` turns out not to be
-> unique within a notebook (the repo's own cassette holds two source ids sharing
-> one `documentId`), so matching on `documentId` alone could return a
-> pre-existing copy and report success for a create that never landed. When that
-> lands, `add_drive` moves up a row: it will bump recency on **every** call rather
-> than only on a retry. The baseline is the correct fix — this table records the
-> recency cost it carries, not an objection to it.
+> **`sources.add_drive()` moved rows in
+> [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113).** It used to
+> probe only on a retry; it now takes an **unconditional** pre-create baseline,
+> the same shape `add_file` already uses. A Drive `documentId` turns out not to
+> be unique within a notebook (the repo's own cassette holds two source ids
+> sharing one `documentId`), so matching on `documentId` alone could return a
+> pre-existing copy and report success for a create that never landed. The
+> baseline is the correct fix — this table records the recency cost it carries,
+> not an objection to it.
 
 Paths that issue `LIST_NOTEBOOKS` — listed for completeness, since they cost an
 RPC but, per the probe above, **do not perturb recency**: `notebooks.create()`

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -108,7 +108,7 @@ Internal integer codes returned by `GET_NOTEBOOK` / `LIST_SOURCES` and consumed 
 
 > Codes outside this map are surfaced as `SourceType.UNKNOWN` and emit `UnknownTypeWarning` on first occurrence so unmapped types don't crash callers.
 
-> **Code `14` is overloaded** (live-captured #1828/#1832): the backend returns `14` for a native Google Sheet *and* for a Drive-hosted PDF. Drive sources carry no URL (`metadata[0]/[5]/[7]` are all null), so the two are disambiguated by the MIME at `metadata[19]` (fallback `metadata[9][2]`): `application/vnd.google-apps.spreadsheet` → `GOOGLE_SPREADSHEET`, `application/pdf` → `PDF`. See `_disambiguate_type_code` in `src/notebooklm/_types/sources.py`.
+> **Code `14` is overloaded** (live-captured #1828/#1832): the backend returns `14` for a native Google Sheet *and* for a Drive-hosted PDF. Drive sources carry no URL (`metadata[5]/[7]` are null and `metadata[0]` holds the Drive metadata block, not a URL — see `SourceRow.drive_document_id`), so the two are disambiguated by the MIME at `metadata[19]` (fallback `metadata[9][2]`): `application/vnd.google-apps.spreadsheet` → `GOOGLE_SPREADSHEET`, `application/pdf` → `PDF`. See `_disambiguate_type_code` in `src/notebooklm/_types/sources.py`.
 
 ---
 

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -24,8 +24,9 @@ This module hosts two cooperating pieces:
 
 Per-API probes used by :func:`idempotent_create` are caller-supplied
 because there is no universal probe key (notebooks: title +
-baseline-diff; sources: url-match; ``add_text``: no probe possible — see
-:class:`~notebooklm.exceptions.NonIdempotentRetryError`).
+baseline-diff; ``add_url``: url-match; ``add_drive``: Drive
+``documentId``-match + baseline-diff; ``add_text``: no probe possible —
+see :class:`~notebooklm.exceptions.NonIdempotentRetryError`).
 
 This module is private (``_idempotency.py``); call sites live in the
 domain APIs (``_notebooks.py``, ``_sources.py``) and the RPC executor
@@ -116,7 +117,8 @@ async def idempotent_create(
         probe: Coroutine factory that returns the resource if it
             already exists server-side, or ``None`` if not. Probes are
             API-specific (notebooks: list-then-baseline-diff by title;
-            sources: list-then-url-match).
+            ``add_url``: list-then-url-match; ``add_drive``:
+            list-then-documentId-match filtered by a pre-create baseline).
         max_attempts: Maximum total ``create()`` invocations (default
             2 — one initial + one retry). Each attempt is followed by
             a probe; the probe runs only after a transport failure.

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -469,11 +469,10 @@ class SourceRow:
         #1832 overload). No corpus row populates both, so the order is an
         arbitrary-but-pinned tie-break, not a precedence claim.
 
-        This is the only identity-bearing echo of the Drive ``file_id`` such a
-        source carries — the URL slots are empty and ``metadata[0]`` holds the
-        Drive block, not a URL, so :attr:`url` is ``None`` on every Drive row.
-        ``sources.add_drive`` probes on it (#2113); non-Drive rows return
-        ``None``, so a ``file_id`` equality match can never select one.
+        The only identity-bearing echo of the Drive ``file_id``: the URL slots
+        are empty and ``metadata[0]`` holds the Drive block, not a URL, so
+        :attr:`url` is ``None`` on every Drive row. ``sources.add_drive`` probes
+        on it (#2113); non-Drive rows return ``None`` and never match a file_id.
         """
         metadata = self.metadata
         if metadata is None:
@@ -486,10 +485,10 @@ class SourceRow:
         """Read a ``documentId`` from the Drive block at ``block_pos``.
 
         Structural absence degrades silently — a missing / non-list block just
-        means "not a Drive row". Semantic drift warns once (like the
-        unmapped-status path): a present, non-empty block IS a Drive row, so a
-        non-string / blank id means the slot moved — the #2113 signature, where
-        the probe then reports "not committed" forever.
+        means "not a Drive row". Semantic drift warns once (like the unmapped-
+        status path): a present block IS a Drive row, so a non-string / blank id
+        means the slot moved — the #2113 signature, where the probe then reports
+        "not committed" forever.
         """
         if len(metadata) <= block_pos:
             return None
@@ -499,11 +498,12 @@ class SourceRow:
         value = block[self._DRIVE_DOCUMENT_ID_POS]
         # Test with ``.strip()`` but return the wire value verbatim: a blank or
         # whitespace-only id is unmatchable (``add_drive`` rejects such a
-        # ``file_id`` outright), so it is drift, not an id.
+        # ``file_id`` outright), so it is drift, not an id. No emptiness guard
+        # below — the length check above already returned for a short block.
         if isinstance(value, str) and value.strip():
             return value
         key = (self.method_id, block_pos)
-        if block and key not in _warned_drive_id_slots:
+        if key not in _warned_drive_id_slots:
             _warned_drive_id_slots.add(key)
             logger.warning(
                 "Drive metadata block at metadata[%d] carries no usable documentId "

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 #: ``_types/sources.py::_warned_source_types``.
 _warned_status_codes: set[int] = set()
 
+#: ``(method_id, block_pos)`` pairs already warned about by
+#: :meth:`SourceRow._document_id_at` — one drift line per drifted slot, not one
+#: per row per poll.
+_warned_drive_id_slots: set[tuple[str, int]] = set()
+
 __all__ = [
     "SourceFulltextRow",
     "SourceGuideRow",
@@ -99,12 +104,11 @@ class SourceRow:
     =====  ============================================================
     Index  Meaning
     =====  ============================================================
-    0      ``SourceMetadata.googleDocsMetadata`` — the Drive metadata
-           block a Google-native Doc / Slides / Sheet carries;
-           ``[0][0]`` is its ``documentId`` (see
-           :attr:`drive_document_id`). Legacy shapes occasionally put a
-           bare ``http(s)://...`` URL here instead, honored only when
-           ``url_allow_bare_http=True``.
+    0      ``SourceMetadata.googleDocsMetadata`` — a Google-native Doc /
+           Slides block whose ``[0][0]`` is the ``documentId`` (see
+           :attr:`drive_document_id`). Legacy shapes put a bare
+           ``http(s)://...`` URL here, honored only under
+           ``url_allow_bare_http``.
     2      timestamp block; ``[2][0]`` is the creation timestamp
            (seconds since epoch).
     4      type code (int — see
@@ -114,11 +118,11 @@ class SourceRow:
     7      url block; ``[7][0]`` is the canonical source URL when
            present (takes precedence over ``metadata[5][0]`` and
            ``metadata[0]``).
-    9      ``SourceMetadata.googleDriveSourceMetadata`` — the Drive-file
-           descriptor for Drive-hosted binaries:
+    9      ``SourceMetadata.googleDriveSourceMetadata`` — the descriptor
+           for Drive-hosted files (native Sheets and Drive PDFs alike):
            ``[document_id, kind_int, mime, ""]``; ``[9][0]`` is the
-           ``documentId`` (see :attr:`drive_document_id`) and ``[9][2]``
-           the MIME.
+           ``documentId`` (see :attr:`drive_document_id`), ``[9][2]`` the
+           MIME.
     19     top-level MIME string for Drive-hosted sources. Used with
            ``[9][2]`` to disambiguate the type-code ``14`` overload
            (native Sheet vs Drive-hosted PDF) — see :attr:`mime`.
@@ -167,31 +171,26 @@ class SourceRow:
     _STATUS_BLOCK_POS: ClassVar[int] = 3
     _STATUS_INNER_POS: ClassVar[int] = 1
 
-    # Metadata sub-list positions.
-    # Index 0 is ``SourceMetadata.googleDocsMetadata`` (schema-confirmed), not
-    # a URL slot: the historical ``_META_BARE_URL_POS`` name described only the
-    # legacy ``url_allow_bare_http`` fallback that reads it as a bare string.
+    # Metadata sub-list positions. Index 0 is googleDocsMetadata, not a URL
+    # slot (the old _META_BARE_URL_POS name meant only the legacy fallback).
     _META_GOOGLE_DOCS_POS: ClassVar[int] = 0
     _META_TIMESTAMP_POS: ClassVar[int] = 2
     _META_TYPE_POS: ClassVar[int] = 4
     _META_YOUTUBE_POS: ClassVar[int] = 5
     _META_URL_POS: ClassVar[int] = 7
     # Drive-hosted sources carry the true file MIME here (#1832 live capture):
-    # the drive-file descriptor ``[document_id, kind_int, mime, ""]`` at [9] and
-    # a top-level MIME string at [19]. Used to disambiguate the type_code==14
-    # overload (native Sheet vs Drive-hosted binary like a PDF), which the URL
-    # slots can't — Drive sources carry no URL (metadata[5]/[7] are null and
-    # metadata[0] holds the Drive metadata block, not a URL string).
+    # the descriptor ``[document_id, kind_int, mime, ""]`` at [9] and a
+    # top-level MIME string at [19]. Used to disambiguate the type_code==14
+    # overload (native Sheet vs Drive PDF), which the URL slots can't — Drive
+    # rows have no URL (metadata[5]/[7] null; metadata[0] is the Drive block).
     _META_DRIVE_DESCRIPTOR_POS: ClassVar[int] = 9
     _META_MIME_POS: ClassVar[int] = 19
     # Position of the MIME string inside the drive-file descriptor at [9].
     _DRIVE_DESCRIPTOR_MIME_POS: ClassVar[int] = 2
-    # Position of the Drive ``documentId`` inside each of the two Drive
-    # metadata blocks (#2113). Both messages declare ``documentId`` as tag 1,
-    # so both read index 0 — kept as two named constants so a future reshape of
-    # either message can move independently.
-    _DRIVE_DESCRIPTOR_DOCUMENT_ID_POS: ClassVar[int] = 0
-    _GOOGLE_DOCS_DOCUMENT_ID_POS: ClassVar[int] = 0
+    # Drive ``documentId`` inside either Drive metadata block (#2113):
+    # GoogleDocsSourceMetadata and GoogleDriveSourceMetadata both declare it as
+    # tag 1, so one constant covers both blocks.
+    _DRIVE_DOCUMENT_ID_POS: ClassVar[int] = 0
 
     # Id-envelope inner positions (the three layouts at ``self._raw[0]``).
     _ID_ENVELOPE_PLAIN_POS: ClassVar[int] = 0
@@ -464,53 +463,55 @@ class SourceRow:
     def drive_document_id(self) -> str | None:
         """Google Drive file id of a Drive-backed source — ``None`` otherwise.
 
-        Read from whichever Drive metadata block the row carries, in order:
-
-        1. ``metadata[0][0]`` — ``googleDocsMetadata.documentId``, the block a
-           Google-native Doc / Slides / Sheet lands in (live-captured shape:
-           ``["1oAk_INJ…", "<opaque>", 17]``).
-        2. ``metadata[9][0]`` — ``googleDriveSourceMetadata.documentId``, the
-           block a Drive-hosted binary (e.g. a Drive PDF) lands in
-           (live-captured shape ``[document_id, kind_int, mime, ""]``, #1832).
-
-        The two blocks belong to different source kinds and carry the same
-        identifier, so the order only decides which wins on a row carrying both.
+        Read from whichever Drive block the row carries: ``metadata[0][0]``
+        (``googleDocsMetadata.documentId``; corpus-observed on type codes 1/2),
+        else ``metadata[9][0]`` (``googleDriveSourceMetadata.documentId``; type
+        code 14 — Drive-hosted files, native Sheet and Drive PDF alike per the
+        #1832 overload). No corpus row populates both, so the order is an
+        arbitrary-but-pinned tie-break, not a precedence claim.
 
         This is the only identity-bearing echo of the Drive ``file_id`` such a
-        source carries: the URL slots (``metadata[7]`` / ``metadata[5]``) are
-        empty and ``metadata[0]`` holds the Drive block rather than a URL
-        string, so :attr:`url` decodes to ``None`` on every Drive row.
-        ``sources.add_drive`` matches on this in its idempotency probe to
-        recognise an already-committed create after a transient failure (#2113).
-        Non-Drive rows return ``None``, so an equality match against a requested
-        ``file_id`` can never select one.
+        source carries — the URL slots are empty and ``metadata[0]`` holds the
+        Drive block, not a URL, so :attr:`url` is ``None`` on every Drive row.
+        ``sources.add_drive`` probes on it (#2113); non-Drive rows return
+        ``None``, so an equality match on a ``file_id`` can never select one.
         """
         metadata = self.metadata
         if metadata is None:
             return None
-        return self._document_id_at(
-            metadata, self._META_GOOGLE_DOCS_POS, self._GOOGLE_DOCS_DOCUMENT_ID_POS
-        ) or self._document_id_at(
-            metadata, self._META_DRIVE_DESCRIPTOR_POS, self._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS
+        return self._document_id_at(metadata, self._META_GOOGLE_DOCS_POS) or self._document_id_at(
+            metadata, self._META_DRIVE_DESCRIPTOR_POS
         )
 
-    @classmethod
-    def _document_id_at(cls, metadata: list[Any], block_pos: int, id_pos: int) -> str | None:
-        """Read a ``documentId`` from the Drive metadata block at ``block_pos``.
+    def _document_id_at(self, metadata: list[Any], block_pos: int) -> str | None:
+        """Read a ``documentId`` from the Drive block at ``block_pos``.
 
-        Returns ``None`` when the block is absent or is not a list — notably the
-        legacy bare ``http(s)://…`` string that :attr:`url_allow_bare_http`
-        honors at ``metadata[0]`` is a ``str``, and indexing it would otherwise
-        yield a one-character "id". Empty strings degrade to ``None`` so a blank
-        slot never compares equal to a caller-supplied ``file_id``.
+        Structural absence degrades silently — a missing / non-list block just
+        means "not a Drive row". Semantic drift warns once (like the
+        unmapped-status path): a present, non-empty block IS a Drive row, so a
+        non-string / blank id means the slot moved — the #2113 signature, where
+        the probe then reports "not committed" forever.
         """
         if len(metadata) <= block_pos:
             return None
         block = metadata[block_pos]
-        if not isinstance(block, list) or len(block) <= id_pos:
+        if not isinstance(block, list) or len(block) <= self._DRIVE_DOCUMENT_ID_POS:
             return None
-        value = block[id_pos]
-        return value if isinstance(value, str) and value else None
+        value = block[self._DRIVE_DOCUMENT_ID_POS]
+        if isinstance(value, str) and value:
+            return value
+        key = (self.method_id, block_pos)
+        if block and key not in _warned_drive_id_slots:
+            _warned_drive_id_slots.add(key)
+            logger.warning(
+                "Drive metadata block at metadata[%d] carries no usable documentId "
+                "(got %s) from RPC %s; sources.add_drive cannot dedupe these rows "
+                "— the wire shape may have changed",
+                block_pos,
+                type(value).__name__,
+                self.method_id,
+            )
+        return None
 
     @property
     def url(self) -> str | None:

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -21,8 +21,7 @@ logger = logging.getLogger(__name__)
 _warned_status_codes: set[int] = set()
 
 #: ``(method_id, block_pos)`` pairs already warned about by
-#: :meth:`SourceRow._document_id_at` — one drift line per drifted slot, not one
-#: per row per poll.
+#: :meth:`SourceRow._document_id_at` — one line per drifted slot, not per row.
 _warned_drive_id_slots: set[tuple[str, int]] = set()
 
 __all__ = [
@@ -474,7 +473,7 @@ class SourceRow:
         source carries — the URL slots are empty and ``metadata[0]`` holds the
         Drive block, not a URL, so :attr:`url` is ``None`` on every Drive row.
         ``sources.add_drive`` probes on it (#2113); non-Drive rows return
-        ``None``, so an equality match on a ``file_id`` can never select one.
+        ``None``, so a ``file_id`` equality match can never select one.
         """
         metadata = self.metadata
         if metadata is None:
@@ -498,7 +497,10 @@ class SourceRow:
         if not isinstance(block, list) or len(block) <= self._DRIVE_DOCUMENT_ID_POS:
             return None
         value = block[self._DRIVE_DOCUMENT_ID_POS]
-        if isinstance(value, str) and value:
+        # Test with ``.strip()`` but return the wire value verbatim: a blank or
+        # whitespace-only id is unmatchable (``add_drive`` rejects such a
+        # ``file_id`` outright), so it is drift, not an id.
+        if isinstance(value, str) and value.strip():
             return value
         key = (self.method_id, block_pos)
         if block and key not in _warned_drive_id_slots:

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -99,8 +99,12 @@ class SourceRow:
     =====  ============================================================
     Index  Meaning
     =====  ============================================================
-    0      Mixed — sometimes a bare ``http(s)://...`` URL (legacy
-           shape, only honored when ``url_allow_bare_http=True``).
+    0      ``SourceMetadata.googleDocsMetadata`` — the Drive metadata
+           block a Google-native Doc / Slides / Sheet carries;
+           ``[0][0]`` is its ``documentId`` (see
+           :attr:`drive_document_id`). Legacy shapes occasionally put a
+           bare ``http(s)://...`` URL here instead, honored only when
+           ``url_allow_bare_http=True``.
     2      timestamp block; ``[2][0]`` is the creation timestamp
            (seconds since epoch).
     4      type code (int — see
@@ -110,8 +114,11 @@ class SourceRow:
     7      url block; ``[7][0]`` is the canonical source URL when
            present (takes precedence over ``metadata[5][0]`` and
            ``metadata[0]``).
-    9      Drive-file descriptor for Drive-hosted sources:
-           ``[drive_id, kind_int, mime, ""]``; ``[9][2]`` is the MIME.
+    9      ``SourceMetadata.googleDriveSourceMetadata`` — the Drive-file
+           descriptor for Drive-hosted binaries:
+           ``[document_id, kind_int, mime, ""]``; ``[9][0]`` is the
+           ``documentId`` (see :attr:`drive_document_id`) and ``[9][2]``
+           the MIME.
     19     top-level MIME string for Drive-hosted sources. Used with
            ``[9][2]`` to disambiguate the type-code ``14`` overload
            (native Sheet vs Drive-hosted PDF) — see :attr:`mime`.
@@ -161,20 +168,30 @@ class SourceRow:
     _STATUS_INNER_POS: ClassVar[int] = 1
 
     # Metadata sub-list positions.
-    _META_BARE_URL_POS: ClassVar[int] = 0
+    # Index 0 is ``SourceMetadata.googleDocsMetadata`` (schema-confirmed), not
+    # a URL slot: the historical ``_META_BARE_URL_POS`` name described only the
+    # legacy ``url_allow_bare_http`` fallback that reads it as a bare string.
+    _META_GOOGLE_DOCS_POS: ClassVar[int] = 0
     _META_TIMESTAMP_POS: ClassVar[int] = 2
     _META_TYPE_POS: ClassVar[int] = 4
     _META_YOUTUBE_POS: ClassVar[int] = 5
     _META_URL_POS: ClassVar[int] = 7
     # Drive-hosted sources carry the true file MIME here (#1832 live capture):
-    # the drive-file descriptor ``[drive_id, kind_int, mime, ""]`` at [9] and a
-    # top-level MIME string at [19]. Used to disambiguate the type_code==14
+    # the drive-file descriptor ``[document_id, kind_int, mime, ""]`` at [9] and
+    # a top-level MIME string at [19]. Used to disambiguate the type_code==14
     # overload (native Sheet vs Drive-hosted binary like a PDF), which the URL
-    # slots can't — Drive sources carry no URL (metadata[0]/[5]/[7] all null).
+    # slots can't — Drive sources carry no URL (metadata[5]/[7] are null and
+    # metadata[0] holds the Drive metadata block, not a URL string).
     _META_DRIVE_DESCRIPTOR_POS: ClassVar[int] = 9
     _META_MIME_POS: ClassVar[int] = 19
     # Position of the MIME string inside the drive-file descriptor at [9].
     _DRIVE_DESCRIPTOR_MIME_POS: ClassVar[int] = 2
+    # Position of the Drive ``documentId`` inside each of the two Drive
+    # metadata blocks (#2113). Both messages declare ``documentId`` as tag 1,
+    # so both read index 0 — kept as two named constants so a future reshape of
+    # either message can move independently.
+    _DRIVE_DESCRIPTOR_DOCUMENT_ID_POS: ClassVar[int] = 0
+    _GOOGLE_DOCS_DOCUMENT_ID_POS: ClassVar[int] = 0
 
     # Id-envelope inner positions (the three layouts at ``self._raw[0]``).
     _ID_ENVELOPE_PLAIN_POS: ClassVar[int] = 0
@@ -444,6 +461,58 @@ class SourceRow:
         return value if isinstance(value, str) and value else None
 
     @property
+    def drive_document_id(self) -> str | None:
+        """Google Drive file id of a Drive-backed source — ``None`` otherwise.
+
+        Read from whichever Drive metadata block the row carries, in order:
+
+        1. ``metadata[0][0]`` — ``googleDocsMetadata.documentId``, the block a
+           Google-native Doc / Slides / Sheet lands in (live-captured shape:
+           ``["1oAk_INJ…", "<opaque>", 17]``).
+        2. ``metadata[9][0]`` — ``googleDriveSourceMetadata.documentId``, the
+           block a Drive-hosted binary (e.g. a Drive PDF) lands in
+           (live-captured shape ``[document_id, kind_int, mime, ""]``, #1832).
+
+        The two blocks belong to different source kinds and carry the same
+        identifier, so the order only decides which wins on a row carrying both.
+
+        This is the only identity-bearing echo of the Drive ``file_id`` such a
+        source carries: the URL slots (``metadata[7]`` / ``metadata[5]``) are
+        empty and ``metadata[0]`` holds the Drive block rather than a URL
+        string, so :attr:`url` decodes to ``None`` on every Drive row.
+        ``sources.add_drive`` matches on this in its idempotency probe to
+        recognise an already-committed create after a transient failure (#2113).
+        Non-Drive rows return ``None``, so an equality match against a requested
+        ``file_id`` can never select one.
+        """
+        metadata = self.metadata
+        if metadata is None:
+            return None
+        return self._document_id_at(
+            metadata, self._META_GOOGLE_DOCS_POS, self._GOOGLE_DOCS_DOCUMENT_ID_POS
+        ) or self._document_id_at(
+            metadata, self._META_DRIVE_DESCRIPTOR_POS, self._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS
+        )
+
+    @classmethod
+    def _document_id_at(cls, metadata: list[Any], block_pos: int, id_pos: int) -> str | None:
+        """Read a ``documentId`` from the Drive metadata block at ``block_pos``.
+
+        Returns ``None`` when the block is absent or is not a list — notably the
+        legacy bare ``http(s)://…`` string that :attr:`url_allow_bare_http`
+        honors at ``metadata[0]`` is a ``str``, and indexing it would otherwise
+        yield a one-character "id". Empty strings degrade to ``None`` so a blank
+        slot never compares equal to a caller-supplied ``file_id``.
+        """
+        if len(metadata) <= block_pos:
+            return None
+        block = metadata[block_pos]
+        if not isinstance(block, list) or len(block) <= id_pos:
+            return None
+        value = block[id_pos]
+        return value if isinstance(value, str) and value else None
+
+    @property
     def url(self) -> str | None:
         """Canonical source URL — ``None`` when absent.
 
@@ -524,9 +593,9 @@ class SourceRow:
         ``metadata[0]`` strings (e.g. drive ids, mime types) as URLs
         on shapes where this slot packs unrelated content.
         """
-        if not self.url_allow_bare_http or len(metadata) <= self._META_BARE_URL_POS:
+        if not self.url_allow_bare_http or len(metadata) <= self._META_GOOGLE_DOCS_POS:
             return None
-        candidate = metadata[self._META_BARE_URL_POS]
+        candidate = metadata[self._META_GOOGLE_DOCS_POS]
         if isinstance(candidate, str) and candidate.startswith("http"):
             return candidate
         return None
@@ -643,8 +712,8 @@ class SourceRow:
                 and isinstance(yt_data[cls._LIST_FIRST_POS], str)
             ):
                 url = yt_data[cls._LIST_FIRST_POS]
-        if not url and allow_bare_http and len(metadata) > cls._META_BARE_URL_POS:
-            candidate = metadata[cls._META_BARE_URL_POS]
+        if not url and allow_bare_http and len(metadata) > cls._META_GOOGLE_DOCS_POS:
+            candidate = metadata[cls._META_GOOGLE_DOCS_POS]
             if isinstance(candidate, str) and candidate.startswith("http"):
                 url = candidate
         return url

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -18,6 +18,7 @@ from ..exceptions import (
     RateLimitError,
     ServerError,
     SourceAddError,
+    ValidationError,
 )
 from ..rpc import RPCError, RPCMethod
 from ..types import Source
@@ -272,6 +273,14 @@ class SourceAddService:
         so a URL-based probe could never match one — it silently duplicated
         the source on every retry until #2113.
 
+        A ``documentId`` is **not** unique within a notebook: the backend
+        happily holds the same Drive file twice. The probe therefore filters
+        matches against a baseline of source ids captured before the first
+        create attempt, exactly like
+        :meth:`~notebooklm._source.upload.SourceUploader.register_file_source`
+        does for filenames, so a pre-existing copy is never handed back as if
+        it were the one just created.
+
         .. note::
            The ``title`` is sent on the wire but **ignored** for native Drive
            imports: NotebookLM re-derives the display title from live Drive
@@ -280,6 +289,13 @@ class SourceAddService:
            :meth:`~notebooklm._sources.SourcesAPI.rename` after the add if you
            need a specific title.
         """
+        if not file_id or not file_id.strip():
+            # Fail before the write rather than POSTing a blank Drive id. A
+            # blank id is also unmatchable by the probe below (a row's
+            # ``drive_document_id`` is never ``""``), so without this guard a
+            # transport failure would retry the blank add and could leave two
+            # garbage sources behind.
+            raise ValidationError("Drive file_id cannot be empty or whitespace-only")
         logger.debug("Adding Drive source to notebook %s: %s", notebook_id, title)
         source_data = [
             [file_id, mime_type, 1, title],
@@ -339,6 +355,25 @@ class SourceAddService:
                 )
             return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
+        # Capture baseline source ids before the first create attempt so the
+        # probe can tell "this Drive add landed" from "the same Drive file was
+        # already in the notebook". A ``documentId`` is NOT unique within a
+        # notebook — live capture (``tests/cassettes/sources_check_freshness_
+        # drive.yaml``) holds two source ids sharing one documentId — so an
+        # unfiltered match could hand back a pre-existing copy as if it were the
+        # one just created, silently masking a failed create. ``None`` is the
+        # "baseline unavailable" sentinel; the probe then refuses to guess.
+        # Mirrors ``register_file_source`` in ``_source/upload.py``.
+        baseline_ids: set[str] | None
+        try:
+            baseline_ids = {source.id for source in await list_sources(notebook_id)}
+        except Exception:
+            logger.debug(
+                "add_drive: baseline list() failed; baseline unavailable",
+                exc_info=True,
+            )
+            baseline_ids = None
+
         # A Drive-backed source echoes the requested ``file_id`` back as the
         # ``documentId`` in its metadata (``SourceRow.drive_document_id``);
         # it carries no URL at all, which is why the previous ``/d/<file_id>``
@@ -348,11 +383,6 @@ class SourceAddService:
         # produce a false positive, and non-Drive rows (``drive_document_id is
         # None``) can never match a requested file_id.
         async def _probe() -> Source | None:
-            if not file_id:
-                # No identity to match on. Bail out before the list() round-trip
-                # rather than letting a falsy file_id compare equal to the
-                # ``None`` ``drive_document_id`` of an unrelated source.
-                return None
             try:
                 sources = await list_sources(notebook_id)
             except (AuthError, RateLimitError, ServerError, NetworkError):
@@ -360,14 +390,44 @@ class SourceAddService:
                 # — see the rationale in ``add_url._probe``.
                 raise
             except Exception:
-                logger.debug(
-                    "add_drive: probe list() failed with non-transport error; treating as no match",
+                # WARNING, not DEBUG: a decode failure here (e.g. the strict
+                # ``RPCError`` GET_NOTEBOOK raises on a drifted response) is
+                # indistinguishable from "the create did not land", so
+                # idempotent_create re-issues the add — and this variant runs
+                # with ``disable_internal_retries=True``, leaving no other net
+                # against the duplicate this probe exists to prevent.
+                logger.warning(
+                    "add_drive: probe list() failed with a non-transport error; treating as "
+                    "no match, so a retry may create a duplicate Drive source",
                     exc_info=True,
                 )
                 return None
-            for source in sources:
-                if source.drive_document_id == file_id:
-                    return source
+            matches = [source for source in sources if source.drive_document_id == file_id]
+            if baseline_ids is not None:
+                matches = [source for source in matches if source.id not in baseline_ids]
+            elif matches:
+                # Without a baseline a match may predate this add — see the
+                # ``baseline_ids`` comment for the failure mode this guards.
+                raise SourceAddError(
+                    title,
+                    message=(
+                        f"Cannot disambiguate Drive source {file_id!r}: baseline snapshot "
+                        "was unavailable, so a matching source may predate this add. "
+                        "Check the notebook source list before retrying."
+                    ),
+                )
+            if len(matches) == 1:
+                (match,) = matches  # exactly one (len==1 guard); unpack, not matches[0]
+                return match
+            if len(matches) > 1:
+                raise SourceAddError(
+                    title,
+                    message=(
+                        f"Cannot disambiguate Drive source {file_id!r}: probe found "
+                        f"{len(matches)} new sources with this documentId after a "
+                        "transport failure. Check the notebook source list before retrying."
+                    ),
+                )
             return None
 
         result = await idempotent_create(

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -85,10 +85,22 @@ async def honor_requested_title_if_fresh(
     result: Source | _IdempotentCreateResult[Source],
     requested_title: str | None,
     logger: logging.Logger,
+    *,
+    probe_proves_freshness: bool = False,
 ) -> Source:
-    """Apply a requested title only to a source created by this call."""
+    """Apply a requested title only to a source created by this call.
+
+    A ``PROBED`` result is normally skipped because the probe may have matched a
+    source that predates this call, and renaming someone else's source would be
+    a surprise. Set ``probe_proves_freshness`` when the caller's probe already
+    guarantees the match is new — ``add_drive`` filters probe matches against a
+    baseline captured before the create, so its ``PROBED`` value is provably a
+    source this call created and must still honor the requested title (#2113).
+    Without this, a Drive add that commits but loses its response silently keeps
+    the Drive-derived name instead of the caller's ``title``.
+    """
     if isinstance(result, _IdempotentCreateResult):
-        if result.kind is _CreateResultKind.PROBED:
+        if result.kind is _CreateResultKind.PROBED and not probe_proves_freshness:
             return result.value
         source = result.value
     else:
@@ -279,7 +291,19 @@ class SourceAddService:
         create attempt, exactly like
         :meth:`~notebooklm._source.upload.SourceUploader.register_file_source`
         does for filenames, so a pre-existing copy is never handed back as if
-        it were the one just created.
+        it were the one just created. This costs one extra source list per
+        call; it is the price of telling "my create landed" apart from "a copy
+        was already there".
+
+        .. warning::
+           The baseline establishes *when* a matching source appeared, not
+           *who* created it. If two callers add the same Drive file to one
+           notebook concurrently and one create fails before committing, the
+           failed caller's probe can attribute the other caller's source to
+           itself. A list-based probe cannot close that gap — the wire carries
+           no client-supplied idempotency key — so serialize concurrent adds of
+           the same file into a notebook if you need that guarantee. The same
+           limitation applies to ``register_file_source``'s filename probe.
 
         .. note::
            The ``title`` is sent on the wire but **ignored** for native Drive

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -266,8 +266,11 @@ class SourceAddService:
         pattern as ``add_url``: a 5xx / network failure
         between server-side commit and client-side response could
         otherwise duplicate the source on a naive retry. The probe matches
-        by ``file_id`` substring against ``source.url`` (Drive URLs embed
-        the file_id, e.g. ``https://docs.google.com/document/d/<id>/edit``).
+        on :attr:`~notebooklm.types.Source.drive_document_id`, the Drive
+        ``documentId`` the backend echoes back in the source metadata.
+        Drive-backed sources carry **no** URL (their URL slots are empty),
+        so a URL-based probe could never match one — it silently duplicated
+        the source on every retry until #2113.
 
         .. note::
            The ``title`` is sent on the wire but **ignored** for native Drive
@@ -336,18 +339,20 @@ class SourceAddService:
                 )
             return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
-        # Drive URLs canonically embed the file_id as a path segment, e.g.
-        # ``https://docs.google.com/document/d/<file_id>/edit``. Match the
-        # ``/d/<file_id>`` slug with a trailing segment boundary (either a
-        # ``/`` or end-of-string) so neither an interior substring nor a
-        # prefix-collision (e.g. ``/d/abc`` matching ``/d/abcdef/edit``)
-        # produces a false-positive. Real-world Drive IDs are 33–44-char
-        # Base64URL strings making prefix collisions astronomically unlikely
-        # in practice, but the boundary check costs nothing.
-        drive_url_marker = f"/d/{file_id}/"
-        drive_url_tail = f"/d/{file_id}"
-
+        # A Drive-backed source echoes the requested ``file_id`` back as the
+        # ``documentId`` in its metadata (``SourceRow.drive_document_id``);
+        # it carries no URL at all, which is why the previous ``/d/<file_id>``
+        # URL-segment probe could never match and let every retry duplicate the
+        # source (#2113). Exact equality — not a substring test — so neither an
+        # interior substring nor a prefix collision (``abc`` vs ``abcdef``) can
+        # produce a false positive, and non-Drive rows (``drive_document_id is
+        # None``) can never match a requested file_id.
         async def _probe() -> Source | None:
+            if not file_id:
+                # No identity to match on. Bail out before the list() round-trip
+                # rather than letting a falsy file_id compare equal to the
+                # ``None`` ``drive_document_id`` of an unrelated source.
+                return None
             try:
                 sources = await list_sources(notebook_id)
             except (AuthError, RateLimitError, ServerError, NetworkError):
@@ -361,9 +366,7 @@ class SourceAddService:
                 )
                 return None
             for source in sources:
-                if source.url and (
-                    drive_url_marker in source.url or source.url.endswith(drive_url_tail)
-                ):
+                if source.drive_document_id == file_id:
                     return source
             return None
 

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -295,6 +295,30 @@ class SourceAddService:
         call; it is the price of telling "my create landed" apart from "a copy
         was already there".
 
+        .. note::
+           **This is a behaviour change.** ``add_drive`` now captures a baseline
+           on *every* call; previously it listed sources only inside ``_probe``,
+           which ``idempotent_create`` runs only after a transport failure. It
+           now matches the shape ``register_file_source`` has always had (an
+           unconditional pre-create baseline), so the cost is an extension of an
+           existing pattern rather than a wholly new one — but for the Drive path
+           it is new, moving from retry-only to every call.
+
+           The concrete cost: that list is a ``GET_NOTEBOOK``, and the backend
+           **writes** ``lastViewedTime`` when answering one (#2126), so every
+           ``add_drive`` now promotes the notebook to the top of the user's
+           *Recent* list in the web UI. No cheaper probe exists — source ids are
+           published only inside the ``GET_NOTEBOOK`` payload, and
+           ``LIST_NOTEBOOKS`` (which does not bump) does not carry them. The bump
+           is accepted: silently returning a pre-existing source and reporting a
+           create that never happened is far worse than a reordered Recent list.
+
+           Sibling paths, so the next reader need not re-derive it: ``add_text``
+           is ``NON_IDEMPOTENT_NO_RETRY`` and has no probe, so it has no such
+           exposure. ``add_url`` *does* share the un-baselined shape this fix
+           replaced — a notebook can hold two sources with the same URL — and is
+           tracked separately in #2204; it is deliberately not changed here.
+
         .. warning::
            The baseline establishes *when* a matching source appeared, not
            *who* created it. If two callers add the same Drive file to one
@@ -388,6 +412,13 @@ class SourceAddService:
         # one just created, silently masking a failed create. ``None`` is the
         # "baseline unavailable" sentinel; the probe then refuses to guess.
         # Mirrors ``register_file_source`` in ``_source/upload.py``.
+        #
+        # NEW on every call (it used to list only inside _probe, i.e. only after
+        # a transport failure). This list is a GET_NOTEBOOK, which the backend
+        # answers by WRITING lastViewedTime (#2126) — so every add_drive now
+        # reshuffles the user's Recent ordering. Unavoidable (source ids live
+        # only in that payload; LIST_NOTEBOOKS does not bump but does not carry
+        # them) and accepted; see the ``.. note::`` on this method.
         baseline_ids: set[str] | None
         try:
             baseline_ids = {source.id for source in await list_sources(notebook_id)}

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -546,11 +546,9 @@ class SourcesAPI:
             title: Display title. Native Drive imports re-derive the title from
                 live Drive metadata server-side, so a supplied ``title`` is honored
                 via a best-effort follow-up :meth:`rename` (non-fatal; #1960).
-            mime_type: MIME type of the Drive document. Common values:
-                - application/vnd.google-apps.document (Google Docs)
-                - application/vnd.google-apps.presentation (Slides)
-                - application/vnd.google-apps.spreadsheet (Sheets)
-                - application/pdf (PDF files in Drive)
+            mime_type: MIME type of the Drive document — ``…google-apps.document``
+                (Docs), ``…presentation`` (Slides), ``…spreadsheet`` (Sheets), or
+                ``application/pdf``. See :class:`~notebooklm.types.DriveMimeType`.
             wait: If True, wait for source to be ready before returning.
             wait_timeout: Maximum seconds to wait if wait=True (default: 120).
 
@@ -559,7 +557,6 @@ class SourcesAPI:
 
         Example:
             from notebooklm.types import DriveMimeType
-
             source = await client.sources.add_drive(
                 notebook_id, file_id="1abc123xyz", title="My Document",
                 mime_type=DriveMimeType.GOOGLE_DOC.value, wait=True)
@@ -577,7 +574,10 @@ class SourcesAPI:
             logger=logger,
             return_result=True,
         )
-        return await honor_requested_title_if_fresh(self.rename, notebook_id, result, title, logger)
+        # Baseline-filtered probe ⇒ even a PROBED result is ours to rename (#2113).
+        return await honor_requested_title_if_fresh(
+            self.rename, notebook_id, result, title, logger, probe_proves_freshness=True
+        )
 
     async def add_drive_file(
         self,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -540,15 +540,16 @@ class SourcesAPI:
     ) -> Source:
         """Add a Google Drive document as a source.
 
+        Fires one ``GET_NOTEBOOK`` before the create for the retry probe (#2113);
+        that read bumps Recent position (#2126). See the service method's docs.
+
         Args:
             notebook_id: The notebook ID.
             file_id: The Google Drive file ID.
-            title: Display title. Native Drive imports re-derive the title from
-                live Drive metadata server-side, so a supplied ``title`` is honored
-                via a best-effort follow-up :meth:`rename` (non-fatal; #1960).
-            mime_type: MIME type of the Drive document — ``…google-apps.document``
-                (Docs), ``…presentation`` (Slides), ``…spreadsheet`` (Sheets), or
-                ``application/pdf``. See :class:`~notebooklm.types.DriveMimeType`.
+            title: Display title. Drive imports re-derive it server-side, so a
+                supplied ``title`` is honored via a follow-up :meth:`rename` (#1960).
+            mime_type: Drive MIME type (Docs / Slides / Sheets /
+                ``application/pdf``) — see :class:`~notebooklm.types.DriveMimeType`.
             wait: If True, wait for source to be ready before returning.
             wait_timeout: Maximum seconds to wait if wait=True (default: 120).
 
@@ -557,9 +558,8 @@ class SourcesAPI:
 
         Example:
             from notebooklm.types import DriveMimeType
-            source = await client.sources.add_drive(
-                notebook_id, file_id="1abc123xyz", title="My Document",
-                mime_type=DriveMimeType.GOOGLE_DOC.value, wait=True)
+            source = await client.sources.add_drive(notebook_id, file_id="1abc123xyz",
+                title="My Document", mime_type=DriveMimeType.GOOGLE_DOC.value, wait=True)
         """
         result = await self._adder.add_drive(
             notebook_id,

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -88,8 +88,10 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 
 # The type_code==14 overload (#1828/#1832): the backend returns 14 for BOTH a
 # native Google Sheet AND a Drive-hosted binary file (e.g. a PDF). Live capture
-# showed Drive sources carry no URL (metadata[0]/[5]/[7] are null), so the only
-# disambiguation signal is the MIME at metadata[19] / metadata[9][2]. A native
+# showed Drive sources carry no URL (metadata[5]/[7] are null and metadata[0]
+# holds the Drive metadata block — see ``SourceRow.drive_document_id`` — rather
+# than a URL), so the only disambiguation signal is the MIME at
+# metadata[19] / metadata[9][2]. A native
 # Sheet carries "application/vnd.google-apps.spreadsheet" (→ stay 14); a Drive
 # PDF carries "application/pdf" (→ 3). Only MIMEs proven by live capture are
 # mapped; anything else under 14 is left as GOOGLE_SPREADSHEET (conservative —
@@ -209,6 +211,12 @@ class Source:
     # with a ``SourceStatus``; ``SourceStatus`` is the accurate declared type
     # and remains ``int``-compatible at runtime and for equality.
     status: SourceStatus = SourceStatus.READY
+    #: Google Drive file id for Drive-backed sources; ``None`` for every other
+    #: kind. Drive sources carry no :attr:`url` (the backend leaves the URL
+    #: slots empty), so this is the only field tying such a source back to the
+    #: ``file_id`` it was created from — ``sources.add_drive`` matches on it to
+    #: stay idempotent when a create has to be retried (#2113).
+    drive_document_id: str | None = None
 
     @property
     def kind(self) -> SourceType:
@@ -267,6 +275,7 @@ class Source:
             _type_code=type_code,
             created_at=row.created_at,
             status=row.status,
+            drive_document_id=row.drive_document_id,
         )
 
     @classmethod

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -90,8 +90,8 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 # native Google Sheet AND a Drive-hosted binary file (e.g. a PDF). Live capture
 # showed Drive sources carry no URL (metadata[5]/[7] are null and metadata[0]
 # holds the Drive metadata block — see ``SourceRow.drive_document_id`` — rather
-# than a URL), so the only disambiguation signal is the MIME at
-# metadata[19] / metadata[9][2]. A native
+# than a URL), so the only disambiguation signal is the MIME at metadata[19] /
+# metadata[9][2]. A native
 # Sheet carries "application/vnd.google-apps.spreadsheet" (→ stay 14); a Drive
 # PDF carries "application/pdf" (→ 3). Only MIMEs proven by live capture are
 # mapped; anything else under 14 is left as GOOGLE_SPREADSHEET (conservative —

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -147,13 +147,15 @@ MAPPINGS: tuple[Mapping, ...] = (
     Mapping(
         "sources",
         "SourceRow",
-        "_META_BARE_URL_POS",
+        "_META_GOOGLE_DOCS_POS",
         "SourceMetadata",
         "googleDocsMetadata",
         note=(
-            "MISLEADING NAME: index 0 is googleDocsMetadata, not a bare URL. The "
-            "url_allow_bare_http branch that reads it as a str is dead — real "
-            "metadata[0] is null 3076/3116 and a list 40/3116, never a str."
+            "renamed from _META_BARE_URL_POS in #2113 — index 0 is "
+            "googleDocsMetadata, not a bare URL. The url_allow_bare_http branch "
+            "that reads it as a str is dead: real metadata[0] is null 3076/3116 "
+            "and a list 40/3116, never a str. The list case is the Drive "
+            "documentId block read by SourceRow.drive_document_id."
         ),
     ),
     Mapping("sources", "SourceRow", "_META_URL_POS", "SourceMetadata", "webpageMetadata"),
@@ -163,6 +165,30 @@ MAPPINGS: tuple[Mapping, ...] = (
         "_META_DRIVE_DESCRIPTOR_POS",
         "SourceMetadata",
         "googleDriveSourceMetadata",
+    ),
+    # ---- Source row: the two Drive documentId slots (#2113) ----------------
+    # Both nested messages declare `documentId` as tag 1, so both constants are
+    # 0. Named separately so a reshape of either message is caught on its own.
+    Mapping(
+        "sources",
+        "SourceRow",
+        "_GOOGLE_DOCS_DOCUMENT_ID_POS",
+        "GoogleDocsSourceMetadata",
+        "documentId",
+    ),
+    Mapping(
+        "sources",
+        "SourceRow",
+        "_DRIVE_DESCRIPTOR_DOCUMENT_ID_POS",
+        "GoogleDriveSourceMetadata",
+        "documentId",
+    ),
+    Mapping(
+        "sources",
+        "SourceRow",
+        "_DRIVE_DESCRIPTOR_MIME_POS",
+        "GoogleDriveSourceMetadata",
+        "mimeType",
     ),
     # ---- Artifact row: Artifact -------------------------------------------
     Mapping("artifacts", "ArtifactRow", "_ID_POS", "Artifact", "artifactId"),
@@ -273,12 +299,11 @@ _ENVELOPE = (
 
 UNMAPPED: tuple[Unmapped, ...] = (
     # sources.py
-    # NOTE: _META_BARE_URL_POS is now a real mapping (see MAPPINGS) — index 0 is
-    # SourceMetadata.googleDocsMetadata, not a bare URL.
+    # NOTE: _META_GOOGLE_DOCS_POS (index 0) is a real mapping (see MAPPINGS) —
+    # it is SourceMetadata.googleDocsMetadata, not a bare URL.
     Unmapped("sources", "SourceRow", "_META_TIMESTAMP_POS", _UNRECOVERED),
     Unmapped("sources", "SourceRow", "_META_YOUTUBE_POS", _UNRECOVERED),
     Unmapped("sources", "SourceRow", "_META_MIME_POS", _UNRECOVERED),
-    Unmapped("sources", "SourceRow", "_DRIVE_DESCRIPTOR_MIME_POS", _NESTED_LOCAL),
     Unmapped(
         "sources",
         "SourceRow",

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -166,22 +166,20 @@ MAPPINGS: tuple[Mapping, ...] = (
         "SourceMetadata",
         "googleDriveSourceMetadata",
     ),
-    # ---- Source row: the two Drive documentId slots (#2113) ----------------
-    # Both nested messages declare `documentId` as tag 1, so both constants are
-    # 0. Named separately so a reshape of either message is caught on its own.
+    # ---- Source row: the Drive documentId slot (#2113) ---------------------
     Mapping(
         "sources",
         "SourceRow",
-        "_GOOGLE_DOCS_DOCUMENT_ID_POS",
-        "GoogleDocsSourceMetadata",
-        "documentId",
-    ),
-    Mapping(
-        "sources",
-        "SourceRow",
-        "_DRIVE_DESCRIPTOR_DOCUMENT_ID_POS",
+        "_DRIVE_DOCUMENT_ID_POS",
         "GoogleDriveSourceMetadata",
         "documentId",
+        note=(
+            "one constant indexes BOTH Drive blocks: GoogleDocsSourceMetadata "
+            "(metadata[0]) and GoogleDriveSourceMetadata (metadata[9]) each "
+            "declare documentId as tag 1, so both read index 0. Asserted here "
+            "against the Drive copy; the Docs copy is checked by "
+            "test_google_docs_document_id_shares_the_drive_tag."
+        ),
     ),
     Mapping(
         "sources",

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -46,6 +46,7 @@ from tests._guardrails._wire_contract import (
     MODULE_LEVEL,
     PINNED,
     UNMAPPED,
+    WIRE,
     Mapping,
     Pinned,
 )
@@ -377,4 +378,29 @@ def test_live_pinned_constants_unchanged(pin: Pinned) -> None:
         f"Established by: {pin.evidence}\n"
         "The proto cannot check this slot, so re-confirm against live data before "
         "changing the pin."
+    )
+
+
+def test_google_docs_document_id_shares_the_drive_tag() -> None:
+    """``SourceRow._DRIVE_DOCUMENT_ID_POS`` indexes BOTH Drive metadata blocks.
+
+    ``SourceRow.drive_document_id`` (#2113) reads one constant against two
+    different nested messages — ``GoogleDocsSourceMetadata`` at ``metadata[0]``
+    and ``GoogleDriveSourceMetadata`` at ``metadata[9]``. MAPPINGS can only
+    assert it against one of them, so this pins the other half of that claim:
+    if Google ever moves ``GoogleDocsSourceMetadata.documentId`` off tag 1, the
+    shared constant silently starts reading the wrong slot for Docs/Slides rows
+    and the add_drive idempotency probe stops matching them.
+    """
+    schema = load_proto_schema()
+    docs_tag = schema.field_tag("GoogleDocsSourceMetadata", "documentId", WIRE)
+    drive_tag = schema.field_tag("GoogleDriveSourceMetadata", "documentId", WIRE)
+    assert docs_tag == drive_tag, (
+        "GoogleDocsSourceMetadata.documentId and GoogleDriveSourceMetadata."
+        f"documentId no longer share a tag ({docs_tag} vs {drive_tag}). "
+        "SourceRow._DRIVE_DOCUMENT_ID_POS can no longer index both blocks — "
+        "split it back into two constants and register each in MAPPINGS."
+    )
+    assert _discover_constants()[("sources", "SourceRow", "_DRIVE_DOCUMENT_ID_POS")] == (
+        docs_tag - 1
     )

--- a/tests/fixtures/rpc_golden/ADD_SOURCE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE.json
@@ -148,6 +148,7 @@
     "url": null,
     "_type_code": null,
     "created_at": null,
-    "status": -1
+    "status": -1,
+    "drive_document_id": null
   }
 }

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -203,9 +203,13 @@ async def test_mcp_source_add_url_over_vcr() -> None:
         "_type_code",
         "created_at",
         "status",
+        # Drive file id for Drive-backed sources; ``None`` here (a URL add) but
+        # always present, since the projection emits every typed field (#2113).
+        "drive_document_id",
         "kind",
         "status_label",
     }
+    assert source["drive_document_id"] is None
     assert source["status"] == 2  # SourceStatus.READY
     assert source["status_label"] == "ready"
 

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -45,6 +45,7 @@ flatly keyed by request shape, not call order.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -514,7 +515,12 @@ async def test_add_drive_probe_does_not_match_unrelated_sources(
     counts = {"add": 0, "get": 0}
     transport = httpx.MockTransport(
         _drive_probe_handler(
-            baseline_rows=rows,
+            # Baseline is EMPTY on purpose: these rows must be rejected by the
+            # *match predicate*, not merely filtered out for pre-dating the add.
+            # With them in the baseline this test passes even against a
+            # substring match or the old `/d/<file_id>/` URL probe — it would
+            # only be re-testing the pre-existing-copy case.
+            baseline_rows=[],
             post_create_rows=rows,
             counts=counts,
         )
@@ -967,3 +973,141 @@ async def test_add_drive_recovered_create_still_honors_the_requested_title(auth_
     assert renames == [(src_id, requested_title)], "the recovery path skipped the rename"
     assert source.title == requested_title
     assert counts["add"] == 1
+
+
+async def test_add_drive_probe_transport_error_propagates(auth_tokens) -> None:
+    """A probe that itself 5xxes must propagate, not read as "no match".
+
+    Mirrors ``test_add_url_probe_network_error_propagates``. Swallowing it would
+    make a broken probe indistinguishable from "the create did not land", so
+    ``idempotent_create`` would retry on top of it — recreating the very
+    duplicate this probe exists to prevent.
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            # Baseline succeeds; every later list (the probe) is a hard 503.
+            if counts["add"] == 0:
+                return httpx.Response(200, text=_get_notebook_response([]))
+            return httpx.Response(503, text="probe unavailable")
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, "My Drive Doc")
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # The probe raised on the first attempt, so no second create was issued.
+    assert counts["add"] == 1
+
+
+async def test_add_drive_probe_decode_failure_warns_and_does_not_match(auth_tokens, caplog) -> None:
+    """A non-transport probe failure is loud, and still lets the retry proceed.
+
+    A drifted GET_NOTEBOOK makes the strict decoder raise ``RPCError``. That is
+    NOT a transport signal, so it must not propagate as one — but it also cannot
+    pass unremarked, because it is indistinguishable from "the create did not
+    land" and this variant has no internal retries to fall back on.
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            if counts["add"] == 0:
+                return httpx.Response(200, text=_get_notebook_response([]))
+            # Structurally undecodable notebook envelope -> RPCError, not 5xx.
+            return httpx.Response(200, text=_wrb_response(RPCMethod.GET_NOTEBOOK.value, "nonsense"))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    with caplog.at_level(logging.WARNING, logger="notebooklm._sources"):
+        try:
+            with pytest.raises(ServerError):
+                await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, "My Drive Doc")
+        finally:
+            await client._collaborators.kernel.get_http_client().aclose()
+
+    # Treated as "no match", so both attempts fire and the transport error wins.
+    assert counts["add"] == 2
+    assert "may create a duplicate Drive source" in caplog.text
+
+
+async def test_add_drive_probe_matches_on_the_second_attempt(auth_tokens) -> None:
+    """The baseline captured before attempt 1 is still correct at probe 2.
+
+    Sequence: create fails, probe finds nothing, create fails again, and only
+    then does the committed source surface (source lists lag). The single
+    pre-create baseline must still identify it as new.
+    """
+    notebook_id = "nb_test"
+    src_id = "src_late"
+    committed = _google_docs_source_row(src_id, "My Drive Doc", _DRIVE_FILE_ID)
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            # baseline (get 1) and probe 1 (get 2) see nothing; probe 2 sees it.
+            rows = [committed] if counts["get"] >= 3 else []
+            return httpx.Response(200, text=_get_notebook_response(rows))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, "My Drive Doc")
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert source.id == src_id
+    assert counts["add"] == 2, "both attempts should have fired before the probe matched"
+
+
+async def test_add_drive_baseline_unavailable_without_a_match_still_retries(auth_tokens) -> None:
+    """No baseline and no match is not ambiguous — it is simply "not committed".
+
+    The ambiguity raise must fire only when there is something to be ambiguous
+    about; otherwise a notebook that legitimately has no copy of the file would
+    turn a recoverable transport blip into a hard error.
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[_url_source_row("src_web", "A Web Page", "https://example.com")],
+            counts=counts,
+            baseline_status=500,  # baseline snapshot unavailable
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, "My Drive Doc")
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # ServerError (the real failure), not SourceAddError — and the retry ran.
+    assert counts["add"] == 2

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -918,3 +918,52 @@ def test_registry_has_variant_entries_for_add_source_and_add_source_file() -> No
     assert drive_entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
     assert text_entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
     assert file_entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
+
+
+async def test_add_drive_recovered_create_still_honors_the_requested_title(auth_tokens) -> None:
+    """A probed-but-fresh Drive add must still get the caller's title (#2113).
+
+    Drive imports re-derive the display title server-side, so ``add_drive``
+    issues a best-effort rename afterwards. That rename is normally skipped for
+    a ``PROBED`` result, because a probe match may predate the call — but this
+    probe filters against a pre-create baseline, so its match is provably ours.
+    Without the freshness signal the caller silently gets the Drive name instead
+    of the title they asked for whenever a create commits but loses its response.
+    """
+    notebook_id = "nb_test"
+    requested_title = "The Title I Asked For"
+    drive_name = "Whatever Drive Called It"
+    src_id = "src_recovered"
+
+    committed = _google_docs_source_row(src_id, drive_name, _DRIVE_FILE_ID)
+    counts = {"add": 0, "get": 0}
+    renames: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            rows = [] if counts["add"] == 0 else [committed]
+            return httpx.Response(200, text=_get_notebook_response(rows))
+        if rpc_id == RPCMethod.UPDATE_SOURCE.value:
+            renames.append((src_id, requested_title))
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.UPDATE_SOURCE.value, [[src_id], requested_title]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, requested_title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert source.id == src_id
+    assert renames == [(src_id, requested_title)], "the recovery path skipped the rename"
+    assert source.title == requested_title
+    assert counts["add"] == 1

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -54,7 +54,13 @@ import pytest
 import notebooklm._runtime.helpers as _runtime_helpers
 from notebooklm import NotebookLMClient
 from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
-from notebooklm.exceptions import NetworkError, NotebookLMError
+from notebooklm.exceptions import (
+    NetworkError,
+    NotebookLMError,
+    ServerError,
+    SourceAddError,
+    ValidationError,
+)
 from notebooklm.rpc import RPCMethod
 from tests._fixtures.kernel_test_helpers import install_http_client_for_test
 
@@ -143,7 +149,7 @@ def _drive_descriptor_source_row(src_id: str, title: str, document_id: str) -> l
     return [[src_id], title, metadata, [None, 2]]
 
 
-def _get_notebook_response(notebook_id: str, src_rows: list) -> str:
+def _get_notebook_response(src_rows: list) -> str:
     """Build a GET_NOTEBOOK response from pre-built source rows."""
     return _wrb_response(RPCMethod.GET_NOTEBOOK.value, [["Test Notebook", src_rows]])
 
@@ -242,11 +248,52 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
 
 
 _DRIVE_ROW_BUILDERS = {
-    # metadata[0] — googleDocsMetadata.documentId (Google-native Doc/Slides/Sheet)
+    # metadata[0] — googleDocsMetadata.documentId. Live-observed on type codes
+    # 1 (Docs) and 2 (Slides).
     "google_docs_metadata": _google_docs_source_row,
-    # metadata[9] — googleDriveSourceMetadata.documentId (Drive-hosted binary)
+    # metadata[9] — googleDriveSourceMetadata.documentId. Live-observed on type
+    # code 14 (Drive-hosted files, incl. native Sheets and Drive PDFs).
     "drive_descriptor": _drive_descriptor_source_row,
 }
+
+#: A Drive file id as it appears on the wire (44-char Base64URL), from the live
+#: ADD_SOURCE capture in ``tests/cassettes/sources_add_drive.yaml``.
+_DRIVE_FILE_ID = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
+
+
+def _drive_probe_handler(
+    *,
+    baseline_rows: list,
+    post_create_rows: list,
+    counts: dict[str, int],
+    baseline_status: int = 200,
+):
+    """Build a mock handler modelling the real add_drive call sequence.
+
+    ``add_drive`` lists once *before* the create to snapshot a baseline, then
+    the create 502s, then the probe lists again. Returning different notebook
+    contents for the two GET_NOTEBOOK calls is what lets a test distinguish "the
+    create landed" from "a copy was already there".
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            # Any list before the first create attempt is the baseline snapshot;
+            # anything after it is a probe. Keyed off the create rather than a
+            # call index so an internally-retried baseline still counts as one.
+            if counts["add"] == 0:
+                if baseline_status != 200:
+                    return httpx.Response(baseline_status, text="baseline unavailable")
+                return httpx.Response(200, text=_get_notebook_response(baseline_rows))
+            return httpx.Response(200, text=_get_notebook_response(post_create_rows))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    return handler
 
 
 @pytest.mark.parametrize("slot", sorted(_DRIVE_ROW_BUILDERS), ids=sorted(_DRIVE_ROW_BUILDERS))
@@ -260,56 +307,159 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(
     thing standing between the user and a second copy of the same Drive file.
 
     Both live-captured Drive row shapes are exercised: the ``documentId`` lands
-    in ``metadata[0]`` for a Google-native doc and in ``metadata[9]`` for a
-    Drive-hosted binary. Neither row carries a URL — the previous
+    in ``metadata[0]`` for a Google-native Doc/Slides and in ``metadata[9]`` for
+    a Drive-hosted file. Neither row carries a URL — the previous
     ``/d/<file_id>``-in-``source.url`` probe therefore matched nothing and let
     ``idempotent_create`` re-issue the add every single time.
     """
     notebook_id = "nb_test"
-    file_id = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
     title = "My Drive Doc"
     src_id = "src_drive_lost"
 
-    add_count = 0
-    get_count = 0
+    # A neighbouring non-Drive source proves the probe skips rows whose
+    # ``drive_document_id`` is ``None``.
+    web_row = _url_source_row("src_web", "A Web Page", "https://example.com/article")
+    committed = _DRIVE_ROW_BUILDERS[slot](src_id, title, _DRIVE_FILE_ID)
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal add_count, get_count
-        rpc_id = _rpc_id_in_request(request)
-        if rpc_id == RPCMethod.ADD_SOURCE.value:
-            add_count += 1
-            return httpx.Response(502, text="bad gateway")
-        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
-            get_count += 1
-            return httpx.Response(
-                200,
-                text=_get_notebook_response(
-                    notebook_id,
-                    [
-                        # A neighbouring non-Drive source proves the probe skips
-                        # rows whose ``drive_document_id`` is ``None``.
-                        _url_source_row("src_web", "A Web Page", "https://example.com/article"),
-                        _DRIVE_ROW_BUILDERS[slot](src_id, title, file_id),
-                    ],
-                ),
-            )
-        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
-
-    transport = httpx.MockTransport(handler)
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=[web_row],
+            post_create_rows=[web_row, committed],
+            counts=counts,
+        )
+    )
     client = _make_client_with_transport(transport, auth_tokens)
     try:
-        source = await client.sources.add_drive(notebook_id, file_id, title)
+        source = await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, title)
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
     assert source.id == src_id
     # The committed source is recognised by its Drive documentId, not a URL.
-    assert source.drive_document_id == file_id
+    assert source.drive_document_id == _DRIVE_FILE_ID
     assert source.url is None
     # Exactly ONE ADD_SOURCE — the retry that would have duplicated the file
-    # never fires.
-    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+    # never fires — and exactly TWO lists (baseline + probe).
+    assert counts == {"add": 1, "get": 2}
+
+
+async def test_add_drive_probe_ignores_a_pre_existing_copy_of_the_same_file(
+    auth_tokens,
+) -> None:
+    """A Drive file already in the notebook must not be adopted as "my create".
+
+    ``documentId`` is NOT unique within a notebook — the backend lets the same
+    Drive file be added twice, and the live capture in
+    ``tests/cassettes/sources_check_freshness_drive.yaml`` contains exactly that
+    (two source ids sharing one documentId). Without the baseline filter the
+    probe would return the pre-existing copy and report success even though the
+    create never landed, hiding the failure instead of surfacing it.
+    """
+    notebook_id = "nb_test"
+    title = "My Drive Doc"
+    # Present before the add, and still the only match afterwards: the create
+    # genuinely did not land.
+    pre_existing = _google_docs_source_row("src_pre_existing", "Older Copy", _DRIVE_FILE_ID)
+
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=[pre_existing],
+            post_create_rows=[pre_existing],
+            counts=counts,
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # The probe found no *new* match, so idempotent_create retried, exhausted
+    # its two attempts, and re-raised the transport error rather than handing
+    # back a source the caller did not create.
+    assert counts["add"] == 2
+
+
+async def test_add_drive_probe_raises_when_baseline_unavailable_and_a_copy_exists(
+    auth_tokens,
+) -> None:
+    """No baseline + a matching source = ambiguity, surfaced rather than guessed.
+
+    Mirrors ``register_file_source``'s contract: when the pre-create snapshot
+    could not be taken, a match may or may not predate the add, and silently
+    picking one is the data-corruption mode the baseline exists to prevent.
+    """
+    notebook_id = "nb_test"
+    title = "My Drive Doc"
+    existing = _google_docs_source_row("src_ambiguous", "Some Copy", _DRIVE_FILE_ID)
+
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[existing],
+            counts=counts,
+            baseline_status=500,  # baseline snapshot unavailable
+        )
+    )
+    # No executor-level retries: the baseline 500 should fail fast here, the
+    # point of the test being what the *probe* does afterwards.
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+
+async def test_add_drive_probe_raises_when_multiple_new_matches_appear(auth_tokens) -> None:
+    """Two *new* sources with the requested documentId is ambiguity, not a match."""
+    notebook_id = "nb_test"
+    title = "My Drive Doc"
+    first = _google_docs_source_row("src_new_a", title, _DRIVE_FILE_ID)
+    second = _google_docs_source_row("src_new_b", title, _DRIVE_FILE_ID)
+
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[first, second],
+            counts=counts,
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+
+async def test_add_drive_rejects_a_blank_file_id_before_writing(auth_tokens) -> None:
+    """A blank Drive id fails validation instead of POSTing an unmatchable add.
+
+    A blank id can never be matched by the probe (a row's ``drive_document_id``
+    is never ``""``), so without this guard a transport failure would retry the
+    blank add and could leave two garbage sources behind.
+    """
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counts["add"] += 1
+        return httpx.Response(200, text="should never be reached")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ValidationError):
+            await client.sources.add_drive("nb_test", "   ", "My Drive Doc")
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert counts["add"] == 0, "no RPC may be issued for a blank file_id"
 
 
 @pytest.mark.parametrize(
@@ -354,40 +504,30 @@ async def test_add_drive_probe_does_not_match_unrelated_sources(
     returned in place of the one being created.
 
     In each case the probe must return ``None`` so ``idempotent_create``
-    retries the create rather than handing back the wrong source.
+    retries the create rather than handing back the wrong source — so both
+    attempts fire and the transport error is re-raised.
     """
-    from notebooklm.exceptions import ServerError
-
     notebook_id = "nb_test"
-    file_id = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
     title = "My Drive Doc"
+    rows = existing_rows_factory(_DRIVE_FILE_ID)
 
-    add_count = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal add_count
-        rpc_id = _rpc_id_in_request(request)
-        if rpc_id == RPCMethod.ADD_SOURCE.value:
-            add_count += 1
-            return httpx.Response(502, text="bad gateway")
-        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
-            return httpx.Response(
-                200,
-                text=_get_notebook_response(notebook_id, existing_rows_factory(file_id)),
-            )
-        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
-
-    transport = httpx.MockTransport(handler)
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _drive_probe_handler(
+            baseline_rows=rows,
+            post_create_rows=rows,
+            counts=counts,
+        )
+    )
     client = _make_client_with_transport(transport, auth_tokens)
     try:
         with pytest.raises(ServerError):
-            await client.sources.add_drive(notebook_id, file_id, title)
+            await client.sources.add_drive(notebook_id, _DRIVE_FILE_ID, title)
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
-    # The probe must NOT have spuriously matched — the wrapper retried,
-    # exhausted, and re-raised.
-    assert add_count >= 1
+    # Both create attempts fired: the probe never spuriously matched.
+    assert counts["add"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -497,8 +637,6 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
     The load-bearing assertion is that the wrapper does NOT return the
     pre-existing source's id under any failure mode.
     """
-    from notebooklm.exceptions import ServerError
-
     notebook_id = "nb_test"
     filename = "report.pdf"
     pre_existing_src_id = "src_OLD_report"

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -17,9 +17,11 @@ sources when the server already committed the write before returning the
    the second attempt. The probe is variant-specific:
 
      - ``add_url`` probes by ``source.url == url``
-     - ``add_drive`` probes by ``/d/<file_id>`` URL-segment marker with a
-       trailing boundary (avoids interior-substring + prefix-collision
-       false-positives)
+     - ``add_drive`` probes by ``source.drive_document_id == file_id`` — the
+       Drive ``documentId`` the backend echoes back in the source metadata.
+       It previously probed a ``/d/<file_id>`` marker inside ``source.url``,
+       which could never match because Drive sources carry no URL at all, so
+       every retry duplicated the source (#2113).
      - ``register_file_source`` probes by baseline-diff + ``source.title ==
        filename`` (filenames are not identity-bearing, so the wrapper
        captures source-ids before the create and filters probe matches to
@@ -84,15 +86,66 @@ def _get_notebook_with_sources_response(
     at index ``[7]`` when present (matches ``_extract_source_url`` precedence
     with ``allow_bare_http=False``).
     """
-    src_rows: list = []
-    for src_id, title, url in sources:
-        metadata: list = [None] * 8
-        if url is not None:
-            metadata[7] = [url]
-        status_block = [None, 2]  # READY
-        src_rows.append([[src_id], title, metadata, status_block])
+    src_rows: list = [_url_source_row(src_id, title, url) for src_id, title, url in sources]
     nb_info = ["Test Notebook", src_rows]
     return _wrb_response(RPCMethod.GET_NOTEBOOK.value, [nb_info])
+
+
+def _url_source_row(src_id: str, title: str, url: str | None) -> list:
+    """One non-Drive source row: URL (when any) at ``metadata[7][0]``.
+
+    Mirrors the live-captured web-page shape
+    ``[[id], title, [null, 28940, [ts, ns], [uuid, [ts, ns]], 5, null, 1, [url]], [null, 2]]``
+    from ``tests/cassettes/sources_check_freshness_drive.yaml``, trimmed to the
+    slots the probe paths read.
+    """
+    metadata: list = [None] * 8
+    if url is not None:
+        metadata[4] = 5  # SourceType.WEB_PAGE
+        metadata[7] = [url]
+    return [[src_id], title, metadata, [None, 2]]  # status block: READY
+
+
+def _google_docs_source_row(src_id: str, title: str, document_id: str) -> list:
+    """One Drive row whose id lands in ``metadata[0]`` (googleDocsMetadata).
+
+    Shape copied verbatim (ids aside) from the live GET_NOTEBOOK capture in
+    ``tests/cassettes/sources_check_freshness_drive.yaml`` and the live
+    ADD_SOURCE capture in ``tests/cassettes/sources_add_drive.yaml``: the Drive
+    metadata block sits at ``metadata[0]`` and **no** URL slot is populated —
+    which is exactly why the old URL-based probe could never match (#2113).
+    """
+    metadata: list = [
+        [document_id, "SCRUBBED_AONS", 12],
+        911,
+        [1769105469, 316769000],
+        ["d4325602-2399-44c2-b45b-9df8f433189f", [1769105982, 178269000]],
+        1,  # SourceType.GOOGLE_DOCS
+        None,
+        1,
+    ]
+    return [[src_id], title, metadata, [None, 2]]
+
+
+def _drive_descriptor_source_row(src_id: str, title: str, document_id: str) -> list:
+    """One Drive row whose id lands in ``metadata[9]`` (googleDriveSourceMetadata).
+
+    The Drive-hosted-binary shape: the descriptor
+    ``[document_id, kind_int, mime, ""]`` at ``metadata[9]`` plus the top-level
+    MIME at ``metadata[19]``, as captured for #1832 (a Drive PDF arrives with
+    the ambiguous ``type_code == 14``). No URL slot here either.
+    """
+    metadata: list = [None] * 20
+    metadata[2] = [1769105469, 316769000]
+    metadata[4] = 14  # ambiguous native-Sheet / Drive-binary code
+    metadata[9] = [document_id, 8, "application/pdf", ""]
+    metadata[19] = "application/pdf"
+    return [[src_id], title, metadata, [None, 2]]
+
+
+def _get_notebook_response(notebook_id: str, src_rows: list) -> str:
+    """Build a GET_NOTEBOOK response from pre-built source rows."""
+    return _wrb_response(RPCMethod.GET_NOTEBOOK.value, [["Test Notebook", src_rows]])
 
 
 def _make_client_with_transport(
@@ -188,20 +241,34 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
 # ---------------------------------------------------------------------------
 
 
-async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_tokens) -> None:
-    """Drive sources: 503 + ``/d/<file_id>`` segment probe returns existing source.
+_DRIVE_ROW_BUILDERS = {
+    # metadata[0] — googleDocsMetadata.documentId (Google-native Doc/Slides/Sheet)
+    "google_docs_metadata": _google_docs_source_row,
+    # metadata[9] — googleDriveSourceMetadata.documentId (Drive-hosted binary)
+    "drive_descriptor": _drive_descriptor_source_row,
+}
 
-    Drive sources canonically embed the file_id as a path segment of
-    ``source.url`` (typical shape: ``https://docs.google.com/document/d/<file_id>/edit``).
-    The probe matches by ``/d/<file_id>/`` segment marker (with trailing
-    boundary) so neither interior-substring nor prefix collisions can
-    spuriously match — see the dedicated false-positive tests below.
+
+@pytest.mark.parametrize("slot", sorted(_DRIVE_ROW_BUILDERS), ids=sorted(_DRIVE_ROW_BUILDERS))
+async def test_add_drive_probe_short_circuits_when_first_response_lost(
+    auth_tokens, slot: str
+) -> None:
+    """Commit-lost-response on a Drive add must NOT duplicate the source (#2113).
+
+    The server committed the create and then the response was lost (5xx). With
+    ``disable_internal_retries=True`` on this variant, the probe is the only
+    thing standing between the user and a second copy of the same Drive file.
+
+    Both live-captured Drive row shapes are exercised: the ``documentId`` lands
+    in ``metadata[0]`` for a Google-native doc and in ``metadata[9]`` for a
+    Drive-hosted binary. Neither row carries a URL — the previous
+    ``/d/<file_id>``-in-``source.url`` probe therefore matched nothing and let
+    ``idempotent_create`` re-issue the add every single time.
     """
     notebook_id = "nb_test"
-    file_id = "drive_file_abc123xyz"
+    file_id = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
     title = "My Drive Doc"
     src_id = "src_drive_lost"
-    drive_url = f"https://docs.google.com/document/d/{file_id}/edit"
 
     add_count = 0
     get_count = 0
@@ -216,117 +283,14 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_toke
             get_count += 1
             return httpx.Response(
                 200,
-                text=_get_notebook_with_sources_response(notebook_id, [(src_id, title, drive_url)]),
-            )
-        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
-
-    transport = httpx.MockTransport(handler)
-    client = _make_client_with_transport(transport, auth_tokens)
-    try:
-        source = await client.sources.add_drive(notebook_id, file_id, title)
-    finally:
-        await client._collaborators.kernel.get_http_client().aclose()
-
-    assert source.id == src_id
-    assert file_id in (source.url or "")
-    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
-
-
-async def test_add_drive_probe_matches_segment_at_end_of_url(auth_tokens) -> None:
-    """Drive probe correctly handles ``/d/<file_id>`` at the very end of the URL.
-
-    Some Drive URLs are stored without a trailing ``/edit`` or other path
-    suffix (e.g. ``https://docs.google.com/document/d/<file_id>``). The
-    end-of-string branch of the probe ensures these still match.
-    """
-    notebook_id = "nb_test"
-    file_id = "drive_file_xyz123"
-    title = "Untrailing Drive Doc"
-    src_id = "src_drive_no_trailing"
-    drive_url = f"https://docs.google.com/document/d/{file_id}"  # no trailing /
-
-    add_count = 0
-    get_count = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal add_count, get_count
-        rpc_id = _rpc_id_in_request(request)
-        if rpc_id == RPCMethod.ADD_SOURCE.value:
-            add_count += 1
-            return httpx.Response(502, text="bad gateway")
-        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
-            get_count += 1
-            return httpx.Response(
-                200,
-                text=_get_notebook_with_sources_response(notebook_id, [(src_id, title, drive_url)]),
-            )
-        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
-
-    transport = httpx.MockTransport(handler)
-    client = _make_client_with_transport(transport, auth_tokens)
-    try:
-        source = await client.sources.add_drive(notebook_id, file_id, title)
-    finally:
-        await client._collaborators.kernel.get_http_client().aclose()
-
-    assert source.id == src_id
-    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
-
-
-@pytest.mark.parametrize(
-    "other_drive_url",
-    [
-        # Interior substring: contains ``abc`` but not as a ``/d/abc/`` segment.
-        "https://docs.google.com/document/d/xabcy/edit",
-        # Prefix collision: another file_id begins with the target file_id.
-        # ``/d/abc`` IS a substring of ``/d/abcdef/edit`` but the trailing
-        # boundary check rejects it.
-        "https://docs.google.com/document/d/abcdef/edit",
-    ],
-    ids=["interior_substring", "prefix_collision"],
-)
-async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
-    auth_tokens, other_drive_url: str
-) -> None:
-    """Drive probe uses ``/d/<file_id>/`` segment match with trailing boundary.
-
-    Regression guard against two false-positive shapes the probe must reject:
-
-    * **Interior substring**: ``/d/xabcy/`` contains ``abc`` as a naked
-      substring, so the original ``file_id in source.url`` check would
-      spuriously match.
-    * **Prefix collision**: ``/d/abc`` is also a substring of ``/d/abcdef/``,
-      so the simpler ``/d/<file_id>`` segment marker (without a trailing
-      boundary) would still false-positive. Real-world Drive IDs are 33–44
-      character Base64URL strings making prefix collisions astronomically
-      unlikely, but the boundary check is essentially free.
-
-    In both cases the probe must return ``None`` so ``idempotent_create``
-    retries the create rather than returning the unrelated source.
-    """
-    from notebooklm.exceptions import ServerError
-
-    notebook_id = "nb_test"
-    target_file_id = "abc"  # short file_id chosen to maximize collision chance
-    title = "My Drive Doc"
-
-    add_count = 0
-    get_count = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal add_count, get_count
-        rpc_id = _rpc_id_in_request(request)
-        if rpc_id == RPCMethod.ADD_SOURCE.value:
-            add_count += 1
-            return httpx.Response(502, text="bad gateway")
-        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
-            get_count += 1
-            return httpx.Response(
-                200,
-                text=_get_notebook_with_sources_response(
-                    notebook_id, [("src_other", title, other_drive_url)]
+                text=_get_notebook_response(
+                    notebook_id,
+                    [
+                        # A neighbouring non-Drive source proves the probe skips
+                        # rows whose ``drive_document_id`` is ``None``.
+                        _url_source_row("src_web", "A Web Page", "https://example.com/article"),
+                        _DRIVE_ROW_BUILDERS[slot](src_id, title, file_id),
+                    ],
                 ),
             )
         return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
@@ -334,13 +298,95 @@ async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens)
     try:
-        with pytest.raises(ServerError):
-            await client.sources.add_drive(notebook_id, target_file_id, title)
+        source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
-    # The probe must NOT have spuriously matched the unrelated Drive
-    # source — instead the wrapper retried, exhausted, and re-raised.
+    assert source.id == src_id
+    # The committed source is recognised by its Drive documentId, not a URL.
+    assert source.drive_document_id == file_id
+    assert source.url is None
+    # Exactly ONE ADD_SOURCE — the retry that would have duplicated the file
+    # never fires.
+    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
+    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+
+
+@pytest.mark.parametrize(
+    "existing_rows_factory",
+    [
+        # A different Drive file in the same notebook must not be adopted.
+        pytest.param(
+            lambda file_id: [_google_docs_source_row("src_other", "Other Doc", file_id + "_other")],
+            id="different_drive_file",
+        ),
+        # A prefix collision: the stored id merely starts with the requested one.
+        pytest.param(
+            lambda file_id: [
+                _drive_descriptor_source_row("src_other", "Other PDF", file_id + "SUFFIX")
+            ],
+            id="prefix_collision",
+        ),
+        # Non-Drive rows decode ``drive_document_id`` as ``None`` and must never
+        # match — including a web source whose URL happens to embed the very
+        # ``/d/<file_id>/`` slug the old probe keyed on.
+        pytest.param(
+            lambda file_id: [
+                _url_source_row(
+                    "src_web",
+                    "A Web Page",
+                    f"https://docs.google.com/document/d/{file_id}/edit",
+                ),
+                _url_source_row("src_web2", "Another Page", None),
+            ],
+            id="non_drive_rows",
+        ),
+    ],
+)
+async def test_add_drive_probe_does_not_match_unrelated_sources(
+    auth_tokens, existing_rows_factory
+) -> None:
+    """The probe matches the Drive ``documentId`` exactly — nothing else.
+
+    Exact equality on an identity-bearing field removes the whole
+    substring/prefix false-positive class the URL probe had to defend against,
+    and ``None`` on every non-Drive row means an unrelated source can never be
+    returned in place of the one being created.
+
+    In each case the probe must return ``None`` so ``idempotent_create``
+    retries the create rather than handing back the wrong source.
+    """
+    from notebooklm.exceptions import ServerError
+
+    notebook_id = "nb_test"
+    file_id = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
+    title = "My Drive Doc"
+
+    add_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            return httpx.Response(
+                200,
+                text=_get_notebook_response(notebook_id, existing_rows_factory(file_id)),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_drive(notebook_id, file_id, title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # The probe must NOT have spuriously matched — the wrapper retried,
+    # exhausted, and re-raised.
     assert add_count >= 1
 
 

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -513,6 +513,12 @@ class TestSourcesAPI:
         build_rpc_response,
     ):
         """Test adding a Google Drive source."""
+        # add_drive snapshots the notebook's source ids before the create so its
+        # idempotency probe can tell a fresh add from a pre-existing copy of the
+        # same Drive file (#2113), so the first request is a GET_NOTEBOOK.
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         response = build_rpc_response(
             RPCMethod.ADD_SOURCE,
             [[[["drive_001"], "My Doc", [None, 0], [None, 2]]]],
@@ -528,8 +534,9 @@ class TestSourcesAPI:
             )
 
         assert source is not None
-        request = httpx_mock.get_request()
-        assert RPCMethod.ADD_SOURCE in str(request.url)
+        urls = [str(request.url) for request in httpx_mock.get_requests()]
+        assert any(RPCMethod.GET_NOTEBOOK in url for url in urls)
+        assert any(RPCMethod.ADD_SOURCE in url for url in urls)
 
     @pytest.mark.asyncio
     async def test_refresh_source(
@@ -1869,6 +1876,10 @@ class TestAddDriveWait:
         build_rpc_response,
     ):
         """Test add_drive() with wait=True calls wait_until_ready (line 526)."""
+        # First request is add_drive's pre-create baseline snapshot (#2113).
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         response = build_rpc_response(
             RPCMethod.ADD_SOURCE,
             [[[["drive_src_wait"], "My Drive Doc", [None, 0], [None, 2]]]],

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -218,8 +218,13 @@ class TestAddSourceDrive:
         """Test add_drive creates the expected payload."""
         # Echo the requested title so the #1960 honor-title path is a no-op (the
         # add already returned "My Document") and only the ADD_SOURCE call fires.
+        # First response is the pre-create baseline GET_NOTEBOOK (an empty
+        # notebook), second is the ADD_SOURCE echo.
         rpc_call = AsyncMock(
-            return_value=[[[["source_id_123"], "My Document", [None, 0], [None, 2]]]]
+            side_effect=[
+                [["Notebook", []]],
+                [[[["source_id_123"], "My Document", [None, 0], [None, 2]]]],
+            ]
         )
         core = make_fake_core(rpc_call=rpc_call)
         sources = SourcesAPI(core.rpc_executor, uploader=MagicMock())

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -231,9 +231,12 @@ class TestAddSourceDrive:
             mime_type=DriveMimeType.GOOGLE_DOC.value,
         )
 
-        rpc_call.assert_called_once()
-        call_args = rpc_call.call_args
-        params = call_args[0][1]
+        # Two calls: add_drive first snapshots the notebook's source ids so its
+        # idempotency probe can tell a fresh add from a pre-existing copy of the
+        # same Drive file (#2113), then issues the ADD_SOURCE.
+        methods = [call.args[0] for call in rpc_call.call_args_list]
+        assert methods == [RPCMethod.GET_NOTEBOOK, RPCMethod.ADD_SOURCE]
+        params = rpc_call.call_args_list[-1].args[1]
 
         # Verify source data structure - params[0] is [source_data] (single wrap)
         source_data = params[0][0]

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1237,8 +1237,8 @@ class TestSourceRowPositionContract:
         assert SourceRow._STATUS_INNER_POS == 1
 
     def test_metadata_positions(self) -> None:
-        """Metadata-sub-list positions: bare-url, timestamp, type, yt, url."""
-        assert SourceRow._META_BARE_URL_POS == 0
+        """Metadata-sub-list positions: google-docs block, timestamp, type, yt, url."""
+        assert SourceRow._META_GOOGLE_DOCS_POS == 0
         assert SourceRow._META_TIMESTAMP_POS == 2
         assert SourceRow._META_TYPE_POS == 4
         assert SourceRow._META_YOUTUBE_POS == 5
@@ -1248,6 +1248,9 @@ class TestSourceRowPositionContract:
         assert SourceRow._META_DRIVE_DESCRIPTOR_POS == 9
         assert SourceRow._META_MIME_POS == 19
         assert SourceRow._DRIVE_DESCRIPTOR_MIME_POS == 2
+        # Drive documentId positions — both messages declare it as tag 1 (#2113).
+        assert SourceRow._GOOGLE_DOCS_DOCUMENT_ID_POS == 0
+        assert SourceRow._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS == 0
 
     def test_id_envelope_positions(self) -> None:
         """Id-envelope positions: plain id at [0]; drive-backed at [2][0]."""
@@ -1271,7 +1274,7 @@ class TestSourceRowPositionContract:
             SourceRow._METADATA_POS,
             SourceRow._STATUS_BLOCK_POS,
             SourceRow._STATUS_INNER_POS,
-            SourceRow._META_BARE_URL_POS,
+            SourceRow._META_GOOGLE_DOCS_POS,
             SourceRow._META_TIMESTAMP_POS,
             SourceRow._META_TYPE_POS,
             SourceRow._META_YOUTUBE_POS,
@@ -1279,11 +1282,13 @@ class TestSourceRowPositionContract:
             SourceRow._META_DRIVE_DESCRIPTOR_POS,
             SourceRow._META_MIME_POS,
             SourceRow._DRIVE_DESCRIPTOR_MIME_POS,
+            SourceRow._GOOGLE_DOCS_DOCUMENT_ID_POS,
+            SourceRow._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS,
             SourceRow._ID_ENVELOPE_PLAIN_POS,
             SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
             SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
             SourceRow._LIST_FIRST_POS,
-        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 2, 0, 0)
+        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 0, 0, 2, 0, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1248,9 +1248,9 @@ class TestSourceRowPositionContract:
         assert SourceRow._META_DRIVE_DESCRIPTOR_POS == 9
         assert SourceRow._META_MIME_POS == 19
         assert SourceRow._DRIVE_DESCRIPTOR_MIME_POS == 2
-        # Drive documentId positions — both messages declare it as tag 1 (#2113).
-        assert SourceRow._GOOGLE_DOCS_DOCUMENT_ID_POS == 0
-        assert SourceRow._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS == 0
+        # Drive documentId position — one constant for both blocks, since
+        # GoogleDocs/GoogleDrive SourceMetadata both declare it as tag 1 (#2113).
+        assert SourceRow._DRIVE_DOCUMENT_ID_POS == 0
 
     def test_id_envelope_positions(self) -> None:
         """Id-envelope positions: plain id at [0]; drive-backed at [2][0]."""
@@ -1282,13 +1282,12 @@ class TestSourceRowPositionContract:
             SourceRow._META_DRIVE_DESCRIPTOR_POS,
             SourceRow._META_MIME_POS,
             SourceRow._DRIVE_DESCRIPTOR_MIME_POS,
-            SourceRow._GOOGLE_DOCS_DOCUMENT_ID_POS,
-            SourceRow._DRIVE_DESCRIPTOR_DOCUMENT_ID_POS,
+            SourceRow._DRIVE_DOCUMENT_ID_POS,
             SourceRow._ID_ENVELOPE_PLAIN_POS,
             SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
             SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
             SourceRow._LIST_FIRST_POS,
-        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 0, 0, 2, 0, 0)
+        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 0, 2, 0, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -427,3 +427,155 @@ def test_non_14_type_code_with_pdf_mime_is_untouched() -> None:
     src = Source.from_row(_row(_meta_with(type_code=5, mime="application/pdf")))
     assert src._type_code == 5
     assert src.kind == SourceType.WEB_PAGE
+
+
+# --- #2113: SourceRow.drive_document_id (the add_drive idempotency key) ------
+
+#: A Drive file id as it appears on the wire (44-char Base64URL), taken from the
+#: live ADD_SOURCE capture in ``tests/cassettes/sources_add_drive.yaml``.
+_DRIVE_FILE_ID = "1oAk_INJHbIPsIh49jgNqj3FESSGHZrzxFY7t05Lvvl0"
+
+
+def _live_google_docs_row(document_id: str = _DRIVE_FILE_ID) -> SourceRow:
+    """The live-captured Google-native Drive row (``metadata[0]`` block).
+
+    Copied verbatim (ids aside) from the ADD_SOURCE response in
+    ``tests/cassettes/sources_add_drive.yaml`` — note that NO url slot is
+    populated, which is the whole reason #2113 existed.
+    """
+    return SourceRow.from_entry(
+        [
+            ["ef72c03c-b429-41cb-ae79-8529d35d6d5b"],
+            "Rubisco Research: Status and Future",
+            [
+                [document_id, "SCRUBBED_AONS", 17],
+                3737,
+                [1769198541, 320332000],
+                ["a25483bc-01fc-4e64-9deb-d2c2cf001887", [1769198540, 885478000]],
+                1,
+                None,
+                1,
+                None,
+                7610,
+            ],
+            [None, 2],
+        ]
+    )
+
+
+def test_drive_document_id_from_google_docs_metadata() -> None:
+    """``metadata[0][0]`` is the Drive documentId on a Google-native row."""
+    row = _live_google_docs_row()
+    assert row.drive_document_id == _DRIVE_FILE_ID
+    # The row that motivated #2113: an identity-bearing id but no URL at all.
+    assert row.url is None
+
+
+def test_drive_document_id_from_drive_descriptor() -> None:
+    """``metadata[9][0]`` is the Drive documentId on a Drive-hosted binary row."""
+    meta = _meta_with(type_code=14, mime="application/pdf", descriptor_mime="application/pdf")
+    meta[9] = [_DRIVE_FILE_ID, 8, "application/pdf", ""]
+    row = _row(meta)
+    assert row.drive_document_id == _DRIVE_FILE_ID
+    assert row.url is None
+
+
+def test_drive_document_id_prefers_google_docs_block_when_both_present() -> None:
+    """Both blocks populated: the ``metadata[0]`` block wins (documented order)."""
+    meta = _meta_with(type_code=1)
+    meta[0] = ["docs-id", "opaque", 17]
+    meta[9] = ["descriptor-id", 8, "application/pdf", ""]
+    assert _row(meta).drive_document_id == "docs-id"
+
+
+def test_drive_document_id_falls_back_when_google_docs_block_absent() -> None:
+    """An empty ``metadata[0]`` block does not shadow the descriptor."""
+    meta = _meta_with(type_code=14)
+    meta[0] = []
+    meta[9] = ["descriptor-id", 8, "application/pdf", ""]
+    assert _row(meta).drive_document_id == "descriptor-id"
+
+
+def test_drive_document_id_is_none_for_web_page_row() -> None:
+    """A live-shaped web-page row (``metadata[0]`` null, URL at ``[7]``) yields None.
+
+    Shape from the GET_NOTEBOOK capture in
+    ``tests/cassettes/sources_check_freshness_drive.yaml``.
+    """
+    row = SourceRow.from_entry(
+        [
+            ["e9e0faae-89b3-4e38-9528-90cd47d8d356"],
+            "Google - Wikipedia",
+            [
+                None,
+                28940,
+                [1769104954, 651598000],
+                ["1274153a-22ea-4acd-bb3d-886c695bff05", [1769104954, 395827000]],
+                5,
+                None,
+                1,
+                ["https://en.wikipedia.org/wiki/Google"],
+            ],
+            [None, 2],
+        ]
+    )
+    assert row.drive_document_id is None
+    assert row.url == "https://en.wikipedia.org/wiki/Google"
+
+
+def test_drive_document_id_is_none_without_metadata() -> None:
+    """A row with no metadata sub-list has no Drive id."""
+    assert SourceRow.from_entry([["src-id"], "Title"]).drive_document_id is None
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        # The legacy bare-http string honored by ``url_allow_bare_http``: a str
+        # must never be indexed character-wise into a one-char "id".
+        "https://example.com/page",
+        None,
+        [],  # present but empty
+        [None],  # documentId slot explicitly null
+        [""],  # documentId slot blank
+        [42],  # non-string
+        {"documentId": "x"},  # non-list container
+    ],
+    ids=["bare_http_str", "null", "empty", "null_id", "blank_id", "non_string", "non_list"],
+)
+def test_drive_document_id_rejects_malformed_google_docs_block(block: object) -> None:
+    meta = _meta_with(type_code=1)
+    meta[0] = block
+    assert _row(meta).drive_document_id is None
+
+
+@pytest.mark.parametrize(
+    "block",
+    [None, [], [None], [""], [42], "not-a-list"],
+    ids=["null", "empty", "null_id", "blank_id", "non_string", "non_list"],
+)
+def test_drive_document_id_rejects_malformed_drive_descriptor(block: object) -> None:
+    meta = _meta_with(type_code=14)
+    meta[9] = block
+    assert _row(meta).drive_document_id is None
+
+
+def test_drive_document_id_survives_short_metadata() -> None:
+    """A metadata list too short to reach ``[9]`` still reads ``[0]``."""
+    assert _row([[_DRIVE_FILE_ID, "opaque", 17], None]).drive_document_id == _DRIVE_FILE_ID
+
+
+def test_source_from_row_carries_drive_document_id() -> None:
+    """``Source`` surfaces the id — this is what the add_drive probe matches on."""
+    from notebooklm._types.sources import Source
+
+    src = Source.from_row(_live_google_docs_row())
+    assert src.drive_document_id == _DRIVE_FILE_ID
+    assert src.url is None
+
+
+def test_source_from_row_leaves_drive_document_id_none_for_non_drive() -> None:
+    from notebooklm._types.sources import Source
+
+    src = Source.from_row(_row(_meta_with(type_code=5)))
+    assert src.drive_document_id is None

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -27,6 +27,7 @@ from notebooklm._row_adapters.sources import (
     SourceFulltextRow,
     SourceGuideRow,
     SourceRow,
+    _warned_drive_id_slots,
 )
 from notebooklm._types.common import _datetime_from_timestamp
 from notebooklm._types.sources import (
@@ -579,3 +580,73 @@ def test_source_from_row_leaves_drive_document_id_none_for_non_drive() -> None:
 
     src = Source.from_row(_row(_meta_with(type_code=5)))
     assert src.drive_document_id is None
+
+
+class TestDriveDocumentIdDriftWarning:
+    """A present-but-drifted Drive block is reported, not silently skipped.
+
+    #2113 hid for so long precisely because the client read a slot that never
+    matched and said nothing. Structural absence stays quiet (most rows are not
+    Drive rows), but a Drive block whose id slot stopped being a usable string is
+    the signature of that bug recurring.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warned_slots(self):
+        """Clear the warn-once set so assertions do not depend on test order.
+
+        ``_warned_drive_id_slots`` is module-level (it has to outlive a row), so
+        an earlier test decoding the same slot would otherwise consume this
+        test's single warning. Mirrors ``_warned_status_codes`` handling in
+        ``tests/unit/test_row_adapters.py::TestSourceRowStatus``.
+        """
+        _warned_drive_id_slots.clear()
+        yield
+        _warned_drive_id_slots.clear()
+
+    def test_non_string_id_in_a_populated_block_warns(self, caplog) -> None:
+        meta = _meta_with(type_code=1)
+        meta[0] = [12345, "opaque", 17]  # documentId slot is not a string
+        assert _row(meta).drive_document_id is None
+        assert "carries no usable documentId" in caplog.text
+        assert "metadata[0]" in caplog.text
+
+    def test_blank_id_in_a_populated_block_warns(self, caplog) -> None:
+        meta = _meta_with(type_code=14)
+        meta[9] = ["", 8, "application/pdf", ""]
+        assert _row(meta).drive_document_id is None
+        assert "carries no usable documentId" in caplog.text
+        assert "metadata[9]" in caplog.text
+
+    def test_warns_once_per_slot(self, caplog) -> None:
+        """A polled notebook re-decodes every row; the drift line fires once."""
+        meta = _meta_with(type_code=1)
+        meta[0] = [None, "opaque", 17]
+        for _ in range(3):
+            assert _row(meta).drive_document_id is None
+        assert caplog.text.count("carries no usable documentId") == 1
+
+        # A *different* slot is still reported.
+        other = _meta_with(type_code=14)
+        other[9] = [None, 8, "application/pdf", ""]
+        assert _row(other).drive_document_id is None
+        assert caplog.text.count("carries no usable documentId") == 2
+
+    @pytest.mark.parametrize(
+        ("block", "why"),
+        [
+            (None, "absent block — the overwhelmingly common non-Drive row"),
+            ([], "empty block carries no claim to be a Drive row"),
+            ("https://example.com/page", "the legacy bare-http string at metadata[0]"),
+        ],
+        ids=["null", "empty", "bare_http_str"],
+    )
+    def test_structural_absence_stays_silent(self, caplog, block: object, why: str) -> None:
+        meta = _meta_with(type_code=5)
+        meta[0] = block
+        assert _row(meta).drive_document_id is None
+        assert "documentId" not in caplog.text, f"must not warn for {why}"
+
+    def test_a_healthy_drive_row_never_warns(self, caplog) -> None:
+        assert _live_google_docs_row().drive_document_id == _DRIVE_FILE_ID
+        assert not caplog.records

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -646,7 +646,7 @@ class TestDriveDocumentIdDriftWarning:
         ("block", "why"),
         [
             (None, "absent block — the overwhelmingly common non-Drive row"),
-            ([], "empty block carries no claim to be a Drive row"),
+            ([], "block too short to hold the id slot at all"),
             ("https://example.com/page", "the legacy bare-http string at metadata[0]"),
         ],
         ids=["null", "empty", "bare_http_str"],

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -539,10 +539,20 @@ def test_drive_document_id_is_none_without_metadata() -> None:
         [],  # present but empty
         [None],  # documentId slot explicitly null
         [""],  # documentId slot blank
+        ["   "],  # documentId slot whitespace-only (unmatchable, so drift)
         [42],  # non-string
         {"documentId": "x"},  # non-list container
     ],
-    ids=["bare_http_str", "null", "empty", "null_id", "blank_id", "non_string", "non_list"],
+    ids=[
+        "bare_http_str",
+        "null",
+        "empty",
+        "null_id",
+        "blank_id",
+        "whitespace_id",
+        "non_string",
+        "non_list",
+    ],
 )
 def test_drive_document_id_rejects_malformed_google_docs_block(block: object) -> None:
     meta = _meta_with(type_code=1)
@@ -552,8 +562,8 @@ def test_drive_document_id_rejects_malformed_google_docs_block(block: object) ->
 
 @pytest.mark.parametrize(
     "block",
-    [None, [], [None], [""], [42], "not-a-list"],
-    ids=["null", "empty", "null_id", "blank_id", "non_string", "non_list"],
+    [None, [], [None], [""], ["   "], [42], "not-a-list"],
+    ids=["null", "empty", "null_id", "blank_id", "whitespace_id", "non_string", "non_list"],
 )
 def test_drive_document_id_rejects_malformed_drive_descriptor(block: object) -> None:
     meta = _meta_with(type_code=14)


### PR DESCRIPTION
## Problem

`sources.add_drive`'s idempotency probe matched a candidate existing source by looking for a `/d/<file_id>` segment inside `source.url` — but **Drive-backed sources never carry a `url` at all**. Their URL slots (`metadata[5]` / `metadata[7]`) are null and `metadata[0]` holds the Drive metadata block rather than a URL string, so `SourceRow.url` decodes to `None` on every Drive row.

Because `add_drive` also sets `disable_internal_retries=True`, that probe is the **only** retry-safety net. It could never match, so a 5xx / network failure after the server had already committed the create made the probe return `None`, `idempotent_create` re-issued the add, and the user ended up with **two copies of the same Drive file**.

The client's own code already documented the root cause — `_types/sources.py` states plainly that Drive sources carry no URL — directly contradicting the probe's own docstring, which assumed one exists to match against.

## Fix

The correct dedup key was already on the wire and unread: the Drive `documentId` the backend echoes back.

| slot | schema field | corpus-observed on |
| --- | --- | --- |
| `metadata[0][0]` | `SourceMetadata.googleDocsMetadata.documentId` | type codes 1 (Docs), 2 (Slides) |
| `metadata[9][0]` | `SourceMetadata.googleDriveSourceMetadata.documentId` | type code 14 (Drive-hosted files — native Sheets **and** Drive PDFs) |

Both messages declare `documentId` as tag 1, so a single `_DRIVE_DOCUMENT_ID_POS = 0` indexes both blocks. `MAPPINGS` asserts it against the Drive copy in `docs/mobile/schema.proto`, and a new guardrail test pins that the Docs copy still shares that tag — so the shared constant cannot silently start reading the wrong slot.

- Expose `SourceRow.drive_document_id` and surface it on the public `Source` dataclass (additive, defaulted — `audit_public_api_compat.py --check-stale` is clean).
- Match the probe on `drive_document_id == file_id`. Exact equality on an identity-bearing field also **removes** the interior-substring / prefix-collision false-positive class the URL probe had to defend against, and can never select a non-Drive row (those decode to `None`).
- Rename `_META_BARE_URL_POS` → `_META_GOOGLE_DOCS_POS`. The wire-contract registry already recorded index 0 as `googleDocsMetadata` with a "MISLEADING NAME" note; reading a `documentId` out of a constant called `_BARE_URL_POS` would have been unreadable.
- Upgrade `_DRIVE_DESCRIPTOR_MIME_POS` from `UNMAPPED` to a checked `Mapping` now that the enclosing message is identified.

### Review follow-ups (these changed the design)

The review team found things I'd have shipped wrong. All were confirmed against the repo's own live data before acting:

1. **A `documentId` is _not_ unique within a notebook.** The backend lets the same Drive file be added twice — `tests/cassettes/sources_check_freshness_drive.yaml` contains exactly that (source ids `337e760d…` and `80ee449b…` sharing documentId `1bAgBGlybk8…`). An unfiltered match would hand back a **pre-existing copy** as if it were the one just created, reporting success for a create that never landed — trading the duplicate bug for a worse silent one. `add_drive` now snapshots source ids before the create and filters probe matches against it, mirroring `register_file_source`; an unavailable snapshot or an ambiguous multi-match raises `SourceAddError` rather than guessing. **This costs one extra `GET_NOTEBOOK` per `add_drive`** — the same price `register_file_source` already pays for the same guarantee.
2. **The probe swallowed non-transport errors at DEBUG.** A decode failure is indistinguishable from "the create did not land", so the add gets re-issued — and this variant has no other net. Now WARNING, naming the consequence.
3. **The requested title was lost on a recovered create** (codex). `honor_requested_title_if_fresh` skips the post-add rename for every `PROBED` result. Now that the probe is baseline-filtered its match is provably ours, so an explicit `probe_proves_freshness` opt-in (set only by `add_drive`) keeps the caller's `title` instead of the Drive-derived name.
4. **`metadata[9]` is not "Drive-hosted binaries".** `tests/cassettes/cli_notebook_create.yaml` carries a **native Google Sheet** there (`["1xpHud…", 4, "application/vnd.google-apps.spreadsheet", ""]`). Docstrings and `docs/rpc-reference.md` corrected.

Also: `_document_id_at` warns once per `(method, slot)` when a *populated* Drive block has no usable documentId — precisely the #2113 signature; the `if not file_id` probe guard (whose comment described an impossible case) is replaced by a real `ValidationError` at the top of `add_drive`; and `_idempotency.py`'s probe taxonomy no longer claims sources probe by url-match.

### Cost of the baseline: an extra `GET_NOTEBOOK`, which bumps *Recent*

Stated plainly rather than left to be discovered. `add_drive` previously listed sources **only inside its retry probe** — `idempotent_create` runs that only after a transport failure. It now takes the snapshot on **every call**. That matches the shape `register_file_source` has always had (an unconditional pre-create baseline), so it extends an existing pattern rather than inventing a cost — but for the Drive path it is genuinely new: retry-only → every call.

The concrete consequence, via [#2126](https://github.com/teng-lin/notebooklm-py/issues/2126) / #2198: the backend **writes** `lastViewedTime` when answering a `GET_NOTEBOOK`, so every `add_drive` now promotes the notebook to the top of the user's *Recent* list in the web UI. `LIST_NOTEBOOKS` does not bump — but it does not carry source ids either, and source ids are published only inside the `GET_NOTEBOOK` payload, so there is no cheaper probe to substitute.

Keeping the baseline anyway: silently returning a pre-existing source and reporting a create that never happened is far worse than a reordered Recent list. Documented at the capture site, on both `add_drive` docstrings, and in the changelog.

### Sibling paths audited (so the next reader need not re-derive it)

- **`add_text`** — classified `NON_IDEMPOTENT_NO_RETRY`, runs no probe at all. No exposure.
- **`add_url`** — *does* still carry the un-baselined shape this PR replaced: it matches `source.url == url` with no baseline filter, and a notebook can legitimately hold two sources with the same URL (`SourceLister.list` dedupes by source id, not URL). So its probe can adopt a pre-existing source and report a phantom success, exactly as the Drive probe could. **Deliberately not fixed here** — filed as #2204, since `add_url` is the highest-traffic add path and the same Recent-bump trade deserves its own decision rather than being inherited by symmetry.

### Known limitation (documented, not fixed)

Codex correctly noted that the baseline establishes *when* a matching source appeared, not *who* created it: two callers adding the same Drive file to one notebook concurrently can cross over. The `batchexecute` wire carries no client-supplied idempotency key, so a list-based probe cannot close that gap, and `register_file_source`'s filename probe has the identical exposure. It is now an explicit `.. warning::` on `add_drive` pointing readers at serializing concurrent same-file adds.

### Deliberately not changed

`_app/serialize.py::source_summary` — the compact `{id, title, type, url}` shape behind the CLI JSON envelopes — does **not** gain `drive_document_id`. That summary is intentionally minimal, and widening it would change the CLI JSON contract for every source (almost always `null`). The full typed projection used by MCP/REST already carries the field, and `tests/integration/mcp_vcr/test_sources.py` is updated to pin that.

## Tests

Fixtures are built from **live-captured** Drive rows, not invented shapes (per the lesson of #2134). Verified by decoding the cassette corpus: across 3,103 source rows, `metadata[0]` is a list in 40 and `metadata[0][0]` is a string in 40/40 (type codes 1/2); `metadata[9]` is a list in 5 and `metadata[9][0]` is a string in 5/5 (type code 14); **zero** rows populate both — so the "arbitrary-but-pinned tie-break, not a precedence claim" wording is accurate.

The drive probe tests model the real call sequence (baseline list → create → probe list) and cover: commit-lost-response for **both** metadata slots, a pre-existing copy of the same file, an unavailable baseline (with and without a match), multiple new matches, a match that only surfaces at the *second* probe, probe transport-error propagation, probe decode-failure, blank `file_id`, and title recovery.

### Mutation testing

`pr-test-analyzer` mutation-tested the suite and found four surviving mutants plus one piece of dead code — all fixed in `fd10293e`. The most important:

> `test_add_drive_probe_does_not_match_unrelated_sources` was **vacuous**. It put the candidate rows in the *baseline*, so the baseline filter stripped them whatever the match predicate did — the test passed against a substring match **and** against the old `/d/<file_id>/` URL probe. Its stated purpose was not what it verified.

That one is worth flagging because it was part of my original "verified to fail against the pre-fix probe" evidence. With `baseline_rows=[]` the rows must now be rejected by the predicate itself, and both mutants die.

All five mutants are now killed — re-verified individually:

| mutant | killed by |
| --- | --- |
| exact match → substring match | `…does_not_match_unrelated_sources[different_drive_file, prefix_collision]` |
| re-add the `/d/<file_id>/` URL fallback | `…does_not_match_unrelated_sources[non_drive_rows]` |
| probe decode-failure `return None` → `raise` | `…probe_decode_failure_warns_and_does_not_match` |
| probe swallows transport errors | `…probe_transport_error_propagates` |
| `elif matches:` → `elif True:` | `…baseline_unavailable_without_a_match_still_retries` |

Verification: `pytest -n auto tests/unit tests/integration tests/_guardrails` (15124 passed), `mypy`, `pre-commit run --all-files`, plus `audit_public_api_compat.py --check-stale`, `check_claude_md_freshness.py`, `check_docs_module_refs.py`, `check_method_coverage.py`, `check_coverage_thresholds.py`, and the cassette/fixture leak gates. Both `_sources.py` and `_row_adapters/sources.py` land at exactly 1000 lines — inside today's ADR-0008 budget (paid for by compressing adjacent prose rather than allowlisting either module), and with 500 lines of headroom once #2201 raises the budget to 1500.

## Live probe

Run against a real account; scratch notebooks created and deleted in the same run. **Final-head re-confirmation is posted as a PR comment before merge.**

Decoding an existing Drive notebook — the id from the issue reproduces exactly, and non-Drive sources correctly decode to `None`:

```
'Claude Science Research OS.pdf'   kind=PDF                 url=None  drive_document_id=1DL3jqmkfSeeyOrP8VoDy316wqLuHdHWY
'Sanya-Lingshui.pdf'               kind=PDF                 url=None  drive_document_id=None
'Screenshot_2026-07-15….jpg'       kind=IMAGE               url=None  drive_document_id=None
'The Subtle Art of Not Giving…'    kind=GOOGLE_DOCS         url=None  drive_document_id=1FDW_u2QKNxpYBBvs-k03F4n039Ufuiv2DgsOP7TR6As
'zz-1828-test-sheet - Untitled'    kind=GOOGLE_SPREADSHEET  url=None  drive_document_id=1MKyfgSIBDfeoub5cNFhElj61Odoq_b2b5x80s6e5gK0
```

**Case B — the create commits, then the response is lost** (the real #2113 failure mode: the ADD_SOURCE RPC is allowed to hit the server and *then* raises a synthetic 503, so the probe runs against the live `GET_NOTEBOOK`):

```
CASE B -> add_drive returned 1a83fef9-a561-4849-9b89-67f269dbfb11
   drive_document_id  = 1FDW_u2QKNxpYBBvs-k03F4n039Ufuiv2DgsOP7TR6As
   matches file_id    = True
   real ADD_SOURCE writes = 1 (1 = probe short-circuited the retry)
sources in notebook: 1 (must be 1 — no duplicate)
cleanup: notebook deleted = True
```

**Case A — a pre-existing copy is present and the create genuinely fails.** The baseline filter must refuse to adopt the older copy:

```
CASE A (pre-existing copy, create really failed) -> ServerError raised
   ADD_SOURCE attempts= 2 (2 = probe correctly found no NEW match)
sources after CASE A: 1 (must still be 1 — no duplicate)
cleanup: notebook deleted = True
```

One source, not two, in both directions — and a genuinely failed create still surfaces as an error instead of quietly returning someone else's source.

Rebased onto `40139e7c` (#2192); the `CHANGELOG.md` conflict was resolved by keeping both entries.

Closes #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Drive file ID information to source data.
  * Improved recovery of Drive sources after interrupted or retried additions by matching the exact file.
  * Added safer title handling for newly recovered Drive sources.

* **Bug Fixes**
  * Prevented duplicate Drive sources after interrupted or retried additions.
  * Added validation for blank Drive file IDs and safeguards for ambiguous or unavailable matches.
  * Improved handling of Drive and Google Docs source metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->