### PR TITLE
fix(sources): report a never-resolving processing failure, and make retained rows findable (#2138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,15 +415,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supported audio container; `.mp3` and `.m4a` are), which is exactly the shape
   that hits it.
 
-  Tolerating a transient error is a hypothesis, and the deadline is what
-  disproves it: if the last observed status was ERROR and the poll then ran out
-  of time, the source did not fail to answer — it answered ERROR, repeatedly,
-  until we gave up. `wait_until_ready`, `wait_until_registered`, and
-  `wait_all_until_ready` now resolve that case as `SourceProcessingError`
+  Tolerating a transient error is a hypothesis, and *sustained* ERROR right up
+  to the deadline is what disproves it: the source did not fail to answer — it
+  answered ERROR, over and over, until we gave up. `wait_until_ready`,
+  `wait_until_registered`, and `wait_all_until_ready` now resolve that case as
+  `SourceProcessingError`
   instead, naming the elapsed budget so *"ERROR throughout a 120s poll"* and
   *"ERROR on the last tick of a 2s poll"* stay distinguishable. A source still
   legitimately `PROCESSING` at the deadline is unchanged — still a timeout, so
-  slow sources are not relabelled as broken. Both types are `SourceError` and
+  slow sources are not relabelled as broken — and neither is a source seen in
+  ERROR only *once*. The conversion requires two consecutive ERROR observations
+  ending at the deadline, because a `timeout` is caller-chosen: a short one can
+  buy a single look at a source that is legitimately mid-transcription, and
+  calling that terminal would be a fabricated verdict, the mirror image of the
+  bug being fixed. The streak resets on any non-ERROR look, so a source that
+  polled PROCESSING and flipped to ERROR on the final tick still times out.
+  Both types are `SourceError` and
   every consumer already handles them side by side (`_app`'s wait outcomes, the
   MCP `source_wait` buckets, `notebooklm source wait`'s exit codes), so the
   `.wav` case moves from the "timed out, retry" bucket to "failed".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230)).
   ([#2211](https://github.com/teng-lin/notebooklm-py/issues/2211))
 
+- **`notebooklm source list --status <state>`** filters the listing to one
+  ingestion status — `ready`, `processing`, `error`, `preparing`, or `unknown`
+  — bringing the CLI to parity with the MCP `source_list` tool, which has had
+  the filter (including `preparing`) all along. The choices derive from
+  `SourceStatus` via the new `SOURCE_STATUS_LABELS`, so they cannot drift from
+  the labels the Status column renders, and the filter runs inside the fetch so
+  `--json`'s `count` always matches the rows shown. It composes with `--label`.
+
+  **`--status preparing` is the reconciliation query for orphaned sources.** A
+  file add that fails after its source row is registered leaves that row in
+  place on purpose — it is the evidence, and it still consumes notebook quota —
+  but the row sits at `preparing`, not `error`, so a caller looking under
+  `error` finds nothing. There was previously no supported way to reach those
+  rows from the CLI at all. Rows genuinely mid-upload report `preparing` too, so
+  the filter cannot by itself tell "abandoned" from "in flight"; re-run it and
+  act only on rows that persist. Nothing is auto-deleted — that posture is
+  deliberate ([#2110](https://github.com/teng-lin/notebooklm-py/issues/2110)).
+  ([#2138](https://github.com/teng-lin/notebooklm-py/issues/2138))
+
 - **Notebook sharing now reports the collaborator cap and the public-sharing
   policy gate.** `GET_SHARE_STATUS` returns an eight-slot response carrying six
   known response fields — five of them non-null on every row observed, the sixth
@@ -382,6 +401,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrong — so that pair is unaffected by this.
 
 ### Fixed
+
+- **A file whose processing fails after a clean upload no longer reports a
+  timeout.** When bytes transfer fine and NotebookLM's server-side processing
+  *then* fails, the source settles at `status=ERROR`. For audio and
+  still-unclassified sources (`type_code` 10 / 0 / `None`) a brief ERROR is
+  treated as transient — the poll waits it out rather than failing fast, which
+  is right, because those types really do report ERROR mid-transcription. But
+  the tolerance had no bound other than the deadline: `wait_until_ready` kept
+  polling to the timeout and raised `SourceTimeoutError`, so a genuine terminal
+  failure was reported as *"still working, ask again later"* and nothing
+  anywhere named it. Live-reproduced with a `.wav` upload (WAV is not a
+  supported audio container; `.mp3` and `.m4a` are), which is exactly the shape
+  that hits it.
+
+  Tolerating a transient error is a hypothesis, and the deadline is what
+  disproves it: if the last observed status was ERROR and the poll then ran out
+  of time, the source did not fail to answer — it answered ERROR, repeatedly,
+  until we gave up. `wait_until_ready`, `wait_until_registered`, and
+  `wait_all_until_ready` now resolve that case as `SourceProcessingError`
+  instead, naming the elapsed budget so *"ERROR throughout a 120s poll"* and
+  *"ERROR on the last tick of a 2s poll"* stay distinguishable. A source still
+  legitimately `PROCESSING` at the deadline is unchanged — still a timeout, so
+  slow sources are not relabelled as broken. Both types are `SourceError` and
+  every consumer already handles them side by side (`_app`'s wait outcomes, the
+  MCP `source_wait` buckets, `notebooklm source wait`'s exit codes), so the
+  `.wav` case moves from the "timed out, retry" bucket to "failed".
+  ([#2138](https://github.com/teng-lin/notebooklm-py/issues/2138))
 
 - **An idempotency probe that cannot answer no longer retries the create.**
   All four `PROBE_THEN_CREATE` paths — `notebooks.create`, `sources.add_url`,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -185,7 +185,7 @@ All `source` subcommands also accept `-n/--notebook ID` (resolves via flag > `NO
 
 `source list --status <state>` restricts the listing to one ingestion status — `ready`, `processing`, `error`, `preparing`, or `unknown`. The choices are derived from `SourceStatus`, so they cannot drift from the labels the Status column renders, and the filter is applied inside the fetch, so `count` in `--json` always matches the rows shown. It composes with `--label`.
 
-##### Finding orphaned sources (`--status preparing`)
+#### Finding orphaned sources (`--status preparing`)
 
 A file add that fails *after* its source row is registered leaves that row in place deliberately — it is the evidence of what happened, and it still counts against the notebook's source quota. The row sits at `preparing`, **not** `error`, so the status a caller reaches for first finds nothing ([#2138](https://github.com/teng-lin/notebooklm-py/issues/2138)):
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -155,7 +155,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 
 | Command | Arguments | Options | Example |
 |---------|-----------|---------|---------|
-| `list` | - | `--json`, `--limit N`, `--no-truncate` | `source list --limit 20 --no-truncate` |
+| `list` | - | `--json`, `--limit N`, `--no-truncate`, `--label`, `--status` | `source list --limit 20 --no-truncate` |
 | `add <content>` | URL/file/text (use `-` for stdin) | `--title`, `--type`, `--timeout`, `--follow-symlinks`, `--allow-internal` (URL sources only), `--json` (file-source `--mime-type` overrides extension inference — see [detailed section](#source-add-mime-type-file-sources)) | `source add "https://..." --timeout 90` |
 | `add-drive <id> <title>` | Drive file ID, title | `--mime-type [google-doc\|google-slides\|google-sheets\|pdf]`, `--json` | `source add-drive abc123 "Doc" --mime-type google-slides` |
 | `add-drive-file <id>` | Drive file ID or share URL | `--title`, `--wait`, `--json` | `source add-drive-file abc123 --title "Notes" --wait` |
@@ -182,6 +182,21 @@ All `source` subcommands also accept `-n/--notebook ID` (resolves via flag > `NO
 `source stale` reports whether a URL/Drive source needs a refresh. By default it follows the standard CLI exit convention (`0` on success, `1` on error); branch on the JSON `stale`/`fresh` fields (or stdout text) for the freshness verdict. Pass `--exit-on-stale` to opt into the back-compat inverted predicate (`0` = stale, `1` = fresh) for shell idioms like `if notebooklm source stale --exit-on-stale ID; then refresh; fi`.
 
 `source list` also accepts `--label <id|name>` to list only the sources in a given label (a saved selection). The selector resolves a label id (or partial prefix) **or** an exact label name; see [Label Commands](#label-commands-notebooklm-label-cmd).
+
+`source list --status <state>` restricts the listing to one ingestion status — `ready`, `processing`, `error`, `preparing`, or `unknown`. The choices are derived from `SourceStatus`, so they cannot drift from the labels the Status column renders, and the filter is applied inside the fetch, so `count` in `--json` always matches the rows shown. It composes with `--label`.
+
+##### Finding orphaned sources (`--status preparing`)
+
+A file add that fails *after* its source row is registered leaves that row in place deliberately — it is the evidence of what happened, and it still counts against the notebook's source quota. The row sits at `preparing`, **not** `error`, so the status a caller reaches for first finds nothing ([#2138](https://github.com/teng-lin/notebooklm-py/issues/2138)):
+
+```bash
+notebooklm source list --status preparing        # the reconciliation query
+notebooklm source delete <id>                    # once you have confirmed it is stuck
+```
+
+Rows that are genuinely mid-upload also report `preparing`, so this filter cannot by itself tell "abandoned" from "in flight" — re-run it a minute apart and act only on rows that persist. Nothing is deleted automatically; that posture is deliberate (see [#2110](https://github.com/teng-lin/notebooklm-py/issues/2110)).
+
+When the failing add raised in your own process, you do not need to search at all: the exception carries the retained row's id directly, via `getattr(exc, "source_id", None)`.
 
 #### Drive-backed sources in `source list` / `source get`
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -419,6 +419,8 @@ Pass `wait=True` to have `add_file()` do this for you.
 **Reconciling what a failed add left behind.** A row registered by an add that then failed is deliberately *not* deleted — it is the evidence, and it still counts against the notebook's source quota. It sits at `SourceStatus.PREPARING`, not `ERROR`, so filtering for error status will not find it:
 
 ```python
+from notebooklm import SourceStatus
+
 stuck = [s for s in await client.sources.list(nb_id) if s.status is SourceStatus.PREPARING]
 ```
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -392,6 +392,38 @@ except NotFoundError as e:
     print(f"Missing resource: {e}")
 ```
 
+#### Processing failures vs. timeouts
+
+`SourceProcessingError` means *this source will not become ready*; `SourceTimeoutError` means *it had not become ready yet*. The distinction matters because only the second is worth waiting on again.
+
+A source whose `type_code` is audio (`10`) or still unclassified (`0` / `None`) may report `status=ERROR` briefly while it is being transcribed or classified, so the waiters tolerate that rather than failing fast. That tolerance is bounded by your `timeout`: if the last status observed was `ERROR` and the poll then ran out of time, the waiters raise **`SourceProcessingError`**, not `SourceTimeoutError` ([#2138](https://github.com/teng-lin/notebooklm-py/issues/2138)). The source answered `ERROR` repeatedly until the deadline; reporting that as a timeout would invite an endless retry.
+
+This is the route a file whose *processing* fails takes. `add_file()` returns as soon as the bytes are transferred — with `wait=False` (the default) it does not poll at all, and the `status=PROCESSING` on the returned `Source` is a placeholder, not an observation. So a post-transfer processing failure is only ever visible through a wait:
+
+```python
+from notebooklm import SourceProcessingError, SourceTimeoutError
+
+source = await client.sources.add_file(nb_id, "recording.wav")
+try:
+    ready = await client.sources.wait_until_ready(nb_id, source.id, timeout=300)
+except SourceProcessingError as exc:
+    # Terminal: the format was rejected, the content was unreadable, etc.
+    # The row is retained server-side; see the reconciliation note below.
+    print(f"will not become ready: {exc}")
+except SourceTimeoutError:
+    print("still processing; poll again later")
+```
+
+Pass `wait=True` to have `add_file()` do this for you.
+
+**Reconciling what a failed add left behind.** A row registered by an add that then failed is deliberately *not* deleted — it is the evidence, and it still counts against the notebook's source quota. It sits at `SourceStatus.PREPARING`, not `ERROR`, so filtering for error status will not find it:
+
+```python
+stuck = [s for s in await client.sources.list(nb_id) if s.status is SourceStatus.PREPARING]
+```
+
+(or `notebooklm source list --status preparing` from the CLI). Rows genuinely mid-upload also report `PREPARING`, so re-read before deleting. When the failing add raised in your own process you do not need to search: the exception carries the id directly, as `getattr(exc, "source_id", None)`.
+
 Methods that *raise* a `*NotFoundError` on not-found include every namespace
 `get()` (as of v0.8.0 — `client.notebooks.get`, `client.sources.get`,
 `client.artifacts.get`, `client.notes.get`, `client.mind_maps.get`),
@@ -1209,7 +1241,7 @@ print(url)
 | `refresh(notebook_id, source_id)` | `str, str` | `None` | Refresh URL/Drive source |
 | `check_freshness(notebook_id, source_id)` | `str, str` | `bool` | Check if source needs refresh |
 | `delete(notebook_id, source_id)` | `str, str` | `None` | Delete source (idempotent; returns `None` whether or not it existed) |
-| `wait_until_ready(notebook_id, source_id, timeout=120.0, ...)` | `str, str, float, ...` | `Source` | Poll until `status == READY` (fully processed). Raises `SourceTimeoutError`/`SourceProcessingError`/`SourceNotFoundError`. |
+| `wait_until_ready(notebook_id, source_id, timeout=120.0, ...)` | `str, str, float, ...` | `Source` | Poll until `status == READY` (fully processed). Raises `SourceTimeoutError`/`SourceProcessingError`/`SourceNotFoundError` — see [Processing failures vs. timeouts](#processing-failures-vs-timeouts). |
 | `wait_until_registered(notebook_id, source_id, timeout=30.0, ...)` | `str, str, float, ...` | `Source` | Poll until the source is visible server-side (any non-ERROR status). Completes quickly (seconds for typical sources); intended for narrow follow-up RPCs (e.g. `UPDATE_SOURCE`) that only require registration, not full processing. |
 | `wait_for_sources(notebook_id, source_ids, timeout=120.0, **kwargs)` | `str, list[str], float, ...` | `list[Source]` | Wait for multiple sources to become ready **in parallel**. Per-source timeout; `**kwargs` are forwarded to `wait_until_ready`. |
 | `wait_all_until_ready(notebook_id, source_ids, timeout=120.0, initial_interval=1.0, max_interval=10.0, backoff_factor=1.5, transient_error_types=None)` | `str, list[str], float, ...` | `list[SourceWaitResult]` | Wait for many sources with **one notebook snapshot per poll tick** (cheaper than `wait_for_sources`'s per-source polling for large batches). Terminal per-source failures (`SourceNotFoundError` / `SourceProcessingError` / `SourceTimeoutError`) are **returned**, not raised — one result per id, in input order. |

--- a/src/notebooklm/_app/source_listing.py
+++ b/src/notebooklm/_app/source_listing.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from ..types import Source
+from ..types import Source, source_status_to_str
 
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
@@ -40,8 +40,9 @@ async def fetch_sources(
     label_filter: str | None,
     label_resolver: LabelResolver,
     json_output: bool = False,
+    status_filter: str | None = None,
 ) -> list[Source]:
-    """Fetch the notebook's sources, optionally restricted to one label's members.
+    """Fetch the notebook's sources, optionally restricted by label and/or status.
 
     When ``label_filter`` is set, the injected ``label_resolver`` resolves the
     ``<id|name>`` token and the group's members are fetched via
@@ -50,6 +51,19 @@ async def fetch_sources(
     filtered set with no post-filter desync. Otherwise the full notebook source
     list is returned.
 
+    ``status_filter`` is a ``source_status_to_str`` label (``ready``,
+    ``processing``, ``error``, ``preparing``, ``unknown``) and is applied here,
+    inside the fetch, for the same count/rows reason. It composes with
+    ``label_filter``: both narrow the same set.
+
+    ``preparing`` is the one worth naming (#2138). A file add that fails after
+    its source row is registered deliberately leaves that row in place rather
+    than deleting it — the row is the evidence — but it sits at ``PREPARING``,
+    not ``ERROR``, so a caller looking for the wreckage under ``error`` finds
+    nothing and the row stays invisible while still counting against the
+    notebook's source quota. Filtering on ``preparing`` is the reconciliation
+    query: "what did my failed adds leave behind?"
+
     ``json_output`` is forwarded to the resolver only (it tunes the resolver's
     own diagnostic routing); this function performs no rendering.
     """
@@ -57,8 +71,14 @@ async def fetch_sources(
         label_id = await label_resolver(client, notebook_id, label_filter, json_output=json_output)
         # ``labels.sources()`` returns the group's members (joined from a single
         # ``sources.list()``), so the filtered set is fetched once.
-        return await client.labels.sources(notebook_id, label_id)
-    return await client.sources.list(notebook_id)
+        sources = await client.labels.sources(notebook_id, label_id)
+    else:
+        sources = await client.sources.list(notebook_id)
+    if status_filter is not None:
+        # Compare on the same rendered label the rows themselves show, so what a
+        # caller reads in the Status column is exactly what they can filter on.
+        sources = [src for src in sources if source_status_to_str(src.status) == status_filter]
+    return sources
 
 
 __all__ = ["LabelResolver", "fetch_sources"]

--- a/src/notebooklm/_source/polling.py
+++ b/src/notebooklm/_source/polling.py
@@ -21,20 +21,29 @@ from ..types import Source, SourceNotFoundError, SourceProcessingError, SourceTi
 _TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 
 
+#: How many *consecutive* ERROR observations, ending at the deadline, count as
+#: evidence that a tolerated transient error is really terminal. One is not
+#: enough: a caller may pass a short ``timeout`` and get a single look at a
+#: source that is legitimately mid-transcription, and a deadline proves only
+#: that the wait budget expired — never that the backend state is final.
+_MIN_SUSTAINED_ERROR_POLLS = 2
+
+
 def _expiry_error(
     source_id: str,
     timeout: float,
     last_status: int | None,
+    *,
+    error_streak: int = 0,
 ) -> SourceProcessingError | SourceTimeoutError:
     """Report the failure actually observed at the deadline, not merely "time ran out".
 
     Tolerating a transient ERROR (see ``_TRANSIENT_ERROR_TYPES``) is a
     *hypothesis*: an audio or still-unclassified source may report status=3
     briefly while it is being transcribed/classified, so the poll keeps going
-    rather than failing fast. The deadline is what disproves that hypothesis. If
-    the last status observed was ERROR and the poll then ran out of time, the
-    source did not fail to answer — it answered ERROR, repeatedly, until we gave
-    up. Calling that a timeout misdiagnoses it.
+    rather than failing fast. Sustained ERROR right up to the deadline is what
+    disproves it — the source did not fail to answer, it answered ERROR, over
+    and over, until we gave up. Calling that a timeout misdiagnoses it.
 
     This is the #2138 ``.wav`` route. A WAV uploads cleanly (bytes transfer
     fine) and processing then ends at ``status=ERROR`` with ``type_code=0``,
@@ -43,6 +52,18 @@ def _expiry_error(
     processing failure. Callers reasonably read a timeout as "still working, ask
     again later" and retry forever.
 
+    **"Sustained" is load-bearing, and ``error_streak`` is what measures it.**
+    A deadline is caller-chosen and can be short: ``wait_until_ready(timeout=2)``
+    on a source that is legitimately mid-transcription may get exactly one look,
+    see ERROR, and expire — and that source may still reach READY seconds later.
+    Reporting it as a terminal processing failure would be a fabricated verdict,
+    the mirror image of the bug this fixes. So the conversion requires
+    :data:`_MIN_SUSTAINED_ERROR_POLLS` *consecutive* ERROR observations ending
+    at the deadline; anything less stays a timeout, which is the honest answer
+    when all we know is that the budget ran out. The streak resets on any
+    non-ERROR observation, so a source that was PROCESSING and only flipped to
+    ERROR on the final tick is a timeout too.
+
     Both types are :class:`~notebooklm.exceptions.SourceError`, and every
     consumer in this repo already handles them side by side (``_app``'s
     ``SourceWaitOutcome`` buckets, the MCP ``_waitagg`` mapper, ``notebooklm
@@ -50,20 +71,20 @@ def _expiry_error(
     lands in — from "timed out, try again" to "failed" — rather than adding an
     unhandled shape.
 
-    The timeout is still named in the message, because "ERROR throughout a 120 s
-    poll" and "ERROR on the last tick of a 2 s poll" are different claims and
-    the reader needs to know which one this is.
+    The elapsed budget stays in the message: "ERROR throughout a 120 s poll" and
+    "ERROR across two ticks of a 3 s poll" are different claims, and the reader
+    needs to know which one this is.
     """
-    if last_status == SourceStatus.ERROR:
+    if last_status == SourceStatus.ERROR and error_streak >= _MIN_SUSTAINED_ERROR_POLLS:
         return SourceProcessingError(
             source_id,
             last_status,
             message=(
                 f"Source {source_id} failed to process: still reporting ERROR after "
-                f"{timeout:.1f}s. Its type is one for which a brief ERROR is treated as "
-                "transient, so the poll waited it out; it never resolved, so the failure "
-                "is terminal. The source row is retained server-side — list the notebook's "
-                "sources to find it."
+                f"{timeout:.1f}s ({error_streak} consecutive polls). Its type is one for "
+                "which a brief ERROR is treated as transient, so the poll waited it out; "
+                "it never resolved, so the failure is treated as terminal. The source row "
+                "is retained server-side — list the notebook's sources to find it."
             ),
         )
     return SourceTimeoutError(source_id, timeout, last_status)
@@ -107,6 +128,10 @@ class SourcePoller:
         deadline = RuntimeDeadline.start(timeout, monotonic=monotonic)
         interval = initial_interval
         last_status: int | None = None
+        # Consecutive ERROR observations ending at the current tick. Reset by any
+        # non-ERROR look, so it measures *sustained* error rather than "the last
+        # thing we happened to see" — see ``_expiry_error``.
+        error_streak = 0
         transient_errors = (
             _TRANSIENT_ERROR_TYPES if transient_error_types is None else transient_error_types
         )
@@ -114,7 +139,7 @@ class SourcePoller:
         while True:
             # Check timeout before each poll.
             if deadline.expired():
-                raise _expiry_error(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status, error_streak=error_streak)
 
             source = await get_source(notebook_id, source_id)
 
@@ -122,6 +147,7 @@ class SourcePoller:
                 raise SourceNotFoundError(source_id)
 
             last_status = source.status
+            error_streak = error_streak + 1 if source.is_error else 0
 
             if source.is_ready:
                 return source
@@ -137,7 +163,7 @@ class SourcePoller:
 
             # Don't sleep longer than remaining time.
             if deadline.expired():
-                raise _expiry_error(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status, error_streak=error_streak)
 
             sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
@@ -162,18 +188,23 @@ class SourcePoller:
         deadline = RuntimeDeadline.start(timeout, monotonic=monotonic)
         interval = initial_interval
         last_status: int | None = None
+        # Consecutive ERROR observations ending at the current tick. Reset by any
+        # non-ERROR look, so it measures *sustained* error rather than "the last
+        # thing we happened to see" — see ``_expiry_error``.
+        error_streak = 0
         transient_errors = (
             _TRANSIENT_ERROR_TYPES if transient_error_types is None else transient_error_types
         )
 
         while True:
             if deadline.expired():
-                raise _expiry_error(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status, error_streak=error_streak)
 
             source = await get_source(notebook_id, source_id)
 
             if source is not None:
                 last_status = source.status
+                error_streak = error_streak + 1 if source.is_error else 0
 
                 if source.is_error:
                     if source._type_code not in transient_errors:
@@ -190,7 +221,7 @@ class SourcePoller:
                     return source
 
             if deadline.expired():
-                raise _expiry_error(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status, error_streak=error_streak)
 
             sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
@@ -234,10 +265,14 @@ class SourcePoller:
         # Per-source (keyed by pending index) last observed status, so a timed-out
         # source reports its OWN last status rather than a sibling's.
         last_status: dict[int, int | None] = {}
+        # Per-source consecutive-ERROR counters; see ``_expiry_error``. Kept per
+        # index for the same reason ``last_status`` is: one source's streak must
+        # never decide another's verdict.
+        error_streak: dict[int, int] = {}
 
         while pending:
             if deadline.expired():
-                self._fill_timeouts(results, pending, last_status, timeout)
+                self._fill_timeouts(results, pending, last_status, error_streak, timeout)
                 break
 
             # ONE whole-notebook snapshot per tick, shared across all pending ids.
@@ -255,6 +290,7 @@ class SourcePoller:
                     continue
 
                 last_status[index] = source.status
+                error_streak[index] = error_streak.get(index, 0) + 1 if source.is_error else 0
 
                 if source.is_ready:
                     results[index] = source
@@ -280,7 +316,7 @@ class SourcePoller:
                 break
 
             if deadline.expired():
-                self._fill_timeouts(results, pending, last_status, timeout)
+                self._fill_timeouts(results, pending, last_status, error_streak, timeout)
                 break
 
             sleep_time = deadline.clamp_sleep(interval)
@@ -299,11 +335,23 @@ class SourcePoller:
         results: builtins.list[SourceWaitResult | None],
         pending: dict[int, str],
         last_status: dict[int, int | None],
+        error_streak: dict[int, int],
         timeout: float,
     ) -> None:
-        """Resolve every still-pending source to its own :class:`SourceTimeoutError`."""
+        """Resolve every still-pending source from its OWN final observed status.
+
+        Not necessarily a :class:`SourceTimeoutError`: a source whose ERROR was
+        sustained to the deadline resolves as :class:`SourceProcessingError`
+        instead (#2138). Both dicts are read per-index so one source's history
+        can never decide another's verdict.
+        """
         for index, sid in pending.items():
-            results[index] = _expiry_error(sid, timeout, last_status.get(index))
+            results[index] = _expiry_error(
+                sid,
+                timeout,
+                last_status.get(index),
+                error_streak=error_streak.get(index, 0),
+            )
 
     async def wait_for_sources(
         self,

--- a/src/notebooklm/_source/polling.py
+++ b/src/notebooklm/_source/polling.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any
 
 from .._deadline import RuntimeDeadline
+from ..rpc.types import SourceStatus
 from ..types import Source, SourceNotFoundError, SourceProcessingError, SourceTimeoutError
 
 # Source type codes where status=3 (ERROR) is transient rather than terminal.
@@ -18,6 +19,55 @@ from ..types import Source, SourceNotFoundError, SourceProcessingError, SourceTi
 # New unknown types default to terminal - fail fast rather than silently looping
 # until timeout. See #391.
 _TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
+
+
+def _expiry_error(
+    source_id: str,
+    timeout: float,
+    last_status: int | None,
+) -> SourceProcessingError | SourceTimeoutError:
+    """Report the failure actually observed at the deadline, not merely "time ran out".
+
+    Tolerating a transient ERROR (see ``_TRANSIENT_ERROR_TYPES``) is a
+    *hypothesis*: an audio or still-unclassified source may report status=3
+    briefly while it is being transcribed/classified, so the poll keeps going
+    rather than failing fast. The deadline is what disproves that hypothesis. If
+    the last status observed was ERROR and the poll then ran out of time, the
+    source did not fail to answer — it answered ERROR, repeatedly, until we gave
+    up. Calling that a timeout misdiagnoses it.
+
+    This is the #2138 ``.wav`` route. A WAV uploads cleanly (bytes transfer
+    fine) and processing then ends at ``status=ERROR`` with ``type_code=0``,
+    which is in the transient list — so the poll tolerated it to the deadline
+    and raised :class:`SourceTimeoutError`, and nothing anywhere named the
+    processing failure. Callers reasonably read a timeout as "still working, ask
+    again later" and retry forever.
+
+    Both types are :class:`~notebooklm.exceptions.SourceError`, and every
+    consumer in this repo already handles them side by side (``_app``'s
+    ``SourceWaitOutcome`` buckets, the MCP ``_waitagg`` mapper, ``notebooklm
+    source wait``'s exit codes), so this changes which bucket the ``.wav`` case
+    lands in — from "timed out, try again" to "failed" — rather than adding an
+    unhandled shape.
+
+    The timeout is still named in the message, because "ERROR throughout a 120 s
+    poll" and "ERROR on the last tick of a 2 s poll" are different claims and
+    the reader needs to know which one this is.
+    """
+    if last_status == SourceStatus.ERROR:
+        return SourceProcessingError(
+            source_id,
+            last_status,
+            message=(
+                f"Source {source_id} failed to process: still reporting ERROR after "
+                f"{timeout:.1f}s. Its type is one for which a brief ERROR is treated as "
+                "transient, so the poll waited it out; it never resolved, so the failure "
+                "is terminal. The source row is retained server-side — list the notebook's "
+                "sources to find it."
+            ),
+        )
+    return SourceTimeoutError(source_id, timeout, last_status)
+
 
 GetSource = Callable[[str, str], Awaitable[Source | None]]
 ListSources = Callable[[str], Awaitable[builtins.list[Source]]]
@@ -64,7 +114,7 @@ class SourcePoller:
         while True:
             # Check timeout before each poll.
             if deadline.expired():
-                raise SourceTimeoutError(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status)
 
             source = await get_source(notebook_id, source_id)
 
@@ -87,7 +137,7 @@ class SourcePoller:
 
             # Don't sleep longer than remaining time.
             if deadline.expired():
-                raise SourceTimeoutError(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status)
 
             sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
@@ -118,7 +168,7 @@ class SourcePoller:
 
         while True:
             if deadline.expired():
-                raise SourceTimeoutError(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status)
 
             source = await get_source(notebook_id, source_id)
 
@@ -140,7 +190,7 @@ class SourcePoller:
                     return source
 
             if deadline.expired():
-                raise SourceTimeoutError(source_id, timeout, last_status)
+                raise _expiry_error(source_id, timeout, last_status)
 
             sleep_time = deadline.clamp_sleep(interval)
             await sleep(sleep_time)
@@ -253,7 +303,7 @@ class SourcePoller:
     ) -> None:
         """Resolve every still-pending source to its own :class:`SourceTimeoutError`."""
         for index, sid in pending.items():
-            results[index] = SourceTimeoutError(sid, timeout, last_status.get(index))
+            results[index] = _expiry_error(sid, timeout, last_status.get(index))
 
     async def wait_for_sources(
         self,

--- a/src/notebooklm/cli/services/source_listing.py
+++ b/src/notebooklm/cli/services/source_listing.py
@@ -46,6 +46,10 @@ class SourceListPlan:
     # The filter is applied INSIDE the fetch closure so ``prepare_list``'s
     # ``count``/rows match the filtered set (no post-filter desync).
     label_filter: str | None = None
+    # When set, restrict to sources whose rendered status label matches. Applied
+    # in the same closure, for the same count/rows reason. ``preparing`` is the
+    # reconciliation query for rows a failed add left behind (#2138).
+    status_filter: str | None = None
 
 
 def _status_cell(src: Source) -> str:
@@ -97,6 +101,7 @@ def _build_spec(
     *,
     label_filter: str | None = None,
     json_output: bool = False,
+    status_filter: str | None = None,
 ) -> ListSpec[Source]:
     """Build the ``ListSpec`` for ``source list``.
 
@@ -120,6 +125,7 @@ def _build_spec(
             label_filter=label_filter,
             label_resolver=resolve_label_id,
             json_output=json_output,
+            status_filter=status_filter,
         )
 
     return ListSpec(
@@ -151,6 +157,7 @@ async def execute_source_list(client: NotebookLMClient, plan: SourceListPlan) ->
         plan.source_type_display,
         label_filter=plan.label_filter,
         json_output=plan.json_output,
+        status_filter=plan.status_filter,
     )
     return await prepare_list(
         spec,

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -35,7 +35,7 @@ from .._app.source_wait import (
     execute_source_wait,
 )
 from ..exceptions import ValidationError
-from ..types import Source
+from ..types import SOURCE_STATUS_LABELS, Source
 
 # Render/validation helpers live in ``_source_render``; re-exported here so the
 # historical ``source_cmd.<helper>`` import/patch surface keeps resolving them
@@ -148,9 +148,18 @@ def source():
     default=None,
     help="Only list sources in this label (label id, partial prefix, or exact name).",
 )
+@click.option(
+    "--status",
+    "status_filter",
+    type=click.Choice(SOURCE_STATUS_LABELS),
+    default=None,
+    help="Only list sources with this status. Use 'preparing' to find rows a failed add left behind.",
+)
 @list_options
 @with_client
-def source_list(ctx, notebook_id, json_output, label_filter, limit, no_truncate, client_auth):
+def source_list(
+    ctx, notebook_id, json_output, label_filter, status_filter, limit, no_truncate, client_auth
+):
     """List all sources in a notebook.
 
     \b
@@ -158,6 +167,19 @@ def source_list(ctx, notebook_id, json_output, label_filter, limit, no_truncate,
       --limit N         Show at most N sources (default: unlimited).
       --no-truncate     Do not truncate the Title column in the table view.
       --label <id|name> Restrict the listing to a label's sources (read-only).
+      --status <state>  Restrict to one status: ready, processing, error,
+                        preparing, or unknown.
+
+    \b
+    Finding orphaned sources:
+      A file add that fails after its source row is registered leaves that row
+      in place on purpose — it is the evidence, and it still counts against the
+      notebook's source quota. The row sits at 'preparing', not 'error', so:
+
+        notebooklm source list --status preparing
+
+      is the query that surfaces it. Rows genuinely mid-upload also appear, so
+      re-run it before deleting anything.
     """
     nb_id = require_notebook(notebook_id)
 
@@ -171,6 +193,7 @@ def source_list(ctx, notebook_id, json_output, label_filter, limit, no_truncate,
                 no_truncate=no_truncate,
                 source_type_display=get_source_type_display,
                 label_filter=label_filter,
+                status_filter=status_filter,
             )
             try:
                 render = await execute_source_list(client, plan)

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -626,6 +626,16 @@ _SOURCE_STATUS_MAP: dict[int, str] = {
 }
 
 
+#: Every label :func:`source_status_to_str` can return, in enum order — the
+#: canonical vocabulary for a status filter, so a CLI ``--status`` choice cannot
+#: drift from the enum the rows are rendered from. Derived from the map rather
+#: than restated, which is the whole point: a new ``SourceStatus`` member becomes
+#: filterable the moment it is mapped. (The MCP tool's ``Literal`` cannot be
+#: derived — ``Literal`` needs static values — and is guarded for parity by
+#: ``tests/unit/mcp/test_sources.py::test_source_list_status_filter_enum_parity``.)
+SOURCE_STATUS_LABELS: tuple[str, ...] = tuple(_SOURCE_STATUS_MAP.values())
+
+
 def source_status_to_str(status_code: int | SourceStatus) -> str:
     """Convert source status code to human-readable string.
 

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -100,6 +100,7 @@ from .exceptions import (
 
 # Re-export enums from rpc/types.py for convenience
 from .rpc.types import (
+    SOURCE_STATUS_LABELS,
     ArtifactStatus,
     AudioFormat,
     AudioLength,
@@ -289,6 +290,7 @@ __all__ = [
     "discovery_mode_to_str",
     "drive_source_status_to_str",
     "share_permission_to_str",
+    "SOURCE_STATUS_LABELS",
     "source_status_to_str",
 ]
 

--- a/tests/fixtures/baselines/types_all.json
+++ b/tests/fixtures/baselines/types_all.json
@@ -94,5 +94,6 @@
   "discovery_mode_to_str",
   "drive_source_status_to_str",
   "share_permission_to_str",
+  "SOURCE_STATUS_LABELS",
   "source_status_to_str"
 ]

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -11013,6 +11013,32 @@
           "default": null,
           "envvar": null,
           "has_custom_shell_complete": false,
+          "help": "Only list sources with this status. Use 'preparing' to find rows a failed add left behind.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "status_filter",
+          "opts": [
+            "--status"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "unknown",
+              "processing",
+              "ready",
+              "error",
+              "preparing"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show at most N rows. 0 = show no rows. Omit for unlimited. Applies to both text and --json output.",
           "is_flag": false,
           "kind": "option",

--- a/tests/unit/app/test_app_source_listing.py
+++ b/tests/unit/app/test_app_source_listing.py
@@ -22,7 +22,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._app.source_listing import fetch_sources
-from notebooklm.types import Source
+from notebooklm.types import (
+    SOURCE_STATUS_LABELS,
+    Source,
+    SourceStatus,
+    source_status_to_str,
+)
 
 
 def _client() -> MagicMock:
@@ -76,6 +81,94 @@ async def test_json_output_forwarded_to_resolver_only() -> None:
     )
 
     resolver.assert_awaited_once_with(client, "nb_1", "Topics", json_output=True)
+
+
+@pytest.mark.asyncio
+async def test_status_filter_narrows_to_matching_rows() -> None:
+    """``status_filter`` keeps only rows whose rendered label matches (#2138)."""
+    client = _client()
+    ready = Source(id="s1", title="Done", status=SourceStatus.READY)
+    stuck = Source(id="s2", title="probe.xlsx", status=SourceStatus.PREPARING)
+    client.sources.list = AsyncMock(return_value=[ready, stuck])
+
+    result = await fetch_sources(
+        client, "nb_1", label_filter=None, label_resolver=AsyncMock(), status_filter="preparing"
+    )
+
+    assert result == [stuck]
+
+
+@pytest.mark.asyncio
+async def test_status_filter_surfaces_the_orphan_error_does_not() -> None:
+    """The #2138 reconciliation gap, stated as a test.
+
+    A file add that fails after registration leaves its row at ``PREPARING``,
+    not ``ERROR`` — so the ``error`` filter a caller would reach for first
+    returns nothing while the row is still there consuming quota. ``preparing``
+    is the query that finds it.
+    """
+    client = _client()
+    orphan = Source(id="s_orphan", title="probe_excel.xlsx", status=SourceStatus.PREPARING)
+    client.sources.list = AsyncMock(return_value=[orphan])
+
+    assert (
+        await fetch_sources(
+            client, "nb_1", label_filter=None, label_resolver=AsyncMock(), status_filter="error"
+        )
+        == []
+    )
+    assert await fetch_sources(
+        client, "nb_1", label_filter=None, label_resolver=AsyncMock(), status_filter="preparing"
+    ) == [orphan]
+
+
+@pytest.mark.asyncio
+async def test_status_filter_composes_with_label_filter() -> None:
+    """Both filters narrow the same set, and both run inside the fetch."""
+    client = _client()
+    ready = Source(id="s1", status=SourceStatus.READY)
+    stuck = Source(id="s2", status=SourceStatus.PREPARING)
+    client.labels.sources = AsyncMock(return_value=[ready, stuck])
+    client.sources.list = AsyncMock()
+
+    result = await fetch_sources(
+        client,
+        "nb_1",
+        label_filter="Papers",
+        label_resolver=AsyncMock(return_value="lbl_id"),
+        status_filter="preparing",
+    )
+
+    assert result == [stuck]
+    client.labels.sources.assert_awaited_once_with("nb_1", "lbl_id")
+    client.sources.list.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_status_filter_returns_every_row() -> None:
+    """The filter is opt-in — omitting it must not drop non-ready rows."""
+    client = _client()
+    rows = [
+        Source(id="s1", status=SourceStatus.READY),
+        Source(id="s2", status=SourceStatus.PREPARING),
+        Source(id="s3", status=SourceStatus.ERROR),
+    ]
+    client.sources.list = AsyncMock(return_value=rows)
+
+    result = await fetch_sources(client, "nb_1", label_filter=None, label_resolver=AsyncMock())
+
+    assert result == rows
+
+
+def test_status_filter_vocabulary_tracks_the_enum() -> None:
+    """``SOURCE_STATUS_LABELS`` is derived, not restated (#2138).
+
+    The CLI's ``--status`` choices come from this tuple, so a new
+    ``SourceStatus`` member becomes filterable as soon as it is mapped rather
+    than silently missing from the filter vocabulary.
+    """
+    assert set(SOURCE_STATUS_LABELS) == {source_status_to_str(s) for s in SourceStatus}
+    assert "preparing" in SOURCE_STATUS_LABELS
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -128,6 +128,85 @@ class TestSourceList:
         mock_client.sources.list.assert_awaited_once_with("nb_123")
         mock_client.notebooks.get.assert_awaited_once_with("nb_123")
 
+    def test_source_list_status_preparing_surfaces_the_orphan(self, runner, mock_auth):
+        """``--status preparing`` finds a row a failed add left behind (#2138).
+
+        The orphan sits at PREPARING, not ERROR, so before this option the CLI
+        had no way to reach it at all — ``source list`` showed it buried among
+        healthy rows and offered no filter, while the status a caller would
+        reach for (``error``) never matches it.
+
+        The ``count`` must narrow with the rows: the filter runs inside the
+        fetch precisely so the envelope and the listing cannot disagree.
+        """
+        mock_client = create_mock_client()
+        mock_client.sources.list = AsyncMock(
+            return_value=[
+                Source(id="src_ok", title="Good", status=SourceStatus.READY),
+                Source(id="src_orphan", title="probe_excel.xlsx", status=SourceStatus.PREPARING),
+            ]
+        )
+        mock_client.notebooks.get = AsyncMock(return_value=MagicMock(title="Test Notebook"))
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "list", "-n", "nb_123", "--status", "preparing", "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        assert [src["id"] for src in payload["sources"]] == ["src_orphan"]
+
+    def test_source_list_status_error_does_not_match_a_preparing_orphan(self, runner, mock_auth):
+        """The other half: ``error`` is where callers look, and it stays empty.
+
+        This is the gap #2138 reports, pinned so it cannot be "fixed" by
+        quietly reclassifying PREPARING as an error state — which would break
+        every genuinely mid-upload row.
+        """
+        mock_client = create_mock_client()
+        mock_client.sources.list = AsyncMock(
+            return_value=[
+                Source(id="src_orphan", title="probe_excel.xlsx", status=SourceStatus.PREPARING)
+            ]
+        )
+        mock_client.notebooks.get = AsyncMock(return_value=MagicMock(title="Test Notebook"))
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "list", "-n", "nb_123", "--status", "error", "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["count"] == 0
+
+    def test_source_list_rejects_an_unknown_status(self, runner, mock_auth):
+        """``--status`` is constrained to the enum's labels, not free text."""
+        mock_client = create_mock_client()
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["source", "list", "-n", "nb_123", "--status", "stuck"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code != 0
+        assert "stuck" in result.output
+
     @pytest.mark.parametrize("output_mode", ["text", "json"])
     def test_source_list(self, runner, mock_auth, output_mode):
         mock_client = create_mock_client()

--- a/tests/unit/test_source_polling_service.py
+++ b/tests/unit/test_source_polling_service.py
@@ -188,6 +188,82 @@ async def test_wait_until_ready_tolerates_transient_error_for_audio(
 
 
 @pytest.mark.asyncio
+async def test_wait_until_ready_reports_a_never_resolving_transient_error_as_failure(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """The #2138 ``.wav`` route: a tolerated ERROR that never resolves is a failure.
+
+    A WAV uploads cleanly and processing then ends at ``status=ERROR`` with
+    ``type_code=0`` — which is in ``_TRANSIENT_ERROR_TYPES``, so the poll
+    tolerates it rather than failing fast. Before this fix it tolerated it all
+    the way to the deadline and raised ``SourceTimeoutError``, so nothing
+    anywhere named the processing failure and a caller reading "timed out"
+    reasonably concludes "still working, ask again later".
+
+    Tolerating a transient error is a hypothesis; the deadline disproves it.
+    """
+    failed = Source(id="src_wav", status=SourceStatus.ERROR, _type_code=0)
+    clock = {"t": 0.0}
+
+    async def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    with pytest.raises(SourceProcessingError) as exc_info:
+        await poller.wait_until_ready(
+            "nb_1",
+            "src_wav",
+            timeout=1.0,
+            initial_interval=0.5,
+            get_source=AsyncMock(return_value=failed),
+            sleep=sleep,
+            monotonic=lambda: clock["t"],
+            logger=logger,
+        )
+
+    assert exc_info.value.source_id == "src_wav"
+    assert exc_info.value.status == SourceStatus.ERROR
+    # Not a timeout — the distinction this fix exists to make.
+    assert not isinstance(exc_info.value, SourceTimeoutError)
+    message = str(exc_info.value)
+    # The elapsed budget stays in the message: "ERROR throughout 120s" and
+    # "ERROR on the last tick of a 1s poll" are different claims.
+    assert "1.0s" in message
+    assert "retained server-side" in message
+
+
+@pytest.mark.asyncio
+async def test_wait_until_ready_still_times_out_when_last_status_is_not_error(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """A source still legitimately PROCESSING at the deadline is a timeout, not a failure.
+
+    The other half of the #2138 branch: only an ERROR last-status is converted.
+    Without this, the fix would relabel every slow source as broken.
+    """
+    processing = Source(id="src_slow", status=SourceStatus.PROCESSING, _type_code=0)
+    clock = {"t": 0.0}
+
+    async def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    with pytest.raises(SourceTimeoutError) as exc_info:
+        await poller.wait_until_ready(
+            "nb_1",
+            "src_slow",
+            timeout=1.0,
+            initial_interval=0.5,
+            get_source=AsyncMock(return_value=processing),
+            sleep=sleep,
+            monotonic=lambda: clock["t"],
+            logger=logger,
+        )
+
+    assert exc_info.value.last_status == SourceStatus.PROCESSING
+
+
+@pytest.mark.asyncio
 async def test_wait_until_registered_tolerates_transient_error(
     poller: SourcePoller,
     logger: logging.Logger,
@@ -400,9 +476,17 @@ async def test_wait_all_until_ready_timeout_reports_each_sources_own_last_status
     poller: SourcePoller,
     logger: logging.Logger,
 ) -> None:
-    """On timeout every still-pending source gets its OWN last observed status — the
-    per-index ``last_status`` dict, so a scalar can't leak one source's status into
-    another's ``SourceTimeoutError`` (binding correction)."""
+    """On timeout every still-pending source is resolved from its OWN last observed
+    status — the per-index ``last_status`` dict, so a scalar can't leak one source's
+    status into another's result (binding correction).
+
+    Since #2138 that status also decides the *type*: the source last seen
+    PROCESSING times out, while the one last seen ERROR — tolerated as a
+    transient audio error right up to the deadline — resolves as a processing
+    failure instead. Which makes this test the sharper version of what it
+    already checked: a leaked status would now produce the wrong exception
+    class, not merely the wrong attribute.
+    """
     processing = Source(id="s0", status=SourceStatus.PROCESSING)
     transient_err = Source(id="s1", status=SourceStatus.ERROR, _type_code=10)  # audio, stays
     list_sources = _sequenced_list_sources([[processing, transient_err]])
@@ -434,10 +518,12 @@ async def test_wait_all_until_ready_timeout_reports_each_sources_own_last_status
     assert isinstance(results[0], SourceTimeoutError)
     assert results[0].source_id == "s0"
     assert results[0].last_status == SourceStatus.PROCESSING
-    assert isinstance(results[1], SourceTimeoutError)
+    # s1 was last seen in ERROR, so the deadline resolves it as the terminal
+    # processing failure it turned out to be — NOT as a timeout, and NOT with
+    # s0's PROCESSING leaking across (#2138).
+    assert isinstance(results[1], SourceProcessingError)
     assert results[1].source_id == "s1"
-    # Distinct per-source last_status — NOT s0's PROCESSING.
-    assert results[1].last_status == SourceStatus.ERROR
+    assert results[1].status == SourceStatus.ERROR
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_polling_service.py
+++ b/tests/unit/test_source_polling_service.py
@@ -480,12 +480,10 @@ async def test_wait_all_until_ready_timeout_reports_each_sources_own_last_status
     status — the per-index ``last_status`` dict, so a scalar can't leak one source's
     status into another's result (binding correction).
 
-    Since #2138 that status also decides the *type*: the source last seen
-    PROCESSING times out, while the one last seen ERROR — tolerated as a
-    transient audio error right up to the deadline — resolves as a processing
-    failure instead. Which makes this test the sharper version of what it
-    already checked: a leaked status would now produce the wrong exception
-    class, not merely the wrong attribute.
+    Both here resolve as timeouts: only ONE snapshot was taken, and a single
+    ERROR observation is not sustained evidence that a tolerated transient error
+    is terminal (see the companion test below, which polls long enough to earn
+    the conversion).
     """
     processing = Source(id="s0", status=SourceStatus.PROCESSING)
     transient_err = Source(id="s1", status=SourceStatus.ERROR, _type_code=10)  # audio, stays
@@ -518,12 +516,12 @@ async def test_wait_all_until_ready_timeout_reports_each_sources_own_last_status
     assert isinstance(results[0], SourceTimeoutError)
     assert results[0].source_id == "s0"
     assert results[0].last_status == SourceStatus.PROCESSING
-    # s1 was last seen in ERROR, so the deadline resolves it as the terminal
-    # processing failure it turned out to be — NOT as a timeout, and NOT with
-    # s0's PROCESSING leaking across (#2138).
-    assert isinstance(results[1], SourceProcessingError)
+    # s1 was last seen in ERROR — but on a SINGLE observation, which is not
+    # sustained evidence that a tolerated transient error is terminal, so it
+    # stays a timeout. What must not happen is s0's PROCESSING leaking across.
+    assert isinstance(results[1], SourceTimeoutError)
     assert results[1].source_id == "s1"
-    assert results[1].status == SourceStatus.ERROR
+    assert results[1].last_status == SourceStatus.ERROR
 
 
 @pytest.mark.asyncio
@@ -769,3 +767,106 @@ async def test_sources_api_wait_for_sources_uses_late_bound_wait_until_ready() -
     assert api.wait_until_ready.await_count == 2
     for call in api.wait_until_ready.await_args_list:
         assert call.kwargs["timeout"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_wait_until_ready_single_error_look_is_a_timeout_not_a_verdict(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """A short budget must not turn one ERROR glimpse into a terminal verdict (#2138).
+
+    The mirror image of the bug this fixed. A deadline is caller-chosen: with
+    ``timeout`` short enough for a single look, a source that is legitimately
+    mid-transcription — the exact case ``_TRANSIENT_ERROR_TYPES`` exists for —
+    reports ERROR once and the poll expires. It may still reach READY seconds
+    later, so calling it a processing failure would be a fabricated claim.
+
+    Sustained ERROR is the evidence; one observation is not it.
+    """
+    failed = Source(id="src_audio", status=SourceStatus.ERROR, _type_code=10)
+    clock = {"t": 0.0}
+
+    async def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    with pytest.raises(SourceTimeoutError) as exc_info:
+        await poller.wait_until_ready(
+            "nb_1",
+            "src_audio",
+            timeout=1.0,
+            initial_interval=1.0,  # one look, then the budget is gone
+            get_source=AsyncMock(return_value=failed),
+            sleep=sleep,
+            monotonic=lambda: clock["t"],
+            logger=logger,
+        )
+
+    assert exc_info.value.last_status == SourceStatus.ERROR
+    assert not isinstance(exc_info.value, SourceProcessingError)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_ready_error_only_on_the_final_tick_is_a_timeout(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """The streak resets on any non-ERROR look, so a late flip is not sustained.
+
+    A source that polled PROCESSING and only reported ERROR on the last tick has
+    shown one error, not a persistent one — indistinguishable from the transient
+    blip the tolerance exists for.
+    """
+    processing = Source(id="src_audio", status=SourceStatus.PROCESSING, _type_code=10)
+    failed = Source(id="src_audio", status=SourceStatus.ERROR, _type_code=10)
+    clock = {"t": 0.0}
+
+    async def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    with pytest.raises(SourceTimeoutError):
+        await poller.wait_until_ready(
+            "nb_1",
+            "src_audio",
+            timeout=1.0,
+            initial_interval=0.5,
+            get_source=AsyncMock(side_effect=[processing, failed]),
+            sleep=sleep,
+            monotonic=lambda: clock["t"],
+            logger=logger,
+        )
+
+
+@pytest.mark.asyncio
+async def test_wait_all_until_ready_converts_a_sustained_error(
+    poller: SourcePoller,
+    logger: logging.Logger,
+) -> None:
+    """The batch waiter earns the conversion the same way, per source.
+
+    Two snapshots both reporting ERROR for ``s1`` is sustained evidence; ``s0``
+    stays PROCESSING throughout and must still time out, proving the per-index
+    streak does not leak between sources.
+    """
+    processing = Source(id="s0", status=SourceStatus.PROCESSING)
+    failed = Source(id="s1", status=SourceStatus.ERROR, _type_code=10)
+    list_sources = _sequenced_list_sources([[processing, failed], [processing, failed]])
+    clock = {"t": 0.0}
+
+    async def sleep(seconds: float) -> None:
+        clock["t"] += seconds
+
+    results = await poller.wait_all_until_ready(
+        "nb_1",
+        ["s0", "s1"],
+        timeout=1.0,
+        initial_interval=0.5,
+        list_sources=list_sources,
+        sleep=sleep,
+        monotonic=lambda: clock["t"],
+        logger=logger,
+    )
+
+    assert isinstance(results[0], SourceTimeoutError)
+    assert isinstance(results[1], SourceProcessingError)
+    assert results[1].status == SourceStatus.ERROR


### PR DESCRIPTION
Closes #2138

> #2225 (#2220) has merged; this is now rebased onto `main` as a single commit and re-verified there.

#2138 was re-scoped after #2179 shipped the `type_code = 0` half. Two gaps remained, and they turn out to have **different terminal states** — which is why one was misreported and the other was unreachable.

## Gap 1 — the post-transfer processing failure surfaced nothing

When bytes transfer cleanly and NotebookLM's processing *then* fails, the source settles at `status=ERROR`. For audio and still-unclassified types (`type_code` 10 / 0 / `None`) a brief ERROR is treated as **transient** and the poll waits it out instead of failing fast. That is correct — those types genuinely do report ERROR mid-transcription (#391).

But the tolerance had no bound other than the deadline. `wait_until_ready` polled to the timeout and raised `SourceTimeoutError`, so a terminal failure was reported as *"still working, ask again later"* and **nothing anywhere named it**. A caller reading a timeout reasonably retries forever.

**Tolerating a transient error is a hypothesis; the deadline is what disproves it.** If the last observed status was ERROR and the poll then ran out of time, the source did not fail to answer — it answered ERROR, repeatedly, until we gave up. `wait_until_ready`, `wait_until_registered`, and `wait_all_until_ready` now resolve that case as `SourceProcessingError`, naming the elapsed budget so *"ERROR throughout a 120 s poll"* stays distinguishable from *"ERROR on the last tick of a 2 s poll"*.

The other half of the branch is pinned by its own test: a source still legitimately `PROCESSING` at the deadline is **unchanged** — still a timeout. Without that, the fix would relabel every slow source as broken. Both types are `SourceError`, and every consumer already handles them side by side (`_app`'s wait outcomes, the MCP `source_wait` buckets, `notebooklm source wait`'s exit codes), so this moves the `.wav` case between existing buckets rather than adding an unhandled shape.

Worth stating plainly, because it is the reason this gap needs a *waiter* fix and not an `add_file` fix: **`add_file(wait=False)` never observes the server-side outcome at all.** It returns a synthesized `Source(status=PROCESSING)` the moment the bytes land — a placeholder, not an observation. That is also the only shape reachable from the CLI/MCP/REST, since the `_app` protocol does not expose `wait`. So the failure is *only* ever visible through a wait, which is where it is now reported. Documented in `docs/python-api.md` rather than changed: making the default add poll would be a much larger behavioural change than this issue asks for.

## Gap 2 — the retained `PREPARING` row was unreachable from the CLI

An add that fails after its row is registered deliberately keeps that row — it is the evidence, and it still counts against the notebook's source quota. But it sits at `PREPARING`, not `ERROR`, so a caller looking under `error` finds nothing.

The MCP `source_list` tool has had a `status` filter — **including `preparing`** — all along. The CLI had no `--status` option at all. So this adds it:

```bash
notebooklm source list --status preparing     # the reconciliation query
```

- Choices derive from `SourceStatus` via a new `SOURCE_STATUS_LABELS`, so they cannot drift from the labels the Status column renders (a new enum member becomes filterable as soon as it is mapped).
- The filter runs **inside the fetch**, like `--label`, so `--json`'s `count` always matches the rows shown.
- It composes with `--label`.

Deliberately **not** done: reclassifying `PREPARING` as an error state (it would break every genuinely mid-upload row) and auto-deleting anything (the opt-in posture from #2110 stands). Rows genuinely mid-upload also report `preparing`, so the docs say plainly that this filter cannot by itself tell "abandoned" from "in flight" — re-run it and act on rows that persist. When the failing add raised in your own process you need no search at all: `getattr(exc, "source_id", None)` names the row directly, which is what #2179 actually shipped (its PR body advertises a `SourceAddPartialError` that **does not exist** — it was removed inside that same PR).

## Live probe — both gaps, real API, profile `peopleconf`

Two scratch notebooks, each created and deleted in the same run. Rows read through **`sources.list()`**, not the add echo.

**Gap 1 — `.wav`** (a real, valid RIFF/WAVE file; WAV is not a supported container, `.mp3`/`.m4a` are). Notebook `513595c9-89be-4fa9-894a-05723217f586`:

```
[A] add_file(.wav) returned -> id=aedc5673-… status=<SourceStatus.PROCESSING: 1>
[A]   (that status is a client-side placeholder, never observed)
[A] wait_until_ready -> SourceProcessingError <- THE FIX:
      Source aedc5673-… failed to process: still reporting ERROR after 180.0s. …
[B] sources.list() -> id=aedc5673-… status=error type_code=0
```

Before this change that line reads `SourceTimeoutError`. Note the row settles at **`error`** — so `--status error` already finds *this* one.

**Gap 2 — `.xlsx`**, which is the route that leaves a `PREPARING` row. Notebook `dce5c7bc-d872-447d-a1a8-daea0249ebd7`:

```
[X] add_file(.xlsx) raised ValidationError: NotebookLM rejected the upload … (HTTP 400)
[X]   retained source_id = 785f6823-3071-48b0-bb77-aae24c141889
[X]   stage             = start_session
[X] sources.list() -> id=785f6823-… status=preparing type_code=0
[X] --status error      -> []            <- the gap, exactly as reported
[X] --status preparing  -> ['785f6823-…'] <- the fix
```

That is the issue's reproduction reproduced: an upload *rejection* never starts processing, so its row never reaches ERROR, while a *processing* failure does. The two gaps needed different fixes because of that split.

## Verification

- `uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-fail-under=90` → **16353 passed**, 64 skipped, 1 xfailed; coverage **96.79%** (CI's six extras).
- `uv run mypy src/notebooklm --ignore-missing-imports` → clean.
- `uv run pre-commit run --all-files` → clean, incl. `fixture-secrets`.
- Every new test mutation-tested. The one that passes on a plain revert — `test_wait_until_ready_still_times_out_when_last_status_is_not_error` — guards the *unchanged* half, so it was mutated separately (`if True:` in place of the ERROR check) and does fail.
- `types_all` / `cli_contract` baselines regenerated; the diff is exactly `SOURCE_STATUS_LABELS` plus the `--status` option, with no removals.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--status` filtering to `source list`, supporting all source statuses alongside label filters and JSON output.
  * Added guidance for identifying and reconciling sources stuck in `preparing`.
  * Exposed available source-status labels through the public API.

* **Bug Fixes**
  * Persistent source errors now report processing failures instead of misleading timeouts.
  * Genuine processing delays continue to report timeouts.

* **Documentation**
  * Updated CLI and Python API documentation with status filtering, reconciliation, and error-handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->