### PR TITLE
fix(ci): repair the two artifacts the d7f28d32 merge left on main

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -154,6 +154,9 @@
       "code": "changed-enum-value",
       "object": "notebooklm.types.ArtifactStatus.PROCESSING",
       "reason": "Value changed 1 -> 2. #2127: this client had ArtifactStatus wire codes 1 and 2 transposed relative to Google's backend enum. Code 1 is ARTIFACT_STATUS_INITIALIZED (queued; the worker has not started) and code 2 is ARTIFACT_STATUS_PROCESSING (actively generating) \u2014 confirmed by the recovered enum dump in docs/mobile/enums.txt, by two independent live traces showing 2 -> 3 on a generating artifact, and by a live probe on the fixing branch. The old integers were wrong about the wire rather than a contract worth preserving, so this is a decode correction, not an API redesign. Member NAMES and the status-string vocabulary are unchanged: PENDING has always meant 'queued' and PROCESSING 'actively generating', so callers using .is_pending / .is_processing / .status_str / GenerationState get the correct answer with no change. Only callers comparing the raw integers must flip them. Documented in CHANGELOG.md (with the timeout-exception consequence), docs/stability.md and docs/python-api.md; pinned by tests/_guardrails/_wire_contract.py ENUM_BINDINGS against the backend dump."
+    },
+    {
+      "code": "changed-enum-value",
       "object": "notebooklm.QuizQuantity.MORE",
       "reason": "QuizQuantity.MORE was a value-alias of STANDARD (2) with a docstring asserting Google's API could not distinguish the two. That is false: the backend accepts and persists cardQuantity = 3, and both QuizGenerationOptions.QuestionQuantity and FlashcardsGenerationOptions.CardQuantity declare MORE = 3 (docs/mobile/enums.txt). Live-confirmed: a flashcard set generated with quantity=MORE echoed back cardQuantity=3 from the server. Deliberate wire-value correction for #2117 -- '--quantity more' previously produced a standard-sized set with no warning. MORE no longer compares equal to STANDARD; see the ### Changed entry in CHANGELOG.md."
     },

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -37,8 +37,8 @@ from pathlib import Path
 
 import pytest
 
-from notebooklm.rpc.types import ARTIFACT_STATUS_SUGGESTED_WIRE_NAME, ArtifactStatus
 import notebooklm.rpc.types as rpc_types
+from notebooklm.rpc.types import ARTIFACT_STATUS_SUGGESTED_WIRE_NAME, ArtifactStatus
 from tests._guardrails._wire_contract import (
     ENUM_BINDINGS,
     ENUM_GAPS,


### PR DESCRIPTION
## Summary

`main` is red. The merge `d7f28d32` ("Merge branch 'main' into fix/2127-artifact-status-codes", landed via #2200) dropped three lines from `scripts/api-compat-allowlist.json` and left one import block un-sorted. Both sides of that merge were fine; the resolution fused them. This restores exactly what was lost.

No issue to reference — found while running a pre-push check against `origin/main`.

## Evidence

| Claim | Provenance |
|---|---|
| The allowlist is not valid JSON on `main` | **Measured**: `json.load` on `origin/main:scripts/api-compat-allowlist.json` → `Expecting ',' delimiter: line 157 column 7` |
| Neither merge parent is broken | **Measured**: `5f82bf54` and `0ea65061` both parse, **31/31** `allowed_breaks` entries each |
| The two sides added disjoint entries | **Measured**: branch side → `ArtifactStatus.PENDING`, `ArtifactStatus.PROCESSING`; main side → `QuizQuantity.MORE`, `types.QuizQuantity.MORE` |
| The repair invents nothing | **Measured**: the fixed file is the set union of both parents — **33 entries**, and every entry byte-identical to the parent it came from |
| The break takes CI down | **Measured** on run for `bde3d46e`: `Code Quality` + all four `Test` legs fail; `RuntimeError: invalid JSON in …api-compat-allowlist.json` |
| `ruff check .` also fails on `main` | **Measured**: `I001` on `tests/_guardrails/test_wire_contract.py`, same merge, introduced with the interleaved import additions |

The seam, verbatim from `main` — the first entry never closes and the second never opens:

```
      "reason": "Value changed 1 -> 2. #2127: …"
      "object": "notebooklm.QuizQuantity.MORE",
```

## What changed

Two commits, one per artifact of that merge, so either can be dropped independently:

1. `scripts/api-compat-allowlist.json` — reinsert the three lines that close the `ArtifactStatus.PROCESSING` entry and open the `QuizQuantity.MORE` one (`},` / `{` / `"code": "changed-enum-value",`). Nothing else in the file moves.
2. `tests/_guardrails/test_wire_contract.py` — the one-line import reorder `ruff check --fix` produces.

## Scope boundary / Not done

- **No new test.** The existing gate already catches this exactly — `test_baseline_matches_committed_file[ungated_surface]` and `test_ungated_public_surface_covers_exactly_the_unpinned_modules` are the two tests failing on `main`. Adding a "the JSON parses" test would only duplicate a check that already works; what failed here was that the merge landed, not that the gate was missing.
- **No CHANGELOG entry.** Nothing a caller can observe changes: this is repo-internal guardrail data plus an import order.
- **No other content in the allowlist was reviewed or touched**, including whether the four entries involved are still warranted.

## Verification

```
python -c "json.load(open('scripts/api-compat-allowlist.json'))"   # 33 allowed_breaks entries
uv run python scripts/audit_public_api_compat.py --check-stale     # runs, exit 0
uv run ruff check .                                                # All checks passed
uv run pytest tests/_guardrails                                    # 1918 passed, 1 xfailed
```

The two tests currently failing on `main` pass here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Recorded the updated wire value for quiz quantity settings.
  * Reordered internal test imports without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->