### PR TITLE
fix(auth): normalize millisecond cookie expiry to seconds

### DIFF
--- a/src/notebooklm/_auth/cookie_semantics.py
+++ b/src/notebooklm/_auth/cookie_semantics.py
@@ -51,6 +51,8 @@ class NormalizedExpiry:
 # browser cookie store, so treating the ambiguity as "assume milliseconds"
 # is the safer default here.
 _MAX_PLAUSIBLE_EXPIRY_SECONDS = 32_503_680_000  # 3000-01-01T00:00:00Z
+_MAX_PLAUSIBLE_EXPIRY_MILLISECONDS = 32_503_680_000_000  # 3000-01-01 in ms
+_MAX_PLAUSIBLE_EXPIRY_MICROSECONDS = 32_503_680_000_000_000  # 3000-01-01 in µs
 
 
 def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
@@ -60,7 +62,7 @@ def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
     session-cookie forms.  Every other accepted numeric representation is a
     dated value, including ``-1.0`` and ``"-1"``.  Dated values use the same
     ``int(float(value))`` conversion as ``http.cookiejar``, then get rescaled
-    from milliseconds to seconds if implausibly large (see
+    from milliseconds or microseconds to seconds if implausibly large (see
     ``_MAX_PLAUSIBLE_EXPIRY_SECONDS``).
     """
     if raw is None or (type(raw) is int and raw == -1):
@@ -79,7 +81,9 @@ def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
     except (ValueError, TypeError, OverflowError) as exc:
         raise CookieRowError("expires", "not numeric") from exc
 
-    while value > _MAX_PLAUSIBLE_EXPIRY_SECONDS:
+    if _MAX_PLAUSIBLE_EXPIRY_MILLISECONDS < value <= _MAX_PLAUSIBLE_EXPIRY_MICROSECONDS:
+        value //= 1_000_000
+    elif _MAX_PLAUSIBLE_EXPIRY_SECONDS < value <= _MAX_PLAUSIBLE_EXPIRY_MILLISECONDS:
         value //= 1000
 
     # Preserve the distinction between a dated -1 and Playwright's session

--- a/src/notebooklm/_auth/cookie_semantics.py
+++ b/src/notebooklm/_auth/cookie_semantics.py
@@ -37,13 +37,31 @@ class NormalizedExpiry:
     session: bool
 
 
+# Firefox 142+ (schema version >= 16) stores ``moz_cookies.expiry`` in
+# milliseconds instead of seconds. Callers that can see the schema version
+# (``_firefox_containers.py``) correct for this precisely; callers that read
+# through ``rookie_cookies`` directly (unscoped ``firefox``/``auto``) cannot,
+# because the library hands back a bare epoch number with no unit tag and,
+# as of rookie-cookies 0.5.8, does not correct for the schema-16 switch
+# itself. As a magnitude-only backstop, any expiry beyond this bound is
+# implausible as a "seconds since epoch" value for a browser cookie (year
+# 3000) but lands in a plausible year once treated as milliseconds, so it is
+# rescaled. This cannot distinguish a genuine multi-millennium seconds
+# sentinel from a millisecond value — none has been observed from a real
+# browser cookie store, so treating the ambiguity as "assume milliseconds"
+# is the safer default here.
+_MAX_PLAUSIBLE_EXPIRY_SECONDS = 32_503_680_000  # 3000-01-01T00:00:00Z
+
+
 def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
     """Normalize a storage expiry without allowing ``Cookie`` to guess.
 
     ``None`` and the exact non-boolean integer ``-1`` are Playwright's
     session-cookie forms.  Every other accepted numeric representation is a
     dated value, including ``-1.0`` and ``"-1"``.  Dated values use the same
-    ``int(float(value))`` conversion as ``http.cookiejar``.
+    ``int(float(value))`` conversion as ``http.cookiejar``, then get rescaled
+    from milliseconds to seconds if implausibly large (see
+    ``_MAX_PLAUSIBLE_EXPIRY_SECONDS``).
     """
     if raw is None or (type(raw) is int and raw == -1):
         return NormalizedExpiry(None, True)
@@ -60,6 +78,9 @@ def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
         raise
     except (ValueError, TypeError, OverflowError) as exc:
         raise CookieRowError("expires", "not numeric") from exc
+
+    if value > _MAX_PLAUSIBLE_EXPIRY_SECONDS:
+        value //= 1000
 
     # Preserve the distinction between a dated -1 and Playwright's session
     # sentinel after the row is handed to ``http.cookiejar.Cookie``.

--- a/src/notebooklm/_auth/cookie_semantics.py
+++ b/src/notebooklm/_auth/cookie_semantics.py
@@ -79,7 +79,7 @@ def normalize_cookie_expiry(raw: Any) -> NormalizedExpiry:
     except (ValueError, TypeError, OverflowError) as exc:
         raise CookieRowError("expires", "not numeric") from exc
 
-    if value > _MAX_PLAUSIBLE_EXPIRY_SECONDS:
+    while value > _MAX_PLAUSIBLE_EXPIRY_SECONDS:
         value //= 1000
 
     # Preserve the distinction between a dated -1 and Playwright's session

--- a/src/notebooklm/cli/_firefox_containers.py
+++ b/src/notebooklm/cli/_firefox_containers.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import configparser
 import json
+import logging
 import re
 import shutil
 import sqlite3
@@ -47,6 +48,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
 
 # ``"none"`` is a sentinel for the no-container default. An ``int`` selects a
 # specific container by ``userContextId``. ``None`` means "no filter at all"
@@ -352,17 +355,26 @@ def _row_to_rookie_cookies_dict(row: tuple[Any, ...], *, expiry_in_ms: bool) -> 
     Columns match the SELECT in :func:`_select_for_container` exactly:
     ``(host, name, value, path, expiry, isSecure, isHttpOnly, sameSite)``.
 
-    rookie-cookies' Firefox path emits the same shape, so the resulting list
+    The output keys match rookie-cookies' Firefox row shape, so the result
     can flow into :func:`notebooklm.auth.convert_rookiepy_cookies_to_storage_state`
-    unchanged.
+    unchanged, but the ``expires`` *value* is not a blind passthrough:
+    ``moz_cookies.expiry`` uses ``0`` as Firefox's "session cookie, no
+    persistent expiry" sentinel (rookie-cookies maps this to ``None``), and
+    schema version >= 16 stores it in milliseconds rather than seconds.
     """
     host, name, value, path, expiry, is_secure, is_http_only, same_site = row
-    if expiry_in_ms and expiry is not None:
+    if expiry == 0:
+        expiry = None
+    elif expiry_in_ms and expiry is not None:
         try:
             expiry = expiry // 1000
         except TypeError:
-            # best-effort: cookie expiry is non-numeric; leave as-is.
-            pass
+            logger.warning(
+                "Firefox cookie %r on %r has non-numeric expiry %r; leaving as-is",
+                name,
+                host,
+                expiry,
+            )
     return {
         "domain": host or "",
         "name": name or "",

--- a/src/notebooklm/cli/services/login/__init__.py
+++ b/src/notebooklm/cli/services/login/__init__.py
@@ -4,7 +4,7 @@ This package is split across multiple modules to keep every
 implementation module ≤ 400 LOC, eliminate the
 ``_read_browser_cookies`` / ``_enumerate_browser_accounts`` circular-
 dispatch trap, and document the leaf-ward import DAG (chromium-family
-and firefox-family modules share ``cookie_jar`` + ``rookiepy_errors``
+and firefox-family modules share ``cookie_jar`` + ``rookie_cookies_errors``
 helpers; ``browser_accounts`` sits above both as the dispatcher;
 ``refresh`` is the top of the graph).
 
@@ -65,7 +65,6 @@ from .cookie_domains import (
 )
 from .cookie_jar import (
     _ROOKIE_COOKIES_BROWSER_ALIASES,
-    _ROOKIEPY_BROWSER_ALIASES,
     _enumerate_one_jar,
 )
 from .cookie_writes import (
@@ -103,7 +102,6 @@ __all__ = [
     "_warn_missing_optional_domains",
     # Cookie jar enumeration.
     "_ROOKIE_COOKIES_BROWSER_ALIASES",
-    "_ROOKIEPY_BROWSER_ALIASES",
     "_enumerate_one_jar",
     # Browser-account discovery + reading.
     "_enumerate_browser_accounts",

--- a/src/notebooklm/cli/services/login/browser_accounts.py
+++ b/src/notebooklm/cli/services/login/browser_accounts.py
@@ -16,7 +16,7 @@ the caller sees a uniform outcome shape on the auth-inspect path.
 
 Imports from :mod:`.chromium_accounts`, :mod:`.firefox_accounts`,
 :mod:`.cookie_jar` (``_enumerate_one_jar`` + the
-``_ROOKIEPY_BROWSER_ALIASES`` map), :mod:`.rookiepy_errors`, and
+``_ROOKIE_COOKIES_BROWSER_ALIASES`` map), :mod:`.rookie_cookies_errors`, and
 :mod:`.cookie_domains` (the "auto" + named-alias branch of
 ``_read_browser_cookies`` builds its own domain list).
 """
@@ -226,7 +226,7 @@ def _read_browser_cookies(
 
     Args:
         browser_name: ``"auto"`` to use ``rookiepy.load()``, a specific
-            browser alias from :data:`_ROOKIEPY_BROWSER_ALIASES`, or
+            browser alias from :data:`_ROOKIE_COOKIES_BROWSER_ALIASES`, or
             ``"chrome::<profile-name-or-directory>"`` for a single Chromium
             user-data profile, or
             ``"firefox::<container-name>"`` (or ``"firefox::none"``) to
@@ -252,7 +252,7 @@ def _read_browser_cookies(
         :class:`.outcomes.UnsupportedBrowser` (rookiepy lacks the
         platform-specific function), :class:`.outcomes.CookieValidationFailure`
         (rookiepy not installed, empty Firefox container spec, or read
-        failure surfaced by :func:`_handle_rookiepy_error`).
+        failure surfaced by :func:`_handle_rookie_cookies_error`).
     """
     io = resolve_login_io(io)
     # Firefox container syntax: ``firefox::<name>`` or ``firefox::none``.

--- a/src/notebooklm/cli/services/login/cookie_jar.py
+++ b/src/notebooklm/cli/services/login/cookie_jar.py
@@ -62,9 +62,9 @@ _ROOKIE_COOKIES_BROWSER_ALIASES: dict[str, str] = {
     "chromium": "chromium",
     "edge": "edge",
     "firefox": "firefox",
-    "ie": "ie",
+    "ie": "internet_explorer",
     "librewolf": "librewolf",
-    "octo": "octo",
+    "octo": "octo_browser",
     "opera": "opera",
     "opera-gx": "opera_gx",
     "opera_gx": "opera_gx",
@@ -72,7 +72,6 @@ _ROOKIE_COOKIES_BROWSER_ALIASES: dict[str, str] = {
     "vivaldi": "vivaldi",
     "zen": "zen",
 }
-_ROOKIEPY_BROWSER_ALIASES = _ROOKIE_COOKIES_BROWSER_ALIASES
 
 
 def _enumerate_one_jar(

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -492,7 +492,7 @@ def test_phase_13_caller_cleanup_modules_are_measured_exactly() -> None:
         "cli/services/login/browser_accounts.py": 365,
         "cli/services/login/chromium_accounts.py": 268,
         "cli/services/login/cookie_domains.py": 155,
-        "cli/services/login/cookie_jar.py": 245,
+        "cli/services/login/cookie_jar.py": 244,
         "cli/services/login/master_token.py": 152,
         "cli/services/login/profile_targets.py": 150,
         "cli/services/playwright_login.py": 542,

--- a/tests/fixtures/baselines/auth_import_graph.json
+++ b/tests/fixtures/baselines/auth_import_graph.json
@@ -778,7 +778,7 @@
       "path": "src/notebooklm/_auth/cookie_policy.py"
     },
     {
-      "lines": 254,
+      "lines": 275,
       "name": "cookie_semantics",
       "path": "src/notebooklm/_auth/cookie_semantics.py"
     },
@@ -926,7 +926,7 @@
     "function_local_edges": 12,
     "module_edges": 130,
     "modules": 41,
-    "total_lines": 16149,
+    "total_lines": 16170,
     "unique_edges": 142
   },
   "version": 1

--- a/tests/fixtures/baselines/auth_import_graph.json
+++ b/tests/fixtures/baselines/auth_import_graph.json
@@ -778,7 +778,7 @@
       "path": "src/notebooklm/_auth/cookie_policy.py"
     },
     {
-      "lines": 275,
+      "lines": 279,
       "name": "cookie_semantics",
       "path": "src/notebooklm/_auth/cookie_semantics.py"
     },
@@ -926,7 +926,7 @@
     "function_local_edges": 12,
     "module_edges": 130,
     "modules": 41,
-    "total_lines": 16170,
+    "total_lines": 16174,
     "unique_edges": 142
   },
   "version": 1

--- a/tests/unit/app/test_app_login_cookie.py
+++ b/tests/unit/app/test_app_login_cookie.py
@@ -466,10 +466,10 @@ def test_quiet_network_error_is_reraised_same_object(monkeypatch: pytest.MonkeyP
 _SEMANTIC_HASHES = {
     "login_cookie": "ba59ebbc0bec733f33a8e8239fc747a8da391b5293a52a94a0a2f7c039daed2c",
     "cookie_import": "5a50d08f573f05bf6eba1879014d9c6736a152a37456009da8306a9f6f49281f",
-    "browser_accounts": "211784ea2464ca1a7067361a132442e6e4ac14286daf353a07fda095ea563251",
+    "browser_accounts": "1630a821af90a41440da92df589beee1fbf6666639b6ad3fbb87016c9977d480",
     "chromium_accounts": "3f7241d07681f66823c212bb3b8292caa59b65a402d022537b134ca3e6995c92",
     "cookie_domains": "9874aab5c760feab5cc772bf0792f3775c1377896db7bf4ba22542432c31b534",
-    "cookie_jar": "7a96aa889e7a174e37bc1fb6c17d8e654d54e4bdffcd047dd6b4b339b0aac83a",
+    "cookie_jar": "7c90f535d9d380b6879a884133395ec996f484fb868d428990c8652e5e5ea4ca",
 }
 
 

--- a/tests/unit/cli/test_cookie_jar_enumerate.py
+++ b/tests/unit/cli/test_cookie_jar_enumerate.py
@@ -196,3 +196,15 @@ class TestSuccessPath:
         assert len(out) == 1
         assert out[0].browser_profile == "Profile 1"
         assert out[0].email == "a@gmail.com"
+
+
+class TestBrowserAliasMap:
+    def test_ie_and_octo_resolve_to_real_rookie_cookies_attribute_names(self):
+        # rookie_cookies only exports "internet_explorer" / "octo_browser"
+        # (Windows-only, gated in its __init__.py) -- there is no "ie" or
+        # "octo" attribute on the module at all. A stale "ie" -> "ie" /
+        # "octo" -> "octo" mapping means getattr(rookie_cookies, alias)
+        # always misses, so --browser-cookies ie/octo could never resolve.
+        aliases = cookie_jar._ROOKIE_COOKIES_BROWSER_ALIASES
+        assert aliases["ie"] == "internet_explorer"
+        assert aliases["octo"] == "octo_browser"

--- a/tests/unit/test_audit_auth_import_graph.py
+++ b/tests/unit/test_audit_auth_import_graph.py
@@ -92,7 +92,7 @@ def test_live_projection_is_the_frozen_scorecard(audit):
     result = audit.build_projection()
     assert result["summary"] == {
         "modules": 41,
-        "total_lines": 16170,
+        "total_lines": 16174,
         "unique_edges": 142,
         "module_edges": 130,
         "function_local_edges": 12,

--- a/tests/unit/test_audit_auth_import_graph.py
+++ b/tests/unit/test_audit_auth_import_graph.py
@@ -92,7 +92,7 @@ def test_live_projection_is_the_frozen_scorecard(audit):
     result = audit.build_projection()
     assert result["summary"] == {
         "modules": 41,
-        "total_lines": 16149,
+        "total_lines": 16170,
         "unique_edges": 142,
         "module_edges": 130,
         "function_local_edges": 12,

--- a/tests/unit/test_auth_cookie_types.py
+++ b/tests/unit/test_auth_cookie_types.py
@@ -105,6 +105,34 @@ class TestConstructorEquivalence:
         assert next(iter(jar)).expires is None
         assert jar.to_storage_state()["cookies"][0]["expires"] == -1
 
+    def test_firefox_millisecond_expiry_rescaled_through_the_full_pipeline(self) -> None:
+        """A schema-16 Firefox millisecond expiry survives conversion as seconds.
+
+        ``rookie_cookies.firefox()``/``any_browser()`` (the unscoped
+        ``--browser-cookies firefox``/``auto`` path) hand back Firefox 142+
+        expiry values in raw milliseconds with no unit tag —
+        ``_firefox_containers.py``'s schema-version correction only covers the
+        container-bypass path. Without a rescale, a live cookie's ms expiry
+        reads as a date thousands of years out, so it is never treated as
+        expired downstream. Pins that the full
+        ``convert_rookiepy_cookies_to_storage_state`` conversion catches this
+        regardless of which Firefox path the row came from.
+        """
+        near_term_seconds = 1_800_000_000  # a plausible near-term expiry
+        rows = [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "psidts",
+                "domain": ".google.com",
+                "path": "/",
+                "expires": near_term_seconds * 1000,
+                "secure": True,
+                "http_only": True,
+            }
+        ]
+        legacy_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state(rows)
+        assert legacy_state["cookies"][0]["expires"] == near_term_seconds
+
     def test_dated_minus_one_is_not_a_session_cookie(self) -> None:
         """``-1.0`` / ``"-1"`` are dated values, not the session sentinel.
 

--- a/tests/unit/test_auth_issue_2061.py
+++ b/tests/unit/test_auth_issue_2061.py
@@ -104,6 +104,7 @@ def _rotate_requests(httpx_mock: HTTPXMock) -> list[httpx.Request]:
         # milliseconds with no unit tag. Anything past year 3000 as seconds
         # is implausible for a browser cookie, so it is rescaled.
         (1_755_000_000_000, 1_755_000_000, False),
+        (1_755_000_000_000_000, 1_755_000_000, False),  # raw microseconds: rescaled twice
         (32_503_680_000, 32_503_680_000, False),  # exactly year 3000: not rescaled
         (32_503_680_001, 32_503_680, False),  # one second past: rescaled
     ],

--- a/tests/unit/test_auth_issue_2061.py
+++ b/tests/unit/test_auth_issue_2061.py
@@ -99,6 +99,13 @@ def _rotate_requests(httpx_mock: HTTPXMock) -> list[httpx.Request]:
         (0, 0, False),
         (12.9, 12, False),
         ("12.9", 12, False),
+        # Firefox 142+ (schema >= 16) expiry read through the unscoped
+        # ``rookie_cookies.firefox()``/``any_browser()`` path arrives in
+        # milliseconds with no unit tag. Anything past year 3000 as seconds
+        # is implausible for a browser cookie, so it is rescaled.
+        (1_755_000_000_000, 1_755_000_000, False),
+        (32_503_680_000, 32_503_680_000, False),  # exactly year 3000: not rescaled
+        (32_503_680_001, 32_503_680, False),  # one second past: rescaled
     ],
 )
 def test_cookie_expiry_normalization_preserves_session_and_epoch(

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -241,7 +241,12 @@ class TestPsidtsExpiryGate:
     """
 
     _PAST = 1_000_000_000  # 2001-09-09, comfortably in the past
-    _FUTURE = 99_999_999_999  # year 5138, comfortably in the future
+    # Year 2100, comfortably in the future. Matches the project-wide
+    # "far future" sentinel used elsewhere (e.g. tests/unit/cli/_session_helpers.py)
+    # rather than a value that would exceed cookie_semantics.py's
+    # millisecond-plausibility bound (_MAX_PLAUSIBLE_EXPIRY_SECONDS, year 3000)
+    # and get misread as a millisecond timestamp.
+    _FUTURE = 4_102_444_800
 
     @staticmethod
     def _with_psidts(*, expires) -> list[dict]:
@@ -734,7 +739,7 @@ class TestPsidtsExpiryGate:
                     "value": "rotated",
                     "domain": ".google.com",
                     "path": "/",
-                    "expires": 99_999_999_999,
+                    "expires": 4_102_444_800,
                 },
             ],
         )
@@ -975,7 +980,7 @@ class TestRecoveryConcurrentCasRejection:
             "value": "sibling_fresh_value",
             "domain": ".google.com",
             "path": "/",
-            "expires": 99_999_999_999,  # comfortably in the future
+            "expires": 4_102_444_800,  # comfortably in the future
         }
         self._install_concurrent_write(
             httpx_mock,
@@ -1499,7 +1504,7 @@ class TestMalformedExpiresAcrossLoaders:
                     "value": "fresh",
                     "domain": ".google.com",
                     "path": "/",
-                    "expires": 99_999_999_999,
+                    "expires": 4_102_444_800,
                 }
             )
         rows.append(
@@ -1792,7 +1797,7 @@ class TestEdgeCases:
                 "value": "healed_by_sibling",
                 "domain": ".google.com",
                 "path": "/",
-                "expires": 99_999_999_999,
+                "expires": 4_102_444_800,
             }
         ]
         _stage_storage_reads(

--- a/tests/unit/test_firefox_containers.py
+++ b/tests/unit/test_firefox_containers.py
@@ -820,6 +820,20 @@ class TestRowToRookieCookiesDict:
         result = _row_to_rookie_cookies_dict(row, expiry_in_ms=True)
         assert result["expires"] == 9_999_999_999
 
+    def test_zero_expiry_is_session_cookie_not_epoch(self):
+        # moz_cookies.expiry == 0 is Firefox's sentinel for "session cookie,
+        # no persistent expiry" (matching rookie_cookies' own 0 -> None
+        # mapping). Passing 0 through as a dated value makes it read as
+        # 1970-01-01 -- i.e. permanently expired -- downstream.
+        row = (".google.com", "SID", "v", "/", 0, 1, 0, 0)
+        result = _row_to_rookie_cookies_dict(row, expiry_in_ms=False)
+        assert result["expires"] is None
+
+    def test_zero_expiry_is_session_cookie_regardless_of_ms_schema(self):
+        row = (".google.com", "SID", "v", "/", 0, 1, 0, 0)
+        result = _row_to_rookie_cookies_dict(row, expiry_in_ms=True)
+        assert result["expires"] is None
+
     def test_none_values_get_defaults(self):
         row = (None, None, None, None, None, 0, 0, None)
         result = _row_to_rookie_cookies_dict(row, expiry_in_ms=False)

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -305,9 +305,11 @@ def _file_contains_best_effort_after_except(filepath: Path, except_line: int) ->
 # best-effort rewrite-from-scratch) was retired — that branch now
 # uses :func:`notebooklm._atomic_io.atomic_update_json` with explicit
 # JSONDecodeError handling that re-runs the mutator on an empty dict.
+# Note: the previous ``cli/_firefox_containers.py:364`` site
+# (``_row_to_rookie_cookies_dict``'s non-numeric-expiry branch) is no longer
+# silent — it now logs a warning instead of passing.
 _SILENT_SITES = [
     ("cli/_firefox_containers.py", 133),
-    ("cli/_firefox_containers.py", 364),
     ("notebooklm_cli.py", 66),
 ]
 


### PR DESCRIPTION
## Summary

Addresses cookie expiration values returned in milliseconds by browser extraction tools (including modern Firefox 142+ schema 16 SQLite databases and Chromium extractors via `rookie-cookies`), normalizing them to Unix epoch seconds.

This builds upon and completes the investigation initiated in #2248 by @lesterppo — special thanks to @lesterppo for discovering and raising the millisecond expiry issue!

## Root Cause & Scope

- **Firefox 142+ (Schema ≥ 16)**: `moz_cookies` stores `expiry` in milliseconds rather than seconds. When reading cookies via `rookie_cookies.firefox()` or `rookie_cookies.load()` (the unscoped `--browser-cookies firefox` or `auto` paths), `rookie-cookies` returns the raw database integer with no unit tag.
- **Chromium**: `rookie-cookies` divides raw $\mu s$ timestamps by 1,000 instead of 1,000,000, returning milliseconds.
- **Impact**: Millisecond values (~`1.77e12`) cause:
  1. Corrupted `storage_state.json` (`expires` treated by Playwright as year 57,400+ AD).
  2. `notebooklm auth check` failure (`datetime.fromtimestamp` raises `ValueError: year 57457 is out of range`).
  3. `Cookie.is_expired(now)` bypass in `_auth/psidts_recovery.py` (treating expired tokens as valid for 55,000 years).

## Fix Details

1. **Leaf-Level Normalization in `normalize_cookie_expiry()`**:
   - Rather than normalizing only at the surface adapter (`rookiepy_row_to_storage_row`), normalization is placed inside `normalize_cookie_expiry()` in `src/notebooklm/_auth/cookie_semantics.py`.
   - Uses `_MAX_PLAUSIBLE_EXPIRY_SECONDS = 32_503_680_000` (year 3000-01-01) as a boundary. Any timestamp exceeding this threshold is rescaled via integer division `value //= 1000`.
   - Automatically covers `convert_rookiepy_cookies_to_storage_state`, `CookieJar.from_rookiepy`, `CookieJar.from_storage_state`, `auth_check`, and in-memory PSIDTS recovery.
2. **Firefox `0` Sentinel**:
   - In `_firefox_containers.py`, `moz_cookies.expiry == 0` is mapped to `None` (session cookie sentinel) to avoid treating session cookies as epoch 1970-01-01.
3. **Browser Aliases**:
   - Fixed `ie` -> `internet_explorer` and `octo` -> `octo_browser` mappings in `cookie_jar.py`.
4. **Test Fixtures & Coverage**:
   - Added unit tests for ms-to-s rescaling in `test_auth_issue_2061.py` and `test_auth_cookie_types.py`.
   - Updated far-future test fixtures in `test_auth_psidts_recovery.py` from `99_999_999_999` to `4_102_444_800` (year 2100).

## Commands Run Locally

```bash
uv sync --extra dev --extra browser --extra markdown
uv run ruff format --check src tests
uv run ruff check src tests
uv run mypy src/notebooklm
uv run pytest -m "not e2e"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Firefox cookie expiry handling for millisecond and microsecond timestamps.
  * Correctly recognizes session cookies and normalizes expiry values across supported formats.
  * Added warnings for invalid cookie expiry values instead of silently ignoring them.
  * Updated browser aliases for Internet Explorer and Octo Browser.

* **Tests**
  * Added regression coverage for expiry normalization, session cookies, and browser aliases.
  * Updated validation baselines and fixtures to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->