### PR TITLE
docs(CLAUDE.md): install the extras CI actually tests with

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,10 @@ Guidance for Claude Code working in this repo. Also follow the file/naming conve
 ## Development Commands
 
 ```bash
-# Canonical contributor install (respects uv.lock; full guide: docs/installation.md)
-uv sync --frozen --extra browser --extra dev --extra markdown
+# Canonical contributor install — matches the extras CI's test job installs.
+# Full guide: docs/installation.md
+uv sync --frozen --extra browser --extra dev --extra markdown \
+        --extra mcp --extra server --extra impersonate
 source .venv/bin/activate
 uv run playwright install chromium
 
@@ -21,6 +23,26 @@ uv run pytest --cov               # with coverage
 uv run pytest tests/e2e -m e2e    # e2e (requires auth)
 uv run notebooklm --help          # CLI
 ```
+
+**Install the full extras set.** Omitting `mcp`/`server` does not fail — it
+*skips*. `tests/unit/mcp/` and the server suites are `importorskip`-guarded, so
+without `fastmcp`/`fastapi` they vanish silently and their source counts as
+uncovered. Measured on one commit: the three-extra install runs **13,939** tests
+at **84.39%** coverage and fails the 90% gate, while CI's set runs **15,478** at
+**96.61%** and passes. That ~1,500-test blind spot hid a real MCP-adapter defect
+through eight red CI jobs on #2198.
+
+To reproduce a CI test run exactly (`.github/workflows/test.yml`):
+
+```bash
+uv run pytest -n auto --dist loadgroup --cov=src/notebooklm \
+  --cov-report=term-missing --cov-fail-under=90
+```
+
+`--dist loadgroup` matters: it honors `@pytest.mark.xdist_group`, and at least
+one test fails under plain `-n auto` but passes under `loadgroup`. Check the
+exit status directly rather than through a pipe — piping into `tail`/`grep`
+reports the *pipeline's* status, which has masked real failures here before.
 
 ## Before Pushing
 


### PR DESCRIPTION
## The gap

`CLAUDE.md` documented:

```
uv sync --frozen --extra browser --extra dev --extra markdown
```

CI's test job (`.github/workflows/test.yml:220`) installs **six**:

```
uv sync --frozen --extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate
```

## Why it matters — the failure is silent, not loud

`tests/unit/mcp/` and the server suites are `importorskip`-guarded. Without `fastmcp`/`fastapi` they don't error, they **vanish**, and their source then counts as uncovered.

Measured on a single commit:

| install | tests | coverage | `--cov-fail-under=90` |
|---|---|---|---|
| documented (3 extras) | 13,939 | 84.39% | **fails** |
| CI (6 extras) | 15,478 | 96.61% | passes |

So a contributor following the docs sees a coverage failure that looks like their own change, and ~1,500 tests that silently never ran.

**This is not hypothetical.** That blind spot hid a real MCP-adapter defect on #2198 through **eight red CI jobs**, while local runs honestly reported green — the failing test lived in `tests/unit/mcp/`, which the documented install skips.

## Also added

- The exact CI pytest invocation, so "reproduce CI locally" is copy-pasteable.
- Why `--dist loadgroup` is not optional: it honors `@pytest.mark.xdist_group`, and at least one test fails under plain `-n auto` but passes under `loadgroup`.
- A note to check exit status **directly, not through a pipe** — `cmd | tail` reports the pipeline's status. That exact trap produced a false "verified" claim in this repo earlier.

## Verification

- Extras list checked **character-identical** to `test.yml`'s (only delta is CI's trailing `; do` from its retry loop).
- `pre-commit run --all-files` exit **0**.
- Docs-only; no source or test files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup instructions to include all CI testing extras.
  * Added guidance on test and coverage limitations when extras are omitted.
  * Documented the CI test command, parallel test distribution requirements, and reliable exit-status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->