### PR TITLE
chore(pre-commit): scan committed fixtures for credential shapes before push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,23 @@ repos:
         language: system
         types_or: [python, pyi]
         require_serial: true
+      # Credential shapes in committed fixtures/cassettes, caught BEFORE push.
+      #
+      # The same scan already runs in CI (test.yml, "Check fixtures for
+      # credential leaks") and as a pytest guardrail, but both fire *after* the
+      # push that publishes the secret. In #2120 a live-captured fixture carrying
+      # a signed Google user-content URL and its capability token reached a public
+      # branch and was only flagged by review; scrubbing the file afterwards does
+      # not unpublish the pushed objects, which GitHub keeps fetchable by SHA.
+      # This hook closes that window — the scan is worthless once the object is
+      # public, so it has to run before the commit exists.
+      #
+      # Scoped by ``files:`` to the directories that hold committed captures, so
+      # the common Python-only commit skips it entirely. The script accepts
+      # individual paths, so pre-commit passes only the staged files.
+      - id: fixture-secrets
+        name: fixture-secrets (no credential shapes in captures)
+        entry: uv run python tests/scripts/check_cassettes_clean.py --secrets-only
+        language: system
+        files: ^tests/(cassettes|fixtures|unit/fixtures)/.*\.(json|ya?ml|html)$
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,17 @@ repos:
       # Scoped by ``files:`` to the directories that hold committed captures, so
       # the common Python-only commit skips it entirely. The script accepts
       # individual paths, so pre-commit passes only the staged files.
+      # ``--strict`` disables the repair allowlist. Without it, staging a leaked
+      # fixture's basename into ``cassette_repair_allowlist.txt`` in the same
+      # commit makes the hook skip the file and exit 0 — CI catches that, but
+      # only after the push this hook exists to prevent.
+      #
+      # ``txt`` is in the file filter because ``--secrets-only`` already scans
+      # it (``_SECRETS_ONLY_EXTENSIONS``); omitting it here would let a
+      # credential-bearing ``.txt`` capture skip the hook entirely.
       - id: fixture-secrets
         name: fixture-secrets (no credential shapes in captures)
-        entry: uv run python tests/scripts/check_cassettes_clean.py --secrets-only
+        entry: uv run python tests/scripts/check_cassettes_clean.py --secrets-only --strict
         language: system
-        files: ^tests/(cassettes|fixtures|unit/fixtures)/.*\.(json|ya?ml|html)$
+        files: ^tests/(cassettes|fixtures|unit/fixtures)/.*\.(json|ya?ml|html|txt)$
         require_serial: true

--- a/tests/_guardrails/test_cassettes_clean.py
+++ b/tests/_guardrails/test_cassettes_clean.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.cassette_patterns import find_credential_leaks, is_clean
+
 pytestmark = pytest.mark.repo_lint
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -167,3 +169,54 @@ def test_guard_detects_novel_high_entropy_token(tmp_path: Path) -> None:
         f"exit 1 but no high-entropy leak reported — the entropy detector may be "
         f"dead or the guard crashed:\n{result.stdout}\n{result.stderr}"
     )
+
+
+# --- Signed blob-capability URLs (#2120 / #2215) ---------------------------
+# These must be caught in BOTH scan modes. ``--secrets-only`` reaches the
+# detector via ``_CREDENTIAL_DETECTORS``; the full cassette scan routes through
+# ``is_clean`` instead, so a detector registered in only one place leaves the
+# other gate blind. The negative cases pin the query-delimiter anchoring: a
+# ``\b`` boundary would match ``c=`` inside a *value* (``?redirect=-c=1``) and
+# reject valid content.
+_CAPABILITY_POSITIVE = [
+    pytest.param(
+        "https://contribution.usercontent.google.com/download?c=AIP70Bshort&filename=x.md",
+        id="download-capability",
+    ),
+    pytest.param("https://drive.google.com/viewer/upload?ck=a&ds=1&p=2", id="viewer-wrapper"),
+    pytest.param(
+        "/blobstore/prod/contrib_service/blobrefs/notebooklm/nos_files/x", id="blobrefs-path"
+    ),
+    pytest.param(
+        "https://contribution.usercontent.google.com/download?x=1&amp;c=AIP70B",
+        id="amp-escaped-delimiter",
+    ),
+]
+
+_CAPABILITY_NEGATIVE = [
+    pytest.param(
+        "https://contribution.usercontent.google.com/download?redirect=-c=1",
+        id="c-inside-a-value-not-a-key",
+    ),
+    pytest.param(
+        "https://drive.google.com/viewer/upload?redirect=-ds=1", id="ds-inside-a-value-not-a-key"
+    ),
+    pytest.param(
+        "https://drive.google.com/file/d/1FDW_u2QKNxpYBBvs-k03F4n039Ufuiv2/view",
+        id="benign-public-file-id",
+    ),
+]
+
+
+@pytest.mark.parametrize("text", _CAPABILITY_POSITIVE)
+def test_capability_urls_are_caught_in_both_scan_modes(text: str) -> None:
+    """A signed capability must fail --secrets-only AND the full scan."""
+    assert find_credential_leaks(text), "missed by --secrets-only (find_credential_leaks)"
+    assert not is_clean(text)[0], "missed by the full cassette scan (is_clean)"
+
+
+@pytest.mark.parametrize("text", _CAPABILITY_NEGATIVE)
+def test_capability_detector_does_not_fire_on_lookalikes(text: str) -> None:
+    """Parameter-like text inside a value is not a capability."""
+    assert not find_credential_leaks(text), "false positive in --secrets-only"
+    assert is_clean(text)[0], "false positive in the full cassette scan"

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -1206,9 +1206,16 @@ _DETECT_AUTHUSER_EMAIL_DOUBLE_ENCODED = re.compile(
 # Scoped to the two hosts actually observed carrying capabilities, so an
 # ordinary ``drive.google.com/file/d/<id>`` reference in a fixture (a public
 # document id, not a credential) does not trip the guard.
+# The parameter alternatives anchor on a real query delimiter — ``?``, ``&`` or
+# an HTML/JSON-escaped ``&amp;`` — rather than ``\b``. A word boundary is not a
+# key boundary: ``...download?redirect=-c=1`` has no ``c`` parameter at all, yet
+# ``\bc=`` matches inside the *value*, so the strict fixture hook would reject
+# valid content. Keyed delimiters make the match mean what the name says.
 _DETECT_BLOB_CAPABILITY_URL = re.compile(
-    r"https?://contribution\.usercontent\.google\.com/download\?[^\s\"'<>]*\bc="
-    r"|https?://drive\.google\.com/viewer/upload\?[^\s\"'<>]*\b(?:ck|ds|dsmi|p)="
+    r"https?://contribution\.usercontent\.google\.com/download"
+    r"[^\s\"'<>]*(?:\?|&|&amp;)c="
+    r"|https?://drive\.google\.com/viewer/upload"
+    r"[^\s\"'<>]*(?:\?|&|&amp;)(?:ck|ds|dsmi|p)="
     r"|/blobstore/[^\s\"'<>]*/blobrefs/"
 )
 
@@ -1496,6 +1503,16 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
     # match of the raw URL form here is by definition a leak.
     for match in _DETECT_AVATAR_URL.finditer(text):
         leaks.append(f"Leak (avatar URL): {match.group(0)!r}")
+
+    # --- 7b. Signed blob-capability URLs ----------------------------------
+    # Must run in BOTH modes. ``find_credential_leaks`` (``--secrets-only``)
+    # reaches this detector via :data:`_CREDENTIAL_DETECTORS`, but the full
+    # cassette scan routes through this function instead — so registering it
+    # only there would leave ``check_cassettes_clean.py --strict --recursive``,
+    # the gate CI runs over ``tests/cassettes/``, blind to a capability URL in
+    # a recorded cassette. Same detector, both paths.
+    for match in _DETECT_BLOB_CAPABILITY_URL.finditer(text):
+        leaks.append(f"Leak (signed blob-capability URL): {match.group(0)!r}")
 
     # --- 8. Catch-all Google auth-token shapes -----------------------------
     # ``g.a000-...`` / ``sidts-...`` / ``ya29....`` tokens are scrubbed to

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -1189,10 +1189,34 @@ _DETECT_AUTHUSER_EMAIL_DOUBLE_ENCODED = re.compile(
 # fixtures, docs, source) with no per-file allowlist. This is what the
 # ``--secrets-only`` mode of ``check_cassettes_clean.py`` uses to extend leak
 # detection beyond ``tests/cassettes/`` without drowning in false positives.
+# Signed blob-capability URLs (#2120). A live source-fulltext capture embeds a
+# download URL whose query parameter carries an opaque capability addressing a
+# NotebookLM blob, plus a Drive viewer wrapper around the same blob:
+#
+#     https://contribution.usercontent.google.com/download?c=<capability>&filename=…
+#     https://drive.google.com/viewer/upload?ck=…&ds=…&dsmi=…&p=…
+#
+# These are NAME-ANCHORED on the host + path, deliberately, rather than on the
+# capability's shape. The capability is an opaque base64 blob with no prefix to
+# key on, and the existing high-entropy scan only catches it when it happens to
+# be long enough: a 117-char capability trips it, a short one does NOT (measured
+# on #2215 — a synthetic ``?c=AIP70Bshortcap123`` URL scanned clean). Anchoring
+# on the endpoint makes detection independent of capability length.
+#
+# Scoped to the two hosts actually observed carrying capabilities, so an
+# ordinary ``drive.google.com/file/d/<id>`` reference in a fixture (a public
+# document id, not a credential) does not trip the guard.
+_DETECT_BLOB_CAPABILITY_URL = re.compile(
+    r"https?://contribution\.usercontent\.google\.com/download\?[^\s\"'<>]*\bc="
+    r"|https?://drive\.google\.com/viewer/upload\?[^\s\"'<>]*\b(?:ck|ds|dsmi|p)="
+    r"|/blobstore/[^\s\"'<>]*/blobrefs/"
+)
+
 _CREDENTIAL_DETECTORS: list[tuple[str, re.Pattern[str]]] = [
     ("auth token", _DETECT_AUTH_TOKEN),
     ("Google API key", _DETECT_GOOGLE_API_KEY),
     ("double-encoded authuser email", _DETECT_AUTHUSER_EMAIL_DOUBLE_ENCODED),
+    ("signed blob-capability URL", _DETECT_BLOB_CAPABILITY_URL),
 ]
 
 


### PR DESCRIPTION
## The gap this closes

The fixture credential scan already exists in two places — CI (`test.yml`, "Check fixtures for credential leaks") and a pytest guardrail (`tests/_guardrails/test_cassettes_clean.py`). **Both fire after the push that publishes the secret.**

In #2120 a live-captured fixture carrying a signed Google user-content URL and its 117-character capability token reached a public branch. Review caught it and the file was scrubbed — but scrubbing does not unpublish. GitHub keeps force-pushed objects fetchable by SHA, and **four commits still serve that content** (`3b99d871`, `c56d53d5`, `7bab1e09`, `c4ac61d0`); removing them needs GitHub Support.

The scan was never broken. It just ran at a point where the damage was already done.

## The change

One pre-commit hook running the same script, before the commit exists:

```yaml
- id: fixture-secrets
  entry: uv run python tests/scripts/check_cassettes_clean.py --secrets-only
  files: ^tests/(cassettes|fixtures|unit/fixtures)/.*\.(json|ya?ml|html)$
```

Scoped by `files:` so an ordinary Python-only commit skips it entirely. The script already handles individual paths (`candidate.is_file()`), so pre-commit passes just the staged files — no full-tree walk on every commit.

## Verified in both directions, not assumed

| case | result |
|---|---|
| clean tree, `pre-commit run --all-files` | **exit 0**, hook reports `Passed` |
| staging the **actual leaked fixture** fetched from exposed SHA `7bab1e09` | **exit 1**, both tokens reported — commit blocked |

The negative case is the one that matters: a guard that has never been shown to fail on real bad input is not evidence of anything. The probe file was removed and the tree left clean.

## What this does not do

It does not remove the four already-exposed objects — only GitHub Support can expunge unreachable objects. This prevents the next occurrence; it does not undo the last one.

## Note on defence ordering

`main` itself was never affected: none of the four SHAs is an ancestor of `main`, and the fixture on `main` is clean. The exposure is orphaned objects only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit security check for credential-like secrets in staged test fixtures.
  * Supports JSON, YAML, HTML, and TXT files with consistent serial scanning.
* **Bug Fixes**
  * Improved detection of signed access URLs used for downloads, uploads, and blob references, identifying them as high-severity credential leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->