### PR TITLE
fix(sources): disambiguate the add_url idempotency probe with a pre-create baseline (#2204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,8 +196,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `READY`. Probe matches are now filtered against a snapshot of source
   ids taken before the create — the same shape `add_file` has always had and
   `add_drive` adopted in [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113)
-  — and an unavailable snapshot or an ambiguous multi-match raises
-  `SourceAddError` rather than guessing. A probed-but-fresh result now also
+  — and a match the snapshot cannot vouch for, or an ambiguous multi-match,
+  raises `SourceAddError` rather than guessing. An unavailable snapshot on its
+  own does not: with no matching source there is nothing to be ambiguous about,
+  so the call still retries and still ends in the underlying transport error. A probed-but-fresh result now also
   honors a requested `title`, which the pre-fix code skipped because a probe
   match could not be proven to be the caller's own. The probe's non-transport
   failure branch moved from `DEBUG` to `WARNING`: with internal retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sources.add_url` no longer reports success for a create that never
+  landed.** Its idempotency probe matched `source.url == url` against the whole
+  notebook with no baseline filter, so after a transport failure it could adopt
+  a source that was already there and hand the caller that id. A URL is not
+  unique within a notebook — the backend accepts the same URL twice and
+  `SourceLister.list` dedupes by source id, not by URL — and a live probe on
+  this account reproduced the worst shape of it: an `add_url` whose create
+  **did** commit (as `df618843-…`) returned the pre-existing `0d2c15a1-…`
+  instead, leaving the caller holding the wrong source id *and* an unreported
+  duplicate. With `wait=True` the mask is total, since the adopted source is
+  already `READY`. Probe matches are now filtered against a snapshot of source
+  ids taken before the create — the same shape `add_file` has always had and
+  `add_drive` adopted in [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113)
+  — and an unavailable snapshot or an ambiguous multi-match raises
+  `SourceAddError` rather than guessing. A probed-but-fresh result now also
+  honors a requested `title`, which the pre-fix code skipped because a probe
+  match could not be proven to be the caller's own. The probe's non-transport
+  failure branch moved from `DEBUG` to `WARNING`: with internal retries
+  disabled on this variant it is the last net against a duplicate.
+  ([#2204](https://github.com/teng-lin/notebooklm-py/issues/2204))
+
+  **Behaviour change:** `add_url` previously listed sources only inside its
+  retry probe (i.e. only after a transport failure); it now takes that snapshot
+  on *every* call. That is one extra `GET_NOTEBOOK` per `add_url`, and because
+  the backend writes `lastViewedTime` when answering one
+  ([#2126](https://github.com/teng-lin/notebooklm-py/issues/2126)), every
+  `add_url` now bumps the notebook's position in the web UI's *Recent* list.
+  `ADD_SOURCE` alone does not — the same live probe held `last_viewed_at`
+  pinned across an `add_url` — so on this, the highest-traffic add path, the
+  bump is genuinely new rather than already paid. It is accepted because no
+  cheaper probe exists (source ids are published only inside the
+  `GET_NOTEBOOK` payload, and `LIST_NOTEBOOKS`, which does not bump, does not
+  carry them) and because capturing the baseline lazily on the retry path is
+  not merely cheaper but wrong: the probe runs *after* the create, so a list
+  taken there already contains the just-created source. The bump does not
+  compound across a bulk import, and `wait=True` callers and the REST batch
+  preflight were paying it already.
+
 - **`docs/rpc-reference.md` no longer misstates the research path.** Four
   corrections, each against a captured payload: `START_FAST_RESEARCH` returns a
   one-element response (only deep carries `report_id`); the `1` / `5` start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,8 +218,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carry them) and because capturing the baseline lazily on the retry path is
   not merely cheaper but wrong: the probe runs *after* the create, so a list
   taken there already contains the just-created source. The bump does not
-  compound across a bulk import, and `wait=True` callers and the REST batch
-  preflight were paying it already.
+  compound across a bulk import, and `wait=True` callers were paying it already
+  via `wait_until_ready`'s polling. The *request count* does compound, though: a
+  sequential bulk add — the REST `POST /v1/notebooks/{id}/sources/batch` route,
+  whose one shared preflight covers none of the per-item baselines — goes from
+  N+1 to 2N+1 requests, which is worth budgeting against the backend's bulk rate
+  limits.
+
+- **A failed idempotency baseline is no longer invisible.** `add_url` and
+  `add_drive` swallow a failure to snapshot source ids before the create and
+  carry on with the probe disabled. That swallow logged at `DEBUG`, and the
+  `notebooklm` logger defaults to `WARNING`, so the record was discarded before
+  any handler saw it — the call ran without the protection and said nothing.
+  (Found by review, and not hypothetical: five of the repo's own VCR tests were
+  replaying a cassette that predates the baseline read and silently exercising
+  the disabled path.) Both now log at `WARNING` and name the failure type, and
+  `add_url`'s resulting ambiguity error carries the underlying exception as its
+  `cause` and names the source ids it could not disambiguate, so a caller told
+  to "check the notebook source list" knows which rows to look at.
+  ([#2204](https://github.com/teng-lin/notebooklm-py/issues/2204))
 
 - **`docs/rpc-reference.md` no longer misstates the research path.** Four
   corrections, each against a captured payload: `START_FAST_RESEARCH` returns a

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -459,8 +459,8 @@ The following methods are idempotent under retry:
 | Method | Probe |
 |---|---|
 | `client.notebooks.create(title)` | Snapshot notebook IDs *before*, list *after* a transport failure, return the single new notebook with the matching title (or raise on ambiguity). |
-| `client.sources.add_url(notebook_id, url)` | List the notebook's sources, return the existing source whose `url` exactly matches. |
-| `client.sources.add_url(notebook_id, youtube_url)` | Same probe via canonical YouTube URL. |
+| `client.sources.add_url(notebook_id, url)` | Snapshot source IDs *before*, list *after* a transport failure, return the single **new** source whose `url` exactly matches (or raise on ambiguity). The same URL can legitimately appear twice in one notebook, so an unfiltered match could hand back a source that predates the call ([#2204](https://github.com/teng-lin/notebooklm-py/issues/2204)). |
+| `client.sources.add_url(notebook_id, youtube_url)` | Same probe; the backend echoes the requested YouTube URL back verbatim, short (`youtu.be/…`) forms included. |
 
 `client.sources.add_text(notebook_id, title, content)` is **not** retry-safe: text sources lack a reliable server-side dedupe key (titles aren't unique; content isn't exposed in the source list). The default behavior is unchanged from previous releases. If you want explicit failure rather than possible silent duplication on retry, opt in:
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2210,19 +2210,24 @@ effect of doing something else:
 | `notebooks.rename()` | Re-reads after the mutation to return the updated `Notebook`. |
 | `notebooks.create()` (CLI/MCP/REST path) | One best-effort re-read to backfill the timestamps `CREATE_NOTEBOOK` leaves null; skipped when both are already populated. |
 | `chat.get_settings()` | Chat config lives in the notebook payload. |
-| `sources.add_file()` / `add_drive()` | An **unconditional** pre-create baseline of existing source ids, on every call — the idempotency probe needs it to tell a source it created from one that was already there. |
-| `sources.add_url()` | Only **on a retry**: its idempotency probe runs after a transport failure, not on the happy path. (`add_text()` is `NON_IDEMPOTENT_NO_RETRY` and runs no probe at all, so it never bumps recency.) |
+| `sources.add_file()` / `add_drive()` / `add_url()` | An **unconditional** pre-create baseline of existing source ids, on every call — the idempotency probe needs it to tell a source it created from one that was already there. (`add_text()` is `NON_IDEMPOTENT_NO_RETRY` and runs no probe at all, so it never bumps recency.) |
 | REST `POST /v1/notebooks/{id}/sources/batch` preflight | One shared existence/auth check before the per-URL loop. |
 
-> **`sources.add_drive()` moved rows in
-> [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113).** It used to
-> probe only on a retry; it now takes an **unconditional** pre-create baseline,
-> the same shape `add_file` already uses. A Drive `documentId` turns out not to
-> be unique within a notebook (the repo's own cassette holds two source ids
-> sharing one `documentId`), so matching on `documentId` alone could return a
-> pre-existing copy and report success for a create that never landed. The
-> baseline is the correct fix — this table records the recency cost it carries,
-> not an objection to it.
+> **`sources.add_drive()` and `sources.add_url()` moved rows**, in
+> [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113) and
+> [#2204](https://github.com/teng-lin/notebooklm-py/issues/2204) respectively.
+> Both used to probe only on a retry; both now take an **unconditional**
+> pre-create baseline, the same shape `add_file` already uses. Neither probe key
+> is unique within a notebook — the repo's own cassette holds two source ids
+> sharing one Drive `documentId`, and a live probe added the same URL twice and
+> got two distinct source ids — so matching on the key alone could return a
+> pre-existing copy and report success for a create that never landed. (The
+> #2204 probe caught exactly that: a create that *did* land as `df618843-…`
+> returned the pre-existing `0d2c15a1-…`.) The baseline is the correct fix —
+> this table records the recency cost it carries, not an objection to it. The
+> cost is real for `add_url` specifically: `ADD_SOURCE` alone does **not** bump
+> `lastViewedTime` (live-verified), so the baseline read is a genuinely new
+> side effect on the highest-traffic add path.
 
 Paths that issue `LIST_NOTEBOOKS` — listed for completeness, since they cost an
 RPC but, per the probe above, **do not perturb recency**: `notebooks.create()`

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -24,9 +24,9 @@ This module hosts two cooperating pieces:
 
 Per-API probes used by :func:`idempotent_create` are caller-supplied
 because there is no universal probe key (notebooks: title +
-baseline-diff; ``add_url``: url-match; ``add_drive``: Drive
-``documentId``-match + baseline-diff; ``add_text``: no probe possible —
-see :class:`~notebooklm.exceptions.NonIdempotentRetryError`).
+baseline-diff; ``add_url``: url-match + baseline-diff; ``add_drive``:
+Drive ``documentId``-match + baseline-diff; ``add_text``: no probe
+possible — see :class:`~notebooklm.exceptions.NonIdempotentRetryError`).
 
 This module is private (``_idempotency.py``); call sites live in the
 domain APIs (``_notebooks.py``, ``_sources.py``) and the RPC executor
@@ -117,8 +117,9 @@ async def idempotent_create(
         probe: Coroutine factory that returns the resource if it
             already exists server-side, or ``None`` if not. Probes are
             API-specific (notebooks: list-then-baseline-diff by title;
-            ``add_url``: list-then-url-match; ``add_drive``:
-            list-then-documentId-match filtered by a pre-create baseline).
+            ``add_url``: list-then-url-match and ``add_drive``:
+            list-then-documentId-match, both filtered by a pre-create
+            baseline).
         max_attempts: Maximum total ``create()`` invocations (default
             2 — one initial + one retry). Each attempt is followed by
             a probe; the probe runs only after a transport failure.

--- a/src/notebooklm/_idempotency_policy.py
+++ b/src/notebooklm/_idempotency_policy.py
@@ -262,11 +262,18 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
     # content). Each variant has a different retry-safety profile because the
     # server-side dedupe key differs:
     #
-    # * ``"url"`` — probe by ``source.url == url`` on a notebook list. The probe
-    #   is a single GET_NOTEBOOK; the wrapper retries the create once if the
-    #   probe finds nothing. PROBE_THEN_CREATE.
-    # * ``"drive"`` — probe by ``file_id in source.url`` (Drive URLs embed the
-    #   file_id). Same wrapper as ``"url"``. PROBE_THEN_CREATE.
+    # * ``"url"`` — probe by ``source.url == url`` on a notebook list, filtered
+    #   against a baseline of source ids captured before the create: a URL is
+    #   NOT unique within a notebook, so an unfiltered match could hand back a
+    #   pre-existing source and report a create that never landed (#2204). The
+    #   probe is a single GET_NOTEBOOK; the wrapper retries the create once if
+    #   the probe finds nothing. PROBE_THEN_CREATE.
+    # * ``"drive"`` — probe by ``source.drive_document_id == file_id``, the
+    #   Drive ``documentId`` echoed back in the source metadata, filtered
+    #   against the same kind of pre-create baseline (a ``documentId`` is not
+    #   unique within a notebook either; #2113). Drive rows carry no URL at
+    #   all, so the ``/d/<file_id>``-in-``source.url`` probe this replaced
+    #   could never match. Same wrapper as ``"url"``. PROBE_THEN_CREATE.
     # * ``"text"`` — no reliable dedupe key (titles non-unique, body not
     #   exposed in the source list). NON_IDEMPOTENT_NO_RETRY: force-disable the
     #   inner transport retries and let the first failure surface so the caller
@@ -301,13 +308,19 @@ def register_default_policies(registry: IdempotencyRegistry) -> None:
         RPCMethod.ADD_SOURCE,
         IdempotencyPolicy.PROBE_THEN_CREATE,
         variant="url",
-        notes="probe by source.url == url on notebook list (web + YouTube)",
+        notes=(
+            "probe by source.url == url on notebook list (web + YouTube), "
+            "filtered against a pre-create source-id baseline"
+        ),
     )
     registry.register(
         RPCMethod.ADD_SOURCE,
         IdempotencyPolicy.PROBE_THEN_CREATE,
         variant="drive",
-        notes="probe by /d/<file_id> URL segment marker on notebook list",
+        notes=(
+            "probe by source.drive_document_id == file_id on notebook list, "
+            "filtered against a pre-create source-id baseline"
+        ),
     )
     registry.register(
         RPCMethod.ADD_SOURCE,

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -93,11 +93,12 @@ async def honor_requested_title_if_fresh(
     A ``PROBED`` result is normally skipped because the probe may have matched a
     source that predates this call, and renaming someone else's source would be
     a surprise. Set ``probe_proves_freshness`` when the caller's probe already
-    guarantees the match is new — ``add_drive`` filters probe matches against a
-    baseline captured before the create, so its ``PROBED`` value is provably a
-    source this call created and must still honor the requested title (#2113).
-    Without this, a Drive add that commits but loses its response silently keeps
-    the Drive-derived name instead of the caller's ``title``.
+    guarantees the match is new — ``add_drive`` (#2113) and ``add_url`` (#2204)
+    both filter probe matches against a baseline captured before the create, so
+    their ``PROBED`` value is provably a source this call created and must still
+    honor the requested title. Without this, an add that commits but loses its
+    response silently keeps the backend-derived name instead of the caller's
+    ``title``.
     """
     if isinstance(result, _IdempotentCreateResult):
         if result.kind is _CreateResultKind.PROBED and not probe_proves_freshness:
@@ -127,7 +128,67 @@ class SourceAddService:
         logger: logging.Logger,
         return_result: bool = False,
     ) -> Source | _IdempotentCreateResult[Source]:
-        """Add a URL source to a notebook."""
+        """Add a URL source to a notebook.
+
+        Runs the probe-then-create idempotency pattern: the create is issued
+        with internal retries disabled, and a 5xx / network failure that may
+        have committed server-side is followed by a probe for the committed
+        source before any retry. The probe matches ``source.url == url``.
+
+        A URL is **not** unique within a notebook — the backend happily holds
+        the same URL twice (live-verified on #2204: two adds of
+        ``https://example.com/`` produced two distinct source ids), and
+        ``SourceLister.list`` dedupes by source id, not by URL. So a bare
+        URL match cannot tell *"the create I just issued landed"* from *"a
+        source with this URL was already here"*. Probe matches are therefore
+        filtered against a baseline of source ids captured **before** the
+        first create attempt, exactly like
+        :meth:`~notebooklm._source.upload.SourceUploader.register_file_source`
+        does for filenames and ``add_drive`` does for Drive ``documentId``\\ s.
+        An unavailable baseline or an ambiguous multi-match raises
+        :class:`~notebooklm.exceptions.SourceAddError` rather than guessing.
+
+        .. note::
+           **This is a behaviour change (#2204).** ``add_url`` used to list
+           sources only inside ``_probe``, which ``idempotent_create`` runs
+           only after a transport failure; it now takes that snapshot on
+           *every* call, matching the shape ``add_file`` has always had and
+           ``add_drive`` adopted in #2113.
+
+           The concrete cost: that list is a ``GET_NOTEBOOK``, and the backend
+           **writes** ``lastViewedTime`` when answering one (#2126), so every
+           ``add_url`` now promotes the notebook to the top of the user's
+           *Recent* list in the web UI. ``ADD_SOURCE`` alone does not — the
+           #2204 live probe held ``last_viewed_at`` pinned at ``1786617745``
+           across an ``add_url`` — so this is a genuinely new side effect on
+           the highest-traffic add path, not a pre-existing one. It is
+           accepted because the alternative is what the same probe run
+           demonstrated: a create that *did* land as ``df618843-…`` returned
+           the pre-existing ``0d2c15a1-…`` instead, so the caller held the
+           wrong source id **and** an unreported duplicate. No cheaper probe
+           exists — source ids are published only inside the ``GET_NOTEBOOK``
+           payload, and ``LIST_NOTEBOOKS`` (which does not bump) does not
+           carry them — and a lazily captured baseline is not merely cheaper
+           but wrong: the probe runs *after* the create, so a list taken
+           there already contains the just-created source.
+
+           The bump is idempotent (bulk adds do not compound it) and is
+           already paid by any ``wait=True`` caller, whose
+           ``wait_until_ready`` polls ``GET_NOTEBOOK``, and by the REST batch
+           preflight. ``add_text`` is ``NON_IDEMPOTENT_NO_RETRY``, runs no
+           probe, and is unaffected.
+
+        .. warning::
+           The baseline establishes *when* a matching source appeared, not
+           *who* created it. If two callers add the same URL to one notebook
+           concurrently and one create fails before committing, the failed
+           caller's probe can attribute the other caller's source to itself
+           (or see two new matches and raise). A list-based probe cannot close
+           that gap — the wire carries no client-supplied idempotency key — so
+           serialize concurrent adds of the same URL into a notebook if you
+           need that guarantee. The same limitation applies to ``add_drive``
+           and ``register_file_source``.
+        """
         logger.debug("Adding URL source to notebook %s: %s", notebook_id, url[:80])
         video_id = extract_youtube_video_id(url)
         if not video_id and is_youtube_url(url):
@@ -160,6 +221,32 @@ class SourceAddService:
                 raise SourceAddError(url, message=f"API returned no data for URL: {url}")
             return Source.from_api_response(result, method_id=RPCMethod.ADD_SOURCE.value)
 
+        # Capture baseline source ids before the first create attempt so the
+        # probe can tell "this URL add landed" from "the same URL was already
+        # in the notebook". A URL is NOT unique within a notebook — live
+        # capture (#2204) added ``https://example.com/`` twice and got two
+        # distinct source ids — so an unfiltered match could hand back a
+        # pre-existing copy as if it were the one just created, masking a
+        # failed create. ``None`` is the "baseline unavailable" sentinel; the
+        # probe then refuses to guess. Mirrors ``add_drive`` above and
+        # ``register_file_source`` in ``_source/upload.py``.
+        #
+        # NEW on every call (it used to list only inside _probe, i.e. only
+        # after a transport failure). This list is a GET_NOTEBOOK, which the
+        # backend answers by WRITING lastViewedTime (#2126) — so every add_url
+        # now reshuffles the user's Recent ordering. Unavoidable (source ids
+        # live only in that payload; LIST_NOTEBOOKS does not bump but does not
+        # carry them) and accepted; see the ``.. note::`` on this method.
+        baseline_ids: set[str] | None
+        try:
+            baseline_ids = {source.id for source in await list_sources(notebook_id)}
+        except Exception:
+            logger.debug(
+                "add_url: baseline list() failed; baseline unavailable",
+                exc_info=True,
+            )
+            baseline_ids = None
+
         async def _probe() -> Source | None:
             try:
                 sources = await list_sources(notebook_id)
@@ -170,14 +257,44 @@ class SourceAddService:
                 # exactly the duplicate-source bug we are guarding against.
                 raise
             except Exception:
-                logger.debug(
-                    "add_url: probe list() failed with non-transport error; treating as no match",
+                # WARNING, not DEBUG: a decode failure here (e.g. the strict
+                # ``RPCError`` GET_NOTEBOOK raises on a drifted response) is
+                # indistinguishable from "the create did not land", so
+                # idempotent_create re-issues the add — and this variant runs
+                # with ``disable_internal_retries=True``, leaving no other net
+                # against the duplicate this probe exists to prevent (#2204).
+                logger.warning(
+                    "add_url: probe list() failed with a non-transport error; treating as "
+                    "no match, so a retry may create a duplicate source",
                     exc_info=True,
                 )
                 return None
-            for source in sources:
-                if source.url == url:
-                    return source
+            matches = [source for source in sources if source.url == url]
+            if baseline_ids is not None:
+                matches = [source for source in matches if source.id not in baseline_ids]
+            elif matches:
+                # Without a baseline a match may predate this add — see the
+                # ``baseline_ids`` comment for the failure mode this guards.
+                raise SourceAddError(
+                    url,
+                    message=(
+                        f"Cannot disambiguate URL source {url!r}: baseline snapshot was "
+                        "unavailable, so a matching source may predate this add. "
+                        "Check the notebook source list before retrying."
+                    ),
+                )
+            if len(matches) == 1:
+                (match,) = matches  # exactly one (len==1 guard); unpack, not matches[0]
+                return match
+            if len(matches) > 1:
+                raise SourceAddError(
+                    url,
+                    message=(
+                        f"Cannot disambiguate URL source {url!r}: probe found "
+                        f"{len(matches)} new sources with this URL after a transport "
+                        "failure. Check the notebook source list before retrying."
+                    ),
+                )
             return None
 
         result = await idempotent_create(
@@ -315,9 +432,9 @@ class SourceAddService:
 
            Sibling paths, so the next reader need not re-derive it: ``add_text``
            is ``NON_IDEMPOTENT_NO_RETRY`` and has no probe, so it has no such
-           exposure. ``add_url`` *does* share the un-baselined shape this fix
-           replaced — a notebook can hold two sources with the same URL — and is
-           tracked separately in #2204; it is deliberately not changed here.
+           exposure. ``add_url`` shared the un-baselined shape this fix replaced
+           — a notebook can hold two sources with the same URL — and was given
+           the same pre-create baseline in #2204.
 
         .. warning::
            The baseline establishes *when* a matching source appeared, not

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -34,6 +34,16 @@ ValidateVideoId = Callable[[str], bool]
 YoutubeDetector = Callable[[str], bool]
 
 
+def _describe_sources(sources: list[Source]) -> str:
+    """Render matched sources as ``id (title)`` for an ambiguity message.
+
+    The ambiguity raises tell the caller to go check the notebook's source
+    list; naming the exact rows saves them diffing a list by eye against a URL
+    that, by definition, appears in it more than once.
+    """
+    return ", ".join(f"{source.id} ({source.title!r})" for source in sources)
+
+
 async def honor_requested_title(
     rename: RenameSource,
     notebook_id: str,
@@ -95,10 +105,13 @@ async def honor_requested_title_if_fresh(
     a surprise. Set ``probe_proves_freshness`` when the caller's probe already
     guarantees the match is new — ``add_drive`` (#2113) and ``add_url`` (#2204)
     both filter probe matches against a baseline captured before the create, so
-    their ``PROBED`` value is provably a source this call created and must still
-    honor the requested title. Without this, an add that commits but loses its
-    response silently keeps the backend-derived name instead of the caller's
-    ``title``.
+    their ``PROBED`` value is attributable to this call and must still honor the
+    requested title. Without this, an add that commits but loses its response
+    silently keeps the backend-derived name instead of the caller's ``title``.
+
+    "Attributable", not "proven": a baseline establishes *when* a source
+    appeared, not *who* created it — see the concurrency ``.. warning::`` on
+    :meth:`SourceAddService.add_url`.
     """
     if isinstance(result, _IdempotentCreateResult):
         if result.kind is _CreateResultKind.PROBED and not probe_proves_freshness:
@@ -165,29 +178,42 @@ class SourceAddService:
            accepted because the alternative is what the same probe run
            demonstrated: a create that *did* land as ``df618843-…`` returned
            the pre-existing ``0d2c15a1-…`` instead, so the caller held the
-           wrong source id **and** an unreported duplicate. No cheaper probe
-           exists — source ids are published only inside the ``GET_NOTEBOOK``
-           payload, and ``LIST_NOTEBOOKS`` (which does not bump) does not
-           carry them — and a lazily captured baseline is not merely cheaper
-           but wrong: the probe runs *after* the create, so a list taken
-           there already contains the just-created source.
+           wrong source id **and** an unreported duplicate.
 
-           The bump is idempotent (bulk adds do not compound it) and is
-           already paid by any ``wait=True`` caller, whose
-           ``wait_until_ready`` polls ``GET_NOTEBOOK``, and by the REST batch
-           preflight. ``add_text`` is ``NON_IDEMPOTENT_NO_RETRY``, runs no
-           probe, and is unaffected.
+           No cheaper *id-based* probe exists: source ids are published only
+           inside the ``GET_NOTEBOOK`` payload, and ``LIST_NOTEBOOKS`` (which
+           does not bump) does not carry them. Two non-id alternatives were
+           weighed and rejected. A lazily captured baseline is not merely
+           cheaper but wrong — the probe runs *after* the create, so a list
+           taken there already contains the just-created source. Filtering by
+           :attr:`~notebooklm.types.Source.created_at` would need no pre-create
+           read at all, but it compares a second-resolution *server* timestamp
+           against a client clock of unknown skew, and it fails precisely in
+           the bulk-import case this path serves, where the pre-existing copy
+           was added seconds earlier.
+
+           The bump itself is idempotent, so a bulk import reorders *Recent*
+           once rather than once per URL, and any ``wait=True`` caller already
+           pays it via ``wait_until_ready``'s polling. The request count is the
+           part that does compound: a sequential bulk add — the REST
+           ``sources/batch`` route, whose one shared preflight covers none of
+           the per-item baselines — goes from N+1 to 2N+1 requests, worth
+           budgeting against the backend's bulk rate limits. ``add_text`` is
+           ``NON_IDEMPOTENT_NO_RETRY``, runs no probe, and is unaffected.
 
         .. warning::
            The baseline establishes *when* a matching source appeared, not
            *who* created it. If two callers add the same URL to one notebook
            concurrently and one create fails before committing, the failed
            caller's probe can attribute the other caller's source to itself
-           (or see two new matches and raise). A list-based probe cannot close
-           that gap — the wire carries no client-supplied idempotency key — so
-           serialize concurrent adds of the same URL into a notebook if you
-           need that guarantee. The same limitation applies to ``add_drive``
-           and ``register_file_source``.
+           (or see two new matches and raise). Because the recovered result is
+           treated as fresh, a requested ``title`` would then be applied to the
+           other caller's source — a visible mutation, not merely a
+           misattributed id. A list-based probe cannot close that gap — the
+           wire carries no client-supplied idempotency key — so serialize
+           concurrent adds of the same URL into a notebook if you need that
+           guarantee. The same limitation applies to ``add_drive`` and
+           ``register_file_source``.
         """
         logger.debug("Adding URL source to notebook %s: %s", notebook_id, url[:80])
         video_id = extract_youtube_video_id(url)
@@ -228,7 +254,7 @@ class SourceAddService:
         # distinct source ids — so an unfiltered match could hand back a
         # pre-existing copy as if it were the one just created, masking a
         # failed create. ``None`` is the "baseline unavailable" sentinel; the
-        # probe then refuses to guess. Mirrors ``add_drive`` above and
+        # probe then refuses to guess. Mirrors ``add_drive`` below and
         # ``register_file_source`` in ``_source/upload.py``.
         #
         # NEW on every call (it used to list only inside _probe, i.e. only
@@ -238,11 +264,27 @@ class SourceAddService:
         # live only in that payload; LIST_NOTEBOOKS does not bump but does not
         # carry them) and accepted; see the ``.. note::`` on this method.
         baseline_ids: set[str] | None
+        # Retained so the ambiguity raise below can name what went wrong: the
+        # caller sees "baseline unavailable" long after this line ran, and
+        # without the cause there is nothing in the process that can explain it.
+        baseline_error: Exception | None = None
         try:
             baseline_ids = {source.id for source in await list_sources(notebook_id)}
-        except Exception:
-            logger.debug(
-                "add_url: baseline list() failed; baseline unavailable",
+        except Exception as exc:
+            # WARNING, not DEBUG: the default logger level is WARNING
+            # (``_logging.py``), so a DEBUG record here is discarded before any
+            # handler sees it and this call would silently run with the #2204
+            # protection disabled. Louder than the probe's own swallow is
+            # justified — a failed probe costs one extra create attempt, while a
+            # failed baseline disables the probe for the whole call AND turns a
+            # recoverable transport error into a hard ambiguity error below.
+            baseline_error = exc
+            logger.warning(
+                "add_url: baseline list() failed (%s); the idempotency probe can no "
+                "longer tell a source this call created from one that was already "
+                "there, so a transport failure will surface as an ambiguity error "
+                "instead of recovering",
+                type(exc).__name__,
                 exc_info=True,
             )
             baseline_ids = None
@@ -275,12 +317,18 @@ class SourceAddService:
             elif matches:
                 # Without a baseline a match may predate this add — see the
                 # ``baseline_ids`` comment for the failure mode this guards.
+                # Both halves of the ambiguity are worth stating: the match may
+                # predate the add, or it may BE the add, in which case the create
+                # landed and the caller will otherwise never learn its id.
                 raise SourceAddError(
                     url,
+                    cause=baseline_error,
                     message=(
-                        f"Cannot disambiguate URL source {url!r}: baseline snapshot was "
-                        "unavailable, so a matching source may predate this add. "
-                        "Check the notebook source list before retrying."
+                        f"Cannot disambiguate URL source {url!r}: the pre-create baseline "
+                        f"snapshot failed ({type(baseline_error).__name__}), so "
+                        f"{_describe_sources(matches)} may either predate this add or be "
+                        "the source it just created. Check the notebook source list "
+                        "before retrying."
                     ),
                 )
             if len(matches) == 1:
@@ -292,7 +340,8 @@ class SourceAddService:
                     message=(
                         f"Cannot disambiguate URL source {url!r}: probe found "
                         f"{len(matches)} new sources with this URL after a transport "
-                        "failure. Check the notebook source list before retrying."
+                        f"failure ({_describe_sources(matches)}). Check the notebook "
+                        "source list before retrying."
                     ),
                 )
             return None
@@ -539,9 +588,17 @@ class SourceAddService:
         baseline_ids: set[str] | None
         try:
             baseline_ids = {source.id for source in await list_sources(notebook_id)}
-        except Exception:
-            logger.debug(
-                "add_drive: baseline list() failed; baseline unavailable",
+        except Exception as exc:
+            # WARNING, not DEBUG, for the reason spelled out on ``add_url``'s
+            # copy of this block (#2204): the default logger level is WARNING,
+            # so a DEBUG record here is dropped before any handler sees it and
+            # the call silently runs with its idempotency probe disabled.
+            logger.warning(
+                "add_drive: baseline list() failed (%s); the idempotency probe can no "
+                "longer tell a source this call created from one that was already "
+                "there, so a transport failure will surface as an ambiguity error "
+                "instead of recovering",
+                type(exc).__name__,
                 exc_info=True,
             )
             baseline_ids = None

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -388,6 +388,9 @@ class SourcesAPI:
 
         Automatically detects YouTube URLs and uses the appropriate method.
 
+        Fires one ``GET_NOTEBOOK`` before the create for the retry probe (#2204);
+        that read bumps Recent position (#2126). See the service method's docs.
+
         Args:
             notebook_id: The notebook ID.
             url: The URL to add.
@@ -417,7 +420,10 @@ class SourcesAPI:
             logger=logger,
             return_result=True,
         )
-        return await honor_requested_title_if_fresh(self.rename, notebook_id, result, title, logger)
+        # Baseline-filtered probe ⇒ even a PROBED result is ours to rename (#2204).
+        return await honor_requested_title_if_fresh(
+            self.rename, notebook_id, result, title, logger, probe_proves_freshness=True
+        )
 
     async def add_text(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -629,21 +629,27 @@ def legacy_vcr_follow_up_probe(monkeypatch):
 
 @pytest.fixture
 def legacy_vcr_add_url_baseline(monkeypatch):
-    """Supply the pre-create source baseline omitted from legacy add_url cassettes.
+    """Answer the pre-create source baseline omitted from legacy add_url cassettes.
 
     ``sources.add_url`` snapshots the notebook's source ids before issuing the
     create so its idempotency probe can tell a source it created from one that
     was already there (#2204). Cassettes recorded before that change hold no
-    such ``GET_NOTEBOOK``, so replay would consume a later poll's response and
-    desynchronise the rest of the journey.
+    such ``GET_NOTEBOOK``. Without this fixture the read still *fires*: VCR
+    refuses it, the add swallows the failure, and the call proceeds with the
+    probe disabled — green, and silently not testing the thing it names. In a
+    cassette that also records later ``GET_NOTEBOOK``s the miss is worse, since
+    the baseline consumes a poll's response and desynchronises the journey.
 
-    Keep those recordings immutable and answer only the missing read, with the
-    value the live call would have returned: in every such cassette the add is
-    the notebook's *first* source, so the pre-create list is empty. Every later
-    list — the probe's included — still replays from the cassette. Dedicated
-    tests in ``tests/integration/test_sources_idempotency.py`` drive the probe
-    against explicit request sequences, so nothing here is the only coverage of
-    it. Mirrors :func:`legacy_vcr_follow_up_probe`.
+    Keep those recordings immutable and answer only the missing read. Every
+    consumer of this fixture replays a cassette whose create **succeeds**, so
+    the probe never runs and the returned value is never compared against
+    anything — ``[]`` is the neutral answer, not a claim about the notebook.
+    That invariant is enforced rather than trusted: a second call means the
+    probe fired, and the fixture fails the test instead of letting an invented
+    empty baseline license a match. Every other list still replays from the
+    cassette. The probe itself is covered against explicit request sequences in
+    ``tests/integration/test_sources_idempotency.py``, so nothing here is its
+    only coverage. Mirrors :func:`legacy_vcr_follow_up_probe`.
     """
     from notebooklm._source.add import SourceAddService
 
@@ -655,11 +661,23 @@ def legacy_vcr_add_url_baseline(monkeypatch):
         async def _list_sources(nb_id: str):
             nonlocal calls
             calls += 1
-            if calls == 1:
-                return []
-            return await list_sources(nb_id)
+            if calls > 1:
+                raise AssertionError(
+                    "legacy_vcr_add_url_baseline: the idempotency probe fired, so this "
+                    "cassette's create did not succeed. The stubbed empty baseline would "
+                    "decide the probe's answer — record the probe's GET_NOTEBOOK instead "
+                    "of stubbing the baseline."
+                )
+            return []
 
-        return await original_add_url(self, notebook_id, url, list_sources=_list_sources, **kwargs)
+        result = await original_add_url(
+            self, notebook_id, url, list_sources=_list_sources, **kwargs
+        )
+        assert calls == 1, (
+            "legacy_vcr_add_url_baseline: add_url no longer captures a pre-create "
+            "baseline, so this fixture is stale — drop it."
+        )
+        return result
 
     monkeypatch.setattr(SourceAddService, "add_url", _add_url)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -628,6 +628,43 @@ def legacy_vcr_follow_up_probe(monkeypatch):
 
 
 @pytest.fixture
+def legacy_vcr_add_url_baseline(monkeypatch):
+    """Supply the pre-create source baseline omitted from legacy add_url cassettes.
+
+    ``sources.add_url`` snapshots the notebook's source ids before issuing the
+    create so its idempotency probe can tell a source it created from one that
+    was already there (#2204). Cassettes recorded before that change hold no
+    such ``GET_NOTEBOOK``, so replay would consume a later poll's response and
+    desynchronise the rest of the journey.
+
+    Keep those recordings immutable and answer only the missing read, with the
+    value the live call would have returned: in every such cassette the add is
+    the notebook's *first* source, so the pre-create list is empty. Every later
+    list — the probe's included — still replays from the cassette. Dedicated
+    tests in ``tests/integration/test_sources_idempotency.py`` drive the probe
+    against explicit request sequences, so nothing here is the only coverage of
+    it. Mirrors :func:`legacy_vcr_follow_up_probe`.
+    """
+    from notebooklm._source.add import SourceAddService
+
+    original_add_url = SourceAddService.add_url
+
+    async def _add_url(self, notebook_id, url, *, list_sources, **kwargs):
+        calls = 0
+
+        async def _list_sources(nb_id: str):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return []
+            return await list_sources(nb_id)
+
+        return await original_add_url(self, notebook_id, url, list_sources=_list_sources, **kwargs)
+
+    monkeypatch.setattr(SourceAddService, "add_url", _add_url)
+
+
+@pytest.fixture
 def auth_tokens():
     """Canonical mock ``AuthTokens`` for unit tests.
 

--- a/tests/integration/cli_vcr/test_sources.py
+++ b/tests/integration/cli_vcr/test_sources.py
@@ -222,8 +222,21 @@ class TestSourceAddCommand:
             ),
         ],
     )
-    def test_source_add(self, runner, mock_auth_for_vcr, mock_context, cassette, args):
-        """Add source (URL or text) works with real client."""
+    def test_source_add(
+        self,
+        runner,
+        mock_auth_for_vcr,
+        mock_context,
+        cassette,
+        args,
+        legacy_vcr_add_url_baseline,
+    ):
+        """Add source (URL or text) works with real client.
+
+        ``legacy_vcr_add_url_baseline`` answers the pre-create source list
+        ``add_url`` now takes (#2204) and ``sources_add_url.yaml`` predates; it
+        is inert for the ``text`` parameter, which runs no probe at all.
+        """
         with notebooklm_vcr.use_cassette(cassette):
             result = runner.invoke(cli, args)
             assert_command_success(result)

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -12,8 +12,8 @@ Post-fix:
 - An API-layer ``_idempotency.idempotent_create`` wrapper owns
   probe-then-retry with API-specific probes:
     - notebooks.create → baseline-diff by title
-    - sources.add_url → list-then-url-match
-    - sources._add_youtube_source → list-then-url-match
+    - sources.add_url → list-then-url-match, baseline-diff (#2204)
+    - sources._add_youtube_source → same wrapper as sources.add_url
 - ``sources.add_text`` is decision-not-to-fix: the new ``idempotent=True``
   keyword raises ``NonIdempotentRetryError`` rather than silently
   duplicating (no reliable server-side dedupe key for text sources).
@@ -295,7 +295,11 @@ async def test_notebooks_create_raises_on_ambiguous_probe(auth_tokens) -> None:
 
 
 async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
-    """ADD_SOURCE 5xx + probe(list)-finds-url returns existing source."""
+    """ADD_SOURCE 5xx + probe(list)-finds-url returns the source it created.
+
+    The source is absent from the pre-create baseline and present at probe
+    time, so it is provably the one this call committed (#2204).
+    """
     notebook_id = "nb_test"
     url = "https://example.com/article"
     src_id = "src_existing"
@@ -310,11 +314,13 @@ async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
             add_count += 1
             return httpx.Response(503, text="service unavailable")
         if rpc_id == RPCMethod.GET_NOTEBOOK.value:
-            # SourcesAPI.list calls GET_NOTEBOOK
+            # SourcesAPI.list calls GET_NOTEBOOK. Any list before the first
+            # create attempt is the pre-create baseline; later ones are probes.
             get_count += 1
+            rows = [] if add_count == 0 else [(src_id, "Existing", url)]
             return httpx.Response(
                 200,
-                text=_get_notebook_with_sources_response(notebook_id, [(src_id, "Existing", url)]),
+                text=_get_notebook_with_sources_response(notebook_id, rows),
             )
         return httpx.Response(404, text="unexpected")
 
@@ -329,8 +335,8 @@ async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
     assert source.url == url
     # Exactly ONE ADD_SOURCE: no naive re-POST after the 503
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    # Exactly ONE GET_NOTEBOOK (the probe — no baseline for sources)
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+    # TWO GET_NOTEBOOKs: the pre-create baseline plus the probe (#2204).
+    assert get_count == 2, f"expected baseline + probe GET_NOTEBOOK, got {get_count}"
 
 
 async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
@@ -350,11 +356,10 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
             return httpx.Response(502, text="bad gateway")
         if rpc_id == RPCMethod.GET_NOTEBOOK.value:
             get_count += 1
+            rows = [] if add_count == 0 else [(src_id, "Video Title", url)]
             return httpx.Response(
                 200,
-                text=_get_notebook_with_sources_response(
-                    notebook_id, [(src_id, "Video Title", url)]
-                ),
+                text=_get_notebook_with_sources_response(notebook_id, rows),
             )
         return httpx.Response(404, text="unexpected")
 
@@ -368,7 +373,7 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
     assert source.id == src_id
     assert source.url == url
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+    assert get_count == 2, f"expected baseline + probe GET_NOTEBOOK, got {get_count}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -101,6 +101,8 @@ def _create_notebook_response(notebook_id: str, title: str) -> str:
 def _get_notebook_with_sources_response(
     notebook_id: str,
     sources: list[tuple[str, str, str]],
+    *,
+    type_code: int = 5,
 ) -> str:
     """Build a GET_NOTEBOOK response that ``SourcesAPI.list`` parses.
 
@@ -108,12 +110,18 @@ def _get_notebook_with_sources_response(
     the parsing path in ``SourcesAPI.list`` (which reads from
     ``GET_NOTEBOOK``): each src entry is roughly
     ``[[id], title, metadata_with_url_at_[7], status]``.
+
+    ``type_code`` is the source-type code at ``metadata[4]`` — 5 (web page) by
+    default, 9 for YouTube (``SourceType``). It does not steer the probe, which
+    reads only ``source.url``, but a YouTube test that hands the probe a
+    web-page row is not exercising a YouTube row.
     """
     src_rows = []
     for src_id, title, url in sources:
         # metadata: url at index [7] (matches Source.from_api_response /
         # _extract_source_url precedence, allow_bare_http=False).
         metadata: list = [None] * 8
+        metadata[4] = type_code
         metadata[7] = [url]
         # status block at src[3] — [_, READY=2]
         status_block = [None, 2]
@@ -359,7 +367,9 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
             rows = [] if add_count == 0 else [(src_id, "Video Title", url)]
             return httpx.Response(
                 200,
-                text=_get_notebook_with_sources_response(notebook_id, rows),
+                # type_code 9: a real YouTube row, not a web-page row wearing a
+                # YouTube URL — otherwise this test never sees a YouTube shape.
+                text=_get_notebook_with_sources_response(notebook_id, rows, type_code=9),
             )
         return httpx.Response(404, text="unexpected")
 
@@ -372,6 +382,7 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
 
     assert source.id == src_id
     assert source.url == url
+    assert source.kind == "youtube"
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
     assert get_count == 2, f"expected baseline + probe GET_NOTEBOOK, got {get_count}"
 

--- a/tests/integration/mcp_vcr/test_sources.py
+++ b/tests/integration/mcp_vcr/test_sources.py
@@ -165,7 +165,7 @@ async def test_mcp_source_delete_two_step_confirm_over_vcr() -> None:
 
 @pytest.mark.asyncio
 @notebooklm_vcr.use_cassette("sources_add_url.yaml")
-async def test_mcp_source_add_url_over_vcr() -> None:
+async def test_mcp_source_add_url_over_vcr(legacy_vcr_add_url_baseline) -> None:
     """``source_add source_type=url`` replays the recorded ``ADD_SOURCE`` RPC.
 
     The url flow runs ``_app.source_add`` (``build_source_add_plan`` →

--- a/tests/integration/test_golden_decoded_vcr_expansion.py
+++ b/tests/integration/test_golden_decoded_vcr_expansion.py
@@ -313,7 +313,7 @@ class TestSourceMutationsGoldenDecoded:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("sources_add_url.yaml")
-    async def test_add_url_decoded_golden(self):
+    async def test_add_url_decoded_golden(self, legacy_vcr_add_url_baseline):
         """``sources.add_url`` decodes the server-extracted page title.
 
         The title is the strongest pin here: the test passes only the URL, so

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -255,8 +255,9 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     assert get_count == 2, f"expected baseline + probe GET_NOTEBOOK, got {get_count}"
 
 
-#: The URL under test, and a same-URL source that is already in the notebook
-#: before the add. Live-verified on #2204: two ``add_url`` calls with
+#: The URL these ``add_url`` probe tests add. Each test builds its own rows with
+#: :func:`_url_source_row`, so the pre-existing same-URL source is per-test, not
+#: shared. Live-verified on #2204: two ``add_url`` calls with
 #: ``https://example.com/`` produced two distinct source ids
 #: (``9bed3c8a-…`` and ``0d2c15a1-…``), so a URL is NOT unique per notebook.
 _PROBE_URL = "https://example.com/article"
@@ -598,6 +599,53 @@ async def test_add_url_recovered_create_still_honors_the_requested_title(auth_to
     assert renames == [(src_id, requested_title)], "the recovery path skipped the rename"
     assert source.title == requested_title
     assert counts["add"] == 1
+
+
+async def test_add_url_bulk_cost_is_one_baseline_read_per_call(auth_tokens) -> None:
+    """Pin the request cost the docs claim for sequential bulk adds (#2204).
+
+    ``add_url``'s docstring and the CHANGELOG tell callers a sequential bulk add
+    goes from N+1 to 2N+1 requests, because the baseline is per-call and no
+    preflight covers it. That is a numeric claim about backend load on the
+    highest-traffic add path, so it is asserted rather than asserted-in-prose:
+    three URLs must cost exactly three ``ADD_SOURCE``s and three
+    ``GET_NOTEBOOK``s — one baseline each, no probes (every create succeeds).
+
+    It also catches the regression a reader would most fear: a second baseline
+    read sneaking into the path, which would double the cost again.
+    """
+    notebook_id = "nb_test"
+    urls = [f"https://example.com/article-{index}" for index in range(3)]
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(
+                200,
+                text=_wrb_response(
+                    RPCMethod.ADD_SOURCE.value,
+                    [[_url_source_row(f"src_{counts['add']}", "Article", urls[counts["add"] - 1])]],
+                ),
+            )
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            return httpx.Response(200, text=_get_notebook_response([]))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        for url in urls:
+            await client.sources.add_url(notebook_id, url)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert counts == {"add": 3, "get": 3}, (
+        "a sequential bulk add should cost exactly one baseline GET_NOTEBOOK per "
+        f"add_url and no probes; got {counts}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -16,7 +16,10 @@ sources when the server already committed the write before returning the
    retryable transport error (5xx / 429 / network) runs a probe before
    the second attempt. The probe is variant-specific:
 
-     - ``add_url`` probes by ``source.url == url``
+     - ``add_url`` probes by ``source.url == url``, filtered against a
+       baseline of source ids captured before the create. A URL is not unique
+       within a notebook, so an unfiltered match could return a pre-existing
+       source and report a create that never landed (#2204).
      - ``add_drive`` probes by ``source.drive_document_id == file_id`` — the
        Drive ``documentId`` the backend echoes back in the source metadata.
        It previously probed a ``/d/<file_id>`` marker inside ``source.url``,
@@ -204,10 +207,14 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     create successfully, but the response was lost (e.g. proxy timeout
     returned 503 to the caller). The probe finds the new source already
     landed and returns it; only ONE ADD_SOURCE actually fires.
+
+    A neighbouring source that was already in the notebook proves the probe
+    filters on the baseline rather than merely picking the first row.
     """
     notebook_id = "nb_test"
     url = "https://example.com/article"
     src_id = "src_lost_response"
+    pre_existing = ("src_pre_existing", "Older Copy", url)
 
     add_count = 0
     get_count = 0
@@ -222,9 +229,14 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
             return httpx.Response(503, text="service unavailable")
         if rpc_id == RPCMethod.GET_NOTEBOOK.value:
             get_count += 1
+            # Any list before the first create attempt is the baseline
+            # snapshot; anything after it is a probe.
+            rows = [pre_existing]
+            if add_count > 0:
+                rows = [pre_existing, (src_id, "Article", url)]
             return httpx.Response(
                 200,
-                text=_get_notebook_with_sources_response(notebook_id, [(src_id, "Article", url)]),
+                text=_get_notebook_with_sources_response(notebook_id, rows),
             )
         return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
 
@@ -235,12 +247,357 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     finally:
         await client._collaborators.kernel.get_http_client().aclose()
 
-    assert source.id == src_id
+    assert source.id == src_id, "the probe adopted the pre-existing same-URL source"
     assert source.url == url
     # Exactly ONE ADD_SOURCE (no naive re-POST after the 503)
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
-    # Exactly ONE GET_NOTEBOOK (the probe)
-    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+    # TWO GET_NOTEBOOKs: the pre-create baseline plus the probe.
+    assert get_count == 2, f"expected baseline + probe GET_NOTEBOOK, got {get_count}"
+
+
+#: The URL under test, and a same-URL source that is already in the notebook
+#: before the add. Live-verified on #2204: two ``add_url`` calls with
+#: ``https://example.com/`` produced two distinct source ids
+#: (``9bed3c8a-…`` and ``0d2c15a1-…``), so a URL is NOT unique per notebook.
+_PROBE_URL = "https://example.com/article"
+
+
+def _url_probe_handler(
+    *,
+    baseline_rows: list,
+    post_create_rows: list,
+    counts: dict[str, int],
+    baseline_status: int = 200,
+):
+    """Build a mock handler modelling the real ``add_url`` call sequence (#2204).
+
+    ``add_url`` lists once *before* the create to snapshot a baseline, then the
+    create 502s, then the probe lists again. Returning different notebook
+    contents for the two GET_NOTEBOOK calls is what lets a test distinguish
+    "the create landed" from "a same-URL source was already there".
+
+    Mirrors :func:`_drive_probe_handler`.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            # Keyed off the create rather than a call index so an internally
+            # retried baseline still counts as one.
+            if counts["add"] == 0:
+                if baseline_status != 200:
+                    return httpx.Response(baseline_status, text="baseline unavailable")
+                return httpx.Response(200, text=_get_notebook_response(baseline_rows))
+            return httpx.Response(200, text=_get_notebook_response(post_create_rows))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    return handler
+
+
+async def test_add_url_probe_ignores_a_pre_existing_copy_of_the_same_url(
+    auth_tokens,
+) -> None:
+    """A URL already in the notebook must not be adopted as "my create" (#2204).
+
+    A URL is NOT unique within a notebook — the backend lets the same URL be
+    added twice and ``SourceLister.list`` dedupes by source id, not by URL.
+    Without the baseline filter the probe returns the pre-existing copy and
+    reports success even though the create never landed, so the caller walks
+    away holding a source id that belongs to an earlier add.
+    """
+    notebook_id = "nb_test"
+    # Present before the add, and still the only match afterwards: the create
+    # genuinely did not land.
+    pre_existing = _url_source_row("src_pre_existing", "Older Copy", _PROBE_URL)
+
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _url_probe_handler(
+            baseline_rows=[pre_existing],
+            post_create_rows=[pre_existing],
+            counts=counts,
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # The probe found no *new* match, so idempotent_create retried, exhausted
+    # its two attempts, and re-raised the transport error rather than handing
+    # back a source the caller did not create.
+    assert counts["add"] == 2
+
+
+async def test_add_url_probe_raises_when_baseline_unavailable_and_a_copy_exists(
+    auth_tokens,
+) -> None:
+    """No baseline + a matching URL = ambiguity, surfaced rather than guessed.
+
+    Mirrors ``add_drive`` / ``register_file_source``: when the pre-create
+    snapshot could not be taken, a match may or may not predate the add, and
+    silently picking one is the failure mode the baseline exists to prevent.
+    """
+    notebook_id = "nb_test"
+    existing = _url_source_row("src_ambiguous", "Some Copy", _PROBE_URL)
+
+    counts = {"add": 0, "get": 0}
+    transport = httpx.MockTransport(
+        _url_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[existing],
+            counts=counts,
+            baseline_status=500,  # baseline snapshot unavailable
+        )
+    )
+    # No executor-level retries: the baseline 500 should fail fast here, the
+    # point of the test being what the *probe* does afterwards.
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+            await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+
+async def test_add_url_baseline_unavailable_without_a_match_still_retries(auth_tokens) -> None:
+    """No baseline and no match is not ambiguous — it is simply "not committed".
+
+    The ambiguity raise must fire only when there is something to be ambiguous
+    about; otherwise a notebook that legitimately has no copy of the URL would
+    turn a recoverable transport blip into a hard error.
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    transport = httpx.MockTransport(
+        _url_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[_url_source_row("src_other", "Another Page", "https://other.test/")],
+            counts=counts,
+            baseline_status=500,  # baseline snapshot unavailable
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # ServerError (the real failure), not SourceAddError — and the retry ran.
+    assert counts["add"] == 2
+
+
+async def test_add_url_probe_raises_when_multiple_new_matches_appear(auth_tokens) -> None:
+    """Two *new* sources with the requested URL is ambiguity, not a match."""
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    transport = httpx.MockTransport(
+        _url_probe_handler(
+            baseline_rows=[],
+            post_create_rows=[
+                _url_source_row("src_new_a", "Article", _PROBE_URL),
+                _url_source_row("src_new_b", "Article", _PROBE_URL),
+            ],
+            counts=counts,
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+            await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+
+@pytest.mark.parametrize(
+    "rows_factory",
+    [
+        # A different URL entirely.
+        pytest.param(
+            lambda url: [_url_source_row("src_other", "Another Page", "https://other.test/")],
+            id="different_url",
+        ),
+        # A prefix of the requested URL: the probe is exact equality, not a
+        # substring/startswith test, so this must not match.
+        pytest.param(
+            lambda url: [_url_source_row("src_prefix", "Prefix", url[: len(url) - 4])],
+            id="prefix_of_requested_url",
+        ),
+        # The requested URL with an extra path segment appended.
+        pytest.param(
+            lambda url: [_url_source_row("src_suffix", "Suffix", url + "/comments")],
+            id="requested_url_is_a_prefix",
+        ),
+        # A row carrying no URL at all (e.g. a Drive or file source) decodes
+        # ``url`` as ``None`` and can never match.
+        pytest.param(
+            lambda url: [_url_source_row("src_no_url", "A File", None)],
+            id="row_without_a_url",
+        ),
+    ],
+)
+async def test_add_url_probe_does_not_match_unrelated_sources(auth_tokens, rows_factory) -> None:
+    """The probe matches the requested URL exactly — nothing else.
+
+    In each case the probe must return ``None`` so ``idempotent_create``
+    retries the create rather than handing back the wrong source — so both
+    attempts fire and the transport error is re-raised.
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    transport = httpx.MockTransport(
+        _url_probe_handler(
+            # Baseline is EMPTY on purpose: these rows must be rejected by the
+            # *match predicate*, not merely filtered out for pre-dating the add.
+            baseline_rows=[],
+            post_create_rows=rows_factory(_PROBE_URL),
+            counts=counts,
+        )
+    )
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    # Both create attempts fired: the probe never spuriously matched.
+    assert counts["add"] == 2
+
+
+async def test_add_url_probe_matches_on_the_second_attempt(auth_tokens) -> None:
+    """The baseline captured before attempt 1 is still correct at probe 2.
+
+    Sequence: create fails, probe finds nothing, create fails again, and only
+    then does the committed source surface (source lists lag). The single
+    pre-create baseline must still identify it as new — and must still exclude
+    the same-URL source that was there all along.
+    """
+    notebook_id = "nb_test"
+    src_id = "src_late"
+    pre_existing = _url_source_row("src_pre_existing", "Older Copy", _PROBE_URL)
+    committed = _url_source_row(src_id, "Article", _PROBE_URL)
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            # baseline (get 1) and probe 1 (get 2) see only the older copy;
+            # probe 2 finally sees the committed source.
+            rows = [pre_existing, committed] if counts["get"] >= 3 else [pre_existing]
+            return httpx.Response(200, text=_get_notebook_response(rows))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_url(notebook_id, _PROBE_URL)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert source.id == src_id
+    assert counts["add"] == 2, "both attempts should have fired before the probe matched"
+
+
+async def test_add_url_probe_decode_failure_warns_and_does_not_match(auth_tokens, caplog) -> None:
+    """A non-transport probe failure is loud, and still lets the retry proceed.
+
+    A drifted GET_NOTEBOOK makes the strict decoder raise ``RPCError``. That is
+    NOT a transport signal, so it must not propagate as one — but it also cannot
+    pass unremarked at DEBUG, because it is indistinguishable from "the create
+    did not land" and this variant has no internal retries to fall back on
+    (#2204).
+    """
+    notebook_id = "nb_test"
+    counts = {"add": 0, "get": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            if counts["add"] == 0:
+                return httpx.Response(200, text=_get_notebook_response([]))
+            # Structurally undecodable notebook envelope -> RPCError, not 5xx.
+            return httpx.Response(200, text=_wrb_response(RPCMethod.GET_NOTEBOOK.value, "nonsense"))
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    with caplog.at_level(logging.WARNING, logger="notebooklm._sources"):
+        try:
+            with pytest.raises(ServerError):
+                await client.sources.add_url(notebook_id, _PROBE_URL)
+        finally:
+            await client._collaborators.kernel.get_http_client().aclose()
+
+    # Treated as "no match", so both attempts fire and the transport error wins.
+    assert counts["add"] == 2
+    assert "may create a duplicate source" in caplog.text
+
+
+async def test_add_url_recovered_create_still_honors_the_requested_title(auth_tokens) -> None:
+    """A probed-but-fresh URL add must still get the caller's title (#2204).
+
+    Web-page and YouTube imports re-derive the display title server-side, so
+    ``add_url`` issues a best-effort rename afterwards. That rename used to be
+    skipped for a ``PROBED`` result, because a probe match could predate the
+    call — but the probe now filters against a pre-create baseline, so its match
+    is provably ours.
+    """
+    notebook_id = "nb_test"
+    requested_title = "The Title I Asked For"
+    upstream_title = "Whatever The Page Called Itself"
+    src_id = "src_recovered"
+
+    committed = _url_source_row(src_id, upstream_title, _PROBE_URL)
+    counts = {"add": 0, "get": 0}
+    renames: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            counts["add"] += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            counts["get"] += 1
+            rows = [] if counts["add"] == 0 else [committed]
+            return httpx.Response(200, text=_get_notebook_response(rows))
+        if rpc_id == RPCMethod.UPDATE_SOURCE.value:
+            renames.append((src_id, requested_title))
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.UPDATE_SOURCE.value, [[src_id], requested_title]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_url(notebook_id, _PROBE_URL, title=requested_title)
+    finally:
+        await client._collaborators.kernel.get_http_client().aclose()
+
+    assert source.id == src_id
+    assert renames == [(src_id, requested_title)], "the recovery path skipped the rename"
+    assert source.title == requested_title
+    assert counts["add"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -360,7 +360,7 @@ async def test_add_url_probe_raises_when_baseline_unavailable_and_a_copy_exists(
     # point of the test being what the *probe* does afterwards.
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
     try:
-        with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+        with pytest.raises(SourceAddError, match="pre-create baseline snapshot failed"):
             await client.sources.add_url(notebook_id, _PROBE_URL)
     finally:
         await client._collaborators.kernel.get_http_client().aclose()

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -53,6 +53,12 @@ class TestAddSource:
         httpx_mock: HTTPXMock,
         build_rpc_response,
     ):
+        # add_url snapshots the notebook's source ids before the create so its
+        # idempotency probe can tell a fresh add from a pre-existing source with
+        # the same URL (#2204), so the first request is a GET_NOTEBOOK.
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         response = build_rpc_response(
             RPCMethod.ADD_SOURCE,
             [
@@ -74,6 +80,9 @@ class TestAddSource:
         assert isinstance(source, Source)
         assert source.id == "source_id"
         assert source.url == "https://example.com"
+        urls = [str(request.url) for request in httpx_mock.get_requests()]
+        assert any(RPCMethod.GET_NOTEBOOK in url for url in urls)
+        assert any(RPCMethod.ADD_SOURCE in url for url in urls)
 
     @pytest.mark.asyncio
     async def test_add_source_text(
@@ -1713,6 +1722,10 @@ class TestAddUrlErrorPaths:
         build_rpc_response,
     ):
         """Test add_url() with wait=True calls wait_until_ready (lines 335-336)."""
+        # First request is add_url's pre-create baseline snapshot (#2204).
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         source_data = [[[["src_wait_url"], "Example", [None, 11], [None, 2]]]]
         ready_source = Source(id="src_wait_url", title="Example")
         response = build_rpc_response(RPCMethod.ADD_SOURCE, source_data)
@@ -1738,6 +1751,10 @@ class TestAddUrlErrorPaths:
         build_rpc_response,
     ):
         """Test add_url() warns when URL looks like YouTube but has no video ID (line 320)."""
+        # First request is add_url's pre-create baseline snapshot (#2204).
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         response = build_rpc_response(
             RPCMethod.ADD_SOURCE,
             [[[["src_channel"], "YouTube Channel", [None, 11], [None, 2]]]],
@@ -2684,6 +2701,10 @@ class TestAddYoutubeSourceDirect:
         build_rpc_response,
     ):
         """Test add_url() with YouTube URL calls _add_youtube_source internally (lines 870-876)."""
+        # First request is add_url's pre-create baseline snapshot (#2204).
+        httpx_mock.add_response(
+            content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook", []]]).encode()
+        )
         response = build_rpc_response(
             RPCMethod.ADD_SOURCE,
             [

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -1742,6 +1742,12 @@ class TestAddUrlErrorPaths:
 
         mock_wait.assert_called_once()
         assert result.id == "src_wait_url"
+        urls = [str(request.url) for request in httpx_mock.get_requests()]
+        assert any(RPCMethod.GET_NOTEBOOK in url for url in urls), (
+            "add_url must issue its pre-create baseline GET_NOTEBOOK (#2204); without "
+            "it the queued baseline response is consumed by ADD_SOURCE instead"
+        )
+        assert any(RPCMethod.ADD_SOURCE in url for url in urls)
 
     @pytest.mark.asyncio
     async def test_add_url_youtube_like_no_id_warning(
@@ -1769,6 +1775,12 @@ class TestAddUrlErrorPaths:
 
         assert source is not None
         mock_is_yt.assert_called_once()
+        urls = [str(request.url) for request in httpx_mock.get_requests()]
+        assert any(RPCMethod.GET_NOTEBOOK in url for url in urls), (
+            "add_url must issue its pre-create baseline GET_NOTEBOOK (#2204); without "
+            "it the queued baseline response is consumed by ADD_SOURCE instead"
+        )
+        assert any(RPCMethod.ADD_SOURCE in url for url in urls)
 
 
 class TestAddTextErrorPaths:
@@ -2736,6 +2748,12 @@ class TestAddYoutubeSourceDirect:
 
         assert source.id == "yt_src_001"
         assert source.kind == "youtube"
+        urls = [str(request.url) for request in httpx_mock.get_requests()]
+        assert any(RPCMethod.GET_NOTEBOOK in url for url in urls), (
+            "add_url must issue its pre-create baseline GET_NOTEBOOK (#2204); without "
+            "it the queued baseline response is consumed by ADD_SOURCE instead"
+        )
+        assert any(RPCMethod.ADD_SOURCE in url for url in urls)
 
 
 class TestRegisterFileSourceError:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -196,7 +196,7 @@ class TestSourcesAPI:
     @pytest.mark.vcr
     @pytest.mark.asyncio
     @notebooklm_vcr.use_cassette("sources_add_url.yaml")
-    async def test_add_url(self):
+    async def test_add_url(self, legacy_vcr_add_url_baseline):
         """Add a URL source."""
         async with vcr_client() as client:
             source = await client.sources.add_url(

--- a/tests/integration/test_workflow_tracer_vcr.py
+++ b/tests/integration/test_workflow_tracer_vcr.py
@@ -111,7 +111,11 @@ class TestWorkflowTracerBullet:
         match_on=["method", "scheme", "host", "port", "path", "rpcids", "freq"],
     )
     async def test_full_workflow(
-        self, tmp_path: Path, fast_sleep: None, legacy_vcr_follow_up_probe
+        self,
+        tmp_path: Path,
+        fast_sleep: None,
+        legacy_vcr_follow_up_probe,
+        legacy_vcr_add_url_baseline,
     ) -> None:
         """End-to-end user journey produces a downloadable report.
 

--- a/tests/server/test_integration_real_client.py
+++ b/tests/server/test_integration_real_client.py
@@ -152,7 +152,9 @@ class TestRestSeamMatrix:
     """One representative REST adapter → client/service composition path."""
 
     @notebooklm_vcr.use_cassette("sources_add_url.yaml", allow_playback_repeats=True)
-    def test_url_add_crosses_rest_to_client_boundary(self, real_authed_client: TestClient) -> None:
+    def test_url_add_crosses_rest_to_client_boundary(
+        self, real_authed_client: TestClient, legacy_vcr_add_url_baseline
+    ) -> None:
         """Drive the route through the real client and project its decoded source."""
         resp = real_authed_client.post(
             f"/v1/notebooks/{_NB}/sources/url", json={"url": "https://example.com/x"}

--- a/tests/unit/test_idempotent_create_contract.py
+++ b/tests/unit/test_idempotent_create_contract.py
@@ -63,22 +63,35 @@ async def test_idempotent_create_reraises_last_exception_by_identity() -> None:
 
 
 @pytest.mark.asyncio
-async def test_probe_result_never_honors_url_title_even_after_wait() -> None:
+async def test_probed_url_result_honors_the_title_but_does_not_re_wait() -> None:
+    """A ``PROBED`` ``add_url`` result is renamed, and never waited on twice.
+
+    #1988 skipped the rename for every ``PROBED`` result because a probe match
+    could not be proven to be the caller's own — renaming a stranger's source
+    would be a surprise. #2204 filters ``add_url`` probe matches against a
+    baseline captured before the create, so a match now *is* provably fresh and
+    the requested title must win (the same flip #2113 made for ``add_drive``).
+
+    The wait half of the #1988 contract is unchanged: ``wait`` is handled inside
+    the service, so ``SourcesAPI`` must not re-await ``wait_until_ready``.
+    """
     api = SourcesAPI(MagicMock(), uploader=MagicMock())
-    existing = Source(id="existing", title="Drive title", url="https://example.test")
+    existing = Source(id="existing", title="Upstream title", url="https://example.test")
     api._adder.add_url = AsyncMock(
         return_value=_IdempotentCreateResult(existing, _CreateResultKind.PROBED)
     )
     api.wait_until_ready = AsyncMock(  # type: ignore[method-assign]
         return_value=Source(id="existing", title="Ready")
     )
-    api.rename = AsyncMock()  # type: ignore[method-assign]
+    api.rename = AsyncMock(  # type: ignore[method-assign]
+        return_value=Source(id="existing", title="Retitle me")
+    )
 
-    result = await api.add_url("nb", existing.url, title="Do not retitle", wait=True)
+    result = await api.add_url("nb", existing.url, title="Retitle me", wait=True)
 
-    assert result.title == "Drive title"
+    assert result.title == "Retitle me"
+    api.rename.assert_awaited_once_with("nb", "existing", "Retitle me")
     api.wait_until_ready.assert_not_awaited()
-    api.rename.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -114,7 +127,9 @@ async def test_private_service_preserves_probe_provenance_through_wait() -> None
         wait=True,
         add_youtube_source=AsyncMock(),
         add_url_source=AsyncMock(side_effect=NetworkError("lost response")),
-        list_sources=AsyncMock(return_value=[existing]),
+        # Baseline (empty) then probe: the source must be absent before the
+        # create for the probe to claim it as this call's own (#2204).
+        list_sources=AsyncMock(side_effect=[[], [existing]]),
         wait_until_ready=AsyncMock(return_value=ready),
         extract_youtube_video_id=MagicMock(return_value=None),
         is_youtube_url=MagicMock(return_value=False),

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -99,23 +99,151 @@ async def test_add_url_probe_returns_existing_after_transport_error(
     service: SourceAddService,
     logger: logging.Logger,
 ) -> None:
-    existing = Source(id="src_existing", url="https://example.com")
+    """A source absent from the baseline and present at probe time is ours.
+
+    ``list_sources`` is called twice: once for the pre-create baseline (empty)
+    and once for the probe. Returning ``[created]`` from *both* would make the
+    match ambiguous — see
+    ``test_add_url_probe_ignores_a_source_present_before_the_create``.
+    """
+    created = Source(id="src_created", url="https://example.com")
     add_url_source = AsyncMock(side_effect=NetworkError("temporary network failure"))
+    list_sources = AsyncMock(side_effect=[[], [created]])
 
     source = await service.add_url(
         "nb_1",
-        existing.url,
+        created.url,
         add_youtube_source=AsyncMock(),
         add_url_source=add_url_source,
-        list_sources=AsyncMock(return_value=[existing]),
+        list_sources=list_sources,
         wait_until_ready=AsyncMock(),
         extract_youtube_video_id=MagicMock(return_value=None),
         is_youtube_url=MagicMock(return_value=False),
         logger=logger,
     )
 
-    assert source is existing
-    add_url_source.assert_awaited_once_with("nb_1", existing.url)
+    assert source is created
+    add_url_source.assert_awaited_once_with("nb_1", created.url)
+    assert list_sources.await_count == 2, "baseline + probe"
+
+
+@pytest.mark.asyncio
+async def test_add_url_probe_ignores_a_source_present_before_the_create(
+    service: SourceAddService,
+    logger: logging.Logger,
+) -> None:
+    """The probe must not adopt a same-URL source that predates the call (#2204).
+
+    A URL is not unique within a notebook, so the ``source.url == url`` match
+    alone cannot tell "my create landed" from "a copy was already there". Here
+    the notebook holds the URL both before and after the failed create — i.e.
+    nothing new appeared — so the probe must report no match and let
+    ``idempotent_create`` retry rather than hand back the pre-existing id.
+    """
+    pre_existing = Source(id="src_pre_existing", url="https://example.com")
+    add_url_source = AsyncMock(side_effect=NetworkError("temporary network failure"))
+
+    with pytest.raises(NetworkError):
+        await service.add_url(
+            "nb_1",
+            pre_existing.url,
+            add_youtube_source=AsyncMock(),
+            add_url_source=add_url_source,
+            list_sources=AsyncMock(return_value=[pre_existing]),
+            wait_until_ready=AsyncMock(),
+            extract_youtube_video_id=MagicMock(return_value=None),
+            is_youtube_url=MagicMock(return_value=False),
+            logger=logger,
+        )
+
+    # Both attempts fired: the probe refused to claim the pre-existing source.
+    assert add_url_source.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_add_url_baseline_failure_makes_a_match_ambiguous(
+    service: SourceAddService,
+    logger: logging.Logger,
+) -> None:
+    """No baseline + a match = ``SourceAddError``, not a guess (#2204).
+
+    The baseline list is best-effort; when it fails, a probe match may or may
+    not predate this add, and adopting it is exactly the failure mode the
+    baseline exists to prevent.
+    """
+    existing = Source(id="src_ambiguous", url="https://example.com")
+    # First call = the baseline (fails, non-transport); second = the probe.
+    list_sources = AsyncMock(side_effect=[RPCError("baseline decode failed"), [existing]])
+
+    with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+        await service.add_url(
+            "nb_1",
+            existing.url,
+            add_youtube_source=AsyncMock(),
+            add_url_source=AsyncMock(side_effect=NetworkError("temporary network failure")),
+            list_sources=list_sources,
+            wait_until_ready=AsyncMock(),
+            extract_youtube_video_id=MagicMock(return_value=None),
+            is_youtube_url=MagicMock(return_value=False),
+            logger=logger,
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_url_probe_raises_on_multiple_new_matches(
+    service: SourceAddService,
+    logger: logging.Logger,
+) -> None:
+    """Two *new* same-URL sources after the failure is ambiguity, not a match."""
+    url = "https://example.com"
+    list_sources = AsyncMock(
+        side_effect=[[], [Source(id="src_a", url=url), Source(id="src_b", url=url)]]
+    )
+
+    with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+        await service.add_url(
+            "nb_1",
+            url,
+            add_youtube_source=AsyncMock(),
+            add_url_source=AsyncMock(side_effect=NetworkError("temporary network failure")),
+            list_sources=list_sources,
+            wait_until_ready=AsyncMock(),
+            extract_youtube_video_id=MagicMock(return_value=None),
+            is_youtube_url=MagicMock(return_value=False),
+            logger=logger,
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_url_probe_decode_failure_warns(
+    service: SourceAddService,
+    logger: logging.Logger,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-transport probe failure logs at WARNING, not DEBUG (#2204).
+
+    It is indistinguishable from "the create did not land", so the add is
+    re-issued with no internal retries left as a net — the operator needs to
+    see it.
+    """
+    add_url_source = AsyncMock(side_effect=NetworkError("temporary network failure"))
+    list_sources = AsyncMock(side_effect=[[], RPCError("probe decode failed"), [], []])
+
+    with caplog.at_level(logging.WARNING, logger=logger.name), pytest.raises(NetworkError):
+        await service.add_url(
+            "nb_1",
+            "https://example.com",
+            add_youtube_source=AsyncMock(),
+            add_url_source=add_url_source,
+            list_sources=list_sources,
+            wait_until_ready=AsyncMock(),
+            extract_youtube_video_id=MagicMock(return_value=None),
+            is_youtube_url=MagicMock(return_value=False),
+            logger=logger,
+        )
+
+    assert "may create a duplicate source" in caplog.text
+    assert add_url_source.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -161,26 +161,43 @@ async def test_add_url_probe_ignores_a_source_present_before_the_create(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "baseline_failure",
+    [
+        # A drifted GET_NOTEBOOK: the strict decoder raises, not the transport.
+        pytest.param(RPCError("baseline decode failed"), id="decode_failure"),
+        # A transport failure. The probe deliberately re-RAISES this class; the
+        # baseline capture deliberately swallows it, so pin that asymmetry.
+        pytest.param(ServerError("baseline 503"), id="transport_failure"),
+    ],
+)
 async def test_add_url_baseline_failure_makes_a_match_ambiguous(
     service: SourceAddService,
     logger: logging.Logger,
+    caplog: pytest.LogCaptureFixture,
+    baseline_failure: Exception,
 ) -> None:
     """No baseline + a match = ``SourceAddError``, not a guess (#2204).
 
     The baseline list is best-effort; when it fails, a probe match may or may
     not predate this add, and adopting it is exactly the failure mode the
-    baseline exists to prevent.
+    baseline exists to prevent. The error must carry enough to act on: what
+    broke the baseline (as ``cause``), and which source is ambiguous.
     """
-    existing = Source(id="src_ambiguous", url="https://example.com")
-    # First call = the baseline (fails, non-transport); second = the probe.
-    list_sources = AsyncMock(side_effect=[RPCError("baseline decode failed"), [existing]])
+    existing = Source(id="src_ambiguous", title="Some Copy", url="https://example.com")
+    # First call = the baseline (fails); second = the probe.
+    list_sources = AsyncMock(side_effect=[baseline_failure, [existing]])
+    transport_error = NetworkError("temporary network failure")
 
-    with pytest.raises(SourceAddError, match="baseline snapshot was unavailable"):
+    with (
+        caplog.at_level(logging.WARNING, logger=logger.name),
+        pytest.raises(SourceAddError) as raised,
+    ):
         await service.add_url(
             "nb_1",
             existing.url,
             add_youtube_source=AsyncMock(),
-            add_url_source=AsyncMock(side_effect=NetworkError("temporary network failure")),
+            add_url_source=AsyncMock(side_effect=transport_error),
             list_sources=list_sources,
             wait_until_ready=AsyncMock(),
             extract_youtube_video_id=MagicMock(return_value=None),
@@ -188,19 +205,34 @@ async def test_add_url_baseline_failure_makes_a_match_ambiguous(
             logger=logger,
         )
 
+    # The message names the ambiguous source, so the caller told to "check the
+    # notebook source list" knows which row to look at.
+    assert "src_ambiguous" in str(raised.value)
+    # ``cause`` carries what broke the baseline — otherwise nothing in the
+    # process can explain why the snapshot was unavailable.
+    assert raised.value.cause is baseline_failure
+    # The transport error that triggered the probe survives as context.
+    assert raised.value.__context__ is transport_error
+    # The swallow is visible at the default logger level (WARNING), not DEBUG.
+    assert "baseline list() failed" in caplog.text
+
 
 @pytest.mark.asyncio
 async def test_add_url_probe_raises_on_multiple_new_matches(
     service: SourceAddService,
     logger: logging.Logger,
 ) -> None:
-    """Two *new* same-URL sources after the failure is ambiguity, not a match."""
+    """Two *new* same-URL sources after the failure is ambiguity, not a match.
+
+    The message must name both, since the caller is being told to go and
+    disambiguate a URL that by definition appears in the list more than once.
+    """
     url = "https://example.com"
     list_sources = AsyncMock(
         side_effect=[[], [Source(id="src_a", url=url), Source(id="src_b", url=url)]]
     )
 
-    with pytest.raises(SourceAddError, match="probe found 2 new sources"):
+    with pytest.raises(SourceAddError, match="probe found 2 new sources") as raised:
         await service.add_url(
             "nb_1",
             url,
@@ -212,6 +244,9 @@ async def test_add_url_probe_raises_on_multiple_new_matches(
             is_youtube_url=MagicMock(return_value=False),
             logger=logger,
         )
+
+    assert "src_a" in str(raised.value)
+    assert "src_b" in str(raised.value)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -12,7 +12,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._app import source_add as cli_source_add
-from notebooklm._source.add import SourceAddService
+from notebooklm._idempotency import _CreateResultKind, _IdempotentCreateResult
+from notebooklm._source.add import SourceAddService, honor_requested_title_if_fresh
 from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import (
     AuthError,
@@ -247,6 +248,62 @@ async def test_add_url_probe_raises_on_multiple_new_matches(
 
     assert "src_a" in str(raised.value)
     assert "src_b" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_add_url_baseline_failure_does_not_break_a_successful_add(
+    service: SourceAddService,
+    logger: logging.Logger,
+) -> None:
+    """A failed baseline degrades the probe; it must not fail the add (#2204).
+
+    The baseline is best-effort by design: it exists to disambiguate a *retry*,
+    so a transient notebook read must not turn an otherwise perfectly good
+    ``add_url`` into an error. Pins the resilience half of the swallow — the
+    regression this catches is someone narrowing that ``except Exception`` to
+    mirror the probe's transport re-raise, which would fail every add whenever
+    the notebook read blips.
+    """
+    add_url_source = AsyncMock(return_value=source_response("ok", "Example"))
+
+    source = await service.add_url(
+        "nb_1",
+        "https://example.com",
+        add_youtube_source=AsyncMock(),
+        add_url_source=add_url_source,
+        list_sources=AsyncMock(side_effect=ServerError("baseline 503")),
+        wait_until_ready=AsyncMock(),
+        extract_youtube_video_id=MagicMock(return_value=None),
+        is_youtube_url=MagicMock(return_value=False),
+        logger=logger,
+    )
+
+    assert source.id == "src_ok"
+    assert add_url_source.await_count == 1, "the add must not be retried"
+
+
+@pytest.mark.asyncio
+async def test_probed_result_without_proven_freshness_skips_the_rename() -> None:
+    """The #1988 default still holds for a probe that cannot prove freshness.
+
+    Both production call sites now pass ``probe_proves_freshness=True``, so the
+    default branch would otherwise be unreachable and unpinned — and it is the
+    only thing stopping a future third caller with an un-baselined probe from
+    renaming a source it did not create.
+    """
+    probed = Source(id="not_mine", title="Someone Else's Title")
+    rename = AsyncMock()
+
+    result = await honor_requested_title_if_fresh(
+        rename,
+        "nb_1",
+        _IdempotentCreateResult(probed, _CreateResultKind.PROBED),
+        "Retitle me",
+        logging.getLogger("tests.source_add"),
+    )
+
+    assert result is probed
+    rename.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2204.

`sources.add_url`'s idempotency probe matched `source.url == url` across the whole notebook with no baseline filter, so it could not tell *"the create I just issued landed"* from *"a source with this URL was already here"*. After a transport failure it adopted whichever it found and reported success.

## The bug, live

Scratch notebook `6ac2e020-467c-4080-8ca0-b1c2282664de` on `peopleconf@gmail.com`, created and deleted in one run:

```
[A] add the same URL twice
  add #1: id=9bed3c8a-5dd1-41bc-a86c-631fcb215589 url='https://example.com/'
  add #2: id=0d2c15a1-9809-4090-9449-e298bd392b30 url='https://example.com/'
  VERDICT A: 2 sources share 'https://example.com/'

[C] commit-lost-response with a pre-existing same-URL source
  ids before the lossy add: ['0d2c15a1-…', '9bed3c8a-…', 'fd1ee78a-…']
  add_url returned: id=0d2c15a1-9809-4090-9449-e298bd392b30
  VERDICT C: ADOPTED A PRE-EXISTING SOURCE (bug)
  new ids: ['df618843-16b9-4bc0-bd31-ef25f509298f']
  total sources with that URL: 3
```

Worse than the issue describes. The create **did** commit — `df618843-…` really landed — and the probe handed back `0d2c15a1-…`, an earlier add. So the caller walks away holding the wrong source id *and* an unreported duplicate stays in the notebook. With `wait=True` the mask is total: the adopted source is already `READY`, so the wait returns instantly.

Worth noting for anyone who thinks the retry path is exotic: run `[A]` above hit a genuine `RPCTimeoutError` on its very first `add_url` and went through the probe unprompted.

## The decision: unconditional pre-create baseline

Same shape `add_file` has always had and `add_drive` adopted in #2113 — capture `{source.id …}` before the create, accept only matches absent from it, raise `SourceAddError` on an unavailable baseline with a match or on a multi-match.

The issue asked for this to be decided rather than copied, because `add_url` is the highest-traffic add path. The three options, and why the other two lose:

**Baseline only on the retry path — unsound, not just cheaper.** The probe runs *after* the create. If the create committed, a list taken there already contains the just-created source, so a lazily captured "baseline" would swallow the very row it exists to detect. Nothing recoverable at probe time reconstructs the pre-create state: the response that carried the new id is exactly what was lost. Mutation `M7` in the table below encodes this option directly and 10 tests fail.

**Fail closed without a baseline — sound, but it deletes the feature.** Zero happy-path cost; on a match it raises instead of adopting. It does prevent the wrong-id bug, but it converts *every* genuine commit-lost-response recovery — including the overwhelmingly common single-source-per-URL case — into a hard error, and a caller who then retries by hand creates the duplicate the probe exists to prevent.

**Rejected in passing:** a `created_at`-based freshness window (second-resolution server timestamps plus client/server skew, and it fails precisely in the bulk-import case where the pre-existing copy was added seconds earlier); a process-local cache of known source ids (a concurrent add by another client makes the stale baseline miss a pre-existing source, reintroducing the bug quietly). There is no cheaper listing RPC — source ids are published only inside the `GET_NOTEBOOK` payload, and `LIST_NOTEBOOKS`, which does not bump recency, does not carry them.

### The cost, measured rather than assumed

One extra `GET_NOTEBOOK` per `add_url`, which bumps the notebook to the top of the web UI's *Recent* list (#2126). I checked whether `ADD_SOURCE` already bumps it, which would have made the cost nil. It does not:

```
[B] does add_url alone bump Recent order?
  before add_url: recent_index=1 last_viewed_at=1786617745.0
  after add_url : recent_index=2 last_viewed_at=1786617745.0
  VERDICT B: ADD_SOURCE bumped lastViewedTime: False
```

(read via `LIST_NOTEBOOKS`, which #2126/#2198 established does *not* bump). So this is a genuinely new side effect, not one already paid — and the honest framing is that it is a real cost accepted, not a free lunch. Mitigating it: the bump is idempotent, so a 50-URL bulk import reorders Recent once, not fifty times; `wait=True` callers already pay it via `wait_until_ready`'s polling; and the REST batch endpoint already does a preflight `GET_NOTEBOOK`. Silently reporting a create that never happened is worse than a reordered Recent list.

## Also in this change

- **Probe swallow `DEBUG` → `WARNING`**, as #2199 did for Drive. A decode failure there is indistinguishable from "the create did not land", so `idempotent_create` re-issues the add — and this variant runs with `disable_internal_retries=True`, leaving no other net.
- **A probed-but-fresh result now honors a requested `title`.** #1988 skipped the rename for every `PROBED` result because a match could not be proven to be the caller's own; the baseline now proves it, so the same flip #2113 made for Drive applies here.
- **Docstrings corrected.** `add_url` had a one-line docstring that documented none of this. `_idempotency_policy.py`'s registry notes still described the Drive probe as `/d/<file_id>` URL-segment matching — dead since #2199 — so that adjacent line is corrected too.
- The user-facing idempotency table in `docs/python-api.md` described `add_url` as a bare url-match; the recency table moves `add_url` from the retry-only row to the unconditional-baseline row.

**Is exact equality the right predicate?** Checked live rather than assumed — the backend echoes the requested URL back verbatim in all four shapes tried, including the short `youtu.be/…` form and a query string:

```
  requested 'https://example.com'                                   -> returned identical (WEB_PAGE)
  requested 'https://www.iana.org/help/example-domains'             -> returned identical (WEB_PAGE)
  requested 'https://youtu.be/dQw4w9WgXcQ'                          -> returned identical (YOUTUBE)
  requested 'https://en.wikipedia.org/wiki/Tracer_bullet?utm_source=probe' -> returned identical (WEB_PAGE)
```

## Tests

The issue recorded that the probe's match loop was **untested on `main`** — the unsafe comparison had nothing pinning it. Four existing tests had to be modified because they encoded the pre-fix belief: their `list_sources` doubles returned the *same* list before and after the create, i.e. exactly the ambiguous case the fix now refuses to adopt. Each was rewritten to model the real call sequence (empty/pre-existing baseline, then the post-create list), not merely to go green.

Every new test was mutation-tested — the code it covers was broken and the failure confirmed:

| Mutation | Tests that caught it |
|---|---|
| M1 drop the baseline filter (**the bug itself**) | 10 |
| M2 adopt a match when the baseline is unavailable | 2 |
| M3 take the first of several new matches | 2 |
| M4 downgrade the probe warning back to `DEBUG` | 2 |
| M5 match the URL by substring | 1 |
| M6 skip the rename on a probed-but-fresh add | 1 |
| M7 capture the baseline *after* the create (the lazy option) | 10 |
| M8 match every source regardless of URL | 5 |
| M9 match when the stored URL is a prefix of the requested one | 1 |
| M10 downgrade the *baseline* swallow back to `DEBUG` | 2 |
| M11 drop the baseline failure `cause` from the ambiguity error | 2 |
| M12 stop naming the ambiguous sources in the multi-match error | 1 |

`_source/add.py` is at **100%** coverage — 197 statements, 60 branches, none missed.

`tests/integration/test_workflow_tracer_vcr.py` needed a `legacy_vcr_add_url_baseline` fixture: that cassette predates the baseline read, so replay would consume a later poll's response and desynchronise the rest of the journey. It answers only the missing read, with the value the live call would have returned (the add is that notebook's first source, so the pre-create list is empty) and lets every later list replay from the cassette. Mirrors the existing `legacy_vcr_follow_up_probe`. `allow_playback_repeats=True` was tried first and rejected — it makes the artifact-generation poll replay "in progress" forever.

## Review round

Three reviewers (code review, silent-failure, test coverage) plus CodeRabbit, Codex and `claude[bot]`. What actually changed as a result:

**A silently disabled protection, found by the silent-failure review.** The new baseline capture swallowed its failure at `DEBUG`, and the `notebooklm` logger defaults to `WARNING` — so the record was dropped before any handler saw it and the call ran with the probe disabled, quietly. Not hypothetical: five of the repo's own VCR tests replay `sources_add_url.yaml`, which predates the baseline read, and were exercising exactly that disabled path while reporting success. Proven by removing the fixture and watching the log:

```
WARNING notebooklm._sources:add.py:266 add_url: baseline list() failed
(CannotOverwriteExistingCassetteException); the idempotency probe can no longer
tell a source this call created from one that was already there, ...
```

Both `add_url` and `add_drive` now log a failed baseline at `WARNING` (`add_drive`'s corrected in the same pass so the two don't disagree inside one file), the ambiguity errors carry the baseline failure as `cause` and name the source ids they could not disambiguate, and the five VCR consumers take a fixture that now *fails the test* if the probe ever fires rather than letting an invented empty baseline decide the answer.

**Coverage gaps, found by the test review.** Nothing pinned "baseline failed but the create succeeded" — the resilience half of the swallow, whose regression is someone narrowing that `except Exception` and failing every add whenever the notebook read blips. `probe_proves_freshness=False` became unreachable from production once both call sites passed `True`, leaving the #1988 default — the only thing stopping a future third caller with an un-baselined probe from renaming a source it did not create — unpinned. The 2N+1 bulk cost was a numeric claim made only in prose. The YouTube probe test fed the probe a web-page row wearing a YouTube URL. All four now have tests.

**One push-back.** CodeRabbit asked for the probe's non-transport failure to propagate rather than retry. Declined here and filed as #2220: it is not a strictly better trade (propagating turns every decode blip into a hard failure of an add that in the common case never landed), and all three probe paths share this behaviour, so changing `add_url` alone would split a uniform pattern inside the very PR that exists to align it with `add_drive`. #2220 carries the trade-off table, the three call sites, and the `register_file_source` `DEBUG` parity fix that should happen regardless.

## Verification

```
uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90
  -> 15902 passed, 64 skipped, 1 xfailed | 96.71% | exit 0
uv run mypy src/notebooklm --ignore-missing-imports   -> Success: 351 source files | exit 0
uv run pre-commit run --all-files                     -> Passed | exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL and YouTube source creation to avoid reusing existing duplicate sources.
  - Added safer recovery when source creation responses are delayed or unavailable.
  - Ambiguous matches now produce clear errors instead of incorrect results.
  - Newly created sources correctly retain requested titles.
  - Probe issues are logged as warnings before retrying where possible.
  - Improved duplicate handling for Drive and file sources.

- **Documentation**
  - Clarified source creation behavior, duplicate handling, and potential Recent-order updates caused by source checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
