### PR TITLE
fix(rpc): surface the server's rejection status instead of a client guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,8 +224,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`google.rpc.Status.message` is no longer discarded.** Index 1 of the
   rejection envelope is the only slot in which the *server* can state a reason;
   nothing in this client read it, on either the `batchexecute` or the streamed-chat
-  path. It is now read (defensively — a non-empty string only) and, when
-  present, leads the error message on both paths. **No captured response has
+  path. It is now read (defensively — a non-empty string only) and surfaced on
+  both. Only the rate-limit message *leads* with it; the decoder's bare-status
+  path and both streamed-chat sites APPEND it and keep the client-authored
+  guidance, because nobody has seen the slot populated and so there is no
+  evidence a server sentence would be as actionable as the advice it displaced. **No captured response has
   ever populated it**, so in practice users still see the client-authored
   wording; this changes what happens if the server ever does explain itself, and
   it records on the wire-contract registry that the slot is unobserved rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [`docs/deprecations.md`](docs/deprecations.md)). The genuinely answer-side
   range is the new `answer_anchor_*` pair above.
   ([#2120](https://github.com/teng-lin/notebooklm-py/issues/2120))
+- **A rejected artifact generation now reports the server's reason instead of
+  "generation is unavailable".** A live probe (2026-08-13) showed
+  `CREATE_ARTIFACT` answering an Audio Overview request on a source-less
+  notebook with `[["wrb.fr","R7cb6c",null,null,null,[3],"generic"]]` — an
+  explicit `google.rpc.Status` of `INVALID_ARGUMENT`. The `allow_null=True`
+  decode returned `None` *before* consulting that status, so the client
+  discarded what the server said and substituted its own guess,
+  `ArtifactFeatureUnavailableError("Audio generation is unavailable")`. Callers
+  can now pass `raise_on_null_status=True` (as `CREATE_ARTIFACT`,
+  `RETRY_ARTIFACT` and `REVISE_SLIDE` do) to have a status-tagged null raise
+  with the server's code and label. It is opt-in per call site rather than a
+  blanket change because `REMOVE_RECENTLY_VIEWED` answers `[13]` (INTERNAL) on
+  a call the client treats as a successful no-op. A generation rejected with no
+  status at all still raises `ArtifactFeatureUnavailableError`.
+  ([#2188](https://github.com/teng-lin/notebooklm-py/issues/2188))
+- **`google.rpc.Status.message` is no longer discarded.** Index 1 of the
+  rejection envelope is the only slot in which the *server* can state a reason;
+  nothing in this client read it, on either the `batchexecute` or the streamed-chat
+  path. It is now read (defensively — a non-empty string only) and, when
+  present, leads the error message on both paths. **No captured response has
+  ever populated it**, so in practice users still see the client-authored
+  wording; this changes what happens if the server ever does explain itself, and
+  it records on the wire-contract registry that the slot is unobserved rather
+  than unknown. Every other rejection sentence this client prints is
+  client-authored, including "API rate limit or quota exceeded" — see
+  `docs/rpc-reference.md`.
+  ([#2188](https://github.com/teng-lin/notebooklm-py/issues/2188))
+- **#239's quota-failure guarantee has a regression test again.** #2134 removed
+  the phantom `failed_error_text` read and, with it, the tests that were the
+  only guard on "a quota failure surfaces a helpful message" — tests that had
+  asserted against a row shape the backend has never emitted. The replacement
+  drives the **real** decoder: a recorded `UserDisplayableError` rejection and
+  the verbatim live `INVALID_ARGUMENT` body are decoded unmocked and asserted at
+  the `generate_audio` boundary, and the surviving behaviour — a late FAILED
+  artifact carries no reason, so the user gets the generic
+  `"{Type} generation failed"` fallback — is pinned to that fallback.
+  ([#2193](https://github.com/teng-lin/notebooklm-py/issues/2193))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,11 +209,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discarded what the server said and substituted its own guess,
   `ArtifactFeatureUnavailableError("Audio generation is unavailable")`. Callers
   can now pass `raise_on_null_status=True` (as `CREATE_ARTIFACT`,
-  `RETRY_ARTIFACT` and `REVISE_SLIDE` do) to have a status-tagged null raise
-  with the server's code and label. It is opt-in per call site rather than a
-  blanket change because `REMOVE_RECENTLY_VIEWED` answers `[13]` (INTERNAL) on
-  a call the client treats as a successful no-op. A generation rejected with no
-  status at all still raises `ArtifactFeatureUnavailableError`.
+  `RETRY_ARTIFACT` and `REVISE_SLIDE` do — all three live-verified: retry and
+  revise answer `[5]` NOT_FOUND for an unknown artifact id) to have a
+  status-tagged null raise with the server's code and label. It is opt-in per
+  call site rather than a blanket change because three *other* RPCs are
+  recorded doing the same thing on flows this client reports as successful —
+  `SHARE_NOTEBOOK` and `SHARE_ARTIFACT` answer `[3]`, `REMOVE_RECENTLY_VIEWED`
+  answers `[13]` — and only the last of those has ever been reasoned about.
+  Whether the two share rejections are benign is an open question this change
+  deliberately does not answer; a swallowed status now logs at DEBUG so they
+  are findable. A generation rejected with no status at all still raises
+  `ArtifactFeatureUnavailableError`.
   ([#2188](https://github.com/teng-lin/notebooklm-py/issues/2188))
 - **`google.rpc.Status.message` is no longer discarded.** Index 1 of the
   rejection envelope is the only slot in which the *server* can state a reason;

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -973,6 +973,7 @@ class NotebookLMClient:
         *,
         disable_internal_retries: bool = False,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
     ) -> Any:
 ```
 
@@ -983,6 +984,13 @@ defaults. `read_timeout` (added in #2187) overrides the client-wide read
 timeout for this one call — internal callers use it for RPCs known to run
 long (e.g. `ResearchAPI.import_sources`'s batch-scaled IMPORT_RESEARCH
 timeout); `None` (the default) inherits the client's configured `timeout`.
+`raise_on_null_status` (added in #2188) pairs with `allow_null=True`: a null
+result the server tagged with a recognized non-OK `google.rpc.Status` raises
+with that status instead of decoding to `None`, so a rejection is reported
+with the server's own code rather than a client-invented reason. It is opt-in
+because several RPCs are recorded answering a status on flows this client
+treats as successful — see
+[rpc-reference.md](rpc-reference.md#rejection-frames-googlerpcstatus-at-wrbfr-index-5).
 
 **Cookie persistence override:** `cookie_saver=None` (the default) uses the
 canonical typed `ProfileStore` merge for close, refresh, and keepalive saves.

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2825,6 +2825,75 @@ await rpc_call(
 
 ---
 
+## Rejection Frames: `google.rpc.Status` at `wrb.fr` index 5
+
+**Verified 2026-08-13** (live probe + a sweep of all 141 cassettes).
+
+When a `batchexecute` RPC is rejected, the server answers with a `wrb.fr` frame
+whose *result* slot (index 2) is `null` and whose index 5 carries a
+JSON-array-encoded [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto).
+That is a **public** Google type, not a Tailwind message, so it is absent from
+`docs/mobile/schema.proto` and its positions are the proto tags minus one:
+
+| Index | `google.rpc.Status` field | Observed |
+|-------|---------------------------|----------|
+| 0 | `code` (tag 1) | Yes — see the table below |
+| 1 | `message` (tag 2) | **Never populated.** See "The reason gap" |
+| 2 | `details` (tag 3) | Yes — the `UserDisplayableError` block |
+
+Observed codes:
+
+| Payload | RPC | Where |
+|---------|-----|-------|
+| `[3]` INVALID_ARGUMENT | `CREATE_ARTIFACT` (`R7cb6c`) | Live 2026-08-13: audio overview on a source-less notebook |
+| `[3]` INVALID_ARGUMENT | streamed chat | `tests/cassettes/chat_ask_oversized_rejection.yaml` (#1472) |
+| `[5]` NOT_FOUND | `CREATE_ARTIFACT`, `GET_NOTEBOOK` | Live 2026-08-13 (unknown notebook id); #114 / #294 |
+| `[13]` INTERNAL | `REMOVE_RECENTLY_VIEWED` (`fejl7e`) | `tests/cassettes/notebooks_remove_from_recent.yaml` — treated as a **successful** no-op |
+| `[8, null, [[…UserDisplayableError…]]]` | any | The rate-limit / quota shape |
+
+A sweep of all 141 cassettes found 397 `wrb.fr` frames, only 5 of them
+null-result — and all 5 carried one of the shapes above.
+
+### The reason gap
+
+`google.rpc.Status.message` is the one slot in this envelope where the *server*
+could state a human-readable reason. **No captured frame has ever populated
+it**: the bare rejections are length-1 arrays, and the recorded
+`UserDisplayableError` sample holds `null` there with an int-only detail body.
+
+So every rejection sentence this client prints today is **client-authored** —
+including "API rate limit or quota exceeded. Please wait before retrying.",
+which is a client guess at what a `UserDisplayableError` means, not something
+the server said. The decoder reads the `message` slot defensively (a non-empty
+string only) and leads with it when one ever arrives, but until then the guess
+is the ceiling. Do not describe this path as "carrying the server's error text"
+(#2188).
+
+### `allow_null` and status-tagged nulls
+
+`allow_null=True` means "an empty payload is an acceptable outcome". It used to
+also swallow a null the server had *tagged with a rejection*, which is how
+`generate_audio` came to report "Audio generation is unavailable" for a live
+INVALID_ARGUMENT. Callers that want the server's status instead pass
+`raise_on_null_status=True` (`CREATE_ARTIFACT`, `RETRY_ARTIFACT`,
+`REVISE_SLIDE` do). It is opt-in rather than blanket because
+`REMOVE_RECENTLY_VIEWED` answers `[13]` on a call the client treats as
+successful.
+
+### Artifact failures have no reason at all
+
+`Artifact` in `docs/mobile/schema.proto` has **no error or failure field**. An
+artifact accepted at create time that later transitions to
+`ARTIFACT_STATUS_FAILED` therefore carries nothing to explain itself: no cassette
+contains a status-4 row, and a live sweep of 27 notebooks / 99 rows found index 3
+holding `sources` and index 5 holding `null` on both real FAILED artifacts. The
+existence of `RETRY_ARTIFACT` (`Rytqqe`) is consistent with the backend not
+persisting a reason — retry is offered because the resource remembers nothing.
+Downstream, `_app/generate_retry.py` falls back to a generic
+`"{Type} generation failed"`, which is the honest ceiling for that path.
+
+---
+
 ## Operation Timing Categories
 
 ### Quick Operations

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2854,8 +2854,10 @@ Observed codes:
 | `[8, null, [[…UserDisplayableError…]]]` | any | The rate-limit / quota shape |
 
 A sweep of all 141 cassettes found 397 `wrb.fr` frames, only 5 of them
-null-result — and all 5 carried one of the shapes above, on three RPCs
-(`SHARE_NOTEBOOK` ×2, `SHARE_ARTIFACT`, `REMOVE_RECENTLY_VIEWED`).
+null-result — and all 5 carried one of the shapes above. Four are `batchexecute`
+RPCs, across three method ids (`SHARE_NOTEBOOK` ×2, `SHARE_ARTIFACT`,
+`REMOVE_RECENTLY_VIEWED`); the fifth is the streamed-chat `[3]` from #1472,
+which carries no rpc id and is decoded by `_chat/wire.py`, not `decode_response`.
 
 **Open question.** Only `REMOVE_RECENTLY_VIEWED`'s tolerance has ever been
 reasoned about (a cosmetic no-op). Whether the two share rejections are benign

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -2847,12 +2847,25 @@ Observed codes:
 |---------|-----|-------|
 | `[3]` INVALID_ARGUMENT | `CREATE_ARTIFACT` (`R7cb6c`) | Live 2026-08-13: audio overview on a source-less notebook |
 | `[3]` INVALID_ARGUMENT | streamed chat | `tests/cassettes/chat_ask_oversized_rejection.yaml` (#1472) |
-| `[5]` NOT_FOUND | `CREATE_ARTIFACT`, `GET_NOTEBOOK` | Live 2026-08-13 (unknown notebook id); #114 / #294 |
+| `[3]` INVALID_ARGUMENT | `SHARE_NOTEBOOK` (`QDyure`) | `tests/cassettes/cli_share_add.yaml`, `cli_share_remove.yaml` — swallowed; the flow reports success |
+| `[3]` INVALID_ARGUMENT | `SHARE_ARTIFACT` (`RGP97b`) | `tests/cassettes/notebooks_share.yaml` — swallowed; the flow reports success |
+| `[5]` NOT_FOUND | `CREATE_ARTIFACT`, `RETRY_ARTIFACT`, `REVISE_SLIDE`, `GET_NOTEBOOK` | Live 2026-08-13 (unknown notebook / artifact id); #114 / #294 |
 | `[13]` INTERNAL | `REMOVE_RECENTLY_VIEWED` (`fejl7e`) | `tests/cassettes/notebooks_remove_from_recent.yaml` — treated as a **successful** no-op |
 | `[8, null, [[…UserDisplayableError…]]]` | any | The rate-limit / quota shape |
 
 A sweep of all 141 cassettes found 397 `wrb.fr` frames, only 5 of them
-null-result — and all 5 carried one of the shapes above.
+null-result — and all 5 carried one of the shapes above, on three RPCs
+(`SHARE_NOTEBOOK` ×2, `SHARE_ARTIFACT`, `REMOVE_RECENTLY_VIEWED`).
+
+**Open question.** Only `REMOVE_RECENTLY_VIEWED`'s tolerance has ever been
+reasoned about (a cosmetic no-op). Whether the two share rejections are benign
+or a refusal being reported as a successful share is unresolved and is *not*
+answered here.
+
+Byte-count framing note: the live `CREATE_ARTIFACT` rejection bodies declare
+chunk lengths two higher than the chunks actually are (`104` for 102 chars,
+`25` for 23), consistently across independent captures. `parse_chunked_response`
+is deliberately tolerant of that and counts it via `byte_count_mismatch_total`.
 
 ### The reason gap
 
@@ -2876,9 +2889,11 @@ also swallow a null the server had *tagged with a rejection*, which is how
 `generate_audio` came to report "Audio generation is unavailable" for a live
 INVALID_ARGUMENT. Callers that want the server's status instead pass
 `raise_on_null_status=True` (`CREATE_ARTIFACT`, `RETRY_ARTIFACT`,
-`REVISE_SLIDE` do). It is opt-in rather than blanket because
-`REMOVE_RECENTLY_VIEWED` answers `[13]` on a call the client treats as
-successful.
+`REVISE_SLIDE` do — all three live-verified above). It is opt-in rather than
+blanket because three *other* RPCs are recorded answering a status on flows
+this client reports as successful (the table above); flipping them all at once
+would change behaviour nobody has evidence about. A swallowed status now logs
+at DEBUG, so the remaining cases are findable.
 
 ### Artifact failures have no reason at all
 

--- a/src/notebooklm/_app/generate_plans.py
+++ b/src/notebooklm/_app/generate_plans.py
@@ -77,8 +77,13 @@ NotebookResolver = Callable[..., Awaitable[str]]
 #: Backend contract every resolver MUST honor: return ``None`` for "no sources
 #: given" (⇒ generate over ALL sources), NOT an empty list. ``[]``/``()`` means
 #: "zero sources", which the backend refuses for source-needing kinds
-#: (quiz/audio/flashcards): it replies HTTP 200 with a null artifact id, surfaced
-#: as ``ArtifactFeatureUnavailableError`` ("… generation is unavailable"). This was
+#: (quiz/audio/flashcards): it replies HTTP 200 with a null artifact id. Since
+#: #2188 that surfaces as whatever the server said — live 2026-08-13, a
+#: source-less notebook answers ``[3]`` INVALID_ARGUMENT, so the caller sees
+#: ``RPCError("The server rejected this request (invalid argument).")``; a null
+#: carrying no status at all still surfaces as
+#: ``ArtifactFeatureUnavailableError`` ("… generation is unavailable"). Either
+#: way it is a raised error, which is what the parity pin cares about. This was
 #: #1652 — the MCP pass-through resolver sent ``()`` where the CLI resolver sent
 #: ``None``, so the two adapters diverged. A new adapter's resolver must map the
 #: empty case to ``None``; ``tests/unit/cli/test_cli_mcp_parity.py`` pins it.

--- a/src/notebooklm/_artifact/generation.py
+++ b/src/notebooklm/_artifact/generation.py
@@ -363,6 +363,9 @@ class ArtifactGenerationService:
             params,
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
+            # See ``_call_generate``: a server-stated rejection reason beats the
+            # client's "feature unavailable" guess (#2188).
+            raise_on_null_status=True,
         )
         if result is None:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
@@ -408,6 +411,9 @@ class ArtifactGenerationService:
             params,
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
+            # See ``_call_generate``: a server-stated rejection reason beats the
+            # client's "feature unavailable" guess (#2188).
+            raise_on_null_status=True,
         )
         if result is None:
             logger.warning("RETRY_ARTIFACT returned null result for artifact %s", artifact_id)
@@ -570,6 +576,15 @@ class ArtifactGenerationService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
             operation_variant=None,
+            # ``allow_null=True`` keeps the "no task row" case decodable so the
+            # ``ArtifactFeatureUnavailableError`` below can name the artifact
+            # type. ``raise_on_null_status=True`` stops that guess from
+            # overwriting a reason the server DID give: live-verified
+            # 2026-08-13, a source-less notebook answers
+            # ``[["wrb.fr","R7cb6c",null,null,null,[3],"generic"]]`` — an
+            # explicit INVALID_ARGUMENT that used to be reported as
+            # "Audio generation is unavailable" (#2188).
+            raise_on_null_status=True,
         )
         if result is None and null_result_artifact_type is not None:
             raise ArtifactFeatureUnavailableError(

--- a/src/notebooklm/_chat/notes.py
+++ b/src/notebooklm/_chat/notes.py
@@ -32,9 +32,13 @@ logger = logging.getLogger(__name__)
 class SaveChatNoteRpc(Protocol):
     """RPC surface needed to persist a saved-from-chat note.
 
-    Mirrors the dispatch shape :class:`RpcCaller` exposes; a concrete
-    :class:`notebooklm._rpc_executor.RpcExecutor` (or any structural
-    equivalent in tests) satisfies this protocol.
+    Mirrors the SUBSET of the :class:`RpcCaller` dispatch shape this call site
+    uses; a concrete :class:`notebooklm._rpc_executor.RpcExecutor` (or any
+    structural equivalent in tests) satisfies it. The keyword-only options
+    ``RpcCaller`` also carries — ``disable_internal_retries`` / ``read_timeout``
+    / ``raise_on_null_status`` — are deliberately absent because saving a chat
+    note passes none of them; widen this before opting the call site into any
+    of them.
     """
 
     async def rpc_call(

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -488,8 +488,16 @@ def _raise_chat_rejection(error_payload: list) -> NoReturn:
     error. The status is echoed so callers see the real failure. ``ErrorPayloadRow``
     centralises the ``error_payload[0]`` position (issue #1491).
     """
-    status = ErrorPayloadRow(error_payload).status_code
+    row = ErrorPayloadRow(error_payload)
+    status = row.status_code
     detail = f" (status {status!r})" if status is not None else ""
+    # ``google.rpc.Status.message`` is the only server-authored text in this
+    # envelope; the sentence below is this client's guess. Lead with the
+    # server's own words when it sent any (#2188) — the recorded ``[3]``
+    # rejection does not, so in practice the guess still stands.
+    server_reason = row.message
+    if server_reason is not None:
+        raise ChatError(f"Chat request was rejected by the server{detail}: {server_reason}")
     raise ChatError(
         f"Chat request was rejected by the server{detail}. "
         "This usually means the request was malformed or too large — most often "
@@ -535,6 +543,14 @@ def raise_if_rate_limited(error_payload: list) -> None:
         for entry in row.entries:
             entry_type = ErrorPayloadRow.entry_type(entry)
             if entry_type is not None and "UserDisplayableError" in entry_type:
+                # Prefer the server's ``google.rpc.Status.message`` over the
+                # client-authored sentence; no recorded sample carries one, so
+                # the fallback is what users see today (#2188).
+                server_reason = row.message
+                if server_reason is not None:
+                    raise ChatError(
+                        f"Chat request was rate limited or rejected by the API: {server_reason}"
+                    )
                 raise ChatError(
                     "Chat request was rate limited or rejected by the API. "
                     "Wait a few seconds and try again."

--- a/src/notebooklm/_chat/wire.py
+++ b/src/notebooklm/_chat/wire.py
@@ -492,17 +492,19 @@ def _raise_chat_rejection(error_payload: list) -> NoReturn:
     status = row.status_code
     detail = f" (status {status!r})" if status is not None else ""
     # ``google.rpc.Status.message`` is the only server-authored text in this
-    # envelope; the sentence below is this client's guess. Lead with the
-    # server's own words when it sent any (#2188) — the recorded ``[3]``
-    # rejection does not, so in practice the guess still stands.
+    # envelope; the sentence below is this client's guess. Append the server's
+    # own words when it sent any (#2188) rather than replacing the guidance:
+    # the slot has never been observed populated, so nobody knows whether a
+    # server message would be as actionable as the advice it displaced — a
+    # terse "Invalid argument." would be a downgrade. The decoder's bare-status
+    # path appends for the same reason.
     server_reason = row.message
-    if server_reason is not None:
-        raise ChatError(f"Chat request was rejected by the server{detail}: {server_reason}")
+    suffix = f" The server said: {server_reason}" if server_reason is not None else ""
     raise ChatError(
         f"Chat request was rejected by the server{detail}. "
         "This usually means the request was malformed or too large — most often "
         "an over-long question past the server-side size limit; shorten it and "
-        "try again."
+        f"try again.{suffix}"
     )
 
 
@@ -543,17 +545,15 @@ def raise_if_rate_limited(error_payload: list) -> None:
         for entry in row.entries:
             entry_type = ErrorPayloadRow.entry_type(entry)
             if entry_type is not None and "UserDisplayableError" in entry_type:
-                # Prefer the server's ``google.rpc.Status.message`` over the
-                # client-authored sentence; no recorded sample carries one, so
-                # the fallback is what users see today (#2188).
+                # Append the server's ``google.rpc.Status.message`` when it
+                # sent one, keeping the client-authored remedy (#2188). No
+                # recorded sample carries one, so the sentence below is what
+                # users see today.
                 server_reason = row.message
-                if server_reason is not None:
-                    raise ChatError(
-                        f"Chat request was rate limited or rejected by the API: {server_reason}"
-                    )
+                suffix = f" The server said: {server_reason}" if server_reason else ""
                 raise ChatError(
                     "Chat request was rate limited or rejected by the API. "
-                    "Wait a few seconds and try again."
+                    f"Wait a few seconds and try again.{suffix}"
                 )
     except ChatError:
         raise

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -85,6 +85,7 @@ from typing import Any, ClassVar
 from .._types.documents import StructuredDocument
 from ..exceptions import UnknownRPCMethodError
 from ..rpc import RPCMethod, safe_index
+from ..rpc.decoder import sanitize_status_message
 from .documents import build_document
 
 __all__ = [
@@ -607,10 +608,6 @@ class ErrorPayloadRow:
     _MESSAGE_POS: ClassVar[int] = 1
     _ENTRIES_POS: ClassVar[int] = 2
 
-    #: Ceiling on echoed server text — the field is server-controlled and
-    #: unbounded, and it lands in a user-facing exception message.
-    _MAX_MESSAGE_CHARS: ClassVar[int] = 300
-
     @property
     def status_code(self) -> Any:
         """Leading status/code at ``error_payload[0]`` (e.g. ``3`` for a bare
@@ -631,22 +628,17 @@ class ErrorPayloadRow:
 
         **No captured response has ever carried a populated message**: the one
         recorded rich sample holds ``None`` here and the bare rejections are
-        length-1 arrays. Only a non-empty ``str`` is accepted, so the read stays
-        inert on all traffic observed to date instead of inventing a reason out
-        of whatever else may occupy the slot (the #2134 failure mode).
-        Whitespace is collapsed and the text capped at ``_MAX_MESSAGE_CHARS``.
+        length-1 arrays. The normalising rule (non-empty string only, whitespace
+        collapsed, length capped, non-string warned about) is shared with the
+        ``batchexecute`` decoder via :func:`sanitize_status_message` so the two
+        layers cannot drift in what users see; only the position is declared
+        twice, because ``rpc`` cannot import ``_row_adapters``.
         """
         if len(self._raw) <= self._MESSAGE_POS:
             return None
-        value = self._raw[self._MESSAGE_POS]
-        if not isinstance(value, str):
-            return None
-        text = " ".join(value.split())
-        if not text:
-            return None
-        if len(text) > self._MAX_MESSAGE_CHARS:
-            text = text[: self._MAX_MESSAGE_CHARS].rstrip() + "…"
-        return text
+        return sanitize_status_message(
+            self._raw[self._MESSAGE_POS], source="ErrorPayloadRow.message"
+        )
 
     @property
     def entries(self) -> list[Any]:

--- a/src/notebooklm/_row_adapters/chat.py
+++ b/src/notebooklm/_row_adapters/chat.py
@@ -592,16 +592,24 @@ class ErrorPayloadRow:
 
     Structure: ``[8, None, [["type.googleapis.com/.../UserDisplayableError", …]]]``
     for the rich rate-limit shape, or a bare ``[3]`` status for a request-level
-    rejection (issue #1472). Centralises the ``error_payload[0]`` status, the
+    rejection (issue #1472). Both are the same envelope — a JSON-array-encoded
+    ``google.rpc.Status`` — at different arities, which is why index 0 is the
+    code, index 1 the message, and index 2 the details. Centralises the
+    ``error_payload[0]`` status, the ``error_payload[1]`` message, the
     ``error_payload[2]`` entries, and the inner ``entry[0]`` reads so
     ``raise_if_rate_limited`` / ``_raise_chat_rejection`` stop open-coding them
-    (issue #1491).
+    (issues #1491, #2188).
     """
 
     _raw: list[Any] = field(repr=False)
 
     _STATUS_POS: ClassVar[int] = 0
+    _MESSAGE_POS: ClassVar[int] = 1
     _ENTRIES_POS: ClassVar[int] = 2
+
+    #: Ceiling on echoed server text — the field is server-controlled and
+    #: unbounded, and it lands in a user-facing exception message.
+    _MAX_MESSAGE_CHARS: ClassVar[int] = 300
 
     @property
     def status_code(self) -> Any:
@@ -610,6 +618,35 @@ class ErrorPayloadRow:
         if not self._raw:
             return None
         return self._raw[self._STATUS_POS]
+
+    @property
+    def message(self) -> str | None:
+        """Server-authored ``google.rpc.Status.message`` at ``error_payload[1]``.
+
+        The envelope is a ``google.rpc.Status`` (``code`` tag 1 → index 0,
+        ``message`` tag 2 → index 1, ``details`` tag 3 → index 2), so this slot
+        is the one place the *server* can say why it rejected the request —
+        everything else this client shows for a rejection is client-authored
+        wording (#2188).
+
+        **No captured response has ever carried a populated message**: the one
+        recorded rich sample holds ``None`` here and the bare rejections are
+        length-1 arrays. Only a non-empty ``str`` is accepted, so the read stays
+        inert on all traffic observed to date instead of inventing a reason out
+        of whatever else may occupy the slot (the #2134 failure mode).
+        Whitespace is collapsed and the text capped at ``_MAX_MESSAGE_CHARS``.
+        """
+        if len(self._raw) <= self._MESSAGE_POS:
+            return None
+        value = self._raw[self._MESSAGE_POS]
+        if not isinstance(value, str):
+            return None
+        text = " ".join(value.split())
+        if not text:
+            return None
+        if len(text) > self._MAX_MESSAGE_CHARS:
+            text = text[: self._MAX_MESSAGE_CHARS].rstrip() + "…"
+        return text
 
     @property
     def entries(self) -> list[Any]:

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -79,7 +79,14 @@ def _error_host_suffix(request: httpx.Request | None) -> str:
 
 
 class DecodeResponse(Protocol):
-    def __call__(self, raw: str, rpc_id: str, *, allow_null: bool = False) -> Any: ...
+    def __call__(
+        self,
+        raw: str,
+        rpc_id: str,
+        *,
+        allow_null: bool = False,
+        raise_on_null_status: bool = False,
+    ) -> Any: ...
 
 
 class RpcExecutor:
@@ -126,6 +133,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
         _refresh_budget: RefreshBudget | None = None,
         _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any:
@@ -169,6 +177,13 @@ class RpcExecutor:
         ``RuntimeTransport.perform_authed_post`` (see ``_chat/transport.py``).
         ``None`` inherits the client default, so callers that omit it are
         unaffected.
+
+        ``raise_on_null_status`` (default ``False``) only matters alongside
+        ``allow_null=True``: it tells the decoder that a null result the server
+        tagged with a non-OK ``google.rpc.Status`` is a rejection to raise on,
+        not an empty-but-acceptable payload to swallow. See
+        :func:`notebooklm.rpc.decoder.decode_response` for why it is opt-in per
+        call site (#2188).
         """
         # Pre-open guard — preserves the historical ``RuntimeError`` surface by
         # routing through ``Kernel.get_http_client()`` (which raises the same
@@ -194,6 +209,7 @@ class RpcExecutor:
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
                 read_timeout=read_timeout,
+                raise_on_null_status=raise_on_null_status,
                 _refresh_budget=_refresh_budget,
                 _retry_deadline=_retry_deadline,
             )
@@ -216,6 +232,7 @@ class RpcExecutor:
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
                 read_timeout=read_timeout,
+                raise_on_null_status=raise_on_null_status,
                 _refresh_budget=_refresh_budget,
                 _retry_deadline=_retry_deadline,
             )
@@ -234,6 +251,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
         _refresh_budget: RefreshBudget | None = None,
         _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any:
@@ -352,7 +370,12 @@ class RpcExecutor:
             self.raise_rpc_error_from_http_status(exc, method)
 
         try:
-            result = self._decode_response(response.text, resolved_id, allow_null=allow_null)
+            result = self._decode_response(
+                response.text,
+                resolved_id,
+                allow_null=allow_null,
+                raise_on_null_status=raise_on_null_status,
+            )
             elapsed = time.perf_counter() - start
             logger.debug("RPC %s completed in %.3fs", method.name, elapsed)
             return result
@@ -394,6 +417,7 @@ class RpcExecutor:
                     disable_internal_retries=disable_internal_retries,
                     operation_variant=operation_variant,
                     read_timeout=read_timeout,
+                    raise_on_null_status=raise_on_null_status,
                     _refresh_budget=_refresh_budget,
                     _retry_deadline=_retry_deadline,
                 )
@@ -571,6 +595,7 @@ class RpcExecutor:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
         _refresh_budget: RefreshBudget,
         _retry_deadline: RuntimeDeadline | None = None,
     ) -> Any | None:
@@ -645,6 +670,7 @@ class RpcExecutor:
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
             read_timeout=read_timeout,
+            raise_on_null_status=raise_on_null_status,
             _refresh_budget=_refresh_budget,
             _retry_deadline=_retry_deadline,
         )

--- a/src/notebooklm/_runtime/contracts.py
+++ b/src/notebooklm/_runtime/contracts.py
@@ -84,6 +84,7 @@ class RpcCaller(Protocol):
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
     ) -> Any: ...
 
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -578,6 +578,7 @@ class NotebookLMClient:
         *,
         disable_internal_retries: bool = False,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
     ) -> Any:
         """Make a raw NotebookLM RPC call.
 
@@ -596,6 +597,12 @@ class NotebookLMClient:
         timeout for this one call — useful for RPCs known to run long (e.g.
         bulk imports) without lowering the default for every other call.
 
+        ``raise_on_null_status`` (default ``False``) pairs with
+        ``allow_null=True``: it turns a null result that the server tagged with
+        a non-OK ``google.rpc.Status`` into a raised error instead of a silent
+        ``None``, so the server's own rejection is reported rather than
+        swallowed (#2188).
+
         .. versionchanged:: 0.6.0
             The deprecated keyword arguments previously documented here
             were removed (see :doc:`/deprecations`). The default-shape
@@ -607,6 +614,7 @@ class NotebookLMClient:
             allow_null=allow_null,
             disable_internal_retries=disable_internal_retries,
             read_timeout=read_timeout,
+            raise_on_null_status=raise_on_null_status,
         )
 
     @property

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -35,7 +35,16 @@ from ..._app import notes as note_core
 from ..._app.language import is_supported_language
 from ..._app.resolve import FULL_ID_PATTERN
 from ..._app.serialize import to_jsonable
-from ...exceptions import ArtifactFeatureUnavailableError, NotFoundError, ValidationError
+from ...exceptions import (
+    AuthError,
+    DecodingError,
+    NetworkError,
+    NotFoundError,
+    RateLimitError,
+    RPCError,
+    ServerError,
+    ValidationError,
+)
 from .._coerce import coerce_list
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -823,14 +832,30 @@ def register(mcp: Any) -> None:
             art_id = await resolve_artifact(client, nb_id, artifact)
             try:
                 result = await artifact_core.retry_artifact(client, nb_id, art_id)
-            except ArtifactFeatureUnavailableError:
-                # Retry refused (null result). The most common cause is retrying an
-                # artifact that is not FAILED (retry only re-runs a failed one). Turn
-                # the generic "Retry generation is unavailable" into an actionable
-                # message naming the current state — but only on the refusal path, so
-                # the happy path stays free of the extra ``get_or_none`` list (#1924
-                # F15). Re-raise the generic error when the state doesn't explain it
+            except (AuthError, RateLimitError, ServerError, NetworkError, DecodingError):
+                # ADR-0019 catch ordering: these typed transport signals subclass
+                # RPCError, and each carries handling the broad clause below would
+                # destroy (back-off, re-login, transient retry, drift detection).
+                # None of them is ever the "artifact is not failed" story, so
+                # relabelling one would hide the real cause.
+                raise
+            except RPCError:
+                # Retry refused. The most common cause is retrying an artifact
+                # that is not FAILED (retry only re-runs a failed one). Turn the
+                # generic refusal into an actionable message naming the current
+                # state — but only on the refusal path, so the happy path stays
+                # free of the extra ``get_or_none`` list (#1924 F15). Re-raise
+                # the original error when the state doesn't explain it
                 # (already-failed artifact, or it vanished between resolve and here).
+                #
+                # The catch is ``RPCError``, not just
+                # ``ArtifactFeatureUnavailableError``: since #2188 a refusal the
+                # server tagged with a ``google.rpc.Status`` surfaces as a plain
+                # ``RPCError``/``ClientError`` instead (live-verified — a retry
+                # against an unknown artifact id answers ``[5]`` NOT_FOUND), and
+                # narrowing to the old type would have silently dropped this
+                # enrichment for exactly the refusals that now carry a reason.
+                #
                 art = await client.artifacts.get_or_none(nb_id, art_id)
                 if art is not None and not art.is_failed:
                     raise ValidationError(

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -36,6 +36,7 @@ from ..._app.language import is_supported_language
 from ..._app.resolve import FULL_ID_PATTERN
 from ..._app.serialize import to_jsonable
 from ...exceptions import (
+    ArtifactFeatureUnavailableError,
     AuthError,
     DecodingError,
     NetworkError,
@@ -45,6 +46,7 @@ from ...exceptions import (
     ServerError,
     ValidationError,
 )
+from ...rpc.types import GrpcStatusCode
 from .._coerce import coerce_list
 from .._confirm import DESTRUCTIVE, READ_ONLY, needs_confirmation
 from .._context import get_client, get_file_transfer
@@ -839,7 +841,7 @@ def register(mcp: Any) -> None:
                 # None of them is ever the "artifact is not failed" story, so
                 # relabelling one would hide the real cause.
                 raise
-            except RPCError:
+            except RPCError as exc:
                 # Retry refused. The most common cause is retrying an artifact
                 # that is not FAILED (retry only re-runs a failed one). Turn the
                 # generic refusal into an actionable message naming the current
@@ -856,6 +858,21 @@ def register(mcp: Any) -> None:
                 # narrowing to the old type would have silently dropped this
                 # enrichment for exactly the refusals that now carry a reason.
                 #
+                # But only a WRONG-STATE refusal may be relabelled. The typed
+                # exclusions above do not cover every misfit: a bare ``[7]``
+                # PERMISSION_DENIED decodes to ``ClientError`` and a bare ``[14]``
+                # UNAVAILABLE to a plain ``RPCError``, and rewriting either into
+                # "artifact is not failed" would give the caller the wrong
+                # category AND the wrong recovery advice. So the state story is
+                # told only for the shapes that can plausibly mean it: a refusal
+                # with no status at all (``ArtifactFeatureUnavailableError``), or
+                # one the server tagged INVALID_ARGUMENT / FAILED_PRECONDITION.
+                # Anything else keeps its own error.
+                if not isinstance(exc, ArtifactFeatureUnavailableError) and exc.rpc_code not in (
+                    GrpcStatusCode.INVALID_ARGUMENT,
+                    GrpcStatusCode.FAILED_PRECONDITION,
+                ):
+                    raise
                 art = await client.artifacts.get_or_none(nb_id, art_id)
                 if art is not None and not art.is_failed:
                     raise ValidationError(

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -170,11 +170,17 @@ _MAX_STATUS_MESSAGE_CHARS = 300
 
 #: RPCs observed answering a null result with a non-OK ``google.rpc.Status`` on
 #: a flow this client currently treats as SUCCESSFUL. A sweep of all 141
-#: cassettes finds five such frames, across three RPCs:
+#: cassettes finds 397 ``wrb.fr`` frames, 5 of them null-result. FOUR of those
+#: five reach this decoder, across three RPCs:
 #:
 #:   ``REMOVE_RECENTLY_VIEWED``  ``[13]``  notebooks_remove_from_recent.yaml
 #:   ``SHARE_NOTEBOOK``          ``[3]``   cli_share_add.yaml, cli_share_remove.yaml
 #:   ``SHARE_ARTIFACT``          ``[3]``   notebooks_share.yaml
+#:
+#: The fifth is chat_ask_oversized_rejection.yaml's ``[3]`` (#1472). It carries
+#: no rpc id at all because streamed chat is not a ``batchexecute`` RPC, so it
+#: never passes through ``decode_response`` — it is handled by ``_chat/wire.py``
+#: and is not part of this list.
 #:
 #: Recorded here as a *finding*, not a blessing: only the first has ever been
 #: reasoned about (a cosmetic no-op), and whether the two share rejections are
@@ -187,10 +193,6 @@ _RPCS_OBSERVED_SWALLOWING_A_STATUS = (
     RPCMethod.SHARE_NOTEBOOK.value,
     RPCMethod.SHARE_ARTIFACT.value,
 )
-
-#: Distinguishes "the frame carried no index-5 payload" from "it carried
-#: ``None`` there" in :func:`_find_null_result_payload`.
-_MISSING_STATUS_PAYLOAD = object()
 
 #: Statuses the decoder routes through ``ClientError`` rather than the generic
 #: ``RPCError``, so ``is_auth_error`` cannot misclassify them and fire a
@@ -540,14 +542,20 @@ def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
     return code, _GRPC_STATUS_MESSAGES[code]
 
 
-def _find_null_result_payload(chunks: list[Any], rpc_id: str) -> Any:
-    """Return the raw index-5 payload of a null-result frame for ``rpc_id``.
+def _null_result_payloads(chunks: list[Any], rpc_id: str) -> list[Any]:
+    """Every non-null index-5 payload on a null-result frame for ``rpc_id``.
 
-    ``_MISSING_STATUS_PAYLOAD`` when no such frame exists or it carried nothing
-    there. Shared walk behind :func:`_find_wrb_status` and
-    :func:`_is_unclassified_status` so the two agree on which frame they mean.
+    Returns ALL of them rather than the first: in ``rt=c`` streamed mode the
+    backend can emit more than one frame per rpc id (``extract_rpc_result``
+    handles the same case), so stopping at the first would let a placeholder
+    frame's unclassifiable payload hide a real status on a later frame — which
+    is what the pre-#2188 loop avoided by continuing until a code parsed.
+
+    Shared walk behind :func:`_find_wrb_status` and
+    :func:`_has_null_result_payload` so the two agree on which frames they mean.
     """
-    source = "decoder._find_null_result_payload"
+    source = "decoder._null_result_payloads"
+    payloads: list[Any] = []
     for chunk in chunks:
         if not isinstance(chunk, list) or not chunk:
             # Skip empty chunks before safe_index, which raises on shape drift
@@ -566,24 +574,25 @@ def _find_null_result_payload(chunks: list[Any], rpc_id: str) -> Any:
             error_info = safe_index(item, 5, method_id=rpc_id, source=source)
             if result_data is not None or error_info is None:
                 continue
-            return error_info
-    return _MISSING_STATUS_PAYLOAD
+            payloads.append(error_info)
+    return payloads
 
 
-def _is_unclassified_status(chunks: list[Any], rpc_id: str) -> bool:
-    """Whether the server attached an index-5 payload we could not name.
+def _has_null_result_payload(chunks: list[Any], rpc_id: str) -> bool:
+    """Whether the server attached anything at index 5 of a null-result frame.
 
     Distinguishes "no payload at all" (a genuinely empty result — nothing to
-    report) from "a payload this decoder cannot classify" (drift worth a log).
+    report) from "a payload is there". The only caller consults this AFTER
+    :func:`_find_wrb_status` has already returned ``None``, so at that point
+    "a payload is there" means "there, and this decoder could not name it" —
+    which is drift worth logging. Re-checking classifiability here would be
+    dead logic, so it is not re-checked.
     """
-    payload = _find_null_result_payload(chunks, rpc_id)
-    if payload is _MISSING_STATUS_PAYLOAD:
-        return False
-    return _extract_status_code(payload) is None
+    return bool(_null_result_payloads(chunks, rpc_id))
 
 
 def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | None:
-    """Locate bare status code at index 5 of a wrb.fr entry for ``rpc_id``.
+    """Locate the status code at index 5 of a null-result frame for ``rpc_id``.
 
     Used by ``decode_response`` to enrich the null-result error message when
     the server explicitly flagged the RPC with a status code.
@@ -592,14 +601,12 @@ def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | N
     ``google.rpc.Status`` array, so the caller can also read the server's
     ``message`` field without re-walking the chunks.
     """
-    payload = _find_null_result_payload(chunks, rpc_id)
-    if payload is _MISSING_STATUS_PAYLOAD:
-        return None
-    status = _extract_status_code(payload)
-    if status is None:
-        return None
-    code, label = status
-    return code, label, payload
+    for payload in _null_result_payloads(chunks, rpc_id):
+        status = _extract_status_code(payload)
+        if status is not None:
+            code, label = status
+            return code, label, payload
+    return None
 
 
 def _contains_user_displayable_error(obj: Any, max_depth: int = 20) -> bool:
@@ -964,7 +971,7 @@ def decode_response(
                     rpc_id,
                     status[1],
                 )
-            elif raise_on_null_status and _is_unclassified_status(chunks, rpc_id):
+            elif raise_on_null_status and _has_null_result_payload(chunks, rpc_id):
                 # The caller asked for strictness and the server DID attach
                 # something at index 5, but not a status this decoder can name —
                 # a code outside 0-16, a bool, a string, a nested ``[[3]]``. That

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -863,6 +863,20 @@ def decode_response(
         # rejection (#2188).
         rejected = status is not None and status[0] != GrpcStatusCode.OK
         if allow_null and not (raise_on_null_status and rejected):
+            if rejected and status is not None:
+                # Still swallowed, but no longer without trace. DEBUG rather
+                # than WARNING because at least one caller's tolerance is
+                # deliberate and evidence-backed (REMOVE_RECENTLY_VIEWED's
+                # ``[13]``), so a warning would be noise on a healthy call. The
+                # other ``allow_null=True`` call sites have not been evaluated
+                # against live rejections; this line is what makes such a
+                # swallow findable when one of them misbehaves (#2188).
+                logger.debug(
+                    "Null result for %s carried status %s; swallowed because the "
+                    "call site did not pass raise_on_null_status",
+                    rpc_id,
+                    status[1],
+                )
             return None
 
         if status is not None:

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -131,6 +131,42 @@ _GRPC_STATUS_MESSAGES: dict[int, str] = {
     GrpcStatusCode.UNAUTHENTICATED: "Unauthenticated",
 }
 
+# Index 5 of a ``wrb.fr`` frame is a JSON-array-encoded ``google.rpc.Status``
+# (the PUBLIC google/rpc/status.proto envelope, not a Tailwind message), so the
+# array positions are the proto tags minus one:
+#
+#   ===== ================== ==================================================
+#   Index Field              Evidence
+#   ===== ================== ==================================================
+#   0     ``code`` (tag 1)   Live: ``[3]`` INVALID_ARGUMENT from CREATE_ARTIFACT
+#                            on a source-less notebook and ``[5]`` NOT_FOUND for
+#                            an unknown notebook id (2026-08-13); ``[13]`` in
+#                            tests/cassettes/notebooks_remove_from_recent.yaml;
+#                            ``8`` (RESOURCE_EXHAUSTED) leading the recorded
+#                            ``UserDisplayableError`` shape.
+#   1     ``message`` (tag 2) NEVER OBSERVED POPULATED. Null in the recorded
+#                            rate-limit sample and absent from every captured
+#                            bare-status frame (the array is length 1). Read
+#                            defensively below so a server-authored reason is
+#                            surfaced *if* one ever arrives, but the
+#                            client-authored wording remains the observed
+#                            ceiling — see docs/rpc-reference.md and #2188.
+#   2     ``details``(tag 3) The ``[["type.googleapis.com/…UserDisplayableError",
+#                            …]]`` block; ``ErrorPayloadRow._ENTRIES_POS``
+#                            models the same slot for streamed chat.
+#   ===== ================== ==================================================
+#
+# ``_row_adapters/chat.py`` cannot be reused here: it imports ``notebooklm.rpc``,
+# so a decoder-side import would close an import cycle. The positions are
+# therefore declared twice, once per layer, with this table as the shared
+# rationale.
+_STATUS_MESSAGE_POS = 1
+
+#: Ceiling on how much server-authored status text is echoed into an exception
+#: message. The field is server-controlled and unbounded; a runaway payload must
+#: not become a multi-kilobyte exception string.
+_MAX_STATUS_MESSAGE_CHARS = 300
+
 #: Statuses the decoder routes through ``ClientError`` rather than the generic
 #: ``RPCError``, so ``is_auth_error`` cannot misclassify them and fire a
 #: spurious token refresh. Both also carry the account-routing hint below.
@@ -440,13 +476,22 @@ def collect_rpc_ids(chunks: list[Any]) -> list[str]:
 
 
 def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
-    """Extract a bare status code from a wrb.fr error_info block.
+    """Extract the leading status code from a wrb.fr error_info block.
 
-    Returns ``(code, label)`` only for the bare single-element form ``[code]``
-    in the gRPC canonical range (0-16). Longer structures (e.g. the
-    ``[8, None, [[UserDisplayableError, ...]]]`` rate-limit shape) are handled
-    by the UserDisplayableError path and fall through here by returning
-    ``None``.
+    ``error_info`` is a ``google.rpc.Status`` array, so the code is at index 0
+    whatever the array's length: the bare ``[code]`` form issues #114 / #294
+    observed, and the longer ``[code, message, details]` form the proto allows.
+    Only the leading value is inspected, and only when it is an ``int`` in the
+    gRPC canonical range; anything else returns ``None``.
+
+    The arity restriction this used to carry (``len(error_info) != 1``) made
+    every longer status invisible — including the ``message`` slot #2188 is
+    about, which can only ever appear in a longer array. The
+    ``[8, None, [[UserDisplayableError, ...]]]`` rate-limit shape still raises
+    on the ``UserDisplayableError`` path *before* this helper is consulted; when
+    that path does not fire (e.g. the marker scan hit its depth cap), reporting
+    the leading status is strictly better than the unqualified
+    "empty result" fallback.
 
     Note: we do not claim these codes are unambiguously gRPC — REMOVE_RECENTLY_VIEWED
     returns ``[13]`` on what the client treats as a successful no-op (see
@@ -457,9 +502,9 @@ def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
         error_info: Value at index 5 of a ``wrb.fr`` response item.
 
     Returns:
-        ``(code, label)`` tuple for a recognized bare status, else ``None``.
+        ``(code, label)`` tuple for a recognized status, else ``None``.
     """
-    if not isinstance(error_info, list) or len(error_info) != 1:
+    if not isinstance(error_info, list) or not error_info:
         return None
     code = error_info[0]
     # type(code) is int (not isinstance) — bool is a subclass of int, so
@@ -470,11 +515,15 @@ def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
     return code, _GRPC_STATUS_MESSAGES[code]
 
 
-def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str] | None:
+def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | None:
     """Locate bare status code at index 5 of a wrb.fr entry for ``rpc_id``.
 
     Used by ``decode_response`` to enrich the null-result error message when
     the server explicitly flagged the RPC with a status code.
+
+    Returns ``(code, label, payload)`` where ``payload`` is the raw
+    ``google.rpc.Status`` array, so the caller can also read the server's
+    ``message`` field without re-walking the chunks.
     """
     source = "decoder._find_wrb_status"
     for chunk in chunks:
@@ -499,7 +548,8 @@ def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str] | None:
                 continue
             status = _extract_status_code(error_info)
             if status is not None:
-                return status
+                code, label = status
+                return code, label, error_info
     return None
 
 
@@ -540,23 +590,57 @@ def _contains_user_displayable_error(obj: Any, max_depth: int = 20) -> bool:
     return False
 
 
-def _extract_user_displayable_status(error_info: Any) -> tuple[int, str] | None:
-    """Extract the leading gRPC status from a UserDisplayableError block."""
-    if not isinstance(error_info, list) or not error_info:
+def _server_status_message(status_payload: Any) -> str | None:
+    """Return the server-authored ``google.rpc.Status.message``, or ``None``.
+
+    ``status_payload`` is the raw value at index 5 of a ``wrb.fr`` frame — a
+    JSON-array-encoded ``google.rpc.Status`` whose ``message`` field (tag 2)
+    lands at index 1 (see the position table near ``_STATUS_MESSAGE_POS``).
+
+    The read is deliberately narrow, because **no captured response has ever
+    carried a populated message** (#2188): only a non-empty ``str`` counts, and
+    anything else — a short array, ``None``, a nested structure, a number —
+    yields ``None`` so the caller keeps its existing client-authored wording.
+    That way the enrichment is inert on all traffic observed to date and cannot
+    invent a "reason" out of a slot that holds something else, which is the
+    failure mode #2134 was about.
+
+    Whitespace is collapsed and the text is capped at
+    ``_MAX_STATUS_MESSAGE_CHARS`` so a server-controlled field cannot blow up
+    an exception message.
+    """
+    if not isinstance(status_payload, list) or len(status_payload) <= _STATUS_MESSAGE_POS:
         return None
-    code = error_info[0]
-    if type(code) is not int or code not in _GRPC_STATUS_MESSAGES:
+    value = status_payload[_STATUS_MESSAGE_POS]
+    if not isinstance(value, str):
         return None
-    return code, _GRPC_STATUS_MESSAGES[code]
+    text = " ".join(value.split())
+    if not text:
+        return None
+    if len(text) > _MAX_STATUS_MESSAGE_CHARS:
+        text = text[:_MAX_STATUS_MESSAGE_CHARS].rstrip() + "…"
+    return text
 
 
 def _user_displayable_error_message(error_info: Any) -> str:
-    """Build a non-sensitive diagnostic for a user-displayable rejection."""
-    message = "API rate limit or quota exceeded. Please wait before retrying."
-    status = _extract_user_displayable_status(error_info)
+    """Build a non-sensitive diagnostic for a user-displayable rejection.
+
+    Prefers the server's own ``google.rpc.Status.message`` when one is present;
+    otherwise falls back to the client-authored sentence below. The two are
+    NOT interchangeable and the distinction matters when reading a bug report:
+    the fallback is this client's guess at what a ``UserDisplayableError``
+    means, and every recorded sample has taken that branch.
+    """
+    message = _server_status_message(error_info) or (
+        "API rate limit or quota exceeded. Please wait before retrying."
+    )
+    # Same ``google.rpc.Status`` envelope as the bare-status path, so the same
+    # leading-code extractor serves both (the two used to be byte-identical
+    # helpers under different names).
+    status = _extract_status_code(error_info)
     if status is None:
         return message
-    code, label = status
+    _code, label = status
     # Keep the stable, human-readable status label but not the raw numeric gRPC
     # code — it carries no end-user value and is volatile internal detail
     # (#1921). The numeric code stays available on the exception's ``rpc_code``.
@@ -664,7 +748,13 @@ def extract_rpc_result(chunks: list[Any], rpc_id: str) -> Any:
     return last_result
 
 
-def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) -> Any:
+def decode_response(
+    raw_response: str,
+    rpc_id: str,
+    allow_null: bool = False,
+    *,
+    raise_on_null_status: bool = False,
+) -> Any:
     """
     Complete decode pipeline: strip prefix -> parse chunks -> extract result.
 
@@ -672,6 +762,15 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
         raw_response: Raw response text from batchexecute
         rpc_id: RPC method ID to extract result for
         allow_null: If True, return None instead of raising error when result is null
+        raise_on_null_status: Opt-in strictness for ``allow_null`` callers. When
+            True, a null result that the server tagged with a **non-OK**
+            ``google.rpc.Status`` at index 5 raises instead of decoding to
+            ``None``, so the caller reports the server's reason rather than
+            inventing one. Callers that legitimately tolerate a status-tagged
+            null leave it False — ``REMOVE_RECENTLY_VIEWED`` answers ``[13]``
+            (INTERNAL) on what the client treats as a successful no-op
+            (tests/cassettes/notebooks_remove_from_recent.yaml), which is why
+            this is opt-in per call site rather than a blanket change (#2188).
 
     Returns:
         Decoded result data
@@ -740,12 +839,6 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
                 raw_response=response_preview,
             )
 
-        # ``rpc_id`` is present in ``found_ids`` but ``extract_rpc_result`` returned
-        # None — the requested frame carried a genuinely null payload. Honor
-        # ``allow_null`` here and return None for callers that opt in.
-        if allow_null:
-            return None
-
         # RPC ID was found but extract_rpc_result returned None.
         # This means wrb.fr had null result_data without UserDisplayableError.
         # Enrich the message if the server attached a bare status code at
@@ -759,9 +852,29 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
         # for logging and debugging, but keep the human-readable message free of
         # them — only the stable gRPC status label is user-facing.
         status = _find_wrb_status(chunks, rpc_id)
+
+        # ``rpc_id`` is present in ``found_ids`` but ``extract_rpc_result``
+        # returned None — the requested frame carried a genuinely null payload.
+        # Honor ``allow_null`` and return None for callers that opt in, EXCEPT
+        # when the caller asked for strictness and the server tagged that null
+        # with a non-OK status. A status-tagged null is the server saying "no",
+        # not an empty-but-fine payload; swallowing it made ``generate_*``
+        # report "<type> generation is unavailable" for a live INVALID_ARGUMENT
+        # rejection (#2188).
+        rejected = status is not None and status[0] != GrpcStatusCode.OK
+        if allow_null and not (raise_on_null_status and rejected):
+            return None
+
         if status is not None:
-            code, label = status
+            code, label, payload = status
             message = f"The server rejected this request ({label.lower()})."
+            # Echo the server's own ``google.rpc.Status.message`` when it sent
+            # one. No captured frame ever has (#2188), so in practice this is
+            # the client-authored sentence above — the wording is only
+            # server-authored when this suffix appears.
+            server_message = _server_status_message(payload)
+            if server_message is not None:
+                message = f"{message} {server_message}"
             # Route NOT_FOUND / PERMISSION_DENIED through ClientError so
             # is_auth_error does not misclassify them as auth failures and
             # trigger a spurious token-refresh retry. The account-routing hint

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -21,7 +21,7 @@ from ..exceptions import (
     UnknownRPCMethodError,
 )
 from ._safe_index import safe_index
-from .types import GrpcStatusCode
+from .types import GrpcStatusCode, RPCMethod
 
 # Re-export for backward compatibility (imports from notebooklm.rpc.decoder still work)
 __all__ = [
@@ -156,16 +156,41 @@ _GRPC_STATUS_MESSAGES: dict[int, str] = {
 #                            models the same slot for streamed chat.
 #   ===== ================== ==================================================
 #
-# ``_row_adapters/chat.py`` cannot be reused here: it imports ``notebooklm.rpc``,
-# so a decoder-side import would close an import cycle. The positions are
-# therefore declared twice, once per layer, with this table as the shared
-# rationale.
+# ``_row_adapters/chat.py`` models the same envelope for streamed chat. Its
+# POSITIONS are declared separately because it imports ``notebooklm.rpc``, so a
+# decoder-side import of it would close a cycle — this table is the shared
+# rationale for both. The normalising rule is NOT duplicated: both layers call
+# :func:`sanitize_status_message` below, so they cannot drift in what users see.
 _STATUS_MESSAGE_POS = 1
 
 #: Ceiling on how much server-authored status text is echoed into an exception
 #: message. The field is server-controlled and unbounded; a runaway payload must
 #: not become a multi-kilobyte exception string.
 _MAX_STATUS_MESSAGE_CHARS = 300
+
+#: RPCs observed answering a null result with a non-OK ``google.rpc.Status`` on
+#: a flow this client currently treats as SUCCESSFUL. A sweep of all 141
+#: cassettes finds five such frames, across three RPCs:
+#:
+#:   ``REMOVE_RECENTLY_VIEWED``  ``[13]``  notebooks_remove_from_recent.yaml
+#:   ``SHARE_NOTEBOOK``          ``[3]``   cli_share_add.yaml, cli_share_remove.yaml
+#:   ``SHARE_ARTIFACT``          ``[3]``   notebooks_share.yaml
+#:
+#: Recorded here as a *finding*, not a blessing: only the first has ever been
+#: reasoned about (a cosmetic no-op), and whether the two share rejections are
+#: benign or a silently-dropped refusal is an open question this change does not
+#: answer. That unresolved-ness is exactly why the swallow below logs at DEBUG
+#: rather than WARNING — warning would fire on ordinary ``share add`` traffic and
+#: assert a judgement the evidence does not support (#2188).
+_RPCS_OBSERVED_SWALLOWING_A_STATUS = (
+    RPCMethod.REMOVE_RECENTLY_VIEWED.value,
+    RPCMethod.SHARE_NOTEBOOK.value,
+    RPCMethod.SHARE_ARTIFACT.value,
+)
+
+#: Distinguishes "the frame carried no index-5 payload" from "it carried
+#: ``None`` there" in :func:`_find_null_result_payload`.
+_MISSING_STATUS_PAYLOAD = object()
 
 #: Statuses the decoder routes through ``ClientError`` rather than the generic
 #: ``RPCError``, so ``is_auth_error`` cannot misclassify them and fire a
@@ -515,23 +540,18 @@ def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
     return code, _GRPC_STATUS_MESSAGES[code]
 
 
-def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | None:
-    """Locate bare status code at index 5 of a wrb.fr entry for ``rpc_id``.
+def _find_null_result_payload(chunks: list[Any], rpc_id: str) -> Any:
+    """Return the raw index-5 payload of a null-result frame for ``rpc_id``.
 
-    Used by ``decode_response`` to enrich the null-result error message when
-    the server explicitly flagged the RPC with a status code.
-
-    Returns ``(code, label, payload)`` where ``payload`` is the raw
-    ``google.rpc.Status`` array, so the caller can also read the server's
-    ``message`` field without re-walking the chunks.
+    ``_MISSING_STATUS_PAYLOAD`` when no such frame exists or it carried nothing
+    there. Shared walk behind :func:`_find_wrb_status` and
+    :func:`_is_unclassified_status` so the two agree on which frame they mean.
     """
-    source = "decoder._find_wrb_status"
+    source = "decoder._find_null_result_payload"
     for chunk in chunks:
-        if not isinstance(chunk, list):
-            continue
-        # Skip empty chunks before safe_index, which raises on shape drift
-        # under strict decoding on an out-of-bounds descent.
-        if not chunk:
+        if not isinstance(chunk, list) or not chunk:
+            # Skip empty chunks before safe_index, which raises on shape drift
+            # under strict decoding on an out-of-bounds descent.
             continue
         first = safe_index(chunk, 0, method_id=rpc_id, source=source)
         items = chunk if isinstance(first, list) else [chunk]
@@ -546,11 +566,40 @@ def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | N
             error_info = safe_index(item, 5, method_id=rpc_id, source=source)
             if result_data is not None or error_info is None:
                 continue
-            status = _extract_status_code(error_info)
-            if status is not None:
-                code, label = status
-                return code, label, error_info
-    return None
+            return error_info
+    return _MISSING_STATUS_PAYLOAD
+
+
+def _is_unclassified_status(chunks: list[Any], rpc_id: str) -> bool:
+    """Whether the server attached an index-5 payload we could not name.
+
+    Distinguishes "no payload at all" (a genuinely empty result — nothing to
+    report) from "a payload this decoder cannot classify" (drift worth a log).
+    """
+    payload = _find_null_result_payload(chunks, rpc_id)
+    if payload is _MISSING_STATUS_PAYLOAD:
+        return False
+    return _extract_status_code(payload) is None
+
+
+def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str, Any] | None:
+    """Locate bare status code at index 5 of a wrb.fr entry for ``rpc_id``.
+
+    Used by ``decode_response`` to enrich the null-result error message when
+    the server explicitly flagged the RPC with a status code.
+
+    Returns ``(code, label, payload)`` where ``payload`` is the raw
+    ``google.rpc.Status`` array, so the caller can also read the server's
+    ``message`` field without re-walking the chunks.
+    """
+    payload = _find_null_result_payload(chunks, rpc_id)
+    if payload is _MISSING_STATUS_PAYLOAD:
+        return None
+    status = _extract_status_code(payload)
+    if status is None:
+        return None
+    code, label = status
+    return code, label, payload
 
 
 def _contains_user_displayable_error(obj: Any, max_depth: int = 20) -> bool:
@@ -590,29 +639,42 @@ def _contains_user_displayable_error(obj: Any, max_depth: int = 20) -> bool:
     return False
 
 
-def _server_status_message(status_payload: Any) -> str | None:
-    """Return the server-authored ``google.rpc.Status.message``, or ``None``.
+def sanitize_status_message(value: Any, *, source: str) -> str | None:
+    """Normalize a raw ``google.rpc.Status.message`` slot into display text.
 
-    ``status_payload`` is the raw value at index 5 of a ``wrb.fr`` frame — a
-    JSON-array-encoded ``google.rpc.Status`` whose ``message`` field (tag 2)
-    lands at index 1 (see the position table near ``_STATUS_MESSAGE_POS``).
+    Shared by the two layers that read the slot — this decoder for
+    ``batchexecute`` frames and ``_row_adapters.chat.ErrorPayloadRow`` for the
+    streamed-chat envelope. Only the *positions* are declared per layer (the
+    ``rpc`` → ``_row_adapters`` import direction forbids sharing those); the
+    sanitising rule is here so the two cannot drift in what users see.
 
-    The read is deliberately narrow, because **no captured response has ever
-    carried a populated message** (#2188): only a non-empty ``str`` counts, and
-    anything else — a short array, ``None``, a nested structure, a number —
-    yields ``None`` so the caller keeps its existing client-authored wording.
-    That way the enrichment is inert on all traffic observed to date and cannot
-    invent a "reason" out of a slot that holds something else, which is the
-    failure mode #2134 was about.
+    The rule is deliberately narrow, because **no captured response has ever
+    carried a populated message** (#2188): only a non-empty ``str`` counts, so
+    the enrichment is inert on all traffic observed to date and cannot invent a
+    "reason" out of a slot holding something else — the failure mode #2134 was
+    about.
 
-    Whitespace is collapsed and the text is capped at
+    A non-string, non-null value is the interesting case: it would mean the
+    envelope is not the ``google.rpc.Status`` this client believes it is. That
+    cannot raise — this runs while *reporting* an error, and replacing a real
+    server rejection with a decoder crash is a worse outcome than the
+    client-authored fallback — but per ADR-0011's spirit it must not be
+    inaudible either, or the only evidence of the drift would be that the
+    message silently failed to change. So it warns and degrades.
+
+    Whitespace is collapsed and the text capped at
     ``_MAX_STATUS_MESSAGE_CHARS`` so a server-controlled field cannot blow up
     an exception message.
     """
-    if not isinstance(status_payload, list) or len(status_payload) <= _STATUS_MESSAGE_POS:
+    if value is None:
         return None
-    value = status_payload[_STATUS_MESSAGE_POS]
     if not isinstance(value, str):
+        logger.warning(
+            "google.rpc.Status.message slot held %s, not a string (%s); "
+            "ignoring it and keeping the client-authored wording",
+            type(value).__name__,
+            source,
+        )
         return None
     text = " ".join(value.split())
     if not text:
@@ -622,8 +684,29 @@ def _server_status_message(status_payload: Any) -> str | None:
     return text
 
 
+def _server_status_message(status_payload: Any) -> str | None:
+    """Return the server-authored ``google.rpc.Status.message``, or ``None``.
+
+    ``status_payload`` is the raw value at index 5 of a ``wrb.fr`` frame — a
+    JSON-array-encoded ``google.rpc.Status`` whose ``message`` field (tag 2)
+    lands at index 1 (see the position table near ``_STATUS_MESSAGE_POS``).
+    """
+    if not isinstance(status_payload, list) or len(status_payload) <= _STATUS_MESSAGE_POS:
+        return None
+    return sanitize_status_message(
+        status_payload[_STATUS_MESSAGE_POS], source="decoder.wrb.fr[5][1]"
+    )
+
+
 def _user_displayable_error_message(error_info: Any) -> str:
-    """Build a non-sensitive diagnostic for a user-displayable rejection.
+    """Build a diagnostic for a user-displayable rejection.
+
+    The client-authored parts stay free of volatile internal detail — no
+    obfuscated method id, no raw numeric gRPC code (#1921). The server's own
+    ``message``, when present, is echoed as-is (whitespace-collapsed and capped)
+    because it is by definition the text Google chose to *display* to this user;
+    that part is outside this client's control, so "non-sensitive" is a
+    guarantee only over the wording this client writes.
 
     Prefers the server's own ``google.rpc.Status.message`` when one is present;
     otherwise falls back to the client-authored sentence below. The two are
@@ -635,8 +718,10 @@ def _user_displayable_error_message(error_info: Any) -> str:
         "API rate limit or quota exceeded. Please wait before retrying."
     )
     # Same ``google.rpc.Status`` envelope as the bare-status path, so the same
-    # leading-code extractor serves both (the two used to be byte-identical
-    # helpers under different names).
+    # leading-code extractor serves both. Before #2188 these were two helpers
+    # differing only in their arity guard (``len(error_info) != 1`` here versus
+    # ``not error_info`` there); dropping the arity gate collapsed the
+    # difference, so the duplicate was removed rather than kept in sync.
     status = _extract_status_code(error_info)
     if status is None:
         return message
@@ -763,14 +848,15 @@ def decode_response(
         rpc_id: RPC method ID to extract result for
         allow_null: If True, return None instead of raising error when result is null
         raise_on_null_status: Opt-in strictness for ``allow_null`` callers. When
-            True, a null result that the server tagged with a **non-OK**
-            ``google.rpc.Status`` at index 5 raises instead of decoding to
-            ``None``, so the caller reports the server's reason rather than
-            inventing one. Callers that legitimately tolerate a status-tagged
-            null leave it False — ``REMOVE_RECENTLY_VIEWED`` answers ``[13]``
-            (INTERNAL) on what the client treats as a successful no-op
-            (tests/cassettes/notebooks_remove_from_recent.yaml), which is why
-            this is opt-in per call site rather than a blanket change (#2188).
+            True, a null result the server tagged with a **recognized** non-OK
+            ``google.rpc.Status`` at index 5 (a code this decoder can name — see
+            ``_GRPC_STATUS_MESSAGES``; an unrecognized one still decodes to
+            ``None``, loudly) raises instead of decoding to ``None``, so the
+            caller reports the server's reason rather than inventing one.
+            Callers that tolerate a status-tagged null leave it False. This is
+            opt-in per call site rather than a blanket change because three RPCs
+            are RECORDED doing exactly that on flows the client reports as
+            successful — see ``_RPCS_OBSERVED_SWALLOWING_A_STATUS`` (#2188).
 
     Returns:
         Decoded result data
@@ -864,18 +950,33 @@ def decode_response(
         rejected = status is not None and status[0] != GrpcStatusCode.OK
         if allow_null and not (raise_on_null_status and rejected):
             if rejected and status is not None:
-                # Still swallowed, but no longer without trace. DEBUG rather
-                # than WARNING because at least one caller's tolerance is
-                # deliberate and evidence-backed (REMOVE_RECENTLY_VIEWED's
-                # ``[13]``), so a warning would be noise on a healthy call. The
-                # other ``allow_null=True`` call sites have not been evaluated
-                # against live rejections; this line is what makes such a
-                # swallow findable when one of them misbehaves (#2188).
+                # Still swallowed, but no longer without trace. DEBUG, not
+                # WARNING: three RPCs are recorded doing this on flows the
+                # client reports as successful (see
+                # ``_RPCS_OBSERVED_SWALLOWING_A_STATUS``), so warning would fire
+                # on ordinary ``share add`` traffic while asserting a
+                # benign-vs-broken judgement nobody has made yet. The trace is
+                # what makes such a swallow findable; deciding which of them are
+                # real failures needs its own evidence (#2188).
                 logger.debug(
                     "Null result for %s carried status %s; swallowed because the "
                     "call site did not pass raise_on_null_status",
                     rpc_id,
                     status[1],
+                )
+            elif raise_on_null_status and _is_unclassified_status(chunks, rpc_id):
+                # The caller asked for strictness and the server DID attach
+                # something at index 5, but not a status this decoder can name —
+                # a code outside 0-16, a bool, a string, a nested ``[[3]]``. That
+                # is a rejection in a shape we do not recognise, so it lands back
+                # on the very defect #2188 fixed (the caller invents its own
+                # reason) and must not be the quietest branch here.
+                logger.warning(
+                    "Null result for %s carried an unrecognized index-5 payload; "
+                    "treating it as a benign null. If %s is being reported as "
+                    "unavailable, this is the drift to look at",
+                    rpc_id,
+                    rpc_id,
                 )
             return None
 

--- a/tests/_fixtures/rpc_error_frames.py
+++ b/tests/_fixtures/rpc_error_frames.py
@@ -19,6 +19,9 @@ __all__ = [
     "CREATE_ARTIFACT_METHOD_ID",
     "INVALID_ARGUMENT_STATUS",
     "LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY",
+    "LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY",
+    "LIVE_REVISE_SLIDE_NOT_FOUND_BODY",
+    "MIND_MAP_HAS_NO_OBSERVED_REJECTION",
     "USER_DISPLAYABLE_RATE_LIMIT_STATUS",
     "raw_batchexecute_body",
     "user_displayable_rejection_chunks",
@@ -61,13 +64,24 @@ USER_DISPLAYABLE_RATE_LIMIT_STATUS: list[Any] = [
 INVALID_ARGUMENT_STATUS: list[Any] = [3]
 
 #: The complete raw HTTP body of that live rejection, verbatim except for the
-#: ``af.httprm`` nonce (replaced with zeroes).
+#: ``af.httprm`` nonce (replaced with the same number of zeroes).
 #:
 #: Provenance: live probe 2026-08-13, ``NOTEBOOKLM_PROFILE=peopleconf``,
 #: ``generate_audio`` on a freshly created source-less notebook. Kept as raw
 #: text — anti-XSSI prefix, byte-count framing and trailing frames included —
 #: so tests can drive the *whole* decode pipeline rather than a hand-assembled
 #: chunk list.
+#:
+#: **Do not "correct" the byte counts.** They read ``104`` and ``25`` for chunks
+#: of 102 and 23 characters — a consistent +2 — and that is what the server
+#: sent: two independent captures (2026-08-13, different notebooks and
+#: nonces) declare exactly the same pair, and the scrub is width-preserving so
+#: it cannot have shifted them. Note the blank line after the anti-XSSI prefix,
+#: which :func:`raw_batchexecute_body` does not reproduce; this body is the
+#: only fixture in the suite that carries real server framing, and decoding it
+#: increments ``byte_count_mismatch_total`` (pinned by
+#: ``tests/unit/test_decoder.py::TestLiveCapturedFraming``). The decoder is
+#: deliberately tolerant of that — see ``parse_chunked_response``'s Note: block.
 LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY = (
     ")]}'\n\n"
     "104\n"
@@ -76,6 +90,42 @@ LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY = (
     "25\n"
     '[["e",4,null,null,140]]\n'
 )
+
+#: ``RETRY_ARTIFACT`` refused for an artifact id that does not exist.
+#:
+#: Provenance: live probe 2026-08-13, same session — ``retry_failed`` against
+#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``. Nonce zeroed,
+#: width-preserved; the ``+2`` byte-count offset above holds here too.
+LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY = (
+    ")]}'\n\n"
+    "107\n"
+    '[["wrb.fr","Rytqqe",null,null,null,[5],"generic"],["di",113],'
+    '["af.httprm",113,"-0000000000000000000",11]]\n'
+    "25\n"
+    '[["e",4,null,null,143]]\n'
+)
+
+#: ``REVISE_SLIDE`` refused for an artifact id that does not exist.
+#:
+#: Provenance: live probe 2026-08-13, same session — ``revise_slide`` against
+#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``.
+LIVE_REVISE_SLIDE_NOT_FOUND_BODY = (
+    ")]}'\n\n"
+    "104\n"
+    '[["wrb.fr","KmcKPe",null,null,null,[5],"generic"],["di",87],'
+    '["af.httprm",86,"0000000000000000000",11]]\n'
+    "25\n"
+    '[["e",4,null,null,140]]\n'
+)
+
+#: Live evidence that the mind-map path has NO observed rejection shape.
+#:
+#: ``GENERATE_MIND_MAP`` on the same source-less notebook was **not refused** —
+#: the backend generated a generic mind map and returned it. So unlike the three
+#: artifact RPCs above, that call site has no captured status-tagged null, and
+#: opting it into ``raise_on_null_status`` would be inference rather than
+#: evidence. Recorded here so the next reader does not re-derive it (#2188).
+MIND_MAP_HAS_NO_OBSERVED_REJECTION = True
 
 
 def raw_batchexecute_body(frames: list[Any]) -> str:

--- a/tests/_fixtures/rpc_error_frames.py
+++ b/tests/_fixtures/rpc_error_frames.py
@@ -94,8 +94,12 @@ LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY = (
 #: ``RETRY_ARTIFACT`` refused for an artifact id that does not exist.
 #:
 #: Provenance: live probe 2026-08-13, same session — ``retry_failed`` against
-#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``. Nonce zeroed,
-#: width-preserved; the ``+2`` byte-count offset above holds here too.
+#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``. The ``+2`` byte-count
+#: offset above holds here too (107 declared for 105 characters), enforced by
+#: ``TestLiveCapturedFraming``. The nonce is zeroed width-preservingly: this
+#: capture's was NEGATIVE (``-3683449295807497843``, 20 chars incl. the sign),
+#: so the placeholder keeps the sign and is 20 too — it is not a stray extra
+#: digit relative to the 19-char create placeholder.
 LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY = (
     ")]}'\n\n"
     "107\n"
@@ -108,7 +112,10 @@ LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY = (
 #: ``REVISE_SLIDE`` refused for an artifact id that does not exist.
 #:
 #: Provenance: live probe 2026-08-13, same session — ``revise_slide`` against
-#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``.
+#: ``"no-such-artifact-id"``. Code 5 is ``NOT_FOUND``. The ``["di",87]`` /
+#: ``["af.httprm",86,…]`` pair genuinely disagrees by one in this capture while
+#: the other two fixtures repeat the same number — transcribed as received, and
+#: another reason not to tidy these bodies into looking uniform.
 LIVE_REVISE_SLIDE_NOT_FOUND_BODY = (
     ")]}'\n\n"
     "104\n"

--- a/tests/_fixtures/rpc_error_frames.py
+++ b/tests/_fixtures/rpc_error_frames.py
@@ -1,0 +1,112 @@
+"""Captured ``batchexecute`` rejection frames, kept in one place.
+
+Every constant here is a **recorded** shape, not a shape someone believed the
+backend emits. That distinction is the point: issue #2134 shipped a positional
+read validated only by fixtures that encoded the author's guess, and #2193
+exists because the tests that guarded issue #239 asserted against a row shape
+the backend has never sent.
+
+Each entry records where it came from. When you add one, add its provenance
+too — "I made this up to make the test pass" is not provenance.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = [
+    "CREATE_ARTIFACT_METHOD_ID",
+    "INVALID_ARGUMENT_STATUS",
+    "LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY",
+    "USER_DISPLAYABLE_RATE_LIMIT_STATUS",
+    "raw_batchexecute_body",
+    "user_displayable_rejection_chunks",
+]
+
+#: ``CREATE_ARTIFACT``. Duplicated as a literal rather than imported from
+#: ``RPCMethod`` so a test that decodes a captured body is comparing the body
+#: against the id that was actually on the wire when it was captured — if
+#: Google re-obfuscates the method, the mismatch should surface as a test
+#: failure rather than being silently papered over by the enum.
+CREATE_ARTIFACT_METHOD_ID = "R7cb6c"
+
+#: The ``google.rpc.Status`` block a ``UserDisplayableError`` rejection carries
+#: at index 5 of its ``wrb.fr`` frame.
+#:
+#: Provenance: the "Real-world structure from API rate limit response" sample
+#: that has been pinned in ``tests/unit/test_decoder.py`` since the rate-limit
+#: path was written. Note what it does NOT contain: index 1
+#: (``google.rpc.Status.message``) is ``None`` and the detail body is int-only,
+#: so this frame carries **no server-authored human-readable text at all**. The
+#: message a caller sees for it is entirely client-authored (#2188).
+USER_DISPLAYABLE_RATE_LIMIT_STATUS: list[Any] = [
+    8,
+    None,
+    [
+        [
+            "type.googleapis.com/google.internal.labs.tailwind"
+            ".orchestration.v1.UserDisplayableError",
+            [None, None, None, None, [None, [[1]], 2]],
+        ]
+    ],
+]
+
+#: The bare ``google.rpc.Status`` a create-time rejection carries.
+#:
+#: Provenance: live probe 2026-08-13 against a real account — ``CREATE_ARTIFACT``
+#: for an Audio Overview on a notebook with no sources. Code 3 is
+#: ``INVALID_ARGUMENT``. The array is length 1: the server sent no message and
+#: no details.
+INVALID_ARGUMENT_STATUS: list[Any] = [3]
+
+#: The complete raw HTTP body of that live rejection, verbatim except for the
+#: ``af.httprm`` nonce (replaced with zeroes).
+#:
+#: Provenance: live probe 2026-08-13, ``NOTEBOOKLM_PROFILE=peopleconf``,
+#: ``generate_audio`` on a freshly created source-less notebook. Kept as raw
+#: text — anti-XSSI prefix, byte-count framing and trailing frames included —
+#: so tests can drive the *whole* decode pipeline rather than a hand-assembled
+#: chunk list.
+LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY = (
+    ")]}'\n\n"
+    "104\n"
+    '[["wrb.fr","R7cb6c",null,null,null,[3],"generic"],["di",64],'
+    '["af.httprm",64,"0000000000000000000",10]]\n'
+    "25\n"
+    '[["e",4,null,null,140]]\n'
+)
+
+
+def raw_batchexecute_body(frames: list[Any]) -> str:
+    """Wrap decoded ``wrb.fr`` frames back into a raw batchexecute body.
+
+    Mirrors the anti-XSSI prefix and byte-count framing the server uses, so a
+    test can feed ``decode_response`` the same kind of string the transport
+    hands it instead of pre-parsed chunks.
+    """
+    chunk = json.dumps(frames)
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def user_displayable_rejection_chunks(method_id: str) -> list[Any]:
+    """Parsed chunks for a ``UserDisplayableError`` rejection of ``method_id``.
+
+    A null result plus :data:`USER_DISPLAYABLE_RATE_LIMIT_STATUS` at index 5 —
+    the shape ``tests/fixtures/rpc_golden/CREATE_ARTIFACT.json`` pins as its
+    ``user_displayable_rate_limit`` drift case, with the detail body restored to
+    the recorded structure.
+    """
+    return [
+        [
+            [
+                "wrb.fr",
+                method_id,
+                None,
+                None,
+                None,
+                USER_DISPLAYABLE_RATE_LIMIT_STATUS,
+                "generic",
+            ]
+        ]
+    ]

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -632,6 +632,17 @@ UNMAPPED: tuple[Unmapped, ...] = (
         "_STATUS_POS",
         "google.rpc.Status envelope, not a Tailwind message",
     ),
+    Unmapped(
+        "chat",
+        "ErrorPayloadRow",
+        "_MESSAGE_POS",
+        "google.rpc.Status.message (tag 2 -> index 1) — a PUBLIC google/rpc/status.proto "
+        "field, not a Tailwind one, so mobile/schema.proto cannot check it. Its two "
+        "siblings in the same envelope ARE live-confirmed (code at index 0: [3] / [5] "
+        "live from CREATE_ARTIFACT 2026-08-13, [13] in notebooks_remove_from_recent.yaml; "
+        "details at index 2: the recorded UserDisplayableError block). The message slot "
+        "itself has NEVER been observed populated — see #2188",
+    ),
     Unmapped("chat", "ErrorPayloadRow", "_ENTRIES_POS", "google.rpc.Status envelope"),
     Unmapped("chat", "CitationRow", "_CHUNK_BLOCK_POS", _NESTED_LOCAL),
     Unmapped("chat", "CitationRow", "_DETAIL_POS", _NESTED_LOCAL),

--- a/tests/unit/mcp/test_studio.py
+++ b/tests/unit/mcp/test_studio.py
@@ -31,8 +31,10 @@ from notebooklm._types.research import MindMapResult  # noqa: E402
 from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
     ArtifactFeatureUnavailableError,
     ArtifactNotFoundError,
+    ClientError,
     NotebookNotFoundError,
     RateLimitError,
+    RPCError,
 )
 from notebooklm.mcp.tools.studio import _KIND_OPTIONS  # noqa: E402
 from notebooklm.types import Artifact, ArtifactType, GenerationState, Note  # noqa: E402
@@ -1914,6 +1916,67 @@ async def test_artifact_retry_completed_gives_actionable_error(mcp_call, mock_cl
     assert "completed" in msg  # names the current status
     assert "studio_generate" in msg  # actionable next step
     assert "Retry generation is unavailable" not in msg  # not the generic text
+
+
+@pytest.mark.parametrize(
+    "refusal",
+    [
+        pytest.param(ClientError("denied", rpc_code=7), id="permission_denied"),
+        pytest.param(RPCError("unavailable", rpc_code=14), id="unavailable"),
+        pytest.param(ClientError("gone", rpc_code=5), id="not_found"),
+    ],
+)
+async def test_artifact_retry_preserves_non_state_refusals(mcp_call, mock_client, refusal) -> None:
+    """#2188: only a wrong-STATE refusal may be relabelled "artifact is not failed".
+
+    A bare ``[7]`` PERMISSION_DENIED decodes to ``ClientError`` and ``[14]``
+    UNAVAILABLE to a plain ``RPCError`` — neither is caught by the typed
+    exclusions, so without a status check both would be rewritten into a
+    validation error, handing the caller the wrong category AND the wrong
+    recovery advice.
+    """
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.retry_failed = AsyncMock(side_effect=refusal)
+    mock_client.artifacts.get_or_none = AsyncMock(return_value=art)
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+
+    assert "artifact is not failed" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("code", [3, 9])
+async def test_artifact_retry_state_refusal_with_status_is_enriched(
+    mcp_call, mock_client, code
+) -> None:
+    """A status-tagged state refusal still gets the actionable message (#2188).
+
+    INVALID_ARGUMENT / FAILED_PRECONDITION are the shapes that can plausibly
+    mean "wrong state", so the #1924 F15 enrichment must survive them — that is
+    the whole reason the catch was widened past ``ArtifactFeatureUnavailableError``.
+    """
+    art = Artifact(
+        id=_ART_FULL,
+        title="Podcast 1",
+        _artifact_type=ArtifactTypeCode.AUDIO.value,
+        status=int(ArtifactStatus.COMPLETED),
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    mock_client.artifacts.retry_failed = AsyncMock(side_effect=RPCError("rejected", rpc_code=code))
+    mock_client.artifacts.get_or_none = AsyncMock(return_value=art)
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("studio_retry", {"notebook": NB_ID, "artifact": _ART_FULL})
+
+    msg = str(excinfo.value)
+    assert "completed" in msg
+    assert "studio_generate" in msg
 
 
 async def test_artifact_retry_refusal_on_failed_reraises_generic(mcp_call, mock_client) -> None:

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -16,6 +16,8 @@ adapter:
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from notebooklm._row_adapters.chat import (
@@ -33,6 +35,7 @@ from notebooklm._row_adapters.chat import (
 )
 from notebooklm.exceptions import UnknownRPCMethodError
 from notebooklm.rpc import RPCMethod
+from notebooklm.rpc.decoder import _MAX_STATUS_MESSAGE_CHARS
 
 # ---------------------------------------------------------------------------
 # 1. Position-contract pins (the canaries)
@@ -368,10 +371,18 @@ class TestErrorPayloadRow:
         assert ErrorPayloadRow([8, "  Slow  down\tplease ", []]).message == "Slow down please"
 
     def test_message_is_truncated(self) -> None:
+        """Shares the decoder's cap, so the two layers cannot diverge."""
         message = ErrorPayloadRow([8, "x" * 5000]).message
         assert message is not None
-        assert len(message) <= ErrorPayloadRow._MAX_MESSAGE_CHARS + 1
+        assert len(message) <= _MAX_STATUS_MESSAGE_CHARS + 1
         assert message.endswith("…")
+
+    def test_non_string_message_slot_warns(self, caplog) -> None:
+        """An unexpected type there is drift, and must not be inaudible."""
+        with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
+            assert ErrorPayloadRow([8, ["nested"], []]).message is None
+
+        assert any("not a string" in r.getMessage() for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_chat_row_adapter.py
+++ b/tests/unit/test_chat_row_adapter.py
@@ -82,7 +82,12 @@ class TestFramePositionContract:
         ) == (0, 2, 2, 5)
 
     def test_error_payload_positions_pinned(self) -> None:
-        assert (ErrorPayloadRow._STATUS_POS, ErrorPayloadRow._ENTRIES_POS) == (0, 2)
+        # ``google.rpc.Status``: code tag 1, message tag 2, details tag 3.
+        assert (
+            ErrorPayloadRow._STATUS_POS,
+            ErrorPayloadRow._MESSAGE_POS,
+            ErrorPayloadRow._ENTRIES_POS,
+        ) == (0, 1, 2)
 
 
 class TestConversationTurnPositionContract:
@@ -342,6 +347,31 @@ class TestErrorPayloadRow:
     @pytest.mark.parametrize("entry", [[], [123], "x", None])
     def test_non_string_entry_type_is_none(self, entry: object) -> None:
         assert ErrorPayloadRow.entry_type(entry) is None
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # Every captured rejection: the bare status has no message slot,
+            # and the recorded rate-limit shape holds ``None`` there (#2188).
+            [3],
+            [8, None, []],
+            [],
+            [8, 42],
+            [8, ["nested"]],
+            [8, "   "],
+        ],
+    )
+    def test_message_is_none_for_every_captured_shape(self, payload: list) -> None:
+        assert ErrorPayloadRow(payload).message is None
+
+    def test_message_returns_server_text_when_present(self) -> None:
+        assert ErrorPayloadRow([8, "  Slow  down\tplease ", []]).message == "Slow down please"
+
+    def test_message_is_truncated(self) -> None:
+        message = ErrorPayloadRow([8, "x" * 5000]).message
+        assert message is not None
+        assert len(message) <= ErrorPayloadRow._MAX_MESSAGE_CHARS + 1
+        assert message.endswith("…")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -29,6 +29,8 @@ from notebooklm.rpc.types import RPCMethod
 from tests._fixtures.rpc_error_frames import (
     CREATE_ARTIFACT_METHOD_ID,
     LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+    LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY,
+    LIVE_REVISE_SLIDE_NOT_FOUND_BODY,
     USER_DISPLAYABLE_RATE_LIMIT_STATUS,
 )
 
@@ -1711,9 +1713,25 @@ class TestLiveCapturedFraming:
     exactly that.
     """
 
-    def test_declared_counts_exceed_the_payloads_by_two(self):
-        lines = LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY.split("\n")
-        # ")]}'", "", "104", <chunk>, "25", <trailer>, ""
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY, id="create_artifact"),
+            pytest.param(LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY, id="retry_artifact"),
+            pytest.param(LIVE_REVISE_SLIDE_NOT_FOUND_BODY, id="revise_slide"),
+        ],
+    )
+    def test_declared_counts_exceed_the_payloads_by_two(self, body):
+        """All three captures show the same +2, on both chunks.
+
+        Parametrized over every live body after a reviewer hand-counted the
+        retry and revise chunks as +1 and asked for the comments to be
+        "corrected". They are +2; measuring beats counting, so the claim is now
+        enforced for each body instead of asserted for one and described for
+        the other two.
+        """
+        lines = body.split("\n")
+        # ")]}'", "", <count>, <chunk>, <count>, <trailer>, ""
         assert int(lines[2]) == len(lines[3]) + 2
         assert int(lines[4]) == len(lines[5]) + 2
 
@@ -1815,8 +1833,10 @@ class TestRaiseOnNullStatus:
     def test_recorded_swallowing_rpcs_are_declared(self):
         """The three RPCs observed doing this are on the record, not folklore.
 
-        Re-derived from tests/cassettes/ by the sweep in the #2188 PR: five
-        null-result ``wrb.fr`` frames across 397, on exactly these RPCs.
+        Re-derived from tests/cassettes/ by the sweep in the #2188 PR: 5
+        null-result frames out of 397, FOUR of which carry a batchexecute rpc
+        id — on exactly these three. (The fifth is the streamed-chat ``[3]``
+        from #1472, which has no rpc id and never reaches this decoder.)
         """
         assert set(_RPCS_OBSERVED_SWALLOWING_A_STATUS) == {
             RPCMethod.REMOVE_RECENTLY_VIEWED.value,
@@ -1881,6 +1901,37 @@ class TestRaiseOnNullStatus:
         message = str(exc_info.value)
         assert message.startswith("The server rejected this request (failed precondition).")
         assert message.endswith("This notebook has no sources yet")
+
+    def test_a_later_frames_status_is_not_hidden_by_an_earlier_one(self):
+        """Multi-frame ``rt=c``: an unclassifiable placeholder must not shadow.
+
+        The backend can emit several frames for one rpc id. Scanning only the
+        first would let a placeholder's unrecognized payload swallow the real
+        status on the frame that follows — the pre-#2188 loop avoided that by
+        continuing until a code parsed, and the refactor must keep it.
+        """
+        placeholder = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, [99], "generic"])
+        real = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, [3], "generic"])
+        raw = f")]}}'\n{len(placeholder)}\n{placeholder}\n{len(real)}\n{real}\n"
+
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, self.RPC_ID, allow_null=True, raise_on_null_status=True)
+
+        assert exc_info.value.rpc_code == 3
+
+    def test_unclassified_warning_needs_every_frame_to_be_unclassifiable(self, caplog):
+        """One nameable status among several means it is not 'unrecognized'."""
+        placeholder = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, [99], "generic"])
+        real = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, [3], "generic"])
+        raw = f")]}}'\n{len(placeholder)}\n{placeholder}\n{len(real)}\n{real}\n"
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"),
+            pytest.raises(RPCError),
+        ):
+            decode_response(raw, self.RPC_ID, allow_null=True, raise_on_null_status=True)
+
+        assert not any("unrecognized index-5 payload" in r.message for r in caplog.records)
 
     def test_opt_in_does_not_change_a_populated_result(self):
         """Strictness only concerns null results."""

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -7,6 +7,7 @@ import pytest
 
 from notebooklm.exceptions import DecodingError
 from notebooklm.rpc.decoder import (
+    _RPCS_OBSERVED_SWALLOWING_A_STATUS,
     AuthError,
     ClientError,
     RateLimitError,
@@ -25,7 +26,11 @@ from notebooklm.rpc.decoder import (
     strip_anti_xssi,
 )
 from notebooklm.rpc.types import RPCMethod
-from tests._fixtures.rpc_error_frames import USER_DISPLAYABLE_RATE_LIMIT_STATUS
+from tests._fixtures.rpc_error_frames import (
+    CREATE_ARTIFACT_METHOD_ID,
+    LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+    USER_DISPLAYABLE_RATE_LIMIT_STATUS,
+)
 
 
 class TestStripAntiXSSI:
@@ -1694,6 +1699,40 @@ class TestServerStatusMessage:
         assert "This notebook has no sources yet" in message
 
 
+class TestLiveCapturedFraming:
+    """The one fixture carrying real server framing, pinned as captured.
+
+    ``LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY`` declares byte counts two
+    higher than its chunks are long. That is not a typo: two independent live
+    captures (2026-08-13, different notebooks and nonces) declare the same
+    pair, and the nonce scrub is width-preserving. This test exists so nobody
+    "corrects" the fixture into agreement with ``raw_batchexecute_body`` and
+    quietly turns a real capture into a synthetic one — a reviewer proposed
+    exactly that.
+    """
+
+    def test_declared_counts_exceed_the_payloads_by_two(self):
+        lines = LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY.split("\n")
+        # ")]}'", "", "104", <chunk>, "25", <trailer>, ""
+        assert int(lines[2]) == len(lines[3]) + 2
+        assert int(lines[4]) == len(lines[5]) + 2
+
+    def test_decoding_it_records_a_byte_count_mismatch(self):
+        """The decoder tolerates the mismatch but counts it as a drift signal."""
+        reset_byte_count_mismatch_total()
+        try:
+            with pytest.raises(RPCError):
+                decode_response(
+                    LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+                    CREATE_ARTIFACT_METHOD_ID,
+                    allow_null=True,
+                    raise_on_null_status=True,
+                )
+            assert byte_count_mismatch_total() == 2
+        finally:
+            reset_byte_count_mismatch_total()
+
+
 class TestRaiseOnNullStatus:
     """``allow_null`` tolerates an empty payload, not an explicit rejection."""
 
@@ -1752,16 +1791,69 @@ class TestRaiseOnNullStatus:
 
         assert exc_info.value.rpc_code == 5
 
-    def test_swallowed_rejection_is_logged(self, caplog):
-        """A swallow without opt-in leaves a trace instead of vanishing."""
+    def test_swallowed_rejection_leaves_a_debug_trace(self, caplog):
+        """A swallow leaves a trace instead of vanishing — but only at DEBUG.
+
+        WARNING was considered and rejected: three RPCs are RECORDED swallowing
+        a status-tagged null on flows this client reports as successful
+        (SHARE_NOTEBOOK / SHARE_ARTIFACT ``[3]``, REMOVE_RECENTLY_VIEWED
+        ``[13]``), so warning would fire on ordinary ``share add`` traffic and
+        assert a benign-vs-broken judgement the evidence does not support.
+        """
         with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
             assert decode_response(self._raw([13]), self.RPC_ID, allow_null=True) is None
 
-        assert any(
-            "swallowed because the call site did not pass raise_on_null_status" in r.message
-            and "Internal" in r.getMessage()
+        matching = [
+            r
             for r in caplog.records
-        )
+            if "swallowed because the call site did not pass raise_on_null_status" in r.message
+        ]
+        assert matching, "the swallow left no trace"
+        assert all(r.levelno == logging.DEBUG for r in matching)
+        assert "Internal" in matching[0].getMessage()
+
+    def test_recorded_swallowing_rpcs_are_declared(self):
+        """The three RPCs observed doing this are on the record, not folklore.
+
+        Re-derived from tests/cassettes/ by the sweep in the #2188 PR: five
+        null-result ``wrb.fr`` frames across 397, on exactly these RPCs.
+        """
+        assert set(_RPCS_OBSERVED_SWALLOWING_A_STATUS) == {
+            RPCMethod.REMOVE_RECENTLY_VIEWED.value,
+            RPCMethod.SHARE_NOTEBOOK.value,
+            RPCMethod.SHARE_ARTIFACT.value,
+        }
+
+    def test_unclassifiable_status_under_opt_in_warns(self, caplog):
+        """A rejection in a shape we cannot name must not be the quietest branch.
+
+        ``[99]`` is outside the gRPC range, so ``rejected`` is False and the
+        caller falls back to inventing its own reason — the exact #2188 defect.
+        The opt-in says the caller wanted the server's word, so say so.
+        """
+        with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
+            assert (
+                decode_response(
+                    self._raw([99]), self.RPC_ID, allow_null=True, raise_on_null_status=True
+                )
+                is None
+            )
+
+        matching = [r for r in caplog.records if "unrecognized index-5 payload" in r.message]
+        assert matching, "an unclassifiable rejection payload left no trace"
+        assert matching[0].levelno == logging.WARNING
+
+    def test_a_reasonless_null_under_opt_in_stays_quiet(self, caplog):
+        """No payload at all is a genuinely empty result, not drift."""
+        with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
+            assert (
+                decode_response(
+                    self._raw(None), self.RPC_ID, allow_null=True, raise_on_null_status=True
+                )
+                is None
+            )
+
+        assert not any("unrecognized index-5 payload" in r.message for r in caplog.records)
 
     @pytest.mark.parametrize("status", [None, [0]])
     def test_a_benign_null_logs_nothing(self, caplog, status):
@@ -1770,6 +1862,25 @@ class TestRaiseOnNullStatus:
             assert decode_response(self._raw(status), self.RPC_ID, allow_null=True) is None
 
         assert not any("swallowed because" in r.message for r in caplog.records)
+
+    def test_opt_in_appends_a_server_message_when_one_is_sent(self):
+        """The #2188 headline path composes label + server text.
+
+        Synthetic by necessity — no captured rejection has ever populated the
+        message slot — so the captured-shape case above is the one that pins
+        what users see today.
+        """
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(
+                self._raw([9, "This notebook has no sources yet"]),
+                self.RPC_ID,
+                allow_null=True,
+                raise_on_null_status=True,
+            )
+
+        message = str(exc_info.value)
+        assert message.startswith("The server rejected this request (failed precondition).")
+        assert message.endswith("This notebook has no sources yet")
 
     def test_opt_in_does_not_change_a_populated_result(self):
         """Strictness only concerns null results."""

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -1752,6 +1752,25 @@ class TestRaiseOnNullStatus:
 
         assert exc_info.value.rpc_code == 5
 
+    def test_swallowed_rejection_is_logged(self, caplog):
+        """A swallow without opt-in leaves a trace instead of vanishing."""
+        with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
+            assert decode_response(self._raw([13]), self.RPC_ID, allow_null=True) is None
+
+        assert any(
+            "swallowed because the call site did not pass raise_on_null_status" in r.message
+            and "Internal" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.parametrize("status", [None, [0]])
+    def test_a_benign_null_logs_nothing(self, caplog, status):
+        """A genuinely empty payload is not a rejection, so it stays quiet."""
+        with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
+            assert decode_response(self._raw(status), self.RPC_ID, allow_null=True) is None
+
+        assert not any("swallowed because" in r.message for r in caplog.records)
+
     def test_opt_in_does_not_change_a_populated_result(self):
         """Strictness only concerns null results."""
         chunk = json.dumps(["wrb.fr", self.RPC_ID, '["art_1"]', None, None, [3], "generic"])

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -14,6 +14,7 @@ from notebooklm.rpc.decoder import (
     RPCErrorCode,
     UnknownRPCMethodError,
     _contains_user_displayable_error,
+    _server_status_message,
     byte_count_mismatch_total,
     collect_rpc_ids,
     decode_response,
@@ -24,6 +25,7 @@ from notebooklm.rpc.decoder import (
     strip_anti_xssi,
 )
 from notebooklm.rpc.types import RPCMethod
+from tests._fixtures.rpc_error_frames import USER_DISPLAYABLE_RATE_LIMIT_STATUS
 
 
 class TestStripAntiXSSI:
@@ -431,17 +433,9 @@ class TestExtractRPCResult:
         Google's API returns this pattern for rate limiting, quota exceeded,
         and other user-facing restrictions.
         """
-        # Real-world structure from API rate limit response
-        error_info = [
-            8,
-            None,
-            [
-                [
-                    "type.googleapis.com/google.internal.labs.tailwind.orchestration.v1.UserDisplayableError",
-                    [None, None, None, None, [None, [[1]], 2]],
-                ]
-            ],
-        ]
+        # Real-world structure from an API rate limit response, shared with
+        # the #239 regression suite (tests/_fixtures/rpc_error_frames.py).
+        error_info = USER_DISPLAYABLE_RATE_LIMIT_STATUS
         chunks = [
             [
                 "wrb.fr",
@@ -882,16 +876,20 @@ class TestNullResultStatusCodeEnrichment:
         assert "empty result" in message
         assert "status code" not in message
 
-    def test_multi_element_error_info_falls_through(self):
-        """[5, null, 'x'] is not the bare form — no enrichment."""
-        with pytest.raises(RPCError) as exc_info:
+    def test_multi_element_status_is_still_read_as_a_status(self):
+        """``[5, null, 'x']`` is the same google.rpc.Status at a longer arity.
+
+        The old ``len(error_info) != 1`` gate made every non-bare status
+        invisible, which also made ``google.rpc.Status.message`` (index 1)
+        unreachable by construction — a read that could never fire is the
+        #2134 defect, so the arity gate had to go (#2188). The leading code is
+        what identifies the rejection at any length.
+        """
+        with pytest.raises(ClientError) as exc_info:
             decode_response(self._build_raw([5, None, "x"]), self.RPC_ID)
 
-        assert not isinstance(exc_info.value, ClientError)
-        assert exc_info.value.rpc_code is None
-        message = str(exc_info.value)
-        assert "empty result" in message
-        assert "status code" not in message
+        assert exc_info.value.rpc_code == 5
+        assert "not found" in str(exc_info.value).lower()
 
     def test_allow_null_suppresses_enrichment_for_client_error_codes(self):
         """allow_null=True must short-circuit even for [5] / [7].
@@ -1576,3 +1574,189 @@ class TestGetErrorMessageForCode:
             message, is_retryable = get_error_message_for_code(int(code))
             assert isinstance(message, str) and message
             assert isinstance(is_retryable, bool)
+
+
+class TestServerStatusMessage:
+    """``google.rpc.Status.message`` (index 1) — the only server-authored text.
+
+    Every other word this client prints for a rejection is client-authored. The
+    slot has **never** been observed populated, so the tests below split cleanly
+    in two: the *captured* shapes pin that nothing is invented from them, and
+    the *populated* cases pin what would happen if the server ever filled it in.
+    The populated payloads are the only synthetic fixtures here, and they are
+    synthetic by necessity — you cannot capture a field the server has not sent.
+    """
+
+    def test_recorded_rate_limit_status_yields_no_server_message(self):
+        """The one recorded rich sample carries ``None`` at index 1."""
+        assert _server_status_message(USER_DISPLAYABLE_RATE_LIMIT_STATUS) is None
+
+    def test_bare_status_array_yields_no_server_message(self):
+        """A live ``[3]`` / ``[13]`` rejection has no message slot at all."""
+        assert _server_status_message([3]) is None
+        assert _server_status_message([13]) is None
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            [],
+            "not-a-status",
+            [3, None],
+            [3, 42],
+            [3, ["nested"]],
+            [3, ""],
+            [3, "   "],
+        ],
+    )
+    def test_non_text_slots_are_ignored(self, payload):
+        """Only a non-empty ``str`` counts — never a guess at something else."""
+        assert _server_status_message(payload) is None
+
+    def test_populated_message_is_returned(self):
+        """A server-sent string is surfaced verbatim."""
+        assert _server_status_message([8, "Daily limit reached", []]) == "Daily limit reached"
+
+    def test_whitespace_is_collapsed(self):
+        assert _server_status_message([8, "  Daily  \n limit\treached  "]) == "Daily limit reached"
+
+    def test_overlong_message_is_truncated(self):
+        """The field is server-controlled; it must not blow up an exception."""
+        result = _server_status_message([8, "x" * 5000])
+
+        assert result is not None
+        assert len(result) <= 301  # 300 chars + the ellipsis
+        assert result.endswith("…")
+
+    def test_rate_limit_error_prefers_server_text_over_the_client_sentence(self):
+        """When the server explains itself, its words lead (#2188)."""
+        chunks = [
+            [
+                "wrb.fr",
+                RPCMethod.LIST_NOTEBOOKS.value,
+                None,
+                None,
+                None,
+                [8, "Daily limit for Video Overviews reached", [["UserDisplayableError", []]]],
+            ]
+        ]
+
+        with pytest.raises(RateLimitError) as exc_info:
+            extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+
+        message = str(exc_info.value)
+        assert message.startswith("Daily limit for Video Overviews reached")
+        assert "API rate limit or quota exceeded" not in message
+        # The upstream label is still appended for diagnosis.
+        assert "(Upstream: Resource exhausted.)" in message
+
+    def test_rate_limit_error_keeps_the_client_sentence_when_the_server_is_silent(self):
+        """The recorded shape still produces exactly today's wording."""
+        chunks = [
+            [
+                "wrb.fr",
+                RPCMethod.LIST_NOTEBOOKS.value,
+                None,
+                None,
+                None,
+                USER_DISPLAYABLE_RATE_LIMIT_STATUS,
+            ]
+        ]
+
+        with pytest.raises(RateLimitError) as exc_info:
+            extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+
+        assert str(exc_info.value) == (
+            "API rate limit or quota exceeded. Please wait before retrying. "
+            "(Upstream: Resource exhausted.)"
+        )
+
+    def test_null_result_rejection_appends_server_text(self):
+        """The bare-status path echoes a server message when one is sent."""
+        chunk = json.dumps(
+            [
+                "wrb.fr",
+                RPCMethod.GET_NOTEBOOK.value,
+                None,
+                None,
+                None,
+                [9, "This notebook has no sources yet"],
+                "generic",
+            ]
+        )
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, RPCMethod.GET_NOTEBOOK.value)
+
+        message = str(exc_info.value)
+        assert "failed precondition" in message.lower()
+        assert "This notebook has no sources yet" in message
+
+
+class TestRaiseOnNullStatus:
+    """``allow_null`` tolerates an empty payload, not an explicit rejection."""
+
+    RPC_ID = RPCMethod.CREATE_ARTIFACT.value
+
+    def _raw(self, status):
+        chunk = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, status, "generic"])
+        return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+    def test_default_still_swallows_a_status_tagged_null(self):
+        """Unchanged for every caller that did not opt in.
+
+        ``REMOVE_RECENTLY_VIEWED`` answers ``[13]`` on what the client treats as
+        a successful no-op (tests/cassettes/notebooks_remove_from_recent.yaml),
+        so blanket strictness would have broken a recorded interaction.
+        """
+        for code in (3, 5, 7, 13, 16):
+            assert decode_response(self._raw([code]), self.RPC_ID, allow_null=True) is None
+
+    def test_opt_in_raises_for_a_non_ok_status(self):
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._raw([3]), self.RPC_ID, allow_null=True, raise_on_null_status=True)
+
+        assert exc_info.value.rpc_code == 3
+        assert "invalid argument" in str(exc_info.value).lower()
+
+    def test_opt_in_still_returns_none_without_a_status(self):
+        """No status means no reason to report — the null stays a null."""
+        assert (
+            decode_response(
+                self._raw(None), self.RPC_ID, allow_null=True, raise_on_null_status=True
+            )
+            is None
+        )
+
+    def test_opt_in_still_returns_none_for_an_ok_status(self):
+        """``[0]`` is OK — an explicitly fine empty payload, not a rejection."""
+        assert (
+            decode_response(self._raw([0]), self.RPC_ID, allow_null=True, raise_on_null_status=True)
+            is None
+        )
+
+    def test_opt_in_still_returns_none_for_an_unrecognized_status(self):
+        """Out-of-range codes stay unclassified rather than guessed at."""
+        assert (
+            decode_response(
+                self._raw([99]), self.RPC_ID, allow_null=True, raise_on_null_status=True
+            )
+            is None
+        )
+
+    def test_opt_in_routes_account_scoped_codes_through_client_error(self):
+        """NOT_FOUND / PERMISSION_DENIED keep their ``ClientError`` routing."""
+        with pytest.raises(ClientError) as exc_info:
+            decode_response(self._raw([5]), self.RPC_ID, allow_null=True, raise_on_null_status=True)
+
+        assert exc_info.value.rpc_code == 5
+
+    def test_opt_in_does_not_change_a_populated_result(self):
+        """Strictness only concerns null results."""
+        chunk = json.dumps(["wrb.fr", self.RPC_ID, '["art_1"]', None, None, [3], "generic"])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+        result = decode_response(raw, self.RPC_ID, allow_null=True, raise_on_null_status=True)
+
+        assert result == ["art_1"]

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -573,7 +573,9 @@ def _build_rpc_executor() -> Any:
     timeout = 30.0
     refresh_retry_delay = 0.0
 
-    def _decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
+    def _decode(
+        raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         return []
 
     async def _sleep(_: float) -> None:

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -250,6 +250,7 @@ async def test_retry_inherits_parent_request_id():
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
         _refresh_budget=None,
         _retry_deadline=None,
     ):

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -50,7 +50,9 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
     # the test brittle to RPC-ID changes. Stubbing keeps the test focused
     # on observability semantics (counters + events + correlation) rather
     # than wire-format details.
-    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
+    def fake_decode(
+        raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> dict:
         return {"ok": True}
 
     core = build_client_shell_for_tests(
@@ -120,7 +122,9 @@ async def test_rpc_decode_error_bumps_drift_counter(auth_tokens: AuthTokens) -> 
     """
     from notebooklm.exceptions import DecodingError
 
-    def drifting_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
+    def drifting_decode(
+        raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> dict:
         raise DecodingError("Google reshaped the response", method_id=rpc_id)
 
     core = build_client_shell_for_tests(auth_tokens, decode_response=drifting_decode)

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -200,7 +200,8 @@ async def test_client_rpc_call_forwards_supported_kwargs() -> None:
 
     After the v0.6.0 cut, the public wrapper exposes only the supported
     surface (``method``, ``params``, ``allow_null``, and the keyword-only
-    ``disable_internal_retries`` / ``read_timeout``); the previously-deprecated
+    ``disable_internal_retries`` / ``read_timeout`` /
+    ``raise_on_null_status``); the previously-deprecated
     ``source_path`` / ``_is_retry`` / ``operation_variant`` kwargs were
     removed and are no longer forwarded by this layer. ``read_timeout``
     (#2187) is the per-call read-timeout override used by callers like
@@ -233,6 +234,7 @@ async def test_client_rpc_call_forwards_supported_kwargs() -> None:
         allow_null=True,
         disable_internal_retries=True,
         read_timeout=45.0,
+        raise_on_null_status=True,
     )
 
     assert result == {"ok": True}
@@ -242,6 +244,7 @@ async def test_client_rpc_call_forwards_supported_kwargs() -> None:
         allow_null=True,
         disable_internal_retries=True,
         read_timeout=45.0,
+        raise_on_null_status=True,
     )
 
 
@@ -278,4 +281,5 @@ async def test_client_rpc_call_forwards_default_arguments() -> None:
         allow_null=False,
         disable_internal_retries=False,
         read_timeout=None,
+        raise_on_null_status=False,
     )

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -9,7 +9,29 @@ Root causes:
    from the list (the API removes quota-rejected artifacts).
 2. wait_for_completion() had no mechanism to detect a sustained run of
    "artifact not found" responses and would spin until timeout.
-3. Failed artifacts had no error message surfaced to the caller.
+3. A quota rejection at generation time had to fail fast instead of polling
+   to a timeout.
+
+Where a failure reason does and does not come from (#2134 / #2188 / #2193)
+--------------------------------------------------------------------------
+Root cause 3 used to read "failed artifacts had no error message surfaced to
+the caller", and the tests below tried to surface one from the artifact row.
+No such field exists. ``Artifact`` in ``docs/mobile/schema.proto`` has no error
+or failure field at all: index 3 is ``sources`` and index 5 is
+``isPubliclyReadable``, and #2134 deleted the reader that pretended otherwise.
+
+A reason exists in exactly one place — the ``google.rpc.Status`` on the
+``CreateArtifact`` RPC at generation time, which is why ``RETRY_ARTIFACT``
+exists at all: the resource remembers nothing, so retry is the only affordance
+left. Two consequences are pinned here:
+
+* ``TestRejectionAtGenerationTime`` — a rejected ``CreateArtifact`` reaches the
+  ``generate_*`` caller as an exception, through the REAL decoder, so #239's
+  fail-fast guarantee has a regression test again.
+* ``TestLateFailureHasNoReason`` — an artifact accepted at create time that
+  only later flips to FAILED carries ``error=None`` forever, and the user-facing
+  string comes from the generic ``"{Type} generation failed"`` fallback in
+  ``_app/generate_retry.py``.
 """
 
 from contextlib import asynccontextmanager
@@ -17,23 +39,36 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from notebooklm._app.generate_retry import generation_outcome_from_status
 from notebooklm._artifacts import ArtifactsAPI
-from notebooklm.rpc.types import ArtifactStatus
+from notebooklm.exceptions import ArtifactFeatureUnavailableError, RateLimitError, RPCError
+from notebooklm.rpc.decoder import decode_response, extract_rpc_result
+from notebooklm.rpc.types import ArtifactStatus, RPCMethod
 from notebooklm.types import GenerationStatus
+from tests._fixtures.rpc_error_frames import (
+    CREATE_ARTIFACT_METHOD_ID,
+    LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+    raw_batchexecute_body,
+    user_displayable_rejection_chunks,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_api():
-    """Return an ArtifactsAPI with mocked runtime + mind-map services."""
+def _make_api(rpc_call: AsyncMock | None = None):
+    """Return an ArtifactsAPI with mocked runtime + mind-map services.
+
+    ``rpc_call`` overrides the RPC seam so a test can answer with a real
+    decoded response instead of a bare mock return value.
+    """
     from notebooklm._mind_map import NoteBackedMindMapService
     from notebooklm._note_service import NoteService
     from tests._fixtures.fake_core import make_fake_core
 
     core = make_fake_core(
-        rpc_call=AsyncMock(),
+        rpc_call=rpc_call if rpc_call is not None else AsyncMock(),
         operation_scope=MagicMock(side_effect=lambda _label: _noop_operation_scope()),
     )
     # ``ArtifactsAPI`` constructs its own ``PollRegistry`` internally; the fake
@@ -522,3 +557,170 @@ class TestGenerationStatusIsRemoved:
     def test_removed_without_quota_wording_is_not_rate_limited(self):
         status = GenerationStatus(task_id="x", status="removed", error="just gone")
         assert status.is_rate_limited is False
+
+
+# ---------------------------------------------------------------------------
+# #239 / #2193: a rejection at generation time reaches the caller
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionAtGenerationTime:
+    """A ``CreateArtifact`` rejection fails fast, through the real decoder.
+
+    These tests deliberately do **not** stub the decode step. The rejection is
+    handed to the production decoder as the server sent it, and the assertion
+    is on what ``generate_audio`` raises — the chain decoder → ``rpc_call`` →
+    ``ArtifactGenerationService`` → ``ArtifactsAPI`` is exactly where the #239
+    regression lived, and stubbing the decoder would have hidden it.
+    """
+
+    @staticmethod
+    def _api_answering_with(decoded):
+        """Build an API whose RPC seam runs ``decoded(method_id)`` for real."""
+
+        async def rpc_call(method, *_args, **kwargs):
+            method_id = getattr(method, "value", method)
+            return decoded(method_id, **kwargs)
+
+        return _make_api(rpc_call=AsyncMock(side_effect=rpc_call))
+
+    @pytest.mark.asyncio
+    async def test_quota_rejection_raises_rate_limit_error_to_the_caller(self):
+        """#239: a UserDisplayableError rejection raises before any polling."""
+        api = self._api_answering_with(
+            lambda method_id, **_kw: extract_rpc_result(
+                user_displayable_rejection_chunks(method_id), method_id
+            )
+        )
+
+        with pytest.raises(RateLimitError) as exc_info:
+            await api.generate_audio("nb1")
+
+        assert exc_info.value.rpc_code == "USER_DISPLAYABLE_ERROR"
+        message = str(exc_info.value)
+        # The condition and the remedy are both named. Both halves of this
+        # sentence are CLIENT-authored: the recorded rejection carries no
+        # server text at all (see USER_DISPLAYABLE_RATE_LIMIT_STATUS).
+        assert "quota" in message.lower()
+        assert "retry" in message.lower()
+        # The upstream gRPC label is kept for diagnosis; the raw code is not.
+        assert "Resource exhausted" in message
+
+    @pytest.mark.asyncio
+    async def test_quota_rejection_reaches_the_caller_only_from_create_artifact(self):
+        """The rejection travels on ``CREATE_ARTIFACT``, not a later poll."""
+        seen: list[str] = []
+
+        def decoded(method_id, **_kw):
+            seen.append(method_id)
+            return extract_rpc_result(user_displayable_rejection_chunks(method_id), method_id)
+
+        api = self._api_answering_with(decoded)
+
+        with pytest.raises(RateLimitError):
+            await api.generate_audio("nb1")
+
+        assert seen == [RPCMethod.CREATE_ARTIFACT.value]
+
+    @pytest.mark.asyncio
+    async def test_live_captured_invalid_argument_rejection_reports_the_server_status(self):
+        """The server's own status survives to the caller (#2188).
+
+        Drives the verbatim body a live ``CREATE_ARTIFACT`` returned for an
+        Audio Overview on a source-less notebook (2026-08-13) through
+        ``decode_response``. Before #2188 the ``allow_null=True`` decode
+        swallowed the ``[3]`` and the caller reported "Audio generation is
+        unavailable" — a client-invented reason that contradicted the one the
+        server actually gave.
+        """
+        api = self._api_answering_with(
+            lambda method_id, **kwargs: decode_response(
+                LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+                method_id,
+                allow_null=kwargs.get("allow_null", False),
+                raise_on_null_status=kwargs.get("raise_on_null_status", False),
+            )
+        )
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.generate_audio("nb1")
+
+        assert not isinstance(exc_info.value, ArtifactFeatureUnavailableError)
+        assert exc_info.value.rpc_code == 3
+        assert "invalid argument" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_null_result_without_a_status_still_reports_feature_unavailable(self):
+        """A reasonless null keeps its existing "unavailable" surface.
+
+        The server sometimes answers a create with nothing at all — no payload
+        and no status. There is no reason to report there, so the client's own
+        wording remains the honest ceiling and must not regress into a bare
+        decode error.
+        """
+        body = raw_batchexecute_body(
+            [["wrb.fr", CREATE_ARTIFACT_METHOD_ID, None, None, None, None, "generic"]]
+        )
+        api = self._api_answering_with(
+            lambda method_id, **kwargs: decode_response(
+                body,
+                method_id,
+                allow_null=kwargs.get("allow_null", False),
+                raise_on_null_status=kwargs.get("raise_on_null_status", False),
+            )
+        )
+
+        with pytest.raises(ArtifactFeatureUnavailableError) as exc_info:
+            await api.generate_audio("nb1")
+
+        assert exc_info.value.artifact_type == "audio"
+
+
+# ---------------------------------------------------------------------------
+# #2193: an artifact that fails LATE carries no reason — pin the fallback
+# ---------------------------------------------------------------------------
+
+
+class TestLateFailureHasNoReason:
+    """An accepted-then-FAILED artifact has no reason, and the CLI says so."""
+
+    @pytest.mark.asyncio
+    async def test_failed_row_polls_to_status_failed_with_no_error(self):
+        """``Artifact`` has no failure field, so ``error`` stays ``None``."""
+        api = _make_api()
+        api._list_raw = AsyncMock(return_value=[_art("task_abc", ArtifactStatus.FAILED)])
+
+        status = await api.poll_status("nb1", "task_abc")
+
+        assert status.is_failed is True
+        assert status.error is None
+        assert status.error_code is None
+
+    @pytest.mark.asyncio
+    async def test_late_failure_renders_the_generic_fallback_message(self):
+        """The reasonless poll result still gives the user *something*.
+
+        Links a late-FAILED poll to ``generate_retry.generation_outcome_from_status``,
+        whose ``or f"{artifact_type.title()} generation failed"`` fallback is the
+        only thing standing between the user and an empty error string.
+        """
+        api = _make_api()
+        api._list_raw = AsyncMock(return_value=[_art("task_abc", ArtifactStatus.FAILED)])
+
+        status = await api.poll_status("nb1", "task_abc")
+        outcome = generation_outcome_from_status(status, "audio")
+
+        assert outcome.status == "failed"
+        assert outcome.error == "Audio generation failed"
+
+    def test_a_server_reason_would_win_over_the_fallback(self):
+        """The fallback is a fallback: a real reason is preferred if one exists.
+
+        Nothing on the artifact resource can populate ``error`` today (that is
+        the point of the test above), so this pins the *precedence* rather than
+        a reachable path — if a future RPC is ever shown to carry a reason,
+        wiring it into ``GenerationStatus.error`` is all that is required.
+        """
+        status = GenerationStatus(task_id="x", status="failed", error="Daily limit reached")
+
+        assert generation_outcome_from_status(status, "audio").error == "Daily limit reached"

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -48,6 +48,8 @@ from notebooklm.types import GenerationStatus
 from tests._fixtures.rpc_error_frames import (
     CREATE_ARTIFACT_METHOD_ID,
     LIVE_CREATE_ARTIFACT_INVALID_ARGUMENT_BODY,
+    LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY,
+    LIVE_REVISE_SLIDE_NOT_FOUND_BODY,
     raw_batchexecute_body,
     user_displayable_rejection_chunks,
 )
@@ -648,6 +650,45 @@ class TestRejectionAtGenerationTime:
         assert not isinstance(exc_info.value, ArtifactFeatureUnavailableError)
         assert exc_info.value.rpc_code == 3
         assert "invalid argument" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("body", "call"),
+        [
+            pytest.param(
+                LIVE_RETRY_ARTIFACT_NOT_FOUND_BODY,
+                lambda api: api.retry_failed("nb1", "no-such-artifact-id"),
+                id="retry_artifact",
+            ),
+            pytest.param(
+                LIVE_REVISE_SLIDE_NOT_FOUND_BODY,
+                lambda api: api.revise_slide("nb1", "no-such-artifact-id", 0, "tweak it"),
+                id="revise_slide",
+            ),
+        ],
+    )
+    async def test_retry_and_revise_also_report_the_server_status(self, body, call):
+        """The other two opt-in call sites are evidence-backed too (#2188).
+
+        Live probe 2026-08-13: both answer ``[5]`` NOT_FOUND for an unknown
+        artifact id. Before the opt-in each reported "… generation is
+        unavailable", which says nothing about the id being wrong.
+        """
+        api = self._api_answering_with(
+            lambda method_id, **kwargs: decode_response(
+                body,
+                method_id,
+                allow_null=kwargs.get("allow_null", False),
+                raise_on_null_status=kwargs.get("raise_on_null_status", False),
+            )
+        )
+
+        with pytest.raises(RPCError) as exc_info:
+            await call(api)
+
+        assert not isinstance(exc_info.value, ArtifactFeatureUnavailableError)
+        assert exc_info.value.rpc_code == 5
+        assert "not found" in str(exc_info.value).lower()
 
     @pytest.mark.asyncio
     async def test_null_result_without_a_status_still_reports_feature_unavailable(self):

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -131,7 +131,9 @@ def _executor(
     async def _no_sleep(_: float) -> None:
         return None
 
-    def _decode(_: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+    def _decode(
+        _: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> dict[str, Any]:
         return {"rpc_id": rpc_id, "allow_null": allow_null}
 
     # ADR-0014 Rule 5 (Wave 4 of session-decoupling): the executor takes
@@ -240,7 +242,9 @@ async def test_constructor_injected_decode_response_drives_executor(monkeypatch)
     """
     decode_calls: list[dict[str, Any]] = []
 
-    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+    def fake_decode(
+        raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> dict[str, Any]:
         decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
         return {"decoded": rpc_id}
 
@@ -290,7 +294,9 @@ async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeyp
     owner = _Owner()
     decode_calls: list[dict[str, Any]] = []
 
-    def decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+    def decode(
+        raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> dict[str, Any]:
         decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
         return {"ok": True}
 
@@ -356,7 +362,9 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
     is_auth_error_calls: list[Exception] = []
     decode_allow_nulls: list[bool] = []
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         decode_allow_nulls.append(allow_null)
         if len(decode_allow_nulls) == 1:
             raise RPCError("not matched by the built-in auth detector")
@@ -421,7 +429,9 @@ async def test_decode_time_auth_retry_gives_up_when_aggregate_deadline_exhausted
     auth_rpc_error = RPCError("authentication expired")
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         raise auth_rpc_error
@@ -463,7 +473,9 @@ async def test_decode_time_auth_retry_preserves_none_result() -> None:
     owner = _Owner(refresh_callback=refresh_callback)
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:
@@ -505,7 +517,9 @@ async def test_decode_time_auth_retry_skipped_for_non_idempotent_method() -> Non
     owner = _Owner(refresh_callback=refresh_callback)
     auth_rpc_error = RPCError("authentication expired")
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise auth_rpc_error
 
     with pytest.raises(RPCError) as raised:
@@ -544,7 +558,9 @@ async def test_decode_time_auth_retry_skipped_when_caller_disables_retries() -> 
     owner = _Owner(refresh_callback=refresh_callback)
     auth_rpc_error = RPCError("authentication expired")
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise auth_rpc_error
 
     with pytest.raises(RPCError) as raised:
@@ -583,7 +599,9 @@ async def test_decode_time_auth_retry_threads_refresh_budget_to_transport() -> N
     owner = _Owner(refresh_callback=refresh_callback)
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:
@@ -624,7 +642,9 @@ async def test_decode_time_auth_retry_threads_read_timeout_to_transport() -> Non
     owner = _Owner(refresh_callback=refresh_callback)
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:
@@ -669,7 +689,9 @@ async def test_decode_time_auth_retry_threads_retry_deadline_to_transport() -> N
     owner._timeout = 30.0
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:
@@ -714,7 +736,9 @@ async def test_decode_time_auth_retry_skips_when_shared_budget_already_spent() -
     owner = _Owner(refresh_callback=refresh_callback)
     auth_rpc_error = RPCError("authentication expired")
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise auth_rpc_error
 
     spent_budget = RefreshBudget()
@@ -754,7 +778,9 @@ async def test_decode_time_auth_retry_increments_auth_retry_metric() -> None:
     owner = _Owner(refresh_callback=refresh_callback)
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:
@@ -821,6 +847,7 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
         read_timeout: float | None = None,
+        raise_on_null_status: bool = False,
         _refresh_budget: Any = None,
         _retry_deadline: Any = None,
     ) -> dict[str, bool]:
@@ -975,7 +1002,9 @@ async def test_decode_shape_error_wrapped(
     decoder_exc = decoder_exc_factory()
     owner = _Owner()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise decoder_exc
 
     with pytest.raises(RPCError) as raised:
@@ -1003,7 +1032,9 @@ async def test_decode_shape_error_json_decode_wrapped() -> None:
     owner = _Owner()
     decoder_exc = _json.JSONDecodeError("expecting value", "doc", 0)
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise decoder_exc
 
     with pytest.raises(RPCError) as raised:
@@ -1024,7 +1055,9 @@ async def test_rpc_error_log_includes_class_code_and_retry_after(caplog) -> None
     """Decode-time RPCError logs carry enough non-sensitive CI diagnostics."""
     owner = _Owner()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise RateLimitError(
             "quota",
             method_id=RPCMethod.START_DEEP_RESEARCH.value,
@@ -1082,7 +1115,9 @@ async def test_decode_code_bug_propagates(
     decoder_exc = decoder_exc_factory()
     owner = _Owner()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise decoder_exc
 
     with pytest.raises(type(decoder_exc)) as raised:
@@ -1146,7 +1181,9 @@ async def test_decode_errors_metric_increments_on_wrapped_shape_drift(
     """The wrap branch (bad JSON / missing key-or-index) bumps the counter."""
     owner = _Owner()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise decoder_exc_factory()
 
     with pytest.raises(RPCError):
@@ -1180,7 +1217,9 @@ async def test_decode_errors_metric_increments_on_surfaced_drift(
     owner = _Owner()
     drift_exc = drift_exc_factory()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise drift_exc
 
     with pytest.raises(DecodingError) as raised:
@@ -1204,7 +1243,9 @@ async def test_decode_errors_metric_not_bumped_for_non_drift_rpc_error() -> None
     """
     owner = _Owner()
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         raise RateLimitError("quota", method_id=RPCMethod.LIST_NOTEBOOKS.value)
 
     with pytest.raises(RateLimitError):
@@ -1231,7 +1272,9 @@ async def test_decode_errors_metric_not_counted_when_recovered_by_retry() -> Non
     owner = _Owner(refresh_callback=refresh_callback)
     decode_calls = 0
 
-    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+    def decode(
+        _: str, __: str, *, allow_null: bool = False, raise_on_null_status: bool = False
+    ) -> Any:
         nonlocal decode_calls
         decode_calls += 1
         if decode_calls == 1:

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -297,7 +297,14 @@ async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeyp
     def decode(
         raw: str, rpc_id: str, *, allow_null: bool = False, raise_on_null_status: bool = False
     ) -> dict[str, Any]:
-        decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
+        decode_calls.append(
+            {
+                "raw": raw,
+                "rpc_id": rpc_id,
+                "allow_null": allow_null,
+                "raise_on_null_status": raise_on_null_status,
+            }
+        )
         return {"ok": True}
 
     result = await _executor(owner, decode_response=decode)._execute_once(
@@ -307,6 +314,7 @@ async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeyp
         True,
         False,
         disable_internal_retries=True,
+        raise_on_null_status=True,
     )
 
     assert result == {"ok": True}
@@ -320,7 +328,19 @@ async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeyp
     body = httpx.QueryParams(owner.perform_calls[0]["body"])
     assert body["at"] == "CSRF_SNAPSHOT"
     assert '"OverrideRpc"' in body["f.req"]
-    assert decode_calls == [{"raw": "raw", "rpc_id": "OverrideRpc", "allow_null": True}]
+    # ``raise_on_null_status`` is asserted here because this is the ONLY link
+    # between "the call site asked for strictness" and "the decoder received
+    # it" — the end-to-end tests replace ``rpc_call``, which sits above the
+    # executor. Dropping the kwarg at the decode call left the whole suite
+    # green before this assertion existed (#2188).
+    assert decode_calls == [
+        {
+            "raw": "raw",
+            "rpc_id": "OverrideRpc",
+            "allow_null": True,
+            "raise_on_null_status": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -858,6 +878,12 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         assert _is_retry is True
         assert disable_internal_retries is True
         assert operation_variant is None
+        # The post-refresh retry must inherit the per-call options, not silently
+        # fall back to the module defaults. This repo has already shipped that
+        # exact bug once — ``read_timeout`` was dropped here in the #2187 PR and
+        # only caught in review — so both are pinned (#2188).
+        assert read_timeout == 45.0
+        assert raise_on_null_status is True
         return {"ok": True}
 
     # ADR-0014 Rule 5 (Wave 4): executor calls ``self._auth_refresh.await_refresh()``
@@ -874,6 +900,8 @@ async def test_constructor_injected_sleep_drives_executor(monkeypatch) -> None:
         True,
         RPCError("auth"),
         disable_internal_retries=True,
+        read_timeout=45.0,
+        raise_on_null_status=True,
         _refresh_budget=RefreshBudget(),
     )
 

--- a/tests/unit/test_runtime_contracts.py
+++ b/tests/unit/test_runtime_contracts.py
@@ -111,6 +111,7 @@ def test_rpc_caller_signature_matches_legacy_session_rpc_call() -> None:
         "disable_internal_retries",
         "operation_variant",
         "read_timeout",
+        "raise_on_null_status",
     ]
     assert sig.parameters["source_path"].default == "/"
     assert sig.parameters["allow_null"].default is False
@@ -124,6 +125,11 @@ def test_rpc_caller_signature_matches_legacy_session_rpc_call() -> None:
     # lowering the client-wide default for every other RPC.
     assert sig.parameters["read_timeout"].kind is inspect.Parameter.KEYWORD_ONLY
     assert sig.parameters["read_timeout"].default is None
+    # #2188: opt-in strictness for ``allow_null`` callers — a null result the
+    # server tagged with a non-OK google.rpc.Status raises instead of decoding
+    # to None, so an artifact rejection reports the server's reason.
+    assert sig.parameters["raise_on_null_status"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["raise_on_null_status"].default is False
 
 
 def test_kernel_protocol_signatures_are_pinned() -> None:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -735,6 +735,27 @@ def test_user_displayable_error_payload_raises_same_chat_error_message() -> None
         raise_if_rate_limited(payload)
 
 
+def test_user_displayable_error_payload_surfaces_server_message_when_present() -> None:
+    """``google.rpc.Status.message`` beats the client-authored sentence (#2188).
+
+    No captured chat rejection has ever populated index 1 — the test above pins
+    the wording users actually see. This one pins that a server-authored reason
+    would take precedence rather than being discarded.
+    """
+    payload = [
+        8,
+        "You have reached your daily chat limit",
+        [["type.googleapis.com/google.rpc.UserDisplayableError", "details"]],
+    ]
+
+    with pytest.raises(ChatError) as exc_info:
+        raise_if_rate_limited(payload)
+
+    message = str(exc_info.value)
+    assert "You have reached your daily chat limit" in message
+    assert "Wait a few seconds and try again" not in message
+
+
 def _wrb_envelope(inner: Any) -> str:
     """Length-prefixed single-``wrb.fr``-frame body wrapping ``inner``."""
     return _length_prefixed(json.dumps([["wrb.fr", None, json.dumps(inner)]]))
@@ -817,6 +838,25 @@ def test_oversized_request_rejection_surfaces_status_not_parse_error() -> None:
 
     with pytest.raises(ChatError, match=r"rejected by the server \(status 3\)"):
         parse_streaming_chat_response(wire)
+
+
+def test_bare_rejection_surfaces_a_server_message_when_present() -> None:
+    """A request-level rejection echoes the server's own reason (#2188).
+
+    The captured #1472 rejection is a bare ``[3]`` with no message, so the
+    generic guidance above is what users see; this pins the alternative.
+    """
+    wire = _length_prefixed(
+        json.dumps([["wrb.fr", None, None, None, None, [3, "Question exceeds 100000 characters"]]])
+    )
+
+    with pytest.raises(ChatError) as exc_info:
+        parse_streaming_chat_response(wire)
+
+    message = str(exc_info.value)
+    assert "Question exceeds 100000 characters" in message
+    assert "status 3" in message
+    assert "shorten it and" not in message
 
 
 def test_null_inner_frame_with_empty_payload_still_raises_without_status() -> None:

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -736,11 +736,12 @@ def test_user_displayable_error_payload_raises_same_chat_error_message() -> None
 
 
 def test_user_displayable_error_payload_surfaces_server_message_when_present() -> None:
-    """``google.rpc.Status.message`` beats the client-authored sentence (#2188).
+    """``google.rpc.Status.message`` is surfaced ALONGSIDE the client guidance (#2188).
 
     No captured chat rejection has ever populated index 1 — the test above pins
     the wording users actually see. This one pins that a server-authored reason
-    would take precedence rather than being discarded.
+    is appended rather than discarded, and that appending it does not cost the
+    client's remedy.
     """
     payload = [
         8,

--- a/tests/unit/test_streaming_chat_wire.py
+++ b/tests/unit/test_streaming_chat_wire.py
@@ -753,7 +753,10 @@ def test_user_displayable_error_payload_surfaces_server_message_when_present() -
 
     message = str(exc_info.value)
     assert "You have reached your daily chat limit" in message
-    assert "Wait a few seconds and try again" not in message
+    # APPENDED, not substituted: nobody has ever seen this slot populated, so
+    # there is no evidence a server message would be as actionable as the
+    # remedy it would displace (#2188).
+    assert "Wait a few seconds and try again" in message
 
 
 def _wrb_envelope(inner: Any) -> str:
@@ -856,7 +859,23 @@ def test_bare_rejection_surfaces_a_server_message_when_present() -> None:
     message = str(exc_info.value)
     assert "Question exceeds 100000 characters" in message
     assert "status 3" in message
-    assert "shorten it and" not in message
+    # The client's guidance is kept alongside the server's words, not replaced.
+    assert "shorten it and" in message
+
+
+def test_message_without_a_status_is_still_surfaced() -> None:
+    """``[None, "text"]`` — a reason with no code. The reason still reaches the user."""
+    wire = _length_prefixed(
+        json.dumps([["wrb.fr", None, None, None, None, [None, "Try a shorter question"]]])
+    )
+
+    with pytest.raises(ChatError) as exc_info:
+        parse_streaming_chat_response(wire)
+
+    message = str(exc_info.value)
+    assert "Try a shorter question" in message
+    # No code, so no "(status …)" detail is fabricated.
+    assert "status" not in message.split("The server said:")[0].lower()
 
 
 def test_null_inner_frame_with_empty_payload_still_raises_without_status() -> None:


### PR DESCRIPTION
Closes #2193
Closes #2188

Both issues are about the same thing: **where an artifact failure reason actually comes from**. A live probe answered it, and the answer changed the shape of the fix.

## What the wire actually says

`wrb.fr` index 5 is a JSON-array-encoded **`google.rpc.Status`** — the public `google/rpc/status.proto`, not a Tailwind message. Positions are tags minus one: `code`→0, `message`→1, `details`→2. Index 0 and index 2 are live-confirmed; index 1 has **never** been observed populated.

Live probe, 2026-08-13, `NOTEBOOKLM_PROFILE=peopleconf`, one temporary empty notebook (deleted after):

```
generate_audio on a source-less notebook
  RAW: )]}'\n\n104\n[["wrb.fr","R7cb6c",null,null,null,[3],"generic"],...]
  before: ArtifactFeatureUnavailableError: Audio generation is unavailable
```

The server said **INVALID_ARGUMENT**. The client threw that away and substituted its own guess. `decode_response`'s `allow_null=True` path returned `None` *before* consulting index 5 — so #2188's "the sync rejection path discards `google.rpc.Status`" is not hypothetical, it fires on ordinary traffic.

## #2188 — stop discarding the status

New opt-in `raise_on_null_status`, threaded `decode_response` → `RpcExecutor.rpc_call`/`_execute_once`/`try_refresh_and_retry` → `RpcCaller` → `client.rpc_call`. `CREATE_ARTIFACT`, `RETRY_ARTIFACT` and `REVISE_SLIDE` opt in — **all three live-verified**, retry and revise answering `[5]` NOT_FOUND for an unknown artifact id. Post-fix probe on this branch:

```
  decode kwargs: {'allow_null': True, 'raise_on_null_status': True}
  RPCError: The server rejected this request (invalid argument).  rpc_code=3
```

It is opt-in rather than blanket because **three other RPCs are recorded doing the same thing on flows this client reports as successful**:

| RPC | status | cassette |
|---|---|---|
| `SHARE_NOTEBOOK` | `[3]` | `cli_share_add.yaml`, `cli_share_remove.yaml` |
| `SHARE_ARTIFACT` | `[3]` | `notebooks_share.yaml` |
| `REMOVE_RECENTLY_VIEWED` | `[13]` | `notebooks_remove_from_recent.yaml` |

Only the last has ever been reasoned about (a cosmetic no-op). **Whether the two share rejections are benign, or a refusal being reported as a successful share, is an open question this PR deliberately does not answer** — it is recorded in `docs/rpc-reference.md` and the CHANGELOG, and a swallowed status now logs at DEBUG so they are findable. Worth a follow-up issue.

### `google.rpc.Status.message`

Now read on both the batchexecute and streamed-chat paths. Read defensively — non-empty `str` only, whitespace collapsed, capped at 300 chars, non-string warns. Composition differs by site and the difference is deliberate: the rate-limit message **leads** with the server text (its client sentence is a guess at what a `UserDisplayableError` means, so server words are strictly better), while the bare-status path and both streamed-chat sites **append** it and keep their client-authored remedy — nobody has seen the slot populated, so there is no evidence a server sentence would be as actionable as the advice it would displace.

**Be precise about what this changes: nothing users see today.** No captured response has ever populated the slot. Every rejection sentence this client prints — including *"API rate limit or quota exceeded. Please wait before retrying."* — is **client-authored**. The recorded `UserDisplayableError` sample holds `None` at index 1 and an int-only detail body; there is no server string in it. That is recorded in `tests/_guardrails/_wire_contract.py` as *unobserved*, not *unknown*.

### Async FAILED artifacts: nothing is possible, and here is why

`Artifact` in `docs/mobile/schema.proto` has **no error or failure field**. An artifact accepted at create time that later flips to `ARTIFACT_STATUS_FAILED` carries nothing; no cassette contains a status-4 row at all. `RETRY_ARTIFACT` existing is consistent with the backend not persisting a reason. So `error=None` is the correct surface and the generic `"{Type} generation failed"` fallback is the honest ceiling — documented rather than papered over with an invented field.

### The headline finding: #2188's premise is partly refuted by the wire

`google.rpc.Status.message` **has never been observed populated.** Five live captures on 2026-08-13 (`CREATE_ARTIFACT` `[3]`, `RETRY_ARTIFACT` `[5]`, `REVISE_SLIDE` `[5]`, and two earlier `CREATE_ARTIFACT` runs) plus **all 5 null-result frames across 141 cassettes** carry a status code and nothing else — length-1 arrays, or `null` at index 1 in the one recorded `UserDisplayableError` sample.

So the answer to "is a specific server-authored reason being thrown away?" is **no, there is nothing there to throw away.** What *was* being thrown away is the status **code**, and that is what this PR recovers. **No user-visible message in this client is server-authored** — not "The server rejected this request (invalid argument).", not "API rate limit or quota exceeded. Please wait before retrying.". Both are this client's own words.

The `message` read still ships, because it costs nothing when the slot is empty and the envelope is a public proto whose siblings at index 0 and 2 are both live-confirmed. But it is recorded as **unobserved, not unknown** in `tests/_guardrails/_wire_contract.py`, and anyone reading a bug report should assume the wording came from this repo, not from Google.

## #2193 — #239's guard, rebuilt against the path that carries a reason

Both new suites drive the **real decoder unmocked**. The recorded `UserDisplayableError` rejection and the **verbatim live** `INVALID_ARGUMENT` / `NOT_FOUND` bodies are decoded and asserted at the `generate_audio` / `retry` / `revise_slide` boundary. The surviving behaviour is pinned too: a late-FAILED poll carries no reason and renders as `"Audio generation failed"` via `_app/generate_retry.py`.

Captured frames now live in one place with per-entry provenance (`tests/_fixtures/rpc_error_frames.py`), including the negative result: **`GENERATE_MIND_MAP` on a source-less notebook is not refused at all** — it generates — so that call site has no observed rejection shape and is deliberately *not* opted in.

## Review, and one correction I had to make to myself

Reviewed by `code-reviewer`, `pr-test-analyzer` and `silent-failure-hunter` before opening, then by `codex` (2 × P2) and `coderabbit` (4) and `claude` on the PR — all six threads addressed and resolved. They caught real things:

- **My cassette sweep was wrong.** I grouped frames by shape and read only the first example, so I reported the `[3]` frames as all belonging to streamed chat. Re-swept per frame: they are `SHARE_NOTEBOOK` and `SHARE_ARTIFACT`. The WARNING level I had added would have fired on ordinary `share add` traffic. Corrected to DEBUG, with the real list on the record.
- **MCP `studio_retry`** kept catching only `ArtifactFeatureUnavailableError`, so the "artifact is not failed" enrichment (#1924 F15) died for exactly the refusals that now carry a status. Broadened, with an ADR-0019-ordered `except (AuthError, RateLimitError, ServerError, NetworkError, DecodingError): raise` first so a quota/auth/drift failure is never relabelled.
- **Executor→decoder threading had no test** — dropping the kwarg left all 15,930 tests green. Now pinned, along with the auth-retry recursion (the #2187 trap).
- **`_find_wrb_status` stopped at the first null-result frame** (Codex P2, and I caught the same thing independently) — in a multi-frame `rt=c` response an earlier unclassifiable payload could hide a later real `[3]`/`[5]`, putting an opted-in caller straight back on the client guess. The walk now collects every payload and scans for the first that classifies.
- **Widening the MCP catch to `RPCError` introduced a new mis-attribution** (Codex P2): a bare `[7]` PERMISSION_DENIED decodes to `ClientError` and `[14]` UNAVAILABLE to a plain `RPCError`, so both would have been rewritten as "artifact is not failed". The relabel is now restricted to `ArtifactFeatureUnavailableError` / `INVALID_ARGUMENT` / `FAILED_PRECONDITION`.
- Two reviewers asked me to "correct" the live fixtures' byte counts (they declare 104/25 for 102/23-char chunks; one hand-counted retry and revise as +1). Measured from the fixtures: **all three are +2 on both chunks**, and five independent captures now agree. It is verbatim server framing, so it stays — and `TestLiveCapturedFraming` is parametrized over all three bodies, so nobody synthesises it away by accident.
- **The cassette arithmetic did not close** (CodeRabbit): 5 null-result frames, 4 enumerated. Both true — the fifth is the streamed-chat `[3]`, which carries no rpc id and never reaches `decode_response`. Now stated instead of dangling.

## Verification

- `pytest -n auto --dist loadgroup --cov --cov-fail-under=90` → **15,966 passed**, 96.72% (exit code checked directly, not through a pipe)
- `mypy src/notebooklm --ignore-missing-imports` → clean
- `pre-commit run --all-files` → clean
- **35 mutations run, all detected** — every behaviour change was reverted one at a time and the covering test confirmed to fail, six against the specific target node id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional strict status handling so server rejection details can be surfaced instead of returning empty results.
  * Artifact generation, retries, and slide revisions now include available server-provided reasons.
* **Bug Fixes**
  * Preserved and sanitized server messages in rate-limit and request-rejection errors.
  * Improved quota-failure handling and generic messaging for failed artifacts.
* **Documentation**
  * Documented rejection statuses, strict handling, error behavior, and source-less generation outcomes.
* **Tests**
  * Added regression coverage for rejection statuses, server messages, quota failures, and fallback errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

