### PR TITLE
fix(documents): separate table cells in the readable rendering (#2230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flattens rows and cells into the block's spans and a cell is several runs.
   Separating spans would split cells as often as it separated them, so giving
   tables their boundaries back is a decoder change
-  ([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230)).
+  ([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230), fixed below).
   ([#2211](https://github.com/teng-lin/notebooklm-py/issues/2211))
 
 - **`notebooklm source list --status <state>`** filters the listing to one
@@ -401,6 +401,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrong — so that pair is unaffected by this.
 
 ### Fixed
+
+- **A table in the readable rendering no longer runs its cells together.**
+  `StructuredDocument.render()` — and through it
+  `SourceFulltext.rendered_content` and the passage
+  `resolve_chat_reference_passage()` returns — rendered a table as one line
+  with its cell values adjacent: `"Operating systemAndroid 10+, iOS 17+
+  [a]Included withGemini…"` on this repo's own captured infobox. A table now
+  renders as **one line per row, cells tab-separated**.
+
+  The boundary was being *computed and discarded*. The parse walks rows, then
+  cells, then the blocks inside each cell, and flattens every run it finds into
+  one span sequence — which is what the offset-faithful layout needs, and which
+  loses the one thing a reader needs. Nothing downstream could recover it: a
+  single cell is several runs (`"Android 10"`, `"+, "`, `"iOS 17"`, `"+ "`,
+  `"[a]"` are one cell on that capture), so separating *runs* would have split
+  cells as often as it separated them. `DocumentBlock` now carries the cell
+  ranges the walk already computed, as the new `table_rows` (a tuple of rows of
+  `TableCell`), and only `render()` reads them.
+
+  **No offset moves.** The boundaries are carried as *offsets, never as
+  characters*: `StructuredDocument.text` — the coordinate space every citation
+  offset indexes — is byte-identical, and so are `DocumentBlock.text`,
+  `ChatReference.cited_text`, `slice()`, `extent`, and the legacy
+  `SourceFulltext.content`. The tab exists in the readable rendering alone,
+  alongside the newline that rendering already inserted between blocks, and
+  that rendering was never offset-addressable. Both invariants are pinned by
+  tests against the captured fixture.
+  ([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230))
 
 - **A file whose processing fails after a clean upload no longer reports a
   timeout.** When bytes transfer fine and NotebookLM's server-side processing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -972,7 +972,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `exceptions.py` | Public exception hierarchy plus safe diagnostic preview/redaction helpers |
 | `paths.py`, `migration.py` | Profile-aware path resolution and locked migration from the legacy flat layout |
 | `_types/`, `types.py` | Dataclass implementation package and public type/re-export facade |
-| `_types/documents.py` | `StructuredDocument` / `DocumentBlock` / `TextSpan` / `DocumentAnnotation` / `BlockKind` / `BlockStyle` / `ListStyle` / `ListInfo` — the transport-neutral parsed-document types behind `SourceFulltext.document` and `AskResult.answer_document`, carrying the character offsets citations anchor to (#2128, #2120). `StructuredDocument.render()` derives the readable flat rendering (`SourceFulltext.rendered_content`) from the same tree, and is what `utils.resolve_chat_reference_passage` returns once it has resolved a citation by offset (#2211) |
+| `_types/documents.py` | `StructuredDocument` / `DocumentBlock` / `TextSpan` / `TableCell` / `DocumentAnnotation` / `BlockKind` / `BlockStyle` / `ListStyle` / `ListInfo` — the transport-neutral parsed-document types behind `SourceFulltext.document` and `AskResult.answer_document`, carrying the character offsets citations anchor to (#2128, #2120). `StructuredDocument.render()` derives the readable flat rendering (`SourceFulltext.rendered_content`) from the same tree, and is what `utils.resolve_chat_reference_passage` returns once it has resolved a citation by offset (#2211); `DocumentBlock.table_rows` carries the table cell ranges that rendering separates on, as offsets, so the coordinate space is untouched (#2230) |
 | `_types/labels.py` | `Label` pure-value type (source-label topic grouping; `source_ids` only, no artifact members) re-exported by `types.py` |
 | `_types/collections.py` | `Collection` pure-value type (account-level notebook grouping; `notebook_ids`, no notebook parent) re-exported by `types.py`; decodes positionally (its own strict descent, not `LabelRow` — populated members are bare notebook-id strings, not `LabelRow`'s wrapped-singleton source ids) |
 | `_row_adapters/artifacts.py` | `ArtifactRow` typed view over raw positional artifact RPC rows, plus `ReportSuggestionRow` over `GET_SUGGESTED_REPORTS` rows |
@@ -1276,7 +1276,7 @@ src/notebooklm/
 │   ├── artifacts.py
 │   ├── chat.py
 │   ├── common.py
-│   ├── documents.py             # StructuredDocument / DocumentBlock / TextSpan / DocumentAnnotation / BlockKind / BlockStyle / ListStyle / ListInfo — parsed-document types behind SourceFulltext.document and AskResult.answer_document, carrying the offsets citations anchor to (#2128, #2120)
+│   ├── documents.py             # StructuredDocument / DocumentBlock / TextSpan / TableCell / DocumentAnnotation / BlockKind / BlockStyle / ListStyle / ListInfo — parsed-document types behind SourceFulltext.document and AskResult.answer_document, carrying the offsets citations anchor to (#2128, #2120)
 │   ├── labels.py                # Label pure-value type (source membership; no kind/artifact_ids)
 │   ├── collections.py           # Collection pure-value type (account-level notebook grouping; notebook_ids)
 │   ├── mind_maps.py             # MindMap + MindMapKind pure-value types (#1256)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -3104,9 +3104,12 @@ costs no extra request, `content` does not move, and like `content` it is
 deliberately **not** offset-addressable — its separators are its own. It is
 also marker-free: list glyphs and heading levels stay on `blocks` rather than
 being rendered, so this is the flat rendering `content` should have been, not
-a markdown one. A **table** renders as one line with its cells running
-together, because the parse flattens rows and cells into the block's spans
-([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230)).
+a markdown one. A **table** is the one block that is not one line: it renders
+one line per row with its cells tab-separated, read from the cell offsets the
+parse carries on `DocumentBlock.table_rows`
+([#2230](https://github.com/teng-lin/notebooklm-py/issues/2230)). Those are
+offsets only — `document.text`, `DocumentBlock.text` and `cited_text` are
+byte-for-byte what they were, and the tab lives in the rendering alone.
 
 With `output_format="markdown"` the two are not the same material: `content`
 is then built from the response's HTML rendition while `document` — and so
@@ -3125,7 +3128,9 @@ and `source read --offset` keeps windowing `content` in those same units, not
 in the document's.
 
 `StructuredDocument` exposes `blocks` (`DocumentBlock`: `start_index`,
-`end_index`, `spans`, `style`, `list_info`, `kind`), `annotations`
+`end_index`, `spans`, `style`, `list_info`, `kind`, `table_rows` — a tuple of
+rows of `TableCell` ranges, non-empty only for a `BlockKind.TABLE`),
+`annotations`
 (`DocumentAnnotation`: `object_id`, `start_index`, `end_index`), `text`,
 `extent`, `slice()`, `render()` and `annotations_for()`. Each `TextSpan`
 carries its own range plus `bold` / `italic` / `underline` / `url`.

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -187,6 +187,7 @@ from .types import (
     StructuredDocument,
     # Enums for configuration
     SuggestedTopic,
+    TableCell,
     TextSpan,
     # Warnings
     UnknownTypeWarning,
@@ -349,6 +350,7 @@ __all__ = [
     "ListInfo",
     "ListStyle",
     "StructuredDocument",
+    "TableCell",
     "TextSpan",
     "utf16_len",
 ]

--- a/src/notebooklm/_row_adapters/documents.py
+++ b/src/notebooklm/_row_adapters/documents.py
@@ -375,18 +375,18 @@ class TableRow:
                 continue
             cells: list[TableCell] = []
             for cell in _as_list(_at(row, self._ROW_CELLS_POS)) or []:
-                cell_bounds = _narrow(
+                cell_bounds = _clamp(
                     row_bounds, _at(cell, self._CELL_START_POS), _at(cell, self._CELL_END_POS)
                 )
-                if cell_bounds is None:
-                    continue
                 cell_start, cell_end = cell_bounds
                 cells.append(TableCell(start_index=cell_start, end_index=cell_end))
+                if cell_start == cell_end:
+                    continue  # an empty column: a boundary to keep, no text to walk
                 for block in build_blocks(
                     _at(cell, self._CELL_CONTENT_POS), depth, bounds=cell_bounds
                 ):
                     collected.extend(block.spans)
-            if cells:
+            if any(cell.start_index < cell.end_index for cell in cells):
                 rows.append(tuple(cells))
         return TableContent(spans=tuple(collected), rows=tuple(rows))
 
@@ -564,12 +564,16 @@ class DocumentBodyRow:
         return self._container(self._ANNOTATIONS_POS, "annotation_entries")
 
 
-def _narrow(bounds: tuple[int, int], raw_start: Any, raw_end: Any) -> tuple[int, int] | None:
-    """``bounds`` intersected with a declared child range, or ``None`` if empty.
+def _clamp(bounds: tuple[int, int], raw_start: Any, raw_end: Any) -> tuple[int, int]:
+    """``bounds`` intersected with a declared child range, empty result kept.
 
     A malformed child range cannot widen its parent — only narrow it — so an
     absent or unusable one leaves the parent's bounds untouched rather than
-    dropping the subtree.
+    dropping the subtree. An intersection that is *empty* comes back as a
+    zero-width range at the intersection point rather than as ``None``: for
+    text that means "nothing here" (see :func:`_narrow`), but for a **table
+    cell** it means "a column that holds no characters", which is information a
+    reader needs — a row of ``A``, ``""``, ``C`` must not read as two columns.
     """
     start, end = bounds
     child_start = _as_index(raw_start)
@@ -578,6 +582,16 @@ def _narrow(bounds: tuple[int, int], raw_start: Any, raw_end: Any) -> tuple[int,
         start = max(start, child_start)
     if child_end is not None:
         end = min(end, child_end)
+    return (start, max(start, end))
+
+
+def _narrow(bounds: tuple[int, int], raw_start: Any, raw_end: Any) -> tuple[int, int] | None:
+    """:func:`_clamp`, with an empty intersection reported as ``None``.
+
+    What every caller that is descending after *text* wants: a subtree
+    occupying no positions can carry none, so there is nothing to walk.
+    """
+    start, end = _clamp(bounds, raw_start, raw_end)
     return None if end <= start else (start, end)
 
 

--- a/src/notebooklm/_row_adapters/documents.py
+++ b/src/notebooklm/_row_adapters/documents.py
@@ -59,7 +59,7 @@ from __future__ import annotations
 import logging
 import reprlib
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import Any, ClassVar, NamedTuple
 
 from .._types.documents import (
     BlockKind,
@@ -69,6 +69,7 @@ from .._types.documents import (
     ListInfo,
     ListStyle,
     StructuredDocument,
+    TableCell,
     TextSpan,
 )
 
@@ -79,6 +80,7 @@ __all__ = [
     "ParagraphElementRow",
     "ParagraphRow",
     "StructuralElementRow",
+    "TableContent",
     "TableRow",
     "TextRunRow",
     "build_blocks",
@@ -291,6 +293,20 @@ class ParagraphRow:
         return BulletInfoRow(raw).info
 
 
+class TableContent(NamedTuple):
+    """What a ``Table`` decodes to: flattened runs, and the grid holding them.
+
+    Two views of the same walk, which is why they are returned together rather
+    than by two properties that would each have to make it. ``spans`` is the
+    offset-bearing sequence :class:`~notebooklm.types.DocumentBlock` carries
+    like any other block's; ``rows`` is the boundary information that
+    flattening those runs into one sequence destroys (#2230).
+    """
+
+    spans: tuple[TextSpan, ...]
+    rows: tuple[tuple[TableCell, ...], ...]
+
+
 @dataclass(frozen=True)
 class TableRow:
     """Typed view of a ``Table`` — ``[rows, columns, tableRows]``.
@@ -324,8 +340,8 @@ class TableRow:
     _CELL_END_POS: ClassVar[int] = 1
     _CELL_CONTENT_POS: ClassVar[int] = 2
 
-    def spans(self, depth: int, bounds: tuple[int, int]) -> tuple[TextSpan, ...]:
-        """Every text run in the table, row-major, in document order.
+    def decode(self, depth: int, bounds: tuple[int, int]) -> TableContent:
+        """Every text run in the table, row-major, **and** the grid it came from.
 
         ``bounds`` is the enclosing table element's range, narrowed at each
         level by the row's and then the cell's own declared range. A cell's
@@ -334,23 +350,45 @@ class TableRow:
         down: a child block whose own range overruns its cell is valid relative
         to itself, and only the container knows better. Without this, one
         malformed cell's text overlaps — and so displaces — its sibling's.
+
+        The runs stay flattened, because the flat sequence is what
+        :attr:`~notebooklm.types.StructuredDocument.text` lays out at the
+        backend's offsets. What changed in #2230 is that the *cell bounds* this
+        walk computes are no longer thrown away one line later: they are
+        returned alongside as :class:`~notebooklm.types.TableCell` ranges, so a
+        reader can tell a cell boundary from a formatting change. They are the
+        narrowed bounds — the same ranges the cell's own blocks were clamped
+        to — so a cell can never claim a position its table does not own, and
+        carrying them adds no character to the coordinate space.
+
+        A cell holding a nested table contributes that table's text to *its*
+        cell rather than its own cells to the grid: the inner boundaries would
+        overlap the outer cell that contains them, and a grid of overlapping
+        cells cannot be rendered as rows. Nested tables therefore read as they
+        did before — one cell of run-together text.
         """
         collected: list[TextSpan] = []
+        rows: list[tuple[TableCell, ...]] = []
         for row in _as_list(_at(self._raw, self._TABLE_ROWS_POS)) or []:
             row_bounds = _narrow(bounds, _at(row, self._ROW_START_POS), _at(row, self._ROW_END_POS))
             if row_bounds is None:
                 continue
+            cells: list[TableCell] = []
             for cell in _as_list(_at(row, self._ROW_CELLS_POS)) or []:
                 cell_bounds = _narrow(
                     row_bounds, _at(cell, self._CELL_START_POS), _at(cell, self._CELL_END_POS)
                 )
                 if cell_bounds is None:
                     continue
+                cell_start, cell_end = cell_bounds
+                cells.append(TableCell(start_index=cell_start, end_index=cell_end))
                 for block in build_blocks(
                     _at(cell, self._CELL_CONTENT_POS), depth, bounds=cell_bounds
                 ):
                     collected.extend(block.spans)
-        return tuple(collected)
+            if cells:
+                rows.append(tuple(cells))
+        return TableContent(spans=tuple(collected), rows=tuple(rows))
 
 
 @dataclass(frozen=True)
@@ -423,11 +461,13 @@ class StructuralElementRow:
                 return None
         kind = self.kind
         if kind is BlockKind.TABLE:
+            table = TableRow(_at(self._raw, self._TABLE_POS)).decode(depth, (start, end))
             return DocumentBlock(
                 start_index=start,
                 end_index=end,
-                spans=TableRow(_at(self._raw, self._TABLE_POS)).spans(depth, (start, end)),
+                spans=table.spans,
                 kind=kind,
+                table_rows=table.rows,
             )
         paragraph = ParagraphRow(_at(self._raw, self._PARAGRAPH_POS))
         return DocumentBlock(

--- a/src/notebooklm/_types/documents.py
+++ b/src/notebooklm/_types/documents.py
@@ -45,6 +45,7 @@ The types here are transport-neutral and carry no positional knowledge; the
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import NamedTuple
@@ -57,6 +58,7 @@ __all__ = [
     "ListInfo",
     "ListStyle",
     "StructuredDocument",
+    "TableCell",
     "TextSpan",
     "utf16_len",
 ]
@@ -67,6 +69,16 @@ __all__ = [
 #: at an inline object. It is a BMP character, so one of them occupies exactly
 #: one UTF-16 unit and filler never perturbs the offsets it is holding open.
 _PLACEHOLDER = "￼"
+
+#: What :meth:`StructuredDocument.render` puts between two table cells on the
+#: same row — a tab, so a rendered table is the TSV every reader and
+#: spreadsheet already understands, and so the separator stays a *separator*
+#: rather than the markdown pipes this deliberately marker-free rendering does
+#: not emit. Rows are separated by the newline that separates blocks. Like
+#: every separator this rendering inserts it is **its own**: it exists in the
+#: rendering only and never in :attr:`StructuredDocument.text`, whose offsets
+#: account for no separators at all.
+_CELL_SEPARATOR = "\t"
 
 #: Ceiling on the span a single document may claim, in UTF-16 units. Filler is
 #: synthesized locally from offsets the server chose, so a drifted or hostile
@@ -205,6 +217,114 @@ def _clip_span(span: TextSpan, lower: int, upper: int) -> str:
     return _utf16_slice(span.text, lead, lead + width)
 
 
+def _row_position(row: tuple[TableCell, ...]) -> tuple[int, int]:
+    """A table row's position — its first cell's range. ``row`` is never empty."""
+    first = next(iter(row))
+    return (first.start_index, first.end_index)
+
+
+def _render_runs(spans: Iterable[TextSpan], lower: int, upper: int, cursor: int) -> tuple[str, int]:
+    """``spans`` concatenated over ``[lower, upper)``, and the cursor left behind.
+
+    Each run is trimmed against ``cursor`` — how far the caller has already
+    rendered — so runs that overlap each other are not rendered twice and no
+    result is wider than the window that selected it. The cursor is returned
+    rather than kept locally because a table renders one group of runs per
+    cell and the rule has to hold *across* those groups as well as inside one.
+    """
+    parts: list[str] = []
+    for span in spans:
+        parts.append(_clip_span(span, max(lower, cursor), upper))
+        cursor = max(cursor, min(span.end_index, upper))
+    return "".join(parts), cursor
+
+
+def _spans_by_cell(block: DocumentBlock) -> tuple[list[list[list[TextSpan]]], list[TextSpan]]:
+    """``block``'s runs bucketed by table cell, plus any that land in none.
+
+    Returns one list of runs per cell, nested one level per row so the caller
+    can rebuild the grid, and a flat list of *strays*. Both the block's spans
+    and its cells are ordered by position (each normalised on construction), so
+    a single forward walk assigns them: a run belongs to every cell it
+    overlaps, and the caller clips it to the cell it is rendering. A run
+    overlapping two cells is a wire inconsistency — a cell's blocks are clamped
+    to it during the parse — but assigning it to both is what stops it being
+    rendered in one column at its full width.
+
+    Strays cannot arise from a decoded document — every run in a table block
+    was read out of one of its cells — but :class:`DocumentBlock` is public and
+    can be built by hand with cells that do not cover its spans. Collecting
+    them rather than letting the walk drop them is what keeps this a
+    *regrouping* of the block's text: no input renders less text than it did
+    before the cells were carried.
+    """
+    cells = [cell for row in block.table_rows for cell in row]
+    buckets: list[list[TextSpan]] = [[] for _ in cells]
+    strays: list[TextSpan] = []
+    index = 0
+    for span in block.spans:
+        while index < len(cells) and cells[index].end_index <= span.start_index:
+            index += 1
+        overlapping = index
+        while overlapping < len(cells) and cells[overlapping].start_index < span.end_index:
+            buckets[overlapping].append(span)
+            overlapping += 1
+        if overlapping == index:
+            strays.append(span)  # lands in a gap the grid does not cover
+    grouped: list[list[list[TextSpan]]] = []
+    at = 0
+    for row in block.table_rows:
+        grouped.append(buckets[at : at + len(row)])
+        at += len(row)
+    return grouped, strays
+
+
+def _render_table(block: DocumentBlock, lower: int, upper: int) -> list[str]:
+    """``block`` rendered as one line per table row, cells tab-separated.
+
+    The boundaries come from :attr:`DocumentBlock.table_rows`, which the parse
+    carries precisely because they cannot be recovered here: a cell is several
+    runs (``"Android 10"``, ``"+, "``, ``"iOS 17"`` are one cell in this
+    library's captured infobox), so separating *runs* would split cells as
+    often as it separated them (#2230).
+
+    A cell the window selects no position of is left out of its row entirely,
+    and a row left with nothing to read is dropped — the same rule that omits a
+    block with no text, applied one level down, so a window over one cell reads
+    as that cell rather than as its column position in the grid. A cell the
+    window *does* select but which renders empty keeps its place: a trailing one
+    then drops its separator with it, while a *leading* one keeps it, so a value
+    stays in the column it was written in rather than sliding left into an empty
+    neighbour's.
+
+    Runs the grid does not cover (see :func:`_spans_by_cell`) render as a final
+    line, on a cursor of their own: the grid's cursor has by then passed them,
+    so sharing it would clip exactly the text this line exists to keep.
+    """
+    grouped, strays = _spans_by_cell(block)
+    lines: list[str] = []
+    cursor = lower
+    for row, row_spans in zip(block.table_rows, grouped, strict=True):
+        cells: list[str] = []
+        for cell, spans in zip(row, row_spans, strict=True):
+            # Each cell renders inside its own range as well as inside the
+            # window, so a run that overruns the cell it started in is cut at
+            # the boundary rather than pulling the next cell's text along.
+            start, end = max(lower, cell.start_index), min(upper, cell.end_index)
+            if end <= start:
+                continue  # the window selects none of this cell's positions
+            text, cursor = _render_runs(spans, start, end, cursor)
+            cells.append(text)
+        line = _CELL_SEPARATOR.join(cells).rstrip(_CELL_SEPARATOR)
+        if line:
+            lines.append(line)
+    if strays:
+        line, _ = _render_runs(strays, lower, upper, lower)
+        if line:
+            lines.append(line)
+    return lines
+
+
 class BlockKind(str, Enum):
     """Which variant of ``StructuralElement`` a :class:`DocumentBlock` came from.
 
@@ -341,6 +461,37 @@ class TextSpan:
 
 
 @dataclass(frozen=True)
+class TableCell:
+    """One cell of a table, as the range of the document it occupies.
+
+    A :attr:`BlockKind.TABLE` block's text arrives *flattened*: the parse walks
+    rows, then cells, then the blocks inside each cell, and concatenates every
+    run it finds into one span sequence (:attr:`DocumentBlock.spans`), because
+    that sequence is what :attr:`StructuredDocument.text` lays out at the
+    backend's offsets. Flattening loses exactly one thing — where one cell ends
+    and the next begins — and no reader can recover it from the runs, since a
+    single cell is routinely several of them.
+
+    This carries that boundary alongside the flattened runs, as **offsets and
+    nothing else**. It adds no characters and moves none: the coordinate space
+    is untouched, and only :meth:`StructuredDocument.render` — the rendering
+    whose separators are its own — consumes it.
+
+    Attributes:
+        start_index: Inclusive start offset (UTF-16 code units) in
+            :attr:`StructuredDocument.text`.
+        end_index: Exclusive end offset.
+    """
+
+    start_index: int
+    end_index: int
+
+    def __post_init__(self) -> None:
+        """Reject a range that cannot index the document."""
+        _validate_range("TableCell", self.start_index, self.end_index)
+
+
+@dataclass(frozen=True)
 class DocumentBlock:
     """One structural element of a document — a paragraph, heading or list item.
 
@@ -354,6 +505,13 @@ class DocumentBlock:
         style: Named paragraph style (heading level, title, body prose).
         list_info: List membership when the block is a list item, else ``None``.
         kind: Which ``StructuralElement`` variant produced this block.
+        table_rows: For a :attr:`BlockKind.TABLE`, the grid its :attr:`spans`
+            were flattened out of — one tuple of :class:`TableCell` per row, in
+            document order. Empty for every other kind, and for a table whose
+            rows and cells all declared unusable ranges. The cells partition
+            the runs; they do not add to them, so this changes nothing about
+            :attr:`text` or :attr:`StructuredDocument.text` and is read only by
+            :meth:`StructuredDocument.render` (#2230).
     """
 
     start_index: int
@@ -362,6 +520,7 @@ class DocumentBlock:
     style: BlockStyle = BlockStyle.UNSPECIFIED
     list_info: ListInfo | None = None
     kind: BlockKind = BlockKind.UNKNOWN
+    table_rows: tuple[tuple[TableCell, ...], ...] = ()
 
     def __post_init__(self) -> None:
         """Establish the three things a block guarantees about its own spans.
@@ -389,6 +548,36 @@ class DocumentBlock:
         """
         _validate_range("DocumentBlock", self.start_index, self.end_index)
         object.__setattr__(self, "spans", self._normalised_spans())
+        object.__setattr__(self, "table_rows", self._normalised_table_rows())
+
+    def _normalised_table_rows(self) -> tuple[tuple[TableCell, ...], ...]:
+        """This block's cells, ordered by position and clamped to its range.
+
+        The same three guarantees :meth:`_normalised_spans` gives the runs, for
+        the boundaries that group them — ordering by offset rather than by
+        container order, refusing a cell that claims positions its block does
+        not own, and freezing what was passed in. A cell left holding no
+        positions is dropped, and a row left holding no cells with it, so a row
+        the wire declares zero-width (the captured infobox opens with one)
+        cannot render as a line of separators with nothing between them.
+        """
+        rows: list[tuple[TableCell, ...]] = []
+        for row in self.table_rows:
+            cells: list[TableCell] = []
+            for cell in sorted(row, key=lambda cell: (cell.start_index, cell.end_index)):
+                start = max(cell.start_index, self.start_index)
+                end = min(cell.end_index, self.end_index)
+                if end <= start:
+                    continue  # holds no positions of this block
+                cells.append(
+                    cell
+                    if (start, end) == (cell.start_index, cell.end_index)
+                    else replace(cell, start_index=start, end_index=end)
+                )
+            if cells:
+                rows.append(tuple(cells))
+        rows.sort(key=_row_position)
+        return tuple(rows)
 
     def _normalised_spans(self) -> tuple[TextSpan, ...]:
         """This block's spans, ordered by position and clamped to its range."""
@@ -647,16 +836,18 @@ class StructuredDocument:
         than a change of what this returns. Read :attr:`blocks` when you want
         the structure.
 
-        A :attr:`BlockKind.TABLE` renders as **one line with its cell text
-        running together** — ``"Operating system"`` and ``"Android 10"``
-        adjacent, in this library's captured infobox. That is not a choice made
-        here: the parse flattens every row and cell into the table block's
-        spans (#2128), and a cell is several runs rather than one, so nothing
-        at this level can tell a cell boundary from a formatting change. It is
-        the same reading :attr:`DocumentBlock.text` and
-        ``ChatReference.cited_text`` already give. Giving tables their
-        boundaries back means teaching the *parse* to keep them, which is
-        `#2230 <https://github.com/teng-lin/notebooklm-py/issues/2230>`_.
+        A :attr:`BlockKind.TABLE` renders as **one line per row, with its cells
+        separated by a tab** — the one block kind that is not one line. Its
+        runs are flattened into a single span sequence by the parse (#2128) and
+        a cell is several of them, so nothing at this level could tell a cell
+        boundary from a formatting change; the boundaries are read from
+        :attr:`DocumentBlock.table_rows`, which the parse now carries as
+        offsets alongside the flattened runs
+        (`#2230 <https://github.com/teng-lin/notebooklm-py/issues/2230>`_).
+        They are offsets only, so nothing about the coordinate space moves:
+        :attr:`DocumentBlock.text` and ``ChatReference.cited_text`` still read
+        a table's cells run together, and the separators here — like the
+        newline between blocks — exist in this rendering alone.
 
         Args:
             start_index: Inclusive start of the range to render, in **UTF-16
@@ -700,18 +891,18 @@ class StructuredDocument:
         for block in sorted(self.blocks, key=lambda block: (block.start_index, block.end_index)):
             if block.end_index <= lower or block.start_index >= upper:
                 continue
-            # Trim each run against what the block has already rendered, the
-            # same rule :attr:`text` applies across the document. A block's
-            # spans are ordered and clamped to it but may still *overlap* each
-            # other, and concatenating them then repeats the overlap — a line
-            # wider than the window that selected it, reading as duplicated
-            # citation text.
-            parts: list[str] = []
-            cursor = lower
-            for span in block.spans:
-                parts.append(_clip_span(span, max(lower, cursor), upper))
-                cursor = max(cursor, min(span.end_index, upper))
-            line = "".join(parts)
+            # A table knows where its cells are (:attr:`DocumentBlock.
+            # table_rows`) and renders one line per row; everything else is one
+            # line of runs. Either way each run is trimmed against what has
+            # already been rendered, the same rule :attr:`text` applies across
+            # the document: a block's spans are ordered and clamped to it but
+            # may still *overlap* each other, and concatenating them then
+            # repeats the overlap — a line wider than the window that selected
+            # it, reading as duplicated citation text.
+            if block.table_rows:
+                lines.extend(_render_table(block, lower, upper))
+                continue
+            line, _ = _render_runs(block.spans, lower, upper, lower)
             if line:
                 lines.append(line)
         return "\n".join(lines)

--- a/src/notebooklm/_types/documents.py
+++ b/src/notebooklm/_types/documents.py
@@ -507,11 +507,14 @@ class DocumentBlock:
         kind: Which ``StructuralElement`` variant produced this block.
         table_rows: For a :attr:`BlockKind.TABLE`, the grid its :attr:`spans`
             were flattened out of — one tuple of :class:`TableCell` per row, in
-            document order. Empty for every other kind, and for a table whose
-            rows and cells all declared unusable ranges. The cells partition
-            the runs; they do not add to them, so this changes nothing about
-            :attr:`text` or :attr:`StructuredDocument.text` and is read only by
-            :meth:`StructuredDocument.render` (#2230).
+            document order. The parse populates it for no other kind, and
+            leaves it empty for a table whose rows and cells all declared
+            unusable ranges; :meth:`StructuredDocument.render` keys off the
+            cells themselves rather than off :attr:`kind`, so a hand-built
+            block carrying them renders as a grid whatever it calls itself.
+            The cells partition the runs; they do not add to them, so this
+            changes nothing about :attr:`text` or
+            :attr:`StructuredDocument.text` (#2230).
     """
 
     start_index: int

--- a/src/notebooklm/_types/documents.py
+++ b/src/notebooklm/_types/documents.py
@@ -288,13 +288,14 @@ def _render_table(block: DocumentBlock, lower: int, upper: int) -> list[str]:
     library's captured infobox), so separating *runs* would split cells as
     often as it separated them (#2230).
 
-    A cell the window selects no position of is left out of its row entirely,
-    and a row left with nothing to read is dropped — the same rule that omits a
-    block with no text, applied one level down, so a window over one cell reads
-    as that cell rather than as its column position in the grid. A cell the
-    window *does* select but which renders empty keeps its place: a trailing one
-    then drops its separator with it, while a *leading* one keeps it, so a value
-    stays in the column it was written in rather than sliding left into an empty
+    A cell the window does not reach is left out of its row entirely, and a row
+    left with nothing to read is dropped — the same rule that omits a block
+    with no text, applied one level down, so a window over one cell reads as
+    that cell rather than as its column position in the grid. A cell the window
+    *does* reach but which renders empty (including a zero-width one — a real
+    column holding no characters) keeps its place: a trailing one then drops
+    its separator with it, while a *leading* one keeps it, so a value stays in
+    the column it was written in rather than sliding left into an empty
     neighbour's.
 
     Runs the grid does not cover (see :func:`_spans_by_cell`) render as a final
@@ -306,16 +307,25 @@ def _render_table(block: DocumentBlock, lower: int, upper: int) -> list[str]:
     cursor = lower
     for row, row_spans in zip(block.table_rows, grouped, strict=True):
         cells: list[str] = []
+        filled = 0  # how many cells reach the last one that has text
         for cell, spans in zip(row, row_spans, strict=True):
             # Each cell renders inside its own range as well as inside the
             # window, so a run that overruns the cell it started in is cut at
             # the boundary rather than pulling the next cell's text along.
+            if cell.end_index < lower or cell.start_index > upper:
+                continue  # the window does not reach this cell at all
             start, end = max(lower, cell.start_index), min(upper, cell.end_index)
-            if end <= start:
-                continue  # the window selects none of this cell's positions
             text, cursor = _render_runs(spans, start, end, cursor)
             cells.append(text)
-        line = _CELL_SEPARATOR.join(cells).rstrip(_CELL_SEPARATOR)
+            if text:
+                filled = len(cells)
+        # Separators run only as far as the last cell that has text, so a
+        # trailing empty *cell* drops its separator. Note this drops empty
+        # cells rather than stripping separator *characters* off the joined
+        # line: a run may legitimately end in a tab (plain-text sources keep
+        # their whitespace in :attr:`TextSpan.text`), and stripping would eat
+        # the cell's own content along with it.
+        line = _CELL_SEPARATOR.join(cells[:filled])
         if line:
             lines.append(line)
     if strays:
@@ -559,10 +569,14 @@ class DocumentBlock:
         The same three guarantees :meth:`_normalised_spans` gives the runs, for
         the boundaries that group them — ordering by offset rather than by
         container order, refusing a cell that claims positions its block does
-        not own, and freezing what was passed in. A cell left holding no
-        positions is dropped, and a row left holding no cells with it, so a row
-        the wire declares zero-width (the captured infobox opens with one)
-        cannot render as a line of separators with nothing between them.
+        not own, and freezing what was passed in.
+
+        A **zero-width** cell is kept, because it is a column that holds no
+        characters rather than a cell that does not exist: dropping it would
+        slide every value after it one column to the left. A row of *nothing
+        but* those is dropped, though — it has no column positions to hold and
+        would render as a line of separators with nothing between them, which
+        is what the captured infobox's declared header row is.
         """
         rows: list[tuple[TableCell, ...]] = []
         for row in self.table_rows:
@@ -570,14 +584,14 @@ class DocumentBlock:
             for cell in sorted(row, key=lambda cell: (cell.start_index, cell.end_index)):
                 start = max(cell.start_index, self.start_index)
                 end = min(cell.end_index, self.end_index)
-                if end <= start:
-                    continue  # holds no positions of this block
+                if end < start:
+                    continue  # lies wholly outside the block that claims it
                 cells.append(
                     cell
                     if (start, end) == (cell.start_index, cell.end_index)
                     else replace(cell, start_index=start, end_index=end)
                 )
-            if cells:
+            if any(cell.start_index < cell.end_index for cell in cells):
                 rows.append(tuple(cells))
         rows.sort(key=_row_position)
         return tuple(rows)

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -544,8 +544,11 @@ class SourceFulltext:
         had parsed, not a rendering anybody chose. Since #2128 the tree *is*
         parsed, so this property renders from it instead — runs joined
         **within** a block, blocks separated, blocks with nothing to read
-        omitted. :meth:`~notebooklm.types.StructuredDocument.render` carries the
-        full account, including the measurement on this repo's own capture.
+        omitted. A table is the one exception to "one line per block": it reads
+        as one line per **row**, cells tab-separated, from the cell boundaries
+        the parse carries alongside its flattened runs (#2230).
+        :meth:`~notebooklm.types.StructuredDocument.render` carries the full
+        account, including the measurement on this repo's own capture.
 
         It is derived, additive and free — the document is parsed on every
         ``get_fulltext`` regardless of ``output_format``, so nothing extra is

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -45,6 +45,7 @@ from ._types.documents import (
     ListInfo,
     ListStyle,
     StructuredDocument,
+    TableCell,
     TextSpan,
     utf16_len,
 )
@@ -218,6 +219,7 @@ __all__ = [
     "ListInfo",
     "ListStyle",
     "StructuredDocument",
+    "TableCell",
     "TextSpan",
     "utf16_len",
     "AskResult",

--- a/tests/fixtures/baselines/types_all.json
+++ b/tests/fixtures/baselines/types_all.json
@@ -29,6 +29,7 @@
   "ListInfo",
   "ListStyle",
   "StructuredDocument",
+  "TableCell",
   "TextSpan",
   "utf16_len",
   "AskResult",

--- a/tests/fixtures/baselines/ungated_surface.json
+++ b/tests/fixtures/baselines/ungated_surface.json
@@ -127,6 +127,7 @@
     "ListInfo",
     "ListStyle",
     "StructuredDocument",
+    "TableCell",
     "TextSpan",
     "utf16_len",
     "configure_logging"

--- a/tests/unit/test_citation_alignment.py
+++ b/tests/unit/test_citation_alignment.py
@@ -668,6 +668,55 @@ class TestReadableRendering:
         )
         assert document.render() == "\tmid"
 
+    def test_an_empty_column_holds_its_place_instead_of_shifting_the_row(self) -> None:
+        """A cell with no characters is still a column (#2230 review).
+
+        An empty cell's natural range is zero-width, and dropping it would
+        slide every value after it one column left — a three-column row of
+        ``A`` / *nothing* / ``C`` reading as ``A\\tC``, which says ``C`` is in
+        column two. The boundary is kept; only a row that is *nothing but*
+        empty columns goes, since it has no positions to hold.
+        """
+        block = DocumentBlock(
+            0,
+            2,
+            (TextSpan(0, 1, "A"), TextSpan(1, 2, "C")),
+            kind=BlockKind.TABLE,
+            table_rows=(
+                (TableCell(0, 1), TableCell(1, 1), TableCell(1, 2)),
+                (TableCell(2, 2), TableCell(2, 2)),  # nothing but empty columns
+            ),
+        )
+        assert block.table_rows == ((TableCell(0, 1), TableCell(1, 1), TableCell(1, 2)),)
+        assert StructuredDocument(blocks=(block,)).render() == "A\t\tC"
+
+    def test_a_cells_own_tab_survives_the_row_join(self) -> None:
+        """Trailing empty *cells* are dropped, not trailing separator characters.
+
+        A run keeps its own whitespace (:attr:`TextSpan.text` is the literal
+        run), so a cell can legitimately end in a tab. Stripping the joined
+        line would eat that character along with the separator, silently
+        editing the source's text — which a rendering may never do.
+
+        Both review findings meet in one row here: an empty middle column that
+        must keep its separator, and a final cell whose own tab must survive
+        the rule that removes trailing ones. Hand-built rather than taken from
+        a capture because no capture in this repo contains either shape — the
+        infobox's cells are all non-empty and none ends in a tab.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    3,
+                    (TextSpan(0, 1, "A"), TextSpan(1, 3, "C\t")),
+                    kind=BlockKind.TABLE,
+                    table_rows=((TableCell(0, 1), TableCell(1, 1), TableCell(1, 3)),),
+                ),
+            )
+        )
+        assert document.render() == "A\t\tC\t"
+
     def test_cells_are_ordered_and_clamped_like_every_other_offset_here(self) -> None:
         """``table_rows`` gets the guarantees ``spans`` gets, for the same reasons.
 
@@ -1642,6 +1691,45 @@ class TestFragmentDescent:
         assert document.slice(1610, 1626) == "Operating system"
         assert document.slice(1626, 1650) == "Android 10+, iOS 17+ [a]"
         assert document.slice(1693, 1727) == "Duration: 11 minutes and 15 second"
+
+    def test_the_parse_keeps_an_empty_cell_as_a_column(self) -> None:
+        """An empty cell is a boundary the decode must keep (#2230 review).
+
+        The capture proves the shape: its second table's declared header cells
+        are literally ``[1610, 1610]`` — a zero-width range, which is how an
+        empty cell arrives. The text walk rightly skips such a cell (there is
+        nothing to descend into), and the *boundary* walk must not, or a row of
+        ``A`` / *nothing* / ``C`` decodes as two columns and reports ``C`` in
+        column two.
+
+        The rows below are built in the capture's own positional shape —
+        ``StructuralElement = [start, end, paragraph]``, ``Table = [rows,
+        columns, tableRows]``, ``TableCell = [start, end, content]`` — because
+        no captured table has an empty interior cell to read this off.
+        """
+        elements = json.loads((FIXTURES_DIR / "citation_fragment_with_tables.json").read_text())
+        assert elements[1][4][2][0][2][0] == [1610, 1610]  # the wire's empty cell
+
+        def paragraph(start: int, end: int, text: str) -> list[Any]:
+            return [start, end, [[[start, end, [text, None]]], [None, 1]]]
+
+        table = [
+            0,
+            3,
+            None,
+            None,
+            [
+                1,
+                3,
+                [[0, 3, [[0, 1, [paragraph(0, 1, "A")]], [1, 1], [1, 3, [paragraph(1, 3, "C")]]]]],
+            ],
+        ]
+        block = build_blocks([table])[0]
+        assert block.kind is BlockKind.TABLE
+        assert block.table_rows == ((TableCell(0, 1), TableCell(1, 1), TableCell(1, 3)),)
+        assert StructuredDocument(blocks=(block,)).render() == "A\t\tC"
+        # ...and the empty column costs the coordinate space nothing.
+        assert StructuredDocument(blocks=(block,)).text == "AC￼"
 
     def test_the_legacy_flat_rendering_does_not_see_the_cells_at_all(self) -> None:
         """``SourceFulltext.content`` is byte-frozen, and stays that way (#2230).

--- a/tests/unit/test_citation_alignment.py
+++ b/tests/unit/test_citation_alignment.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import replace
 from itertools import pairwise
 from pathlib import Path
 from typing import Any
@@ -53,6 +54,7 @@ from notebooklm.types import (
     ListStyle,
     SourceFulltext,
     StructuredDocument,
+    TableCell,
     TextSpan,
     utf16_len,
 )
@@ -578,6 +580,138 @@ class TestReadableRendering:
         assert StructuredDocument().render() == ""
         # A negative lower bound is clamped, not reinterpreted end-relative.
         assert document.render(-4, 5) == "hello"
+
+    def test_a_table_renders_one_line_per_row_with_its_cells_separated(self) -> None:
+        """The #2230 shape, isolated from the capture.
+
+        A table is the one block kind that is not one line: its rows are the
+        lines and its cells are separated within them. Both boundaries come
+        from ``table_rows`` — a cell is several runs, so neither is recoverable
+        from the spans, which is exactly why the parse carries them.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    16,
+                    (
+                        TextSpan(0, 2, "OS"),
+                        # Two runs, one cell — separating runs would split it.
+                        TextSpan(2, 9, "Android"),
+                        TextSpan(9, 12, " 10"),
+                        TextSpan(12, 16, "Cost"),
+                    ),
+                    kind=BlockKind.TABLE,
+                    table_rows=(
+                        (TableCell(0, 2), TableCell(2, 12)),
+                        (TableCell(12, 16),),
+                    ),
+                ),
+            )
+        )
+        assert document.render() == "OS\tAndroid 10\nCost"
+        # The layout is untouched: no separator, one line, same offsets.
+        assert document.text == "OSAndroid 10Cost"
+        assert document.blocks[0].text == "OSAndroid 10Cost"
+
+    def test_a_table_row_renders_only_the_cells_the_window_selects(self) -> None:
+        """A window through a table stays a window, as it does through prose.
+
+        Rows and cells outside the range contribute nothing and are dropped
+        with their separators, so a citation window over one cell does not read
+        as the whole grid.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    12,
+                    (TextSpan(0, 3, "aaa"), TextSpan(3, 6, "bbb"), TextSpan(6, 12, "cccddd")),
+                    kind=BlockKind.TABLE,
+                    table_rows=(
+                        (TableCell(0, 3), TableCell(3, 6)),
+                        (TableCell(6, 9), TableCell(9, 12)),
+                    ),
+                ),
+            )
+        )
+        assert document.render() == "aaa\tbbb\nccc\tddd"
+        assert document.render(0, 6) == "aaa\tbbb"
+        assert document.render(6, 12) == "ccc\tddd"
+        # A window inside one cell renders that cell alone, no separator.
+        assert document.render(4, 6) == "bb"
+        # A row the window misses entirely is dropped, not rendered blank.
+        assert document.render(0, 3) == "aaa"
+
+    def test_an_empty_cell_keeps_its_column_but_not_a_trailing_separator(self) -> None:
+        """Where the separator survives an empty cell, and where it does not.
+
+        A *leading* empty cell keeps its separator, so a value stays in the
+        column it was written in rather than sliding left into a neighbour's. A
+        *trailing* one has no column to hold open, so it drops its separator
+        with it — and a row that is empty all the way across drops entirely,
+        like any other block with nothing to read.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    9,
+                    (TextSpan(3, 6, "mid"),),
+                    kind=BlockKind.TABLE,
+                    table_rows=(
+                        (TableCell(0, 3), TableCell(3, 6), TableCell(6, 9)),
+                        (TableCell(6, 9), TableCell(6, 9)),
+                    ),
+                ),
+            )
+        )
+        assert document.render() == "\tmid"
+
+    def test_cells_are_ordered_and_clamped_like_every_other_offset_here(self) -> None:
+        """``table_rows`` gets the guarantees ``spans`` gets, for the same reasons.
+
+        Container order is not authoritative; a cell claiming positions its
+        block does not own is drift and is clamped to the block, or dropped
+        when nothing survives; and a row left with no cells goes with them.
+        """
+        block = DocumentBlock(
+            0,
+            6,
+            (TextSpan(0, 3, "abc"), TextSpan(3, 6, "def")),
+            kind=BlockKind.TABLE,
+            table_rows=(
+                (TableCell(20, 30),),  # wholly outside — dropped, and its row with it
+                (TableCell(3, 9),),  # overruns the block — clamped to 3..6
+                (TableCell(0, 3),),  # arrives after the row that follows it
+            ),
+        )
+        assert block.table_rows == ((TableCell(0, 3),), (TableCell(3, 6),))
+        assert StructuredDocument(blocks=(block,)).render() == "abc\ndef"
+
+    def test_a_run_no_cell_claims_is_rendered_rather_than_dropped(self) -> None:
+        """The regrouping may not lose text, however inconsistent its input.
+
+        Unreachable from a decoded document — every run in a table block was
+        read out of one of its cells — but ``DocumentBlock`` is public and can
+        be built with cells that do not cover its spans. Such a run renders
+        after the grid rather than vanishing into it.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    9,
+                    (TextSpan(0, 3, "aaa"), TextSpan(3, 6, "bbb"), TextSpan(6, 9, "ccc")),
+                    kind=BlockKind.TABLE,
+                    table_rows=((TableCell(0, 3), TableCell(6, 9)),),
+                ),
+            )
+        )
+        assert document.render() == "aaa\tccc\nbbb"
+        # It is still a windowed rendering: a window that excludes the stray
+        # drops its line rather than emitting a blank one.
+        assert document.render(0, 3) == "aaa"
 
     @pytest.mark.asyncio
     async def test_fulltext_exposes_the_rendering_without_moving_content(
@@ -1421,24 +1555,27 @@ class TestFragmentDescent:
         assert tables[0].text.startswith("Android2026.01.06")
         assert "Operating system" in tables[1].text
 
-    def test_a_tables_cells_run_together_because_the_parse_flattens_them(self) -> None:
-        """The readable rendering's one known blind spot, pinned (#2230).
+    def test_a_tables_cells_are_separated_by_the_boundaries_the_parse_carries(self) -> None:
+        """The readable rendering's former blind spot, fixed (#2230).
 
         ``render()`` joins a block's runs with no separator, which is right for
-        a paragraph and lossy for a table: the parse flattens every row and
-        cell into the table block's spans, so cell values end up adjacent.
+        a paragraph and was lossy for a table: the parse flattens every row and
+        cell into the table block's spans, so cell values used to end up
+        adjacent — ``"Operating systemAndroid 10+, iOS 17+ [a]Included
+        with…"``.
 
-        Pinned rather than fixed because the obvious cheap fix is wrong on this
-        very capture — a single cell is *several* runs (``"Android 10"``,
-        ``"+, "``, ``"iOS 17"``, ``"+ "``, ``"[a]"`` are one cell), so
-        separating spans would split cells as often as it separated them.
-        Nothing at this level can tell a cell boundary from a formatting
-        change; the boundary has to survive the parse first.
+        Separating *runs* was never the fix, and this capture is why: a single
+        cell is several runs (``"Android 10"``, ``"+, "``, ``"iOS 17"``,
+        ``"+ "``, ``"[a]"`` are one cell), so run separation would split cells
+        as often as it separated them. The boundary has to survive the parse,
+        which is what :attr:`DocumentBlock.table_rows` now carries — as
+        offsets, so nothing about the coordinate space moves.
         """
         elements = json.loads((FIXTURES_DIR / "citation_fragment_with_tables.json").read_text())
         document = StructuredDocument(blocks=tuple(build_blocks(elements)))
         table = document.blocks[1]
         assert table.kind is BlockKind.TABLE
+        # The runs are still flattened, and still cut across cell values.
         assert [span.text for span in table.spans][:5] == [
             "Operating system",
             "Android 10",
@@ -1446,14 +1583,91 @@ class TestFragmentDescent:
             "iOS 17",
             "+ ",
         ]
-        rendered = document.render(table.start_index, table.end_index)
-        assert (
-            rendered
-            == "Operating systemAndroid 10+, iOS 17+ [a]Included withGeminiWebsitenotebooklm.google"
+        # The capture declares *four* rows; the first is zero-width and holds
+        # no positions, so it is dropped rather than rendered as a line of
+        # separators with nothing between them.
+        assert len(elements[1][4][2]) == 4
+        assert table.table_rows == (
+            (TableCell(1610, 1626), TableCell(1626, 1650)),
+            (TableCell(1650, 1663), TableCell(1663, 1669)),
+            (TableCell(1669, 1676), TableCell(1676, 1693)),
         )
-        # ...and the same reading ``cited_text`` already gives, so this is a
-        # limitation inherited from the parse, not one introduced here.
-        assert rendered == table.text
+        assert document.render(table.start_index, table.end_index) == (
+            "Operating system\tAndroid 10+, iOS 17+ [a]\n"
+            "Included with\tGemini\n"
+            "Website\tnotebooklm.google"
+        )
+        # The cell ranges are the document's own offsets, not a rendering
+        # artefact: each one resolves on the addressable surface.
+        assert [
+            document.slice(cell.start_index, cell.end_index) for cell in table.table_rows[0]
+        ] == [
+            "Operating system",
+            "Android 10+, iOS 17+ [a]",
+        ]
+        # ...and ``DocumentBlock.text`` — the reading ``cited_text`` gives —
+        # is deliberately unchanged, because no character was added anywhere.
+        assert table.text == (
+            "Operating systemAndroid 10+, iOS 17+ [a]Included withGeminiWebsitenotebooklm.google"
+        )
+
+    def test_carrying_the_cell_boundaries_moves_no_offset(self) -> None:
+        """The regression the fix had to avoid, asserted directly (#2230).
+
+        ``StructuredDocument.text`` is the coordinate space every citation
+        offset indexes, so the cheap version of this fix — inserting a
+        separator into the layout — would have shifted every offset after the
+        capture's first table and broken the alignment #2226 / #2210 landed.
+        The boundaries are therefore carried as *offsets*: the document laid
+        out with them is byte-identical to the same document with every one of
+        them stripped, which is what the parse produced before this change.
+        """
+        elements = json.loads((FIXTURES_DIR / "citation_fragment_with_tables.json").read_text())
+        blocks = build_blocks(elements)
+        document = StructuredDocument(blocks=blocks)
+        stripped = StructuredDocument(blocks=tuple(replace(b, table_rows=()) for b in blocks))
+
+        assert any(block.table_rows for block in document.blocks)
+        assert not any(block.table_rows for block in stripped.blocks)
+        assert document.text == stripped.text
+        assert utf16_len(document.text) == document.extent == stripped.extent == 2089
+        assert [(b.start_index, b.end_index, b.text) for b in document.blocks] == [
+            (b.start_index, b.end_index, b.text) for b in stripped.blocks
+        ]
+        # The rendering's separator exists in the rendering alone.
+        assert "\t" not in document.text
+        assert "\t" in document.render()
+        # Spot-check the space itself against the capture: the two cells that
+        # straddle the fix, and the paragraph that follows both tables.
+        assert document.slice(1610, 1626) == "Operating system"
+        assert document.slice(1626, 1650) == "Android 10+, iOS 17+ [a]"
+        assert document.slice(1693, 1727) == "Duration: 11 minutes and 15 second"
+
+    def test_the_legacy_flat_rendering_does_not_see_the_cells_at_all(self) -> None:
+        """``SourceFulltext.content`` is byte-frozen, and stays that way (#2230).
+
+        It is harvested by a separate recursive string walk over the raw rows —
+        every string in traversal order, structure discarded — so a change to
+        the parsed tree cannot reach it. Asserted rather than assumed, because
+        "the legacy rendering is unaffected" is exactly the claim a decoder
+        change is most likely to break silently.
+        """
+        from notebooklm._source.content import SourceContentRenderer
+
+        elements = json.loads((FIXTURES_DIR / "citation_fragment_with_tables.json").read_text())
+        flat = "\n".join(SourceContentRenderer(None).extract_all_text(elements))
+
+        # One line per *run* (and per link URL), the pre-#2128 behaviour.
+        assert flat.split("\n")[:3] == [
+            "Android",
+            "2026.01.06 (Build 853388154) / 8 January 2026; 4 months ago ( 2026-01-08) ",
+            "[1]",
+        ]
+        assert (
+            "Operating system\nhttps://en.wikipedia.org/wiki/Operating_system\n"
+            "Android 10\nhttps://en.wikipedia.org/wiki/Android_10\n+, \niOS 17"
+        ) in flat
+        assert "\t" not in flat
 
     def test_absent_fragment_degrades_to_all_none(self) -> None:
         assert extract_text_passages([None, None, 0.5, [[None, 0, 5]]]) == (None, None, None)

--- a/tests/unit/test_citation_alignment.py
+++ b/tests/unit/test_citation_alignment.py
@@ -738,6 +738,45 @@ class TestReadableRendering:
         assert block.table_rows == ((TableCell(0, 3),), (TableCell(3, 6),))
         assert StructuredDocument(blocks=(block,)).render() == "abc\ndef"
 
+    def test_rows_that_interleave_degrade_to_the_stray_line_not_to_a_wrong_cell(
+        self,
+    ) -> None:
+        """The bound on the forward walk's monotonicity assumption (#2230 review).
+
+        :func:`_spans_by_cell` walks the flattened cells once, so its cursor
+        assumes they advance. Rows are ordered by position and cells within a
+        row are too, but a hand-built block can still *interleave* them — a
+        later row starting inside an earlier one — and no decoded document can
+        (row and cell bounds come from successive narrowings of the table's own
+        range).
+
+        What matters is which way it fails. A run is only ever assigned to a
+        cell that actually contains its start, so it can never be rendered in
+        the wrong column; the cursor can only make it match *fewer* cells than
+        it overlaps, and a run matching none becomes the trailing stray line.
+        Fewer columns and a visible extra line, never a value silently sitting
+        under the wrong header.
+        """
+        document = StructuredDocument(
+            blocks=(
+                DocumentBlock(
+                    0,
+                    30,
+                    (
+                        TextSpan(0, 5, "aaaaa"),
+                        TextSpan(10, 15, "bbbbb"),
+                        TextSpan(20, 30, "cccccccccc"),
+                    ),
+                    kind=BlockKind.TABLE,
+                    # The second row opens inside the first row's span.
+                    table_rows=((TableCell(0, 5), TableCell(20, 30)), (TableCell(10, 15),)),
+                ),
+            )
+        )
+        assert document.render() == "aaaaa\tcccccccccc\nbbbbb"
+        # Every run still reaches the rendering, and the layout is untouched.
+        assert document.text == "aaaaa￼￼￼￼￼bbbbb￼￼￼￼￼cccccccccc"
+
     def test_a_run_no_cell_claims_is_rendered_rather_than_dropped(self) -> None:
         """The regrouping may not lose text, however inconsistent its input.
 


### PR DESCRIPTION
Closes #2230.

## The defect

`StructuredDocument.render()` — and through it `SourceFulltext.rendered_content` and the passage `resolve_chat_reference_passage()` returns — rendered a table as **one line with its cell values adjacent**. On this repo's own captured infobox (`tests/unit/fixtures/citation_fragment_with_tables.json`):

```
Operating systemAndroid 10+, iOS 17+ [a]Included withGeminiWebsitenotebooklm.google
```

where the cells are `Operating system` / `Android 10+, iOS 17+ [a]` / `Included with` / `Gemini` / `Website` / `notebooklm.google`.

## Where the boundary was lost

`TableRow.spans()` narrowed each row's and then each cell's declared range, used the result to clamp the cell's own blocks — and then flattened every run into the table block's span sequence one statement later. The cell bounds existed for exactly one line and were discarded.

Nothing downstream could recover them, which is why #2226 pinned the behaviour rather than fixing it: **a single cell is several runs.** On this same capture `"Android 10"`, `"+, "`, `"iOS 17"`, `"+ "`, `"[a]"` are one cell, so separating a table block's *spans* would have split cells as often as it separated them.

## The fix

The adapter returns the bounds it already computes (`TableContent(spans, rows)`), `DocumentBlock` carries them as `table_rows` — a tuple of rows of the new public `TableCell(start_index, end_index)` — and only `render()` reads them. A table now renders **one line per row, cells tab-separated**:

```
Operating system	Android 10+, iOS 17+ [a]
Included with	Gemini
Website	notebooklm.google
```

Tab rather than markdown pipes because this rendering is deliberately marker-free (no `#`, no list glyphs); a tab is a separator, and the row separator is the newline `render()` already put between blocks.

## Offset invariance — the argument

`StructuredDocument.text` is documented as "the offset-bearing surface citation alignment is built on": every span is placed at its declared `start_index`, and that string *is* the coordinate space every offset refers to. Inserting a cell separator there would have shifted every offset after the capture's first table and silently broken the alignment work that landed in #2226 / #2210 — the failure mode is a plausible-looking wrong passage, not an error.

So the boundaries are carried as **offsets and nothing else**:

- `TableCell` holds two integers. It adds no character to the document anywhere.
- `DocumentBlock.spans` is unchanged — still the flattened row-major run sequence the layout needs. `table_rows` *partitions* those runs; it does not add to them.
- `render()` is the only consumer. Its separators have always been its own (it is not offset-addressable — that is `slice()`), so a tab there is the same class of insertion as the newline it already emitted between blocks.

Byte-identical after this change: `StructuredDocument.text`, `extent`, `slice()`, `DocumentBlock.text`, `ChatReference.cited_text`, and the legacy `SourceFulltext.content` (which is harvested by a separate recursive string walk over the raw rows and never sees the parsed tree at all).

Both halves are pinned by tests against the captured fixture, not against the implementation:

- `test_a_tables_cells_are_separated_by_the_boundaries_the_parse_carries` — the rendering, the carried cell ranges, and the *unchanged* `DocumentBlock.text`.
- `test_carrying_the_cell_boundaries_moves_no_offset` — the document laid out with the boundaries is byte-identical to the same document with every one of them stripped (i.e. what the parse produced before this change), extent still 2089, and each cell range still resolves through `slice()`.
- `test_the_legacy_flat_rendering_does_not_see_the_cells_at_all` — `content`'s per-run lines, asserted rather than assumed.

Mutation-tested three ways, each confirmed red before being restored: dropping the carried rows in the adapter (2 fixture tests fail), making `render()` ignore `table_rows` (7 tests fail), and injecting a separator into the coordinate space (35 tests fail, including the invariance test).

## Behaviour notes

- **An empty cell is a column, not an absence.** Its wire range is zero-width — the capture proves the shape, its second table's declared header cells being literally `[1610, 1610]` — so `_narrow()` is now expressed on top of a `_clamp()` that keeps an empty intersection: the *text* walk still skips a cell with no positions, the *boundary* walk keeps it. Without this, `A` / *nothing* / `C` renders `A\tC` and puts `C` in column two.
- A row of *nothing but* empty columns is dropped, as is a row the window does not reach — the "omit a block with nothing to read" rule, one level down. That is what the captured header row is, so the infobox is unaffected.
- Separators run only as far as the last cell that has text, so a trailing empty cell drops its separator. This drops empty *cells* rather than stripping separator *characters* off the joined line: a run keeps its literal whitespace, so a cell may legitimately end in a tab and the rendering may not eat it.
- A leading empty cell keeps its separator, so a value stays in the column it was written in.
- A run that no cell claims renders as a trailing line rather than vanishing. Unreachable from a decoded document, but `DocumentBlock` is public — as is the interleaved-rows case, where the forward walk can match a run to fewer cells than it overlaps but never to the wrong one (pinned by its own test).
- Nested tables read as before: an inner table's cells would overlap the outer cell containing them, and a grid of overlapping cells cannot be rendered as rows, so its text stays run-together inside its parent cell. Documented on `TableRow.decode`.

## Verification

```
uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-fail-under=90
  → 16518 passed, 64 skipped, 1 xfailed — 96.81% (exit 0)
uv run mypy src/notebooklm --ignore-missing-imports  → Success: 353 files
uv run pre-commit run --all-files                    → all hooks pass
uv run python scripts/audit_public_api_compat.py     → OK, compatible with v0.8.0
```

`src/notebooklm/_types/documents.py` and `src/notebooklm/_row_adapters/documents.py` are both at **100%** line and branch coverage.

`TableCell` is exported from `notebooklm.types` **and** `notebooklm` (AGENTS.md L30) — it is the field type of the public `DocumentBlock.table_rows`, so a caller cannot annotate or construct one without it, exactly as with `TextSpan` and `spans`. `types_all.json` and `ungated_surface.json` are regenerated (`scripts/regen_baselines.py`); the compat audit needs no allowlist entry, since an added export is additive.

**Live probe:** not run — the maintainer's auth is currently expired. My honest read is that one is not required here: this changes no request, no RPC id and no wire read. It reads two integer slots (`TableCell.startIndex` / `endIndex`) the decoder *already* read and already used to clamp each cell's blocks — the same `_narrow()` call, with its result now kept instead of discarded — and the wire-contract guardrail still pins those positions against `docs/mobile/schema.proto`. The behaviour is validated against a real captured response body (the first citation of this repo's own `chat_ask.yaml` cassette). What a live probe *would* add is a second capture's confirmation that cell ranges partition their row on other table shapes (merged cells, nested tables); the rendering degrades to the previous run-together reading if they do not, so the downside is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013614cii5BoFap7MEnNoVrx
