### PR TITLE
feat(sources): use batch-capable AddSources for URL batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-item result arrays, including partial and all-failed batches. Transport-
   uncertain writes are never replayed blindly, and a partially admitted group
   of exact duplicate URLs fails closed because the response carries no request
-  positions. The public single-item `sources.add_url()` path and its precise
+  positions. On REST/MCP, that uncertainty deliberately overrides the original
+  transport label: even a typed `RateLimitError` projects as a non-retriable,
+  `unconfirmed` RPC failure (REST 502 rather than 429), preventing downstream
+  retry middleware from duplicating an already-committed subset. Python callers
+  still receive the original typed exception. The public single-item
+  `sources.add_url()` path and its precise
   probe-then-create recovery remain unchanged. Its two ambiguity messages now
   front-load the manual source-list instruction so MCP/REST's real 300-character
   truncation cannot cut away the only actionable guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Existing MCP/REST URL-batch endpoints now use the batch-capable
+  `ADD_SOURCE` wire shape.** Valid URLs share one write RPC; successful rows
+  and silently omitted failures are reconciled back into the existing ordered,
+  per-item result arrays, including partial and all-failed batches. Transport-
+  uncertain writes are never replayed blindly, and a partially admitted group
+  of exact duplicate URLs fails closed because the response carries no request
+  positions. The public single-item `sources.add_url()` path and its precise
+  probe-then-create recovery remain unchanged. Its two ambiguity messages now
+  front-load the manual source-list instruction so MCP/REST's real 300-character
+  truncation cannot cut away the only actionable guidance.
+  ([#2115](https://github.com/teng-lin/notebooklm-py/issues/2115),
+  [#2238](https://github.com/teng-lin/notebooklm-py/issues/2238))
+
 - **Source listings retain original-file and revision metadata already present
   on the wire.** `Source` now exposes `download_url`, `viewer_url`, and
   `content_mime` for uploaded files, plus `word_count`, `revision_id`,
@@ -887,11 +900,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not merely cheaper but wrong: the probe runs *after* the create, so a list
   taken there already contains the just-created source. The bump does not
   compound across a bulk import, and `wait=True` callers were paying it already
-  via `wait_until_ready`'s polling. The *request count* does compound, though: a
-  sequential bulk add — the REST `POST /v1/notebooks/{id}/sources/batch` route,
-  whose one shared preflight covers none of the per-item baselines — goes from
-  N+1 to 2N+1 requests, which is worth budgeting against the backend's bulk rate
-  limits.
+  via `wait_until_ready`'s polling. A caller looping over single-item `add_url`
+  still pays one baseline read per item. The REST/MCP URL-batch endpoints used
+  that same sequential path in this release; #2115 later moved those already
+  batch-shaped endpoints to one true-batch write plus optional reconciliation,
+  without changing single-item `add_url`.
 
 - **A failed idempotency baseline is no longer invisible.** `add_url` and
   `add_drive` swallow a failure to snapshot source ids before the create and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1010,6 +1010,7 @@ Per-file index plus the full `src/notebooklm` + `tests` repository tree. The tre
 | `_artifact/listing.py` | Listing and filtering operations for notebook artifacts |
 | `_artifact/polling.py` | Poll coordination service for artifact generation tasks |
 | `_source/add.py` | Core service layer for adding text, URL, or Google Drive sources |
+| `_source/batch.py` | True-batch URL `ADD_SOURCE` service for the existing MCP/REST batch endpoints: typed positional outcomes, omitted-row reconciliation, and fail-closed transport/duplicate ambiguity policy |
 | `_source/drive_import.py` | Auto-route add-from-Drive (#1884): download + upload the upload-only Drive types (epub/docx/txt/…); native import (`add_drive`) instead takes Docs/Slides/Sheets + PDF by reference; header-first cookie-authed streaming fetch behind injected seams |
 | `_source/content.py` | Core service layer for fetching source HTML/markdown content |
 | `_source/markdown.py` | Source fulltext HTML-to-Markdown conversion policy, including Markdown-source and LaTeX/table handling |
@@ -1187,6 +1188,7 @@ src/notebooklm/
 │   ├── __init__.py              # Re-exports the cluster's public service classes
 │   ├── _upload_decode.py        # Pure URL/source-id/content-type decode + validation helpers (extracted from upload.py)
 │   ├── add.py                   # Source addition coordinator
+│   ├── batch.py                 # True-batch URL ADD_SOURCE coordinator + typed positional outcomes for MCP/REST batch adapters (#2115)
 │   ├── content.py               # Source content fetcher
 │   ├── markdown.py               # Source fulltext HTML-to-Markdown conversion policy
 │   ├── drive_import.py          # Auto-route add-from-Drive (#1884): DriveImportService + DriveFetcher — parse id/URL, cookie-authed header-first streaming download of the upload-only Drive types (epub/docx/txt/…), confirm-token handling + 0600 temp cleanup, then hand to add_file (native Docs/Slides/Sheets → pointer error)

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -342,6 +342,16 @@ error, never added as text); `source_type`/`url`/`text`/`title`/`path`/
 `document_id`/`mime_type` are not valid with `urls`, but `allow_internal`
 applies to every entry.
 
+Validated URLs share one batch-capable `ADD_SOURCE` RPC rather than issuing one
+write per item. NotebookLM can admit a subset and omit rejected rows from that
+response, so the client reconciles omissions with one `source_list(status="error")`
+read while keeping `results[i]` paired with `urls[i]`. The public single-item
+`sources.add_url()` path is unchanged. A transport failure is deliberately not
+replayed: an unknown subset may already have committed, so first reconcile with
+`source_list` before resubmitting. Avoid exact duplicate URLs within one batch;
+if the backend admits only some identical copies, it returns no request positions
+with which to disambiguate them and the call fails closed with the same guidance.
+
 ### Content-sanity warnings on ready web pages
 
 A dead link, [soft-404](https://en.wikipedia.org/wiki/HTTP_404#Soft_404), or

--- a/docs/notes/pr-2102-quota-source-state-review-2026-08-07.md
+++ b/docs/notes/pr-2102-quota-source-state-review-2026-08-07.md
@@ -167,6 +167,14 @@ Findings:
 
 ### Wave 2 — structural probes (batch, duplicates, Drive, schemes, timeout, content-type, concurrency)
 
+> **Correction (2026-08-13):** The batch-contamination conclusion below did not
+> survive a controlled retest. The supposed good control URL also failed when
+> added alone. Retesting with independently verified controls showed that
+> `ADD_SOURCE` is per-item, admits good entries regardless of bad-neighbor
+> position, and silently omits failed rows unless every entry fails. The quota
+> boundary likewise admitted exactly the first entries that fit. See #2110 and
+> #2115; the historical observation is retained below only as audit context.
+
 - **Batching contaminates good sources with bad ones.** Sent a single raw `ADD_SOURCE` RPC with two
   entries (one good URL, one 404) by bypassing the client's one-source-per-call policy (the RPC method
   is documented as "batch-capable" in `rpc/types.py`, this client just doesn't use that). The whole
@@ -596,9 +604,10 @@ probing actually showed (several of these are weaker than they looked before pro
   there's no strong reason to expect this client fetching from a different IP/UA would fare better,
   and it adds a new failure/security surface for uncertain benefit.
 - **Doc note on the URL/PDF content-type boundary** (PDF via URL: yes; image via URL: no).
-- **Doc/comment note on batch-RPC contamination**, so a future contributor doesn't "optimize" the
-  sequential-loop batch adapters into a single multi-entry RPC call and reintroduce failure
-  contamination of good sources.
+- **Superseded: doc/comment note on batch-RPC contamination.** The corrected
+  controlled retest described above established per-item admission rather than
+  atomic contamination. #2115 therefore uses the true batch RPC for the already
+  batch-shaped MCP/REST endpoints while retaining single-item add separately.
 - **Optional: cheap scheme pre-validation** on `add_url` to skip obviously-non-http(s) input before
   spending an RPC round trip and creating a ghost row.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2437,7 +2437,7 @@ effect of doing something else:
 | `notebooks.create()` (CLI/MCP/REST path) | One best-effort re-read to backfill the timestamps `CREATE_NOTEBOOK` leaves null; skipped when both are already populated. |
 | `chat.get_settings()` | Chat config lives in the notebook payload. |
 | `sources.add_file()` / `add_drive()` / `add_url()` | An **unconditional** pre-create baseline of existing source ids, on every call — the idempotency probe needs it to tell a source it created from one that was already there. (`add_text()` is `NON_IDEMPOTENT_NO_RETRY` and runs no probe at all, so it never bumps recency.) |
-| REST `POST /v1/notebooks/{id}/sources/batch` preflight | One shared existence/auth check before the per-URL loop. |
+| REST `POST /v1/notebooks/{id}/sources/batch` | One shared existence/auth check before one multi-URL `ADD_SOURCE`; omitted failures trigger one reconciliation `GET_NOTEBOOK`. It never blindly replays a transport-uncertain batch. |
 
 > **`sources.add_drive()` and `sources.add_url()` moved rows**, in
 > [#2113](https://github.com/teng-lin/notebooklm-py/issues/2113) and

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -461,6 +461,16 @@ params = [
 ]
 ```
 
+The existing MCP `source_add(urls=[...])` and REST `/sources/batch` endpoints
+put multiple URL specs in `params[0]` and issue this RPC once. `AddSources` is
+per-item rather than atomic: successful Source rows remain in request order,
+while failed entries are silently omitted unless every entry fails (then the
+RPC raises). The adapters reconcile omissions with an ERROR-status source list
+and restore positional result rows. This true-batch path disables transport
+retries because a timeout leaves the committed subset unknown; the ordinary
+single-item `sources.add_url()` path still uses its dedicated probe-then-create
+recovery unchanged.
+
 ### RPC: ADD_SOURCE (izAoDd) - Text
 
 **Source:** `_source/add.py::SourceAddService.add_text()`

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -449,7 +449,8 @@ button (`mattooltip='Close source view'`).
 
 ### RPC: ADD_SOURCE (izAoDd) - URL
 
-**Source:** `_source/add.py::SourceAddService.add_url_source()`
+**Sources:** `_source/add.py::SourceAddService.add_url_source()` (single item),
+`_source/batch.py::SourceBatchAddService.add_urls()` (true batch)
 
 ```python
 # URL goes at position [2] in an 11-element source spec.

--- a/src/notebooklm/_app/source_batch.py
+++ b/src/notebooklm/_app/source_batch.py
@@ -22,8 +22,8 @@ from .errors import ErrorCategory, classify
 
 __all__ = ["MAX_BATCH_URLS", "batch_item_is_fatal"]
 
-#: Max URL entries accepted by one batch add. Bounds how long a single request can
-#: occupy one shared source-mutation slot (each entry is added sequentially).
+#: Max URL entries accepted by one batch add. Bounds one request's wire payload,
+#: backend work, result projection, and time in the shared source-mutation slot.
 MAX_BATCH_URLS = 20
 
 #: Categories whose REST projection (server ``CATEGORY_STATUS``) is 401 / 429 / >=500

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -49,6 +49,7 @@ __all__ = [
     "SourceGuideRow",
     "SourceRow",
     "SourceRowShape",
+    "unwrap_add_source_rows",
 ]
 
 
@@ -90,6 +91,78 @@ class SourceRowShape(str, Enum):
     #: separately so drift logs can distinguish "dispatcher produced
     #: this" from "caller handed us an already-unwrapped entry".
     ENTRY = "entry"
+
+
+def _looks_like_source_entry(value: Any) -> bool:
+    """Whether ``value`` resembles one already-unwrapped Source row."""
+    if not isinstance(value, list) or not value:
+        return False
+    # An entry's second field is its title. Reject a nested list here so a
+    # repeated collection of short rows (``[[id-a], [id-b]]``) is not mistaken
+    # for one entry whose id envelope happens to be the first row.
+    if len(value) > 1 and value[1] is not None and not isinstance(value[1], str):
+        return False
+    raw_id = value[0]
+    if isinstance(raw_id, str):
+        return True
+    if not isinstance(raw_id, list) or not raw_id:
+        return False
+    if isinstance(raw_id[0], str):
+        return True
+    return (
+        len(raw_id) == 3
+        and raw_id[0] is None
+        and isinstance(raw_id[2], list)
+        and bool(raw_id[2])
+        and isinstance(raw_id[2][0], str)
+    )
+
+
+def _unwrap_source_entry(value: Any) -> list[Any] | None:
+    """Unwrap one flat/medium/deep Source payload to its entry, if recognized."""
+    candidate = value
+    for _ in range(3):
+        if _looks_like_source_entry(candidate):
+            return candidate
+        if not isinstance(candidate, list) or len(candidate) != 1:
+            return None
+        candidate = candidate[0]
+    return None
+
+
+def unwrap_add_source_rows(payload: Any) -> list[list[Any]]:
+    """Extract repeated Source rows from known ``AddSources`` envelopes.
+
+    A single result historically decodes as one medium/deep Source payload;
+    a multi-entry response may be either a flat repeated-row list or carry one
+    additional outer list. Anything else is schema drift: the general Source
+    parser intentionally degrades malformed listing rows, which is unsafe for a
+    mutating response whose returned ids are the only proof of which writes
+    committed.
+    """
+    if not isinstance(payload, list) or not payload:
+        raise DecodingError(
+            "Unrecognized ADD_SOURCE response envelope",
+            raw_response=repr(payload),
+            method_id=RPCMethod.ADD_SOURCE.value,
+        )
+    single = _unwrap_source_entry(payload)
+    if single is not None:
+        return [single]
+
+    repeated = [_unwrap_source_entry(item) for item in payload]
+    if all(item is not None for item in repeated):
+        return [item for item in repeated if item is not None]
+
+    if len(payload) == 1 and isinstance(payload[0], list) and payload[0]:
+        wrapped_repeated = [_unwrap_source_entry(item) for item in payload[0]]
+        if all(item is not None for item in wrapped_repeated):
+            return [item for item in wrapped_repeated if item is not None]
+    raise DecodingError(
+        "Unrecognized ADD_SOURCE response envelope",
+        raw_response=repr(payload),
+        method_id=RPCMethod.ADD_SOURCE.value,
+    )
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/_row_adapters/sources.py
+++ b/src/notebooklm/_row_adapters/sources.py
@@ -131,14 +131,16 @@ def _unwrap_source_entry(value: Any) -> list[Any] | None:
 
 
 def unwrap_add_source_rows(payload: Any) -> list[list[Any]]:
-    """Extract repeated Source rows from known ``AddSources`` envelopes.
+    """Extract repeated Source payloads from known ``AddSources`` envelopes.
 
     A single result historically decodes as one medium/deep Source payload;
     a multi-entry response may be either a flat repeated-row list or carry one
     additional outer list. Anything else is schema drift: the general Source
     parser intentionally degrades malformed listing rows, which is unsafe for a
     mutating response whose returned ids are the only proof of which writes
-    committed.
+    committed. Recognized per-row wrappers are deliberately retained so
+    :meth:`SourceRow.from_unknown_shape` can preserve shape-dependent decoding,
+    including the legacy deeply-nested ``metadata[0]`` URL fallback.
     """
     if not isinstance(payload, list) or not payload:
         raise DecodingError(
@@ -148,16 +150,16 @@ def unwrap_add_source_rows(payload: Any) -> list[list[Any]]:
         )
     single = _unwrap_source_entry(payload)
     if single is not None:
-        return [single]
+        return [payload]
 
     repeated = [_unwrap_source_entry(item) for item in payload]
     if all(item is not None for item in repeated):
-        return [item for item in repeated if item is not None]
+        return list(payload)
 
     if len(payload) == 1 and isinstance(payload[0], list) and payload[0]:
         wrapped_repeated = [_unwrap_source_entry(item) for item in payload[0]]
         if all(item is not None for item in wrapped_repeated):
-            return [item for item in wrapped_repeated if item is not None]
+            return list(payload[0])
     raise DecodingError(
         "Unrecognized ADD_SOURCE response envelope",
         raw_response=repr(payload),

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -225,13 +225,12 @@ class SourceAddService:
            the bulk-import case this path serves, where the pre-existing copy
            was added seconds earlier.
 
-           The bump itself is idempotent, so a caller looping over this
-           single-item method reorders *Recent* once rather than once per URL,
-           and any ``wait=True`` caller already pays it via
-           ``wait_until_ready``'s polling. Such a caller still pays one baseline
-           read per item. The existing MCP/REST URL-batch endpoints deliberately
-           bypass this method and use one true-batch write plus, when needed, one
-           reconciliation read (#2115). ``add_text`` is
+           A caller looping over this single-item method keeps the notebook at
+           the top of *Recent* when no other activity intervenes, but every
+           baseline read still writes ``lastViewedTime``. Any ``wait=True``
+           caller also pays the polling reads. The existing MCP/REST URL-batch
+           endpoints deliberately bypass this method and use one true-batch
+           write plus, when needed, one reconciliation read (#2115). ``add_text`` is
            ``NON_IDEMPOTENT_NO_RETRY``, runs no probe, and is unaffected.
 
         .. warning::

--- a/src/notebooklm/_source/add.py
+++ b/src/notebooklm/_source/add.py
@@ -225,13 +225,13 @@ class SourceAddService:
            the bulk-import case this path serves, where the pre-existing copy
            was added seconds earlier.
 
-           The bump itself is idempotent, so a bulk import reorders *Recent*
-           once rather than once per URL, and any ``wait=True`` caller already
-           pays it via ``wait_until_ready``'s polling. The request count is the
-           part that does compound: a sequential bulk add — the REST
-           ``sources/batch`` route, whose one shared preflight covers none of
-           the per-item baselines — goes from N+1 to 2N+1 requests, worth
-           budgeting against the backend's bulk rate limits. ``add_text`` is
+           The bump itself is idempotent, so a caller looping over this
+           single-item method reorders *Recent* once rather than once per URL,
+           and any ``wait=True`` caller already pays it via
+           ``wait_until_ready``'s polling. Such a caller still pays one baseline
+           read per item. The existing MCP/REST URL-batch endpoints deliberately
+           bypass this method and use one true-batch write plus, when needed, one
+           reconciliation read (#2115). ``add_text`` is
            ``NON_IDEMPOTENT_NO_RETRY``, runs no probe, and is unaffected.
 
         .. warning::
@@ -393,11 +393,13 @@ class SourceAddService:
                         url,
                         cause=baseline_error,
                         message=(
+                            # Action first: MCP and REST truncate at 300 chars,
+                            # while the URL + matched-row description are unbounded.
+                            "UNRESOLVED — check the notebook source list before retrying. "
                             f"Cannot disambiguate URL source {url!r}: the pre-create baseline "
                             f"snapshot failed ({type(baseline_error).__name__}), so "
                             f"{_describe_sources(matches)} may either predate this add or be "
-                            "the source it just created. Check the notebook source list "
-                            "before retrying."
+                            "the source it just created."
                         ),
                     )
                 )
@@ -409,10 +411,12 @@ class SourceAddService:
                     SourceAddError(
                         url,
                         message=(
+                            # _describe_sources grows with every match; keep the
+                            # manual-reconciliation instruction inside [:300].
+                            "UNRESOLVED — check the notebook source list before retrying. "
                             f"Cannot disambiguate URL source {url!r}: probe found "
                             f"{len(matches)} new sources with this URL after a transport "
-                            f"failure ({_describe_sources(matches)}). Check the notebook "
-                            "source list before retrying."
+                            f"failure ({_describe_sources(matches)})."
                         ),
                     )
                 )

--- a/src/notebooklm/_source/batch.py
+++ b/src/notebooklm/_source/batch.py
@@ -10,10 +10,13 @@ per-item failures.
 from __future__ import annotations
 
 import logging
+import re
 from collections import Counter, defaultdict, deque
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from ipaddress import IPv6Address, ip_address
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from .._idempotency import mark_unconfirmed
 from .._row_adapters.sources import unwrap_add_source_rows
@@ -31,6 +34,7 @@ from ..types import Source
 from .upload_payloads import build_template_block
 
 ListSources = Callable[..., Awaitable[list[Source]]]
+_PERCENT_ESCAPE = re.compile(r"%[0-9a-fA-F]{2}")
 
 
 @dataclass(frozen=True)
@@ -51,6 +55,64 @@ def _url_spec(url: str, *, youtube: bool) -> list[Any]:
     if youtube:
         return [None, None, None, None, None, None, None, [url], None, None, 1]
     return [None, None, [url], None, None, None, None, None, None, None, 1]
+
+
+def _url_identity(
+    url: str,
+    *,
+    extract_youtube_video_id: Callable[[str], str | None],
+) -> tuple[str, str]:
+    """Return a conservative identity for sparse-response reconciliation."""
+
+    def _normalize_percent_escapes(value: str) -> str:
+        return _PERCENT_ESCAPE.sub(lambda match: match.group(0).upper(), value)
+
+    candidate = url.strip()
+    video_id = extract_youtube_video_id(candidate)
+    if video_id is not None:
+        return ("youtube", video_id)
+
+    try:
+        parsed = urlsplit(candidate)
+        # URL inputs are validated before this private service is called, but a
+        # response URL is untrusted wire data. Keep malformed values distinct
+        # and let the caller fail closed rather than raising from normalization.
+        port = parsed.port
+    except (AttributeError, TypeError, ValueError):
+        return ("raw", candidate)
+    if not parsed.scheme or not parsed.hostname:
+        return ("raw", candidate)
+
+    hostname = parsed.hostname.lower()
+    is_ipv6 = False
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        hostname = address.compressed
+        is_ipv6 = isinstance(address, IPv6Address)
+    if is_ipv6:
+        hostname = f"[{hostname}]"
+    default_port = (parsed.scheme.lower() == "http" and port == 80) or (
+        parsed.scheme.lower() == "https" and port == 443
+    )
+    authority = hostname if port is None or default_port else f"{hostname}:{port}"
+    if parsed.username is not None:
+        userinfo = _normalize_percent_escapes(parsed.username)
+        if parsed.password is not None:
+            userinfo += f":{_normalize_percent_escapes(parsed.password)}"
+        authority = f"{userinfo}@{authority}"
+    normalized = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            authority,
+            _normalize_percent_escapes(parsed.path or "/"),
+            _normalize_percent_escapes(parsed.query),
+            "",
+        )
+    )
+    return ("url", normalized)
 
 
 def _unresolved_batch_error(urls: Sequence[str], message: str, cause: Exception) -> SourceAddError:
@@ -177,14 +239,65 @@ class SourceBatchAddService:
                 error,
             )
 
-        requested_counts = Counter(urls)
-        sources_by_url: dict[str, deque[Source]] = defaultdict(deque)
+        if len(sources) > len(urls):
+            error = RPCError(
+                f"ADD_SOURCE returned {len(sources)} rows for {len(urls)} requests",
+                method_id=RPCMethod.ADD_SOURCE.value,
+            )
+            raise _unresolved_batch_error(
+                urls,
+                "The batch response contained more sources than requested, so positional "
+                "outcomes cannot be trusted; no automatic retry was attempted.",
+                error,
+            )
+
+        requested_identities = [
+            _url_identity(url, extract_youtube_video_id=extract_youtube_video_id) for url in urls
+        ]
+
+        # Live characterization establishes that successful rows retain request
+        # order. A complete response is therefore attributable positionally,
+        # but every URL-bearing row must still identify the corresponding input
+        # (after conservative canonicalization) so an unexpected or duplicated
+        # row is never assigned to the wrong request. Legacy short rows without
+        # URL metadata retain the documented positional fallback.
+        if len(sources) == len(urls):
+            for source, requested_identity in zip(sources, requested_identities, strict=True):
+                if source.url is None:
+                    continue
+                response_identity = _url_identity(
+                    source.url,
+                    extract_youtube_video_id=extract_youtube_video_id,
+                )
+                if response_identity != requested_identity:
+                    error = RPCError(
+                        f"ADD_SOURCE returned unexpected positional URL {source.url!r}",
+                        method_id=RPCMethod.ADD_SOURCE.value,
+                    )
+                    raise _unresolved_batch_error(
+                        urls,
+                        "The complete batch response did not match request order, so positional "
+                        "outcomes cannot be trusted; no automatic retry was attempted.",
+                        error,
+                    )
+            return [
+                SourceUrlBatchItem(url=url, source=source)
+                for url, source in zip(urls, sources, strict=True)
+            ]
+
+        requested_counts = Counter(requested_identities)
+        identity_to_url = dict(zip(requested_identities, urls, strict=True))
+        sources_by_identity: dict[tuple[str, str], deque[Source]] = defaultdict(deque)
         sources_without_url: list[Source] = []
         for source in sources:
             if source.url is None:
                 sources_without_url.append(source)
                 continue
-            if source.url not in requested_counts:
+            identity = _url_identity(
+                source.url,
+                extract_youtube_video_id=extract_youtube_video_id,
+            )
+            if identity not in requested_counts:
                 error = RPCError(
                     f"ADD_SOURCE returned an unrequested URL {source.url!r}",
                     method_id=RPCMethod.ADD_SOURCE.value,
@@ -195,34 +308,29 @@ class SourceBatchAddService:
                     "outcomes cannot be trusted; no automatic retry was attempted.",
                     error,
                 )
-            sources_by_url[source.url].append(source)
+            sources_by_identity[identity].append(source)
 
-        # A sparse response must identify rows by URL: response order alone
-        # cannot reveal which request positions were silently omitted.  A full
-        # response is safe to zip positionally even when the legacy short row
-        # carries only an id.
+        # A sparse response must identify every returned row by URL: response
+        # order alone cannot reveal which request positions were silently
+        # omitted. Complete responses returned positionally above.
         if sources_without_url:
-            if len(sources) != len(urls) or sources_by_url:
-                error = RPCError(
-                    "ADD_SOURCE returned sparse source rows without URL metadata",
-                    method_id=RPCMethod.ADD_SOURCE.value,
-                )
-                raise _unresolved_batch_error(
-                    urls,
-                    "The partial batch response omitted URL metadata needed to match rows "
-                    "back to inputs; no automatic retry was attempted.",
-                    error,
-                )
-            return [
-                SourceUrlBatchItem(url=url, source=source)
-                for url, source in zip(urls, sources, strict=True)
-            ]
+            error = RPCError(
+                "ADD_SOURCE returned sparse source rows without URL metadata",
+                method_id=RPCMethod.ADD_SOURCE.value,
+            )
+            raise _unresolved_batch_error(
+                urls,
+                "The partial batch response omitted URL metadata needed to match rows "
+                "back to inputs; no automatic retry was attempted.",
+                error,
+            )
 
-        # Exact duplicate URLs are representable when all copies share one
-        # outcome.  A partial duplicate group is not attributable per position:
+        # Equivalent URL identities are representable when all copies share one
+        # outcome. A partial duplicate group is not attributable per position:
         # the response has no request index or idempotency key, so fail closed.
-        for url, count in requested_counts.items():
-            success_count = len(sources_by_url[url])
+        for identity, count in requested_counts.items():
+            success_count = len(sources_by_identity[identity])
+            url = identity_to_url[identity]
             if success_count > count:
                 error = RPCError(
                     f"ADD_SOURCE returned {success_count} rows for {count} request(s) of {url!r}",
@@ -247,13 +355,12 @@ class SourceBatchAddService:
                     error,
                 )
 
-        missing_urls: list[str] = []
-        for url in urls:
-            if not sources_by_url[url]:
-                missing_urls.append(url)
+        missing_identities = [
+            identity for identity in requested_identities if not sources_by_identity[identity]
+        ]
 
-        error_rows_by_url: dict[str, list[Source]] = defaultdict(list)
-        if missing_urls:
+        error_rows_by_identity: dict[tuple[str, str], list[Source]] = defaultdict(list)
+        if missing_identities:
             try:
                 error_rows = await list_sources(notebook_id, statuses={SourceStatus.ERROR})
             except Exception:
@@ -269,20 +376,28 @@ class SourceBatchAddService:
             else:
                 for row in error_rows:
                     row_url = row.url
-                    if row_url is not None and row_url in requested_counts:
-                        error_rows_by_url[row_url].append(row)
+                    if row_url is None:
+                        continue
+                    identity = _url_identity(
+                        row_url,
+                        extract_youtube_video_id=extract_youtube_video_id,
+                    )
+                    if identity in requested_counts:
+                        error_rows_by_identity[identity].append(row)
 
         outcomes: list[SourceUrlBatchItem] = []
-        for url in urls:
-            if sources_by_url[url]:
-                outcomes.append(SourceUrlBatchItem(url=url, source=sources_by_url[url].popleft()))
+        for url, identity in zip(urls, requested_identities, strict=True):
+            if sources_by_identity[identity]:
+                outcomes.append(
+                    SourceUrlBatchItem(url=url, source=sources_by_identity[identity].popleft())
+                )
                 continue
-            ghosts = error_rows_by_url[url]
+            ghosts = error_rows_by_identity[identity]
             ghost_text = ""
             if ghosts:
                 ids = ", ".join(source.id for source in ghosts[:3])
                 suffix = "" if len(ghosts) <= 3 else f", … ({len(ghosts)} rows)"
-                ghost_text = f" Matching ERROR source row(s): {ids}{suffix}."
+                ghost_text = f" Existing matching ERROR source row(s): {ids}{suffix}."
             outcomes.append(
                 SourceUrlBatchItem(
                     url=url,

--- a/src/notebooklm/_source/batch.py
+++ b/src/notebooklm/_source/batch.py
@@ -1,0 +1,302 @@
+"""Private true-batch URL source creation service.
+
+The public single-item :meth:`SourcesAPI.add_url` path deliberately keeps its
+probe-then-create retry contract.  This module is only for the already
+batch-shaped MCP and REST endpoints: one ``ADD_SOURCE`` request carries every
+validated URL, and omitted response rows are projected back into positional
+per-item failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter, defaultdict, deque
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .._idempotency import mark_unconfirmed
+from .._row_adapters.sources import unwrap_add_source_rows
+from .._runtime.contracts import RpcCaller
+from ..exceptions import (
+    AuthError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+    SourceAddError,
+)
+from ..rpc import RPCError, RPCMethod
+from ..rpc.types import GrpcStatusCode, SourceStatus, normalize_rpc_code
+from ..types import Source
+from .upload_payloads import build_template_block
+
+ListSources = Callable[..., Awaitable[list[Source]]]
+
+
+@dataclass(frozen=True)
+class SourceUrlBatchItem:
+    """One positional outcome from a true-batch URL add."""
+
+    url: str
+    source: Source | None = None
+    error: SourceAddError | None = None
+
+    def __post_init__(self) -> None:
+        if (self.source is None) == (self.error is None):
+            raise ValueError("exactly one of source or error must be set")
+
+
+def _url_spec(url: str, *, youtube: bool) -> list[Any]:
+    """Build one repeated web-page or YouTube ``UserContent`` entry."""
+    if youtube:
+        return [None, None, None, None, None, None, None, [url], None, None, 1]
+    return [None, None, [url], None, None, None, None, None, None, None, 1]
+
+
+def _unresolved_batch_error(urls: Sequence[str], message: str, cause: Exception) -> SourceAddError:
+    preview = ", ".join(repr(url) for url in urls[:3])
+    if len(urls) > 3:
+        preview += f", … ({len(urls)} total)"
+    return mark_unconfirmed(
+        SourceAddError(
+            preview,
+            cause=cause,
+            message=(
+                "UNRESOLVED — do not blindly retry; check the notebook source list and "
+                f"reconcile these URLs first: {preview}. {message}"
+            ),
+        )
+    )
+
+
+class SourceBatchAddService:
+    """Issue and reconcile one multi-entry ``ADD_SOURCE`` request."""
+
+    async def add_urls(
+        self,
+        notebook_id: str,
+        urls: Sequence[str],
+        *,
+        rpc: RpcCaller,
+        list_sources: ListSources,
+        extract_youtube_video_id: Callable[[str], str | None],
+        logger: logging.Logger,
+    ) -> list[SourceUrlBatchItem]:
+        """Add URL entries once and return positional typed outcomes.
+
+        The batch write is never automatically replayed.  A transport failure
+        can occur after an arbitrary subset committed, so retrying the entire
+        request would duplicate that subset.  A protocol-level rejection, by
+        contrast, is the backend's documented all-failed result; it is converted
+        into per-item ``SourceAddError`` values after the same ERROR-row
+        reconciliation used for partial success.
+        """
+        if not urls:
+            return []
+
+        params = [
+            [_url_spec(url, youtube=extract_youtube_video_id(url) is not None) for url in urls],
+            notebook_id,
+            build_template_block(),
+        ]
+        rpc_error: RPCError | None = None
+        try:
+            payload = await rpc.rpc_call(
+                RPCMethod.ADD_SOURCE,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+                allow_null=False,
+                disable_internal_retries=True,
+                # Reuse the established URL idempotency-registry variant while
+                # explicitly disabling its internal replay above.  The outer
+                # single-item probe loop is intentionally not used here.
+                operation_variant="url",
+            )
+        except AuthError:
+            # Authentication rejection cannot have committed the write and
+            # keeps its normal adapter contract (401 / re-auth guidance).
+            raise
+        except (RateLimitError, ServerError, NetworkError) as exc:
+            # Preserve the typed transport exception (ADR-0019) while making
+            # the write-uncertainty dominate retry classification (#2220).
+            original = str(exc)
+            mark_unconfirmed(exc)
+            exc.args = (
+                "UNRESOLVED — do not blindly retry; check the notebook source list and "
+                "reconcile the batch URLs first. The batch transport failed and an "
+                f"unknown subset may have committed; no automatic retry was attempted. {original}",
+            )
+            raise
+        except RPCError as exc:
+            # Live-characterized all-failed URL batches use the same explicit
+            # FAILED_PRECONDITION status as a single rejected URL.  A generic
+            # decoder/protocol failure is not that evidence: the write may have
+            # committed, so fail closed instead of pretending every item failed.
+            if normalize_rpc_code(exc.rpc_code) != GrpcStatusCode.FAILED_PRECONDITION.value:
+                original = str(exc)
+                mark_unconfirmed(exc)
+                exc.args = (
+                    "UNRESOLVED — do not blindly retry; check the notebook source list and "
+                    "reconcile the batch URLs first. The batch RPC failed without the "
+                    "documented all-rejected status, so its committed subset is unknown; "
+                    f"no automatic retry was attempted. {original}",
+                )
+                raise
+            # Preserve the existing per-item adapter contract instead of
+            # turning an all-bad input batch into a top-level failure.
+            rpc_error = exc
+            payload = []
+
+        try:
+            rows = [] if rpc_error is not None else unwrap_add_source_rows(payload)
+            sources = [
+                Source.from_api_response(row, method_id=RPCMethod.ADD_SOURCE.value) for row in rows
+            ]
+        except Exception as exc:  # noqa: BLE001 - strict decode boundary; fail closed
+            raise _unresolved_batch_error(
+                urls,
+                "The batch response could not be decoded, so its committed subset is unknown; "
+                "no automatic retry was attempted.",
+                exc,
+            ) from exc
+
+        # ``Source.from_api_response`` is deliberately tolerant on listing
+        # paths, but a mutating response cannot use that degradation policy:
+        # outside the explicit FAILED_PRECONDITION branch, an empty/malformed
+        # payload does not prove that every write was rejected. Treat it as an
+        # unresolved write, and never surface an id-less Source as success.
+        if rpc_error is None and any(not source.id for source in sources):
+            error = RPCError(
+                "ADD_SOURCE returned no decodable source rows with non-empty ids",
+                method_id=RPCMethod.ADD_SOURCE.value,
+            )
+            raise _unresolved_batch_error(
+                urls,
+                "The batch response did not identify its successful writes, so the "
+                "committed subset is unknown; no automatic retry was attempted.",
+                error,
+            )
+
+        requested_counts = Counter(urls)
+        sources_by_url: dict[str, deque[Source]] = defaultdict(deque)
+        sources_without_url: list[Source] = []
+        for source in sources:
+            if source.url is None:
+                sources_without_url.append(source)
+                continue
+            if source.url not in requested_counts:
+                error = RPCError(
+                    f"ADD_SOURCE returned an unrequested URL {source.url!r}",
+                    method_id=RPCMethod.ADD_SOURCE.value,
+                )
+                raise _unresolved_batch_error(
+                    urls,
+                    "The batch response contained an unrequested source, so positional "
+                    "outcomes cannot be trusted; no automatic retry was attempted.",
+                    error,
+                )
+            sources_by_url[source.url].append(source)
+
+        # A sparse response must identify rows by URL: response order alone
+        # cannot reveal which request positions were silently omitted.  A full
+        # response is safe to zip positionally even when the legacy short row
+        # carries only an id.
+        if sources_without_url:
+            if len(sources) != len(urls) or sources_by_url:
+                error = RPCError(
+                    "ADD_SOURCE returned sparse source rows without URL metadata",
+                    method_id=RPCMethod.ADD_SOURCE.value,
+                )
+                raise _unresolved_batch_error(
+                    urls,
+                    "The partial batch response omitted URL metadata needed to match rows "
+                    "back to inputs; no automatic retry was attempted.",
+                    error,
+                )
+            return [
+                SourceUrlBatchItem(url=url, source=source)
+                for url, source in zip(urls, sources, strict=True)
+            ]
+
+        # Exact duplicate URLs are representable when all copies share one
+        # outcome.  A partial duplicate group is not attributable per position:
+        # the response has no request index or idempotency key, so fail closed.
+        for url, count in requested_counts.items():
+            success_count = len(sources_by_url[url])
+            if success_count > count:
+                error = RPCError(
+                    f"ADD_SOURCE returned {success_count} rows for {count} request(s) of {url!r}",
+                    method_id=RPCMethod.ADD_SOURCE.value,
+                )
+                raise _unresolved_batch_error(
+                    urls,
+                    "The batch response contained more sources than requested, so positional "
+                    "outcomes cannot be trusted; no automatic retry was attempted.",
+                    error,
+                )
+            if count > 1 and 0 < success_count < count:
+                error = RPCError(
+                    f"ADD_SOURCE partially admitted duplicate URL {url!r}",
+                    method_id=RPCMethod.ADD_SOURCE.value,
+                )
+                raise _unresolved_batch_error(
+                    [url] * count,
+                    "The backend partially admitted identical URLs without returning request "
+                    "positions, so the successful copies are ambiguous; no automatic retry "
+                    "was attempted.",
+                    error,
+                )
+
+        missing_urls: list[str] = []
+        for url in urls:
+            if not sources_by_url[url]:
+                missing_urls.append(url)
+
+        error_rows_by_url: dict[str, list[Source]] = defaultdict(list)
+        if missing_urls:
+            try:
+                error_rows = await list_sources(notebook_id, statuses={SourceStatus.ERROR})
+            except Exception:
+                # The success response already proves which entries were
+                # admitted (or rpc_error proves none were).  Reconciliation only
+                # enriches failure diagnostics with ghost ids, so its own failure
+                # must not discard otherwise-known positional outcomes.
+                logger.warning(
+                    "add_urls_batch: failed to list ERROR rows after ADD_SOURCE; "
+                    "returning per-item failures without ghost ids",
+                    exc_info=True,
+                )
+            else:
+                for row in error_rows:
+                    row_url = row.url
+                    if row_url is not None and row_url in requested_counts:
+                        error_rows_by_url[row_url].append(row)
+
+        outcomes: list[SourceUrlBatchItem] = []
+        for url in urls:
+            if sources_by_url[url]:
+                outcomes.append(SourceUrlBatchItem(url=url, source=sources_by_url[url].popleft()))
+                continue
+            ghosts = error_rows_by_url[url]
+            ghost_text = ""
+            if ghosts:
+                ids = ", ".join(source.id for source in ghosts[:3])
+                suffix = "" if len(ghosts) <= 3 else f", … ({len(ghosts)} rows)"
+                ghost_text = f" Matching ERROR source row(s): {ids}{suffix}."
+            outcomes.append(
+                SourceUrlBatchItem(
+                    url=url,
+                    error=SourceAddError(
+                        url,
+                        cause=rpc_error,
+                        message=(
+                            f"Failed to add URL source {url!r}: the backend omitted it from "
+                            f"the batch success response.{ghost_text}"
+                        ),
+                    ),
+                )
+            )
+        return outcomes
+
+
+__all__ = ["SourceBatchAddService", "SourceUrlBatchItem"]

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -18,6 +18,7 @@ from ._runtime.contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._source import upload as _source_upload
 from ._source.add import SourceAddService, honor_requested_title_if_fresh
+from ._source.batch import SourceBatchAddService, SourceUrlBatchItem
 from ._source.content import SourceContentRenderer
 from ._source.drive_import import DriveFetcher, DriveImportService
 from ._source.listing import SourceLister
@@ -97,6 +98,7 @@ class SourcesAPI:
         # historical attributes for callers that introspect the instance.
         self._rpc = rpc
         self._adder = SourceAddService()
+        self._batch_adder = SourceBatchAddService()
         self._content = SourceContentRenderer(self._rpc, logger=logger)
         self._lister = SourceLister(self._rpc)
         self._poller = SourcePoller()
@@ -442,6 +444,28 @@ class SourcesAPI:
         # Baseline-filtered probe ⇒ even a PROBED result is ours to rename (#2204).
         return await honor_requested_title_if_fresh(
             self.rename, notebook_id, result, title, logger, probe_proves_freshness=True
+        )
+
+    async def _add_urls_batch(
+        self,
+        notebook_id: str,
+        urls: builtins.list[str],
+    ) -> builtins.list[SourceUrlBatchItem]:
+        """Add validated URL entries with one batch-capable ``ADD_SOURCE`` RPC.
+
+        Internal adapter seam for the existing MCP/REST batch endpoints.  The
+        public single-item :meth:`add_url` contract remains unchanged; in
+        particular, it retains precise probe-then-create recovery.  This bulk
+        path never replays an uncertain write and returns typed positional
+        outcomes after reconciling silently omitted failures.
+        """
+        return await self._batch_adder.add_urls(
+            notebook_id,
+            urls,
+            rpc=self._rpc,
+            list_sources=self.list,
+            extract_youtube_video_id=self._extract_youtube_video_id,
+            logger=logger,
         )
 
     async def add_text(

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -9,9 +9,10 @@ the typed result to the wire with :func:`to_jsonable`.
 flow through ``_app.source_add`` (``build_source_add_plan`` + ``execute_source_add``);
 ``drive`` flows through ``_app.source_mutations.execute_source_add_drive`` (the
 neutral ``source_add`` core has no Drive path). It also has a batch mode
-(``urls=[...]``) that adds many http(s) URLs sequentially and returns an explicit
-per-item result list. ``source_wait`` waits for a subset when ``sources`` is
-given, one source when ``source`` is given, else every source in the notebook.
+(``urls=[...]``) that sends many http(s) URLs in one batch-capable ``ADD_SOURCE``
+write and returns an explicit per-item result list. ``source_wait`` waits for a
+subset when ``sources`` is given, one source when ``source`` is given, else every
+source in the notebook.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -36,9 +37,11 @@ from ..._app.serialize import to_jsonable
 from ..._app.source_batch import MAX_BATCH_URLS, batch_item_is_fatal
 from ..._app.views import source_view as _source_view
 from ...exceptions import (
+    RPCError,
     SourceNotFoundError,
     ValidationError,
 )
+from ...rpc import RPCMethod
 from ...types import source_status_to_str
 from ...urls import is_youtube_url
 from .._coerce import coerce_list
@@ -873,13 +876,11 @@ async def _add_url_batch(
 ) -> dict[str, Any]:
     """Add many http(s) URLs in one call, returning an explicit per-item result list.
 
-    The saving over N single ``source_add`` calls is the per-call MCP/agent
-    round-trip overhead: the URL adds themselves run **sequentially** here, on
-    purpose — concurrent bulk writes invite backend rate-limiting (CLAUDE.md
-    pitfall #4). A **fatal** failure (expired auth, ``RATE_LIMITED``, an upstream
-    5xx — classified by :func:`_app.source_batch.batch_item_is_fatal`, shared with
-    the REST route) is re-raised so the whole tool call fails at the top level,
-    letting the agent re-auth/retry; only per-URL 4xx-input failures isolate.
+    Valid entries are sent through the batch-capable ``ADD_SOURCE`` RPC once.
+    The backend returns successful rows in request order and silently omits
+    failed entries; the SDK batch seam reconciles those omissions with one
+    ERROR-status list and returns typed positional outcomes. The single-item
+    ``add_url`` path remains unchanged and keeps its precise probe/retry contract.
 
     Each entry is added with ``source_type="url"`` so :func:`add_core.validate_url`
     enforces the http/https scheme allowlist + SSRF guard per item; a non-URL entry
@@ -900,39 +901,69 @@ async def _add_url_batch(
     adds return still-PROCESSING, so this often does not fire here and such sources
     surface the warning later via ``source_wait``.
     """
-    results: list[dict[str, Any]] = []
+    results: list[dict[str, Any] | None] = [None] * len(urls)
+    valid_positions: list[int] = []
+    valid_urls: list[str] = []
+    for index, entry in enumerate(urls):
+        try:
+            # Build the normal URL plan for validation only.  Executing it
+            # would call single-item add_url and defeat the true-batch path.
+            add_core.build_source_add_plan(
+                content=entry,
+                source_type="url",
+                title=None,
+                mime_type=None,
+                follow_symlinks=False,
+                validate_path=add_core.validate_upload_path,
+                looks_path_shaped=add_core.looks_like_path,
+                allow_internal=allow_internal,
+            )
+        except Exception as exc:  # noqa: BLE001 - positional input isolation
+            if batch_item_is_fatal(exc):
+                raise
+            results[index] = {
+                "input": entry,
+                "status": "error",
+                "error": tool_error_payload(exc),
+            }
+        else:
+            valid_positions.append(index)
+            valid_urls.append(entry)
+
+    outcomes = await client.sources._add_urls_batch(notebook_id, valid_urls) if valid_urls else []
+    if len(outcomes) != len(valid_urls):
+        raise RPCError(
+            "Internal source batch result count did not match validated input count",
+            method_id=RPCMethod.ADD_SOURCE.value,
+        )
+
     # Keep each added item's Source alongside its result dict so a synchronously-ready
     # web-page item can be annotated with the content-sanity warning after the loop,
     # concurrently — never N×fetch in-loop (reuses :func:`_annotate_thin_warnings`).
     ready_pairs: list[tuple[dict[str, Any], Source]] = []
-    for entry in urls:
-        try:
-            src = await _add_one(
-                client,
-                notebook_id,
-                entry,
-                source_type="url",
-                title=None,
-                mime_type=None,
-                allow_internal=allow_internal,
-            )
-        except Exception as exc:  # noqa: BLE001 - per-item isolation; CancelledError (BaseException) still propagates
-            # A service/infra failure (auth expiry, rate limit, upstream 5xx) is not
-            # specific to this URL — re-raise so the tool call fails at the top level
-            # (letting the agent re-auth/retry) instead of masking it as a per-item
-            # "error" in a success envelope. Only per-URL 4xx-input failures isolate.
-            # Shares REST's classifier via _app.source_batch (#1871).
-            if batch_item_is_fatal(exc):
-                raise
-            results.append({"input": entry, "status": "error", "error": tool_error_payload(exc)})
+    for index, outcome in zip(valid_positions, outcomes, strict=True):
+        if outcome.error is not None:
+            if batch_item_is_fatal(outcome.error):
+                raise outcome.error
+            results[index] = {
+                "input": outcome.url,
+                "status": "error",
+                "error": tool_error_payload(outcome.error),
+            }
         else:
+            src = outcome.source
+            if src is None:  # pragma: no cover - SourceUrlBatchItem invariant
+                raise RPCError(
+                    "Internal source batch outcome had neither source nor error",
+                    method_id=RPCMethod.ADD_SOURCE.value,
+                )
             # Deliberately NOT a ``_source_view`` row: this is a per-input
             # RESULT record for a source that was just created, so Drive health
             # (#2111) carries no signal yet — read it back with ``source_list`` /
             # ``source_read``, which do project it. The REST ``/sources/batch``
             # echo mirrors this shape for the same reason.
             item: dict[str, Any] = {
-                "input": entry,
+                "input": outcome.url,
                 "status": "added",
                 "source_id": src.id,
                 "title": src.title,
@@ -946,13 +977,19 @@ async def _add_url_batch(
                 )
             elif src.is_ready:
                 ready_pairs.append((item, src))
-            results.append(item)
+            results[index] = item
+    finalized = [item for item in results if item is not None]
+    if len(finalized) != len(urls):
+        raise RPCError(
+            "Internal source batch projection lost positional outcomes",
+            method_id=RPCMethod.ADD_SOURCE.value,
+        )
     # Annotate any synchronously-ready web-page items with a thin / soft-404 warning
     # (concurrent; web-page-filtered; degrades any fetch failure to no warning).
     await _annotate_thin_warnings(client, notebook_id, ready_pairs)
     # Derive the tallies from `results` (single source of truth) rather than
     # maintaining parallel counters that must be kept in sync with each append.
-    added = sum(1 for item in results if item["status"] == "added")
+    added = sum(1 for item in finalized if item["status"] == "added")
     return {
         # "added" once at least one source was added; "error" when every item
         # failed (so the top-level envelope can't claim success while
@@ -961,8 +998,8 @@ async def _add_url_batch(
         "status": "added" if added else "error",
         "notebook_id": notebook_id,
         "added": added,
-        "failed": len(results) - added,
-        "results": results,
+        "failed": len(finalized) - added,
+        "results": finalized,
     }
 
 

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -78,7 +78,9 @@ class RPCMethod(str, Enum):
     DELETE_NOTEBOOK = "WWINqb"  # -> DeleteProjects (single id; batch shapes probed & rejected, see _notebooks.delete)
 
     # Source operations
-    ADD_SOURCE = "izAoDd"  # -> AddSources (batch-capable; we send a single source)
+    # -> AddSources. Single-item SDK methods send one source; the existing
+    # MCP/REST batch endpoints deliberately send repeated URL entries (#2115).
+    ADD_SOURCE = "izAoDd"
     # NOTE: the live registry path-extractor paired o4cbdc with ``AddTentativeSources``,
     # but that is almost certainly a mis-pairing — this id is the upload-register
     # step for a file already staged via the upload endpoint, whereas

--- a/src/notebooklm/server/routes/sources.py
+++ b/src/notebooklm/server/routes/sources.py
@@ -459,13 +459,9 @@ async def add_batch(
     so a whole-batch failure is never masked as ``201`` with every item errored.
     Only per-entry **input** failures (bad URL / 404 / SSRF-blocked host) are
     isolated — recorded as an ``error`` item and skipped — so partial failure stays
-    visible; a **fatal** service failure (auth / rate-limit / 5xx, per
-    :func:`batch_item_is_fatal`) re-raises so the top-level handler maps it to the
-    right 401 / 429 / 5xx instead of a partial-success envelope. Each entry is added
-    SEQUENTIALLY (concurrent bulk writes
-    invite backend rate-limiting) with ``source_type="url"`` so the http/https
-    SSRF guard runs per item. Results are positional (``results[i]`` ↔
-    ``urls[i]``).
+    visible. Valid entries are sent in one batch-capable ``ADD_SOURCE`` RPC; its
+    typed positional outcomes preserve this route's existing response contract.
+    A **fatal** service failure re-raises so the top-level handler maps it normally.
 
     The top-level ``status`` is ``"added"`` once at least one source was added,
     else ``"error"`` (every item failed) — so the envelope can't claim success
@@ -479,10 +475,15 @@ async def add_batch(
     # swallowed into a 201-all-errored body. Letting it raise here routes it
     # through the normal classify → 404 / 401 contract.
     await client.notebooks.get(notebook_id)
-    results: list[dict[str, Any]] = []
-    for entry in body.urls:
+    results: list[dict[str, Any] | None] = [None] * len(body.urls)
+    valid_positions: list[int] = []
+    valid_urls: list[str] = []
+    for index, entry in enumerate(body.urls):
         try:
-            plan = add_core.build_source_add_plan(
+            # Validate through the normal URL plan, but do not execute it: the
+            # execution step is the single-item add_url path this endpoint is
+            # specifically avoiding.
+            add_core.build_source_add_plan(
                 content=entry,
                 source_type="url",
                 title=None,
@@ -492,10 +493,7 @@ async def add_batch(
                 looks_path_shaped=add_core.looks_like_path,
                 allow_internal=body.allow_internal,
             )
-            result = await add_core.execute_source_add(
-                client, add_core.SourceAddExecutionPlan(notebook_id=notebook_id, plan=plan)
-            )
-        except Exception as exc:  # noqa: BLE001 - per-item isolation; CancelledError still propagates
+        except Exception as exc:  # noqa: BLE001 - positional input isolation
             # Re-raise service/infra failures (auth / rate-limit / server /
             # transport) so the top-level handler maps them to the correct
             # 401 / 429 / 5xx instead of masking them as a 200/201 batch
@@ -505,24 +503,45 @@ async def add_batch(
             # ``error_item`` routes ``str(exc)`` through the shared ``_redact``
             # chokepoint (same scrubber as ``safe_detail``), so the per-item text
             # carries no raw exception/stack detail (CodeQL information-exposure).
-            results.append({"input": entry, "status": "error", "error": error_item(exc)})
+            results[index] = {"input": entry, "status": "error", "error": error_item(exc)}
         else:
-            pending.record(notebook_id, result.source.id)
-            view = source_view(result.source)
+            valid_positions.append(index)
+            valid_urls.append(entry)
+
+    outcomes = await client.sources._add_urls_batch(notebook_id, valid_urls) if valid_urls else []
+    if len(outcomes) != len(valid_urls):
+        raise RuntimeError("source batch result count did not match validated input count")
+
+    for index, outcome in zip(valid_positions, outcomes, strict=True):
+        if outcome.error is not None:
+            if batch_item_is_fatal(outcome.error):
+                raise outcome.error
+            results[index] = {
+                "input": outcome.url,
+                "status": "error",
+                "error": error_item(outcome.error),
+            }
+        else:
+            source = outcome.source
+            if source is None:  # pragma: no cover - SourceUrlBatchItem invariant
+                raise RuntimeError("source batch outcome had neither source nor error")
+            pending.record(notebook_id, source.id)
+            view = source_view(source)
             # Mirrors the MCP batch envelope: a per-input RESULT record for a
             # just-created source, not a full source view. Drive health (#2111)
             # is deliberately absent — it carries no signal at add time; read it
             # back through GET /sources or /sources/{id}, which do project it.
-            results.append(
-                {
-                    "input": entry,
-                    "status": "added",
-                    "source_id": result.source.id,
-                    "title": result.source.title,
-                    "status_label": view["status_label"],
-                }
-            )
-    added = sum(1 for item in results if item["status"] == "added")
+            results[index] = {
+                "input": outcome.url,
+                "status": "added",
+                "source_id": source.id,
+                "title": source.title,
+                "status_label": view["status_label"],
+            }
+    finalized = [item for item in results if item is not None]
+    if len(finalized) != len(body.urls):
+        raise RuntimeError("source batch projection lost positional outcomes")
+    added = sum(1 for item in finalized if item["status"] == "added")
     # Nothing created → 200 (not 201). ``status`` mirrors the MCP batch envelope:
     # "added" when ≥1 succeeded, "error" when every item failed.
     if not added:
@@ -531,8 +550,8 @@ async def add_batch(
         "status": "added" if added else "error",
         "notebook_id": notebook_id,
         "added": added,
-        "failed": len(results) - added,
-        "results": results,
+        "failed": len(finalized) - added,
+        "results": finalized,
     }
 
 

--- a/tests/server/fakes.py
+++ b/tests/server/fakes.py
@@ -17,6 +17,9 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
+from notebooklm._app.source_batch import batch_item_is_fatal
+from notebooklm._idempotency import mark_unconfirmed
+from notebooklm._source.batch import SourceUrlBatchItem
 from notebooklm._types.artifacts import Artifact, GenerationState, GenerationStatus
 from notebooklm._types.chat import AskResult, ChatSettings, ConversationTurnKey
 from notebooklm._types.common import AccountLimits, UserSettings
@@ -33,8 +36,11 @@ from notebooklm._types.sharing import SharedUser, ShareStatus
 from notebooklm._types.sources import Source, SourceFulltext
 from notebooklm.exceptions import (
     ArtifactNotFoundError,
+    NetworkError,
     NotebookNotFoundError,
     NoteNotFoundError,
+    RateLimitError,
+    ServerError,
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
@@ -138,6 +144,22 @@ class FakeSources:
 
     async def add_url(self, notebook_id: str, url: str) -> Source:
         return self._add(notebook_id, title=url, url=url)
+
+    async def _add_urls_batch(self, notebook_id: str, urls: list[str]) -> list[SourceUrlBatchItem]:
+        """Model typed outcomes; real-client wire batching is unit-tested separately."""
+        outcomes: list[SourceUrlBatchItem] = []
+        for url in urls:
+            try:
+                source = await self.add_url(notebook_id, url)
+            except Exception as exc:  # noqa: BLE001 - scripted per-item outcome
+                if isinstance(exc, (NetworkError, RateLimitError, ServerError)):
+                    mark_unconfirmed(exc)
+                if batch_item_is_fatal(exc):
+                    raise
+                outcomes.append(SourceUrlBatchItem(url=url, error=exc))  # type: ignore[arg-type]
+            else:
+                outcomes.append(SourceUrlBatchItem(url=url, source=source))
+        return outcomes
 
     async def add_text(self, notebook_id: str, title: str, content: str) -> Source:
         return self._add(notebook_id, title=title)

--- a/tests/server/test_sources.py
+++ b/tests/server/test_sources.py
@@ -630,10 +630,12 @@ def test_add_batch_mid_item_auth_is_top_level_401(
     assert "results" not in resp.json()
 
 
-def test_add_batch_mid_item_rate_limit_is_top_level_429(
+def test_add_batch_transport_rate_limit_is_unconfirmed_502(
     authed_client: TestClient, fake_client: FakeClient, monkeypatch: object
 ) -> None:
-    # A RATE_LIMIT failure mid-batch is fatal too (429), not a per-item error.
+    # The typed RateLimitError still reaches Python callers, but this batch write
+    # may have committed before the response failed. REST must prevent a blind
+    # retry by projecting it as an unconfirmed, non-retriable RPC failure.
     import pytest
 
     from notebooklm.exceptions import RateLimitError
@@ -648,8 +650,12 @@ def test_add_batch_mid_item_rate_limit_is_top_level_429(
     resp = authed_client.post(
         "/v1/notebooks/nb-1/sources/batch", json={"urls": ["https://a.example.com"]}
     )
-    assert resp.status_code == 429
-    assert resp.json()["error"]["category"] == "rate_limited"
+    assert resp.status_code == 502
+    error = resp.json()["error"]
+    assert error["category"] == "rpc"
+    assert error["unconfirmed"] is True
+    assert error["retriable"] is False
+    assert "reconcile" in error["hint"].lower()
     assert "results" not in resp.json()
 
 

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 from collections.abc import AsyncIterator, Callable
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -71,6 +72,36 @@ def mock_client() -> MagicMock:
     client = MagicMock()
     for namespace in _NAMESPACES:
         setattr(client, namespace, MagicMock())
+
+    async def _batch_add(notebook_id: str, urls: list[str]) -> list[SimpleNamespace]:
+        """Adapter-test seam: model typed batch outcomes through mocked add_url.
+
+        Production reaches the real one-RPC ``SourcesAPI._add_urls_batch``;
+        this keeps existing tool tests focused on their JSON contract while
+        dedicated source-batch service tests pin the wire call count/shape.
+        """
+        from notebooklm._app.source_batch import batch_item_is_fatal
+        from notebooklm._idempotency import mark_unconfirmed
+        from notebooklm.exceptions import NetworkError, RateLimitError, ServerError
+
+        outcomes: list[SimpleNamespace] = []
+        for url in urls:
+            try:
+                source = await client.sources.add_url(notebook_id, url)
+            except Exception as exc:  # noqa: BLE001 - scripted per-item outcome
+                # Production sends every URL in one write. Any transport-class
+                # failure leaves its committed subset unknown and is therefore
+                # projected as non-retriable RPC, not as NETWORK / 429 / 5xx.
+                if isinstance(exc, (NetworkError, RateLimitError, ServerError)):
+                    mark_unconfirmed(exc)
+                if batch_item_is_fatal(exc):
+                    raise
+                outcomes.append(SimpleNamespace(url=url, source=None, error=exc))
+            else:
+                outcomes.append(SimpleNamespace(url=url, source=source, error=None))
+        return outcomes
+
+    client.sources._add_urls_batch = AsyncMock(side_effect=_batch_add)
     # `_app.download.execute_download` probes `client.artifacts._list_for_download`
     # (the #1488 raw-rows fast path). A bare MagicMock auto-vivifies it as a
     # truthy, non-awaitable attr; pin it to None so download tests exercise the

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 from collections.abc import AsyncIterator, Callable
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -73,7 +72,9 @@ def mock_client() -> MagicMock:
     for namespace in _NAMESPACES:
         setattr(client, namespace, MagicMock())
 
-    async def _batch_add(notebook_id: str, urls: list[str]) -> list[SimpleNamespace]:
+    from notebooklm._source.batch import SourceUrlBatchItem
+
+    async def _batch_add(notebook_id: str, urls: list[str]) -> list[SourceUrlBatchItem]:
         """Adapter-test seam: model typed batch outcomes through mocked add_url.
 
         Production reaches the real one-RPC ``SourcesAPI._add_urls_batch``;
@@ -84,7 +85,7 @@ def mock_client() -> MagicMock:
         from notebooklm._idempotency import mark_unconfirmed
         from notebooklm.exceptions import NetworkError, RateLimitError, ServerError
 
-        outcomes: list[SimpleNamespace] = []
+        outcomes: list[SourceUrlBatchItem] = []
         for url in urls:
             try:
                 source = await client.sources.add_url(notebook_id, url)
@@ -96,9 +97,9 @@ def mock_client() -> MagicMock:
                     mark_unconfirmed(exc)
                 if batch_item_is_fatal(exc):
                     raise
-                outcomes.append(SimpleNamespace(url=url, source=None, error=exc))
+                outcomes.append(SourceUrlBatchItem(url=url, error=exc))  # type: ignore[arg-type]
             else:
-                outcomes.append(SimpleNamespace(url=url, source=source, error=None))
+                outcomes.append(SourceUrlBatchItem(url=url, source=source))
         return outcomes
 
     client.sources._add_urls_batch = AsyncMock(side_effect=_batch_add)

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1980,6 +1980,9 @@ async def test_source_add_batch_all_success(mcp_call, mock_client) -> None:
             },
         ],
     }
+    mock_client.sources._add_urls_batch.assert_awaited_once_with(
+        NB_ID, ["https://example.com/a", "https://example.com/b"]
+    )
     assert mock_client.sources.add_url.await_count == 2
     # Both ready web_page items were content-checked.
     assert mock_client.sources.get_fulltext.await_count == 2
@@ -2010,6 +2013,9 @@ async def test_source_add_batch_partial_failure(mcp_call, mock_client) -> None:
     assert bad["status"] == "error"
     assert bad["error"]["code"] == "VALIDATION"
     # The disallowed scheme is rejected by validate_url before reaching the client.
+    mock_client.sources._add_urls_batch.assert_awaited_once_with(
+        NB_ID, ["https://good.example.com"]
+    )
     mock_client.sources.add_url.assert_awaited_once_with(NB_ID, "https://good.example.com")
     # The one ready item was content-checked; the rejected entry never reaches it.
     mock_client.sources.get_fulltext.assert_awaited_once_with(NB_ID, SRC_ID, output_format="text")
@@ -2032,12 +2038,16 @@ async def test_source_add_batch_non_url_entry_errors_not_text(mcp_call, mock_cli
     mock_client.sources.add_url.assert_not_called()
     mock_client.sources.add_text.assert_not_called()
     mock_client.sources.add_file.assert_not_called()
+    mock_client.sources._add_urls_batch.assert_not_awaited()
 
 
 async def test_source_add_batch_fatal_error_aborts_the_call(mcp_call, mock_client) -> None:
-    """A mid-batch FATAL failure (network/auth/rate-limit/5xx) aborts the whole tool
-    call rather than being masked as a per-item error in a success envelope (#1871).
-    The batch stops at the first fatal item — the second URL is never attempted."""
+    """A batch-level fatal failure aborts instead of being masked per item (#1871).
+
+    The real RPC receives both URLs at once and may have committed an unknown
+    subset. The fixture's sequential outcome model happens to raise on its first
+    scripted item, but the adapter contract under test is the top-level failure.
+    """
     mock_client.sources.add_url = AsyncMock(
         side_effect=[NetworkError("boom"), FakeSource(id=SRC2_ID, title="Second")]
     )
@@ -2049,9 +2059,13 @@ async def test_source_add_batch_fatal_error_aborts_the_call(mcp_call, mock_clien
                 "urls": ["https://first.example.com", "https://second.example.com"],
             },
         )
-    assert "NETWORK" in str(excinfo.value)
-    # Aborted at the first fatal item — the batch did NOT continue to the second URL.
-    assert mock_client.sources.add_url.await_count == 1
+    error_text = str(excinfo.value)
+    assert "RPC" in error_text
+    assert "unconfirmed=true" in error_text
+    assert "reconcile" in error_text.lower()
+    mock_client.sources._add_urls_batch.assert_awaited_once_with(
+        NB_ID, ["https://first.example.com", "https://second.example.com"]
+    )
 
 
 async def test_source_add_batch_isolates_non_fatal_input_error(mcp_call, mock_client) -> None:

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -228,6 +228,7 @@ async def test_add_url_baseline_failure_makes_a_match_ambiguous(
     assert classify(raised.value).category is ErrorCategory.RPC
     assert classify(raised.value).retriable is False
     # The action survives the real MCP/REST truncation slice (#2238).
+    assert len(str(raised.value)) > 300
     assert "check the notebook source list before retrying" in str(raised.value)[:300].lower()
     # The swallow is visible at the default logger level (WARNING), not DEBUG.
     assert "baseline list() failed" in caplog.text
@@ -277,6 +278,7 @@ async def test_add_url_probe_raises_on_multiple_new_matches(
     assert getattr(raised.value, "unconfirmed", False) is True
     assert classify(raised.value).category is ErrorCategory.RPC
     # _describe_sources grows with every match; guidance must remain before it.
+    assert len(str(raised.value)) > 300
     assert "check the notebook source list before retrying" in str(raised.value)[:300].lower()
     assert classify(raised.value).retriable is False
 

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -186,7 +186,11 @@ async def test_add_url_baseline_failure_makes_a_match_ambiguous(
     baseline exists to prevent. The error must carry enough to act on: what
     broke the baseline (as ``cause``), and which source is ambiguous.
     """
-    existing = Source(id="src_ambiguous", title="Some Copy", url="https://example.com")
+    existing = Source(
+        id="src_ambiguous",
+        title="Highly accurate protein structure prediction with AlphaFold",
+        url="https://www.nature.com/articles/s41586-024-07487-w",
+    )
     # First call = the baseline (fails); second = the probe.
     list_sources = AsyncMock(side_effect=[baseline_failure, [existing]])
     transport_error = NetworkError("temporary network failure")
@@ -223,6 +227,8 @@ async def test_add_url_baseline_failure_makes_a_match_ambiguous(
     assert getattr(raised.value, "unconfirmed", False) is True
     assert classify(raised.value).category is ErrorCategory.RPC
     assert classify(raised.value).retriable is False
+    # The action survives the real MCP/REST truncation slice (#2238).
+    assert "check the notebook source list before retrying" in str(raised.value)[:300].lower()
     # The swallow is visible at the default logger level (WARNING), not DEBUG.
     assert "baseline list() failed" in caplog.text
 
@@ -237,9 +243,15 @@ async def test_add_url_probe_raises_on_multiple_new_matches(
     The message must name both, since the caller is being told to go and
     disambiguate a URL that by definition appears in the list more than once.
     """
-    url = "https://example.com"
+    url = "https://www.nature.com/articles/s41586-024-07487-w"
     list_sources = AsyncMock(
-        side_effect=[[], [Source(id="src_a", url=url), Source(id="src_b", url=url)]]
+        side_effect=[
+            [],
+            [
+                Source(id="src_a", title="Highly accurate protein structure prediction", url=url),
+                Source(id="src_b", title="A second long duplicate source title", url=url),
+            ],
+        ]
     )
 
     with pytest.raises(SourceAddError, match="probe found 2 new sources") as raised:
@@ -264,6 +276,8 @@ async def test_add_url_probe_raises_on_multiple_new_matches(
     # a batch add would keep going, issuing more unresolvable writes.
     assert getattr(raised.value, "unconfirmed", False) is True
     assert classify(raised.value).category is ErrorCategory.RPC
+    # _describe_sources grows with every match; guidance must remain before it.
+    assert "check the notebook source list before retrying" in str(raised.value)[:300].lower()
     assert classify(raised.value).retriable is False
 
 

--- a/tests/unit/test_source_batch_add_service.py
+++ b/tests/unit/test_source_batch_add_service.py
@@ -126,6 +126,26 @@ async def test_true_batch_preserves_mixed_web_page_and_youtube_wire_shapes() -> 
 
 
 @pytest.mark.asyncio
+async def test_complete_legacy_short_rows_are_zipped_positionally() -> None:
+    urls = ["https://a.example.com", "https://b.example.com"]
+    rpc = RecordingRpc([["src-a"], ["src-b"]])
+    list_sources = AsyncMock()
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=list_sources,
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert [item.url for item in outcomes] == urls
+    assert [item.source.id if item.source else None for item in outcomes] == ["src-a", "src-b"]
+    list_sources.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_partial_batch_reconciles_omission_and_keeps_positional_outcomes() -> None:
     urls = [
         "https://good-a.example.com",

--- a/tests/unit/test_source_batch_add_service.py
+++ b/tests/unit/test_source_batch_add_service.py
@@ -35,6 +35,11 @@ def _url_row(
     return [[source_id], url, metadata, [None, status.value]]
 
 
+def _deep_bare_url_payload(source_id: str, url: str) -> list[Any]:
+    metadata: list[Any] = [url, None, None, None, 5]
+    return [[[[source_id], url, metadata, [None, SourceStatus.PROCESSING.value]]]]
+
+
 class RecordingRpc:
     def __init__(self, result: Any = None, *, error: Exception | None = None) -> None:
         self.result = result
@@ -146,6 +151,143 @@ async def test_complete_legacy_short_rows_are_zipped_positionally() -> None:
 
 
 @pytest.mark.asyncio
+async def test_complete_canonicalized_urls_are_zipped_in_documented_response_order() -> None:
+    urls = ["https://youtu.be/abc123", "https://example.com"]
+    rpc = RecordingRpc(
+        [
+            _url_row("src-yt", "https://www.youtube.com/watch?v=abc123"),
+            _url_row("src-web", "https://example.com/"),
+        ]
+    )
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=AsyncMock(),
+        extract_youtube_video_id=lambda url: (
+            "abc123" if "youtu.be/abc123" in url or "v=abc123" in url else None
+        ),
+        logger=logging.getLogger(__name__),
+    )
+
+    assert [item.url for item in outcomes] == urls
+    assert [item.source.id if item.source else None for item in outcomes] == [
+        "src-yt",
+        "src-web",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response_urls",
+    [
+        ["https://a.example.com", "https://other.example.com"],
+        ["https://a.example.com", "https://a.example.com"],
+    ],
+)
+async def test_complete_response_with_wrong_positional_identity_fails_closed(
+    response_urls: list[str],
+) -> None:
+    urls = ["https://a.example.com", "https://b.example.com"]
+    rpc = RecordingRpc(
+        [
+            _url_row("src-first", response_urls[0]),
+            _url_row("src-second", response_urls[1]),
+        ]
+    )
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            urls,
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "did not match request order" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_sparse_deep_row_preserves_bare_metadata_url_for_attribution() -> None:
+    urls = ["https://good.example.com", "https://bad.example.com"]
+    rpc = RecordingRpc(_deep_bare_url_payload("src-good", urls[0]))
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=AsyncMock(return_value=[]),
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert outcomes[0].source is not None
+    assert outcomes[0].source.id == "src-good"
+    assert outcomes[0].source.url == urls[0]
+    assert isinstance(outcomes[1].error, SourceAddError)
+
+
+@pytest.mark.asyncio
+async def test_sparse_canonical_youtube_url_matches_requested_video_identity() -> None:
+    urls = ["https://youtu.be/abc123", "https://bad.example.com"]
+    rpc = RecordingRpc([_url_row("src-yt", "https://www.youtube.com/watch?v=abc123")])
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=AsyncMock(return_value=[]),
+        extract_youtube_video_id=lambda url: (
+            "abc123" if "youtu.be/abc123" in url or "v=abc123" in url else None
+        ),
+        logger=logging.getLogger(__name__),
+    )
+
+    assert outcomes[0].source is not None
+    assert outcomes[0].source.id == "src-yt"
+    assert isinstance(outcomes[1].error, SourceAddError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_url", "response_url"),
+    [
+        (
+            "http://[2001:db8::1]:80/article",
+            "http://[2001:0DB8:0000:0000:0000:0000:0000:0001]/article",
+        ),
+        (
+            "https://user%2fname:pa%3ass@example.com/item%2fpart?q=%ab",
+            "https://user%2Fname:pa%3Ass@example.com/item%2Fpart?q=%AB",
+        ),
+    ],
+)
+async def test_sparse_equivalent_url_spellings_share_one_identity(
+    requested_url: str,
+    response_url: str,
+) -> None:
+    urls = [requested_url, "https://bad.example.com"]
+    rpc = RecordingRpc([_url_row("src-good", response_url)])
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=AsyncMock(return_value=[]),
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert outcomes[0].source is not None
+    assert outcomes[0].source.id == "src-good"
+    assert isinstance(outcomes[1].error, SourceAddError)
+
+
+@pytest.mark.asyncio
 async def test_partial_batch_reconciles_omission_and_keeps_positional_outcomes() -> None:
     urls = [
         "https://good-a.example.com",
@@ -172,6 +314,7 @@ async def test_partial_batch_reconciles_omission_and_keeps_positional_outcomes()
     ]
     assert isinstance(outcomes[1].error, SourceAddError)
     assert "ghost-bad" in str(outcomes[1].error)
+    assert "Existing matching ERROR source row" in str(outcomes[1].error)
     assert classify(outcomes[1].error).category is ErrorCategory.SOURCE_ADD
     list_sources.assert_awaited_once_with("nb-1", statuses={SourceStatus.ERROR})
 
@@ -335,3 +478,69 @@ async def test_partially_admitted_duplicate_url_is_reported_as_ambiguous() -> No
     assert getattr(raised.value, "unconfirmed", False) is True
     assert "partially admitted identical URLs" in str(raised.value)
     assert "do not blindly retry" in str(raised.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_sparse_response_with_unrequested_url_fails_closed() -> None:
+    rpc = RecordingRpc([_url_row("src-other", "https://other.example.com")])
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com", "https://b.example.com"],
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "unrequested source" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_sparse_response_with_too_many_rows_for_one_identity_fails_closed() -> None:
+    urls = [
+        "https://a.example.com",
+        "https://b.example.com",
+        "https://c.example.com",
+    ]
+    rpc = RecordingRpc([_url_row("src-a1", urls[0]), _url_row("src-a2", urls[0])])
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            urls,
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "more sources than requested" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_failure_preserves_known_positional_outcomes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    urls = ["https://good.example.com", "https://bad.example.com"]
+    rpc = RecordingRpc([_url_row("src-good", urls[0])])
+    list_sources = AsyncMock(side_effect=RPCError("listing drifted"))
+
+    with caplog.at_level(logging.WARNING):
+        outcomes = await SourceBatchAddService().add_urls(
+            "nb-1",
+            urls,
+            rpc=rpc,
+            list_sources=list_sources,
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert outcomes[0].source is not None
+    assert outcomes[0].source.id == "src-good"
+    assert isinstance(outcomes[1].error, SourceAddError)
+    assert "ERROR source row" not in str(outcomes[1].error)
+    assert "failed to list ERROR rows" in caplog.text

--- a/tests/unit/test_source_batch_add_service.py
+++ b/tests/unit/test_source_batch_add_service.py
@@ -1,0 +1,317 @@
+"""True-batch ADD_SOURCE semantics for the existing MCP/REST batch endpoints."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm._app.errors import ErrorCategory, classify
+from notebooklm._row_adapters.sources import unwrap_add_source_rows
+from notebooklm._source.batch import SourceBatchAddService
+from notebooklm.exceptions import (
+    AuthError,
+    NetworkError,
+    RateLimitError,
+    RPCError,
+    ServerError,
+    SourceAddError,
+)
+from notebooklm.rpc import RPCMethod
+from notebooklm.rpc.types import SourceStatus
+from notebooklm.types import Source
+
+
+def _extract_youtube_video_id(_url: str) -> None:
+    return None
+
+
+def _url_row(
+    source_id: str, url: str, *, status: SourceStatus = SourceStatus.PROCESSING
+) -> list[Any]:
+    metadata: list[Any] = [None, None, None, None, 5, None, None, [url]]
+    return [[source_id], url, metadata, [None, status.value]]
+
+
+class RecordingRpc:
+    def __init__(self, result: Any = None, *, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def rpc_call(self, method: RPCMethod, params: list[Any], **kwargs: Any) -> Any:
+        self.calls.append({"method": method, "params": params, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [["src-a"], ["src-b"]],
+        [[["src-a"], "A"], [["src-b"], "B"]],
+        [[["src-a"], "A"], [[["src-b"], "B"]]],
+        [[[["src-a"], "A"]], [[["src-b"], "B"]]],
+        [[[["src-a"], "A"], [["src-b"], "B"]]],
+    ],
+)
+def test_unwrap_add_source_rows_accepts_known_repeated_envelopes(payload: Any) -> None:
+    assert [Source.from_api_response(row).id for row in unwrap_add_source_rows(payload)] == [
+        "src-a",
+        "src-b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_true_batch_uses_one_add_sources_rpc_and_preserves_order() -> None:
+    urls = ["https://a.example.com", "https://b.example.com"]
+    rpc = RecordingRpc([_url_row("src-a", urls[0]), _url_row("src-b", urls[1])])
+    list_sources = AsyncMock()
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=list_sources,
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert [item.url for item in outcomes] == urls
+    assert [item.source.id if item.source else None for item in outcomes] == ["src-a", "src-b"]
+    assert [item.error for item in outcomes] == [None, None]
+    assert rpc.calls == [
+        {
+            "method": RPCMethod.ADD_SOURCE,
+            "params": [
+                [
+                    [None, None, [urls[0]], None, None, None, None, None, None, None, 1],
+                    [None, None, [urls[1]], None, None, None, None, None, None, None, 1],
+                ],
+                "nb-1",
+                [2, None, None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+            ],
+            "source_path": "/notebook/nb-1",
+            "allow_null": False,
+            "disable_internal_retries": True,
+            "operation_variant": "url",
+        }
+    ]
+    list_sources.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_true_batch_preserves_mixed_web_page_and_youtube_wire_shapes() -> None:
+    web_url = "https://example.com/article"
+    youtube_url = "https://www.youtube.com/watch?v=abc123"
+    rpc = RecordingRpc([_url_row("src-web", web_url), _url_row("src-yt", youtube_url)])
+
+    await SourceBatchAddService().add_urls(
+        "nb-1",
+        [web_url, youtube_url],
+        rpc=rpc,
+        list_sources=AsyncMock(),
+        extract_youtube_video_id=lambda url: "abc123" if url == youtube_url else None,
+        logger=logging.getLogger(__name__),
+    )
+
+    specs = rpc.calls[0]["params"][0]
+    assert specs == [
+        [None, None, [web_url], None, None, None, None, None, None, None, 1],
+        [None, None, None, None, None, None, None, [youtube_url], None, None, 1],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_partial_batch_reconciles_omission_and_keeps_positional_outcomes() -> None:
+    urls = [
+        "https://good-a.example.com",
+        "https://bad.example.com",
+        "https://good-b.example.com",
+    ]
+    rpc = RecordingRpc([_url_row("src-a", urls[0]), _url_row("src-b", urls[2])])
+    ghost = Source(id="ghost-bad", title="Bad", url=urls[1], status=SourceStatus.ERROR)
+    list_sources = AsyncMock(return_value=[ghost])
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=list_sources,
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert [item.source.id if item.source else None for item in outcomes] == [
+        "src-a",
+        None,
+        "src-b",
+    ]
+    assert isinstance(outcomes[1].error, SourceAddError)
+    assert "ghost-bad" in str(outcomes[1].error)
+    assert classify(outcomes[1].error).category is ErrorCategory.SOURCE_ADD
+    list_sources.assert_awaited_once_with("nb-1", statuses={SourceStatus.ERROR})
+
+
+@pytest.mark.asyncio
+async def test_all_failed_rpc_is_still_a_per_item_result_array() -> None:
+    urls = ["https://bad-a.example.com", "https://bad-b.example.com"]
+    rejected = RPCError("all sources rejected", method_id=RPCMethod.ADD_SOURCE.value, rpc_code=9)
+    rpc = RecordingRpc(error=rejected)
+    list_sources = AsyncMock(return_value=[])
+
+    outcomes = await SourceBatchAddService().add_urls(
+        "nb-1",
+        urls,
+        rpc=rpc,
+        list_sources=list_sources,
+        extract_youtube_video_id=_extract_youtube_video_id,
+        logger=logging.getLogger(__name__),
+    )
+
+    assert [item.url for item in outcomes] == urls
+    assert all(item.source is None for item in outcomes)
+    assert all(item.error is not None and item.error.cause is rejected for item in outcomes)
+    list_sources.assert_awaited_once_with("nb-1", statuses={SourceStatus.ERROR})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        NetworkError("connection reset after write"),
+        RateLimitError("rate limit response after write"),
+        ServerError("upstream failed after write"),
+    ],
+)
+async def test_transport_failure_preserves_type_is_unconfirmed_and_never_replayed(
+    transport_error: Exception,
+) -> None:
+    rpc = RecordingRpc(error=transport_error)
+    list_sources = AsyncMock()
+
+    with pytest.raises(type(transport_error)) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com", "https://b.example.com"],
+            rpc=rpc,
+            list_sources=list_sources,
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert raised.value is transport_error
+    assert len(rpc.calls) == 1
+    list_sources.assert_not_awaited()
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert classify(raised.value).category is ErrorCategory.RPC
+    assert "do not blindly retry" in str(raised.value).lower()
+    assert "reconcile" in str(raised.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_preserves_typed_reauthentication_contract() -> None:
+    auth_error = AuthError("csrf token expired")
+    rpc = RecordingRpc(error=auth_error)
+    list_sources = AsyncMock()
+
+    with pytest.raises(AuthError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com", "https://b.example.com"],
+            rpc=rpc,
+            list_sources=list_sources,
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert raised.value is auth_error
+    assert getattr(raised.value, "unconfirmed", False) is False
+    assert len(rpc.calls) == 1
+    list_sources.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_rpc_failure_is_not_misreported_as_all_rejected() -> None:
+    rpc = RecordingRpc(
+        error=RPCError("response decode drift", method_id=RPCMethod.ADD_SOURCE.value)
+    )
+
+    with pytest.raises(RPCError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com", "https://b.example.com"],
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert len(rpc.calls) == 1
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "without the documented all-rejected status" in str(raised.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [{}, [], [[]], [123], [None], [""]])
+async def test_malformed_success_payload_is_unconfirmed_not_per_item_rejection(
+    payload: Any,
+) -> None:
+    rpc = RecordingRpc(payload)
+    list_sources = AsyncMock()
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com"],
+            rpc=rpc,
+            list_sources=list_sources,
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "committed subset is unknown" in str(raised.value)
+    assert len(rpc.calls) == 1
+    list_sources.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sparse_short_rows_fail_closed_when_omissions_cannot_be_located() -> None:
+    rpc = RecordingRpc([["src-only"]])
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            ["https://a.example.com", "https://b.example.com"],
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "partial batch response" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_partially_admitted_duplicate_url_is_reported_as_ambiguous() -> None:
+    url = "https://same.example.com"
+    rpc = RecordingRpc([_url_row("src-one", url)])
+
+    with pytest.raises(SourceAddError) as raised:
+        await SourceBatchAddService().add_urls(
+            "nb-1",
+            [url, url],
+            rpc=rpc,
+            list_sources=AsyncMock(),
+            extract_youtube_video_id=_extract_youtube_video_id,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert getattr(raised.value, "unconfirmed", False) is True
+    assert "partially admitted identical URLs" in str(raised.value)
+    assert "do not blindly retry" in str(raised.value).lower()


### PR DESCRIPTION
## Summary

- send validated MCP/REST URL batches through one batch-capable `ADD_SOURCE` RPC while preserving ordered per-item result arrays
- reconcile silently omitted failures once, preserve mixed web/YouTube wire shapes, and fail closed on duplicate attribution, malformed responses, and transport-uncertain writes without blind replay
- front-load `add_url` ambiguity reconciliation guidance so it survives the real 300-character MCP/REST truncation boundary
- update wire/docs guardrails and retain the public single-item `sources.add_url()` probe-then-create contract unchanged

## Validation

- `uv run pytest` — 16,656 passed, 77 skipped, 1 xfailed
- `uv run ruff check .`
- scoped `uv run ruff format --check` for changed Python files
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`
- independent native agent review plus follow-up verification: no findings remain

Closes #2115
Closes #2238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch URL source creation through a single operation for MCP and REST endpoints.
  * Preserved input order with per-URL success or error results, including partial and complete failures.
  * Added safeguards for duplicate, incomplete, malformed, and transport-uncertain responses.
  * Kept single-URL source addition behavior unchanged.

* **Documentation**
  * Updated API, RPC, MCP, architecture, and changelog documentation with batch behavior and recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->