### PR TITLE
test(auth): stop asserting on ambient exception-chaining state (#2224)

### DIFF
--- a/tests/unit/test_auth_master_token_bootstrap.py
+++ b/tests/unit/test_auth_master_token_bootstrap.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import sys
 import threading
+import traceback
 from http.cookiejar import Cookie as HttpCookie
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -454,13 +454,27 @@ async def test_public_token_read_io_projection_with_outer_exception(tmp_path, lo
             await mt.remint_from_stored_token(tmp_path / "storage_state.json")
 
     error = raised.value
+    # ``__cause__`` and ``__suppress_context__`` are set explicitly by the
+    # projection (``raise ... from lower`` semantics) and ARE the contract.
     assert error.__cause__ is lower
-    expected_context = lower if sys.version_info >= (3, 13) else outer
-    assert error.__context__ is expected_context
     assert error.__suppress_context__ is True
+    assert not isinstance(error.__cause__, _BootstrapError)
     assert lower.__context__ is None
-    if sys.version_info >= (3, 13):
-        assert outer not in (error.__cause__, error.__context__)
+
+    # ``__context__`` is deliberately NOT asserted here (#2224). CPython
+    # re-chains an exception as it propagates out of a coroutine, so the value
+    # a caller observes depends on ambient exception state and await depth --
+    # not on the code under test. Measured: it flips between the first and a
+    # later invocation *within one process on one interpreter*, which is why
+    # the old ``sys.version_info >= (3, 13)`` branch could not stabilise it.
+    #
+    # What the projection actually owes the user is asserted instead, and is
+    # invariant: because the context is suppressed, the rendered traceback
+    # shows the real cause and never leaks the caller's unrelated exception.
+    rendered = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    assert str(lower) in rendered
+    assert "active caller" not in rendered
+    assert "_BootstrapError" not in rendered
 
 
 @pytest.mark.parametrize("active_outer", [False, True])
@@ -489,10 +503,18 @@ async def test_public_malformed_projection_preserves_ordinary_context(
         error = await invoke()
 
     assert error.__cause__ is None
-    expected_context = outer if active_outer and sys.version_info >= (3, 13) else None
-    assert error.__context__ is expected_context
     assert error.__suppress_context__ is False
+    # Same reasoning as #2224 above: the *identity* of ``__context__`` under an
+    # active outer exception is ambient, so only the leak contract is asserted
+    # -- no private bootstrap/record shape may reach the caller, by type or by
+    # rendered text. With no outer exception active there is nothing ambient to
+    # pick up, so that arm still pins the exact value.
     assert not isinstance(error.__context__, (_BootstrapError, _MasterTokenRecordError))
+    if not active_outer:
+        assert error.__context__ is None
+    rendered = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    assert "private shape" not in rendered
+    assert "_MasterTokenRecordError" not in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_master_token_bootstrap.py
+++ b/tests/unit/test_auth_master_token_bootstrap.py
@@ -460,6 +460,15 @@ async def test_public_token_read_io_projection_with_outer_exception(tmp_path, lo
     assert error.__suppress_context__ is True
     assert not isinstance(error.__cause__, _BootstrapError)
     assert lower.__context__ is None
+    # The public-chain sanitization contract, asserted directly rather than
+    # inferred from the rendered traceback (#2229 review). *Which* exception
+    # ``__context__`` holds is ambient — that is the whole point of #2224 — but
+    # it must never be the private ``_BootstrapError`` in any of them. A
+    # regression that re-chained the private error here would satisfy every
+    # other assertion above: ``__suppress_context__`` is true, so
+    # ``format_exception`` follows ``__cause__`` and omits the context entirely,
+    # leaving the rendered-output check blind to it.
+    assert not isinstance(error.__context__, _BootstrapError)
 
     # ``__context__`` is deliberately NOT asserted here (#2224). CPython
     # re-chains an exception as it propagates out of a coroutine, so the value

--- a/tests/unit/test_auth_master_token_bootstrap.py
+++ b/tests/unit/test_auth_master_token_bootstrap.py
@@ -515,6 +515,7 @@ async def test_public_malformed_projection_preserves_ordinary_context(
     rendered = "".join(traceback.format_exception(type(error), error, error.__traceback__))
     assert "private shape" not in rendered
     assert "_MasterTokenRecordError" not in rendered
+    assert "_BootstrapError" not in rendered
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause — established by measurement, not inference

The issue asked whether 3.14 changed chaining again (needing another version arm) or whether it is ambient state, noting *"the fix differs materially between them"*. It is **ambient state**. Evidence:

**1. Production sets `__context__` correctly; the caller observes something else.** Instrumenting `remint_from_stored_token` (`master_token.py:378-385`, which explicitly assigns `error.__context__ = error_snapshot[2]`):

```
PROBE final error.__context__= 4486872128 JSONDecodeError('bad json: ...')
  AT-CATCH   ctx= 4487211200 RuntimeError('active caller')
```

The value the projection assigns is not the value one frame up sees. CPython re-chains the exception as it propagates out of the coroutine.

**2. The value flips within one process, on one interpreter version.** Running the *unmodified* `origin/main` assertion body twice on **Python 3.13**:

```
test_current_assertion_holds_on_the_first_invocation  PASSED
test_current_assertion_holds_again_in_the_same_process FAILED
E   AssertionError: __context__ was outer, expected lower
```

Same interpreter, same production code, same test body — only the ordering differed. No version arm can stabilise that.

**3. 3.14 did not change chaining.** Run in isolation the existing test passes on **3.10, 3.11, 3.12, 3.13 and 3.14** as written — 3.14 already matches the `>= (3, 13)` arm. So the macOS 3.14 CI failure was *not* a new interpreter behaviour, and adding a 3.14 arm would have fixed nothing.

Full matrix (`__context__` observed vs. whether the replacement assertions hold):

| version | call #1 | call #2 | call #3 | replacement assertions |
|---|---|---|---|---|
| 3.10 | outer | outer | outer | all hold |
| 3.11 | outer | outer | outer | all hold |
| 3.12 | outer | outer | outer | all hold |
| 3.13 | **lower** | **outer** | outer | all hold |
| 3.14 | **lower** | **outer** | outer | all hold |

## What changed

`__cause__` and `__suppress_context__` are set explicitly by `raise ... from ...` and capture the real contract — **kept**, as the issue directed. Only the `__context__` identity assertion and its version branch are removed.

They are not simply deleted. In their place the tests assert the contract that is both **invariant** and **actually user-visible**: because the context is suppressed, the rendered traceback shows the real cause and never leaks the caller's unrelated exception or a private `_BootstrapError` / `_MasterTokenRecordError` shape.

**A second test carried the identical latent defect.** `test_public_malformed_projection_preserves_ordinary_context` has the same `sys.version_info >= (3, 13)` branch on `__context__`. I measured it rather than assuming: its `active_outer=True` arm is ambient-dependent (fails on repetition), its `active_outer=False` arm is stable. It gets the same treatment, and the stable arm still pins the exact value. Fixing only the reported test would have left an identical landmine for the next unlucky worker composition.

## Verification

The replacement assertions were stress-tested in exactly the ambient states that broke the old ones — repeated invocation, extra nested await depth, and execution inside an unrelated active exception — on **3.10 / 3.11 / 3.12 / 3.13 / 3.14**. All pass.

Then mutation-tested against **production**, to prove the tests were not weakened into vacuity:

| production mutation | result |
|---|---|
| projection stops suppressing context (ambient caller leaks into the traceback) | **4 fail** |
| projection drops `__cause__` | **4 fail** |
| private `_BootstrapError` leaks out as the cause | **6 fail** |
| malformed path leaks the private record error (`private shape` reaches the user) | **2 fail** |

Gates, exit codes read directly:

- `pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-fail-under=90` → **0** — 16150 passed, 64 skipped, 1 xfailed, **96.76%**
- `mypy src/notebooklm --ignore-missing-imports` → **0**
- `pre-commit run --all-files` → **0**

Test-only change; no live probe applicable.

Closes #2224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling validation to prevent internal exception details from appearing in error contexts or rendered tracebacks.
  * Updated malformed-error handling to reliably distinguish incidental context from protected error information.
  * Improved compatibility across Python interpreter versions by removing brittle exception identity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->