### PR TITLE
feat(artifacts): read the quiz/flashcards option pair back off the wire (#2195, #2196, #2197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both surfaces are additive: new fields at the end of their dataclasses, empty
   (never `None`) when a response carries no decodable document.
 
+- **The stored quiz/flashcards option pair can now be read back off the wire**
+  ([#2195](https://github.com/teng-lin/notebooklm-py/issues/2195)).
+  `ArtifactRow.quiz_options` / `ArtifactRow.flashcards_options` decode the
+  `[quantity, difficulty]` pair the backend echoes at `data[9][1][7]` /
+  `data[9][1][6]`, returning a named `QuizOptionPair` rather than a positional
+  tuple — a bare 2-tuple would reintroduce on the decode side exactly the
+  ambiguity that produced the transposition on the encode side.
+
+  This closes the structural gap behind [#2116](https://github.com/teng-lin/notebooklm-py/issues/2116)
+  and [#2117](https://github.com/teng-lin/notebooklm-py/issues/2117): nothing in
+  the client read these options back, so the only thing between a wrong pair and
+  a user was a fixture written from the same belief as the code. The e2e
+  generation tests now assert the server's echo against what they sent, and
+  every option pair in that tier is asymmetric — `MORE` and `HARD` are both `3`,
+  so `more` + `hard` is as blind as `standard` + `medium`.
+
 ### Changed
+
+- **Passing a non-enum `quantity` / `difficulty` to `generate_quiz()` /
+  `generate_flashcards()` now raises `ValidationError`**
+  ([#2196](https://github.com/teng-lin/notebooklm-py/issues/2196)). Previously a
+  bare `int` reached `.value` and produced `AttributeError: 'int' object has no
+  attribute 'value'`. The check also rejects the *other* option enum:
+  `quantity=QuizDifficulty.HARD` used to encode silently as `MORE`, since both
+  are `3`. No working call changes — neither ints nor strings were ever accepted.
+
+  The same issue asked whether `None` should mean "let the server choose". It
+  does not, and now says so: `None` resolves to `STANDARD` / `MEDIUM` and is
+  sent **explicitly**. Omission *is* accepted by the backend (live-probed:
+  generation completes normally), but the stored options then echo back as
+  `null`, so what the server picked is invisible to the caller and to the new
+  read-back above. That trade — a value we can name, echo and assert against one
+  we cannot see — is now a documented decision with a test, not an inline `else`.
+
+- **The CLI's `--quantity` / `--difficulty` choice lists are derived from the
+  enum maps** instead of hardcoded
+  ([#2197](https://github.com/teng-lin/notebooklm-py/issues/2197)). The MCP and
+  REST copies were already pinned to `_QUIZ_QUANTITY_MAP` / `_QUIZ_DIFFICULTY_MAP`
+  by tests; the CLI had no such binding, so a new `QuizQuantity` member would
+  have become reachable via MCP and REST while staying silently absent from the
+  CLI with nothing red. Same choices, same order, no user-visible change today.
 
 - **`ChatReference.cited_text` now returns a different value for the same
   citation.** This is the point of the change rather than a side effect, and it

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1477,6 +1477,18 @@ status = await client.artifacts.generate_quiz(
 )
 ```
 
+**Omitting an option does not mean "let the server choose."** `quantity=None` /
+`difficulty=None` (the defaults) are resolved to `QuizQuantity.STANDARD` and
+`QuizDifficulty.MEDIUM` and sent **explicitly**, matching the web UI and every
+other `generate_*` method here. The backend does accept an omitted option
+message, but then stores nothing, so neither you nor this client can see what it
+picked — the artifact echoes the pair back only when it was sent (#2196). Pass
+the member you want if you need a specific setting.
+
+Anything other than an enum member or `None` raises `ValidationError`, including
+the *other* option enum: `quantity=QuizDifficulty.HARD` used to encode silently
+as `MORE`, because both are `3`.
+
 **Rate-limit retry for generation:**
 
 ```python

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1587,6 +1587,34 @@ params = [
 # Codes 1 and 2 were transposed in this client before #2127.
 ```
 
+**Quiz/flashcards options are echoed back (#2195).** The server stores the
+generation options and returns them on every listing, inside the same type-4
+options block that carries the variant and the free-text prompt:
+
+```python
+row[9][1][0]   # variant: 1=flashcards, 2=quiz, 4=interactive mind map
+row[9][1][2]   # free-text prompt
+row[9][1][6]   # flashcards [quantity, difficulty] — null on a quiz row
+row[9][1][7]   # quiz       [quantity, difficulty] — null on a flashcards row
+```
+
+Positions follow `AppArtifactGenerationOptions` in `docs/mobile/schema.proto`
+(`flashcardsGenerationOptions` = tag 7, `quizGenerationOptions` = tag 8), and
+each pair is `[quantity, difficulty]` — the same order both builders send. Read
+them through `ArtifactRow.quiz_options` / `ArtifactRow.flashcards_options`, which
+return a named `QuizOptionPair` rather than a positional tuple.
+
+This is the **only** client-side check on the option pair that does not depend
+on a fixture we wrote ourselves, which is why #2116 (a transposed flashcards
+pair) and #2117 (`MORE` aliased to `STANDARD`) both shipped unnoticed. Live
+observations worth knowing:
+
+* an omitted option message echoes back as `null`, and a `[0, 0]`
+  (proto3 `*_UNSPECIFIED`) pair echoes back as `[]` — both are accepted and
+  generate normally, but what the server then chose is not observable; and
+* the VCR tier cannot pin any of this: the `freq` matcher compares request
+  bodies shape-only, so `[1,3]`, `[3,1]` and `[null,null]` are identical to it.
+
 **Python API Note:** `artifacts.list()` also fetches mind maps from GET_NOTES_AND_MIND_MAPS and includes them as Artifact objects (type=5). This provides a unified list of all AI-generated content. Mind maps with status=2 (deleted) are filtered out — note that this is the *note* row's own status field, unrelated to the `ArtifactStatus` table above.
 
 ---

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar
 
+from ..exceptions import ValidationError
 from ..rpc import (
     INTERACTIVE_MIND_MAP_VARIANT,
     ArtifactTypeCode,
@@ -250,6 +251,68 @@ def build_report_artifact_params(
     ]
 
 
+#: The client-side defaults applied when a quiz/flashcards option is omitted.
+#: These are *sent explicitly*; see :func:`_quiz_option_code` for why.
+DEFAULT_QUIZ_QUANTITY = QuizQuantity.STANDARD
+DEFAULT_QUIZ_DIFFICULTY = QuizDifficulty.MEDIUM
+
+_QuizOption = TypeVar("_QuizOption", QuizQuantity, QuizDifficulty)
+
+
+def _quiz_option_code(
+    value: _QuizOption | None,
+    default: _QuizOption,
+    *,
+    parameter: str,
+) -> int:
+    """Resolve one quiz/flashcards option to the integer code sent on the wire.
+
+    ``None`` means **"use this client's default"**, not "let the server
+    choose": the default is substituted here and transmitted explicitly, so
+    every request carries a concrete quantity and difficulty. That is a
+    deliberate choice, not an oversight (#2196), and the alternative was
+    measured rather than assumed:
+
+    * Omission *is* accepted. Live probe: a ``CREATE_ARTIFACT`` with the option
+      message left ``null`` (and one with the proto3 default pair ``[0, 0]``,
+      which the backend stores as an empty message) both generate normally and
+      reach ``ARTIFACT_STATUS_READY``.
+    * But what the server picked is then **unobservable**. The stored options
+      echo back as ``null`` / ``[]``, and the generated content is not carried
+      in ``LIST_ARTIFACTS``, so a caller could not tell what they got — nor
+      could :attr:`~notebooklm._row_adapters.artifacts.ArtifactRow.quiz_options`,
+      the read-back added in #2195 precisely so this surface stops being
+      fixture-only. Passing ``None`` through would trade a value we can name,
+      echo and assert for one we cannot see at all.
+    * The web UI always sends an explicit pair, and every sibling builder in
+      this module (audio, video, infographic, slide deck) resolves ``None`` to
+      an explicit client default the same way. Diverging here would make quiz
+      and flashcards the lone exception.
+
+    A caller who genuinely wants the backend's own default should pass the
+    member they want; there is no ``UNSPECIFIED`` member on
+    :class:`~notebooklm.rpc.QuizQuantity` / :class:`~notebooklm.rpc.QuizDifficulty`
+    because a value that cannot be read back could not be tested.
+
+    Raises:
+        ValidationError: If ``value`` is neither ``None`` nor a member of the
+            expected enum. Previously a bare ``int`` reached ``.value`` and
+            produced ``AttributeError: 'int' object has no attribute 'value'``.
+            The ``isinstance`` check also rejects the *other* option enum —
+            ``quantity=QuizDifficulty.HARD`` used to encode silently as
+            ``MORE``, since both are ``3``.
+    """
+    if value is None:
+        return default.value
+    expected = type(default)
+    if not isinstance(value, expected):
+        raise ValidationError(
+            f"{parameter} must be a {expected.__name__} member or None, got "
+            f"{value!r} ({type(value).__name__})"
+        )
+    return value.value
+
+
 def build_quiz_artifact_params(
     notebook_id: str,
     source_ids: list[str],
@@ -260,8 +323,8 @@ def build_quiz_artifact_params(
 ) -> list[Any]:
     """Build ``CREATE_ARTIFACT`` params for quiz generation."""
     source_ids_triple = nest_source_ids(source_ids, 2)
-    quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
-    difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+    quantity_code = _quiz_option_code(quantity, DEFAULT_QUIZ_QUANTITY, parameter="quantity")
+    difficulty_code = _quiz_option_code(difficulty, DEFAULT_QUIZ_DIFFICULTY, parameter="difficulty")
 
     return [
         _artifact_client_options(),
@@ -303,8 +366,8 @@ def build_flashcards_artifact_params(
 ) -> list[Any]:
     """Build ``CREATE_ARTIFACT`` params for flashcard generation."""
     source_ids_triple = nest_source_ids(source_ids, 2)
-    quantity_code = quantity.value if quantity is not None else QuizQuantity.STANDARD.value
-    difficulty_code = difficulty.value if difficulty is not None else QuizDifficulty.MEDIUM.value
+    quantity_code = _quiz_option_code(quantity, DEFAULT_QUIZ_QUANTITY, parameter="quantity")
+    difficulty_code = _quiz_option_code(difficulty, DEFAULT_QUIZ_DIFFICULTY, parameter="difficulty")
 
     return [
         _artifact_client_options(),

--- a/src/notebooklm/_artifact/payloads.py
+++ b/src/notebooklm/_artifact/payloads.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 
 from ..exceptions import ValidationError
 from ..rpc import (
@@ -252,9 +252,11 @@ def build_report_artifact_params(
 
 
 #: The client-side defaults applied when a quiz/flashcards option is omitted.
-#: These are *sent explicitly*; see :func:`_quiz_option_code` for why.
-DEFAULT_QUIZ_QUANTITY = QuizQuantity.STANDARD
-DEFAULT_QUIZ_DIFFICULTY = QuizDifficulty.MEDIUM
+#: These are *sent explicitly*; see :func:`_quiz_option_code` for why. The CLI
+#: binds its ``--quantity`` / ``--difficulty`` flag defaults to these too, so
+#: the flag default and the wire default cannot drift apart (#2197).
+DEFAULT_QUIZ_QUANTITY: Final = QuizQuantity.STANDARD
+DEFAULT_QUIZ_DIFFICULTY: Final = QuizDifficulty.MEDIUM
 
 _QuizOption = TypeVar("_QuizOption", QuizQuantity, QuizDifficulty)
 
@@ -313,6 +315,30 @@ def _quiz_option_code(
     return value.value
 
 
+def _quiz_option_pair(
+    quantity: QuizQuantity | None,
+    difficulty: QuizDifficulty | None,
+) -> list[int]:
+    """Build the ``[quantity, difficulty]`` pair both option messages carry.
+
+    The ONE place this client decides that quantity comes first. Both
+    ``QuizGenerationOptions`` and ``FlashcardsGenerationOptions`` number
+    ``quantity`` 1 and ``difficulty`` 2, so the two builders emit an identical
+    pair into different slots (quiz ``[9][1][7]``, flashcards ``[9][1][6]``).
+
+    Sharing it is the point rather than a tidy-up: #2116 was two hand-written
+    literals drifting apart, with the flashcards one transposed for long enough
+    that ``docs/rpc-reference.md`` documented the inversion as intended. One
+    expression cannot disagree with itself. The decode side is symmetric —
+    :class:`~notebooklm._row_adapters.artifacts.QuizOptionPair` reads the pair
+    back through named fields rather than positions.
+    """
+    return [
+        _quiz_option_code(quantity, DEFAULT_QUIZ_QUANTITY, parameter="quantity"),
+        _quiz_option_code(difficulty, DEFAULT_QUIZ_DIFFICULTY, parameter="difficulty"),
+    ]
+
+
 def build_quiz_artifact_params(
     notebook_id: str,
     source_ids: list[str],
@@ -323,8 +349,7 @@ def build_quiz_artifact_params(
 ) -> list[Any]:
     """Build ``CREATE_ARTIFACT`` params for quiz generation."""
     source_ids_triple = nest_source_ids(source_ids, 2)
-    quantity_code = _quiz_option_code(quantity, DEFAULT_QUIZ_QUANTITY, parameter="quantity")
-    difficulty_code = _quiz_option_code(difficulty, DEFAULT_QUIZ_DIFFICULTY, parameter="difficulty")
+    option_pair = _quiz_option_pair(quantity, difficulty)
 
     return [
         _artifact_client_options(),
@@ -349,7 +374,7 @@ def build_quiz_artifact_params(
                     None,
                     None,
                     None,
-                    [quantity_code, difficulty_code],
+                    option_pair,
                 ],
             ],
         ],
@@ -366,8 +391,7 @@ def build_flashcards_artifact_params(
 ) -> list[Any]:
     """Build ``CREATE_ARTIFACT`` params for flashcard generation."""
     source_ids_triple = nest_source_ids(source_ids, 2)
-    quantity_code = _quiz_option_code(quantity, DEFAULT_QUIZ_QUANTITY, parameter="quantity")
-    difficulty_code = _quiz_option_code(difficulty, DEFAULT_QUIZ_DIFFICULTY, parameter="difficulty")
+    option_pair = _quiz_option_pair(quantity, difficulty)
 
     return [
         _artifact_client_options(),
@@ -391,10 +415,10 @@ def build_flashcards_artifact_params(
                     None,
                     None,
                     None,
-                    # ``FlashcardsGenerationOptions`` is {1: cardQuantity,
-                    # 2: flashcardsDifficulty}, i.e. quantity first — the same
-                    # order the quiz builder above uses (#2116).
-                    [quantity_code, difficulty_code],
+                    # Same expression as the quiz builder above — the ordering
+                    # lives in ``_quiz_option_pair`` so the two cannot drift
+                    # apart again (#2116).
+                    option_pair,
                 ],
             ],
         ],

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -13,10 +13,46 @@ from ..rpc import ArtifactStatus, ArtifactTypeCode, RPCMethod, safe_index
 __all__ = [
     "MIND_MAP_LEAF_ABSENT",
     "ArtifactRow",
+    "QuizOptionPair",
     "ReportSuggestionRow",
     "unwrap_artifact_rows",
     "unwrap_mind_map_generation_leaf",
 ]
+
+
+@dataclass(frozen=True)
+class QuizOptionPair:
+    """The quantity/difficulty pair a quiz or flashcards artifact was generated with.
+
+    The backend stores this pair inside the artifact and echoes it back on
+    ``LIST_ARTIFACTS``, which makes it the one place the *sent* options can be
+    verified against the *stored* options. Nothing read it before #2195, so the
+    only thing standing between a wrong pair and the user was a hand-written
+    fixture — which is exactly how #2116 (a transposed pair) survived.
+
+    Both ``QuizGenerationOptions`` and ``FlashcardsGenerationOptions`` declare
+    the same two fields in the same order, so one type covers both families —
+    mirroring the shared :class:`~notebooklm.rpc.QuizQuantity` /
+    :class:`~notebooklm.rpc.QuizDifficulty` enums.
+
+    The fields are **named, not positional**, on purpose: a bare
+    ``tuple[int, int]`` read-back would reintroduce on the decode side the very
+    ambiguity that produced the transposition on the encode side.
+
+    Values are raw ``int`` codes rather than enum members (matching
+    :attr:`ArtifactRow.type_code` / :attr:`ArtifactRow.status`) so a value
+    Google adds before this client models it decodes as itself instead of
+    raising. ``QuizQuantity`` / ``QuizDifficulty`` are ``int`` enums, so
+    ``pair.quantity == QuizQuantity.FEWER`` compares as expected.
+
+    Either field is ``None`` when the stored options message leaves it unset —
+    live-observed: a request carrying the proto3 default pair ``[0, 0]`` echoes
+    back as an empty list, since default-valued fields are dropped from the
+    JSON encoding.
+    """
+
+    quantity: int | None
+    difficulty: int | None
 
 
 def unwrap_artifact_rows(result: list[Any], *, method_id: str, source: str) -> list[Any]:
@@ -122,7 +158,9 @@ class ArtifactRow:
     8      video metadata; nested media variants
     9      options block; ``[9][1][0]`` is the variant code (used to
            distinguish among QUIZ, FLASHCARDS, and the interactive mind map
-           (variant 4) when type == 4); ``[9][1][2]`` is the generation prompt
+           (variant 4) when type == 4); ``[9][1][2]`` is the generation prompt;
+           ``[9][1][6]`` and ``[9][1][7]`` are the stored flashcards / quiz
+           ``[quantity, difficulty]`` pairs
     14     infographic metadata; ``[14][0][0]`` is the generation prompt
     15     timestamp block; ``[15][0]`` is the creation timestamp
            (seconds since epoch)
@@ -184,11 +222,24 @@ class ArtifactRow:
     # and the interactive mind map, which share one options block. Verified live
     # across every studio artifact type; note-backed mind maps (synthetic type
     # 5) are absent here and therefore have no prompt.
+    # ---- Inside the type-4 options block (``data[9]``) ---------------------
+    # ``AppArtifact.generationOptions`` and the four leaves this adapter reads
+    # from it. The whole family is quantity-then-difficulty: both
+    # ``QuizGenerationOptions`` and ``FlashcardsGenerationOptions`` number
+    # quantity 1 and difficulty 2, so one pair of constants indexes both (the
+    # shared numbering is asserted in test_wire_contract.py).
+    _GENERATION_OPTIONS_POS: ClassVar[int] = 1
+    _APP_TYPE_POS: ClassVar[int] = 0
+    _FLASHCARDS_OPTIONS_POS: ClassVar[int] = 6
+    _QUIZ_OPTIONS_POS: ClassVar[int] = 7
+    _OPTION_QUANTITY_POS: ClassVar[int] = 0
+    _OPTION_DIFFICULTY_POS: ClassVar[int] = 1
+
     _PROMPT_LOCATION: ClassVar[dict[int, tuple[int, ...]]] = {
         ArtifactTypeCode.AUDIO.value: (_AUDIO_METADATA_POS, 1, 0),
         ArtifactTypeCode.REPORT.value: (_REPORT_MARKDOWN_POS, 1, 5),
         ArtifactTypeCode.VIDEO.value: (_VIDEO_METADATA_POS, 2, 2),
-        ArtifactTypeCode.QUIZ.value: (_OPTIONS_POS, 1, 2),
+        ArtifactTypeCode.QUIZ.value: (_OPTIONS_POS, _GENERATION_OPTIONS_POS, 2),
         ArtifactTypeCode.INFOGRAPHIC.value: (_INFOGRAPHIC_METADATA_POS, 0, 0),
         ArtifactTypeCode.SLIDE_DECK.value: (_SLIDE_DECK_METADATA_POS, 0, 0),
         ArtifactTypeCode.DATA_TABLE.value: (_DATA_TABLE_PAYLOAD_POS, 1, 0),
@@ -301,12 +352,76 @@ class ArtifactRow:
             return None
         value = safe_index(
             options_block,
-            1,
-            0,
+            self._GENERATION_OPTIONS_POS,
+            self._APP_TYPE_POS,
             method_id=self.method_id,
             source="ArtifactRow.variant",
         )
         return value if isinstance(value, int) else None
+
+    @property
+    def flashcards_options(self) -> QuizOptionPair | None:
+        """Stored flashcards ``[quantity, difficulty]`` pair at ``data[9][1][6]``.
+
+        Returns ``None`` for every row that does not carry the flashcards
+        options message — a short row, a non-flashcards artifact (the slot is
+        ``null`` on a quiz or mind-map row), or a leaf whose shape is not the
+        expected list.
+
+        See :attr:`quiz_options` for why this is worth reading at all.
+        """
+        return self._option_pair(self._FLASHCARDS_OPTIONS_POS, "ArtifactRow.flashcards_options")
+
+    @property
+    def quiz_options(self) -> QuizOptionPair | None:
+        """Stored quiz ``[quantity, difficulty]`` pair at ``data[9][1][7]``.
+
+        This is the backend's own echo of the options the artifact was created
+        with, so it is the only client-side read that can check a
+        :func:`~notebooklm._artifact.payloads.build_quiz_artifact_params`
+        payload against reality rather than against a fixture (#2195). It is
+        deliberately a *decode* of what the server stored, never a
+        reconstruction of what we sent.
+
+        Returns ``None`` under the same conditions as
+        :attr:`flashcards_options`.
+        """
+        return self._option_pair(self._QUIZ_OPTIONS_POS, "ArtifactRow.quiz_options")
+
+    def _option_pair(self, position: int, source: str) -> QuizOptionPair | None:
+        """Decode one ``[quantity, difficulty]`` leaf out of the options block."""
+        if len(self._raw) <= self._OPTIONS_POS:
+            return None
+        options_block = self._raw[self._OPTIONS_POS]
+        if not isinstance(options_block, list):
+            # Same legacy soft-degrade as ``variant`` for ``data[9] = None``.
+            return None
+        generation_options = safe_index(
+            options_block,
+            self._GENERATION_OPTIONS_POS,
+            method_id=self.method_id,
+            source=source,
+        )
+        # The two option slots are optional trailing positions inside the
+        # generation-options message (a mind-map row carries neither), so a
+        # short block is an absence rather than drift.
+        if not isinstance(generation_options, list) or len(generation_options) <= position:
+            return None
+        pair = generation_options[position]
+        if not isinstance(pair, list):
+            return None
+        return QuizOptionPair(
+            quantity=self._option_code(pair, self._OPTION_QUANTITY_POS),
+            difficulty=self._option_code(pair, self._OPTION_DIFFICULTY_POS),
+        )
+
+    @staticmethod
+    def _option_code(pair: list[Any], position: int) -> int | None:
+        """Read one option code, treating an unset (or non-int) leaf as ``None``."""
+        if len(pair) <= position:
+            return None
+        value = pair[position]
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
 
     @property
     def created_at_raw(self) -> int | float | None:

--- a/src/notebooklm/_row_adapters/artifacts.py
+++ b/src/notebooklm/_row_adapters/artifacts.py
@@ -48,7 +48,18 @@ class QuizOptionPair:
     Either field is ``None`` when the stored options message leaves it unset —
     live-observed: a request carrying the proto3 default pair ``[0, 0]`` echoes
     back as an empty list, since default-valued fields are dropped from the
-    JSON encoding.
+    JSON encoding. ``None`` *also* covers a leaf that is present but not an
+    integer code; the two are not distinguishable here, and
+    :meth:`ArtifactRow._option_code` records why that narrow conflation is
+    accepted while malformed *containers* raise instead.
+
+    Because the fields are plain ``int``, they compare equal across the two
+    option enums — ``QuizOptionPair(quantity=3, ...).quantity ==
+    QuizDifficulty.HARD`` is ``True``, since ``QuizQuantity.MORE`` and
+    ``QuizDifficulty.HARD`` are both ``3``. Compare against the enum matching
+    the field you are reading. The encode side rejects that mix-up outright
+    (:func:`~notebooklm._artifact.payloads._quiz_option_code`); the decode side
+    cannot, because it has only the wire integer to go on.
     """
 
     quantity: int | None
@@ -364,9 +375,14 @@ class ArtifactRow:
         """Stored flashcards ``[quantity, difficulty]`` pair at ``data[9][1][6]``.
 
         Returns ``None`` for every row that does not carry the flashcards
-        options message — a short row, a non-flashcards artifact (the slot is
-        ``null`` on a quiz or mind-map row), or a leaf whose shape is not the
-        expected list.
+        options message — a short row, ``data[9]`` absent or ``null``, or a
+        non-flashcards artifact (the slot is ``null`` on a quiz or mind-map
+        row).
+
+        Raises :class:`UnknownRPCMethodError` when a container that IS present
+        no longer has the expected shape, matching :attr:`variant`'s policy: a
+        reshaped payload is drift, and reporting it as "no options" would hide
+        exactly what this accessor exists to surface.
 
         See :attr:`quiz_options` for why this is worth reading at all.
         """
@@ -383,7 +399,7 @@ class ArtifactRow:
         deliberately a *decode* of what the server stored, never a
         reconstruction of what we sent.
 
-        Returns ``None`` under the same conditions as
+        Returns ``None`` — and raises on drift — under the same conditions as
         :attr:`flashcards_options`.
         """
         return self._option_pair(self._QUIZ_OPTIONS_POS, "ArtifactRow.quiz_options")
@@ -402,14 +418,38 @@ class ArtifactRow:
             method_id=self.method_id,
             source=source,
         )
-        # The two option slots are optional trailing positions inside the
-        # generation-options message (a mind-map row carries neither), so a
-        # short block is an absence rather than drift.
-        if not isinstance(generation_options, list) or len(generation_options) <= position:
+        # ``None`` is a genuine absence (a row with no generation options at
+        # all); any OTHER non-list here is a message that changed shape, which
+        # is drift and must not be reported as "no options" — that would make a
+        # reshaped payload indistinguishable from an unset one, in the accessor
+        # whose entire job is saying what the server stored.
+        if generation_options is None:
+            return None
+        if not isinstance(generation_options, list):
+            raise UnknownRPCMethodError(
+                "expected a list at the generation-options position, got "
+                f"{type(generation_options).__name__}",
+                method_id=self.method_id,
+                path=(self._OPTIONS_POS, self._GENERATION_OPTIONS_POS),
+                source=source,
+                data_at_failure=repr(generation_options)[:200],
+            )
+        # The two option slots ARE optional trailing positions inside that
+        # message (a mind-map row carries neither, and each family's row leaves
+        # the sibling's slot null), so a short block or a null slot is absence.
+        if len(generation_options) <= position:
             return None
         pair = generation_options[position]
-        if not isinstance(pair, list):
+        if pair is None:
             return None
+        if not isinstance(pair, list):
+            raise UnknownRPCMethodError(
+                f"expected a list at the option-pair position, got {type(pair).__name__}",
+                method_id=self.method_id,
+                path=(self._OPTIONS_POS, self._GENERATION_OPTIONS_POS, position),
+                source=source,
+                data_at_failure=repr(pair)[:200],
+            )
         return QuizOptionPair(
             quantity=self._option_code(pair, self._OPTION_QUANTITY_POS),
             difficulty=self._option_code(pair, self._OPTION_DIFFICULTY_POS),
@@ -417,7 +457,20 @@ class ArtifactRow:
 
     @staticmethod
     def _option_code(pair: list[Any], position: int) -> int | None:
-        """Read one option code, treating an unset (or non-int) leaf as ``None``."""
+        """Read one option code, or ``None`` when the leaf is absent/unusable.
+
+        ``None`` covers two cases the caller cannot tell apart, which is a
+        deliberate narrowing of the strictness applied to the *containers*
+        above: the field was genuinely unset (proto3 drops default-valued
+        fields, so an ``[0, 0]`` pair arrives as ``[]``), or the leaf is not an
+        integer code. The container shapes are the ones that signal a reshaped
+        payload; a single odd scalar is not worth raising from a read-back
+        accessor, so it degrades and the pair simply reports the field as unset.
+
+        ``bool`` is excluded explicitly: ``isinstance(True, int)`` is ``True``
+        in Python, and this row genuinely carries a bool two slots further
+        along, so an unguarded read would happily decode ``difficulty=True``.
+        """
         if len(pair) <= position:
             return None
         value = pair[position]

--- a/src/notebooklm/cli/generate_cmd.py
+++ b/src/notebooklm/cli/generate_cmd.py
@@ -45,6 +45,8 @@ from .rendering import (
 from .resolve import require_notebook
 from .services.generate import (
     _INFOGRAPHIC_STYLE_MAP,
+    _QUIZ_DIFFICULTY_MAP,
+    _QUIZ_QUANTITY_MAP,
     GenerationExecutionResult,
     GenerationPlanValidationError,
     build_generation_plan,
@@ -596,13 +598,13 @@ def generate_revise_slide(
 @notebook_option
 @click.option(
     "--quantity",
-    type=click.Choice(["fewer", "standard", "more"]),
+    type=click.Choice(list(_QUIZ_QUANTITY_MAP)),
     default="standard",
     help="Number of questions (default: standard)",
 )
 @click.option(
     "--difficulty",
-    type=click.Choice(["easy", "medium", "hard"]),
+    type=click.Choice(list(_QUIZ_DIFFICULTY_MAP)),
     default="medium",
     help="Question difficulty (default: medium)",
 )
@@ -647,13 +649,13 @@ def generate_quiz(
 @notebook_option
 @click.option(
     "--quantity",
-    type=click.Choice(["fewer", "standard", "more"]),
+    type=click.Choice(list(_QUIZ_QUANTITY_MAP)),
     default="standard",
     help="Number of flashcards (default: standard)",
 )
 @click.option(
     "--difficulty",
-    type=click.Choice(["easy", "medium", "hard"]),
+    type=click.Choice(list(_QUIZ_DIFFICULTY_MAP)),
     default="medium",
     help="Flashcard difficulty (default: medium)",
 )

--- a/src/notebooklm/cli/services/generate.py
+++ b/src/notebooklm/cli/services/generate.py
@@ -38,11 +38,19 @@ from ..._app.generate import (
     execute_generation as _execute_generation,
 )
 
-# ``_INFOGRAPHIC_STYLE_MAP`` is re-exported (via redundant alias, the explicit
-# re-export idiom) because ``cli/generate_cmd.py`` imports the private name
-# directly from this module.
+# These maps are re-exported (via redundant alias, the explicit re-export
+# idiom) because ``cli/generate_cmd.py`` imports the private names directly
+# from this module to derive its ``click.Choice`` lists — see #2197: the quiz /
+# flashcards lists used to be hardcoded, so a new ``QuizQuantity`` member would
+# have reached MCP and REST while staying silently absent from the CLI.
 from ..._app.generate_plans import (
     _INFOGRAPHIC_STYLE_MAP as _INFOGRAPHIC_STYLE_MAP,
+)
+from ..._app.generate_plans import (
+    _QUIZ_DIFFICULTY_MAP as _QUIZ_DIFFICULTY_MAP,
+)
+from ..._app.generate_plans import (
+    _QUIZ_QUANTITY_MAP as _QUIZ_QUANTITY_MAP,
 )
 
 if TYPE_CHECKING:

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -232,6 +232,70 @@ MAPPINGS: tuple[Mapping, ...] = (
     ),
     Mapping("artifacts", "ArtifactRow", "_INFOGRAPHIC_METADATA_POS", "Artifact", "infographic"),
     Mapping("artifacts", "ArtifactRow", "_SLIDE_DECK_METADATA_POS", "Artifact", "slides"),
+    # ---- Inside the AppArtifact options block (#2195) ----------------------
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_GENERATION_OPTIONS_POS",
+        "AppArtifact",
+        "generationOptions",
+        note="the data[9][1] descent shared by variant, generation_prompt and the option pairs",
+    ),
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_APP_TYPE_POS",
+        "AppArtifactGenerationOptions",
+        "appType",
+        note=(
+            "ArtifactRow.variant. AppType: 1=FLASHCARDS, 2=QUIZ, 4=MINDMAP "
+            "(docs/mobile/enums.txt), matching the variant codes the payload "
+            "builders send."
+        ),
+    ),
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_FLASHCARDS_OPTIONS_POS",
+        "AppArtifactGenerationOptions",
+        "flashcardsGenerationOptions",
+        note=(
+            "#2195 — live-verified: a FEWER(1)+HARD(3) flashcards request echoes "
+            "back data[9][1][6] == [1, 3] while data[9][1][7] stays null."
+        ),
+    ),
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_QUIZ_OPTIONS_POS",
+        "AppArtifactGenerationOptions",
+        "quizGenerationOptions",
+        note=(
+            "#2195 — the quiz sibling, live-verified the same way: a "
+            "FEWER(1)+HARD(3) quiz request echoes back data[9][1][7] == [1, 3]."
+        ),
+    ),
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_OPTION_QUANTITY_POS",
+        "QuizGenerationOptions",
+        "questionQuantity",
+        note=(
+            "one constant indexes BOTH option messages: FlashcardsGenerationOptions "
+            "declares cardQuantity at the same tag 1. Asserted here against the quiz "
+            "copy; the flashcards copy is checked by "
+            "test_flashcards_option_pair_shares_the_quiz_tags."
+        ),
+    ),
+    Mapping(
+        "artifacts",
+        "ArtifactRow",
+        "_OPTION_DIFFICULTY_POS",
+        "QuizGenerationOptions",
+        "quizDifficulty",
+        note="likewise shared with FlashcardsGenerationOptions.flashcardsDifficulty (tag 2).",
+    ),
     # ---- Answer row: AnswerResponse / TailwindDoc -------------------------
     # ---- Citation + TailwindDoc tree (#2120, #2128) ------------------------
     # Every one of these was UNMAPPED or absent before #2120. Recovering the

--- a/tests/_guardrails/test_wire_contract.py
+++ b/tests/_guardrails/test_wire_contract.py
@@ -442,3 +442,34 @@ def test_google_docs_document_id_shares_the_drive_tag() -> None:
     assert _discover_constants()[("sources", "SourceRow", "_DRIVE_DOCUMENT_ID_POS")] == (
         docs_tag - 1
     )
+
+
+def test_flashcards_option_pair_shares_the_quiz_tags() -> None:
+    """``ArtifactRow._OPTION_*_POS`` index BOTH option messages (#2195).
+
+    ``QuizGenerationOptions`` and ``FlashcardsGenerationOptions`` are distinct
+    messages that happen to declare the same two fields at the same tags, so
+    :attr:`ArtifactRow.quiz_options` and :attr:`ArtifactRow.flashcards_options`
+    share one pair of constants. MAPPINGS can only assert them against the quiz
+    copy; this pins the other half.
+
+    The sibling check ``test_quiz_and_flashcards_backend_enums_agree`` covers
+    the enum *values*; this covers the field *positions*. Both are needed: Google
+    renumbering only the flashcards message would silently transpose every
+    flashcards read-back while the quiz side stayed green — the same
+    single-sided drift as #2116, just on the decode end.
+    """
+    schema = load_proto_schema()
+    for quiz_field, flashcards_field, const in (
+        ("questionQuantity", "cardQuantity", "_OPTION_QUANTITY_POS"),
+        ("quizDifficulty", "flashcardsDifficulty", "_OPTION_DIFFICULTY_POS"),
+    ):
+        quiz_tag = schema.field_tag("QuizGenerationOptions", quiz_field, WIRE)
+        flashcards_tag = schema.field_tag("FlashcardsGenerationOptions", flashcards_field, WIRE)
+        assert quiz_tag == flashcards_tag, (
+            f"QuizGenerationOptions.{quiz_field} and FlashcardsGenerationOptions."
+            f"{flashcards_field} no longer share a tag ({quiz_tag} vs "
+            f"{flashcards_tag}). ArtifactRow.{const} can no longer index both "
+            "messages — split it into two constants and register each in MAPPINGS."
+        )
+        assert _discover_constants()[("artifacts", "ArtifactRow", const)] == quiz_tag - 1

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,6 @@
 """E2E test fixtures and configuration."""
 
+import asyncio
 import contextlib
 import hashlib
 import logging
@@ -319,8 +320,6 @@ async def read_back_option_pair(
     Raises:
         AssertionError: If the row never appears or carries no option pair.
     """
-    import asyncio
-
     from notebooklm._row_adapters.artifacts import ArtifactRow
 
     assert family in ("quiz", "flashcards"), family

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ import pytest
 from notebooklm._env import get_base_url
 
 if TYPE_CHECKING:
+    from notebooklm._row_adapters.artifacts import QuizOptionPair
     from notebooklm.client import NotebookLMClient
 
 # Load .env file if python-dotenv is available
@@ -285,6 +286,60 @@ def assert_generation_started(result, artifact_type: str = "Artifact") -> None:
         "pending",
         "in_progress",
     ), f"Unexpected {artifact_type.lower()} status: {result.status}"
+
+
+async def read_back_option_pair(
+    client: "NotebookLMClient",
+    notebook_id: str,
+    task_id: str,
+    *,
+    family: str,
+    attempts: int = 10,
+) -> "QuizOptionPair":
+    """Return the ``[quantity, difficulty]`` pair the SERVER stored for an artifact.
+
+    The backend echoes the generation options it persisted, which makes this the
+    only tier that can check a request against reality rather than against a
+    fixture we wrote (#2195). Unit tests pin the decode positions against
+    ``docs/mobile/schema.proto``; this closes the loop against a live
+    generation, and is what would have caught the transposed flashcards pair
+    (#2116) and the ``MORE``-as-``STANDARD`` alias (#2117) without anyone
+    thinking to look.
+
+    The echo is written when the artifact row is created, so this does not wait
+    for generation to finish — only for the row to become listable.
+
+    Args:
+        client: Live client.
+        notebook_id: Notebook the artifact was generated in.
+        task_id: ``GenerationStatus.task_id`` (also the artifact id).
+        family: ``"quiz"`` or ``"flashcards"`` — which option slot to read.
+        attempts: Listing retries before failing.
+
+    Raises:
+        AssertionError: If the row never appears or carries no option pair.
+    """
+    import asyncio
+
+    from notebooklm._row_adapters.artifacts import ArtifactRow
+
+    assert family in ("quiz", "flashcards"), family
+    for attempt in range(attempts):
+        # ``_list_for_download`` is the sanctioned internal seam for the raw
+        # rows (#1488); no public API exposes the stored options today.
+        _, raw_rows, _ = await client.artifacts._list_for_download(notebook_id)
+        for raw in raw_rows:
+            if isinstance(raw, list) and raw and raw[0] == task_id:
+                row = ArtifactRow(raw)
+                options = row.quiz_options if family == "quiz" else row.flashcards_options
+                assert options is not None, (
+                    f"{family} artifact {task_id} carries no stored option pair; "
+                    f"variant={row.variant}, options block={raw[ArtifactRow._OPTIONS_POS]!r}"
+                )
+                return options
+        if attempt < attempts - 1:
+            await asyncio.sleep(POLL_INTERVAL)
+    raise AssertionError(f"artifact {task_id} never appeared in {notebook_id}'s listing")
 
 
 def has_auth() -> bool:

--- a/tests/e2e/test_generation.py
+++ b/tests/e2e/test_generation.py
@@ -226,7 +226,7 @@ class TestQuizGeneration:
     """
 
     @pytest.mark.asyncio
-    async def test_generate_quiz_default(self, client, generation_notebook_id):
+    async def test_generate_quiz_fewer_hard(self, client, generation_notebook_id):
         """Quiz options survive the round trip: what we send is what is stored."""
         result = await client.artifacts.generate_quiz(
             generation_notebook_id,

--- a/tests/e2e/test_generation.py
+++ b/tests/e2e/test_generation.py
@@ -26,7 +26,7 @@ from notebooklm import (
     VideoStyle,
 )
 
-from .conftest import assert_generation_started, requires_auth
+from .conftest import assert_generation_started, read_back_option_pair, requires_auth
 
 # Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
 # floor (tests/e2e/conftest.py, #1819): a fully-throttled run where every marked
@@ -212,62 +212,117 @@ class TestCinematicVideoGeneration:
 
 @requires_auth
 class TestQuizGeneration:
-    """Quiz generation tests."""
+    """Quiz generation tests.
+
+    Every option pair here is **asymmetric** and read back off the wire (#2195).
+    Both rules are load-bearing:
+
+    * ``assert_generation_started`` alone cannot tell "the fewest, hardest
+      questions" from "the most, easiest" — which is why #2116 shipped a fully
+      transposed flashcards payload through a green e2e tier.
+    * a symmetric pair defeats the read-back too, and ``QuizQuantity.MORE`` and
+      ``QuizDifficulty.HARD`` are BOTH ``3``, so ``more`` + ``hard`` is exactly
+      as blind as ``standard`` + ``medium``.
+    """
 
     @pytest.mark.asyncio
     async def test_generate_quiz_default(self, client, generation_notebook_id):
-        """Test quiz generation with non-default difficulty to verify param encoding."""
+        """Quiz options survive the round trip: what we send is what is stored."""
         result = await client.artifacts.generate_quiz(
             generation_notebook_id,
+            quantity=QuizQuantity.FEWER,
             difficulty=QuizDifficulty.HARD,
         )
         assert_generation_started(result)
+        options = await read_back_option_pair(
+            client, generation_notebook_id, result.task_id, family="quiz"
+        )
+        assert options.quantity == QuizQuantity.FEWER
+        assert options.difficulty == QuizDifficulty.HARD
 
     @pytest.mark.asyncio
     @pytest.mark.variants
     async def test_generate_quiz_with_options(self, client, generation_notebook_id):
+        """``MORE`` is a distinct wire value (3), not the alias #2117 claimed.
+
+        Paired with ``EASY`` rather than ``HARD``: ``MORE`` and ``HARD`` are
+        both 3, so that pairing could not detect a transposition.
+        """
         result = await client.artifacts.generate_quiz(
             generation_notebook_id,
             quantity=QuizQuantity.MORE,
-            difficulty=QuizDifficulty.HARD,
+            difficulty=QuizDifficulty.EASY,
             instructions="Focus on key concepts and definitions",
         )
         assert_generation_started(result)
+        options = await read_back_option_pair(
+            client, generation_notebook_id, result.task_id, family="quiz"
+        )
+        assert options.quantity == QuizQuantity.MORE
+        assert options.difficulty == QuizDifficulty.EASY
 
     @pytest.mark.asyncio
     @pytest.mark.variants
-    async def test_generate_quiz_fewer_easy(self, client, generation_notebook_id):
+    async def test_generate_quiz_fewer_medium(self, client, generation_notebook_id):
+        """A third pair, again asymmetric — ``FEWER`` + ``EASY`` are both 1."""
         result = await client.artifacts.generate_quiz(
             generation_notebook_id,
             quantity=QuizQuantity.FEWER,
-            difficulty=QuizDifficulty.EASY,
+            difficulty=QuizDifficulty.MEDIUM,
         )
         assert_generation_started(result)
+        options = await read_back_option_pair(
+            client, generation_notebook_id, result.task_id, family="quiz"
+        )
+        assert options.quantity == QuizQuantity.FEWER
+        assert options.difficulty == QuizDifficulty.MEDIUM
 
 
 @requires_auth
 class TestFlashcardsGeneration:
-    """Flashcards generation tests."""
+    """Flashcards generation tests.
+
+    Same asymmetry + read-back rules as :class:`TestQuizGeneration`, and they
+    matter most here: flashcards is the family that shipped transposed (#2116),
+    and its options live in a *different* slot from the quiz ones
+    (``data[9][1][6]`` vs ``[7]``), so a quiz-only check would not cover it.
+    """
 
     @pytest.mark.asyncio
     async def test_generate_flashcards_default(self, client, generation_notebook_id):
-        """Test flashcards generation with non-default quantity to verify param encoding."""
+        """An omitted ``difficulty`` reaches the wire as the documented default.
+
+        ``quantity=MORE(3)`` with ``difficulty`` left unset stores ``[3, 2]``:
+        asymmetric, and it pins the ``None`` → ``MEDIUM`` coercion the builders
+        apply (#2196) as an observable fact rather than a claim in a docstring.
+        """
         result = await client.artifacts.generate_flashcards(
             generation_notebook_id,
             quantity=QuizQuantity.MORE,
         )
         assert_generation_started(result)
+        options = await read_back_option_pair(
+            client, generation_notebook_id, result.task_id, family="flashcards"
+        )
+        assert options.quantity == QuizQuantity.MORE
+        assert options.difficulty == QuizDifficulty.MEDIUM
 
     @pytest.mark.asyncio
     @pytest.mark.variants
     async def test_generate_flashcards_with_options(self, client, generation_notebook_id):
+        """``STANDARD`` + ``HARD`` — asymmetric, unlike the ``MEDIUM`` it replaced."""
         result = await client.artifacts.generate_flashcards(
             generation_notebook_id,
             quantity=QuizQuantity.STANDARD,
-            difficulty=QuizDifficulty.MEDIUM,
+            difficulty=QuizDifficulty.HARD,
             instructions="Create cards for vocabulary terms",
         )
         assert_generation_started(result)
+        options = await read_back_option_pair(
+            client, generation_notebook_id, result.task_id, family="flashcards"
+        )
+        assert options.quantity == QuizQuantity.STANDARD
+        assert options.difficulty == QuizDifficulty.HARD
 
 
 @requires_auth

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -27,6 +27,7 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+import click  # noqa: E402
 from click.testing import CliRunner  # noqa: E402
 from fastmcp import Client  # noqa: E402 - after importorskip guard
 
@@ -562,3 +563,116 @@ def test_download_audio_parity(tmp_path: Any) -> None:
         ["download", "audio", out, "-n", NB], "artifacts", "download_audio", setup=setup
     )
     assert mcp == cli
+
+
+# ---------------------------------------------------------------------------
+# Option-choice parity (#2197)
+# ---------------------------------------------------------------------------
+# The MCP and REST option tuples are already pinned to the ``_app`` maps by
+# ``tests/unit/mcp/test_studio.py`` and ``tests/server/test_artifacts.py``. The
+# CLI had no such binding: its ``--quantity`` / ``--difficulty`` lists were
+# hardcoded, so a new ``QuizQuantity`` member would have become reachable via
+# MCP and REST while staying silently absent from the CLI, with nothing red.
+# That is the mirror of #2117 (a backend value missing from our enum) — a value
+# in our enum that never reaches one of our surfaces.
+
+_QUIZ_OPTION_AXES = (
+    ("quiz", "--quantity", "quantity"),
+    ("quiz", "--difficulty", "difficulty"),
+    ("flashcards", "--quantity", "quantity"),
+    ("flashcards", "--difficulty", "difficulty"),
+)
+
+
+def _cli_choices(subcommand: str, flag: str) -> tuple[str, ...]:
+    """Return the choices Click actually offers for ``generate <subcommand> <flag>``."""
+    generate = cli.commands["generate"]
+    command = generate.commands[subcommand]  # type: ignore[attr-defined]
+    for param in command.params:
+        if flag in param.opts:
+            assert isinstance(param.type, click.Choice), (
+                f"generate {subcommand} {flag} is no longer a Choice ({param.type!r})"
+            )
+            return tuple(param.type.choices)
+    raise AssertionError(f"generate {subcommand} has no {flag} option")
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "flag", "axis"),
+    _QUIZ_OPTION_AXES,
+    ids=[f"{sub}{flag}" for sub, flag, _ in _QUIZ_OPTION_AXES],
+)
+def test_quiz_option_choices_match_core_and_mcp(subcommand: str, flag: str, axis: str) -> None:
+    """The CLI's quiz/flashcards option lists equal the core maps *and* the MCP set.
+
+    Both halves matter. The map assertion is what ties the user-visible CLI
+    surface to ``QuizQuantity`` / ``QuizDifficulty``; the MCP assertion is what
+    makes this test non-tautological now that the CLI derives its lists — the
+    MCP tuples are still hand-written, so this pins the two surfaces together
+    rather than comparing the map with itself.
+    """
+    from notebooklm._app import generate_plans as gp
+    from notebooklm.mcp.tools.studio import _KIND_OPTIONS
+
+    core_map = gp._QUIZ_QUANTITY_MAP if axis == "quantity" else gp._QUIZ_DIFFICULTY_MAP
+    choices = _cli_choices(subcommand, flag)
+    assert choices == tuple(core_map), (
+        f"generate {subcommand} {flag} offers {choices} but the core map declares "
+        f"{tuple(core_map)} — derive the click.Choice from the map instead of hardcoding it."
+    )
+    assert choices == _KIND_OPTIONS[subcommand][axis]
+
+
+def test_quiz_option_choices_are_derived_not_hardcoded() -> None:
+    """The ``click.Choice`` args are derived expressions, never literal lists.
+
+    The parity test above compares *values*, so re-hardcoding today's three
+    members would still pass it — the protection against a future enum member
+    going missing is the derivation itself, not the comparison. This asserts the
+    mechanism: the ``--quantity`` / ``--difficulty`` decorators on both commands
+    must pass a name (``_QUIZ_QUANTITY_MAP`` / ``_QUIZ_DIFFICULTY_MAP``) into
+    ``click.Choice``, not a list/tuple/set of string constants.
+    """
+    import ast
+    from pathlib import Path
+
+    import notebooklm.cli.generate_cmd as generate_cmd
+
+    tree = ast.parse(Path(generate_cmd.__file__).read_text(encoding="utf-8"))
+    checked: set[tuple[str, str]] = set()
+    wanted = {(f"generate_{sub}", flag) for sub, flag, _ in _QUIZ_OPTION_AXES}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name not in {
+            "generate_quiz",
+            "generate_flashcards",
+        }:
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call) or not decorator.args:
+                continue
+            first = decorator.args[0]
+            if not isinstance(first, ast.Constant) or first.value not in {
+                "--quantity",
+                "--difficulty",
+            }:
+                continue
+            choice_arg = next(
+                (
+                    kw.value.args[0]
+                    for kw in decorator.keywords
+                    if kw.arg == "type" and isinstance(kw.value, ast.Call) and kw.value.args
+                ),
+                None,
+            )
+            assert choice_arg is not None, (
+                f"{node.name} {first.value}: expected type=click.Choice(...)"
+            )
+            assert not isinstance(choice_arg, (ast.List, ast.Tuple, ast.Set)), (
+                f"{node.name} {first.value} passes a literal to click.Choice. Derive it "
+                "from _QUIZ_QUANTITY_MAP / _QUIZ_DIFFICULTY_MAP (#2197) so a new enum "
+                "member cannot reach MCP and REST while staying absent from the CLI."
+            )
+            checked.add((node.name, first.value))
+
+    assert checked == wanted, f"did not inspect every option: missing {wanted - checked}"

--- a/tests/unit/cli/test_cli_mcp_parity.py
+++ b/tests/unit/cli/test_cli_mcp_parity.py
@@ -623,6 +623,45 @@ def test_quiz_option_choices_match_core_and_mcp(subcommand: str, flag: str, axis
     assert choices == _KIND_OPTIONS[subcommand][axis]
 
 
+@pytest.mark.parametrize(
+    ("subcommand", "flag", "axis"),
+    _QUIZ_OPTION_AXES,
+    ids=[f"{sub}{flag}" for sub, flag, _ in _QUIZ_OPTION_AXES],
+)
+def test_quiz_option_flag_default_matches_the_wire_default(
+    subcommand: str, flag: str, axis: str
+) -> None:
+    """The flag's ``default=`` selects the code the builders actually send.
+
+    #2197 removed the duplicated choice *list*; the flag default is the same
+    duplication one line down — ``default="standard"`` restates
+    ``DEFAULT_QUIZ_QUANTITY`` as a string with nothing tying them together, so
+    if the client default ever moved, the CLI would keep sending the old one
+    while the Python API sent the new one.
+
+    Unlike the choice list, this one cannot be fixed by derivation: the layering
+    guardrails (``test_app_boundary`` / ``test_cli_boundary``) forbid both
+    ``_app`` and ``cli`` from importing ``_artifact.payloads``, where the wire
+    default lives. So the binding is enforced here instead — the same
+    hardcode-plus-parity-test shape the MCP and REST option tuples already use.
+    A test is allowed to import across layers precisely so it can check one.
+    """
+    from notebooklm._app import generate_plans as gp
+    from notebooklm._artifact.payloads import DEFAULT_QUIZ_DIFFICULTY, DEFAULT_QUIZ_QUANTITY
+
+    generate = cli.commands["generate"]
+    command = generate.commands[subcommand]  # type: ignore[attr-defined]
+    param = next(p for p in command.params if flag in p.opts)
+
+    if axis == "quantity":
+        core_map, wire_default = gp._QUIZ_QUANTITY_MAP, DEFAULT_QUIZ_QUANTITY
+    else:
+        core_map, wire_default = gp._QUIZ_DIFFICULTY_MAP, DEFAULT_QUIZ_DIFFICULTY
+
+    assert param.default in core_map, f"{flag} default {param.default!r} is not a valid choice"
+    assert core_map[param.default] is wire_default
+
+
 def test_quiz_option_choices_are_derived_not_hardcoded() -> None:
     """The ``click.Choice`` args are derived expressions, never literal lists.
 
@@ -668,10 +707,21 @@ def test_quiz_option_choices_are_derived_not_hardcoded() -> None:
             assert choice_arg is not None, (
                 f"{node.name} {first.value}: expected type=click.Choice(...)"
             )
-            assert not isinstance(choice_arg, (ast.List, ast.Tuple, ast.Set)), (
-                f"{node.name} {first.value} passes a literal to click.Choice. Derive it "
-                "from _QUIZ_QUANTITY_MAP / _QUIZ_DIFFICULTY_MAP (#2197) so a new enum "
-                "member cannot reach MCP and REST while staying absent from the CLI."
+            # Require the map ITSELF to appear in the expression. Rejecting only
+            # bare literals is not enough: `click.Choice(list(("fewer",
+            # "standard", "more")))` is a wrapped literal that passes an
+            # is-not-a-List check while still going stale when a member is
+            # added, and the value-parity test above stays green until the map
+            # actually changes.
+            expected_map = (
+                "_QUIZ_QUANTITY_MAP" if first.value == "--quantity" else "_QUIZ_DIFFICULTY_MAP"
+            )
+            names = {n.id for n in ast.walk(choice_arg) if isinstance(n, ast.Name)}
+            assert expected_map in names, (
+                f"{node.name} {first.value} does not derive its choices from "
+                f"{expected_map} (#2197). Found names: {sorted(names) or 'none — a literal'}. "
+                "A hardcoded (or wrapped-literal) list goes stale silently: a new enum "
+                "member would reach MCP and REST while staying absent from the CLI."
             )
             checked.add((node.name, first.value))
 

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -32,7 +32,11 @@ import json
 
 import pytest
 
-from notebooklm._row_adapters.artifacts import ArtifactRow, ReportSuggestionRow
+from notebooklm._artifact.payloads import (
+    build_flashcards_artifact_params,
+    build_quiz_artifact_params,
+)
+from notebooklm._row_adapters.artifacts import ArtifactRow, QuizOptionPair, ReportSuggestionRow
 from notebooklm._row_adapters.notes import NoteRow
 from notebooklm._row_adapters.sources import (
     SourceRow,
@@ -45,6 +49,8 @@ from notebooklm.exceptions import DecodingError, UnknownRPCMethodError
 from notebooklm.rpc.types import (
     ArtifactStatus,
     ArtifactTypeCode,
+    QuizDifficulty,
+    QuizQuantity,
     SourceStatus,
     artifact_status_to_str,
 )
@@ -85,6 +91,27 @@ class TestPositionContract:
 
     def test_options_position_is_9(self) -> None:
         assert ArtifactRow._OPTIONS_POS == 9
+
+    def test_options_block_inner_positions(self) -> None:
+        """The leaves inside ``data[9]`` (#2195).
+
+        ``AppArtifact.generationOptions`` is tag 2, and inside it ``appType``
+        is 1, ``flashcardsGenerationOptions`` 7 and ``quizGenerationOptions``
+        8 — each ``tag - 1`` here, asserted against ``docs/mobile/schema.proto``
+        in ``tests/_guardrails/test_wire_contract.py``.
+        """
+        assert (
+            ArtifactRow._GENERATION_OPTIONS_POS,
+            ArtifactRow._APP_TYPE_POS,
+            ArtifactRow._FLASHCARDS_OPTIONS_POS,
+            ArtifactRow._QUIZ_OPTIONS_POS,
+        ) == (1, 0, 6, 7)
+
+    def test_option_pair_positions_are_quantity_then_difficulty(self) -> None:
+        """Quantity FIRST. This is the ordering #2116 got backwards on the
+        encode side; the decode side must not repeat it."""
+        assert ArtifactRow._OPTION_QUANTITY_POS == 0
+        assert ArtifactRow._OPTION_DIFFICULTY_POS == 1
 
     def test_infographic_metadata_position_is_14(self) -> None:
         assert ArtifactRow._INFOGRAPHIC_METADATA_POS == 14
@@ -259,6 +286,262 @@ class TestVariantDescent:
         raw[ArtifactRow._OPTIONS_POS] = [None, ["not_an_int"]]
         row = ArtifactRow(raw)
         assert row.variant is None
+
+
+#: Two rows captured verbatim from a live ``LIST_ARTIFACTS`` response (#2195),
+#: for a scratch notebook created and deleted in the same run. Both artifacts
+#: were requested with the SAME asymmetric pair — ``quantity=FEWER(1)``,
+#: ``difficulty=HARD(3)`` — so a transposed read decodes as ``(3, 1)`` and is
+#: detectable. A symmetric pair could not distinguish the two, which is exactly
+#: how #2116 hid (and why pairing ``MORE`` with ``HARD`` is banned here: both
+#: are ``3`` under ``int``-Enum comparison).
+#:
+#: Captured, not synthesised, on purpose: a fixture written from the code's
+#: belief about the wire can only ever confirm that belief.
+_LIVE_FLASHCARDS_ROW: list = [
+    "03124504-a1a6-4357-97b0-f2cfc4ee10fd",
+    "Photosynthesis Flashcards",
+    4,
+    [[["06bbfd9c-17bf-4372-ac86-a3dfaaf880bb"], None, 4]],
+    3,
+    None,
+    None,
+    None,
+    None,
+    ["", [1, None, None, "en", None, None, [1, 3], None, True]],
+    [1786619721, 886749000],
+    None,
+    None,
+    None,
+    None,
+    [1786619697, 143474000],
+    None,
+    [None, None, None, None, True],
+    None,
+    1,
+    None,
+    "MTc4NjYxOTcyMS04ODY3NDkwMDA=",
+]
+
+_LIVE_QUIZ_ROW: list = [
+    "8116e9aa-f6ac-4586-8bae-0d36f59ab283",
+    "Photosynthesis Quiz",
+    4,
+    [[["06bbfd9c-17bf-4372-ac86-a3dfaaf880bb"], None, 4]],
+    2,
+    None,
+    None,
+    None,
+    None,
+    ["", [2, None, None, "en", None, None, None, [1, 3], True]],
+    [1786619698, 906408000],
+    None,
+    None,
+    None,
+    None,
+    [1786619698, 709194000],
+    None,
+    [None, None, None, None, True],
+    None,
+    1,
+    None,
+    "MTc4NjYxOTY5OC05MDY0MDgwMDA=",
+]
+
+
+class TestQuizOptionEcho:
+    """``data[9][1][6]`` / ``data[9][1][7]`` — the server's echo of the stored
+    ``[quantity, difficulty]`` pair (#2195).
+
+    Before this accessor existed, nothing in the client read the option pair
+    back, so a transposed or mis-valued pair was caught only by fixtures we
+    wrote ourselves — the structural reason #2116 and #2117 survived. These
+    tests decode rows captured from the live backend; the e2e round-trip
+    (``tests/e2e/test_generation.py``) closes the loop against a fresh
+    generation.
+    """
+
+    def test_flashcards_pair_decoded_from_a_live_row(self) -> None:
+        row = ArtifactRow(_LIVE_FLASHCARDS_ROW)
+        assert row.variant == 1  # APP_TYPE_FLASHCARDS
+        assert row.flashcards_options == QuizOptionPair(quantity=1, difficulty=3)
+
+    def test_quiz_pair_decoded_from_a_live_row(self) -> None:
+        row = ArtifactRow(_LIVE_QUIZ_ROW)
+        assert row.variant == 2  # APP_TYPE_QUIZ
+        assert row.quiz_options == QuizOptionPair(quantity=1, difficulty=3)
+
+    def test_pair_compares_against_the_client_enums(self) -> None:
+        """The raw codes compare equal to the enum members callers hold.
+
+        Asserted field-by-field: an equality against a 2-tuple would be
+        satisfied by a transposed decode of a symmetric pair, and this is the
+        assertion downstream tests are most likely to copy.
+        """
+        options = ArtifactRow(_LIVE_FLASHCARDS_ROW).flashcards_options
+        assert options is not None
+        assert options.quantity == QuizQuantity.FEWER
+        assert options.difficulty == QuizDifficulty.HARD
+        assert options.quantity != QuizQuantity.MORE
+        assert options.difficulty != QuizDifficulty.EASY
+
+    def test_each_family_reads_only_its_own_slot(self) -> None:
+        """A quiz row leaves the flashcards slot null and vice versa.
+
+        This is what makes the two accessors independent: reading the wrong
+        slot would return ``None`` rather than the sibling's pair, so a
+        crossed-wires accessor cannot silently look correct.
+        """
+        assert ArtifactRow(_LIVE_FLASHCARDS_ROW).quiz_options is None
+        assert ArtifactRow(_LIVE_QUIZ_ROW).flashcards_options is None
+
+    def test_empty_options_message_reads_as_unspecified(self) -> None:
+        """A ``[0, 0]`` (proto3 default) request echoes back as ``[]``.
+
+        Live-observed: default-valued proto fields are dropped from the JSON
+        encoding, so "unspecified" arrives as an empty list rather than
+        ``[0, 0]``. It is present-but-unset, which is not the same as absent.
+        """
+        raw = json.loads(json.dumps(_LIVE_FLASHCARDS_ROW))
+        raw[ArtifactRow._OPTIONS_POS][1][6] = []
+        assert ArtifactRow(raw).flashcards_options == QuizOptionPair(quantity=None, difficulty=None)
+
+    @pytest.mark.parametrize(
+        ("description", "row"),
+        [
+            ("short row without position 9", ["id", "title", 4, None, 3]),
+            ("options block is None", _full_row(type_code=ArtifactTypeCode.QUIZ, variant=None)),
+            (
+                "generation options too short for the slots",
+                ["id", "title", 4, None, 3, None, None, None, None, ["", [1, None]]],
+            ),
+            (
+                "option slot is null (the other family's row)",
+                [
+                    "id",
+                    "title",
+                    4,
+                    None,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    ["", [1, None, None, "en", None, None, None, None]],
+                ],  # fmt: skip
+            ),
+            (
+                "option slot is not a list",
+                [
+                    "id",
+                    "title",
+                    4,
+                    None,
+                    3,
+                    None,
+                    None,
+                    None,
+                    None,
+                    ["", [1, None, None, "en", None, None, 3, None]],
+                ],  # fmt: skip
+            ),
+        ],
+    )
+    def test_absent_or_unusable_slots_return_none(self, description: str, row: list) -> None:
+        assert ArtifactRow(row).flashcards_options is None, description
+
+    def test_non_int_codes_degrade_to_none(self) -> None:
+        """Strings and bools at the option leaves are not codes.
+
+        ``True`` matters specifically: ``isinstance(True, int)`` is ``True`` in
+        Python, and the row genuinely carries a bool two slots later, so an
+        unguarded read would happily decode ``difficulty=True``.
+        """
+        raw = json.loads(json.dumps(_LIVE_FLASHCARDS_ROW))
+        raw[ArtifactRow._OPTIONS_POS][1][6] = ["fewer", True]
+        assert ArtifactRow(raw).flashcards_options == QuizOptionPair(quantity=None, difficulty=None)
+
+    def test_reshaped_options_block_raises(self) -> None:
+        """A present-but-reshaped ``data[9]`` is drift, not absence.
+
+        Matches ``variant``'s policy: once the options block is a list, the
+        descent to ``[1]`` goes through ``safe_index``, which is strict-only
+        since v0.7.0 (ADR-0011). A block missing the generation-options element
+        entirely means Google reshaped it — the exact signal the adapter exists
+        to raise rather than swallow.
+        """
+        raw = json.loads(json.dumps(_LIVE_FLASHCARDS_ROW))
+        raw[ArtifactRow._OPTIONS_POS] = [""]
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ArtifactRow(raw).flashcards_options
+
+
+class TestOptionPairRoundTrip:
+    """The payload the builders SEND decodes back to the options requested.
+
+    This is the encode↔decode loop #2116 lacked. It is only meaningful because
+    the decode positions are pinned independently of the encode positions —
+    against ``docs/mobile/schema.proto`` in
+    ``tests/_guardrails/test_wire_contract.py`` and against a live capture in
+    ``TestQuizOptionEcho`` — so this cannot pass by two mistakes agreeing.
+
+    Transposing either builder fails these.
+    """
+
+    @staticmethod
+    def _echo_row(variant: int, slot: int, pair: list) -> list:
+        """Wrap a sent pair in the row shape the backend echoes it back in."""
+        row: list = ["art_id", "Title", 4, None, 3, None, None, None, None]
+        generation_options: list = [variant, None, None, "en", None, None, None, None, True]
+        generation_options[slot] = pair
+        row.append(["", generation_options])
+        return row
+
+    def test_quiz_builder_pair_round_trips(self) -> None:
+        params = build_quiz_artifact_params(
+            "nb",
+            ["src"],
+            instructions=None,
+            quantity=QuizQuantity.FEWER,
+            difficulty=QuizDifficulty.HARD,
+        )
+        sent = params[2][9][1][7]
+        row = ArtifactRow(self._echo_row(2, ArtifactRow._QUIZ_OPTIONS_POS, sent))
+        assert row.quiz_options == QuizOptionPair(
+            quantity=QuizQuantity.FEWER.value, difficulty=QuizDifficulty.HARD.value
+        )
+
+    def test_flashcards_builder_pair_round_trips(self) -> None:
+        params = build_flashcards_artifact_params(
+            "nb",
+            ["src"],
+            instructions=None,
+            quantity=QuizQuantity.FEWER,
+            difficulty=QuizDifficulty.HARD,
+        )
+        sent = params[2][9][1][6]
+        row = ArtifactRow(self._echo_row(1, ArtifactRow._FLASHCARDS_OPTIONS_POS, sent))
+        assert row.flashcards_options == QuizOptionPair(
+            quantity=QuizQuantity.FEWER.value, difficulty=QuizDifficulty.HARD.value
+        )
+
+    def test_builders_write_the_slots_the_adapter_reads(self) -> None:
+        """The encode and decode sides agree on WHICH slot each family uses.
+
+        A builder writing the sibling's slot would still round-trip above if
+        the test wrapped whatever it produced; this pins the positions.
+        """
+        quiz = build_quiz_artifact_params(
+            "nb", ["src"], instructions=None, quantity=None, difficulty=None
+        )[2][9][1]
+        flashcards = build_flashcards_artifact_params(
+            "nb", ["src"], instructions=None, quantity=None, difficulty=None
+        )[2][9][1]
+        assert isinstance(quiz[ArtifactRow._QUIZ_OPTIONS_POS], list)
+        assert isinstance(flashcards[ArtifactRow._FLASHCARDS_OPTIONS_POS], list)
+        assert len(quiz) <= ArtifactRow._FLASHCARDS_OPTIONS_POS or (
+            quiz[ArtifactRow._FLASHCARDS_OPTIONS_POS] is None
+        )
 
 
 class TestTimestampDescent:

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -430,25 +430,43 @@ class TestQuizOptionEcho:
                     ["", [1, None, None, "en", None, None, None, None]],
                 ],  # fmt: skip
             ),
-            (
-                "option slot is not a list",
-                [
-                    "id",
-                    "title",
-                    4,
-                    None,
-                    3,
-                    None,
-                    None,
-                    None,
-                    None,
-                    ["", [1, None, None, "en", None, None, 3, None]],
-                ],  # fmt: skip
-            ),
         ],
     )
     def test_absent_or_unusable_slots_return_none(self, description: str, row: list) -> None:
         assert ArtifactRow(row).flashcards_options is None, description
+
+    @pytest.mark.parametrize(
+        ("description", "generation_options"),
+        [
+            ("option slot holds a scalar", [1, None, None, "en", None, None, 3, None]),
+            ("option slot holds a dict", [1, None, None, "en", None, None, {"a": 1}, None]),
+        ],
+    )
+    def test_malformed_option_container_raises(
+        self, description: str, generation_options: list
+    ) -> None:
+        """A present-but-wrong-shaped option slot is drift, not absence.
+
+        The distinction this pins: ``null`` at the slot means "this row is not
+        that family" and must stay soft, but a scalar or dict there means the
+        message changed shape. Returning ``None`` for both would make a
+        reshaped payload indistinguishable from an unset option — in the one
+        accessor whose whole job is reporting what the server stored.
+        """
+        row = ["id", "title", 4, None, 3, None, None, None, None, ["", generation_options]]
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ArtifactRow(row).flashcards_options, description
+
+    def test_malformed_generation_options_container_raises(self) -> None:
+        """Same policy one level up, at ``data[9][1]`` itself."""
+        row = ["id", "title", 4, None, 3, None, None, None, None, ["", 7]]
+        with pytest.raises(UnknownRPCMethodError):
+            _ = ArtifactRow(row).flashcards_options
+
+    def test_null_generation_options_stays_soft(self) -> None:
+        """``data[9][1] = null`` is a genuine absence, not drift."""
+        row = ["id", "title", 4, None, 3, None, None, None, None, ["", None]]
+        assert ArtifactRow(row).flashcards_options is None
 
     def test_non_int_codes_degrade_to_none(self) -> None:
         """Strings and bools at the option leaves are not codes.

--- a/tests/unit/test_rpc_golden_payloads.py
+++ b/tests/unit/test_rpc_golden_payloads.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import importlib
 import json
+import re
 import warnings
 from pathlib import Path
 from typing import Any, cast
@@ -36,6 +37,8 @@ import pytest
 
 from notebooklm._app.serialize import to_jsonable
 from notebooklm._artifact.payloads import (
+    DEFAULT_QUIZ_DIFFICULTY,
+    DEFAULT_QUIZ_QUANTITY,
     build_audio_artifact_params,
     build_cinematic_video_artifact_params,
     build_data_table_artifact_params,
@@ -65,6 +68,7 @@ from notebooklm.exceptions import (
     RateLimitError,
     RPCError,
     UnknownRPCMethodError,
+    ValidationError,
 )
 from notebooklm.rpc.decoder import (
     collect_rpc_ids,
@@ -873,6 +877,77 @@ def test_quiz_quantity_more_is_distinct_on_the_wire() -> None:
 
     assert quiz[2][9][1][7] == [3, 1]
     assert flashcards[2][9][1][6] == [3, 1]
+
+
+def test_omitted_quiz_options_are_sent_as_explicit_client_defaults() -> None:
+    """``None`` means "this client's default", and that default goes on the wire.
+
+    The alternative — omitting the option message so the backend picks — is
+    accepted by the server (live-probed: generation completes normally), but
+    what it then chose is unobservable: the stored options echo back as
+    ``null``. #2196 resolves that trade in favour of a value we can name, echo
+    and assert, matching every sibling builder in ``payloads.py`` and the web
+    UI, which always sends an explicit pair.
+
+    Asserted against the named constants rather than the literals so the
+    documented default and the transmitted default cannot drift apart. (This
+    particular pair cannot detect a transposition — ``STANDARD`` and ``MEDIUM``
+    are both 2 — which is why the ordering is pinned by the asymmetric fixtures
+    above instead.)
+    """
+    quiz = build_quiz_artifact_params(
+        "nb_payload", ["src_alpha"], instructions=None, quantity=None, difficulty=None
+    )
+    flashcards = build_flashcards_artifact_params(
+        "nb_payload", ["src_alpha"], instructions=None, quantity=None, difficulty=None
+    )
+
+    for pair in (quiz[2][9][1][7], flashcards[2][9][1][6]):
+        assert isinstance(pair, list), "the option message must be sent, not omitted"
+        assert pair[0] == DEFAULT_QUIZ_QUANTITY.value
+        assert pair[1] == DEFAULT_QUIZ_DIFFICULTY.value
+
+    assert DEFAULT_QUIZ_QUANTITY is QuizQuantity.STANDARD
+    assert DEFAULT_QUIZ_DIFFICULTY is QuizDifficulty.MEDIUM
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [build_quiz_artifact_params, build_flashcards_artifact_params],
+    ids=["quiz", "flashcards"],
+)
+@pytest.mark.parametrize(
+    ("kwargs", "expected_message"),
+    [
+        ({"quantity": 2}, "quantity must be a QuizQuantity member or None"),
+        ({"difficulty": 2}, "difficulty must be a QuizDifficulty member or None"),
+        ({"quantity": "standard"}, "quantity must be a QuizQuantity member or None"),
+        # The cross-enum case is the interesting one: QuizDifficulty.HARD and
+        # QuizQuantity.MORE are both 3, so this used to encode silently as MORE.
+        ({"quantity": QuizDifficulty.HARD}, "quantity must be a QuizQuantity member or None"),
+        ({"difficulty": QuizQuantity.FEWER}, "difficulty must be a QuizDifficulty member or None"),
+    ],
+    ids=[
+        "int-quantity",
+        "int-difficulty",
+        "str-quantity",
+        "swapped-quantity",
+        "swapped-difficulty",
+    ],
+)
+def test_non_enum_quiz_options_raise_a_typed_error(
+    builder: Any, kwargs: dict[str, Any], expected_message: str
+) -> None:
+    """Bad option input fails as ``ValidationError``, not ``AttributeError``.
+
+    Before #2196 a bare ``int`` reached ``.value`` and produced
+    ``AttributeError: 'int' object has no attribute 'value'`` — an internal
+    error shape leaking through a public keyword argument.
+    """
+    call_kwargs: dict[str, Any] = {"instructions": None, "quantity": None, "difficulty": None}
+    call_kwargs.update(kwargs)
+    with pytest.raises(ValidationError, match=re.escape(expected_message)):
+        builder("nb_payload", ["src_alpha"], **call_kwargs)
 
 
 def test_video_style_values_match_live_web_ui() -> None:


### PR DESCRIPTION
The three follow-ups filed from #2194, all on the shared quiz/flashcards option surface.

Closes #2195
Closes #2196
Closes #2197

## #2195 — nothing read the option pair back

`ArtifactRow` parsed `data[9]` but never `data[9][1][6]` / `[7]`, where the backend **echoes back the options it stored**. So the only thing between a wrong quantity/difficulty pair and a user was a fixture written from the same belief as the code — the structural reason a fully transposed flashcards payload (#2116) and a `MORE`-aliased-to-`STANDARD` enum (#2117) both shipped through a green e2e tier.

`ArtifactRow.quiz_options` / `flashcards_options` now decode that echo into a **named** `QuizOptionPair`, not a `tuple[int, int]` — a positional read-back would reintroduce on the decode side exactly the ambiguity that produced the transposition on the encode side.

Six new positional constants enter the wire-contract registry, each asserted against `docs/mobile/schema.proto` (`AppArtifact.generationOptions` = tag 2; `flashcardsGenerationOptions` = 7; `quizGenerationOptions` = 8; quantity/difficulty = 1/2 in both option messages). Plus a companion guard — `test_flashcards_option_pair_shares_the_quiz_tags` — because one pair of constants indexes **both** messages: if Google renumbered only the flashcards side, every flashcards read-back would silently transpose while the quiz side stayed green. That mirrors, on the decode end, the enum check #2194 added on the encode end.

### The fixtures are captured, not written

The unit fixtures are two rows copied verbatim out of a live `LIST_ARTIFACTS` response. A fixture built from the code's belief about the wire can only ever confirm that belief, which is the defect class this whole thread is about.

### The e2e tier could not previously tell the difference

It asserted only `assert_generation_started`, which cannot distinguish "the fewest, hardest cards" from "the most, easiest". Every quiz/flashcards e2e test now reads the server's echo back and asserts it — and every pair is **asymmetric**. Two of the previous ones were not, and were structurally blind:

| test | before | after |
|---|---|---|
| `test_generate_quiz_fewer_easy` → `_fewer_medium` | `FEWER(1)` + `EASY(1)` → `(1,1)` | `FEWER(1)` + `MEDIUM(2)` |
| `test_generate_flashcards_with_options` | `STANDARD(2)` + `MEDIUM(2)` → `(2,2)` | `STANDARD(2)` + `HARD(3)` |
| `test_generate_quiz_with_options` | `MORE(3)` + `HARD(3)` → `(3,3)` | `MORE(3)` + `EASY(1)` |

That last row is the trap #2194 flagged: `QuizQuantity.MORE` and `QuizDifficulty.HARD` are **both 3**, so `more` + `hard` is exactly as blind as `standard` + `medium`.

## #2196 — `None` → `STANDARD`/`MEDIUM`: kept, but now a decision

**Verdict: documented coercion, not pass-through.** I probed the backend before designing, per the issue.

What omission actually does, measured live:

| sent | accepted? | outcome | stored options echo back as |
|---|---|---|---|
| option message `null` | yes | `ARTIFACT_STATUS_READY` | `null` |
| `[0, 0]` (proto3 `*_UNSPECIFIED`) | yes | `ARTIFACT_STATUS_READY` | `[]` (defaults dropped from the JSON encoding) |
| `[1, 3]` | yes | `ARTIFACT_STATUS_READY` | `[1, 3]` |

So "let the server choose" **is** expressible on the wire — but what the server then chose is **unobservable**: the echo is empty, and the generated content is not carried in `LIST_ARTIFACTS` (I waited all four probe artifacts to `READY`; `appHtml` stays `""` there). Passing `None` through would trade a value we can name, echo and assert for one we cannot see at all — defeating the read-back added in the same PR. It would also make quiz/flashcards the lone exception among the builders in `payloads.py`, which all resolve `None` to an explicit client default, and diverge from the web UI, which always sends an explicit pair.

So the coercion stays, moves out of an inline `else` into `_quiz_option_code` with the evidence recorded, and is now **observable**: `test_generate_flashcards_default` sends `MORE` with no difficulty and asserts the wire carried `[3, 2]`.

The issue's second half is fixed outright. A non-enum option raised `AttributeError: 'int' object has no attribute 'value'` — an internal error shape leaking through a public keyword argument. It now raises `ValidationError`. The `isinstance` check also rejects the **other** option enum: `quantity=QuizDifficulty.HARD` used to encode silently as `MORE`, since both are `3`. No working call changes; neither ints nor strings were ever accepted.

## #2197 — CLI choice lists derived

`generate quiz` / `generate flashcards` now build their `click.Choice` from `_QUIZ_QUANTITY_MAP` / `_QUIZ_DIFFICULTY_MAP` — the idiom `--style` already used. Same choices, same order, no user-visible change today.

Two tests, because they catch different things:

- **parity** — the live Click choices equal both the core maps *and* the MCP `_KIND_OPTIONS` tuples. The MCP half is what keeps it from being tautological now that the CLI derives its list.
- **derivation** — an AST check that the `click.Choice` argument is a name, not a literal. A value comparison alone would still pass if someone re-hardcoded today's three members; the protection against a *future* member going missing is the derivation itself, so that is what gets asserted.

## Live probe

On this head, scratch notebook created and deleted in the same run, read back through the new accessor:

```
HEAD: ce13a034c1d3db1745e900c245540e16b738b1c3

sent                                server echo (read back)                   match
------------------------------------------------------------------------------------------
flashcards  FEWER(1) + HARD(3)      QuizOptionPair(quantity=1, difficulty=3)  OK
quiz        FEWER(1) + HARD(3)      QuizOptionPair(quantity=1, difficulty=3)  OK
flashcards  MORE(3) + <omitted>     QuizOptionPair(quantity=3, difficulty=2)  OK

PROBE RESULT: PASS
```

The third row is #2196 made visible: the difficulty was never passed, and reads back as `MEDIUM(2)` precisely because the builder sends the client default explicitly.

## Mutation testing

Every new test was checked against the bug it claims to catch:

| mutation | fails |
|---|---|
| transpose the flashcards builder | `test_flashcards_builder_pair_round_trips` |
| transpose `_OPTION_QUANTITY_POS` / `_OPTION_DIFFICULTY_POS` | 9 tests, incl. both proto mappings |
| swap `_FLASHCARDS_OPTIONS_POS` / `_QUIZ_OPTIONS_POS` | 10 tests |
| remove the `isinstance` validation | 10 tests |
| change the resolved default | `quiz_defaults` golden + the #2196 test |
| re-hardcode the CLI `click.Choice` | `test_quiz_option_choices_are_derived_not_hardcoded` |

The round-trip test wraps the builder's output in the row shape the *server* echoes it back in, at positions pinned independently against the proto and a live capture — so it cannot pass by two mistakes agreeing.

## Verification

- `pytest -n auto --dist loadgroup --cov --cov-fail-under=90` — **15,927 passed**, 64 skipped, 1 xfailed, **96.71%** (exit 0, checked directly)
- `mypy src/notebooklm --ignore-missing-imports` — clean, 353 files
- `pre-commit run --all-files` — clean
- `scripts/audit_public_api_compat.py --check-stale` — exit 0 (no enum values changed; nothing added to the allowlist)

## Not in scope

The other `click.Choice` lists in `generate_cmd.py` (audio, video, slide deck, infographic orientation/detail, report format) are still hardcoded. #2197 is scoped to the quiz/flashcards pair; the same treatment elsewhere is a separate change, and the AST guard here is deliberately narrowed to the two commands the issue names rather than turned into a repo-wide ratchet in a bug-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Quiz and flashcard generation options are now preserved and displayed when reviewing generated artifacts.
  - CLI quantity and difficulty choices stay aligned with supported generation options.

- **Bug Fixes**
  - Omitted quiz options now use explicit defaults: Standard quantity and Medium difficulty.
  - Invalid or mismatched option values now return clear validation errors.

- **Documentation**
  - Updated API and RPC references with option defaults, validation behavior, and read-back details.
  - Added changelog coverage for option preservation and generation-option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->