### PR TITLE
fix: raise promotion-worker wait budget in account-promotion tests

### DIFF
--- a/tests/unit/test_auth_account_promotion.py
+++ b/tests/unit/test_auth_account_promotion.py
@@ -126,6 +126,20 @@ def _drain_promotions_for_tests() -> None:
     _scheduler().drain(30.0)
 
 
+def _wait_for_active_paths_to_clear(timeout: float = 30.0) -> None:
+    """Poll until no promotion worker is active, sharing ``drain``'s budget.
+
+    A fixed short deadline here previously flaked on CI runners under load
+    (observed on Windows): the detached worker had not yet run by the time the
+    poll gave up, so the assertion that follows saw pre-promotion state instead
+    of a genuine failure.
+    """
+    deadline = time.monotonic() + timeout
+    while _scheduler()._active_paths_for_tests() and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert not _scheduler()._active_paths_for_tests()
+
+
 def _in_band_on_disk(storage: Path) -> dict[str, Any] | None:
     data = json.loads(storage.read_text(encoding="utf-8"))
     namespace = data.get("notebooklm")
@@ -447,10 +461,7 @@ class TestRetryableSingleFlight:
         monkeypatch.setattr(ProfileStore, "update_account", _fail_once)
 
         assert read_account_metadata(storage) == {"authuser": 2, "email": "l@example.com"}
-        deadline = time.monotonic() + 5.0
-        while _scheduler()._active_paths_for_tests() and time.monotonic() < deadline:
-            time.sleep(0.001)
-        assert not _scheduler()._active_paths_for_tests()
+        _wait_for_active_paths_to_clear()
 
         assert read_account_metadata(storage) == {"authuser": 2, "email": "l@example.com"}
         _drain_promotions_for_tests()
@@ -476,9 +487,7 @@ class TestRetryableSingleFlight:
         monkeypatch.setattr(LegacyAccountContext, "scrub", _fail_once)
 
         assert read_account_metadata(storage)["email"] == "privacy@example.com"
-        deadline = time.monotonic() + 5.0
-        while _scheduler()._active_paths_for_tests() and time.monotonic() < deadline:
-            time.sleep(0.001)
+        _wait_for_active_paths_to_clear()
         assert _in_band_on_disk(storage) == {
             "authuser": 2,
             "email": "privacy@example.com",


### PR DESCRIPTION
## Summary
- Fixes the Windows CI failure in [run 32778740223](https://github.com/teng-lin/notebooklm-py/actions/runs/32778740223/job/97595753332): `TestRetryableSingleFlight::test_a_failed_post_write_scrub_is_retried_from_the_in_band_state` failed with `assert None == {'authuser': 2, 'email': 'privacy@example.com'}`.
- Root cause: two tests in this class poll `LegacyPromotionScheduler._active_paths_for_tests()` in a busy loop bounded by a hardcoded 5s wall-clock deadline before asserting on the on-disk state written by a detached background promotion worker. Under CI load (observed on `windows-latest` with `-n auto --dist loadgroup` and 16k+ tests), thread scheduling can exceed 5s, so the loop gave up before the worker had written anything, and the subsequent assertion saw pre-promotion state (`None`) instead of a real failure.
- One of the two call sites was also missing the `assert not _scheduler()._active_paths_for_tests()` sanity check present in its sibling, which is why the timeout surfaced as a confusing content mismatch rather than a clear "still active" signal.
- Fix: extract a shared `_wait_for_active_paths_to_clear()` helper that reuses the same 30s budget `LegacyPromotionScheduler.drain()` already uses elsewhere in this file, and always assert the wait actually completed.

## Test plan
- [x] `uv run pytest tests/unit/test_auth_account_promotion.py -v` — all 45 tests pass locally.
- [x] `ruff format --check` / `ruff check` on the changed file.
- [x] `mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports`.
- [ ] CI green across all OS/Python matrix legs, especially `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7DFg6BLuvXPXMCW5fkg1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization by waiting for promotion activity to finish before validating results.
  * Added bounded polling to reduce timing-related test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->