### PR TITLE
fix(ci): unbreak main — invalid allowlist JSON + ruff import order

### DIFF
--- a/scripts/api-compat-allowlist.json
+++ b/scripts/api-compat-allowlist.json
@@ -154,6 +154,9 @@
       "code": "changed-enum-value",
       "object": "notebooklm.types.ArtifactStatus.PROCESSING",
       "reason": "Value changed 1 -> 2. #2127: this client had ArtifactStatus wire codes 1 and 2 transposed relative to Google's backend enum. Code 1 is ARTIFACT_STATUS_INITIALIZED (queued; the worker has not started) and code 2 is ARTIFACT_STATUS_PROCESSING (actively generating) \u2014 confirmed by the recovered enum dump in docs/mobile/enums.txt, by two independent live traces showing 2 -> 3 on a generating artifact, and by a live probe on the fixing branch. The old integers were wrong about the wire rather than a contract worth preserving, so this is a decode correction, not an API redesign. Member NAMES and the status-string vocabulary are unchanged: PENDING has always meant 'queued' and PROCESSING 'actively generating', so callers using .is_pending / .is_processing / .status_str / GenerationState get the correct answer with no change. Only callers comparing the raw integers must flip them. Documented in CHANGELOG.md (with the timeout-exception consequence), docs/stability.md and docs/python-api.md; pinned by tests/_guardrails/_wire_contract.py ENUM_BINDINGS against the backend dump."
+    },
+    {
+      "code": "changed-enum-value",
       "object": "notebooklm.QuizQuantity.MORE",
       "reason": "QuizQuantity.MORE was a value-alias of STANDARD (2) with a docstring asserting Google's API could not distinguish the two. That is false: the backend accepts and persists cardQuantity = 3, and both QuizGenerationOptions.QuestionQuantity and FlashcardsGenerationOptions.CardQuantity declare MORE = 3 (docs/mobile/enums.txt). Live-confirmed: a flashcard set generated with quantity=MORE echoed back cardQuantity=3 from the server. Deliberate wire-value correction for #2117 -- '--quantity more' previously produced a standard-sized set with no warning. MORE no longer compares equal to STANDARD; see the ### Changed entry in CHANGELOG.md."
     },

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -37,8 +37,8 @@ from pathlib import Path
 
 import pytest
 
-from notebooklm.rpc.types import ARTIFACT_STATUS_SUGGESTED_WIRE_NAME, ArtifactStatus
 import notebooklm.rpc.types as rpc_types
+from notebooklm.rpc.types import ARTIFACT_STATUS_SUGGESTED_WIRE_NAME, ArtifactStatus
 from tests._guardrails._wire_contract import (
     ENUM_BINDINGS,
     ENUM_GAPS,


### PR DESCRIPTION
## main is currently red

`scripts/api-compat-allowlist.json` is not parseable. Every PR fails:

```
FAILED tests/_guardrails/test_public_surface_manifest.py::test_ungated_public_surface_covers_exactly_the_unpinned_modules
FAILED tests/_guardrails/test_public_surface_manifest.py::test_baseline_matches_committed_file[ungated_surface]
RuntimeError: invalid JSON in scripts/api-compat-allowlist.json:
  Expecting ',' delimiter: line 157 column 7 (char 17820)
```

Confirmed on `origin/main` itself (`bde3d46e`), not just on a branch.

## Cause — a concurrent-merge hazard, not a bad PR

#2194 (`QuizQuantity.MORE`, #2117) and #2200 (`ArtifactStatus`, #2127) each appended a `changed-enum-value` entry to the same array. **Each was valid alone and each merged green against the main it was tested against.** Merging the second textually joined two adjacent objects:

```json
      "object": "notebooklm.types.ArtifactStatus.PROCESSING",
      "reason": "Value changed 1 -> 2. ..."      <-- no closing }
      "object": "notebooklm.QuizQuantity.MORE",  <-- no opening { or "code"
```

`ArtifactStatus.PROCESSING` lost its closing `}`; `QuizQuantity.MORE` lost its opening `{` and `"code"` key. The result is one malformed object with a duplicated `"object"` key.

Git produced **no conflict marker**, because both sides were syntactically plausible line additions into the same region. Neither PR author did anything wrong, and neither PR's CI could have caught it — the breakage only exists in the merged result.

## The fix

Restores the object boundary. Nothing else changes:

- entry **content** untouched
- **33 entries**, none added or removed
- **no duplicate `object` values**
- both `QuizQuantity.MORE` import paths preserved (`notebooklm.` and `notebooklm.types.`) — these are two deliberate entries, not an accident of the merge

## Verification

| gate | result |
|---|---|
| `pytest tests/_guardrails/test_public_surface_manifest.py` | **286 passed** (was 2 failed) |
| `scripts/audit_public_api_compat.py --check-stale` | **exit 0** |
| `pytest tests/_guardrails` | **1918 passed**, 1 xfailed |
| `json.load()` | parses; 33 entries, no dupes |

## Please merge promptly

Every open PR is red until this lands, and the failure is unrelated to their contents.

## Follow-up worth considering

This file is an append-only JSON array edited by most public-surface PRs, so it will collide again. A `jq . scripts/api-compat-allowlist.json` (or `json.tool`) check in the pre-commit hook would turn a silent textual merge into an immediate local failure. Happy to open that separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the wire value for the `QuizQuantity.MORE` quiz option.
  * Added compatibility coverage to distinguish it from the `STANDARD` option, helping ensure quiz quantity selections are interpreted correctly across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->