### PR TITLE
feat(sources): add typed list filters and strict counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`client.sources.list()` now owns source status/type filtering and exact
+  counts.** The existing method accepts keyword-only `statuses` and `types`
+  collections (OR within one axis, AND across axes) without an extra RPC or a
+  parallel inventory surface. `strict=True` now rejects malformed/id-less rows
+  and conflicting duplicate IDs, so `len(await client.sources.list(...,
+  strict=True))` is the exact count of unique addressable matches; the default
+  remains tolerant of row-level anomalies.
+
 - **`notebooklm research wait --timeout` now defaults to 1800 seconds, up from
   300.** Every observed deep run exceeded the old cap (374s live, 358s in the
   `research_deep_poll_long` cassette), so an unattended wait reported a timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`client.sources.list()` now owns source status/type filtering and exact
   counts.** The existing method accepts keyword-only `statuses` and `types`
   collections (OR within one axis, AND across axes) without an extra RPC or a
-  parallel inventory surface. `strict=True` now rejects malformed/id-less rows
-  and conflicting duplicate IDs, so `len(await client.sources.list(...,
-  strict=True))` is the exact count of unique addressable matches; the default
-  remains tolerant of row-level anomalies.
+  parallel inventory surface. `strict=True` now rejects malformed/id-less rows,
+  incomplete type/status discriminants, and conflicting duplicate IDs, so
+  `len(await client.sources.list(..., strict=True))` is the exact count of
+  unique addressable matches; the default remains tolerant of row-level
+  anomalies. Research-import reconciliation explicitly keeps that tolerant
+  row mode so a known duplicate-ID collision cannot trigger a non-idempotent
+  retry.
 
 - **`notebooklm research wait --timeout` now defaults to 1800 seconds, up from
   300.** Every observed deep run exceeded the old cap (374s live, 358s in the

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1217,9 +1217,10 @@ The `strict` option is for callers that need a trustworthy count. Response-
 envelope drift always raises `RPCError`, regardless of this option. At the row
 level, the default `strict=False` keeps backward-compatible recovery: malformed
 or id-less rows are skipped and duplicate IDs keep their first normalized
-value. `strict=True` instead raises on any malformed/id-less row or on duplicate
-IDs whose normalized values conflict. Duplicate rows that normalize to the same
-`Source` still collapse to one resource because the count is of unique,
+value. `strict=True` instead raises on malformed/id-less rows, on ID-bearing
+rows whose type or status discriminant is missing/malformed, and on duplicate
+IDs whose normalized values conflict. Duplicate rows that normalize to the
+same `Source` still collapse to one resource because the count is of unique,
 addressable sources—not raw wire rows. Therefore the canonical exact-count
 operation is:
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1122,7 +1122,7 @@ print(url)
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `list(notebook_id, strict=False)` | `notebook_id: str, strict: bool = False` | `list[Source]` | List sources |
+| `list(notebook_id, *, strict=False, statuses=None, types=None)` | `str, *, bool, Collection[SourceStatus] \| None, Collection[SourceType] \| None` | `list[Source]` | List sources, optionally filtered after normalization |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details; raises `SourceNotFoundError` on a miss |
 | `get_or_none(notebook_id, source_id)` | `str, str` | `Source \| None` | Optional lookup; returns `None` when absent |
 | `get_fulltext(notebook_id, source_id, *, output_format="text")` | `str, str, *, output_format: Literal["text", "markdown"]` | `SourceFulltext` | Get full content; `"markdown"` requires the optional `markdownify` extra |
@@ -1172,6 +1172,21 @@ sources = await client.sources.list(nb_id)
 for src in sources:
     print(f"{src.id}: {src.title} ({src.kind})")
 
+# Filters are ORed within an axis and ANDed across axes. Backend order is
+# preserved; an explicitly empty filter matches no sources.
+from notebooklm import SourceStatus, SourceType
+
+ready_documents = await client.sources.list(
+    nb_id,
+    statuses={SourceStatus.READY},
+    types={SourceType.PDF, SourceType.DOCX, SourceType.GOOGLE_DOCS},
+)
+
+# The backend does not expose a separate authoritative count endpoint. For an
+# exact count of uniquely addressable sources, request a strict normalized
+# snapshot and count it locally.
+actual_source_count = len(await client.sources.list(nb_id, strict=True))
+
 await client.sources.rename(nb_id, src.id, "Better Title")
 await client.sources.refresh(nb_id, src.id)  # Re-fetch URL content
 
@@ -1190,6 +1205,33 @@ print(f"Summary: {guide.summary}")
 print(f"Keywords: {guide.keywords}")
 # SourceGuide is a typed value; prefer attribute access.
 ```
+
+`sources.list()` performs one `GET_NOTEBOOK` read. `statuses` and `types` do
+not trigger extra RPCs: each collection is snapshotted before the read, then
+matched against normalized `Source.status` and `Source.kind` values. Multiple
+members within `statuses` or `types` are alternatives (OR); supplying both
+axes requires both to match (AND). `None` means no filter on that axis, while
+an explicitly empty collection matches nothing.
+
+The `strict` option is for callers that need a trustworthy count. Response-
+envelope drift always raises `RPCError`, regardless of this option. At the row
+level, the default `strict=False` keeps backward-compatible recovery: malformed
+or id-less rows are skipped and duplicate IDs keep their first normalized
+value. `strict=True` instead raises on any malformed/id-less row or on duplicate
+IDs whose normalized values conflict. Duplicate rows that normalize to the same
+`Source` still collapse to one resource because the count is of unique,
+addressable sources—not raw wire rows. Therefore the canonical exact-count
+operation is:
+
+```python
+actual_count = len(await client.sources.list(notebook_id, strict=True))
+```
+
+Apply `statuses=` / `types=` to that same call when the desired count is for a
+filtered subset. There is intentionally no separate `sources.count()` or
+inventory object: the backend already returns the source rows needed to count,
+so another public surface would imply authority or efficiency that does not
+exist.
 
 ---
 
@@ -2846,10 +2888,14 @@ class SourceStatus(Enum):
 
 **Usage Example:**
 ```python
-from notebooklm import SourceType, ArtifactType
+from notebooklm import ArtifactType, SourceStatus, SourceType
 
-# List sources by type using .kind property
-sources = await client.sources.list(nb_id)
+# Request the source families and states you need directly.
+sources = await client.sources.list(
+    nb_id,
+    statuses={SourceStatus.READY},
+    types={SourceType.PDF, SourceType.MEDIA, SourceType.IMAGE, SourceType.UNKNOWN},
+)
 for src in sources:
     if src.kind == SourceType.PDF:
         print(f"PDF: {src.title}")

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -772,7 +772,12 @@ class ResearchAPI:
         baseline: list[Source] | None
         baseline_ids: set[str] | None
         try:
-            baseline = await self._source_lister.list(notebook_id, strict=True)
+            # Research reconciliation needs every uniquely addressable row it
+            # can recover, even when GET_NOTEBOOK repeats one ID with drifted
+            # metadata. Envelope drift still raises in tolerant row mode; only
+            # row-level skips/first-occurrence dedup remain enabled so a known
+            # duplicate collision cannot disable the idempotency baseline.
+            baseline = await self._source_lister.list(notebook_id, strict=False)
             baseline_ids = {src.id for src in baseline}
         except (NetworkError, RPCError) as snapshot_exc:
             logger.warning(
@@ -856,7 +861,9 @@ class ResearchAPI:
 
                 if requested_urls_norm:
                     try:
-                        current = await self._source_lister.list(notebook_id, strict=True)
+                        # As above, verification must not turn a known duplicate
+                        # row collision into a blind non-idempotent retry.
+                        current = await self._source_lister.list(notebook_id, strict=False)
                         outcome = _reconcile_import_probe(
                             current=current,
                             baseline_ids=baseline_ids,

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -364,6 +364,37 @@ class SourceRow:
         """
         return bool(self.id)
 
+    def listing_shape_error(self) -> str | None:
+        """Return why this row cannot support a strict source-list snapshot.
+
+        The general row adapter intentionally degrades incomplete shapes to
+        ``None`` / ``UNKNOWN`` because non-listing RPCs may omit metadata or a
+        status block. ``GET_NOTEBOOK`` source-list rows have a stronger shape:
+        strict filtering/counting needs both the type and status discriminants
+        to be present and integer-valued. Keeping this check on the adapter
+        preserves its ownership of all positional wire knowledge.
+        """
+        metadata = self.metadata
+        if metadata is None:
+            return "metadata block is missing or malformed"
+        if len(metadata) <= self._META_TYPE_POS:
+            return "metadata type code is missing"
+        type_code = metadata[self._META_TYPE_POS]
+        if not isinstance(type_code, int) or isinstance(type_code, bool):
+            return "metadata type code is malformed"
+
+        if len(self._raw) <= self._STATUS_BLOCK_POS:
+            return "status block is missing"
+        status_block = self._raw[self._STATUS_BLOCK_POS]
+        if not isinstance(status_block, list):
+            return "status block is malformed"
+        if len(status_block) <= self._STATUS_INNER_POS:
+            return "status code is missing"
+        status_code = status_block[self._STATUS_INNER_POS]
+        if not isinstance(status_code, int) or isinstance(status_code, bool):
+            return "status code is malformed"
+        return None
+
     @property
     def title(self) -> str | None:
         """Source title — ``None`` when absent (preserves legacy contract).

--- a/src/notebooklm/_source/listing.py
+++ b/src/notebooklm/_source/listing.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import builtins
 import logging
-from collections.abc import Awaitable, Callable
-from typing import Any
+from collections.abc import Awaitable, Callable, Collection
+from typing import Any, TypeVar
 
 from .._row_adapters.sources import SourceRow
 from .._runtime.contracts import RpcCaller
 from ..rpc import RPCError, RPCMethod, safe_index
-from ..types import Source
+from ..rpc.types import SourceStatus
+from ..types import Source, SourceType
 from .upload_payloads import build_template_block
 
 # Keep source-list warnings on the historical logger so existing log filters
@@ -19,6 +20,26 @@ logger = logging.getLogger("notebooklm").getChild("_sources")
 
 
 SourceListHook = Callable[[str], Awaitable[builtins.list[Source]]]
+_FilterValue = TypeVar("_FilterValue")
+
+
+def _snapshot_enum_filter(
+    values: Collection[_FilterValue] | None,
+    *,
+    enum_type: type[_FilterValue],
+    parameter: str,
+) -> frozenset[_FilterValue] | None:
+    """Validate and snapshot one public source-list filter before I/O."""
+    if values is None:
+        return None
+    if isinstance(values, (str, bytes)) or not isinstance(values, Collection):
+        raise TypeError(f"{parameter} must be a collection of {enum_type.__name__} values")
+
+    snapshot = tuple(values)
+    for value in snapshot:
+        if not isinstance(value, enum_type):
+            raise TypeError(f"{parameter} must contain only {enum_type.__name__} values")
+    return frozenset(snapshot)
 
 
 class SourceLister:
@@ -27,7 +48,14 @@ class SourceLister:
     def __init__(self, rpc: RpcCaller) -> None:
         self._rpc = rpc
 
-    async def list(self, notebook_id: str, *, strict: bool = False) -> builtins.list[Source]:
+    async def list(
+        self,
+        notebook_id: str,
+        *,
+        strict: bool = False,
+        statuses: Collection[SourceStatus] | None = None,
+        types: Collection[SourceType] | None = None,
+    ) -> builtins.list[Source]:
         """List all sources in a notebook.
 
         A malformed or error-shaped ``GET_NOTEBOOK`` response raises
@@ -35,7 +63,22 @@ class SourceLister:
         silently reported as "0 sources" — see issue #1159. The legacy
         ``NOTEBOOKLM_STRICT_DECODE=0`` opt-out into warn-and-return-``[]``
         was retired in v0.7.0; strict decoding is now the only mode.
+        ``strict=True`` additionally rejects malformed source rows and
+        conflicting duplicate IDs instead of skipping/deduplicating them.
+        Filters are applied after normalization: members are ORed within one
+        filter and the status/type filters are ANDed together.
         """
+        status_filter = _snapshot_enum_filter(
+            statuses,
+            enum_type=SourceStatus,
+            parameter="statuses",
+        )
+        type_filter = _snapshot_enum_filter(
+            types,
+            enum_type=SourceType,
+            parameter="types",
+        )
+
         # GET_NOTEBOOK read-path tail migrated to the nested template block
         # (#1549; live-verified forward-compatible). Mirrors
         # ``_notebooks.build_get_notebook_params`` — inlined here because
@@ -58,18 +101,35 @@ class SourceLister:
         # echo an existing id — which would otherwise over-count both
         # ``source_list`` and ``metadata.sources``. A collision is a benign
         # backend artifact, so it logs at DEBUG rather than WARNING.
-        seen_ids: set[str] = set()
+        seen_sources: dict[str, Source] = {}
         sources: builtins.list[Source] = []
-        for src in sources_list:
-            source = self._parse_source(src)
+        for index, src in enumerate(sources_list):
+            source = self._parse_source(
+                src,
+                notebook_id=notebook_id,
+                index=index,
+                strict=strict,
+            )
             if source is None:
                 continue
-            if source.id in seen_ids:
+            previous = seen_sources.get(source.id)
+            if previous is not None:
+                if strict and source != previous:
+                    raise RPCError(
+                        f"Could not list sources for {notebook_id}: "
+                        f"conflicting duplicate source row at index {index}"
+                    )
                 logger.debug("SourcesAPI.list: Skipping duplicate source id %s", source.id)
                 continue
-            seen_ids.add(source.id)
+            seen_sources[source.id] = source
             sources.append(source)
-        return sources
+
+        return [
+            source
+            for source in sources
+            if (status_filter is None or source.status in status_filter)
+            and (type_filter is None or source.kind in type_filter)
+        ]
 
     async def get(
         self,
@@ -171,8 +231,19 @@ class SourceLister:
         raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
 
     @staticmethod
-    def _parse_source(src: Any) -> Source | None:
+    def _parse_source(
+        src: Any,
+        *,
+        notebook_id: str,
+        index: int,
+        strict: bool,
+    ) -> Source | None:
         if not isinstance(src, builtins.list) or len(src) == 0:
+            if strict:
+                raise RPCError(
+                    f"Could not list sources for {notebook_id}: "
+                    f"malformed source row at index {index}"
+                )
             return None
 
         # GET_NOTEBOOK source-list entries arrive in the "entry" layout
@@ -187,6 +258,11 @@ class SourceLister:
                 "SourcesAPI.list: Skipping source with unexpected id shape: %s",
                 repr(src)[:500],
             )
+            if strict:
+                raise RPCError(
+                    f"Could not list sources for {notebook_id}: "
+                    f"source row at index {index} has no usable id"
+                )
             return None
 
         # Funnel through the single ``Source`` construction site shared

--- a/src/notebooklm/_source/listing.py
+++ b/src/notebooklm/_source/listing.py
@@ -265,6 +265,12 @@ class SourceLister:
                 )
             return None
 
+        if strict and (shape_error := row.listing_shape_error()) is not None:
+            raise RPCError(
+                f"Could not list sources for {notebook_id}: "
+                f"incomplete source row at index {index} ({shape_error})"
+            )
+
         # Funnel through the single ``Source`` construction site shared
         # with ``Source.from_api_response`` so the list/get/poll path and
         # the ADD_SOURCE/rename path produce identical Sources.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -3,7 +3,7 @@
 import asyncio
 import builtins
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from pathlib import Path
 from time import monotonic
 from typing import IO, Any, Literal
@@ -31,6 +31,8 @@ from .rpc import RPCMethod
 from .types import (
     Source,
     SourceFulltext,
+    SourceStatus,
+    SourceType,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,18 +135,35 @@ class SourcesAPI:
             operation_variant=operation_variant,
         )
 
-    async def list(self, notebook_id: str, *, strict: bool = False) -> list[Source]:
+    async def list(
+        self,
+        notebook_id: str,
+        *,
+        strict: bool = False,
+        statuses: Collection[SourceStatus] | None = None,
+        types: Collection[SourceType] | None = None,
+    ) -> list[Source]:
         """List all sources in a notebook.
 
         Args:
             notebook_id: The notebook ID.
-            strict: Retained for call-site clarity; malformed source-list
-                responses always raise ``RPCError``. Empty notebooks return ``[]``.
+            strict: Reject malformed source rows and conflicting duplicate IDs.
+                Malformed response envelopes always raise ``RPCError``. Use
+                ``strict=True`` when ``len(result)`` must be an exact count of
+                uniquely addressable matching sources.
+            statuses: Optional collection of accepted statuses. Members are ORed.
+            types: Optional collection of accepted source types. Members are ORed.
+                When both filters are supplied, a source must match both.
 
         Returns:
-            List of Source objects.
+            Source objects in backend order after normalization and filtering.
         """
-        return await self._lister.list(notebook_id, strict=strict)
+        return await self._lister.list(
+            notebook_id,
+            strict=strict,
+            statuses=statuses,
+            types=types,
+        )
 
     async def get(self, notebook_id: str, source_id: str) -> Source:
         """Get details of a specific source.

--- a/tests/unit/test_research_import_with_verification.py
+++ b/tests/unit/test_research_import_with_verification.py
@@ -682,7 +682,7 @@ class TestImportSourcesWithVerification:
         assert research.import_sources.await_count == 2
         assert mock_source_lister.list.await_count == 3
         assert all(
-            awaited_call.kwargs.get("strict") is True
+            awaited_call.kwargs.get("strict") is False
             for awaited_call in mock_source_lister.list.await_args_list
         )
         assert research.import_sources.await_args_list[0].args[2] == sources
@@ -691,6 +691,35 @@ class TestImportSourcesWithVerification:
             {"url": "https://three.example.com", "title": "Source 3"},
         ]
         mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_snapshots_tolerate_duplicate_row_collisions(self):
+        """Review regression: research probes must keep tolerant row semantics.
+
+        ``strict=True`` now rejects conflicting duplicate IDs for exact-count
+        callers. Research import recovery instead needs the first normalized
+        occurrence so a backend duplicate collision cannot disable the
+        idempotency baseline or turn a committed timeout into a blind retry.
+        """
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
+        research, _, mock_source_lister = _make_research()
+        mock_source_lister.list = AsyncMock(side_effect=[[], [new_src]])
+        research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        imported = await research.import_sources_with_verification(
+            "nb_123",
+            "task_123",
+            [{"url": "https://example.com", "title": "Source 1"}],
+        )
+
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
+        assert research.import_sources.await_count == 1
+        assert [call.kwargs for call in mock_source_lister.list.await_args_list] == [
+            {"strict": False},
+            {"strict": False},
+        ]
 
     @pytest.mark.asyncio
     async def test_all_requested_urls_already_present_skips_import_entirely(self):

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from notebooklm._source.listing import SourceLister
+from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import RPCError
 from notebooklm.rpc import RPCMethod
 from notebooklm.rpc.types import SourceStatus
-from notebooklm.types import Source
+from notebooklm.types import Source, SourceType
 
 
 class RecordingRpc:
@@ -264,6 +266,111 @@ async def test_status_and_type_code_parsing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_filters_with_or_within_axes_and_and_across_axes() -> None:
+    lister = SourceLister(
+        RecordingRpc(
+            [
+                [
+                    "Notebook",
+                    [
+                        source_entry(
+                            "src_pdf_ready",
+                            title="PDF ready",
+                            metadata=[None, 11, [1704067200, 0], None, 3],
+                            status=[None, SourceStatus.READY],
+                        ),
+                        source_entry(
+                            "src_pdf_error",
+                            title="PDF error",
+                            metadata=[None, 11, [1704067200, 0], None, 3],
+                            status=[None, SourceStatus.ERROR],
+                        ),
+                        source_entry(
+                            "src_web_ready",
+                            title="Web ready",
+                            metadata=[None, 11, [1704067200, 0], None, 5],
+                            status=[None, SourceStatus.READY],
+                        ),
+                        source_entry(
+                            "src_youtube_processing",
+                            title="YouTube processing",
+                            metadata=[None, 11, [1704067200, 0], None, 9],
+                            status=[None, SourceStatus.PROCESSING],
+                        ),
+                    ],
+                ]
+            ]
+        )
+    )
+
+    sources = await lister.list(
+        "nb_123",
+        statuses={SourceStatus.READY, SourceStatus.ERROR},
+        types={SourceType.PDF, SourceType.WEB_PAGE},
+    )
+
+    assert [source.id for source in sources] == [
+        "src_pdf_ready",
+        "src_pdf_error",
+        "src_web_ready",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"statuses": SourceStatus.READY}, "statuses must be a collection"),
+        ({"statuses": {2}}, "statuses must contain only SourceStatus"),
+        ({"types": SourceType.PDF}, "types must be a collection"),
+        ({"types": {"pdf"}}, "types must contain only SourceType"),
+    ],
+)
+async def test_list_rejects_untyped_filters_before_rpc(
+    kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    rpc = RecordingRpc([["Notebook", []]])
+    lister = SourceLister(rpc)
+
+    with pytest.raises(TypeError, match=message):
+        await lister.list("nb_123", **kwargs)
+
+    assert rpc.calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_filter_matches_no_sources() -> None:
+    lister = SourceLister(
+        RecordingRpc([["Notebook", [source_entry("src_1"), source_entry("src_2")]]])
+    )
+
+    assert await lister.list("nb_123", statuses=set()) == []
+
+
+@pytest.mark.asyncio
+async def test_sources_api_list_delegates_strict_and_filters() -> None:
+    api = SourcesAPI(MagicMock(), uploader=MagicMock())
+    expected = [Source(id="src_1", _type_code=3, status=SourceStatus.READY)]
+    api._lister.list = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await api.list(
+        "nb_123",
+        strict=True,
+        statuses={SourceStatus.READY},
+        types={SourceType.PDF},
+    )
+
+    assert result is expected
+    api._lister.list.assert_awaited_once_with(
+        "nb_123",
+        strict=True,
+        statuses={SourceStatus.READY},
+        types={SourceType.PDF},
+    )
+
+
+@pytest.mark.asyncio
 async def test_nested_drive_source_id_is_extracted() -> None:
     lister = SourceLister(
         RecordingRpc(
@@ -322,6 +429,38 @@ async def test_malformed_source_id_shape_logs_and_skips(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_row",
+    [None, "not-a-row", []],
+)
+async def test_strict_list_rejects_malformed_source_rows(bad_row: Any) -> None:
+    lister = SourceLister(RecordingRpc([["Notebook", [source_entry("src_valid"), bad_row]]]))
+
+    with pytest.raises(RPCError, match="malformed source row at index 1"):
+        await lister.list("nb_123", strict=True)
+
+
+@pytest.mark.asyncio
+async def test_strict_list_rejects_source_without_usable_id() -> None:
+    lister = SourceLister(
+        RecordingRpc(
+            [
+                [
+                    "Notebook",
+                    [
+                        source_entry("src_valid"),
+                        [[None, True, []], "Broken", None, [None, 2]],
+                    ],
+                ]
+            ]
+        )
+    )
+
+    with pytest.raises(RPCError, match="source row at index 1 has no usable id"):
+        await lister.list("nb_123", strict=True)
+
+
+@pytest.mark.asyncio
 async def test_list_dedups_duplicate_ids_keeping_first(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -351,6 +490,37 @@ async def test_list_dedups_duplicate_ids_keeping_first(
     # The FIRST occurrence wins (later duplicate dropped).
     assert sources[0].title == "First"
     assert "duplicate source id" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_strict_list_rejects_conflicting_duplicate_ids() -> None:
+    lister = SourceLister(
+        RecordingRpc(
+            [
+                [
+                    "Notebook",
+                    [
+                        source_entry("src_dup", title="First"),
+                        source_entry("src_dup", title="Second"),
+                    ],
+                ]
+            ]
+        )
+    )
+
+    with pytest.raises(RPCError, match="conflicting duplicate source row at index 1"):
+        await lister.list("nb_123", strict=True)
+
+
+@pytest.mark.asyncio
+async def test_strict_list_dedups_identical_rows_for_exact_unique_count() -> None:
+    row = source_entry("src_dup", title="Same")
+    lister = SourceLister(RecordingRpc([["Notebook", [row, row]]]))
+
+    sources = await lister.list("nb_123", strict=True)
+
+    assert len(sources) == 1
+    assert sources[0].id == "src_dup"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -461,6 +461,61 @@ async def test_strict_list_rejects_source_without_usable_id() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bad_row", "detail"),
+    [
+        ([["src_incomplete"], "Title"], "metadata block is missing"),
+        (
+            [["src_incomplete"], "Title", [None, 11, [1704067200, 0], None]],
+            "metadata type code is missing",
+        ),
+        (
+            [["src_incomplete"], "Title", [None, 11, [1704067200, 0], None, "5"]],
+            "metadata type code is malformed",
+        ),
+        (
+            [["src_incomplete"], "Title", [None, 11, [1704067200, 0], None, 5]],
+            "status block is missing",
+        ),
+        (
+            [["src_incomplete"], "Title", [None, 11, [1704067200, 0], None, 5], []],
+            "status code is missing",
+        ),
+        (
+            [
+                ["src_incomplete"],
+                "Title",
+                [None, 11, [1704067200, 0], None, 5],
+                [None, "2"],
+            ],
+            "status code is malformed",
+        ),
+    ],
+)
+async def test_strict_list_rejects_incomplete_id_bearing_rows(
+    bad_row: list[Any],
+    detail: str,
+) -> None:
+    lister = SourceLister(RecordingRpc([["Notebook", [bad_row]]]))
+
+    with pytest.raises(RPCError, match=rf"incomplete source row at index 0 \({detail}"):
+        await lister.list("nb_123", strict=True)
+
+
+@pytest.mark.asyncio
+async def test_tolerant_list_keeps_incomplete_id_bearing_row_as_unknown() -> None:
+    row = [["src_incomplete"], "Title"]
+    lister = SourceLister(RecordingRpc([["Notebook", [row]]]))
+
+    sources = await lister.list("nb_123")
+
+    assert len(sources) == 1
+    assert sources[0].id == "src_incomplete"
+    assert sources[0].status is SourceStatus.UNKNOWN
+    assert sources[0].kind is SourceType.UNKNOWN
+
+
+@pytest.mark.asyncio
 async def test_list_dedups_duplicate_ids_keeping_first(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

- extend `client.sources.list()` with typed `statuses` and `types` filters
- apply OR semantics within each filter axis and AND semantics across axes after source normalization
- make `strict=True` reject malformed/id-less rows and conflicting duplicate IDs so `len(...)` is an exact count of unique addressable matches
- keep the existing list return type, backend ordering, tolerant default behavior, and one-RPC implementation
- document why this remains one canonical listing surface rather than adding `sources.count()` or an inventory object

## Why

The backend already returns the full source roster through `GET_NOTEBOOK`. A separate count or inventory API would imply a distinct authoritative or cheaper server operation that does not exist. Filtering and exact counting therefore belong on the existing normalized `sources.list()` surface.

## User impact

Existing calls remain compatible:

```python
sources = await client.sources.list(notebook_id)
```

Typed filtering and exact counts are opt-in:

```python
sources = await client.sources.list(
    notebook_id,
    strict=True,
    statuses={SourceStatus.READY},
    types={SourceType.PDF, SourceType.DOCX},
)
actual_count = len(sources)
```

## Validation

- `uv run pytest -q` — 15,624 passed, 64 skipped, 1 xfailed
- `uv run mypy src/notebooklm` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run pre-commit run --all-files` — passed
- `uv run python scripts/audit_public_api_compat.py --json` — no unapproved break

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added source listing filters by status and type.
  - Filters support OR matching within each category and AND matching across categories.
  - Empty filters return no sources.

- **Bug Fixes**
  - Strict mode now rejects malformed entries, missing IDs, and conflicting duplicates.
  - Duplicate identical entries are safely deduplicated.
  - Default tolerant behavior remains unchanged.

- **Documentation**
  - Updated API guidance and examples for filtering, validation, and exact counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->