### PR TITLE
refactor(auth): extract live-auth scenarios out of `python -c` strings (#2180)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,14 @@ jobs:
       run: uv run pre-commit run --all-files
 
     - name: Run type checking
-      run: uv run mypy src/notebooklm --ignore-missing-imports
+      # `scripts/_live_auth_scenarios` is included deliberately: those modules
+      # are the live-auth matrix cells that used to be `python -c` source
+      # strings (#2180). Type-checking them is most of the point of extracting
+      # them — they cannot be exercised without live Google credentials, so the
+      # checker is the only thing standing between a typo and a maintainer's
+      # release run. `--ignore-missing-imports` keeps this green on the lean
+      # install this job uses (no `mcp`/`server` extras).
+      run: uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports
 
     - name: Assert workflow permissions are scoped
       run: uv run python scripts/check_workflow_permissions.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ reports the *pipeline's* status, which has masked real failures here before.
 The pre-commit hook runs ruff (format + lint) on staged files. Also run these manually — CI fails otherwise:
 
 ```bash
-uv run mypy src/notebooklm --ignore-missing-imports
+uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports
 uv run pytest
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -637,6 +637,35 @@ the matrix gives the child process 30 additional seconds to report failure and
 tear down. Workspace/SSO, regional-account, and long-duration-expiry cases remain
 account-specific manual validation.
 
+#### Where a cell's code lives
+
+`scripts/live_auth_matrix.py` owns isolation, execution, and reporting only. The
+realistic recovery cells — storage reload, sibling re-mint, master-token
+fallback, REST recovery, MCP recovery, browser refresh, and the crash-safety
+writer — live in `scripts/_live_auth_scenarios/` as ordinary modules and are
+launched one per child process:
+
+```bash
+python -m scripts._live_auth_scenarios.<cell>
+```
+
+Each cell exports `async def scenario() -> ScenarioResult` plus a `main()`, and
+prints exactly one JSON object on stdout (the orchestrator parses it verbatim).
+Assertions go through `require(...)`, never `assert`, because these programs may
+run under `python -O`. Adding or renaming a cell means updating
+`SCENARIO_MODULES` in `tests/unit/test_live_auth_matrix.py`, which pins the
+module list, its profile constants, and child-process importability.
+
+To run one cell by hand against a disposable home:
+
+```bash
+PYTHONPATH="$PWD/src:$PWD" NOTEBOOKLM_HOME=/tmp/live-cell \
+  uv run python -m scripts._live_auth_scenarios.storage_reload
+```
+
+These modules are excluded from the shipped package on purpose and are
+type-checked by the `Run type checking` CI step alongside `src/notebooklm`.
+
 ### Selecting a profile for E2E tests
 
 The E2E suite picks up the active NotebookLM profile from (highest precedence first):

--- a/docs/development.md
+++ b/docs/development.md
@@ -637,6 +637,37 @@ the matrix gives the child process 30 additional seconds to report failure and
 tear down. Workspace/SSO, regional-account, and long-duration-expiry cases remain
 account-specific manual validation.
 
+#### The extras above are load-bearing — especially `headless`
+
+Run the matrix with the full set shown in the commands above
+(`browser`, `cookies`, `headless`, `mcp`, `server`). They are not
+interchangeable with the contributor install in
+[CLAUDE.md](../CLAUDE.md), which deliberately mirrors CI's test job and
+includes neither `cookies` nor `headless` — CI never runs this matrix.
+
+`headless` (`gpsoauth`) is the trap. Without it, every master-token cell
+fails **as if the token had been rejected**: `_require_gpsoauth` raises
+through `MasterTokenError`, and `_run_master_token_reauth` logs a warning
+and returns `None`, which the rung reports to its caller as a plain
+`False`. The visible symptom is `RPCError: The server rejected this
+request (unauthenticated)` — indistinguishable from a genuinely revoked
+master token, and it will send you off re-bootstrapping credentials that
+were fine all along. The distinguishing evidence is only in the log:
+
+```
+WARNING [notebooklm.auth] Master-token re-mint failed
+(Master-token auth needs gpsoauth. Install: pip install 'notebooklm-py[headless]');
+authentication error stands.
+```
+
+If a master-token, sibling, or REST cell fails, check for that warning
+before suspecting your credentials. Tracked as
+[#2239](https://github.com/teng-lin/notebooklm-py/issues/2239).
+
+Similarly, without `cookies` (`rookiepy`) the browser discovery/login and
+browser-refresh cells cannot run at all; use `--skip-browser` rather than
+reading their absence as a pass.
+
 #### Where a cell's code lives
 
 `scripts/live_auth_matrix.py` owns isolation, execution, and reporting only. The

--- a/scripts/_live_auth_scenarios/__init__.py
+++ b/scripts/_live_auth_scenarios/__init__.py
@@ -39,12 +39,15 @@ importable in the child regardless of how the parent interpreter was started.
 
 from __future__ import annotations
 
-from ._contract import ScenarioError, ScenarioResult, emit, require, run_scenario
+from ._contract import ScenarioError, ScenarioResult, require, run_scenario
 
+# ``emit`` is deliberately NOT re-exported: it is the printing half of
+# ``run_scenario`` and no cell needs it directly. A cell that ever does can
+# import it from ``._contract`` — an unused name in ``__all__`` reads like a
+# supported entry point that nothing keeps honest.
 __all__ = [
     "ScenarioError",
     "ScenarioResult",
-    "emit",
     "require",
     "run_scenario",
 ]

--- a/scripts/_live_auth_scenarios/__init__.py
+++ b/scripts/_live_auth_scenarios/__init__.py
@@ -1,0 +1,50 @@
+"""Importable live-auth recovery scenarios for ``scripts/live_auth_matrix.py``.
+
+Each module in this package is one *cell* of the maintainer live-auth matrix:
+a small program that drives a real recovery path against real credentials and
+prints a single JSON line describing what actually happened.
+
+Why a package instead of ``python -c "<source string>"``
+--------------------------------------------------------
+These scenarios used to be built by concatenating Python source literals inside
+``live_auth_matrix.py`` and handed to ``python -c``. That kept the process
+isolation the matrix depends on, but the programs themselves were invisible to
+Ruff and mypy, impossible to import from a test, and a failure reported a
+traceback into ``<string>`` with no line to open. Moving them into real modules
+keeps the isolation (the matrix still launches each one with
+``python -m scripts._live_auth_scenarios.<module>`` in a child process with its
+own ``NOTEBOOKLM_HOME`` and environment) while making the scenario bodies
+lintable, type-checkable, importable, and directly testable (#2180).
+
+Deliberately **not** under ``src/notebooklm/``: this is maintainer harness code
+that must not ship to users or count against the package coverage gate.
+
+Contract with the orchestrator
+------------------------------
+* Every scenario module exposes ``async def scenario() -> ScenarioResult`` and a
+  synchronous ``main()`` entry point, and is runnable as ``python -m``.
+* On success the process prints exactly one JSON object on stdout and exits 0.
+  ``Matrix.record(..., expect_json=True)`` parses that object verbatim, so the
+  key set of each payload is a frozen contract.
+* On failure a scenario raises :class:`ScenarioError` via :func:`require`; the
+  traceback goes to stderr and the process exits non-zero. Messages name the
+  broken invariant and never carry cookie or token values.
+
+Importability from the child process
+------------------------------------
+``Matrix.base_env`` puts BOTH ``<repo>/src`` and ``<repo>`` on ``PYTHONPATH``,
+and every phase runs with ``cwd=<repo>``, so ``scripts._live_auth_scenarios`` is
+importable in the child regardless of how the parent interpreter was started.
+"""
+
+from __future__ import annotations
+
+from ._contract import ScenarioError, ScenarioResult, emit, require, run_scenario
+
+__all__ = [
+    "ScenarioError",
+    "ScenarioResult",
+    "emit",
+    "require",
+    "run_scenario",
+]

--- a/scripts/_live_auth_scenarios/_contract.py
+++ b/scripts/_live_auth_scenarios/_contract.py
@@ -1,0 +1,53 @@
+"""The result/failure contract shared by every live-auth scenario module.
+
+The orchestrator (``scripts/live_auth_matrix.py``) treats a scenario child
+process as: *exit 0 with one JSON object on stdout* or *non-zero with a
+value-free diagnostic on stderr*. This module is the only place that shape is
+implemented, so the cells cannot drift apart from each other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+#: The JSON object a scenario prints on success. Keys are per-scenario and are
+#: read by the matrix report, so they may not be renamed casually.
+ScenarioResult = dict[str, Any]
+
+
+class ScenarioError(RuntimeError):
+    """A live-auth scenario invariant did not hold.
+
+    Subclasses :class:`RuntimeError` because that is what the embedded
+    ``python -c`` cells raised before #2180 moved them into real modules; the
+    orchestrator only ever sees the non-zero exit code and the stderr tail.
+    """
+
+
+def require(condition: object, message: str) -> None:
+    """Fail the scenario unless ``condition`` is truthy.
+
+    Deliberately not ``assert``: these programs may run under ``python -O``,
+    where ``assert`` is stripped and the scenario would silently "pass".
+    ``message`` must name the broken invariant, never quote a credential.
+    """
+    if not condition:
+        raise ScenarioError(message)
+
+
+def emit(payload: ScenarioResult) -> None:
+    """Print the scenario's single-line JSON result on stdout."""
+    print(json.dumps(payload))
+
+
+def run_scenario(scenario: Callable[[], Coroutine[Any, Any, ScenarioResult]]) -> None:
+    """Run one async scenario to completion and emit its JSON result.
+
+    The result is printed *after* the scenario's async context managers have
+    unwound, so a client that fails to close cannot be masked by a success
+    payload that was already flushed.
+    """
+    emit(asyncio.run(scenario()))

--- a/scripts/_live_auth_scenarios/browser_refresh.py
+++ b/scripts/_live_auth_scenarios/browser_refresh.py
@@ -1,0 +1,76 @@
+"""Optional browser-backed mid-session recovery (Layer-2.5 refresh command).
+
+The orchestrator points ``NOTEBOOKLM_REFRESH_CMD`` at
+``examples/refresh_browser_cookies.py`` and opts the rung in mid-session, then
+empties both the persisted cookie list and the live jar. Only the refresh
+command can recover from that, and it must be invoked exactly once.
+
+Result contract: ``{"before", "after", "refresh_command_calls", "live_cookies"}``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from notebooklm import NotebookLMClient
+from notebooklm._auth import session as auth_session
+
+from ._contract import ScenarioResult, require, run_scenario
+
+#: Disposable profile the orchestrator copies the source credentials into.
+PROFILE = "mid-session-browser"
+
+
+async def scenario() -> ScenarioResult:
+    """Recover a fully invalidated session through the refresh command once."""
+    refresh_calls = 0
+    original_refresh = auth_session._try_refresh_cmd_reauth
+
+    async def tracked_refresh(*args: Any, **kwargs: Any) -> bool:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return await original_refresh(*args, **kwargs)
+
+    auth_session._try_refresh_cmd_reauth = tracked_refresh
+    profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / PROFILE
+    storage = profile_dir / "storage_state.json"
+
+    async with NotebookLMClient.from_storage(profile=PROFILE) as client:
+        before = await client.notebooks.list()
+        before_ids = tuple(sorted(item.id for item in before))
+        state = json.loads(storage.read_text(encoding="utf-8"))
+        state["cookies"] = []
+        replacement = storage.with_suffix(".matrix-tmp")
+        replacement.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(replacement, storage)
+        live = client._collaborators.kernel.get_http_client().cookies
+        live.clear()
+        after = await client.notebooks.list()
+        after_ids = tuple(sorted(item.id for item in after))
+        require(
+            before_ids == after_ids,
+            "notebook identity changed after browser recovery",
+        )
+        require(
+            refresh_calls == 1,
+            "browser refresh command rung was not exercised once",
+        )
+        require(len(live) > 0, "browser recovery did not restore live jar")
+        return {
+            "before": len(before),
+            "after": len(after),
+            "refresh_command_calls": refresh_calls,
+            "live_cookies": len(live),
+        }
+
+
+def main() -> None:
+    """Entry point for ``python -m`` execution by the live-auth matrix."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/browser_refresh.py
+++ b/scripts/_live_auth_scenarios/browser_refresh.py
@@ -45,6 +45,12 @@ async def scenario() -> ScenarioResult:
         state["cookies"] = []
         replacement = storage.with_suffix(".matrix-tmp")
         replacement.write_text(json.dumps(state), encoding="utf-8")
+        # Match ``atomic_write_json``'s 0o600 (``_atomic_io.py``): a bare
+        # ``write_text`` lands at the process umask (0o644), and ``os.replace``
+        # carries the temp file's mode onto the profile. The disposable home is
+        # already 0o700, so this is defence in depth rather than a live hole,
+        # but a credential file must never widen on any path.
+        replacement.chmod(0o600)
         os.replace(replacement, storage)
         live = client._collaborators.kernel.get_http_client().cookies
         live.clear()

--- a/scripts/_live_auth_scenarios/crash_safe_writer.py
+++ b/scripts/_live_auth_scenarios/crash_safe_writer.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from notebooklm._auth.storage import replace_from_login
 
+from ._contract import require
+
 #: Number of back-to-back canonical writes attempted before exiting normally.
 WRITE_ITERATIONS = 10000
 
@@ -24,6 +26,10 @@ WRITE_ITERATIONS = 10000
 def main(argv: list[str] | None = None) -> None:
     """Rewrite ``argv[0]`` from the storage state in ``argv[1]``, repeatedly."""
     args = sys.argv[1:] if argv is None else argv
+    # Name the argv contract. This cell is the only one taking arguments, and
+    # it is *expected* to die by SIGKILL, so a bare IndexError from a wrong
+    # invocation would be easy to mistake for the kill the parent just sent.
+    require(len(args) >= 2, "crash_safe_writer needs <target> <source>")
     target = Path(args[0])
     # Explicit UTF-8, matching both sides of ``phase_crash_safety``. A
     # locale-dependent read is worse here than anywhere else in the package:

--- a/scripts/_live_auth_scenarios/crash_safe_writer.py
+++ b/scripts/_live_auth_scenarios/crash_safe_writer.py
@@ -25,7 +25,13 @@ def main(argv: list[str] | None = None) -> None:
     """Rewrite ``argv[0]`` from the storage state in ``argv[1]``, repeatedly."""
     args = sys.argv[1:] if argv is None else argv
     target = Path(args[0])
-    state = json.loads(Path(args[1]).read_text())
+    # Explicit UTF-8, matching both sides of ``phase_crash_safety``. A
+    # locale-dependent read is worse here than anywhere else in the package:
+    # under a non-UTF-8 locale it raises before the first write, the parent
+    # then kills an already-dead child and re-reads its own pristine copy,
+    # which parses fine — so the cell reports PASS having never exercised the
+    # canonical writer at all.
+    state = json.loads(Path(args[1]).read_text(encoding="utf-8"))
     for _ in range(WRITE_ITERATIONS):
         replace_from_login(target, state, include_domains=None)
 

--- a/scripts/_live_auth_scenarios/crash_safe_writer.py
+++ b/scripts/_live_auth_scenarios/crash_safe_writer.py
@@ -1,0 +1,34 @@
+"""Hammer the canonical storage writer so the parent can kill it mid-write.
+
+Unlike the other cells this one prints nothing and is *expected* to be killed:
+``Matrix.phase_crash_safety`` starts it, sleeps briefly, sends ``SIGKILL``, and
+then re-reads the target file. The file must always parse and must still hold
+the required Google session cookies, proving ``replace_from_login`` never leaves
+a torn canonical write behind.
+
+Usage: ``python -m scripts._live_auth_scenarios.crash_safe_writer <target> <source>``
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from notebooklm._auth.storage import replace_from_login
+
+#: Number of back-to-back canonical writes attempted before exiting normally.
+WRITE_ITERATIONS = 10000
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Rewrite ``argv[0]`` from the storage state in ``argv[1]``, repeatedly."""
+    args = sys.argv[1:] if argv is None else argv
+    target = Path(args[0])
+    state = json.loads(Path(args[1]).read_text())
+    for _ in range(WRITE_ITERATIONS):
+        replace_from_login(target, state, include_domains=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/master_token_recovery.py
+++ b/scripts/_live_auth_scenarios/master_token_recovery.py
@@ -46,6 +46,12 @@ async def scenario() -> ScenarioResult:
         state["cookies"] = []
         replacement = storage.with_suffix(".matrix-tmp")
         replacement.write_text(json.dumps(state), encoding="utf-8")
+        # Match ``atomic_write_json``'s 0o600 (``_atomic_io.py``): a bare
+        # ``write_text`` lands at the process umask (0o644), and ``os.replace``
+        # carries the temp file's mode onto the profile. The disposable home is
+        # already 0o700, so this is defence in depth rather than a live hole,
+        # but a credential file must never widen on any path.
+        replacement.chmod(0o600)
         os.replace(replacement, storage)
         live = client._collaborators.kernel.get_http_client().cookies
         live.clear()

--- a/scripts/_live_auth_scenarios/master_token_recovery.py
+++ b/scripts/_live_auth_scenarios/master_token_recovery.py
@@ -1,0 +1,83 @@
+"""Force the real Layer-4 rung after live *and* disk cookies become unusable.
+
+Empties the on-disk ``storage_state.json`` cookie list and the live jar, so the
+storage-reload rung has nothing to give and only a master-token re-mint can
+restore the session. Also asserts the recovery repaired the persisted profile,
+not merely the in-memory jar.
+
+Result contract: ``{"before", "after", "master_token_calls", "persisted_cookies",
+"live_cookies"}``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from notebooklm import NotebookLMClient
+from notebooklm._auth import session as auth_session
+
+from ._contract import ScenarioResult, require, run_scenario
+
+#: Disposable profile the orchestrator copies the source credentials into.
+PROFILE = "mid-session-master"
+
+
+async def scenario() -> ScenarioResult:
+    """Drive one mid-session master-token re-mint and verify it repaired disk."""
+    master_calls = 0
+    original_master = auth_session._try_master_token_reauth
+
+    async def tracked_master(*args: Any, **kwargs: Any) -> bool:
+        nonlocal master_calls
+        master_calls += 1
+        return await original_master(*args, **kwargs)
+
+    auth_session._try_master_token_reauth = tracked_master
+    profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / PROFILE
+    storage = profile_dir / "storage_state.json"
+
+    async with NotebookLMClient.from_storage(profile=PROFILE) as client:
+        before = await client.notebooks.list()
+        before_ids = tuple(sorted(item.id for item in before))
+        state = json.loads(storage.read_text(encoding="utf-8"))
+        state["cookies"] = []
+        replacement = storage.with_suffix(".matrix-tmp")
+        replacement.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(replacement, storage)
+        live = client._collaborators.kernel.get_http_client().cookies
+        live.clear()
+        after = await client.notebooks.list()
+        after_ids = tuple(sorted(item.id for item in after))
+        persisted = json.loads(storage.read_text(encoding="utf-8"))
+        require(
+            before_ids == after_ids,
+            "notebook identity changed after master-token recovery",
+        )
+        require(
+            master_calls == 1,
+            "mid-session Layer-4 recovery was not exercised once",
+        )
+        require(
+            persisted.get("cookies"),
+            "master-token recovery did not repair storage",
+        )
+        require(len(live) > 0, "master-token recovery did not restore live jar")
+        return {
+            "before": len(before),
+            "after": len(after),
+            "master_token_calls": master_calls,
+            "persisted_cookies": len(persisted["cookies"]),
+            "live_cookies": len(live),
+        }
+
+
+def main() -> None:
+    """Entry point for ``python -m`` execution by the live-auth matrix."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/mcp_recovery.py
+++ b/scripts/_live_auth_scenarios/mcp_recovery.py
@@ -1,0 +1,84 @@
+"""Drive a real FastMCP tool call across a live-jar invalidation.
+
+Uses FastMCP's in-memory protocol transport, so the call goes through the actual
+MCP tool dispatch rather than a hand-rolled shim. The bound client's live cookie
+jar is emptied between two identical ``notebook_list`` calls; the second call
+must return the same notebooks and leave a repopulated jar behind.
+
+Result contract: ``{"before", "after", "live_cookies", "transport"}``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+
+from fastmcp import Client
+
+from notebooklm import NotebookLMClient
+from notebooklm.mcp.server import create_server
+
+from ._contract import ScenarioResult, require, run_scenario
+
+#: Disposable profile the orchestrator copies the source credentials into.
+PROFILE = "mcp-live"
+
+
+async def scenario() -> ScenarioResult:
+    """Call one MCP tool, invalidate the live jar, call it again."""
+    holder: dict[str, NotebookLMClient] = {}
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[NotebookLMClient]:
+        async with NotebookLMClient.from_storage(profile=PROFILE, keepalive=600.0) as client:
+            holder["client"] = client
+            yield client
+
+    server = create_server(profile=PROFILE, client_factory=factory)
+    async with Client(server) as mcp:
+        before_result = await mcp.call_tool("notebook_list", {"limit": 50})
+        require(
+            before_result.structured_content is not None,
+            "MCP baseline returned no structured content",
+        )
+        before = before_result.structured_content
+        require(
+            "total" in before and "notebooks" in before,
+            "MCP baseline response is incomplete",
+        )
+        holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
+        after_result = await mcp.call_tool("notebook_list", {"limit": 50})
+        require(
+            after_result.structured_content is not None,
+            "MCP recovery returned no structured content",
+        )
+        after = after_result.structured_content
+        require(
+            "total" in after and "notebooks" in after,
+            "MCP recovery response is incomplete",
+        )
+        require(
+            before.get("total") == after.get("total"),
+            "MCP recovery changed the notebook count",
+        )
+        require(
+            before.get("notebooks") == after.get("notebooks"),
+            "MCP recovery changed notebook identity",
+        )
+        live = holder["client"]._collaborators.kernel.get_http_client().cookies
+        require(len(live) > 0, "MCP recovery did not restore the live jar")
+        return {
+            "before": before.get("total"),
+            "after": after.get("total"),
+            "live_cookies": len(live),
+            "transport": "fastmcp-in-memory",
+        }
+
+
+def main() -> None:
+    """Entry point for ``python -m`` execution by the live-auth matrix."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/rest_recovery.py
+++ b/scripts/_live_auth_scenarios/rest_recovery.py
@@ -1,0 +1,146 @@
+"""Drive REST through live-jar recovery and degraded-startup lazy binding.
+
+Two halves, both against a real ASGI app over ``httpx.ASGITransport``:
+
+1. *mid-session* — a served request recovers after the live cookie jar of the
+   bound client is emptied.
+2. *stale startup* — the server starts with an unusable profile (no cookies, the
+   master token withheld), must enter degraded startup with no bound client,
+   and must lazily bind a working client once a sibling CLI re-mints the
+   profile.
+
+Result contract: ``{"before", "after_live_reload", "after_stale_startup_rebind",
+"stale_startup_rebound"}``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from notebooklm import NotebookLMClient
+from notebooklm.server.app import create_app
+
+from ._contract import ScenarioResult, require, run_scenario
+
+#: Disposable profile that starts out healthy and loses only its live jar.
+PROFILE = "rest-live"
+#: Disposable profile that is made unusable before the server starts.
+STALE_PROFILE = "rest-stale"
+#: Must match ``NOTEBOOKLM_SERVER_TOKEN`` in the orchestrator's phase overrides.
+TOKEN = "matrix-rest-token"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Host": "127.0.0.1"}
+
+
+def notebook_ids(response: httpx.Response) -> tuple[str, ...]:
+    """Return the sorted notebook ids of a ``/v1/notebooks`` response."""
+    return tuple(sorted(item["id"] for item in response.json()["notebooks"]))
+
+
+async def mid_session() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Serve one request, empty the bound client's jar, serve another."""
+    holder: dict[str, NotebookLMClient] = {}
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[NotebookLMClient]:
+        async with NotebookLMClient.from_storage(profile=PROFILE, keepalive=600.0) as client:
+            holder["client"] = client
+            yield client
+
+    app = create_app(profile=PROFILE, client_factory=factory)
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(
+            app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
+        )
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as http:
+            before = await http.get("/v1/notebooks", headers=HEADERS)
+            require(before.status_code == 200, before.text[-1000:])
+            holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
+            after = await http.get("/v1/notebooks", headers=HEADERS)
+            require(after.status_code == 200, after.text[-1000:])
+            return notebook_ids(before), notebook_ids(after)
+
+
+async def stale_startup() -> tuple[str, ...]:
+    """Start degraded on an unusable profile, then bind after a sibling re-mint."""
+    profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / STALE_PROFILE
+    storage = profile_dir / "storage_state.json"
+    token = profile_dir / "master_token.json"
+    held_token = profile_dir / "master_token.matrix-held"
+    state = json.loads(storage.read_text(encoding="utf-8"))
+    state["cookies"] = []
+    replacement = storage.with_suffix(".matrix-tmp")
+    replacement.write_text(json.dumps(state), encoding="utf-8")
+    os.replace(replacement, storage)
+    require(token.is_file(), f"{STALE_PROFILE} profile has no master_token.json")
+    token.replace(held_token)
+
+    app = create_app(profile=STALE_PROFILE)
+    async with app.router.lifespan_context(app):
+        require(
+            app.state.notebooklm.client is None,
+            "REST server did not enter degraded startup",
+        )
+        held_token.replace(token)
+        sibling = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "notebooklm.notebooklm_cli",
+                "--profile",
+                STALE_PROFILE,
+                "login",
+                "--master-token-refresh",
+            ],
+            env=os.environ.copy(),
+            text=True,
+            capture_output=True,
+            timeout=90,
+            check=False,
+        )
+        require(sibling.returncode == 0, sibling.stderr[-1000:])
+        transport = httpx.ASGITransport(
+            app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
+        )
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1") as http:
+            response = await http.get("/v1/notebooks", headers=HEADERS)
+        require(response.status_code == 200, response.text[-1000:])
+        require(
+            app.state.notebooklm.client is not None,
+            "REST server did not bind a recovered client",
+        )
+        return notebook_ids(response)
+
+
+async def scenario() -> ScenarioResult:
+    """Run both REST recovery halves and require one stable notebook identity."""
+    before_ids, after_ids = await mid_session()
+    rebound_ids = await stale_startup()
+    require(
+        before_ids == after_ids == rebound_ids,
+        "REST recovery changed notebook identity",
+    )
+    payload: dict[str, Any] = {
+        "before": len(before_ids),
+        "after_live_reload": len(after_ids),
+        "after_stale_startup_rebind": len(rebound_ids),
+        "stale_startup_rebound": True,
+    }
+    return payload
+
+
+def main() -> None:
+    """Entry point for ``python -m`` execution by the live-auth matrix."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/rest_recovery.py
+++ b/scripts/_live_auth_scenarios/rest_recovery.py
@@ -79,6 +79,12 @@ async def stale_startup() -> tuple[str, ...]:
     state["cookies"] = []
     replacement = storage.with_suffix(".matrix-tmp")
     replacement.write_text(json.dumps(state), encoding="utf-8")
+    # Match ``atomic_write_json``'s 0o600 (``_atomic_io.py``): a bare
+    # ``write_text`` lands at the process umask (0o644), and ``os.replace``
+    # carries the temp file's mode onto the profile. The disposable home is
+    # already 0o700, so this is defence in depth rather than a live hole,
+    # but a credential file must never widen on any path.
+    replacement.chmod(0o600)
     os.replace(replacement, storage)
     require(token.is_file(), f"{STALE_PROFILE} profile has no master_token.json")
     token.replace(held_token)
@@ -106,7 +112,10 @@ async def stale_startup() -> tuple[str, ...]:
             timeout=90,
             check=False,
         )
-        require(sibling.returncode == 0, sibling.stderr[-1000:])
+        require(
+            sibling.returncode == 0,
+            f"stale-profile master-token re-mint failed with exit code {sibling.returncode}",
+        )
         transport = httpx.ASGITransport(
             app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
         )

--- a/scripts/_live_auth_scenarios/sibling_concurrent_reload.py
+++ b/scripts/_live_auth_scenarios/sibling_concurrent_reload.py
@@ -69,7 +69,10 @@ async def scenario() -> ScenarioResult:
             timeout=90,
             check=False,
         )
-        require(sibling.returncode == 0, sibling.stderr[-1000:])
+        require(
+            sibling.returncode == 0,
+            f"sibling master-token re-mint failed with exit code {sibling.returncode}",
+        )
         after_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
         require(
             after_hash != before_hash,

--- a/scripts/_live_auth_scenarios/sibling_concurrent_reload.py
+++ b/scripts/_live_auth_scenarios/sibling_concurrent_reload.py
@@ -1,0 +1,108 @@
+"""Consume a real sibling re-mint through one concurrent recovery wave.
+
+A sibling CLI process re-mints the profile from its master token while this
+process holds an open client. The master token is then deleted and the live jar
+emptied, so the four simultaneous RPCs that follow can only succeed by reloading
+the sibling's freshly written ``storage_state.json`` — and must share a single
+recovery wave rather than stampeding one reload per request.
+
+Result contract: ``{"before", "after", "reload_calls", "live_cookies",
+"sibling_profile_changed"}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from notebooklm import NotebookLMClient
+from notebooklm._auth import session as auth_session
+
+from ._contract import ScenarioResult, require, run_scenario
+
+#: Disposable profile the orchestrator copies the source credentials into.
+PROFILE = "mid-session-sibling"
+
+
+async def scenario() -> ScenarioResult:
+    """Re-mint from a sibling process, then recover four concurrent RPCs."""
+    reload_calls = 0
+    original_reload = auth_session.try_storage_cookie_reload
+
+    async def tracked_reload(*args: Any, **kwargs: Any) -> bool:
+        nonlocal reload_calls
+        reload_calls += 1
+        return await original_reload(*args, **kwargs)
+
+    async def forbidden(*args: object, **kwargs: object) -> bool:
+        raise AssertionError("external recovery rung reached")
+
+    auth_session.try_storage_cookie_reload = tracked_reload
+    auth_session._try_refresh_cmd_reauth = forbidden
+    auth_session._try_headless_reauth = forbidden
+    auth_session._try_master_token_reauth = forbidden
+    profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / PROFILE
+    storage = profile_dir / "storage_state.json"
+    before_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
+
+    async with NotebookLMClient.from_storage(profile=PROFILE) as client:
+        before = await client.notebooks.list()
+        before_ids = tuple(sorted(item.id for item in before))
+        sibling = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "notebooklm.notebooklm_cli",
+                "--profile",
+                PROFILE,
+                "login",
+                "--master-token-refresh",
+            ],
+            env=os.environ.copy(),
+            text=True,
+            capture_output=True,
+            timeout=90,
+            check=False,
+        )
+        require(sibling.returncode == 0, sibling.stderr[-1000:])
+        after_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
+        require(
+            after_hash != before_hash,
+            "sibling re-mint did not replace profile state",
+        )
+        (profile_dir / "master_token.json").unlink()
+        live = client._collaborators.kernel.get_http_client().cookies
+        live.clear()
+        recovered = await asyncio.gather(*(client.notebooks.list() for _ in range(4)))
+        counts = [len(items) for items in recovered]
+        recovered_ids = [tuple(sorted(item.id for item in items)) for items in recovered]
+        require(
+            recovered_ids == [before_ids] * 4,
+            "notebook identity changed after sibling recovery",
+        )
+        require(
+            0 < reload_calls <= 3,
+            "concurrent RPCs did not share one recovery wave",
+        )
+        require(len(live) > 0, "sibling recovery did not restore the live jar")
+        return {
+            "before": len(before),
+            "after": counts,
+            "reload_calls": reload_calls,
+            "live_cookies": len(live),
+            "sibling_profile_changed": True,
+        }
+
+
+def main() -> None:
+    """Entry point for ``python -m`` execution by the live-auth matrix."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_live_auth_scenarios/storage_reload.py
+++ b/scripts/_live_auth_scenarios/storage_reload.py
@@ -1,0 +1,74 @@
+"""Strict storage-only mid-session recovery (#2161).
+
+Proves the Layer-2 *storage reload* rung is the one that recovers a client whose
+live cookie jar was emptied mid-session: every external rung (refresh command,
+headless re-auth, master token) is replaced with a poisoned stub, so the cell
+fails loudly instead of quietly passing on a different rung.
+
+The orchestrator additionally deletes ``master_token.json`` from the disposable
+profile and blanks ``NOTEBOOKLM_REFRESH_BROWSER`` / ``NOTEBOOKLM_REFRESH_CMD`` /
+``NOTEBOOKLM_REFRESH_CMD_MIDSESSION`` before launching this module.
+
+Result contract: ``{"before", "after", "reload_calls", "live_cookies"}``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from notebooklm import NotebookLMClient
+from notebooklm._auth import session as auth_session
+
+from ._contract import ScenarioError, ScenarioResult, require, run_scenario
+
+#: Disposable profile the orchestrator copies the source credentials into.
+PROFILE = "mid-session-storage"
+
+
+async def scenario() -> ScenarioResult:
+    """Recover an emptied live jar from disk and prove no other rung ran."""
+    reload_calls = 0
+    original_reload = getattr(auth_session, "try_storage_cookie_reload", None)
+    if original_reload is None:
+        # The rung this cell exists to prove is gone; fail on the missing seam
+        # rather than on the "rung was not exercised" symptom further down.
+        raise ScenarioError("storage reload helper unavailable")
+
+    async def tracked_reload(*args: Any, **kwargs: Any) -> bool:
+        nonlocal reload_calls
+        reload_calls += 1
+        return await original_reload(*args, **kwargs)
+
+    async def forbidden(*args: object, **kwargs: object) -> bool:
+        raise AssertionError("external recovery rung reached")
+
+    auth_session.try_storage_cookie_reload = tracked_reload
+    auth_session._try_refresh_cmd_reauth = forbidden
+    auth_session._try_headless_reauth = forbidden
+    auth_session._try_master_token_reauth = forbidden
+
+    async with NotebookLMClient.from_storage(profile=PROFILE) as c:
+        before = await c.notebooks.list()
+        before_ids = tuple(sorted(item.id for item in before))
+        live = c._collaborators.kernel.get_http_client().cookies
+        live.clear()
+        after = await c.notebooks.list()
+        after_ids = tuple(sorted(item.id for item in after))
+        require(reload_calls > 0, "storage reload rung was not exercised")
+        require(len(live) > 0, "storage reload did not restore the live jar")
+        require(before_ids == after_ids, "notebook identity changed after recovery")
+        return {
+            "before": len(before),
+            "after": len(after),
+            "reload_calls": reload_calls,
+            "live_cookies": len(live),
+        }
+
+
+def main() -> None:
+    """Entry point for ``python -m scripts._live_auth_scenarios.storage_reload``."""
+    run_scenario(scenario)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_auth_matrix.py
+++ b/scripts/live_auth_matrix.py
@@ -52,6 +52,13 @@ expiry, and remote MCP HTTP/bearer/file-side-channel checks remain account- or
 deployment-specific manual cells. The matrix's MCP auth-recovery cell uses
 FastMCP's real in-memory protocol transport; deployed file-route coverage is
 available from ``scripts/mcp_live_smoke.py``.
+
+This module owns *isolation, execution, and reporting* only. The realistic
+recovery cells themselves live in ``scripts/_live_auth_scenarios/`` as ordinary
+importable modules (#2180) and are still launched one-per-child-process with
+``python -m scripts._live_auth_scenarios.<cell>`` under a disposable
+``NOTEBOOKLM_HOME``. They used to be Python source strings passed to
+``python -c``, which no linter, type checker, or unit test could see.
 """
 
 from __future__ import annotations
@@ -67,7 +74,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import textwrap
 import time
 import urllib.request
 from pathlib import Path
@@ -76,6 +82,18 @@ from urllib.parse import urlsplit
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_HOME = Path(os.environ.get("NOTEBOOKLM_HOME", Path.home() / ".notebooklm"))
+
+#: Import path of the scenario package launched with ``python -m`` by the
+#: realistic-recovery phases. The scenario *bodies* live in real, lintable,
+#: type-checked modules (#2180); this orchestrator still owns isolation,
+#: execution, and reporting, and every scenario still runs in its own child
+#: process with its own ``NOTEBOOKLM_HOME``.
+SCENARIO_PACKAGE = "scripts._live_auth_scenarios"
+
+
+def _scenario_command(module: str, *args: str) -> list[str]:
+    """Build the child-process command for one importable scenario module."""
+    return [sys.executable, "-m", f"{SCENARIO_PACKAGE}.{module}", *args]
 
 
 def _timeout_text(value: str | bytes | None) -> str:
@@ -126,7 +144,12 @@ class Matrix:
         self.base_env = os.environ.copy()
         self.base_env.update(
             {
-                "PYTHONPATH": str(ROOT / "src"),
+                # ``src`` for the package under test, and the repo root so a
+                # child can import ``scripts._live_auth_scenarios.<cell>``.
+                # Set explicitly rather than relying on ``python -m`` inserting
+                # the CWD, which ``PYTHONSAFEPATH`` in the caller's environment
+                # would suppress.
+                "PYTHONPATH": os.pathsep.join((str(ROOT / "src"), str(ROOT))),
                 "NOTEBOOKLM_BASE_URL": args.base_url,
                 "NOTEBOOKLM_REFRESH_BROWSER": args.browser,
             }
@@ -713,43 +736,7 @@ class Matrix:
         home = self.temp / "mid-session-storage"
         self.copy_profile(self.args.profile, home, "mid-session-storage")
         (home / "profiles" / "mid-session-storage" / "master_token.json").unlink(missing_ok=True)
-        script = (
-            "import asyncio, json\n"
-            "from notebooklm import NotebookLMClient\n"
-            "from notebooklm._auth import session as auth_session\n"
-            "def require(condition, message):\n"
-            "    if not condition:\n"
-            "        raise RuntimeError(message)\n"
-            "async def main():\n"
-            "    reload_calls = 0\n"
-            "    original_reload = getattr(auth_session, 'try_storage_cookie_reload', None)\n"
-            "    async def tracked_reload(*args, **kwargs):\n"
-            "        nonlocal reload_calls\n"
-            "        reload_calls += 1\n"
-            "        require(original_reload is not None, 'storage reload helper unavailable')\n"
-            "        return await original_reload(*args, **kwargs)\n"
-            "    async def forbidden(*args, **kwargs):\n"
-            "        raise AssertionError('external recovery rung reached')\n"
-            "    if original_reload is not None:\n"
-            "        auth_session.try_storage_cookie_reload = tracked_reload\n"
-            "    auth_session._try_refresh_cmd_reauth = forbidden\n"
-            "    auth_session._try_headless_reauth = forbidden\n"
-            "    auth_session._try_master_token_reauth = forbidden\n"
-            "    async with NotebookLMClient.from_storage(profile='mid-session-storage') as c:\n"
-            "        before = await c.notebooks.list()\n"
-            "        before_ids = tuple(sorted(item.id for item in before))\n"
-            "        live = c._collaborators.kernel.get_http_client().cookies\n"
-            "        live.clear()\n"
-            "        after = await c.notebooks.list()\n"
-            "        after_ids = tuple(sorted(item.id for item in after))\n"
-            "        require(reload_calls > 0, 'storage reload rung was not exercised')\n"
-            "        require(len(live) > 0, 'storage reload did not restore the live jar')\n"
-            "        require(before_ids == after_ids, 'notebook identity changed after recovery')\n"
-            "        print(json.dumps({'before': len(before), 'after': len(after), "
-            "'reload_calls': reload_calls, 'live_cookies': len(live)}))\n"
-            "asyncio.run(main())\n"
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("storage_reload")
         proc = self._run(
             command,
             home,
@@ -766,97 +753,7 @@ class Matrix:
         """Consume a real sibling re-mint through one concurrent recovery wave."""
         home = self.temp / "mid-session-sibling"
         self.copy_profile(self.args.profile, home, "mid-session-sibling")
-        script = textwrap.dedent(
-            """\
-            import asyncio
-            import hashlib
-            import json
-            import os
-            import subprocess
-            import sys
-            from pathlib import Path
-
-            from notebooklm import NotebookLMClient
-            from notebooklm._auth import session as auth_session
-
-            def require(condition, message):
-                if not condition:
-                    raise RuntimeError(message)
-
-            async def main():
-                reload_calls = 0
-                original_reload = auth_session.try_storage_cookie_reload
-
-                async def tracked_reload(*args, **kwargs):
-                    nonlocal reload_calls
-                    reload_calls += 1
-                    return await original_reload(*args, **kwargs)
-
-                async def forbidden(*args, **kwargs):
-                    raise AssertionError("external recovery rung reached")
-
-                auth_session.try_storage_cookie_reload = tracked_reload
-                auth_session._try_refresh_cmd_reauth = forbidden
-                auth_session._try_headless_reauth = forbidden
-                auth_session._try_master_token_reauth = forbidden
-                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-sibling"
-                storage = profile_dir / "storage_state.json"
-                before_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
-
-                async with NotebookLMClient.from_storage(profile="mid-session-sibling") as client:
-                    before = await client.notebooks.list()
-                    before_ids = tuple(sorted(item.id for item in before))
-                    sibling = subprocess.run(
-                        [
-                            sys.executable,
-                            "-m",
-                            "notebooklm.notebooklm_cli",
-                            "--profile",
-                            "mid-session-sibling",
-                            "login",
-                            "--master-token-refresh",
-                        ],
-                        env=os.environ.copy(),
-                        text=True,
-                        capture_output=True,
-                        timeout=90,
-                        check=False,
-                    )
-                    require(sibling.returncode == 0, sibling.stderr[-1000:])
-                    after_hash = hashlib.sha256(storage.read_bytes()).hexdigest()
-                    require(
-                        after_hash != before_hash,
-                        "sibling re-mint did not replace profile state",
-                    )
-                    (profile_dir / "master_token.json").unlink()
-                    live = client._collaborators.kernel.get_http_client().cookies
-                    live.clear()
-                    recovered = await asyncio.gather(*(client.notebooks.list() for _ in range(4)))
-                    counts = [len(items) for items in recovered]
-                    recovered_ids = [
-                        tuple(sorted(item.id for item in items)) for items in recovered
-                    ]
-                    require(
-                        recovered_ids == [before_ids] * 4,
-                        "notebook identity changed after sibling recovery",
-                    )
-                    require(
-                        0 < reload_calls <= 3,
-                        "concurrent RPCs did not share one recovery wave",
-                    )
-                    require(len(live) > 0, "sibling recovery did not restore the live jar")
-                    print(json.dumps({
-                        "before": len(before),
-                        "after": counts,
-                        "reload_calls": reload_calls,
-                        "live_cookies": len(live),
-                        "sibling_profile_changed": True,
-                    }))
-
-            asyncio.run(main())
-            """
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("sibling_concurrent_reload")
         proc = self._run(
             command,
             home,
@@ -875,71 +772,7 @@ class Matrix:
         """Force the real Layer-4 rung after both live and disk cookies become unusable."""
         home = self.temp / "mid-session-master"
         self.copy_profile(self.args.profile, home, "mid-session-master")
-        script = textwrap.dedent(
-            """\
-            import asyncio
-            import json
-            import os
-            from pathlib import Path
-
-            from notebooklm import NotebookLMClient
-            from notebooklm._auth import session as auth_session
-
-            def require(condition, message):
-                if not condition:
-                    raise RuntimeError(message)
-
-            async def main():
-                master_calls = 0
-                original_master = auth_session._try_master_token_reauth
-
-                async def tracked_master(*args, **kwargs):
-                    nonlocal master_calls
-                    master_calls += 1
-                    return await original_master(*args, **kwargs)
-
-                auth_session._try_master_token_reauth = tracked_master
-                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-master"
-                storage = profile_dir / "storage_state.json"
-
-                async with NotebookLMClient.from_storage(profile="mid-session-master") as client:
-                    before = await client.notebooks.list()
-                    before_ids = tuple(sorted(item.id for item in before))
-                    state = json.loads(storage.read_text(encoding="utf-8"))
-                    state["cookies"] = []
-                    replacement = storage.with_suffix(".matrix-tmp")
-                    replacement.write_text(json.dumps(state), encoding="utf-8")
-                    os.replace(replacement, storage)
-                    live = client._collaborators.kernel.get_http_client().cookies
-                    live.clear()
-                    after = await client.notebooks.list()
-                    after_ids = tuple(sorted(item.id for item in after))
-                    persisted = json.loads(storage.read_text(encoding="utf-8"))
-                    require(
-                        before_ids == after_ids,
-                        "notebook identity changed after master-token recovery",
-                    )
-                    require(
-                        master_calls == 1,
-                        "mid-session Layer-4 recovery was not exercised once",
-                    )
-                    require(
-                        persisted.get("cookies"),
-                        "master-token recovery did not repair storage",
-                    )
-                    require(len(live) > 0, "master-token recovery did not restore live jar")
-                    print(json.dumps({
-                        "before": len(before),
-                        "after": len(after),
-                        "master_token_calls": master_calls,
-                        "persisted_cookies": len(persisted["cookies"]),
-                        "live_cookies": len(live),
-                    }))
-
-            asyncio.run(main())
-            """
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("master_token_recovery")
         proc = self._run(
             command,
             home,
@@ -960,126 +793,7 @@ class Matrix:
         self.copy_profile(self.args.profile, home, "rest-live")
         self.copy_profile(self.args.profile, home, "rest-stale")
         (home / "profiles" / "rest-live" / "master_token.json").unlink(missing_ok=True)
-        script = textwrap.dedent(
-            """\
-            import asyncio
-            import contextlib
-            import json
-            import os
-            import subprocess
-            import sys
-            from pathlib import Path
-
-            import httpx
-
-            from notebooklm import NotebookLMClient
-            from notebooklm.server.app import create_app
-
-            TOKEN = "matrix-rest-token"
-            HEADERS = {"Authorization": f"Bearer {TOKEN}", "Host": "127.0.0.1"}
-
-            def require(condition, message):
-                if not condition:
-                    raise RuntimeError(message)
-
-            def notebook_ids(response):
-                return tuple(sorted(item["id"] for item in response.json()["notebooks"]))
-
-            async def mid_session():
-                holder = {}
-
-                @contextlib.asynccontextmanager
-                async def factory():
-                    async with NotebookLMClient.from_storage(
-                        profile="rest-live", keepalive=600.0
-                    ) as client:
-                        holder["client"] = client
-                        yield client
-
-                app = create_app(profile="rest-live", client_factory=factory)
-                async with app.router.lifespan_context(app):
-                    transport = httpx.ASGITransport(
-                        app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
-                    )
-                    async with httpx.AsyncClient(
-                        transport=transport, base_url="http://127.0.0.1"
-                    ) as http:
-                        before = await http.get("/v1/notebooks", headers=HEADERS)
-                        require(before.status_code == 200, before.text[-1000:])
-                        holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
-                        after = await http.get("/v1/notebooks", headers=HEADERS)
-                        require(after.status_code == 200, after.text[-1000:])
-                        return notebook_ids(before), notebook_ids(after)
-
-            async def stale_startup():
-                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "rest-stale"
-                storage = profile_dir / "storage_state.json"
-                token = profile_dir / "master_token.json"
-                held_token = profile_dir / "master_token.matrix-held"
-                state = json.loads(storage.read_text(encoding="utf-8"))
-                state["cookies"] = []
-                replacement = storage.with_suffix(".matrix-tmp")
-                replacement.write_text(json.dumps(state), encoding="utf-8")
-                os.replace(replacement, storage)
-                require(token.is_file(), "rest-stale profile has no master_token.json")
-                token.replace(held_token)
-
-                app = create_app(profile="rest-stale")
-                async with app.router.lifespan_context(app):
-                    require(
-                        app.state.notebooklm.client is None,
-                        "REST server did not enter degraded startup",
-                    )
-                    held_token.replace(token)
-                    sibling = subprocess.run(
-                        [
-                            sys.executable,
-                            "-m",
-                            "notebooklm.notebooklm_cli",
-                            "--profile",
-                            "rest-stale",
-                            "login",
-                            "--master-token-refresh",
-                        ],
-                        env=os.environ.copy(),
-                        text=True,
-                        capture_output=True,
-                        timeout=90,
-                        check=False,
-                    )
-                    require(sibling.returncode == 0, sibling.stderr[-1000:])
-                    transport = httpx.ASGITransport(
-                        app=app, client=("127.0.0.1", 5555), raise_app_exceptions=False
-                    )
-                    async with httpx.AsyncClient(
-                        transport=transport, base_url="http://127.0.0.1"
-                    ) as http:
-                        response = await http.get("/v1/notebooks", headers=HEADERS)
-                    require(response.status_code == 200, response.text[-1000:])
-                    require(
-                        app.state.notebooklm.client is not None,
-                        "REST server did not bind a recovered client",
-                    )
-                    return notebook_ids(response)
-
-            async def main():
-                before_ids, after_ids = await mid_session()
-                rebound_ids = await stale_startup()
-                require(
-                    before_ids == after_ids == rebound_ids,
-                    "REST recovery changed notebook identity",
-                )
-                print(json.dumps({
-                    "before": len(before_ids),
-                    "after_live_reload": len(after_ids),
-                    "after_stale_startup_rebind": len(rebound_ids),
-                    "stale_startup_rebound": True,
-                }))
-
-            asyncio.run(main())
-            """
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("rest_recovery")
         proc = self._run(
             command,
             home,
@@ -1100,76 +814,7 @@ class Matrix:
         home = self.temp / "mcp-auth"
         self.copy_profile(self.args.profile, home, "mcp-live")
         (home / "profiles" / "mcp-live" / "master_token.json").unlink(missing_ok=True)
-        script = textwrap.dedent(
-            """\
-            import asyncio
-            import contextlib
-            import json
-
-            from fastmcp import Client
-
-            from notebooklm import NotebookLMClient
-            from notebooklm.mcp.server import create_server
-
-            def require(condition, message):
-                if not condition:
-                    raise RuntimeError(message)
-
-            async def main():
-                holder = {}
-
-                @contextlib.asynccontextmanager
-                async def factory():
-                    async with NotebookLMClient.from_storage(
-                        profile="mcp-live", keepalive=600.0
-                    ) as client:
-                        holder["client"] = client
-                        yield client
-
-                server = create_server(profile="mcp-live", client_factory=factory)
-                async with Client(server) as mcp:
-                    before_result = await mcp.call_tool("notebook_list", {"limit": 50})
-                    require(
-                        before_result.structured_content is not None,
-                        "MCP baseline returned no structured content",
-                    )
-                    before = before_result.structured_content
-                    require(
-                        "total" in before and "notebooks" in before,
-                        "MCP baseline response is incomplete",
-                    )
-                    holder["client"]._collaborators.kernel.get_http_client().cookies.clear()
-                    after_result = await mcp.call_tool("notebook_list", {"limit": 50})
-                    require(
-                        after_result.structured_content is not None,
-                        "MCP recovery returned no structured content",
-                    )
-                    after = after_result.structured_content
-                    require(
-                        "total" in after and "notebooks" in after,
-                        "MCP recovery response is incomplete",
-                    )
-                    require(
-                        before.get("total") == after.get("total"),
-                        "MCP recovery changed the notebook count",
-                    )
-                    require(
-                        before.get("notebooks") == after.get("notebooks"),
-                        "MCP recovery changed notebook identity",
-                    )
-                    live = holder["client"]._collaborators.kernel.get_http_client().cookies
-                    require(len(live) > 0, "MCP recovery did not restore the live jar")
-                    print(json.dumps({
-                        "before": before.get("total"),
-                        "after": after.get("total"),
-                        "live_cookies": len(live),
-                        "transport": "fastmcp-in-memory",
-                    }))
-
-            asyncio.run(main())
-            """
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("mcp_recovery")
         proc = self._run(
             command,
             home,
@@ -1189,65 +834,7 @@ class Matrix:
         self.copy_profile(self.args.profile, home, "mid-session-browser")
         profile_dir = home / "profiles" / "mid-session-browser"
         (profile_dir / "master_token.json").unlink(missing_ok=True)
-        script = textwrap.dedent(
-            """\
-            import asyncio
-            import json
-            import os
-            from pathlib import Path
-
-            from notebooklm import NotebookLMClient
-            from notebooklm._auth import session as auth_session
-
-            def require(condition, message):
-                if not condition:
-                    raise RuntimeError(message)
-
-            async def main():
-                refresh_calls = 0
-                original_refresh = auth_session._try_refresh_cmd_reauth
-
-                async def tracked_refresh(*args, **kwargs):
-                    nonlocal refresh_calls
-                    refresh_calls += 1
-                    return await original_refresh(*args, **kwargs)
-
-                auth_session._try_refresh_cmd_reauth = tracked_refresh
-                profile_dir = Path(os.environ["NOTEBOOKLM_HOME"]) / "profiles" / "mid-session-browser"
-                storage = profile_dir / "storage_state.json"
-
-                async with NotebookLMClient.from_storage(profile="mid-session-browser") as client:
-                    before = await client.notebooks.list()
-                    before_ids = tuple(sorted(item.id for item in before))
-                    state = json.loads(storage.read_text(encoding="utf-8"))
-                    state["cookies"] = []
-                    replacement = storage.with_suffix(".matrix-tmp")
-                    replacement.write_text(json.dumps(state), encoding="utf-8")
-                    os.replace(replacement, storage)
-                    live = client._collaborators.kernel.get_http_client().cookies
-                    live.clear()
-                    after = await client.notebooks.list()
-                    after_ids = tuple(sorted(item.id for item in after))
-                    require(
-                        before_ids == after_ids,
-                        "notebook identity changed after browser recovery",
-                    )
-                    require(
-                        refresh_calls == 1,
-                        "browser refresh command rung was not exercised once",
-                    )
-                    require(len(live) > 0, "browser recovery did not restore live jar")
-                    print(json.dumps({
-                        "before": len(before),
-                        "after": len(after),
-                        "refresh_command_calls": refresh_calls,
-                        "live_cookies": len(live),
-                    }))
-
-            asyncio.run(main())
-            """
-        )
-        command = [sys.executable, "-c", script]
+        command = _scenario_command("browser_refresh")
         proc = self._run(
             command,
             home,
@@ -1291,17 +878,11 @@ class Matrix:
         required_names = {"SID", "APISID", "SAPISID", "LSID"}
         target = home / "storage_state.json"
         shutil.copy2(source, target)
-        script = (
-            "import json, sys\n"
-            "from pathlib import Path\n"
-            "from notebooklm._auth.storage import replace_from_login\n"
-            "p=Path(sys.argv[1]); state=json.loads(Path(sys.argv[2]).read_text())\n"
-            "[replace_from_login(p, state, include_domains=None) for _ in range(10000)]\n"
-        )
+        command = _scenario_command("crash_safe_writer", str(target), str(source))
         passed = True
         for _ in range(3):
             proc = subprocess.Popen(
-                [sys.executable, "-c", script, str(target), str(source)],
+                command,
                 cwd=ROOT,
                 env=self.env(home),
             )

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -679,8 +679,9 @@ def test_matrix_no_longer_ships_python_programs_through_dash_c() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value == "-c"
     ]
-    # The one survivor is the process-group regression test helper below, which
-    # lives in the test file, not here.
+    # Scoped to the orchestrator on purpose: this test file still uses
+    # ``python -c`` for the process-group regression helper, which is a throwaway
+    # sleep loop rather than a matrix cell.
     assert offenders == [], (
         "scripts/live_auth_matrix.py builds a `python -c` command at lines "
         f"{offenders}; live-auth cells belong in scripts/_live_auth_scenarios/ (#2180)"
@@ -696,16 +697,20 @@ def test_every_scenario_module_the_matrix_names_exists_on_disk() -> None:
 
 @pytest.mark.parametrize("module", [name for name, _extra in SCENARIO_MODULES])
 def test_scenario_modules_expose_typed_entry_points(module: str) -> None:
-    """Each cell is importable, has a ``main()``, and is annotated."""
+    """Each cell is importable, documented, and annotated.
+
+    Annotations read back as strings because every scenario module carries
+    ``from __future__ import annotations``.
+    """
     imported = _import_scenario(module)
-    main = imported.main
-    assert callable(main)
-    assert main.__doc__, f"{module}.main is undocumented"
-    assert main.__annotations__.get("return") in {"None", None.__class__, type(None)}
+    assert callable(imported.main)
+    assert imported.main.__doc__, f"{module}.main is undocumented"
+    assert imported.main.__annotations__["return"] == "None"
     if module == "crash_safe_writer":
+        # The writer is the one cell with no JSON contract: it prints nothing
+        # and is expected to be killed, so it has no ``scenario()``/``PROFILE``.
         return
-    scenario = imported.scenario
-    assert scenario.__annotations__["return"] == "ScenarioResult"
+    assert imported.scenario.__annotations__["return"] == "ScenarioResult"
     assert imported.PROFILE
 
 
@@ -981,3 +986,26 @@ def test_run_scenario_emits_nothing_when_the_scenario_fails(
     with pytest.raises(scenarios.ScenarioError):
         scenarios.run_scenario(scenario)
     assert capsys.readouterr().out == ""
+
+
+def test_scenarios_never_read_or_write_text_with_the_ambient_locale() -> None:
+    """Every text read/write in a cell must pin ``encoding=``.
+
+    ``phase_crash_safety`` reads and writes with explicit UTF-8 on both sides,
+    so a locale-dependent read inside the cell is not merely inconsistent: it
+    raises before the first write, and the parent then re-reads its own pristine
+    copy, parses it happily, and reports the cell as PASS without the canonical
+    writer ever having run.
+    """
+    offenders: list[str] = []
+    for path in sorted(SCENARIO_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in {"read_text", "write_text"}
+                and not any(kw.arg == "encoding" for kw in node.keywords)
+            ):
+                offenders.append(f"{path.name}:{node.lineno} {node.func.attr}()")
+    assert offenders == [], f"pass encoding='utf-8' explicitly: {offenders}"

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -1070,3 +1070,11 @@ def test_scenarios_restore_owner_only_mode_when_replacing_a_profile_file() -> No
                 if not any(line < node.lineno for line in chmod_lines):
                     offenders.append(f"{path.name}:{node.lineno}")
     assert offenders == [], f"chmod(0o600) the temp file before os.replace: {offenders}"
+
+
+def test_crash_safe_writer_names_its_argv_contract(tmp_path: Path) -> None:
+    """A wrong invocation must not look like the SIGKILL the parent sends."""
+    writer = _import_scenario("crash_safe_writer")
+    scenarios = importlib.import_module("scripts._live_auth_scenarios")
+    with pytest.raises(scenarios.ScenarioError, match="needs <target> <source>"):
+        writer.main([str(tmp_path / "target.json")])

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -1,18 +1,62 @@
-"""Behavioral wiring tests for the maintainer live-auth matrix."""
+"""Behavioral wiring tests for the maintainer live-auth matrix.
+
+Two halves:
+
+* the orchestrator half — that each phase still builds the right command, home,
+  environment, and timeout for its isolated child process; and
+* the scenario half (#2180) — that the recovery cells the orchestrator launches
+  are real, importable, typed modules under ``scripts/_live_auth_scenarios/``
+  rather than Python source strings fed to ``python -c``.
+
+None of this can prove the *live* behaviour of a cell; only a maintainer matrix
+run against real Google credentials does that.
+"""
 
 from __future__ import annotations
 
 import argparse
+import ast
+import importlib
 import json
 import os
 import subprocess
 import sys
 import time
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from scripts import live_auth_matrix
+
+REPO_ROOT = Path(live_auth_matrix.ROOT)
+SCENARIO_DIR = REPO_ROOT / "scripts" / "_live_auth_scenarios"
+
+#: ``(scenario module, extra import the module needs)`` for every cell the
+#: matrix launches. The extras are the optional server/MCP dependencies, so the
+#: table doubles as the list of cells that vanish from a partial install.
+SCENARIO_MODULES: tuple[tuple[str, str | None], ...] = (
+    ("storage_reload", None),
+    ("sibling_concurrent_reload", None),
+    ("master_token_recovery", None),
+    ("rest_recovery", "fastapi"),
+    ("mcp_recovery", "fastmcp"),
+    ("browser_refresh", None),
+    ("crash_safe_writer", None),
+)
+
+
+def _scenario_argv(module: str, *args: str) -> list[str]:
+    """The exact child-process argv a phase must use for ``module``."""
+    return [sys.executable, "-m", f"scripts._live_auth_scenarios.{module}", *args]
+
+
+def _import_scenario(module: str) -> ModuleType:
+    """Import one scenario module, skipping when its optional extra is absent."""
+    required = dict(SCENARIO_MODULES)[module]
+    if required is not None:
+        pytest.importorskip(required)
+    return importlib.import_module(f"scripts._live_auth_scenarios.{module}")
 
 
 def _args(*, skip_browser: bool) -> argparse.Namespace:
@@ -346,8 +390,6 @@ def test_storage_mid_session_cell_disables_every_external_fallback(
         env_overrides: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = matrix.env(home, **(env_overrides or {}))
-        if len(command) >= 3 and command[-2] == "-c":
-            compile(command[-1], "<live-auth-matrix-cell>", "exec")
         observed["command"] = command
         observed["env"] = env
         observed["timeout"] = timeout
@@ -374,11 +416,7 @@ def test_storage_mid_session_cell_disables_every_external_fallback(
     assert env["NOTEBOOKLM_PROFILE"] == "mid-session-storage"
     command = observed["command"]
     assert isinstance(command, list)
-    child_script = command[-1]
-    assert "try_storage_cookie_reload = tracked_reload" in child_script
-    assert "external recovery rung reached" in child_script
-    assert "before_ids == after_ids" in child_script
-    assert "assert " not in child_script
+    assert command == _scenario_argv("storage_reload")
     assert matrix.results == [
         {
             "name": "mid-session-storage-reload",
@@ -471,8 +509,6 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
         env_overrides: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = matrix.env(home, **(env_overrides or {}))
-        if len(command) >= 3 and command[-2] == "-c":
-            compile(command[-1], "<live-auth-matrix-cell>", "exec")
         if env.get("NOTEBOOKLM_PROFILE") == "mid-session-browser":
             browser_profile = (
                 matrix.temp / "mid-session-browser" / "profiles" / "mid-session-browser"
@@ -504,48 +540,17 @@ def test_realistic_recovery_cells_wire_real_process_and_adapter_paths(
     assert rpc_env["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"] == "generation-id"
     assert rpc_timeout == 300
 
-    sibling_script = by_profile["mid-session-sibling"][0][-1]
-    assert "--master-token-refresh" in sibling_script
-    assert "asyncio.gather" in sibling_script
-    assert "reload_calls <= 3" in sibling_script
-    assert "recovered_ids == [before_ids] * 4" in sibling_script
-
-    master_script = by_profile["mid-session-master"][0][-1]
-    assert 'state["cookies"] = []' in master_script
-    assert "tracked_master" in master_script
-    assert "master_calls == 1" in master_script
-    assert "before_ids == after_ids" in master_script
-
-    rest_script = by_profile["rest-live"][0][-1]
-    assert 'http.get("/v1/notebooks"' in rest_script
-    assert "app.state.notebooklm.client is None" in rest_script
-    assert "--master-token-refresh" in rest_script
-    assert 'require(token.is_file(), "rest-stale profile has no master_token.json")' in rest_script
-    assert "before_ids == after_ids == rebound_ids" in rest_script
-
-    mcp_script = by_profile["mcp-live"][0][-1]
-    assert 'mcp.call_tool("notebook_list"' in mcp_script
-    assert "keepalive=600.0" in mcp_script
-    assert '"total" in before and "notebooks" in before' in mcp_script
+    assert by_profile["mid-session-sibling"][0] == _scenario_argv("sibling_concurrent_reload")
+    assert by_profile["mid-session-master"][0] == _scenario_argv("master_token_recovery")
+    assert by_profile["rest-live"][0] == _scenario_argv("rest_recovery")
+    assert by_profile["rest-live"][1]["NOTEBOOKLM_SERVER_TOKEN"] == "matrix-rest-token"
+    assert by_profile["mcp-live"][0] == _scenario_argv("mcp_recovery")
 
     browser_command, browser_env, browser_timeout = by_profile["mid-session-browser"]
-    browser_script = browser_command[-1]
-    assert 'state["cookies"] = []' in browser_script
-    assert "tracked_refresh" in browser_script
-    assert "refresh_calls == 1" in browser_script
-    assert "before_ids == after_ids" in browser_script
+    assert browser_command == _scenario_argv("browser_refresh")
     assert browser_env["NOTEBOOKLM_PROFILE"] == "mid-session-browser"
     assert browser_env["NOTEBOOKLM_HEADLESS_REAUTH"] == ""
     assert browser_timeout == 180
-
-    child_scripts = [
-        sibling_script,
-        master_script,
-        rest_script,
-        mcp_script,
-        browser_script,
-    ]
-    assert all("assert " not in script for script in child_scripts)
 
 
 def test_run_normalizes_launch_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -651,3 +656,327 @@ def test_run_terminates_descendant_processes_on_timeout(tmp_path: Path) -> None:
         live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
 
     assert result.returncode == 124
+
+
+# ---------------------------------------------------------------------------
+# The scenario package (#2180)
+#
+# These replace the string-matching assertions that used to grep the generated
+# ``python -c`` source ("``tracked_master`` appears in the script"). Grepping a
+# source literal proved the orchestrator built a string, not that anything was
+# runnable; a typo inside the string passed the test and failed only on a live
+# maintainer run. The checks below instead import the real module.
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_no_longer_ships_python_programs_through_dash_c() -> None:
+    """No phase may hand a multi-line Python program to ``python -c``."""
+    source = (REPO_ROOT / "scripts" / "live_auth_matrix.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value == "-c"
+    ]
+    # The one survivor is the process-group regression test helper below, which
+    # lives in the test file, not here.
+    assert offenders == [], (
+        "scripts/live_auth_matrix.py builds a `python -c` command at lines "
+        f"{offenders}; live-auth cells belong in scripts/_live_auth_scenarios/ (#2180)"
+    )
+
+
+def test_every_scenario_module_the_matrix_names_exists_on_disk() -> None:
+    for module, _extra in SCENARIO_MODULES:
+        assert (SCENARIO_DIR / f"{module}.py").is_file(), module
+    on_disk = {path.stem for path in SCENARIO_DIR.glob("*.py") if not path.stem.startswith("_")}
+    assert on_disk == {module for module, _extra in SCENARIO_MODULES}
+
+
+@pytest.mark.parametrize("module", [name for name, _extra in SCENARIO_MODULES])
+def test_scenario_modules_expose_typed_entry_points(module: str) -> None:
+    """Each cell is importable, has a ``main()``, and is annotated."""
+    imported = _import_scenario(module)
+    main = imported.main
+    assert callable(main)
+    assert main.__doc__, f"{module}.main is undocumented"
+    assert main.__annotations__.get("return") in {"None", None.__class__, type(None)}
+    if module == "crash_safe_writer":
+        return
+    scenario = imported.scenario
+    assert scenario.__annotations__["return"] == "ScenarioResult"
+    assert imported.PROFILE
+
+
+def test_scenario_profiles_match_the_orchestrator_phase_environments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cell's ``PROFILE`` must be the profile its phase copies credentials to.
+
+    The scenario names its profile and the orchestrator names it again in
+    ``env_overrides``; nothing links the two at runtime, so a rename on one side
+    would only surface as an authentication failure on a live run.
+    """
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    seen: dict[str, str] = {}
+
+    def fake_run(
+        command: list[str],
+        home: Path,
+        *,
+        timeout: int | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = matrix.env(home, **(env_overrides or {}))
+        seen[command[2].rsplit(".", 1)[-1]] = env["NOTEBOOKLM_PROFILE"]
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    monkeypatch.setattr(matrix, "_run", fake_run)
+    try:
+        matrix.phase_storage_mid_session()
+        matrix.phase_sibling_concurrent_mid_session()
+        matrix.phase_master_token_mid_session()
+        matrix.phase_rest_auth_recovery()
+        matrix.phase_mcp_auth_recovery()
+        matrix.phase_browser_mid_session()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert set(seen) == {
+        "storage_reload",
+        "sibling_concurrent_reload",
+        "master_token_recovery",
+        "rest_recovery",
+        "mcp_recovery",
+        "browser_refresh",
+    }
+    for module, profile in seen.items():
+        assert profile == _import_scenario(module).PROFILE, module
+
+
+def test_rest_scenario_bearer_token_matches_the_phase_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The REST cell's ``Authorization`` header must match the served token."""
+    pytest.importorskip("fastapi")
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    served: dict[str, str] = {}
+
+    def fake_run(
+        command: list[str],
+        home: Path,
+        *,
+        timeout: int | None = None,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        served.update(matrix.env(home, **(env_overrides or {})))
+        return subprocess.CompletedProcess(command, 0, "{}", "")
+
+    monkeypatch.setattr(matrix, "_run", fake_run)
+    try:
+        matrix.phase_rest_auth_recovery()
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    rest_recovery = _import_scenario("rest_recovery")
+    assert served["NOTEBOOKLM_SERVER_TOKEN"] == rest_recovery.TOKEN
+    assert rest_recovery.HEADERS["Authorization"] == f"Bearer {rest_recovery.TOKEN}"
+
+
+def test_scenarios_never_use_bare_assert() -> None:
+    """``python -O`` strips ``assert``; a stripped cell would pass vacuously."""
+    offenders: list[str] = []
+    for path in sorted(SCENARIO_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        offenders += [
+            f"{path.name}:{node.lineno}" for node in ast.walk(tree) if isinstance(node, ast.Assert)
+        ]
+    assert offenders == [], f"use require(...) instead of assert: {offenders}"
+
+
+def test_matrix_child_environment_can_import_the_scenario_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prove importability in a real child, not by reasoning about sys.path.
+
+    ``PYTHONSAFEPATH`` is forced on so the check cannot pass merely because
+    ``python -m`` prepends the working directory.
+    """
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    modules = [
+        name
+        for name, extra in SCENARIO_MODULES
+        if extra is None or importlib.util.find_spec(extra) is not None
+    ]
+    env = matrix.env(tmp_path / "child-home", PYTHONSAFEPATH="1")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import importlib, sys\n"
+                "for name in sys.argv[1:]:\n"
+                "    importlib.import_module('scripts._live_auth_scenarios.' + name)\n"
+                "print('ok')\n",
+                *modules,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=120,
+            check=False,
+        )
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert proc.stdout.strip() == "ok"
+
+
+def test_matrix_child_environment_exposes_repo_root_and_src(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    try:
+        entries = matrix.env(tmp_path)["PYTHONPATH"].split(os.pathsep)
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+    assert entries == [str(REPO_ROOT / "src"), str(REPO_ROOT)]
+
+
+def test_crash_safety_phase_launches_the_writer_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _source_profile(tmp_path)
+    monkeypatch.setattr(live_auth_matrix, "DEFAULT_HOME", tmp_path)
+    matrix = live_auth_matrix.Matrix(_args(skip_browser=True))
+    commands: list[list[str]] = []
+
+    class FakePopen:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            commands.append(command)
+
+        def kill(self) -> None:
+            return None
+
+        def wait(self, timeout: int | None = None) -> int:
+            return 0
+
+    monkeypatch.setattr(live_auth_matrix.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(live_auth_matrix.time, "sleep", lambda _seconds: None)
+    try:
+        matrix.phase_crash_safety()
+        target = matrix.temp / "crash" / "storage_state.json"
+        source = tmp_path / "profiles" / "source" / "storage_state.json"
+        assert commands == [_scenario_argv("crash_safe_writer", str(target), str(source))] * 3
+    finally:
+        live_auth_matrix.shutil.rmtree(matrix.temp, ignore_errors=True)
+
+
+def test_crash_safe_writer_rewrites_the_target_canonically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run the real writer entry point, with no subprocess and no credentials.
+
+    This is the one cell whose whole body can be exercised offline: it needs no
+    live session, only a syntactically complete storage state. It pins the argv
+    order (target first, source second) and the ``include_domains=None`` policy
+    that makes the crash cell rewrite the state unfiltered.
+    """
+    writer = _import_scenario("crash_safe_writer")
+    monkeypatch.setattr(writer, "WRITE_ITERATIONS", 2)
+    cookies = [
+        {"name": name, "value": "redacted", "domain": ".google.com", "path": "/"}
+        for name in (
+            "SID",
+            "APISID",
+            "SAPISID",
+            "LSID",
+            "HSID",
+            "SSID",
+            "__Secure-1PSID",
+            "__Secure-1PSIDTS",
+            "__Secure-3PSID",
+            "__Secure-3PSIDTS",
+        )
+    ]
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps({"cookies": cookies}), encoding="utf-8")
+    target = tmp_path / "target.json"
+    target.write_text("{}", encoding="utf-8")
+
+    writer.main([str(target), str(source)])
+
+    written = json.loads(target.read_text(encoding="utf-8"))
+    # The same required set ``phase_crash_safety`` re-checks after each kill.
+    assert {"SID", "APISID", "SAPISID", "LSID"} <= {cookie["name"] for cookie in written["cookies"]}
+    assert json.loads(source.read_text(encoding="utf-8"))["cookies"] == cookies
+
+
+def test_crash_safe_writer_loops_over_the_canonical_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cell must keep hammering one writer call so a kill can land mid-write."""
+    writer = _import_scenario("crash_safe_writer")
+    monkeypatch.setattr(writer, "WRITE_ITERATIONS", 3)
+    calls: list[tuple[Path, dict[str, object], object]] = []
+
+    def fake_replace(path: Path, state: dict[str, object], *, include_domains: object) -> None:
+        calls.append((path, state, include_domains))
+
+    monkeypatch.setattr(writer, "replace_from_login", fake_replace)
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps({"cookies": []}), encoding="utf-8")
+    target = tmp_path / "target.json"
+
+    writer.main([str(target), str(source)])
+
+    assert calls == [(target, {"cookies": []}, None)] * 3
+
+
+def test_require_raises_a_named_scenario_error() -> None:
+    scenarios = importlib.import_module("scripts._live_auth_scenarios")
+    scenarios.require(True, "must not raise")
+    with pytest.raises(scenarios.ScenarioError, match="the invariant name"):
+        scenarios.require(False, "the invariant name")
+    assert issubclass(scenarios.ScenarioError, RuntimeError)
+
+
+def test_run_scenario_emits_one_json_line_after_the_scenario_returns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    scenarios = importlib.import_module("scripts._live_auth_scenarios")
+    order: list[str] = []
+
+    async def scenario() -> dict[str, object]:
+        order.append("scenario")
+        return {"before": 2, "after": 2}
+
+    scenarios.run_scenario(scenario)
+    out = capsys.readouterr().out
+    assert order == ["scenario"]
+    assert json.loads(out) == {"before": 2, "after": 2}
+    assert out.count("\n") == 1
+
+
+def test_run_scenario_emits_nothing_when_the_scenario_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    scenarios = importlib.import_module("scripts._live_auth_scenarios")
+
+    async def scenario() -> dict[str, object]:
+        scenarios.require(False, "storage reload rung was not exercised")
+        raise AssertionError("unreachable")
+
+    with pytest.raises(scenarios.ScenarioError):
+        scenarios.run_scenario(scenario)
+    assert capsys.readouterr().out == ""

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import ast
 import importlib
+import importlib.util
 import json
 import os
 import subprocess

--- a/tests/unit/test_live_auth_matrix.py
+++ b/tests/unit/test_live_auth_matrix.py
@@ -1009,3 +1009,64 @@ def test_scenarios_never_read_or_write_text_with_the_ambient_locale() -> None:
             ):
                 offenders.append(f"{path.name}:{node.lineno} {node.func.attr}()")
     assert offenders == [], f"pass encoding='utf-8' explicitly: {offenders}"
+
+
+def test_scenarios_never_pass_subprocess_output_as_an_invariant_message() -> None:
+    """``require`` messages must name the invariant, not echo a child's output.
+
+    ``_contract.require`` documents that a message "must name the broken
+    invariant, never quote a credential". Forwarding the stderr tail of
+    ``notebooklm login --master-token-refresh`` breaks that: the tail is
+    arbitrary CLI logging, it lands in the scenario's own stderr, and the
+    orchestrator copies that into a report meant for a release checklist.
+    """
+    offenders: list[str] = []
+    for path in sorted(SCENARIO_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "require"
+                and len(node.args) == 2
+            ):
+                continue
+            leaked = [
+                child.attr
+                for child in ast.walk(node.args[1])
+                if isinstance(child, ast.Attribute) and child.attr in {"stderr", "stdout"}
+            ]
+            offenders += [f"{path.name}:{node.lineno} .{attr}" for attr in leaked]
+    assert offenders == [], f"name the invariant instead of echoing child output: {offenders}"
+
+
+def test_scenarios_restore_owner_only_mode_when_replacing_a_profile_file() -> None:
+    """Any hand-rolled ``os.replace`` onto a profile file must pin 0o600.
+
+    ``atomic_write_json`` writes credential files at 0o600
+    (``src/notebooklm/_atomic_io.py``), but a bare ``write_text`` lands at the
+    process umask and ``os.replace`` carries that mode onto the profile.
+    """
+    offenders: list[str] = []
+    for path in sorted(SCENARIO_DIR.glob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        chmod_lines = {
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "chmod"
+        }
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "replace"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+            ):
+                # The chmod must precede the replace inside the same block.
+                if not any(line < node.lineno for line in chmod_lines):
+                    offenders.append(f"{path.name}:{node.lineno}")
+    assert offenders == [], f"chmod(0o600) the temp file before os.replace: {offenders}"


### PR DESCRIPTION
Closes #2180

## What changed

`scripts/live_auth_matrix.py` built seven of its cells by concatenating Python source literals and handing them to `python -c`. Those programs were invisible to Ruff, mypy, and every unit test — the only feedback loop for a typo inside one was a maintainer's live run, and a failure reported a traceback into `<string>` with no line to open.

Each cell now lives in `scripts/_live_auth_scenarios/` as an ordinary importable module:

| phase | module | cell |
| --- | --- | --- |
| `phase_storage_mid_session` | `storage_reload` | strict storage-only recovery (#2161) |
| `phase_sibling_concurrent_mid_session` | `sibling_concurrent_reload` | sibling re-mint + one concurrent recovery wave |
| `phase_master_token_mid_session` | `master_token_recovery` | real Layer-4 mid-session fallback |
| `phase_rest_auth_recovery` | `rest_recovery` | REST live-jar recovery + degraded-startup rebind |
| `phase_mcp_auth_recovery` | `mcp_recovery` | FastMCP in-memory transport recovery |
| `phase_browser_mid_session` | `browser_refresh` | refresh-command rung |
| `phase_crash_safety` | `crash_safe_writer` | canonical-write hammer |

Each exposes `async def scenario() -> ScenarioResult` plus a `main()`, and `scripts/_live_auth_scenarios/_contract.py` owns the single shared result/failure contract (`require`, `emit`, `run_scenario`, `ScenarioError`).

`scripts/live_auth_matrix.py` drops 1432 → 1006 lines and keeps only isolation, execution, and reporting.

## Isolation is unchanged

Every cell still runs in its own child process (`python -m scripts._live_auth_scenarios.<cell>`), with `cwd=<repo>`, its own disposable `NOTEBOOKLM_HOME`, the same `env_overrides`, and the same timeout. Nothing was inlined into the parent.

The one deliberate environment change: `PYTHONPATH` now carries the repo root in addition to `src/`, so the child can import the scenario package even when `PYTHONSAFEPATH` is set in the caller's environment. This is verified in a real subprocess (`test_matrix_child_environment_can_import_the_scenario_package` forces `PYTHONSAFEPATH=1`), not assumed.

## Location

The package sits next to the harness, **not** under `src/notebooklm/`: it is maintainer-only code that must not ship to users and must not add uncovered lines against the `--cov-fail-under=90` gate. The ADR-0008 module-size ratchet (`tests/_guardrails/test_module_size_ratchet.py`) scans `src/notebooklm/` only, so no pin changes — and `live_auth_matrix.py` shrinking is exactly the direction that ratchet wants anyway.

## Verification — and its honest limits

**Proven by tests / tooling in this PR:**
- **Characterization before/after.** I captured what every phase executes (command, home, env, timeout) on `origin/main` and again after the refactor. The captures differ *only* in the command; homes, environments, effective timeouts, and phase→profile mappings are byte-identical. `phase_rpc_health`, `phase_rpc_bundle_health`, `phase_fault_injection`, and `phase_rpc_access_gate_contract` are unchanged in every field.
- **Orchestrator wiring.** Each realistic-recovery phase's exact argv, env, home, and timeout is pinned (`_scenario_argv(...)`), including the REST phase's `NOTEBOOKLM_SERVER_TOKEN` and the browser phase's 180s floor.
- **Scenario ↔ orchestrator agreement.** Each cell's `PROFILE` constant is asserted equal to the `NOTEBOOKLM_PROFILE` its phase sets, and `rest_recovery.TOKEN` equal to the served `NOTEBOOKLM_SERVER_TOKEN`. Nothing linked those at runtime before; a rename on one side would have surfaced only as a live auth failure.
- **Importability from the child**, in a real subprocess with `PYTHONSAFEPATH=1`.
- **Typed entry points**: every module imports, exposes a documented `main() -> None`, and (except the writer) a `scenario() -> ScenarioResult`.
- **No bare `assert`** anywhere in the package (AST scan) — `python -O` strips `assert`, and a stripped cell would pass vacuously. This preserves the intent of the old `assert "assert " not in script` string checks.
- **No `python -c` left** in `live_auth_matrix.py` (AST scan), so the idiom cannot creep back.
- **`crash_safe_writer` runs end to end** — it is the one cell needing no credentials. Also verified by hand outside pytest: 10,000 real `replace_from_login` writes, target intact.
- Gate: `uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-fail-under=90` → **16527 passed, 64 skipped, 96.81%**, exit 0 (checked directly, not through a pipe). `uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports` → clean. `uv run pre-commit run --all-files` → clean. Full 6-extra install.

**Proven by a LIVE run against the real backend:**

All seven cells were re-run through the **unmodified orchestrator** (real `copy_profile`, real disposable `mkdtemp` home, real `env_overrides`, real timeouts, real `record(expect_json=True)`) and A/B'd against a scratch worktree at `origin/main`. Source profile `peopleconf`, read-only.

| cell | this branch | `origin/main` | verdict |
| --- | --- | --- | --- |
| `storage_reload` (#2161) | **pass** `{"before":27,"after":27,"reload_calls":2,"live_cookies":27}` | **pass** | byte-identical |
| `mcp_recovery` | **pass** `{"before":27,"after":27,"live_cookies":27,"transport":"fastmcp-in-memory"}` | **pass** | byte-identical |
| `master_token_recovery` | **pass** `{"before":27,"after":27,"master_token_calls":1,"persisted_cookies":24,"live_cookies":24}` | **pass** | byte-identical |
| `sibling_concurrent_reload` | **pass** `{"before":27,"after":[27,27,27,27],"reload_calls":2,"live_cookies":24,"sibling_profile_changed":true}` | **pass** | byte-identical |
| `rest_recovery` | **pass** `{"before":27,"after_live_reload":27,"after_stale_startup_rebind":27,"stale_startup_rebound":true}` | **pass** | byte-identical |
| `crash_safe_writer` | **pass** | **pass** | byte-identical |
| `browser_refresh` | **not run** — needs the `cookies` extra (`rookiepy`, not installed) plus a real browser profile | — | **still unverified** |

**All six runnable cells produce byte-identical JSON on both branches.** The master-token rung is exercised exactly once (`master_token_calls: 1`), the concurrent wave shares one recovery (`reload_calls: 2` for four parallel RPCs), and REST rebinds after degraded startup. This is direct live evidence of behaviour preservation.

### Correction — an earlier revision of this PR body was wrong

A previous version claimed the master-token cells failed because *"the source profile's master token dates from Jul 4 and can no longer re-mint."* **That was wrong, and it was an unverified inference** — I saw a months-old file timestamp and a re-mint failure and assumed causation without reading why the re-mint failed.

The real cause: the `headless` extra (`gpsoauth`) was not installed in the test venv. `_require_gpsoauth` raises through `MasterTokenError`, `_run_master_token_reauth` logs a warning and returns `None`, and the rung reports a plain `False` — so a missing install extra surfaces as `RPCError: The server rejected this request (unauthenticated)`, indistinguishable from a revoked token. The master token was fine; all three cells passed unmodified once `gpsoauth` was installed.

Two things worth separating, because only one of them was wrong:
- The **conclusion** ("not a regression") was correct and remains correct — it rested on the failures being identical on both branches, which they were.
- The **stated cause** was fabricated reasoning. Left uncorrected it would have told a future maintainer that the master-token path is unverifiable, when it verifiably works.

Consequences, handled:
- The code-level conflation is filed as **#2239**.
- `docs/development.md` now warns that a missing `headless` extra masquerades as a revoked token, and gives the WARNING line that distinguishes them (e4518799).
- CLAUDE.md's contributor install intentionally omits `cookies`/`headless` because it mirrors CI, which never runs this matrix; the matrix's own `--help` and `docs/development.md` carry the correct set. I did **not** change CLAUDE.md's command, since it is accurate for its stated purpose.

Note the test venv now contains `gpsoauth`. It gates no tests (no `importorskip("gpsoauth")` anywhere), and the gate is unchanged with it present: 16531 passed, 96.80%.

**STILL NOT proven:** `browser_refresh` has never run, on either branch — it needs `rookiepy` and a real browser profile. That is the one remaining cell for a maintainer live run.

## Behavioural deltas (small, deliberate, listed for review)

1. **JSON is printed after the scenario's context managers unwind**, not inside `async with`. The issue explicitly sanctions "return or print a stable JSON result contract". Net effect: a client that fails to close can no longer be masked by a success payload that was already flushed. The stdout contract the orchestrator parses (a single JSON object, same keys) is unchanged.
2. **`require()` raises `ScenarioError(RuntimeError)`** rather than bare `RuntimeError`. The orchestrator only sees the exit code and a bounded stderr tail; messages still name the invariant and carry no cookie or token values.
3. **`storage_reload` fails on the missing seam, not the symptom.** The old cell did `getattr(auth_session, "try_storage_cookie_reload", None)`, skipped patching when absent, and then failed on `"storage reload rung was not exercised"`. It now raises `"storage reload helper unavailable"` (the same message the old, unreachable inner `require` used) at the point of discovery.
4. `rest_recovery`'s `"rest-stale profile has no master_token.json"` message is now built from the `STALE_PROFILE` constant. Rendered text is identical.

## Out of scope — flagged, not fixed

The scenarios still monkeypatch module attributes and reach into privates (`auth_session._try_refresh_cmd_reauth`, `auth_session._try_headless_reauth`, `client._collaborators.kernel.get_http_client()`). Those were relocated **as-is**. Replacing module-attribute patch protocols with operation-scoped injection is #2181 step 3 and belongs there. Two things I noticed while relocating, for whoever picks that up:

- `storage_reload` and `sibling_concurrent_reload` install the identical four-rung poison set through two slightly different idioms (`getattr(..., None)` vs. direct attribute access). That divergence looks like drift, not intent.
- `phase_crash_safety` sleeps 0.08s before `SIGKILL`. On this machine the child needs longer than that just to import `notebooklm._auth.storage`, so the kill probably lands during import and the cell may be asserting on a file no write has touched yet. Pre-existing, unchanged here, but worth a look — it is the kind of thing that makes a cell pass for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive live-authentication recovery scenarios for browser, REST, MCP, storage, token, and concurrent-session workflows.
  * Added crash-safe authentication storage validation.
  * Added standalone module execution for the live-authentication test matrix.

* **Documentation**
  * Documented scenario structure, execution, output, required extras, and development workflow.

* **Tests**
  * Expanded validation for scenario discovery, execution, environment setup, recovery behavior, file safety, and error reporting.
  * Extended type checking to include live-authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

