### PR TITLE
fix(auth): normalize rookiepy millisecond cookie expiry to seconds

### DIFF
--- a/src/notebooklm/_auth/cookie_semantics.py
+++ b/src/notebooklm/_auth/cookie_semantics.py
@@ -171,12 +171,22 @@ def rookiepy_row_to_storage_row(normalized: Mapping[str, Any]) -> dict[str, Any]
     same_site = normalized.get("sameSite", normalized.get("same_site"))
     if same_site not in {"Strict", "Lax", "None"}:
         same_site = "None"
+    expires = normalized["expires"]
+    # rookiepy reports Chromium-family cookie expiry in *milliseconds* (its
+    # Chrome/Edge extractors read the cookie store's raw µs-since-1601 value and
+    # divide by 1_000, not 1_000_000), while the Playwright storage_state format
+    # — and http.cookiejar — expect Unix *seconds*. Any value above the largest
+    # representable seconds timestamp (year 9999) is unambiguously milliseconds,
+    # so convert it. This mirrors the Firefox path, which already normalizes
+    # ms→s in `_firefox_containers._row_to_rookie_cookies_dict`.
+    if isinstance(expires, (int, float)) and expires > 253402300799:
+        expires = int(expires / 1000)
     return {
         "name": normalized["name"],
         "value": normalized["value"],
         "domain": normalized["domain"],
         "path": normalized["path"],
-        "expires": -1 if normalized["expires"] is None else normalized["expires"],
+        "expires": -1 if expires is None else expires,
         "httpOnly": bool(normalized.get("http_only", False)),
         "secure": bool(normalized.get("secure", False)),
         "sameSite": same_site,

--- a/tests/unit/test_cookie_domain_split.py
+++ b/tests/unit/test_cookie_domain_split.py
@@ -891,3 +891,42 @@ class TestAuthInspectCliFlag:
         assert result.exit_code == 0, result.output
         enum.assert_called_once()
         assert enum.call_args.kwargs["include_domains"] == {"youtube"}
+
+
+class TestMillisecondExpiryNormalization:
+    """rookiepy reports Chromium cookie expiry in milliseconds; the storage_state
+    conversion must normalize it to Unix seconds (matching the Firefox path).
+
+    Regression: ``notebooklm login --browser-cookies chrome`` wrote 13-digit
+    millisecond ``expires`` values into ``storage_state.json``, which Playwright
+    rejects ("Cookie should have a valid expires"). See
+    ``notebooklm._auth.cookie_semantics.rookiepy_row_to_storage_row``.
+    """
+
+    @staticmethod
+    def _cookie(expires):
+        return {
+            "domain": ".google.com",
+            "name": "SID",
+            "value": "v",
+            "path": "/",
+            "secure": True,
+            "expires": expires,
+            "http_only": True,
+        }
+
+    def test_millisecond_expiry_converted_to_seconds(self):
+        storage = convert_rookiepy_cookies_to_storage_state(
+            [self._cookie(1821183946403)]  # 2027-09-17T12:52:26.403Z in ms
+        )
+        assert storage["cookies"][0]["expires"] == 1821183946
+
+    def test_second_expiry_preserved(self):
+        storage = convert_rookiepy_cookies_to_storage_state(
+            [self._cookie(1787639026)]  # 2026-08-25 in seconds
+        )
+        assert storage["cookies"][0]["expires"] == 1787639026
+
+    def test_session_cookie_stays_negative_one(self):
+        storage = convert_rookiepy_cookies_to_storage_state([self._cookie(None)])
+        assert storage["cookies"][0]["expires"] == -1


### PR DESCRIPTION
## Summary

`notebooklm login --browser-cookies <chromium-browser>` writes **13-digit millisecond** `expires` values into `storage_state.json`, which breaks direct reuse of the file with Playwright (it expects Unix **seconds**).

```
playwright._impl._errors.Error: Browser.new_context: Error setting storage state:
Cookie should have a valid expires, only -1 or a positive number for the unix timestamp in seconds is allowed
```

## Root cause

`rookiepy`'s Chromium/Edge extractors read the cookie store's `expires_utc` (µs since 1601) and divide by **1_000** (not 1_000_000), so the returned `expires` is in milliseconds. `rookiepy_row_to_storage_row` in `src/notebooklm/_auth/cookie_semantics.py` passes this value through verbatim.

Observed in the wild: `notebooklm login --browser-cookies auto` produced 76/108 cookies with ms timestamps (e.g. `SID` → `expires: 1821183946403`), while the other 32 (mostly `accounts.google.com` session cookies) were already in seconds.

## Fix

`rookiepy_row_to_storage_row` now normalizes any `expires` above the largest representable seconds timestamp (`253402300799` = year 9999) from milliseconds to seconds:

```python
if isinstance(expires, (int, float)) and expires > 253402300799:
    expires = int(expires / 1000)
```

This mirrors the existing Firefox path, which already normalizes ms→s in `_firefox_containers._row_to_rookie_cookies_dict` (Firefox 142+ stores ms). The seconds-bound heuristic is browser-agnostic and leaves already-correct seconds values and session cookies (`None` → `-1`) untouched.

## Tests

Added `TestMillisecondExpiryNormalization` to `tests/unit/test_cookie_domain_split.py`:

- ms → s conversion (`1821183946403` → `1821183946`)
- seconds preserved (`1787639026` stays)
- session cookie stays `-1`

## Commands run locally

```
uv sync --extra dev
uv run pytest tests/unit/test_cookie_domain_split.py -q          # 70 passed
uv run pytest tests/unit/test_auth_cookie_types.py tests/unit/test_auth_cookie_policy.py \
    tests/unit/test_cookie_domain_split.py tests/_guardrails/test_cookie_conversion_ratchet.py \
    tests/unit/app/test_app_login_cookie.py -q                    # 346 passed
uv run ruff check src/notebooklm/_auth/cookie_semantics.py tests/unit/test_cookie_domain_split.py
uv run ruff format src/notebooklm/_auth/cookie_semantics.py tests/unit/test_cookie_domain_split.py
uv run mypy src/notebooklm/_auth/cookie_semantics.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie expiration handling when values are provided in milliseconds.
  * Preserved expiration values already expressed in seconds.
  * Continued to correctly handle session cookies without an expiration date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->