### PR TITLE
feat(sources): expose retained source metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Source listings retain original-file and revision metadata already present
+  on the wire.** `Source` now exposes `download_url`, `viewer_url`, and
+  `content_mime` for uploaded files, plus `word_count`, `revision_id`,
+  `revision_timestamp`, and `last_modified_at`. All fields are optional so
+  source kinds and response shapes that omit the corresponding slots continue
+  to decode cleanly. The MIME from the original-content descriptor also joins
+  the existing Drive-only MIME as a type-disambiguation signal. The recovered
+  mobile schema leaves these slots unnamed; names for the size/revision/update
+  metadata are explicitly evidence-based, backed by live shapes rather than
+  presented as recovered proto names. ([#2112](https://github.com/teng-lin/notebooklm-py/issues/2112),
+  [#2114](https://github.com/teng-lin/notebooklm-py/issues/2114))
+
 - **A readable rendering of a source, and citation resolution that reads
   offsets instead of searching for text.** `SourceFulltext` gains
   `rendered_content`, and `StructuredDocument` gains `render(start, end)` and

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2407,6 +2407,13 @@ class Source:
     status: SourceStatus                 # UNKNOWN when the wire status is missing or unmapped
     drive_document_id: Optional[str]     # Drive file id for Drive-backed sources; None otherwise
     drive_status: Optional[DriveSourceStatus]  # Drive-side health; None when the row makes no claim
+    download_url: Optional[str]          # Original uploaded file; None when unavailable
+    viewer_url: Optional[str]            # Drive viewer for the uploaded file; None when unavailable
+    content_mime: Optional[str]          # True MIME from the original-content blob descriptor
+    word_count: Optional[int]            # Inferred source word count
+    revision_id: Optional[str]           # Opaque source revision identifier
+    revision_timestamp: Optional[datetime]  # Timestamp paired with revision_id (tz-aware UTC)
+    last_modified_at: Optional[datetime] # Last source content update/refresh (tz-aware UTC)
 
     @property
     def kind(self) -> SourceType:
@@ -2431,6 +2438,18 @@ class Source:
 
 > **Removed in v0.5.0:** `Source.source_type` was replaced by `Source.kind`.
 > See [stability.md → Removed in v0.5.0](stability.md#removed-in-v050).
+
+Uploaded-file sources may carry `download_url`, `viewer_url`, and
+`content_mime`. These describe the retained original file, not the indexed text:
+`download_url` retrieves the original bytes, `viewer_url` opens the backend's
+Drive viewer, and `content_mime` is the MIME stored with that original-content
+blob. They are `None` for source kinds whose rows do not include that blob.
+
+`word_count`, `revision_id`, `revision_timestamp`, and `last_modified_at` expose
+metadata already returned by `GET_NOTEBOOK`. The slots and shapes are confirmed
+live, but the recovered mobile schema does not name them; `word_count`, the
+revision-handle interpretation, and the meaning of `last_modified_at` are
+therefore evidence-based names rather than recovered protobuf names.
 
 **Drive-backed sources: `is_ready` is not the whole story.**
 

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -108,7 +108,7 @@ Internal integer codes returned by `GET_NOTEBOOK` / `LIST_SOURCES` and consumed 
 
 > Codes outside this map are surfaced as `SourceType.UNKNOWN` and emit `UnknownTypeWarning` on first occurrence so unmapped types don't crash callers.
 
-> **Code `14` is overloaded** (live-captured #1828/#1832): the backend returns `14` for a native Google Sheet *and* for a Drive-hosted PDF. Drive sources carry no URL (`metadata[5]/[7]` are null and `metadata[0]` holds the Drive metadata block, not a URL — see `SourceRow.drive_document_id`), so the two are disambiguated by the MIME at `metadata[19]` (fallback `metadata[9][2]`): `application/vnd.google-apps.spreadsheet` → `GOOGLE_SPREADSHEET`, `application/pdf` → `PDF`. See `_disambiguate_type_code` in `src/notebooklm/_types/sources.py`.
+> **Code `14` is overloaded** (live-captured #1828/#1832): the backend returns `14` for a native Google Sheet *and* for a Drive-hosted PDF. Drive sources carry no URL (`metadata[5]/[7]` are null and `metadata[0]` holds the Drive metadata block, not a URL — see `SourceRow.drive_document_id`), so the two are disambiguated by the original-content MIME at `source[7][2]`, falling back to the Drive-only MIME at `metadata[19]` / `metadata[9][2]`: `application/vnd.google-apps.spreadsheet` → `GOOGLE_SPREADSHEET`, `application/pdf` → `PDF`. See `_disambiguate_type_code` in `src/notebooklm/_types/sources.py`.
 
 ### Source Settings Block (`source[3]`)
 
@@ -123,6 +123,26 @@ they answer different questions:
 Shapes observed across 409 live source rows (2026-08-07 audit): `[null, 2]` ×402,
 `[null, 2, null, 3]` ×4 (all Drive-backed, all `ACTIVE`), and
 `[null, 2, [null,null,null,[]]]` ×3.
+
+### Additional Source Metadata (`source[5:8]`, `source[2]`)
+
+The web source row carries useful fields beyond the four named by the recovered
+mobile `Source` message. Uploaded-file rows may populate all three trailing
+slots together:
+
+| Index | Proto tag | `Source` field | Meaning |
+|-------|-----------|----------------|---------|
+| 5 | 6 | `download_url` | Direct download URL for the original file |
+| 6 | 7 | `viewer_url` | Drive viewer URL for the original file |
+| 7 | 8 | `content_mime` | MIME at blob descriptor index 2 |
+
+The nested `SourceMetadata` row also exposes `word_count` at index 1,
+`[revision_id, revision_timestamp]` at index 3, and `last_modified_at` at index
+14. Their shapes and population are live-confirmed, but the mobile schema marks
+the slots unused, so those semantic names are inferred and recorded as pinned
+wire evidence rather than schema mappings.
+
+### Drive Source Status Codes
 
 | Code | `DriveSourceStatus` | Backend member |
 |------|---------------------|----------------|

--- a/src/notebooklm/_app/views.py
+++ b/src/notebooklm/_app/views.py
@@ -54,6 +54,21 @@ ACCESS_LABELS = {0: "restricted", 1: "anyone_with_link"}
 VIEW_LEVEL_LABELS = {0: "full", 1: "chat"}
 PERMISSION_LABELS = {1: "owner", 2: "editor", 3: "viewer"}
 
+# Stable source fields exposed by the MCP and REST adapters. ``Source`` also
+# carries Python-only metadata that those established wire contracts do not
+# publish. Keep this allowlist explicit so enriching the dataclass cannot widen
+# every adapter response accidentally.
+_SOURCE_VIEW_FIELDS = (
+    "id",
+    "title",
+    "url",
+    "_type_code",
+    "created_at",
+    "status",
+    "drive_document_id",
+    "drive_status",
+)
+
 
 def label(mapping: dict[int, str], value: int) -> str:
     """Map an ``int, Enum`` member (or raw int) to its label; unknown → ``str``."""
@@ -132,8 +147,13 @@ def source_view(source: Source) -> dict[str, Any]:
     property, so :func:`to_jsonable` would drop it, leaving every non-Python
     consumer to re-derive the degraded set from the label string — exactly the
     per-adapter duplication this module exists to prevent.
+
+    The base fields are an explicit allowlist. ``Source`` is also the public
+    Python model and may gain local metadata without implicitly changing the
+    established MCP/REST response schema.
     """
-    view = to_jsonable(source)
+    serialized = to_jsonable(source)
+    view = {key: serialized[key] for key in _SOURCE_VIEW_FIELDS if key in serialized}
     view["kind"] = source.kind.value
     view["status_label"] = source_status_to_str(source.status)
     view["drive_status_label"] = (

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -118,6 +118,12 @@ class SourceRow:
            ``GET_NOTEBOOK`` source-list rows); ``[3][3]`` is the
            :class:`~notebooklm.rpc.types.DriveSourceStatus` Drive-side code,
            populated on Drive-backed rows only (see :attr:`drive_status`).
+    5      Direct download URL for the original uploaded file, when present
+           (see :attr:`download_url`).
+    6      Drive viewer URL for the uploaded file, when present (see
+           :attr:`viewer_url`).
+    7      Content blob descriptor; ``[7][2]`` is the source's true content
+           MIME type (see :attr:`content_mime`).
     =====  ============================================================
 
     **Metadata sub-list layout** (``self._raw[2]``):
@@ -130,8 +136,13 @@ class SourceRow:
            :attr:`drive_document_id`). Legacy shapes put a bare
            ``http(s)://...`` URL here, honored only under
            ``url_allow_bare_http``.
+    1      Source word/size count (see :attr:`word_count`). The meaning is
+           inferred from live values because the mobile schema leaves the
+           field unnamed.
     2      timestamp block; ``[2][0]`` is the creation timestamp
            (seconds since epoch).
+    3      Revision handle ``[revision_id, [seconds, nanos]]`` (see
+           :attr:`revision_id` and :attr:`revision_timestamp`).
     4      type code (int — see
            :class:`notebooklm._types.sources.SourceType` mapping in
            ``_types/sources.py``).
@@ -144,6 +155,8 @@ class SourceRow:
            ``[document_id, kind_int, mime, ""]``; ``[9][0]`` is the
            ``documentId`` (see :attr:`drive_document_id`), ``[9][2]`` the
            MIME.
+    14     Last-modified timestamp block ``[seconds, nanos]`` (see
+           :attr:`last_modified_at`).
     19     top-level MIME string for Drive-hosted sources. Used with
            ``[9][2]`` to disambiguate the type-code ``14`` overload
            (native Sheet vs Drive-hosted PDF) — see :attr:`mime`.
@@ -194,11 +207,21 @@ class SourceRow:
     # ``SourceSettings.userDriveSourceStatus`` (tag 4) inside the same settings
     # block the ingestion status is read from (#2111).
     _DRIVE_STATUS_INNER_POS: ClassVar[int] = 3
+    # Source tags 6-8 are unnamed ``addUnused()`` slots in the recovered
+    # mobile schema, but are populated together on uploaded-file rows (#2112).
+    _DOWNLOAD_URL_POS: ClassVar[int] = 5
+    _VIEWER_URL_POS: ClassVar[int] = 6
+    _CONTENT_DESCRIPTOR_POS: ClassVar[int] = 7
+    _CONTENT_DESCRIPTOR_MIME_POS: ClassVar[int] = 2
 
     # Metadata sub-list positions. Index 0 is googleDocsMetadata, not a URL
     # slot (the old _META_BARE_URL_POS name meant only the legacy fallback).
     _META_GOOGLE_DOCS_POS: ClassVar[int] = 0
+    # These three fields are also unnamed in the recovered mobile schema. Their
+    # semantics are inferred from live values and context (#2114).
+    _META_WORD_COUNT_POS: ClassVar[int] = 1
     _META_TIMESTAMP_POS: ClassVar[int] = 2
+    _META_REVISION_POS: ClassVar[int] = 3
     _META_TYPE_POS: ClassVar[int] = 4
     _META_YOUTUBE_POS: ClassVar[int] = 5
     _META_URL_POS: ClassVar[int] = 7
@@ -208,6 +231,7 @@ class SourceRow:
     # overload (native Sheet vs Drive PDF), which the URL slots can't — Drive
     # rows have no URL (metadata[5]/[7] null; metadata[0] is the Drive block).
     _META_DRIVE_DESCRIPTOR_POS: ClassVar[int] = 9
+    _META_LAST_MODIFIED_POS: ClassVar[int] = 14
     _META_MIME_POS: ClassVar[int] = 19
     # Position of the MIME string inside the drive-file descriptor at [9].
     _DRIVE_DESCRIPTOR_MIME_POS: ClassVar[int] = 2
@@ -215,6 +239,8 @@ class SourceRow:
     # GoogleDocsSourceMetadata and GoogleDriveSourceMetadata both declare it as
     # tag 1, so one constant covers both blocks.
     _DRIVE_DOCUMENT_ID_POS: ClassVar[int] = 0
+    _REVISION_ID_POS: ClassVar[int] = 0
+    _REVISION_TIMESTAMP_POS: ClassVar[int] = 1
 
     # Id-envelope inner positions (the three layouts at ``self._raw[0]``).
     _ID_ENVELOPE_PLAIN_POS: ClassVar[int] = 0
@@ -425,6 +451,98 @@ class SourceRow:
         value = self._raw[self._METADATA_POS]
         return value if isinstance(value, list) else None
 
+    def _top_level_string(self, position: int) -> str | None:
+        """Return a non-empty string from a top-level source slot."""
+        if len(self._raw) <= position:
+            return None
+        value = self._raw[position]
+        return value if isinstance(value, str) and value else None
+
+    @property
+    def download_url(self) -> str | None:
+        """Direct URL for downloading the original uploaded file.
+
+        This is ``Source`` tag 6 (row index 5), populated only for source kinds
+        whose original bytes remain downloadable. The mobile schema leaves the
+        slot unnamed; the meaning is established by live URLs on the
+        ``contribution.usercontent.google.com/download`` endpoint (#2112).
+        """
+        return self._top_level_string(self._DOWNLOAD_URL_POS)
+
+    @property
+    def viewer_url(self) -> str | None:
+        """Drive viewer URL for the original uploaded file, when available.
+
+        This is the live-confirmed ``Source`` tag-7 slot (row index 6). It is
+        independent of :attr:`url`, which identifies URL/YouTube sources.
+        """
+        return self._top_level_string(self._VIEWER_URL_POS)
+
+    @property
+    def content_mime(self) -> str | None:
+        """True content MIME from the source blob descriptor, when present.
+
+        ``Source`` tag 8 carries a blob descriptor whose third element is the
+        MIME. Unlike :attr:`mime`, this is not Drive-specific and therefore
+        covers uploaded files such as Markdown sources (#2112).
+        """
+        if len(self._raw) <= self._CONTENT_DESCRIPTOR_POS:
+            return None
+        descriptor = self._raw[self._CONTENT_DESCRIPTOR_POS]
+        if not isinstance(descriptor, list) or len(descriptor) <= self._CONTENT_DESCRIPTOR_MIME_POS:
+            return None
+        value = descriptor[self._CONTENT_DESCRIPTOR_MIME_POS]
+        return value if isinstance(value, str) and value else None
+
+    @property
+    def word_count(self) -> int | None:
+        """Inferred source word/size count from ``metadata[1]``.
+
+        The field is populated on every sampled source row, but its proto name
+        was not recovered. Values and the surrounding per-source word-limit
+        contract strongly indicate a word count; callers should treat that
+        semantic label as inferred rather than schema-confirmed (#2114).
+        """
+        metadata = self.metadata
+        if metadata is None or len(metadata) <= self._META_WORD_COUNT_POS:
+            return None
+        value = metadata[self._META_WORD_COUNT_POS]
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    def _revision_handle(self) -> list[Any] | None:
+        """Return the inferred ``[revision_id, timestamp]`` block."""
+        metadata = self.metadata
+        if metadata is None or len(metadata) <= self._META_REVISION_POS:
+            return None
+        value = metadata[self._META_REVISION_POS]
+        return value if isinstance(value, list) else None
+
+    @property
+    def revision_id(self) -> str | None:
+        """Opaque source revision identifier from ``metadata[3][0]``."""
+        handle = self._revision_handle()
+        if handle is None or len(handle) <= self._REVISION_ID_POS:
+            return None
+        value = handle[self._REVISION_ID_POS]
+        return value if isinstance(value, str) and value else None
+
+    @property
+    def revision_timestamp_raw(self) -> int | float | None:
+        """Raw revision timestamp seconds from ``metadata[3][1][0]``."""
+        handle = self._revision_handle()
+        if handle is None or len(handle) <= self._REVISION_TIMESTAMP_POS:
+            return None
+        return self._timestamp_raw_from_block(
+            handle[self._REVISION_TIMESTAMP_POS],
+            source="SourceRow.revision_timestamp_raw",
+        )
+
+    @property
+    def revision_timestamp(self) -> datetime | None:
+        """Revision timestamp as a timezone-aware UTC datetime."""
+        raw = self.revision_timestamp_raw
+        return _datetime_from_timestamp(raw) if raw is not None else None
+
     @property
     def type_code(self) -> int | None:
         """Type code at ``metadata[4]`` (int) or ``None`` when absent.
@@ -628,6 +746,18 @@ class SourceRow:
             return candidate
         return None
 
+    def _timestamp_raw_from_block(self, timestamp_block: Any, *, source: str) -> int | float | None:
+        """Decode seconds from a ``[seconds, nanos]`` block."""
+        if not isinstance(timestamp_block, list) or not timestamp_block:
+            return None
+        value = safe_index(
+            timestamp_block,
+            0,
+            method_id=self.method_id,
+            source=source,
+        )
+        return value if isinstance(value, (int, float)) else None
+
     @property
     def created_at_raw(self) -> int | float | None:
         """Raw creation timestamp (seconds since epoch) at ``metadata[2][0]``.
@@ -645,16 +775,10 @@ class SourceRow:
         metadata = self.metadata
         if metadata is None or len(metadata) <= self._META_TIMESTAMP_POS:
             return None
-        timestamp_block = metadata[self._META_TIMESTAMP_POS]
-        if not isinstance(timestamp_block, list) or not timestamp_block:
-            return None
-        value = safe_index(
-            timestamp_block,
-            0,
-            method_id=self.method_id,
+        return self._timestamp_raw_from_block(
+            metadata[self._META_TIMESTAMP_POS],
             source="SourceRow.created_at_raw",
         )
-        return value if isinstance(value, (int, float)) else None
 
     @property
     def created_at(self) -> datetime | None:
@@ -663,6 +787,23 @@ class SourceRow:
         if raw is None:
             return None
         return _datetime_from_timestamp(raw)
+
+    @property
+    def last_modified_at_raw(self) -> int | float | None:
+        """Raw last-modified timestamp seconds from ``metadata[14][0]``."""
+        metadata = self.metadata
+        if metadata is None or len(metadata) <= self._META_LAST_MODIFIED_POS:
+            return None
+        return self._timestamp_raw_from_block(
+            metadata[self._META_LAST_MODIFIED_POS],
+            source="SourceRow.last_modified_at_raw",
+        )
+
+    @property
+    def last_modified_at(self) -> datetime | None:
+        """Last-modified timestamp as a timezone-aware UTC datetime."""
+        raw = self.last_modified_at_raw
+        return _datetime_from_timestamp(raw) if raw is not None else None
 
     # ---- Metadata-only entry points (legacy ``_types.sources`` helpers) --
     # ``_types/sources._extract_source_url`` / ``_extract_source_created_at``

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -746,8 +746,18 @@ class SourceRow:
             return candidate
         return None
 
-    def _timestamp_raw_from_block(self, timestamp_block: Any, *, source: str) -> int | float | None:
-        """Decode seconds from a ``[seconds, nanos]`` block."""
+    def _timestamp_raw_from_block(
+        self,
+        timestamp_block: Any,
+        *,
+        source: str,
+        allow_bool: bool = False,
+    ) -> int | float | None:
+        """Decode seconds from a ``[seconds, nanos]`` block.
+
+        ``allow_bool`` exists only for the legacy metadata helper, whose
+        long-standing public behavior treats booleans as integers.
+        """
         if not isinstance(timestamp_block, list) or not timestamp_block:
             return None
         value = safe_index(
@@ -756,7 +766,11 @@ class SourceRow:
             method_id=self.method_id,
             source=source,
         )
-        return value if isinstance(value, (int, float)) else None
+        return (
+            value
+            if isinstance(value, (int, float)) and (allow_bool or not isinstance(value, bool))
+            else None
+        )
 
     @property
     def created_at_raw(self) -> int | float | None:
@@ -820,9 +834,8 @@ class SourceRow:
     def _from_metadata(cls, metadata: Any) -> SourceRow:
         """Wrap a bare metadata sub-list as a row whose ``metadata`` is it.
 
-        Used only by :meth:`created_at_from_metadata` so the timestamp walk
-        reuses the strict :attr:`created_at` property unchanged. ``_raw[0]``
-        / ``_raw[1]`` are placeholders the timestamp path never reads.
+        Used only by :meth:`created_at_from_metadata`. ``_raw[0]`` / ``_raw[1]``
+        are placeholders the timestamp path never reads.
         """
         return cls(_raw=[None, None, metadata])
 
@@ -839,7 +852,17 @@ class SourceRow:
         """
         if not isinstance(metadata, list):
             return None
-        return cls._from_metadata(metadata).created_at
+        if len(metadata) <= cls._META_TIMESTAMP_POS:
+            return None
+        row = cls._from_metadata(metadata)
+        raw = row._timestamp_raw_from_block(
+            metadata[cls._META_TIMESTAMP_POS],
+            source="SourceRow.created_at_raw",
+            # The legacy public helper treated bool as an int. Preserve that
+            # compatibility here while real SourceRow properties reject it.
+            allow_bool=True,
+        )
+        return _datetime_from_timestamp(raw) if raw is not None else None
 
     @classmethod
     def url_from_metadata(cls, metadata: Any, *, allow_bare_http: bool = True) -> str | None:

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -320,10 +320,10 @@ class Source:
     drive_status: DriveSourceStatus | None = None
     #: Direct URL for downloading the original uploaded file. Populated only
     #: when the backend retains a downloadable blob for the source (#2112).
-    download_url: str | None = None
+    download_url: str | None = field(default=None, repr=False)
     #: Human-clickable Drive viewer URL for the original uploaded file, when
     #: the backend supplies one (#2112).
-    viewer_url: str | None = None
+    viewer_url: str | None = field(default=None, repr=False)
     #: True MIME type from the source's content blob descriptor. Unlike the
     #: internal Drive MIME used for type disambiguation, this also covers
     #: ordinary uploaded files (#2112).
@@ -431,10 +431,12 @@ class Source:
         single field mapping below therefore covers all three wire shapes
         identically.
         """
-        # Correct the type_code==14 native-Sheet/Drive-PDF overload by the row
-        # MIME before it reaches ``kind`` (#1832). No-op for every other type
-        # code and for real Sheets.
-        type_code = _disambiguate_type_code(row.type_code, row.content_mime or row.mime)
+        # Correct the type_code==14 native-Sheet/Drive-PDF overload before it
+        # reaches ``kind`` (#1832). Prefer the original-content MIME, then fall
+        # back to the Drive-only MIME if the first value is not a known
+        # override. Both passes are no-ops for every other code and real Sheets.
+        type_code = _disambiguate_type_code(row.type_code, row.content_mime)
+        type_code = _disambiguate_type_code(type_code, row.mime)
         return cls(
             id=row.id,
             # #1850: a direct-PDF URL arrives with the raw URL in the title slot

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -168,9 +168,9 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 # native Google Sheet AND a Drive-hosted binary file (e.g. a PDF). Live capture
 # showed Drive sources carry no URL (metadata[5]/[7] are null and metadata[0]
 # holds the Drive metadata block — see ``SourceRow.drive_document_id`` — rather
-# than a URL), so the only disambiguation signal is the MIME at metadata[19] /
-# metadata[9][2]. A native
-# Sheet carries "application/vnd.google-apps.spreadsheet" (→ stay 14); a Drive
+# than a URL), so disambiguation uses the original-content MIME at Source tag 8
+# first (#2112), then the Drive-only MIME at metadata[19] / metadata[9][2]. A
+# native Sheet carries "application/vnd.google-apps.spreadsheet" (→ stay 14); a Drive
 # PDF carries "application/pdf" (→ 3). Only MIMEs proven by live capture are
 # mapped; anything else under 14 is left as GOOGLE_SPREADSHEET (conservative —
 # never relabel a real Sheet, never introduce UNKNOWN). Extend as more
@@ -318,6 +318,26 @@ class Source:
     #: was deleted or unshared keeps reporting ``READY`` because ingestion did
     #: complete (#2111). See :attr:`is_drive_degraded`.
     drive_status: DriveSourceStatus | None = None
+    #: Direct URL for downloading the original uploaded file. Populated only
+    #: when the backend retains a downloadable blob for the source (#2112).
+    download_url: str | None = None
+    #: Human-clickable Drive viewer URL for the original uploaded file, when
+    #: the backend supplies one (#2112).
+    viewer_url: str | None = None
+    #: True MIME type from the source's content blob descriptor. Unlike the
+    #: internal Drive MIME used for type disambiguation, this also covers
+    #: ordinary uploaded files (#2112).
+    content_mime: str | None = None
+    #: Inferred source word count. The wire slot is confirmed live but unnamed
+    #: in the recovered schema, so the semantic label remains provisional.
+    word_count: int | None = None
+    #: Opaque revision identifier from the source metadata revision handle.
+    revision_id: str | None = None
+    #: Timestamp paired with :attr:`revision_id`, decoded as timezone-aware UTC.
+    revision_timestamp: datetime | None = None
+    #: Last time the backend reports the source content was modified/refreshed,
+    #: decoded as timezone-aware UTC.
+    last_modified_at: datetime | None = None
 
     @property
     def kind(self) -> SourceType:
@@ -405,7 +425,8 @@ class Source:
         when no metadata list is present at ``_raw[2]``, so
         :attr:`SourceRow.metadata` returns ``None`` and
         :attr:`~SourceRow.type_code` / :attr:`~SourceRow.url` /
-        :attr:`~SourceRow.created_at` all resolve to ``None`` while
+        :attr:`~SourceRow.created_at` and all optional enrichment properties
+        resolve to ``None`` while
         :attr:`~SourceRow.status` resolves to ``SourceStatus.UNKNOWN``. The
         single field mapping below therefore covers all three wire shapes
         identically.
@@ -413,7 +434,7 @@ class Source:
         # Correct the type_code==14 native-Sheet/Drive-PDF overload by the row
         # MIME before it reaches ``kind`` (#1832). No-op for every other type
         # code and for real Sheets.
-        type_code = _disambiguate_type_code(row.type_code, row.mime)
+        type_code = _disambiguate_type_code(row.type_code, row.content_mime or row.mime)
         return cls(
             id=row.id,
             # #1850: a direct-PDF URL arrives with the raw URL in the title slot
@@ -427,6 +448,13 @@ class Source:
             status=row.status,
             drive_document_id=row.drive_document_id,
             drive_status=row.drive_status,
+            download_url=row.download_url,
+            viewer_url=row.viewer_url,
+            content_mime=row.content_mime,
+            word_count=row.word_count,
+            revision_id=row.revision_id,
+            revision_timestamp=row.revision_timestamp,
+            last_modified_at=row.last_modified_at,
         )
 
     @classmethod

--- a/tests/_guardrails/_wire_contract.py
+++ b/tests/_guardrails/_wire_contract.py
@@ -932,6 +932,87 @@ UNREAD_SHARE_STATUS_SLOTS: dict[int, str] = {
 
 PINNED: tuple[Pinned, ...] = (
     Pinned(
+        "sources",
+        "SourceRow",
+        "_DOWNLOAD_URL_POS",
+        5,
+        "Source tag 6 — direct download URL for the original uploaded file",
+        "#2112: populated on 41/409 live source rows, always as a "
+        "contribution.usercontent.google.com/download URL; independently rechecked "
+        "on 27/305 rows across 12 notebooks",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_VIEWER_URL_POS",
+        6,
+        "Source tag 7 — Drive viewer URL for the original uploaded file",
+        "#2112: populated alongside tag 6 on 41/409 live source rows, always as a "
+        "drive.google.com/viewer/upload URL; independently rechecked on 27/305 rows",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_CONTENT_DESCRIPTOR_POS",
+        7,
+        "Source tag 8 — original-content blob descriptor",
+        "#2112: populated alongside tags 6/7 on 41/409 live rows with blobref, MIME, "
+        "and opaque token payload; independently rechecked on 27/305 rows",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_CONTENT_DESCRIPTOR_MIME_POS",
+        2,
+        "Source tag-8 blob descriptor index 2 — true content MIME",
+        "#2112: non-null MIME (including text/markdown) on every one of the 41 rows "
+        "whose Source tag-8 descriptor was populated",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_META_WORD_COUNT_POS",
+        1,
+        "SourceMetadata tag 2 — inferred source word/size count",
+        "#2114: populated on 409/409 sampled rows with values such as 1498, 4048, "
+        "and 116962; the word-count meaning is inferred from values and the confirmed "
+        "per-source word limit, not a recovered proto name",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_META_REVISION_POS",
+        3,
+        "SourceMetadata tag 4 — inferred [revision id, timestamp] handle",
+        "#2114: populated on 409/409 sampled rows as [uuid, [seconds, nanos]]; the "
+        "revision meaning is inferred because the mobile schema marks the slot unused",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_META_LAST_MODIFIED_POS",
+        14,
+        "SourceMetadata tag 15 — inferred last-modified timestamp",
+        "#2114: populated on 409/409 sampled rows as [seconds, nanos]; the temporal "
+        "meaning is inferred from live values rather than a recovered proto name",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_REVISION_ID_POS",
+        0,
+        "SourceMetadata tag-4 revision handle index 0 — opaque revision UUID",
+        "#2114: 409/409 live revision handles used [uuid, [seconds, nanos]]",
+    ),
+    Pinned(
+        "sources",
+        "SourceRow",
+        "_REVISION_TIMESTAMP_POS",
+        1,
+        "SourceMetadata tag-4 revision handle index 1 — revision timestamp",
+        "#2114: 409/409 live revision handles used [uuid, [seconds, nanos]]",
+    ),
+    Pinned(
         "chat",
         "CitationDetail",
         "_FRAGMENT_RANGE_POS",

--- a/tests/fixtures/rpc_golden/ADD_SOURCE.json
+++ b/tests/fixtures/rpc_golden/ADD_SOURCE.json
@@ -150,6 +150,13 @@
     "created_at": null,
     "status": -1,
     "drive_document_id": null,
-    "drive_status": null
+    "drive_status": null,
+    "download_url": null,
+    "viewer_url": null,
+    "content_mime": null,
+    "word_count": null,
+    "revision_id": null,
+    "revision_timestamp": null,
+    "last_modified_at": null
   }
 }

--- a/tests/unit/app/test_app_serialize.py
+++ b/tests/unit/app/test_app_serialize.py
@@ -228,6 +228,38 @@ def test_source_view_drive_status_label_is_none_when_absent() -> None:
     assert unreadable["is_drive_degraded"] is False
 
 
+def test_source_view_does_not_publish_python_only_source_metadata() -> None:
+    """Enriching ``Source`` must not implicitly widen the MCP/REST contract."""
+    from notebooklm._app.views import source_view
+    from notebooklm.types import Source
+
+    source = Source(
+        id="src-1",
+        download_url="https://example.test/download",
+        viewer_url="https://example.test/view",
+        content_mime="text/markdown",
+        word_count=123,
+        revision_id="revision-1",
+        revision_timestamp=datetime(2026, 8, 13, tzinfo=timezone.utc),
+        last_modified_at=datetime(2026, 8, 14, tzinfo=timezone.utc),
+    )
+
+    view = source_view(source)
+
+    assert (
+        not {
+            "download_url",
+            "viewer_url",
+            "content_mime",
+            "word_count",
+            "revision_id",
+            "revision_timestamp",
+            "last_modified_at",
+        }
+        & view.keys()
+    )
+
+
 def test_source_summary_stays_narrow_so_add_envelopes_do_not_widen() -> None:
     """``source_summary`` must NOT grow the Drive axis.
 

--- a/tests/unit/test_row_adapters.py
+++ b/tests/unit/test_row_adapters.py
@@ -1530,28 +1530,37 @@ class TestSourceRowPositionContract:
     """
 
     def test_top_level_positions(self) -> None:
-        """Entry-level positions: id, title, metadata, status block."""
+        """Entry-level positions: identity, settings, and downloadable content."""
         assert SourceRow._ID_POS == 0
         assert SourceRow._TITLE_POS == 1
         assert SourceRow._METADATA_POS == 2
         assert SourceRow._STATUS_BLOCK_POS == 3
         assert SourceRow._STATUS_INNER_POS == 1
+        assert SourceRow._DOWNLOAD_URL_POS == 5
+        assert SourceRow._VIEWER_URL_POS == 6
+        assert SourceRow._CONTENT_DESCRIPTOR_POS == 7
+        assert SourceRow._CONTENT_DESCRIPTOR_MIME_POS == 2
 
     def test_metadata_positions(self) -> None:
         """Metadata-sub-list positions: google-docs block, timestamp, type, yt, url."""
         assert SourceRow._META_GOOGLE_DOCS_POS == 0
+        assert SourceRow._META_WORD_COUNT_POS == 1
         assert SourceRow._META_TIMESTAMP_POS == 2
+        assert SourceRow._META_REVISION_POS == 3
         assert SourceRow._META_TYPE_POS == 4
         assert SourceRow._META_YOUTUBE_POS == 5
         assert SourceRow._META_URL_POS == 7
         # Drive-hosted MIME positions used to disambiguate the type_code==14
         # overload (native Sheet vs Drive PDF) — live-captured #1832.
         assert SourceRow._META_DRIVE_DESCRIPTOR_POS == 9
+        assert SourceRow._META_LAST_MODIFIED_POS == 14
         assert SourceRow._META_MIME_POS == 19
         assert SourceRow._DRIVE_DESCRIPTOR_MIME_POS == 2
         # Drive documentId position — one constant for both blocks, since
         # GoogleDocs/GoogleDrive SourceMetadata both declare it as tag 1 (#2113).
         assert SourceRow._DRIVE_DOCUMENT_ID_POS == 0
+        assert SourceRow._REVISION_ID_POS == 0
+        assert SourceRow._REVISION_TIMESTAMP_POS == 1
 
     def test_id_envelope_positions(self) -> None:
         """Id-envelope positions: plain id at [0]; drive-backed at [2][0]."""
@@ -1575,20 +1584,29 @@ class TestSourceRowPositionContract:
             SourceRow._METADATA_POS,
             SourceRow._STATUS_BLOCK_POS,
             SourceRow._STATUS_INNER_POS,
+            SourceRow._DOWNLOAD_URL_POS,
+            SourceRow._VIEWER_URL_POS,
+            SourceRow._CONTENT_DESCRIPTOR_POS,
+            SourceRow._CONTENT_DESCRIPTOR_MIME_POS,
             SourceRow._META_GOOGLE_DOCS_POS,
+            SourceRow._META_WORD_COUNT_POS,
             SourceRow._META_TIMESTAMP_POS,
+            SourceRow._META_REVISION_POS,
             SourceRow._META_TYPE_POS,
             SourceRow._META_YOUTUBE_POS,
             SourceRow._META_URL_POS,
             SourceRow._META_DRIVE_DESCRIPTOR_POS,
+            SourceRow._META_LAST_MODIFIED_POS,
             SourceRow._META_MIME_POS,
             SourceRow._DRIVE_DESCRIPTOR_MIME_POS,
             SourceRow._DRIVE_DOCUMENT_ID_POS,
+            SourceRow._REVISION_ID_POS,
+            SourceRow._REVISION_TIMESTAMP_POS,
             SourceRow._ID_ENVELOPE_PLAIN_POS,
             SourceRow._ID_ENVELOPE_DRIVE_PAYLOAD_POS,
             SourceRow._ID_ENVELOPE_DRIVE_INNER_POS,
             SourceRow._LIST_FIRST_POS,
-        ) == (0, 1, 2, 3, 1, 0, 2, 4, 5, 7, 9, 19, 2, 0, 0, 2, 0, 0)
+        ) == (0, 1, 2, 3, 1, 5, 6, 7, 2, 0, 1, 2, 3, 4, 5, 7, 9, 14, 19, 2, 0, 0, 1, 0, 2, 0, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_source_listing_service.py
+++ b/tests/unit/test_source_listing_service.py
@@ -383,6 +383,38 @@ async def test_created_at_uses_shared_timestamp_parser() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_preserves_download_and_revision_metadata() -> None:
+    metadata: list[Any] = [None] * 15
+    metadata[1] = 4048
+    metadata[2] = [1704067200, 0]
+    metadata[3] = ["revision-id", [1704067300, 0]]
+    metadata[4] = 8
+    metadata[14] = [1704067400, 0]
+    entry = source_entry("src_enriched", metadata=metadata)
+    entry.extend(
+        [
+            None,
+            "https://contribution.usercontent.google.com/download?c=token",
+            "https://drive.google.com/viewer/upload?ds=token",
+            ["blobref", None, "text/markdown"],
+        ]
+    )
+    lister = SourceLister(RecordingRpc([["Notebook", [entry]]]))
+
+    [source] = await lister.list("nb_123")
+
+    assert source.download_url == "https://contribution.usercontent.google.com/download?c=token"
+    assert source.viewer_url == "https://drive.google.com/viewer/upload?ds=token"
+    assert source.content_mime == "text/markdown"
+    assert source.word_count == 4048
+    assert source.revision_id == "revision-id"
+    assert source.revision_timestamp is not None
+    assert int(source.revision_timestamp.timestamp()) == 1704067300
+    assert source.last_modified_at is not None
+    assert int(source.last_modified_at.timestamp()) == 1704067400
+
+
+@pytest.mark.asyncio
 async def test_get_filters_list_results() -> None:
     lister = SourceLister(
         RecordingRpc(

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -437,7 +437,10 @@ def test_non_14_type_code_with_pdf_mime_is_untouched() -> None:
 
 
 def _live_enriched_source_row(
-    *, type_code: int = 8, content_mime: str = "text/markdown"
+    *,
+    type_code: int = 8,
+    content_mime: str = "text/markdown",
+    drive_mime: str | None = None,
 ) -> SourceRow:
     """Build the live shape shared by the two source-enrichment issues."""
     metadata: list[object] = [None] * 20
@@ -446,6 +449,7 @@ def _live_enriched_source_row(
     metadata[3] = ["a25483bc-01fc-4e64-9deb-d2c2cf001887", [1_754_560_100, 456_000_000]]
     metadata[4] = type_code
     metadata[14] = [1_754_560_200, 789_000_000]
+    metadata[19] = drive_mime
     return SourceRow.from_entry(
         [
             ["source-id"],
@@ -500,12 +504,53 @@ def test_source_from_row_surfaces_every_enriched_field() -> None:
     assert source.last_modified_at == _datetime_from_timestamp(1_754_560_200)
 
 
+def test_source_repr_omits_signed_capability_urls() -> None:
+    """Routine logging must not persist access-bearing source URL tokens."""
+    from notebooklm._types.sources import Source
+
+    download_token = "download-capability-token"
+    viewer_token = "viewer-capability-token"
+    source = Source(
+        id="source-id",
+        download_url=f"https://example.test/download?token={download_token}",
+        viewer_url=f"https://example.test/view?token={viewer_token}",
+    )
+
+    rendered = repr(source)
+
+    assert download_token not in rendered
+    assert viewer_token not in rendered
+    assert source.download_url is not None
+    assert source.viewer_url is not None
+
+
 def test_content_mime_disambiguates_drive_pdf_without_drive_metadata_mime() -> None:
     """The true content MIME is preferred over the older Drive-only slots."""
     from notebooklm._types.sources import Source, SourceType
 
     source = Source.from_row(
         _live_enriched_source_row(type_code=14, content_mime="application/pdf")
+    )
+
+    assert source.kind is SourceType.PDF
+
+
+@pytest.mark.parametrize(
+    "content_mime",
+    ["application/octet-stream", "application/pdf; charset=binary"],
+)
+def test_drive_mime_disambiguates_when_content_mime_is_unrecognized(
+    content_mime: str,
+) -> None:
+    """An unusable content MIME must not mask the proven Drive MIME fallback."""
+    from notebooklm._types.sources import Source, SourceType
+
+    source = Source.from_row(
+        _live_enriched_source_row(
+            type_code=14,
+            content_mime=content_mime,
+            drive_mime="application/pdf",
+        )
     )
 
     assert source.kind is SourceType.PDF
@@ -549,6 +594,22 @@ def test_enriched_fields_reject_malformed_values() -> None:
     assert row.word_count is None
     assert row.revision_id is None
     assert row.revision_timestamp is None
+    assert row.last_modified_at is None
+
+
+def test_source_row_rejects_boolean_timestamps() -> None:
+    """JSON booleans are not numeric timestamps despite subclassing ``int``."""
+    metadata: list[object] = [None] * 15
+    metadata[2] = [True]
+    metadata[3] = ["revision-id", [False]]
+    metadata[14] = [True]
+    row = SourceRow.from_entry([["source-id"], "Title", metadata, [None, SourceStatus.READY]])
+
+    assert row.created_at_raw is None
+    assert row.created_at is None
+    assert row.revision_timestamp_raw is None
+    assert row.revision_timestamp is None
+    assert row.last_modified_at_raw is None
     assert row.last_modified_at is None
 
 

--- a/tests/unit/test_sources_row_adapter.py
+++ b/tests/unit/test_sources_row_adapter.py
@@ -433,6 +433,125 @@ def test_non_14_type_code_with_pdf_mime_is_untouched() -> None:
     assert src.kind == SourceType.WEB_PAGE
 
 
+# --- #2112 + #2114: retained source content and revision metadata ----------
+
+
+def _live_enriched_source_row(
+    *, type_code: int = 8, content_mime: str = "text/markdown"
+) -> SourceRow:
+    """Build the live shape shared by the two source-enrichment issues."""
+    metadata: list[object] = [None] * 20
+    metadata[1] = 1498
+    metadata[2] = [1_754_560_000, 123_000_000]
+    metadata[3] = ["a25483bc-01fc-4e64-9deb-d2c2cf001887", [1_754_560_100, 456_000_000]]
+    metadata[4] = type_code
+    metadata[14] = [1_754_560_200, 789_000_000]
+    return SourceRow.from_entry(
+        [
+            ["source-id"],
+            "The AI-Enabled Organization.md",
+            metadata,
+            [None, SourceStatus.READY],
+            None,
+            "https://contribution.usercontent.google.com/download?c=token&filename=source.md",
+            "https://drive.google.com/viewer/upload?ds=token",
+            [
+                "/contrib_service/blobrefs/notebooklm/nos_files/MediaDataBlobref/global::0000",
+                None,
+                content_mime,
+                [["opaque-token"]],
+            ],
+        ]
+    )
+
+
+def test_source_row_decodes_original_file_links_and_content_mime() -> None:
+    row = _live_enriched_source_row()
+
+    assert row.download_url == (
+        "https://contribution.usercontent.google.com/download?c=token&filename=source.md"
+    )
+    assert row.viewer_url == "https://drive.google.com/viewer/upload?ds=token"
+    assert row.content_mime == "text/markdown"
+
+
+def test_source_row_decodes_word_revision_and_last_modified_metadata() -> None:
+    row = _live_enriched_source_row()
+
+    assert row.word_count == 1498
+    assert row.revision_id == "a25483bc-01fc-4e64-9deb-d2c2cf001887"
+    assert row.revision_timestamp_raw == 1_754_560_100
+    assert row.revision_timestamp == _datetime_from_timestamp(1_754_560_100)
+    assert row.last_modified_at_raw == 1_754_560_200
+    assert row.last_modified_at == _datetime_from_timestamp(1_754_560_200)
+
+
+def test_source_from_row_surfaces_every_enriched_field() -> None:
+    from notebooklm._types.sources import Source
+
+    source = Source.from_row(_live_enriched_source_row())
+
+    assert source.download_url is not None
+    assert source.viewer_url is not None
+    assert source.content_mime == "text/markdown"
+    assert source.word_count == 1498
+    assert source.revision_id == "a25483bc-01fc-4e64-9deb-d2c2cf001887"
+    assert source.revision_timestamp == _datetime_from_timestamp(1_754_560_100)
+    assert source.last_modified_at == _datetime_from_timestamp(1_754_560_200)
+
+
+def test_content_mime_disambiguates_drive_pdf_without_drive_metadata_mime() -> None:
+    """The true content MIME is preferred over the older Drive-only slots."""
+    from notebooklm._types.sources import Source, SourceType
+
+    source = Source.from_row(
+        _live_enriched_source_row(type_code=14, content_mime="application/pdf")
+    )
+
+    assert source.kind is SourceType.PDF
+
+
+def test_enriched_fields_are_none_on_short_rows() -> None:
+    row = SourceRow.from_entry([["source-id"], "Title"])
+
+    assert row.download_url is None
+    assert row.viewer_url is None
+    assert row.content_mime is None
+    assert row.word_count is None
+    assert row.revision_id is None
+    assert row.revision_timestamp_raw is None
+    assert row.revision_timestamp is None
+    assert row.last_modified_at_raw is None
+    assert row.last_modified_at is None
+
+
+def test_enriched_fields_reject_malformed_values() -> None:
+    metadata: list[object] = [None] * 15
+    metadata[1] = True
+    metadata[3] = [42, "not-a-timestamp"]
+    metadata[14] = ["not-numeric"]
+    row = SourceRow.from_entry(
+        [
+            ["source-id"],
+            "Title",
+            metadata,
+            [None, SourceStatus.READY],
+            None,
+            42,
+            "",
+            ["blobref", None, 123],
+        ]
+    )
+
+    assert row.download_url is None
+    assert row.viewer_url is None
+    assert row.content_mime is None
+    assert row.word_count is None
+    assert row.revision_id is None
+    assert row.revision_timestamp is None
+    assert row.last_modified_at is None
+
+
 # --- #2113: SourceRow.drive_document_id (the add_drive idempotency key) ------
 
 #: A Drive file id as it appears on the wire (44-char Base64URL), taken from the


### PR DESCRIPTION
## Summary

- decode the original-file download URL, viewer URL, and true content MIME from Source tags 6–8
- expose the inferred word count, revision handle, revision timestamp, and last-modified timestamp already returned in SourceMetadata
- use the original-content MIME as the preferred signal for the existing Drive PDF/source-type disambiguation
- pin every unnamed positional slot to its live evidence and document the public fields and wire contract

## Root cause

`SourceRow` normalized only the first four top-level Source fields and a small subset of SourceMetadata. The backend populated the trailing original-content fields and revision metadata, but the adapter discarded them before constructing the public `Source` object.

## Impact

Python callers can now retrieve the original uploaded-file links and MIME, inspect an inferred source word count, and track source revisions and modification time without additional RPCs. Every new field is optional, so short or source-type-specific rows retain their existing soft-decode behavior.

## Validation

- `uv run pytest tests/unit tests/_guardrails -q` — 14,095 passed, 69 skipped, 1 xfailed
- `uv run ruff check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

Closes #2112
Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source information now includes download and viewer links, content MIME type, word count, revision details, and last-modified timestamps.
  * File types are identified more accurately using the original content MIME type when available.
* **Documentation**
  * Updated API and reference documentation to describe the new source metadata and Drive source status codes.
* **Bug Fixes**
  * Improved handling of incomplete or malformed source metadata.
  * Prevented internal metadata fields from appearing in published source views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->