### PR TITLE
refactor(test): complete ADR-0022 guardrail baseline migration

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,9 @@ jobs:
       - uses: actions/checkout@v7
         if: steps.resolve.outputs.is_standard == 'true'
         with:
-          ref: ${{ steps.resolve.outputs.branch }}
+          # Qualify the namespace so a tag named ``release/...`` cannot pass
+          # the standard-branch string gate and reach secret-bearing E2E.
+          ref: refs/heads/${{ steps.resolve.outputs.branch }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -81,6 +83,121 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
           echo "Resolved commit: $SHA"
+
+  # Coverage is intentionally scheduled/manual only. It exercises the same
+  # ordinary suite as pull-request CI, but owns the global and per-file floors
+  # without delaying every PR compatibility cell.
+  coverage:
+    name: Coverage (${{ needs.resolve-branch.outputs.branch }}@${{ needs.resolve-branch.outputs.short_sha }})
+    needs: resolve-branch
+    if: needs.resolve-branch.outputs.is_standard == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-branch.outputs.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Stamp coverage target
+      env:
+        EXPECTED_SHA: ${{ needs.resolve-branch.outputs.sha }}
+        TARGET_BRANCH: ${{ needs.resolve-branch.outputs.branch }}
+      shell: bash
+      run: |
+        ACTUAL_SHA=$(git rev-parse HEAD)
+        if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+          echo "::error::Checked out $ACTUAL_SHA, expected $EXPECTED_SHA"
+          exit 1
+        fi
+        {
+          echo "### Coverage target"
+          echo "- Branch: \`$TARGET_BRANCH\`"
+          echo "- Commit: \`$ACTUAL_SHA\`"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+
+    - name: Install dependencies
+      # Match the normal PR suite's optional surfaces so coverage cannot hide
+      # MCP, server, curl_cffi, or browser-cookie modules behind import skips.
+      shell: bash
+      run: |
+        attempt=1; max=3
+        until uv sync --frozen --extra browser --extra dev --extra markdown --extra mcp --extra server --extra impersonate --extra cookies; do
+          if [ "$attempt" -ge "$max" ]; then
+            echo "::error::uv sync failed after $max attempts" >&2
+            exit 1
+          fi
+          echo "::warning::uv sync attempt $attempt failed; retrying in $((attempt * 15))s" >&2
+          sleep $((attempt * 15))
+          attempt=$((attempt + 1))
+        done
+
+    - name: Install Playwright browsers
+      run: uv run playwright install chromium
+
+    - name: Install Playwright system dependencies (Linux)
+      run: uv run playwright install-deps chromium
+
+    - name: Run ordinary tests with coverage
+      run: >-
+        uv run pytest -n auto --dist loadgroup
+        -m "not repo_lint and not requires_playwright and not requires_chromium"
+        --cov=src/notebooklm --cov-report= --cov-fail-under=0
+
+    - name: Append Playwright-dependent unit coverage
+      run: >-
+        uv run pytest tests/unit
+        -m "(requires_playwright or requires_chromium) and not reality"
+        -n 0 --cov=src/notebooklm --cov-append
+        --cov-report=term-missing --cov-report=json:coverage.json
+        --cov-fail-under=90
+
+    - name: Assert per-file coverage floors
+      run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json
+
+  # AST-heavy repository audits are scheduled here once, while test.yml keeps
+  # a workflow_dispatch lane for feature-branch diagnosis.
+  repo-lint:
+    name: Repository Lint (${{ needs.resolve-branch.outputs.branch }}@${{ needs.resolve-branch.outputs.short_sha }})
+    needs: resolve-branch
+    if: needs.resolve-branch.outputs.is_standard == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-branch.outputs.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+
+    - name: Install dependencies
+      run: >-
+        uv sync --frozen --extra browser --extra dev --extra markdown
+        --extra mcp --extra server --extra impersonate --extra cookies
+
+    - name: Run repository lint tests
+      run: >-
+        uv run pytest -n auto --dist loadgroup -m repo_lint
+        --timeout=180 --no-cov
 
   # Run E2E tests on the resolved branch
   e2e:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,21 +159,64 @@ jobs:
     - name: Verify e2e test fixtures
       run: uv run pytest tests/e2e --collect-only -q
 
+    - name: Assert cassettes are sanitized
+      # This repository-wide content scan runs once in the quality job instead
+      # of once per compatibility cell. ``--strict`` requires the repair
+      # allowlist to stay empty; ``--recursive`` includes nested cassettes.
+      run: uv run python tests/scripts/check_cassettes_clean.py --strict --recursive
+
+    - name: Check fixtures for credential leaks
+      # Golden RPC fixtures carry the same credential-shaped WIZ data as VCR
+      # cassettes. Scan their JSON/HTML/YAML once here rather than repeating the
+      # filesystem walk across every OS/Python compatibility cell.
+      run: uv run python tests/scripts/check_cassettes_clean.py --secrets-only --recursive tests/fixtures tests/unit/fixtures
+
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # Linux carries the full supported Python range. One 3.12 cell on each
+        # secondary OS preserves platform compatibility without multiplying the
+        # entire suite into a 3-by-5 bottleneck. Canonical Ubuntu 3.12 owns
+        # Chromium, external-reality work, and the critical contract guards.
+        include:
+        - os: ubuntu-latest
+          python-version: "3.10"
+          canonical: false
+          windows_playwright: false
+        - os: ubuntu-latest
+          python-version: "3.11"
+          canonical: false
+          windows_playwright: false
+        - os: ubuntu-latest
+          python-version: "3.12"
+          canonical: true
+          windows_playwright: false
+        - os: ubuntu-latest
+          python-version: "3.13"
+          canonical: false
+          windows_playwright: false
+        - os: ubuntu-latest
+          python-version: "3.14"
+          canonical: false
+          windows_playwright: false
+        - os: macos-latest
+          python-version: "3.12"
+          canonical: false
+          windows_playwright: false
+        - os: windows-latest
+          python-version: "3.12"
+          canonical: false
+          windows_playwright: true
     env:
       # Pin Playwright's browser install dir to a single workspace-relative
       # path on every OS. The previous dual-path cache stanza (``~/.cache``
       # + ``~/AppData/Local``) intermittently failed the cache restore on
       # Windows with ``actions/cache@v5`` — the missing Linux path tripped
       # the post-restore validation on a cache hit. Pinning the path here
-      # lets the cache stanza below carry exactly one entry on every OS.
+      # lets the canonical browser cache stanza below carry exactly one entry.
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
 
     steps:
@@ -199,8 +242,8 @@ jobs:
       shell: bash
       run: |
         # Retry to ride out transient registry/network blips during dep
-        # resolution: a single PyPI/GitHub hiccup on one matrix entry was
-        # hard-failing the whole leg while the other 14 passed. `uv sync`
+        # resolution: a single PyPI/GitHub hiccup on one compatibility cell can
+        # hard-fail the whole required matrix while its siblings pass. `uv sync`
         # has no internal retry across the full resolve+download. A real
         # lockfile problem fails all 3 attempts identically, so this only
         # absorbs flakes — it never masks a genuine resolution error.
@@ -211,16 +254,16 @@ jobs:
         # `tests/unit/test_curl_cffi_transport_poc.py`) run in the main matrix
         # instead of being importorskip'd — that gives
         # `src/notebooklm/{mcp,server}/**` and `_curl_cffi_transport.py` real
-        # coverage in coverage.json (no 0% blind spot) across the full
-        # 3.10–3.14 × 3-OS matrix, which also proves curl_cffi's native wheels
-        # resolve on every OS/Python.
+        # coverage in nightly's coverage.json (no 0% blind spot). Installing
+        # them in every compatibility cell also proves curl_cffi's native wheels
+        # resolve across every supported Python version on Linux and on the
+        # representative Python 3.12 macOS/Windows cells.
         # `cookies` is now included since rookie-cookies supports all Python versions.
         #
-        # Tradeoff: the deleted MCP/server jobs each enforced a *scoped*
-        # `--cov=src/notebooklm/{mcp,server} --cov-fail-under=90`. mcp/server (and
-        # the curl_cffi adapter) are now covered only by the global aggregate gate
-        # below — no per-subpackage floor backfills them, so a subpackage could
-        # regress within the aggregate's headroom. Add entries to
+        # Tradeoff: the deleted MCP/server jobs each enforced a scoped 90% floor.
+        # mcp/server (and the curl_cffi adapter) are now covered only by nightly's
+        # global aggregate gate — no per-subpackage floor backfills them, so a
+        # subpackage could regress within the aggregate's headroom. Add entries to
         # `[tool.notebooklm.per_file_coverage_floors]` if that backstop is
         # wanted back.
         attempt=1; max=3
@@ -237,8 +280,8 @@ jobs:
     - name: Assert curl_cffi imports (native wheel; no silent skip)
       # The matrix installs --extra impersonate, so curl_cffi MUST import on every
       # OS/Python. It's a native wheel: if it installs but fails to import, the
-      # importorskip'd curl_cffi suites would silently skip in the coverage run
-      # rather than fail. This makes a broken native import a hard error.
+      # importorskip'd curl_cffi suites would silently skip rather than fail.
+      # This makes a broken native import a hard error in every compatibility cell.
       shell: bash
       run: uv run python -c "import curl_cffi"
 
@@ -254,12 +297,14 @@ jobs:
         assert callable(rookie_cookies.any_browser)"
 
     - name: Get Playwright version
+      if: matrix.canonical
       id: playwright-version
       shell: bash
       run: |
         echo "version=$(uv pip show playwright | grep '^Version:' | cut -d' ' -f2)" >> $GITHUB_OUTPUT
 
     - name: Cache Playwright browsers
+      if: matrix.canonical
       uses: actions/cache@v6
       # Tolerate transient cache-backend failures: a miss already falls
       # through to the install step below, and a backend hiccup should be
@@ -273,10 +318,11 @@ jobs:
         key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}-ws
 
     - name: Install Playwright browsers
+      if: matrix.canonical
       run: uv run playwright install chromium
 
     - name: Install Playwright system dependencies (Linux)
-      if: runner.os == 'Linux'
+      if: matrix.canonical
       shell: bash
       run: |
         if ! timeout 180s uv run playwright install-deps chromium; then
@@ -285,55 +331,86 @@ jobs:
         fi
 
     - name: Run required external-reality probes
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.canonical
       run: >-
         uv run pytest tests/unit/cli/test_playwright_login_coverage.py
         -m reality --require-reality
 
-    - name: Assert cassettes are sanitized
-      # Runs on all matrix entries (ubuntu, macos, windows × 5 Python versions).
-      # An earlier bash-only gate was replaced by a portable Python invocation
-      # so the check runs uniformly across the cross-platform test matrix.
-      #
-      # ``--strict`` flips the repair-allowlist from "best-effort suppressor"
-      # to "must be empty" — the phase-2 cassette cleanup is done, so any
-      # entry sneaking back in is a CI failure (P1-5).
-      # ``--recursive`` extends the scan from ``tests/cassettes/*.yaml`` to
-      # ``tests/cassettes/**/*.yaml`` so a recorder can't smuggle a leak
-      # into a nested folder like ``tests/cassettes/gzip_coverage/`` (P1-5).
-      run: uv run python tests/scripts/check_cassettes_clean.py --strict --recursive
+    - name: Run Playwright-dependent unit tests serially
+      if: matrix.canonical
+      # These tests exercise real Playwright driver subprocesses. Keep them out
+      # of xdist, but retain one complete PR lane instead of silently dropping
+      # them from the reduced compatibility matrix.
+      run: >-
+        uv run pytest tests/unit
+        -m "(requires_playwright or requires_chromium) and not reality"
+        -n 0 --no-cov
 
-    - name: Check fixtures for credential leaks
-      # The cassette guard above is scoped to ``tests/cassettes/*.yaml``. Golden
-      # RPC fixtures live under ``tests/fixtures/`` as ``.json`` (and one
-      # captured ``.html`` page), which embed the same WIZ_global_data shapes —
-      # a Google API key smuggled into a golden HTML fixture would otherwise
-      # slip past CI entirely (the GET_INTERACTIVE_HTML.json class). ``--secrets
-      # -only`` scans .json/.html/.yaml for high-severity credential shapes
-      # (Google auth tokens + API keys) without tripping on the intentional
-      # placeholder content (``"Scrubbed ..."`` names, test emails) that fills
-      # those fixtures.
-      run: uv run python tests/scripts/check_cassettes_clean.py --secrets-only --recursive tests/fixtures tests/unit/fixtures
+    - name: Run critical contract guards
+      if: matrix.canonical
+      # Keep the positive baseline/public/security/CI contracts on every PR
+      # while their expensive mutation variants live in the bounded manual
+      # repo-lint lane.
+      # This is one no-coverage lane, so it can use the runner's full worker set
+      # without recreating the old 15 simultaneous coverage jobs.
+      run: >-
+        uv run pytest -n auto --dist worksteal --timeout=180 --no-cov
+        tests/unit/test_ci_test_matrix.py
+        tests/_guardrails/test_public_surface_manifest.py::test_baseline_registry_is_non_trivial
+        tests/_guardrails/test_public_surface_manifest.py::test_baseline_matches_committed_file
+        tests/_guardrails/test_no_flat_cookies_on_the_wire.py::test_no_flat_cookie_projection_reaches_an_http_request
+        tests/_guardrails/test_master_token_minting_denylist.py::test_no_cli_module_imports_minting_primitives
+        tests/_guardrails/test_master_token_path_single_site.py::test_no_bare_master_token_derivation_outside_paths_module
+        tests/_guardrails/test_playwright_gateway.py::test_raw_sync_playwright_is_confined_to_policy_gateway
 
-    - name: Run tests with coverage
-      # ``-n auto --dist loadgroup`` parallelizes the ~11k-test suite across the
-      # runner's cores (pytest-xdist is already a dev dep). ``loadgroup`` honors
-      # ``@pytest.mark.xdist_group`` — the isolation escape hatch for tests touching
-      # process-global state (tests/integration/concurrency/conftest.py); unmarked
-      # tests distribute like ``load``. The suite is parallel-safe via per-test
-      # ``NOTEBOOKLM_HOME`` tmp isolation, and pytest-cov merges per-worker coverage
-      # automatically, so the coverage.json + per-file floors below are unaffected.
-      #
-      # Emit coverage.json so the per-file floor check below can read it without
-      # re-running the suite. ``term-missing`` is kept so build logs still show the
-      # missing-lines summary.
-      run: uv run pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
+    - name: Run tests without coverage
+      # Every required compatibility cell runs the ordinary suite exactly once.
+      # Repository lint has a bounded manual lane, coverage and per-file floors
+      # run nightly, and real Playwright subprocesses stay outside xdist.
+      run: >-
+        uv run pytest -n auto --dist loadgroup
+        -m "not repo_lint and not requires_playwright and not requires_chromium"
+        --no-cov
 
-    - name: Assert per-file coverage floors
-      # Linux-only because ``coverage.json`` on Windows records backslash
-      # paths (e.g. ``src\notebooklm\cli\doctor.py``) that won't match the
-      # forward-slash keys in ``[tool.notebooklm.per_file_coverage_floors]``
-      # in pyproject.toml. macOS uses forward slashes and would also work,
-      # but a single OS is enough — the floors are platform-independent.
-      if: runner.os == 'Linux'
-      run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json
+    - name: Run Windows Playwright compatibility smoke serially
+      if: matrix.windows_playwright
+      # The #89 regression only needs the real Playwright driver process; it
+      # intentionally does not launch Chromium, so Windows needs no browser
+      # download/cache. ``-n 0`` makes the process-policy smoke explicitly serial.
+      run: >-
+        uv run pytest
+        tests/unit/test_windows_compatibility.py::TestPlaywrightSmokeTest::test_playwright_initializes_with_context_manager
+        -m requires_playwright -n 0 --no-cov
+
+  repo-lint:
+    name: Repository Lint (manual)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.custom_branch || github.ref }}
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      run: >-
+        uv sync --frozen --extra browser --extra dev --extra markdown
+        --extra mcp --extra server --extra impersonate --extra cookies
+
+    - name: Run repository lint tests
+      # Manual-only deep audits use the runner's available workers and a wider
+      # per-test timeout, but never collect coverage or slow pull requests.
+      run: >-
+        uv run pytest -n auto --dist loadgroup -m repo_lint
+        --timeout=180 --no-cov

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: gates
+
+# Run every AST/path/contract guard once with the same shape as CI's bounded
+# manual and nightly lanes.
+gates:
+	uv run --frozen --extra browser --extra dev --extra markdown --extra mcp \
+		--extra server --extra impersonate --extra cookies pytest -n auto \
+		--dist loadgroup -m repo_lint --timeout=180 --no-cov

--- a/docs/adr/0022-regenerable-baselines.md
+++ b/docs/adr/0022-regenerable-baselines.md
@@ -17,6 +17,9 @@ flags removed/changed exports vs the last release tag — it is blind to
   every ungated public module (`notebooklm`, `notebooklm.config`,
   `notebooklm.exceptions`, …).
 - The public CLI command tree, options, help, and aliases.
+- Module-size ceilings and lock-unavailable policy ownership, both shrink-only
+  ratchets whose frozen values are derived from the live tree.
+- The auth import graph and auth test patch-site inventory.
 
 Historically these were frozen as **hand-typed literals inside the test module**
 (`_FROZEN_TYPES_ALL`, `_UNGATED_PUBLIC_ALL_SNAPSHOT` in
@@ -47,6 +50,15 @@ it one clean regen command.
    - `ungated_surface` → `{module: collect_public_surface(module) …}` over
      `UNGATED_PUBLIC_MODULES` (ordered lists).
    - `cli_contract` → `build_cli_contract()` (dict, `sort_keys=True`).
+   - `module_size` → the global budget plus live measurements for authored
+     over-budget exemptions and ADR-0033 shrink locks. The JSON stores measured
+     ceilings; `tests/_baselines/module_size.py` remains the reviewed policy
+     source for which paths are exempt and why.
+   - `storage_transaction_policy` → direct AST-derived callers of the three
+     lock-unavailable policies.
+   - `auth_import_graph` / `auth_patch_sites` → their audit projections.
+   - `guardrail_inline_literals` → the grandfathered inventory of large
+     module-level container literals under `tests/_guardrails/`.
 
 2. **Committed JSON.** Baselines live under `tests/fixtures/baselines/`
    (`types_all.json`, `ungated_surface.json`); `cli_contract` keeps its
@@ -63,6 +75,19 @@ it one clean regen command.
    `tests/conftest.py`) flips the freeze test from *assert* to *write
    `derive()` → `path`*. `scripts/regen_baselines.py` is the discoverable wrapper
    that shells `pytest … --update-baselines`.
+
+5. **Shrink-only growth acknowledgement.** Registry entries may provide a
+   `growth_check(previous, current)` callback. Ordinary regeneration accepts
+   tightening and removal, but refuses ceiling increases, new policy callers,
+   and new or enlarged inline guardrail literals. After reviewing such a change,
+   a developer must acknowledge it explicitly with `python
+   scripts/regen_baselines.py --allow-growth`. CI rejects both regeneration flags.
+
+   Regeneration does not author module-size exceptions. A module above the
+   global budget must first be added to `OVER_BUDGET_EXEMPTIONS` with a durable
+   reason, while ADR-0033 shrink locks remain in `SHRINK_LOCKED_MODULES`.
+   Removing a live shrink lock is itself treated as growth, so `--allow-growth`
+   cannot accidentally turn a protected module back into an ordinary one.
 
 **Dev-only-regen invariant.** Regeneration only ever happens when a developer
 passes `--update-baselines`. **CI must NEVER pass the flag — it only diffs.**
@@ -93,6 +118,9 @@ detected (`CI` env var), failing loudly instead of silently rewriting a baseline
   literals.
 - **No copy drift.** The committed file and the gate derive from the *same*
   function; they cannot disagree by a typo.
+- **Ratchets keep their direction.** One-command regeneration cannot silently
+  bless growth in module ceilings or guardrail snapshot debt; those changes have
+  a separate explicit flag and therefore a conspicuous review diff.
 - **Same diff-visibility.** A surface addition still produces a reviewed diff
   line — the deliberate acknowledgement is preserved, just in JSON.
 

--- a/docs/adr/0033-auth-consolidation-policy.md
+++ b/docs/adr/0033-auth-consolidation-policy.md
@@ -13,7 +13,9 @@ consequence needed handling: the shrink-lock guarantee below was carried by
 all four sanctioned `_auth` pins fell under it, so dropping them — as the raise's first draft did
 — would have silently repealed this ADR's "shrink-locked at its pin" rule and handed 275–410 lines
 of unratcheted growth back to already-consolidated modules. The locks therefore moved to a
-dedicated `SHRINK_LOCKED_CEILINGS` map in `tests/_guardrails/test_module_size_ratchet.py`, which
+dedicated `SHRINK_LOCKED_CEILINGS` view loaded by
+`tests/_guardrails/test_module_size_ratchet.py` from the regenerable
+`tests/fixtures/baselines/module_size.json`, which
 carries the same grow/tighten semantics but is deliberately exempt from the
 budget-below-every-ceiling invariant. **The guarantee in this ADR is unchanged; only its
 enforcement site moved.**
@@ -35,7 +37,7 @@ granularity without weakening its guarantee. Supersedes-by-deferral
 
 Before #2156, `_auth` was 27 modules / 12,730 lines (measured 2026-08-07; regenerate with
 `python -c "from pathlib import Path; ps=sorted(Path('src/notebooklm/_auth').rglob('*.py')); print(len(ps), sum(len(p.read_text(encoding='utf-8').splitlines()) for p in ps))"`
-— the snippet in `tests/_guardrails/test_module_size_ratchet.py` lists per-module counts over the
+— the `module_size.json` baseline lists per-module counts over the
 budget, which is a different figure). The 2026-08-07 architecture review found the
 residual friction has one dominant cause: **ADR-0008's 1000-line cap has been acting as the module
 boundary inside `_auth` instead of the seams.** The evidence is in the code's own comments, which
@@ -101,19 +103,21 @@ consolidation under `src/notebooklm/_auth/`** may register its merged module at 
 line count, annotated `# sanctioned merge (ADR-0033)` with a one-line note naming the absorbed
 modules and the PR.
 
-**Which map to register in** (since the 2026-08-12 amendment there are two, and the choice is
-mechanical — compare the measured LOC against `MODULE_SIZE_BUDGET`):
+**Which authored policy set to register in** (the baseline derives the measured maps from these
+sets, and the choice is mechanical — compare the measured LOC against `MODULE_SIZE_BUDGET`):
 
-| measured LOC | map | enforced by |
-|---|---|---|
-| **over** budget | `ALLOWLISTED_CEILINGS` | `test_allowlisted_modules_do_not_exceed_their_ceiling`, `test_allowlisted_ceilings_ratchet_down`, `test_budget_is_below_every_allowlisted_ceiling` |
-| **at or under** budget | `SHRINK_LOCKED_CEILINGS` | `test_shrink_locked_modules_do_not_exceed_their_pin`, `test_shrink_locked_ceilings_ratchet_down` |
+| measured LOC | authored policy | derived baseline view | enforced by |
+|---|---|---|---|
+| **over** budget | `OVER_BUDGET_EXEMPTIONS` with a durable reason | `ALLOWLISTED_CEILINGS` | `test_allowlisted_modules_do_not_exceed_their_ceiling`, `test_allowlisted_ceilings_ratchet_down`, `test_budget_is_below_every_allowlisted_ceiling` |
+| **at or under** budget | `SHRINK_LOCKED_MODULES` | `SHRINK_LOCKED_CEILINGS` | `test_shrink_locked_modules_do_not_exceed_their_pin`, `test_shrink_locked_ceilings_ratchet_down` |
 
 Both carry identical grow/tighten semantics, so the shrink-lock guarantee below is the same either
 way. They differ only in the budget invariant: an `ALLOWLISTED_CEILINGS` entry must sit strictly
 *above* the budget (a redundant entry is a sign the budget was raised without re-baselining), while
 a `SHRINK_LOCKED_CEILINGS` entry sits *below* it by design. A module belongs to exactly one map —
-`test_shrink_locked_entries_are_disjoint_and_not_stale` fails if it is in both.
+`test_ceiling_sets_are_disjoint_and_not_stale` fails if it is in both. These maps are measured JSON
+projections, not policy authoring surfaces; edit the authored sets in
+`tests/_baselines/module_size.py`, then regenerate the baseline.
 
 This is the **one** exception to the ratchet's "the allowlist only shrinks and ceilings only
 tighten" convention, and it covers three cases:
@@ -252,8 +256,9 @@ Line count alone is never the trigger; any of the above is.
 
 - The plan's merges become legal as pure structural PRs: each merge PR moves file contents wholesale
   and records one annotated ceiling, with no gate-code change required for the ratchet itself
-  (mechanism (b): the ceiling maps carry the exception — `ALLOWLISTED_CEILINGS` when the merged
-  module lands over budget, `SHRINK_LOCKED_CEILINGS` when it lands under; see decision 1).
+  (mechanism (b): the authored policy sets carry the exception — `OVER_BUDGET_EXEMPTIONS` with a
+  reason when the merged module lands over budget, `SHRINK_LOCKED_MODULES` when it lands under;
+  regeneration records the corresponding measured ceiling; see decision 1).
 - Re-accretion protection is preserved everywhere it still applies. The modules the plan does *not*
   merge keep the plain budget; the modules it does merge are shrink-locked at their measured pin.
 - ADR-0029's boundary stays by-construction, but its assertion is now a name list that must be

--- a/docs/development.md
+++ b/docs/development.md
@@ -925,6 +925,11 @@ surface change is a deliberate, diff-visible act. These **regenerable baselines*
 | `types_all` | `notebooklm.types.__all__` | `tests/fixtures/baselines/types_all.json` |
 | `ungated_surface` | collected `__all__` of each ungated public module | `tests/fixtures/baselines/ungated_surface.json` |
 | `cli_contract` | `build_cli_contract()` | `tests/fixtures/cli_contract_baseline.json` |
+| `auth_import_graph` | static direct imports under `notebooklm._auth` | `tests/fixtures/baselines/auth_import_graph.json` |
+| `auth_patch_sites` | auth test patch-site audit | `tests/fixtures/baselines/auth_patch_sites.json` |
+| `module_size` | live over-budget and ADR-0033 shrink-locked LOC | `tests/fixtures/baselines/module_size.json` |
+| `storage_transaction_policy` | AST-derived lock-policy callers | `tests/fixtures/baselines/storage_transaction_policy.json` |
+| `guardrail_inline_literals` | grandfathered large guardrail literals | `tests/fixtures/baselines/guardrail_inline_literals.json` |
 
 The freeze test `test_baseline_matches_committed_file` (in
 `tests/_guardrails/test_public_surface_manifest.py`) asserts each committed file
@@ -935,6 +940,20 @@ the committed files in the **same PR**:
 ```bash
 python scripts/regen_baselines.py
 git diff tests/fixtures/baselines tests/fixtures/cli_contract_baseline.json
+```
+
+Shrink-only baselines reject weakening changes during ordinary regeneration.
+After reviewing an intentional ceiling increase, new policy caller, or new large
+guardrail literal, acknowledge it explicitly:
+
+```bash
+python scripts/regen_baselines.py --allow-growth
+```
+
+Run the complete AST/path/contract guard suite locally with:
+
+```bash
+make gates
 ```
 
 Review the diff — each changed line is the deliberate acknowledgement of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ markers = [
     "reality: tests that validate assumptions about external tools or environments; required lanes must execute them",
     "requires_playwright: tests requiring the Playwright Python package",
     "requires_chromium: tests requiring a launchable Chromium browser",
-    "repo_lint: repo-wide audit/compat checks (cassette shapes, public surface, release gates, doc-sync, CI script audits). Slow; skip locally with `-m \"not repo_lint\"`. CI still runs them by default.",
+    "repo_lint: repo-wide audit/compat checks (cassette shapes, public surface, release gates, doc-sync, CI script audits). Run locally with `make gates`; PR CI keeps critical contracts and nightly runs the full set.",
 ]
 
 [tool.coverage.run]

--- a/scripts/_tracked_files.py
+++ b/scripts/_tracked_files.py
@@ -1,0 +1,29 @@
+"""Small shared helper for repository gates that must ignore local scratch files."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def tracked_files(repo_root: Path, *, fallback_globs: tuple[str, ...]) -> list[Path]:
+    """Return git-tracked files, falling back to globs for synthetic test repos."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "-z"],
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode == 0:
+        return sorted(
+            repo_root / relative.decode("utf-8")
+            for relative in result.stdout.split(b"\0")
+            if relative
+        )
+
+    paths: set[Path] = set()
+    for pattern in fallback_globs:
+        paths.update(path for path in repo_root.glob(pattern) if path.is_file())
+    return sorted(paths)
+
+
+__all__ = ["tracked_files"]

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -1,4 +1,4 @@
-"""Assert pyproject.toml `fail_under` matches `.github/workflows/test.yml` `--cov-fail-under`.
+"""Assert nightly CI ultimately enforces pyproject.toml's coverage threshold.
 
 Prevents the two values from drifting (e.g. CI passing at 70% while pyproject
 demands 90%, or vice versa) by failing CI whenever they disagree.
@@ -10,7 +10,7 @@ files that lag the project-wide 90% are guarded by this script.
 
 Usage:
     python scripts/check_coverage_thresholds.py
-    python scripts/check_coverage_thresholds.py --pyproject custom/pyproject.toml --workflow custom/test.yml
+    python scripts/check_coverage_thresholds.py --pyproject custom/pyproject.toml --workflow custom/nightly.yml
     python scripts/check_coverage_thresholds.py --coverage-json coverage.json
 
 Exit codes:
@@ -40,7 +40,7 @@ else:
 
 
 def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
-    """Compare pyproject ``fail_under`` against CI ``--cov-fail-under``."""
+    """Compare pyproject ``fail_under`` against CI's enforcing threshold."""
     try:
         with open(pyproject_path, "rb") as f:
             pp = tomllib.load(f)
@@ -67,7 +67,9 @@ def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
     # Scan line-by-line and ignore commented YAML lines so a stale
     # `# --cov-fail-under=90` doesn't shadow a real drift in the executed
     # command. Collect ALL occurrences so a workflow with multiple jobs
-    # cannot smuggle a divergent threshold past the check.
+    # cannot smuggle a divergent threshold past the check. A zero threshold is
+    # permitted for an intermediate ``--cov-append`` workflow step, but at
+    # least one later occurrence must enforce the configured project floor.
     thresholds: list[int] = []
     pattern = re.compile(r"(?<!\S)--cov-fail-under(?:=|\s+)(\d+)(?!\S)")
     for line in yml.splitlines():
@@ -82,7 +84,7 @@ def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
         return 2
 
     for ci_threshold in thresholds:
-        if pyproject_threshold != ci_threshold:
+        if ci_threshold not in {0, pyproject_threshold}:
             print(
                 f"DRIFT: pyproject.toml fail_under={pyproject_threshold} but "
                 f"{workflow_path} --cov-fail-under={ci_threshold}",
@@ -90,7 +92,15 @@ def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
             )
             return 1
 
-    print(f"OK: {len(thresholds)} occurrence(s), all at {pyproject_threshold}%")
+    if pyproject_threshold not in thresholds:
+        print(
+            f"DRIFT: {workflow_path} only defers coverage enforcement; no "
+            f"--cov-fail-under={pyproject_threshold} matches pyproject.toml",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(thresholds)} occurrence(s), final floor enforced at {pyproject_threshold}%")
     return 0
 
 
@@ -198,7 +208,7 @@ def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pyproject", default="pyproject.toml")
-    ap.add_argument("--workflow", default=".github/workflows/test.yml")
+    ap.add_argument("--workflow", default=".github/workflows/nightly.yml")
     ap.add_argument(
         "--coverage-json",
         default=None,

--- a/scripts/check_docs_module_refs.py
+++ b/scripts/check_docs_module_refs.py
@@ -50,6 +50,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+if __package__:
+    from scripts._tracked_files import tracked_files
+else:  # pragma: no cover - exercised by the script entry-point subprocess tests
+    from _tracked_files import tracked_files
+
 # The package every reference resolves against.
 _PACKAGE_RELDIR = "src/notebooklm"
 
@@ -206,11 +211,12 @@ def _iter_docs(repo_root: Path):
     :func:`_is_historical_prose`) so the inline check skips them while the link
     check still applies.
     """
-    docs_dir = repo_root / "docs"
-    md_paths: list[Path] = []
-    if docs_dir.is_dir():
-        md_paths.extend(sorted(docs_dir.rglob("*.md")))
-    md_paths.extend(sorted(repo_root.glob("*.md")))
+    md_paths = [
+        path
+        for path in tracked_files(repo_root, fallback_globs=("docs/**/*.md", "*.md"))
+        if path.suffix == ".md"
+        and (path.parent == repo_root or path.is_relative_to(repo_root / "docs"))
+    ]
 
     for path in md_paths:
         rel = path.relative_to(repo_root).as_posix()

--- a/scripts/regen_baselines.py
+++ b/scripts/regen_baselines.py
@@ -15,6 +15,12 @@ changed line is a deliberate, reviewed acknowledgement of a public-surface chang
 
     python scripts/regen_baselines.py
 
+Shrink-only baselines accept tightening/removals with the ordinary command. A
+ceiling increase, new policy caller, or new large guardrail literal additionally
+requires explicit review and acknowledgement::
+
+    python scripts/regen_baselines.py --allow-growth
+
 **Dev-only-regen invariant (ADR-0022):** CI never regenerates — it only diffs the
 committed files against ``derive()``. This script (and the underlying fixture)
 refuses to run when a CI environment is detected, so it cannot silently rewrite
@@ -63,7 +69,7 @@ def main(argv: list[str] | None = None) -> int:
     if result.returncode == 0:
         print(
             "baselines regenerated; review `git diff` — each change is a "
-            "deliberate public-surface acknowledgement.",
+            "deliberate acknowledgement.",
             file=sys.stderr,
         )
     return result.returncode

--- a/tests/_baselines/guardrail_literals.py
+++ b/tests/_baselines/guardrail_literals.py
@@ -1,0 +1,83 @@
+"""Inventory large module-level container literals in guardrail tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+GUARDRAIL_ROOT = PROJECT_ROOT / "tests" / "_guardrails"
+LARGE_LITERAL_THRESHOLD = 20
+_CONTAINER_WRAPPERS = frozenset({"dict", "frozenset", "list", "set", "tuple"})
+
+
+def _target_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    return sorted(target.id for target in targets if isinstance(target, ast.Name))
+
+
+def _is_container_literal(value: ast.AST | None) -> bool:
+    if isinstance(value, ast.Dict | ast.List | ast.Set | ast.Tuple):
+        return True
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id in _CONTAINER_WRAPPERS
+    )
+
+
+def inventory_large_inline_literals(
+    guardrail_root: Path = GUARDRAIL_ROOT,
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> dict[str, dict[str, int]]:
+    """Return large module-level containers as path/name -> literal-leaf count."""
+    inventory: dict[str, dict[str, int]] = {}
+    for path in sorted(guardrail_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        assignments: dict[str, int] = {}
+        for node in tree.body:
+            if not isinstance(node, ast.Assign | ast.AnnAssign) or not _is_container_literal(
+                node.value
+            ):
+                continue
+            leaf_count = sum(isinstance(inner, ast.Constant) for inner in ast.walk(node.value))
+            if leaf_count < LARGE_LITERAL_THRESHOLD:
+                continue
+            for name in _target_names(node):
+                assignments[name] = leaf_count
+        if assignments:
+            inventory[path.relative_to(project_root).as_posix()] = assignments
+    return inventory
+
+
+def guardrail_literal_growth(previous: object, current: object) -> list[str]:
+    """Describe new or enlarged large literals in the guardrail inventory."""
+    if not isinstance(previous, dict) or not isinstance(current, dict):
+        raise ValueError("guardrail literal inventory must be a JSON object")
+
+    growth: list[str] = []
+    for path, assignments in sorted(current.items()):
+        if not isinstance(path, str) or not isinstance(assignments, dict):
+            raise ValueError("guardrail literal inventory must map paths to objects")
+        old_assignments = previous.get(path, {})
+        if not isinstance(old_assignments, dict):
+            raise ValueError("guardrail literal inventory must map paths to objects")
+        for name, size in sorted(assignments.items()):
+            if not isinstance(name, str) or not isinstance(size, int):
+                raise ValueError("guardrail literal sizes must be integers")
+            old_size = old_assignments.get(name)
+            if old_size is None:
+                growth.append(f"{path}:{name}: new {size}-leaf literal")
+            elif not isinstance(old_size, int):
+                raise ValueError("guardrail literal sizes must be integers")
+            elif size > old_size:
+                growth.append(f"{path}:{name}: {old_size} -> {size} literal leaves")
+    return growth
+
+
+__all__ = [
+    "LARGE_LITERAL_THRESHOLD",
+    "guardrail_literal_growth",
+    "inventory_large_inline_literals",
+]

--- a/tests/_baselines/module_size.py
+++ b/tests/_baselines/module_size.py
@@ -1,0 +1,149 @@
+"""Derivation and growth policy for the module-size baseline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOT = PROJECT_ROOT / "src" / "notebooklm"
+
+# This is authored policy, not frozen state. The measured ceilings live in the
+# committed baseline and are derived from the source tree.
+MODULE_SIZE_BUDGET = 1500
+# Authored exemptions preserve the review intent that JSON cannot carry. Values
+# explain why the path may remain over budget; measured ceilings stay derived.
+OVER_BUDGET_EXEMPTIONS: dict[str, str] = {
+    "exceptions.py": (
+        "canonical public exception home; moving classes would fork their documented provenance"
+    ),
+}
+SHRINK_LOCKED_MODULES: tuple[str, ...] = (
+    "_auth/browser_capture.py",
+    "_auth/psidts_recovery.py",
+    "_auth/refresh.py",
+    "_auth/storage.py",
+)
+
+
+def measure_modules(source_root: Path = SOURCE_ROOT) -> dict[str, int]:
+    """Return every package module's splitlines-compatible line count."""
+    return {
+        path.relative_to(source_root).as_posix(): len(path.read_text(encoding="utf-8").splitlines())
+        for path in sorted(source_root.rglob("*.py"))
+    }
+
+
+def derive_module_size() -> dict[str, object]:
+    """Derive the global budget plus every live ratchet ceiling."""
+    measured = measure_modules()
+    invalid_reasons = sorted(
+        path
+        for path, reason in OVER_BUDGET_EXEMPTIONS.items()
+        if not isinstance(reason, str) or not reason.strip()
+    )
+    if invalid_reasons:
+        raise RuntimeError(
+            f"over-budget exemptions require a durable authored reason: {invalid_reasons}"
+        )
+    authored_paths = set(OVER_BUDGET_EXEMPTIONS) | set(SHRINK_LOCKED_MODULES)
+    missing = sorted(authored_paths - set(measured))
+    if missing:
+        raise RuntimeError(f"authored module-size policy paths are stale: {missing}")
+
+    stale_exemptions = sorted(
+        path for path in OVER_BUDGET_EXEMPTIONS if measured[path] <= MODULE_SIZE_BUDGET
+    )
+    if stale_exemptions:
+        raise RuntimeError(
+            "over-budget exemptions are now at or below the budget; remove their authored "
+            f"entries before regenerating: {stale_exemptions}"
+        )
+
+    unapproved = {
+        path: lines
+        for path, lines in measured.items()
+        if lines > MODULE_SIZE_BUDGET and path not in authored_paths
+    }
+    if unapproved:
+        raise RuntimeError(
+            "modules exceed the budget without an authored exemption or ADR-0033 shrink lock: "
+            f"{unapproved}"
+        )
+
+    return {
+        "budget": MODULE_SIZE_BUDGET,
+        "allowlisted_ceilings": {
+            path: measured[path]
+            for path in sorted(authored_paths)
+            if measured[path] > MODULE_SIZE_BUDGET
+        },
+        "shrink_locked_ceilings": {
+            path: measured[path]
+            for path in SHRINK_LOCKED_MODULES
+            if measured[path] <= MODULE_SIZE_BUDGET
+        },
+    }
+
+
+def _integer_mapping(value: object, key: str) -> dict[str, int]:
+    if not isinstance(value, dict) or not isinstance(value.get(key), dict):
+        raise ValueError(f"module-size baseline must contain a {key!r} mapping")
+    mapping = value[key]
+    assert isinstance(mapping, dict)
+    if not all(isinstance(path, str) and isinstance(lines, int) for path, lines in mapping.items()):
+        raise ValueError(f"module-size baseline {key!r} must map paths to integers")
+    return mapping
+
+
+def module_size_growth(previous: object, current: object) -> list[str]:
+    """Describe ceiling/budget increases that weaken the shrink-only ratchet."""
+    if not isinstance(previous, dict) or not isinstance(current, dict):
+        raise ValueError("module-size baseline must be a JSON object")
+    previous_budget = previous.get("budget")
+    current_budget = current.get("budget")
+    if not isinstance(previous_budget, int) or not isinstance(current_budget, int):
+        raise ValueError("module-size baseline budget must be an integer")
+
+    growth: list[str] = []
+    if current_budget > previous_budget:
+        growth.append(f"budget: {previous_budget} -> {current_budget}")
+
+    for section in ("allowlisted_ceilings", "shrink_locked_ceilings"):
+        before = _integer_mapping(previous, section)
+        after = _integer_mapping(current, section)
+        other_section = (
+            "shrink_locked_ceilings"
+            if section == "allowlisted_ceilings"
+            else "allowlisted_ceilings"
+        )
+        other_before = _integer_mapping(previous, other_section)
+        for path, lines in sorted(after.items()):
+            old_lines = before.get(path)
+            if old_lines is None:
+                transition_lines = other_before.get(path)
+                if transition_lines is None:
+                    growth.append(f"{section}.{path}: new ceiling {lines}")
+                elif lines > transition_lines:
+                    growth.append(
+                        f"{path}: {other_section} {transition_lines} -> {section} {lines}"
+                    )
+            elif lines > old_lines:
+                growth.append(f"{section}.{path}: {old_lines} -> {lines}")
+
+    before_shrink_locked = _integer_mapping(previous, "shrink_locked_ceilings")
+    after_shrink_locked = _integer_mapping(current, "shrink_locked_ceilings")
+    after_allowlisted = _integer_mapping(current, "allowlisted_ceilings")
+    for path in sorted(before_shrink_locked):
+        if path not in after_shrink_locked and path not in after_allowlisted:
+            growth.append(f"shrink_locked_ceilings.{path}: protection removed")
+    return growth
+
+
+__all__ = [
+    "MODULE_SIZE_BUDGET",
+    "OVER_BUDGET_EXEMPTIONS",
+    "SHRINK_LOCKED_MODULES",
+    "derive_module_size",
+    "measure_modules",
+    "module_size_growth",
+]

--- a/tests/_baselines/registry.py
+++ b/tests/_baselines/registry.py
@@ -6,6 +6,8 @@ One place that knows, per *regenerable baseline*, how to:
 * where its committed JSON file lives (``Baseline.path``);
 * how to **serialize** it deterministically (``Baseline.dump`` /
   ``Baseline.sort_keys``).
+* for shrink-only ratchets, what counts as reviewed **growth**
+  (``Baseline.growth_check``).
 
 A baseline is a value the code already derives — e.g. ``notebooklm.types.__all__``
 or the collected public surface of the ungated public modules. The freeze tests
@@ -42,6 +44,8 @@ _BASELINES_DIR = _FIXTURES_DIR / "baselines"
 # ``scripts/audit_public_api_compat.py``). The collected public surface for a
 # module is ``__all__`` plus any *resolvable* allowlist extras not already in it.
 _ALLOWLIST_PATH = _PROJECT_ROOT / "scripts" / "api-compat-allowlist.json"
+
+GrowthCheck = Callable[[object, object], list[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +143,45 @@ def _derive_auth_import_graph() -> dict[str, object]:
     return build_projection()
 
 
+def _derive_module_size() -> dict[str, object]:
+    """Current module-size budget, allowlist ceilings, and shrink locks."""
+    from tests._baselines.module_size import derive_module_size
+
+    return derive_module_size()
+
+
+def _module_size_growth(previous: object, current: object) -> list[str]:
+    from tests._baselines.module_size import module_size_growth
+
+    return module_size_growth(previous, current)
+
+
+def _derive_storage_transaction_policy() -> dict[str, list[str]]:
+    """Direct callers of each profile-transaction lock-failure policy."""
+    from tests._baselines.storage_transaction_policy import derive_storage_transaction_policy
+
+    return derive_storage_transaction_policy()
+
+
+def _storage_transaction_policy_growth(previous: object, current: object) -> list[str]:
+    from tests._baselines.storage_transaction_policy import storage_transaction_policy_growth
+
+    return storage_transaction_policy_growth(previous, current)
+
+
+def _derive_guardrail_inline_literals() -> dict[str, dict[str, int]]:
+    """Large inline container literals still grandfathered in guardrail tests."""
+    from tests._baselines.guardrail_literals import inventory_large_inline_literals
+
+    return inventory_large_inline_literals()
+
+
+def _guardrail_inline_literal_growth(previous: object, current: object) -> list[str]:
+    from tests._baselines.guardrail_literals import guardrail_literal_growth
+
+    return guardrail_literal_growth(previous, current)
+
+
 # ---------------------------------------------------------------------------
 # Baseline registry
 # ---------------------------------------------------------------------------
@@ -150,8 +193,9 @@ class Baseline:
 
     ``derive`` returns the live value; ``path`` is the committed JSON file;
     ``sort_keys`` controls JSON key ordering on dump (lists always preserve
-    order — only dict *keys* are affected). ``load()`` reads the committed value;
-    ``write()`` rewrites it from ``derive()`` (dev-only, behind
+    order — only dict *keys* are affected). ``growth_check`` optionally protects
+    shrink-only state from accidental expansion. ``load()`` reads the committed
+    value; ``write()`` rewrites it from ``derive()`` (dev-only, behind
     ``--update-baselines``).
     """
 
@@ -159,6 +203,7 @@ class Baseline:
     path: Path
     derive: Callable[[], object]
     sort_keys: bool = False
+    growth_check: GrowthCheck | None = field(default=None, compare=False)
     # Extra metadata kept out of equality/hash; documents intent.
     description: str = field(default="", compare=False)
 
@@ -170,7 +215,7 @@ class Baseline:
         """The committed baseline value (parsed JSON)."""
         return json.loads(self.path.read_text(encoding="utf-8"))
 
-    def write(self) -> None:
+    def write(self, *, allow_growth: bool = False) -> None:
         """Rewrite the committed file from ``derive()``. Dev-only (regen seam).
 
         Enforces the dev-only-regen invariant at the seam itself (not only at the
@@ -182,11 +227,45 @@ class Baseline:
                 "refusing to regenerate baselines in CI: baselines are dev-only "
                 "regenerated and CI only diffs (ADR-0022)."
             )
+        derived = self.derive()
+        if self.growth_check is not None and self.path.is_file() and not allow_growth:
+            growth = self.growth_check(self.load(), derived)
+            if growth:
+                details = "\n  ".join(growth)
+                raise RuntimeError(
+                    f"refusing to grow the shrink-only {self.name} baseline:\n  {details}\n"
+                    "Review the growth, then rerun `python scripts/regen_baselines.py "
+                    "--allow-growth` to acknowledge it explicitly."
+                )
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(self.dump(self.derive()), encoding="utf-8")
+        self.path.write_text(self.dump(derived), encoding="utf-8")
 
 
 BASELINES: list[Baseline] = [
+    Baseline(
+        name="module_size",
+        path=_BASELINES_DIR / "module_size.json",
+        derive=_derive_module_size,
+        sort_keys=True,
+        growth_check=_module_size_growth,
+        description="Module-size budget plus live over-budget and shrink-locked ceilings.",
+    ),
+    Baseline(
+        name="storage_transaction_policy",
+        path=_BASELINES_DIR / "storage_transaction_policy.json",
+        derive=_derive_storage_transaction_policy,
+        sort_keys=True,
+        growth_check=_storage_transaction_policy_growth,
+        description="Direct owners of the profile transaction's lock-failure policies.",
+    ),
+    Baseline(
+        name="guardrail_inline_literals",
+        path=_BASELINES_DIR / "guardrail_inline_literals.json",
+        derive=_derive_guardrail_inline_literals,
+        sort_keys=True,
+        growth_check=_guardrail_inline_literal_growth,
+        description="Grandfathered large module-level literals in guardrail tests.",
+    ),
     Baseline(
         name="auth_patch_sites",
         path=_BASELINES_DIR / "auth_patch_sites.json",
@@ -237,6 +316,7 @@ def baseline_by_name(name: str) -> Baseline:
 __all__ = [
     "BASELINES",
     "Baseline",
+    "GrowthCheck",
     "UNGATED_PUBLIC_MODULES",
     "allowlist_extra_public_names",
     "baseline_by_name",

--- a/tests/_baselines/storage_transaction_policy.py
+++ b/tests/_baselines/storage_transaction_policy.py
@@ -1,0 +1,76 @@
+"""Derive the frozen lock-unavailable policy ownership snapshot."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+AUTH_ROOT = PROJECT_ROOT / "src" / "notebooklm" / "_auth"
+POLICY_NAMES: tuple[str, ...] = (
+    "raise_on_lock_unavailable",
+    "report_on_lock_unavailable",
+    "skip_on_lock_unavailable",
+)
+
+
+def _owned_functions(path: Path) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    module = path.stem
+    found: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            found[f"{module}.{node.name}"] = node
+        elif isinstance(node, ast.ClassDef):
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef | ast.AsyncFunctionDef):
+                    found[f"{module}.{node.name}.{member.name}"] = member
+    return found
+
+
+def _calls_bare_name(node: ast.AST, target: str) -> bool:
+    return any(
+        isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == target
+        for inner in ast.walk(node)
+    )
+
+
+def derive_storage_transaction_policy() -> dict[str, list[str]]:
+    """Map each policy function to its direct callers in the storage owners."""
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for name in ("profile_store.py", "storage.py"):
+        functions.update(_owned_functions(AUTH_ROOT / name))
+    return {
+        policy: sorted(owner for owner, node in functions.items() if _calls_bare_name(node, policy))
+        for policy in POLICY_NAMES
+    }
+
+
+def storage_transaction_policy_growth(previous: object, current: object) -> list[str]:
+    """Describe newly added policies/callers that need explicit acknowledgement."""
+    if not isinstance(previous, dict) or not isinstance(current, dict):
+        raise ValueError("storage transaction policy baseline must be a JSON object")
+
+    growth: list[str] = []
+    for policy, callers in sorted(current.items()):
+        if (
+            not isinstance(policy, str)
+            or not isinstance(callers, list)
+            or not all(isinstance(caller, str) for caller in callers)
+        ):
+            raise ValueError("storage policy baseline must map names to string lists")
+        old_callers = previous.get(policy, [])
+        if not isinstance(old_callers, list) or not all(
+            isinstance(caller, str) for caller in old_callers
+        ):
+            raise ValueError("storage policy baseline must map names to string lists")
+        for caller in sorted(set(callers) - set(old_callers)):
+            growth.append(f"{policy}: new caller {caller}")
+    return growth
+
+
+__all__ = [
+    "POLICY_NAMES",
+    "derive_storage_transaction_policy",
+    "storage_transaction_policy_growth",
+]

--- a/tests/_guardrails/test_install_docs.py
+++ b/tests/_guardrails/test_install_docs.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from scripts._tracked_files import tracked_files
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -38,6 +39,18 @@ INSTALLATION_LINK_RE = re.compile(r"\bdocs/installation\.md\b")
 
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _tracked_repository_files() -> list[Path]:
+    return tracked_files(REPO_ROOT, fallback_globs=("docs/**/*", "src/**/*", "*.md"))
+
+
+def _tracked_docs() -> list[Path]:
+    return [
+        path
+        for path in _tracked_repository_files()
+        if path.suffix == ".md" and path.is_relative_to(REPO_ROOT / "docs")
+    ]
 
 
 def _pyproject_extras() -> set[str]:
@@ -90,10 +103,6 @@ def test_no_wrong_package_name_anywhere() -> None:
     invalid PyPI package name. It must never appear in user-facing files.
     """
     bad_pattern = re.compile(r"notebooklm\[(browser|cookies|markdown)\]")
-    scan_dirs = [
-        REPO_ROOT / "docs",
-        REPO_ROOT / "src",
-    ]
     scan_files = [
         REPO_ROOT / "README.md",
         REPO_ROOT / "CONTRIBUTING.md",
@@ -103,27 +112,26 @@ def test_no_wrong_package_name_anywhere() -> None:
     ]
 
     hits: list[str] = []
+    tracked = set(_tracked_repository_files())
     for path in scan_files:
-        if path.is_file():
+        if path in tracked and path.is_file():
             for lineno, line in enumerate(_read(path).splitlines(), start=1):
                 if bad_pattern.search(line):
                     hits.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
 
-    for root in scan_dirs:
-        if not root.is_dir():
+    for path in tracked:
+        relative = path.relative_to(REPO_ROOT)
+        if not relative.parts or relative.parts[0] not in {"docs", "src"}:
             continue
-        for path in root.rglob("*"):
-            if not path.is_file():
-                continue
-            if path.suffix not in {".md", ".py", ".yml", ".yaml"}:
-                continue
-            try:
-                text = _read(path)
-            except (OSError, UnicodeDecodeError):
-                continue
-            for lineno, line in enumerate(text.splitlines(), start=1):
-                if bad_pattern.search(line):
-                    hits.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+        if path.suffix not in {".md", ".py", ".yml", ".yaml"}:
+            continue
+        try:
+            text = _read(path)
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if bad_pattern.search(line):
+                hits.append(f"{relative}:{lineno}: {line.strip()}")
 
     assert not hits, (
         "Found `notebooklm[<extra>]` (missing `-py`) — should be `notebooklm-py[<extra>]`:\n"
@@ -220,7 +228,7 @@ def test_installation_md_internal_anchors_resolve() -> None:
     cross_link_re = re.compile(r"\(([^)]*installation\.md)#([a-z0-9-]+)\)")
 
     failures: list[str] = []
-    scan_files = list((REPO_ROOT / "docs").rglob("*.md"))
+    scan_files = _tracked_docs()
     scan_files += [
         REPO_ROOT / "README.md",
         REPO_ROOT / "CONTRIBUTING.md",
@@ -291,9 +299,7 @@ def test_no_uv_sync_all_extras_in_canonical_install_paths() -> None:
         AGENTS_MD,
         SKILL_MD,
     ]
-    forbidden_locations += [
-        p for p in (REPO_ROOT / "docs").rglob("*.md") if p.name not in {"installation.md"}
-    ]
+    forbidden_locations += [path for path in _tracked_docs() if path.name != "installation.md"]
 
     hits: list[str] = []
     for path in forbidden_locations:

--- a/tests/_guardrails/test_module_size_ratchet.py
+++ b/tests/_guardrails/test_module_size_ratchet.py
@@ -1,511 +1,172 @@
-"""Meta-lint: a module-size ratchet for ``src/notebooklm/``.
+"""Module-size invariants backed by the ADR-0022 baseline registry.
 
-ADR-0008 (``docs/adr/0008-cli-services-extraction-pattern.md``) recorded the
-missing line-count gate at the time this guard was introduced: the session
-command shrink target "lands when the proxy block goes", while the existing
-diagnostic (``scripts/audit_test_suite.py``) only printed the top files by line
-count. This lint is the enforcement that closes that gap and prevents oversized
-modules from re-accreting. It complements #1331 (which tracks three concrete
-splits):
-
-1. **No new fat modules.** Any module under ``src/notebooklm/`` that exceeds
-   :data:`MODULE_SIZE_BUDGET` lines and is *not* in :data:`ALLOWLISTED_CEILINGS`
-   fails the gate. New code must come in under budget or split.
-
-2. **Allowlisted ceilings only ratchet down.** Each currently-oversized module
-   is pinned at its *measured* current LOC. If someone grows an allowlisted
-   module past its recorded ceiling, the gate fails. If someone *shrinks* one
-   below its ceiling, the gate **also** fails — but with a "tighten the ceiling"
-   message: the recorded ceiling must be lowered to the new (smaller) count so
-   the saved ground can never be re-accreted. The allowlist can only get
-   smaller and its ceilings can only get tighter.
-
-   *One sanctioned exception* (``docs/adr/0033-auth-consolidation-policy.md``):
-   a **structural consolidation under** ``src/notebooklm/_auth/`` may add its
-   merged module at its *measured* LOC — and may raise an existing ``_auth``
-   entry when a **later** sanctioned merge lands in the same module — annotated
-   ``# sanctioned merge (ADR-0033)`` with the absorbed modules and the PR.
-   "Structural consolidation" is narrow and means one of exactly three things:
-   the recipient **absorbs a sibling** ``_auth`` **module in full** (the sibling
-   is deleted, or reduced to a one-line re-export shim, in the same PR); it takes
-   a **relocation that shrinks the donor by what it grows the recipient** — the
-   gate only ever sees the recipient, so the annotation must name the donor for
-   the reviewer to check; or it is a **template adoption**, where hand-rolled
-   logic inside the module converts onto a shared template. That third class has
-   **no donor** (the change is intra-module) and is still net-additive in lines,
-   because a template call site plus its ``body`` closure header and explicit
-   success return cost more than the inline preamble they replace — measured:
-   #2152 grew the same code 22 lines while converting three writers. What keeps
-   it from becoming "any growth I call a refactor" is that its evidence must be
-   machine-checkable: a raise under this class is legitimate **only** when a
-   companion ratchet's exception list shrinks in the same commit (for the storage
-   writers, ``test_storage_transaction_ratchet._UNCONVERTED``). Inbound code that
-   leaves no donor smaller and converts nothing is ordinary growth and is
-   forbidden. The
-   cap was acting as the module boundary inside ``_auth`` rather than the seams
-   (several modules' own docstrings cite this budget as their reason to exist),
-   so ADR-0033 scopes the cap to *file size* and lets the seams decide the
-   files. Nothing else moves: :data:`MODULE_SIZE_BUDGET` is unchanged and still
-   global, un-merged ``_auth`` modules stay under it (``cookies.py`` must not
-   silently grow), and each entry is **shrink-locked at its pin** the moment it
-   lands — from then on it ratchets down like any other. Entries are pinned at
-   *measured* LOC in the PR that lands the merge, never pre-registered at an
-   end-state estimate: check 2's slack arm below fails on any ceiling above the
-   current count, so ceiling and measurement must agree in the same commit.
-   Outside ``_auth/`` there is no exception — split the module.
-
-3. **No stale allowlist entries.** Every allowlisted path must still exist (a
-   rename/delete must update the allowlist).
-
-The ceilings below were *measured*, not estimated. To regenerate them (the
-``> 1500`` filter must track ``MODULE_SIZE_BUDGET`` below)::
-
-    python -c "from pathlib import Path; src=Path('src/notebooklm'); \
-        [print(f\"{len(p.read_text(encoding='utf-8').splitlines()):>6}  {p.relative_to(src).as_posix()}\") \
-         for p in sorted(src.rglob('*.py')) \
-         if len(p.read_text(encoding='utf-8').splitlines()) > 1500]"
-
-Line counting uses ``str.splitlines()`` to match the diagnostic in
-``scripts/audit_test_suite.py`` (``big_files``), so the two never disagree.
-
-Modelled after the AST/path lints in ``tests/_guardrails/`` (e.g.
-``test_no_inline_deprecation_warnings.py`` / ``test_no_module_shadowing.py``).
+The authored policy is a global line budget plus four ADR-0033 shrink locks.
+Measured ceilings are derived from the live source tree and stored in
+``tests/fixtures/baselines/module_size.json``. Tightening them is the ordinary
+regen path; adding or raising a ceiling requires ``--allow-growth``.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import cast
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SRC_ROOT = REPO_ROOT / "src" / "notebooklm"
+import pytest
 
-# Any *new* module is forbidden from exceeding this many lines: a round 1500-line
-# cap that new work must come in at/under or split before merge. The allowlist
-# below is the *complete* set of modules over budget today, so the gate is green
-# on main. (Raised from 900 -> 1000 once ``_chat/api.py``, ``_research.py`` and
-# ``cli/source_cmd.py`` were trimmed below the round cap.)
-#
-# Raised 1000 -> 1500 because the headroom left under the old cap had shrunk to
-# the point where ordinary feature work tripped it. The concrete case:
-# ``cli/session_cmd.py`` sat at 999 on main, and #2192 — a bug fix to
-# ``Notebook.is_owner`` that merely rendered a role — pushed it to 1006 and
-# failed all 15 test-matrix jobs. It was resolved by extracting the ``use``
-# one-row table into ``cli/_session_render.py``, which was a genuine improvement,
-# but the gate fired on a module the PR was not about.
-#
-# NOTE the trigger is 7 lines, not 1: this gate rejects only ``n > budget``, and
-# ``test_ratchet_checks_detect_their_offending_shapes`` pins that exactly-at-budget
-# passes. A 999-line module absorbs one more line and stays green. An earlier draft
-# of this comment claimed a one-line failure; that was wrong (caught in review) and
-# is corrected here rather than quietly dropped, because the false version overstated
-# the case for weakening the cap by 500 lines.
-MODULE_SIZE_BUDGET = 1500
+from tests._baselines.module_size import (
+    MODULE_SIZE_BUDGET as POLICY_MODULE_SIZE_BUDGET,
+)
+from tests._baselines.module_size import (
+    measure_modules,
+)
+from tests._baselines.registry import baseline_by_name
 
-# Every module currently over budget, pinned at its ratchet ceiling. These are
-# the only sanctioned exceedances; the map can only shrink and ceilings can only
-# tighten when the ratchet reports slack. Paths are POSIX-relative to
-# ``src/notebooklm/``.
-#
-# DO NOT raise a ceiling to make room for new code in a fat module — split it.
-# DO lower a ceiling when a module shrinks (the gate will tell you the value).
-#
-# The ONE exception (ADR-0033, ``docs/adr/0033-auth-consolidation-policy.md``):
-# a deliberate consolidation under ``src/notebooklm/_auth/`` may ADD its merged
-# module here — or RAISE its existing entry when a later sanctioned merge lands
-# in the same module — at the *measured* LOC of that PR, annotated
-# ``# sanctioned merge (ADR-0033)`` naming the absorbed modules and the PR.
-# That annotation is what distinguishes a sanctioned merge from ordinary
-# growth; an unannotated raise is the thing this comment forbids. After the
-# entry lands it is shrink-only like every other, :data:`MODULE_SIZE_BUDGET` is
-# unchanged, and un-merged ``_auth`` modules stay under it. No other directory
-# has this exception.
-#
-# The merge PR must be a PURE MOVE: new code, simplifications, and behavior
-# changes land in separate commits (ideally separate PRs) so the pin measures
-# the merge and not the merge plus growth. Nothing mechanical enforces that —
-# this gate compares a count to a number and cannot see WHY lines exist, so a
-# ceiling raise is only as trustworthy as the reviewer who read the diff.
-# The pin is also EXACT, so it leaves zero headroom: a module that will keep
-# growing under a governing plan takes its pin AFTER that growth, or takes the
-# growth in the same PR as the pin.
-ALLOWLISTED_CEILINGS: dict[str, int] = {
-    # The single remaining oversized module, pinned at its measured LOC.
-    # ``_chat/api.py``, ``_research.py``, ``cli/source_cmd.py``, ``_sources.py``,
-    # ``_artifact/downloads.py``, and ``_source/upload.py`` were drained below the
-    # 1000-line budget and removed (one-way ratchet); ``client.py`` dropped out
-    # earlier when its ``__init__`` body moved to ``_client_assembly.py``.
-    # ``_source/upload.py`` shed its pure decode/validation helpers to the sibling
-    # ``_source/_upload_decode.py``. ``_artifacts.py`` dropped out once its
-    # ``generate_*`` / ``revise_slide`` / ``retry_failed`` kickoff paths moved to
-    # the sibling ``_artifact/generation.py`` (``ArtifactGenerationService``).
-    #
-    # ``exceptions.py`` is the canonical public exception home — ``__all__`` and
-    # the public-surface manifest pin every class to ``notebooklm.exceptions``, so
-    # the classes cannot move to sibling files without forking that home. Bumped
-    # 1512 -> 1524 for ``MissingDependencyError`` (the new DEPENDENCY category's
-    # public exception; #1959), then 1524 -> 1577 for ``CollectionError`` +
-    # ``CollectionNotFoundError`` (the Collections domain; #2006), then
-    # 1577 -> 1599 for ``LockUnavailableError`` (the canonical-storage-writer
-    # fail-closed lock exception; ADR-0029 — replaces ``filelock.Timeout`` and
-    # must be public so callers catch it), then 1599 -> 1575 after the private
-    # response-preview helper moved to its credential-redaction home (#2132).
-    "exceptions.py": 1575,
-    # ``mcp/tools/sources.py`` was allowlisted at 1020 (over the then-1000-line budget
-    # after #1871's shared source-policy wiring + the await_upload era). #1890 folded
-    # source_add_and_wait + source_upload_bytes BACK into source_add — removing the two
-    # tool bodies (and ``_add_source_to_wait_on``) drained it to ~970 LOC, back UNDER the
-    # budget, so its exemption is dropped (one-way ratchet). The module is now gated
-    # by MODULE_SIZE_BUDGET like any other; keep it there.
-    #
-    # The four ``_auth`` modules that used to be listed here did NOT lose their ratchet
-    # when the budget rose 1000 -> 1500. They moved to :data:`SHRINK_LOCKED_CEILINGS`
-    # below, which preserves ADR-0033's shrink-lock guarantee independently of the
-    # global budget. This map is only for modules genuinely OVER budget.
-}
+pytestmark = pytest.mark.repo_lint
 
 
-# ADR-0033 shrink locks that must survive a budget raise.
-#
-# ADR-0033 requires every sanctioned ``_auth`` consolidation to stay **shrink-locked at
-# its measured pin** from the moment it lands. That guarantee was originally carried by
-# :data:`ALLOWLISTED_CEILINGS`, which only works while the pin sits above the budget.
-# When the budget rose 1000 -> 1500 all four fell under it, and simply dropping them
-# would have handed 275-410 lines of unratcheted growth back to modules that were
-# deliberately drained — silently repealing ADR-0033 as a side effect of an ADR-0008
-# change. (Caught in review on the budget-raise PR; the first draft did exactly that.)
-#
-# So the lock moved here instead. Same ratchet semantics as ALLOWLISTED_CEILINGS — may
-# not grow past the pin, must tighten when it shrinks — but deliberately NOT subject to
-# ``test_budget_is_below_every_allowlisted_ceiling``, because these pins are *below* the
-# budget by design. That is the whole point: a module can be under the global budget and
-# still be forbidden from re-accreting.
-#
-# DO NOT raise a pin to make room for new code. Split, or take the ADR-0033 sanctioned
-# route (which requires the ``# sanctioned merge (ADR-0033)`` annotation naming donor
-# and PR). DO lower a pin when a module shrinks — the gate prints the exact value.
-#
-# The arcs these pins lock in, for context on why they are worth keeping:
-#     _auth/storage.py           3102 -> 1089   (ADR-0034 PR4..PR11B, #2172 B3)
-#     _auth/browser_capture.py   1251 -> 1225   (ADR-0033 PR4.1, #2172 B3)
-#     _auth/psidts_recovery.py   1222 -> 1214   (ADR-0033 load-composition merge)
-#     _auth/refresh.py           1184           (ADR-0033 token-route fold)
-# The per-module "sanctioned merge" / "RATCHETED DOWN" annotations are preserved in this
-# file's git history at the commit that raised the budget.
-#
-# Note ``_auth/storage.py`` is *also* pinned at 1089 by
-# ``tests/_guardrails/test_auth_profile_document_boundary.py``, for a different reason
-# (a consumer boundary). Both are deliberate; a shrink there updates both.
-SHRINK_LOCKED_CEILINGS: dict[str, int] = {
-    # 1225 -> 1445: maintainer-sanctioned exception for #2257, NOT a precedent.
-    # The login wait could not be fixed without net growth, because the pin was
-    # exactly the module's size — every path forward (tolerating a failed
-    # navigation, resuming on the remaining budget, tracing the hop that
-    # Playwright hides) adds lines, and no trimming reaches zero. The split that
-    # this map normally demands would have moved the login-landing concern —
-    # including the tracing block ADR-0033 PR 4.1 deliberately absorbed here —
-    # back out into a new leaf; the maintainer chose to keep the consolidation
-    # and spend the pin instead.
-    # Still shrink-only from 1445. The next change to this module that frees
-    # lines should lower this back down; the gate prints the exact value.
-    "_auth/browser_capture.py": 1445,
-    "_auth/psidts_recovery.py": 1214,
-    "_auth/refresh.py": 1184,
-    "_auth/storage.py": 1089,
-}
+def _committed_policy() -> dict[str, object]:
+    value = baseline_by_name("module_size").load()
+    assert isinstance(value, dict)
+    return value
 
 
-def _line_count(path: Path) -> int:
-    """Return the line count of ``path`` using ``splitlines`` (matches the diagnostic)."""
-    return len(path.read_text(encoding="utf-8").splitlines())
-
-
-def _measure_all() -> dict[str, int]:
-    """Map every ``src/notebooklm/`` module (POSIX-relative) to its line count."""
-    return {
-        p.relative_to(SRC_ROOT).as_posix(): _line_count(p) for p in sorted(SRC_ROOT.rglob("*.py"))
-    }
-
-
-# --- Pure ratchet checks (no I/O) ----------------------------------------
-# The helpers below take a measured ``{path: loc}`` map and the policy knobs so
-# the public tests and the synthetic self-check exercise the *same* logic.
-# Keeping them I/O-free means the self-check can feed crafted maps (over budget
-# / grown / shrunk) without touching the filesystem.
+_POLICY = _committed_policy()
+MODULE_SIZE_BUDGET = cast(int, _POLICY["budget"])
+ALLOWLISTED_CEILINGS = cast(dict[str, int], _POLICY["allowlisted_ceilings"])
+SHRINK_LOCKED_CEILINGS = cast(dict[str, int], _POLICY["shrink_locked_ceilings"])
 
 
 def _over_budget_offenders(
     measured: dict[str, int], allowlist: dict[str, int], budget: int
 ) -> dict[str, int]:
-    """Un-allowlisted modules strictly over ``budget`` → ``{path: loc}``."""
-    return {rel: n for rel, n in measured.items() if n > budget and rel not in allowlist}
+    """Return unallowlisted modules strictly over the global budget."""
+    return {
+        path: lines for path, lines in measured.items() if lines > budget and path not in allowlist
+    }
 
 
 def _grown_offenders(
-    measured: dict[str, int], allowlist: dict[str, int]
+    measured: dict[str, int], ceilings: dict[str, int]
 ) -> dict[str, tuple[int, int]]:
-    """Allowlisted modules now larger than their ceiling → ``{path: (current, ceiling)}``."""
+    """Return pinned modules whose current line count exceeds the pin."""
     return {
-        rel: (measured[rel], ceiling)
-        for rel, ceiling in allowlist.items()
-        if rel in measured and measured[rel] > ceiling
+        path: (measured[path], ceiling)
+        for path, ceiling in ceilings.items()
+        if path in measured and measured[path] > ceiling
     }
 
 
 def _slack_offenders(
-    measured: dict[str, int], allowlist: dict[str, int]
+    measured: dict[str, int], ceilings: dict[str, int]
 ) -> dict[str, dict[str, int]]:
-    """Allowlisted modules now smaller than their ceiling → tighten-me map."""
+    """Return pinned modules that shrank and should tighten their pin."""
     return {
-        rel: {"current": measured[rel], "recorded_ceiling": ceiling}
-        for rel, ceiling in allowlist.items()
-        if rel in measured and measured[rel] < ceiling
+        path: {"current": measured[path], "recorded_ceiling": ceiling}
+        for path, ceiling in ceilings.items()
+        if path in measured and measured[path] < ceiling
     }
 
 
-def _stale_entries(measured: dict[str, int], allowlist: dict[str, int]) -> list[str]:
-    """Allowlisted paths that no longer exist under ``src/notebooklm/`` (sorted)."""
-    return sorted(rel for rel in allowlist if rel not in measured)
+def _stale_entries(measured: dict[str, int], ceilings: dict[str, int]) -> list[str]:
+    return sorted(path for path in ceilings if path not in measured)
+
+
+def test_baseline_budget_matches_authored_policy() -> None:
+    assert MODULE_SIZE_BUDGET == POLICY_MODULE_SIZE_BUDGET
 
 
 def test_no_new_modules_over_budget() -> None:
-    """No un-allowlisted module may exceed :data:`MODULE_SIZE_BUDGET` lines.
-
-    A new (or newly-grown) module over budget that is not in the allowlist means
-    the obesity the session-shrink arc pushed into feature modules is
-    re-accreting unchecked. Split the module, or — only if it is a genuinely
-    irreducible existing module — add it to :data:`ALLOWLISTED_CEILINGS` at its
-    measured LOC with a justification in review.
-
-    This is the check a consolidation PR hits first. A sanctioned ``_auth``
-    consolidation clears it the same way — by adding the merged module to
-    :data:`ALLOWLISTED_CEILINGS` at its measured LOC — but under rule 2's
-    exception above (ADR-0033), which additionally requires the
-    ``# sanctioned merge (ADR-0033)`` annotation naming the absorbed modules.
-    """
-    offenders = _over_budget_offenders(_measure_all(), ALLOWLISTED_CEILINGS, MODULE_SIZE_BUDGET)
+    offenders = _over_budget_offenders(measure_modules(), ALLOWLISTED_CEILINGS, MODULE_SIZE_BUDGET)
     assert offenders == {}, (
-        f"Module(s) exceed the {MODULE_SIZE_BUDGET}-line budget and are not "
-        f"allowlisted (ADR-0008 module-size ratchet). Split them, or add them to "
-        f"ALLOWLISTED_CEILINGS at their measured LOC with a review justification: "
-        f"{offenders}"
+        f"Module(s) exceed the {MODULE_SIZE_BUDGET}-line budget: {offenders}. "
+        "Split them, or—only after explicit review—regenerate with "
+        "`python scripts/regen_baselines.py --allow-growth`."
     )
 
 
 def test_allowlisted_modules_do_not_exceed_their_ceiling() -> None:
-    """Allowlisted modules must not grow past their recorded ceiling.
-
-    The ceiling is a *fixed point*, not a moving target: an allowlisted module
-    may shrink (see :func:`test_allowlisted_ceilings_ratchet_down`) but must
-    never grow. Growth past the pin means new bulk landed in an already-fat
-    module instead of being split out.
-    """
-    grown = _grown_offenders(_measure_all(), ALLOWLISTED_CEILINGS)
+    grown = _grown_offenders(measure_modules(), ALLOWLISTED_CEILINGS)
     assert grown == {}, (
-        "Allowlisted module(s) grew past their recorded ceiling (ADR-0008 "
-        "module-size ratchet). Split out the new bulk instead of growing a fat "
-        f"module {{path: (current, ceiling)}}: {grown}"
+        f"Allowlisted module(s) grew past their committed ceilings: {grown}. "
+        "Split the growth, or explicitly acknowledge a reviewed exception with "
+        "`python scripts/regen_baselines.py --allow-growth`."
     )
 
 
 def test_allowlisted_ceilings_ratchet_down() -> None:
-    """A shrunk allowlisted module must tighten its ceiling to the new count.
-
-    This is the ratchet: once a fat module drops below its recorded ceiling, the
-    saved ground is locked in by lowering (or removing) the ceiling. A stale
-    high ceiling would silently let the reclaimed lines re-accrete, defeating the
-    gate. When this fails it prints the exact value to record.
-    """
-    slack = _slack_offenders(_measure_all(), ALLOWLISTED_CEILINGS)
+    slack = _slack_offenders(measure_modules(), ALLOWLISTED_CEILINGS)
     assert slack == {}, (
-        "Allowlisted module(s) shrank below their recorded ceiling — tighten the "
-        "ratchet by lowering each ceiling in ALLOWLISTED_CEILINGS to the "
-        "'current' value (or removing the entry entirely if 'current' is now at "
-        f"or below the {MODULE_SIZE_BUDGET}-line budget): {slack}"
+        f"Allowlisted module(s) shrank: {slack}. Lock in the saved ground with "
+        "`python scripts/regen_baselines.py`."
     )
 
 
 def test_shrink_locked_modules_do_not_exceed_their_pin() -> None:
-    """ADR-0033 sanctioned modules must not re-accrete, budget raise or not.
-
-    These pins sit *below* :data:`MODULE_SIZE_BUDGET` on purpose. Without this
-    check, raising the global budget would silently repeal ADR-0033's shrink-lock
-    guarantee for every already-consolidated ``_auth`` module — which is exactly
-    what the first draft of the 1000 -> 1500 raise did.
-    """
-    grown = _grown_offenders(_measure_all(), SHRINK_LOCKED_CEILINGS)
+    grown = _grown_offenders(measure_modules(), SHRINK_LOCKED_CEILINGS)
     assert grown == {}, (
-        "ADR-0033 shrink-locked module(s) grew past their pin. These are locked "
-        "BELOW the global budget deliberately — being under MODULE_SIZE_BUDGET is "
-        "not permission to grow. Split, or take the sanctioned-merge route with its "
-        f"annotation {{path: (current, pin)}}: {grown}"
+        f"ADR-0033 shrink-locked module(s) grew past their pins: {grown}. "
+        "Split the growth, or explicitly acknowledge a sanctioned exception with "
+        "`python scripts/regen_baselines.py --allow-growth`."
     )
 
 
 def test_shrink_locked_ceilings_ratchet_down() -> None:
-    """A shrunk shrink-locked module must tighten its pin to the new count."""
-    slack = _slack_offenders(_measure_all(), SHRINK_LOCKED_CEILINGS)
+    slack = _slack_offenders(measure_modules(), SHRINK_LOCKED_CEILINGS)
     assert slack == {}, (
-        "ADR-0033 shrink-locked module(s) shrank below their pin — lower each pin in "
-        "SHRINK_LOCKED_CEILINGS to the 'current' value to lock the saved ground. Do "
-        "NOT delete the entry: unlike ALLOWLISTED_CEILINGS these pins are meant to "
-        f"live below the budget: {slack}"
+        f"ADR-0033 shrink-locked module(s) shrank: {slack}. Tighten the baseline with "
+        "`python scripts/regen_baselines.py`; do not delete under-budget shrink locks."
     )
 
 
-def test_shrink_locked_entries_are_disjoint_and_not_stale() -> None:
-    """The two ceiling maps must not overlap, and neither may go stale.
-
-    An overlap would mean one module answers to two pins that can drift apart;
-    a stale path can never trip any check, silently weakening the gate.
-    """
+def test_ceiling_sets_are_disjoint_and_not_stale() -> None:
+    measured = measure_modules()
     overlap = sorted(set(SHRINK_LOCKED_CEILINGS) & set(ALLOWLISTED_CEILINGS))
-    assert overlap == [], (
-        "Module(s) appear in BOTH ALLOWLISTED_CEILINGS and SHRINK_LOCKED_CEILINGS. "
-        "A module is either over budget (allowlist) or shrink-locked under it — "
-        f"never both: {overlap}"
-    )
-    missing = _stale_entries(_measure_all(), SHRINK_LOCKED_CEILINGS)
-    assert missing == [], (
-        "Shrink-locked path(s) no longer exist under src/notebooklm/ (renamed or "
-        f"deleted). Update SHRINK_LOCKED_CEILINGS: {missing}"
-    )
-
-
-def test_allowlist_has_no_stale_entries() -> None:
-    """Every allowlisted path must still exist under ``src/notebooklm/``.
-
-    A rename or deletion that leaves a dangling allowlist entry would silently
-    weaken the gate (the missing path can never trip checks 1-3), so it must be
-    pruned from :data:`ALLOWLISTED_CEILINGS`.
-    """
-    missing = _stale_entries(_measure_all(), ALLOWLISTED_CEILINGS)
-    assert missing == [], (
-        "Allowlisted path(s) no longer exist under src/notebooklm/ (renamed or "
-        f"deleted). Remove the stale ALLOWLISTED_CEILINGS entries: {missing}"
-    )
+    assert overlap == [], f"A module cannot carry both ceiling kinds: {overlap}"
+    missing = _stale_entries(measured, SHRINK_LOCKED_CEILINGS)
+    missing.extend(_stale_entries(measured, ALLOWLISTED_CEILINGS))
+    assert missing == [], f"Committed module-size baseline contains stale paths: {sorted(missing)}"
 
 
 def test_budget_is_below_every_allowlisted_ceiling() -> None:
-    """Invariant: the budget sits strictly below every allowlisted ceiling.
-
-    If the budget were >= some ceiling, that allowlist entry would be redundant
-    (the module would be under budget and need no exemption) — a sign the budget
-    was raised without re-baselining. Keeps the two knobs coherent.
-    """
-    too_low = {
-        rel: ceiling
-        for rel, ceiling in ALLOWLISTED_CEILINGS.items()
+    redundant = {
+        path: ceiling
+        for path, ceiling in ALLOWLISTED_CEILINGS.items()
         if ceiling <= MODULE_SIZE_BUDGET
     }
-    assert too_low == {}, (
-        f"Allowlist entries with a ceiling <= the {MODULE_SIZE_BUDGET}-line budget "
-        f"are redundant — drop them (the budget already covers the module): {too_low}"
+    assert redundant == {}, (
+        "Over-budget allowlist entries at or below the global budget are redundant; "
+        f"regenerate the baseline: {redundant}"
     )
 
 
 def test_ratchet_checks_detect_their_offending_shapes() -> None:
-    """Self-check: the pure ratchet checks flag each offending shape.
-
-    Guards against the lint silently degrading to a no-op (which would let the
-    re-accretion it exists to prevent slip through). Drives the *real* helpers
-    on crafted ``{path: loc}`` maps so we verify behavior, not just that the
-    live tree happens to be clean.
-    """
+    """Red-fires-red proof for every pure module-size detector."""
     budget = 900
-    allowlist = {"fat.py": 1000}
+    ceilings = {"fat.py": 1000}
 
-    # (1) Over-budget detection: un-allowlisted module over budget is flagged;
-    #     an allowlisted one and an under-budget one are not.
     measured = {"new_fat.py": 950, "fat.py": 1000, "small.py": 10}
-    assert _over_budget_offenders(measured, allowlist, budget) == {"new_fat.py": 950}
-    # Exactly at budget is allowed (strictly-greater-than rule).
-    assert _over_budget_offenders({"edge.py": budget}, allowlist, budget) == {}
+    assert _over_budget_offenders(measured, ceilings, budget) == {"new_fat.py": 950}
+    assert _over_budget_offenders({"edge.py": budget}, ceilings, budget) == {}
 
-    # (2) Growth detection: an allowlisted module above its ceiling is flagged
-    #     as (current, ceiling); at or below the ceiling is not.
-    assert _grown_offenders({"fat.py": 1001}, allowlist) == {"fat.py": (1001, 1000)}
-    assert _grown_offenders({"fat.py": 1000}, allowlist) == {}
-    assert _grown_offenders({"fat.py": 999}, allowlist) == {}
-
-    # (3) Slack/ratchet-down detection: an allowlisted module below its ceiling
-    #     is flagged with the tighten-to value; at or above is not.
-    assert _slack_offenders({"fat.py": 950}, allowlist) == {
+    assert _grown_offenders({"fat.py": 1001}, ceilings) == {"fat.py": (1001, 1000)}
+    assert _grown_offenders({"fat.py": 1000}, ceilings) == {}
+    assert _slack_offenders({"fat.py": 950}, ceilings) == {
         "fat.py": {"current": 950, "recorded_ceiling": 1000}
     }
-    assert _slack_offenders({"fat.py": 1000}, allowlist) == {}
-    assert _slack_offenders({"fat.py": 1001}, allowlist) == {}
-
-    # A path in the allowlist but absent from ``measured`` is ignored by the
-    # growth/slack checks (the stale-entry check owns that case)...
-    assert _grown_offenders({}, allowlist) == {}
-    assert _slack_offenders({}, allowlist) == {}
-
-    # (4) Stale-entry detection: an allowlisted path absent from ``measured`` is
-    #     flagged (sorted); a path still present is not.
-    assert _stale_entries({}, allowlist) == ["fat.py"]
-    assert _stale_entries({"fat.py": 1000}, allowlist) == []
-    assert _stale_entries({"other.py": 5}, {"b.py": 1, "a.py": 1}) == ["a.py", "b.py"]
+    assert _slack_offenders({"fat.py": 1000}, ceilings) == {}
+    assert _stale_entries({}, ceilings) == ["fat.py"]
 
 
 def test_credential_store_and_migration_modules_use_the_ordinary_budget() -> None:
-    leaves = {
+    """Retain the boundary invariant without transient exact-LOC snapshots."""
+    modules = {
         "_auth/credential_io.py",
         "_auth/master_token_file.py",
         "_auth/profile_migration.py",
         "_auth/profile_store.py",
     }
-    measured = _measure_all()
-    assert leaves.isdisjoint(ALLOWLISTED_CEILINGS)
-    assert {path: measured[path] for path in leaves} == {
-        "_auth/credential_io.py": 23,
-        "_auth/master_token_file.py": 89,
-        "_auth/profile_migration.py": 636,
-        "_auth/profile_store.py": 876,
-    }
-    assert (
-        measured["_auth/storage.py"]
-        + measured["_auth/profile_store.py"]
-        + measured["_auth/cookie_filter.py"]
-        + measured["_auth/profile_migration.py"]
-        == 2697
-    )
-    synthetic = dict.fromkeys(leaves, MODULE_SIZE_BUDGET + 1)
+    measured = measure_modules()
+    assert modules.isdisjoint(ALLOWLISTED_CEILINGS)
+    assert {path: measured[path] for path in modules if measured[path] > MODULE_SIZE_BUDGET} == {}
+
+    synthetic = dict.fromkeys(modules, MODULE_SIZE_BUDGET + 1)
     assert _over_budget_offenders(synthetic, {}, MODULE_SIZE_BUDGET) == synthetic
-
-
-def test_phase_11d_bootstrap_extraction_modules_are_measured_exactly() -> None:
-    measured = _measure_all()
-    assert {
-        path: measured[path]
-        for path in {
-            "_auth/master_token.py",
-            "_auth/master_token_bootstrap.py",
-            "_auth/storage.py",
-        }
-    } == {
-        "_auth/master_token.py": 469,
-        "_auth/master_token_bootstrap.py": 373,
-        "_auth/storage.py": 1089,
-    }
-
-
-def test_phase_13_caller_cleanup_modules_are_measured_exactly() -> None:
-    measured = _measure_all()
-    expected = {
-        "_app/login_cookie.py": 537,
-        "_app/master_token.py": 223,
-        "_app/profile.py": 355,
-        "cli/_cookie_import.py": 153,
-        "cli/master_token_login.py": 104,
-        "cli/playwright_login_io.py": 254,
-        "cli/profile_cmd.py": 436,
-        "cli/services/auth_refresh.py": 21,
-        "cli/services/login/browser_accounts.py": 365,
-        "cli/services/login/chromium_accounts.py": 268,
-        "cli/services/login/cookie_domains.py": 155,
-        "cli/services/login/cookie_jar.py": 244,
-        "cli/services/login/master_token.py": 152,
-        "cli/services/login/profile_targets.py": 150,
-        "cli/services/playwright_login.py": 542,
-    }
-    assert {path: measured[path] for path in expected} == expected

--- a/tests/_guardrails/test_no_large_inline_snapshots.py
+++ b/tests/_guardrails/test_no_large_inline_snapshots.py
@@ -1,0 +1,146 @@
+"""Prevent new large hand-maintained snapshots in guardrail modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._baselines.guardrail_literals import (
+    LARGE_LITERAL_THRESHOLD,
+    guardrail_literal_growth,
+    inventory_large_inline_literals,
+)
+from tests._baselines.module_size import module_size_growth
+from tests._baselines.registry import baseline_by_name
+from tests._baselines.storage_transaction_policy import storage_transaction_policy_growth
+
+pytestmark = pytest.mark.repo_lint
+
+
+def test_large_inline_literal_inventory_matches_registered_baseline() -> None:
+    committed = baseline_by_name("guardrail_inline_literals").load()
+    assert inventory_large_inline_literals() == committed, (
+        "Large inline guardrail literals changed. Prefer a derived registry baseline; "
+        "otherwise regenerate with `python scripts/regen_baselines.py` (new or larger "
+        "literals require `--allow-growth`)."
+    )
+
+
+def test_large_inline_literal_detector_bites_and_ignores_small_literals(tmp_path: Path) -> None:
+    """Red-fires-red proof for the meta-guard's real detector."""
+    guardrails = tmp_path / "tests" / "_guardrails"
+    guardrails.mkdir(parents=True)
+    leaves = ", ".join(repr(index) for index in range(LARGE_LITERAL_THRESHOLD))
+    (guardrails / "test_synthetic.py").write_text(
+        f"_FROZEN = [{leaves}]\n_SMALL = [1, 2]\n",
+        encoding="utf-8",
+    )
+    (guardrails / "_synthetic.py").write_text(
+        f"_WRAPPED = frozenset({{{leaves}}})\n",
+        encoding="utf-8",
+    )
+
+    assert inventory_large_inline_literals(guardrails, project_root=tmp_path) == {
+        "tests/_guardrails/_synthetic.py": {"_WRAPPED": LARGE_LITERAL_THRESHOLD},
+        "tests/_guardrails/test_synthetic.py": {"_FROZEN": LARGE_LITERAL_THRESHOLD},
+    }
+
+
+def test_growth_policies_detect_only_weakening_changes() -> None:
+    """Red-fires-red proof for the three shrink-only registry policies."""
+    assert module_size_growth(
+        {
+            "budget": 100,
+            "allowlisted_ceilings": {"fat.py": 110},
+            "shrink_locked_ceilings": {"locked.py": 90},
+        },
+        {
+            "budget": 101,
+            "allowlisted_ceilings": {"fat.py": 111, "new.py": 120},
+            "shrink_locked_ceilings": {"locked.py": 90},
+        },
+    ) == [
+        "budget: 100 -> 101",
+        "allowlisted_ceilings.fat.py: 110 -> 111",
+        "allowlisted_ceilings.new.py: new ceiling 120",
+    ]
+    assert (
+        module_size_growth(
+            {
+                "budget": 100,
+                "allowlisted_ceilings": {"fat.py": 110},
+                "shrink_locked_ceilings": {"locked.py": 90},
+            },
+            {
+                "budget": 100,
+                "allowlisted_ceilings": {"fat.py": 105},
+                "shrink_locked_ceilings": {"locked.py": 80},
+            },
+        )
+        == []
+    )
+    assert module_size_growth(
+        {
+            "budget": 100,
+            "allowlisted_ceilings": {},
+            "shrink_locked_ceilings": {"locked.py": 90},
+        },
+        {
+            "budget": 100,
+            "allowlisted_ceilings": {"locked.py": 101},
+            "shrink_locked_ceilings": {},
+        },
+    ) == [
+        "locked.py: shrink_locked_ceilings 90 -> allowlisted_ceilings 101",
+    ]
+    assert (
+        module_size_growth(
+            {
+                "budget": 100,
+                "allowlisted_ceilings": {"locked.py": 101},
+                "shrink_locked_ceilings": {},
+            },
+            {
+                "budget": 100,
+                "allowlisted_ceilings": {},
+                "shrink_locked_ceilings": {"locked.py": 90},
+            },
+        )
+        == []
+    )
+    assert module_size_growth(
+        {
+            "budget": 100,
+            "allowlisted_ceilings": {},
+            "shrink_locked_ceilings": {"locked.py": 90},
+        },
+        {
+            "budget": 100,
+            "allowlisted_ceilings": {},
+            "shrink_locked_ceilings": {},
+        },
+    ) == ["shrink_locked_ceilings.locked.py: protection removed"]
+
+    assert storage_transaction_policy_growth(
+        {"raise_on_lock_unavailable": ["owner.one"]},
+        {"raise_on_lock_unavailable": ["owner.one", "owner.two"]},
+    ) == ["raise_on_lock_unavailable: new caller owner.two"]
+    assert (
+        storage_transaction_policy_growth(
+            {"raise_on_lock_unavailable": ["owner.one", "owner.two"]},
+            {"raise_on_lock_unavailable": ["owner.one"]},
+        )
+        == []
+    )
+
+    assert guardrail_literal_growth(
+        {"tests/_guardrails/test_a.py": {"_FROZEN": 20}},
+        {
+            "tests/_guardrails/test_a.py": {"_FROZEN": 21},
+            "tests/_guardrails/test_b.py": {"_NEW": 30},
+        },
+    ) == [
+        "tests/_guardrails/test_a.py:_FROZEN: 20 -> 21 literal leaves",
+        "tests/_guardrails/test_b.py:_NEW: new 30-leaf literal",
+    ]

--- a/tests/_guardrails/test_public_surface_manifest.py
+++ b/tests/_guardrails/test_public_surface_manifest.py
@@ -1231,12 +1231,10 @@ def test_ungated_public_surface_covers_exactly_the_unpinned_modules() -> None:
 # ---------------------------------------------------------------------------
 # Regenerable-baseline freeze (ADR-0022).
 #
-# Every registered :class:`~tests._baselines.registry.Baseline` (``types_all``,
-# ``ungated_surface``, ``cli_contract``) is frozen here: the committed JSON file
-# must equal ``derive()``. A name added to (or removed from) a public surface
-# fails until the committed file is regenerated in the SAME PR — that diff line
-# is the deliberate, reviewed acknowledgement. Regenerate after an intended
-# change with::
+# Every registered :class:`~tests._baselines.registry.Baseline` is frozen here:
+# the committed JSON file must equal ``derive()``. Public-surface snapshots and
+# shrink-only ratchets share the same reviewable regen seam; ratchet growth also
+# requires ``--allow-growth``. Regenerate after an intended change with::
 #
 #     python scripts/regen_baselines.py
 #
@@ -1255,6 +1253,9 @@ def test_baseline_registry_is_non_trivial() -> None:
     assert {
         "auth_import_graph",
         "auth_patch_sites",
+        "guardrail_inline_literals",
+        "module_size",
+        "storage_transaction_policy",
         "types_all",
         "ungated_surface",
         "cli_contract",
@@ -1264,7 +1265,11 @@ def test_baseline_registry_is_non_trivial() -> None:
 
 
 @pytest.mark.parametrize("baseline", BASELINES, ids=lambda b: b.name)
-def test_baseline_matches_committed_file(baseline: Baseline, update_baselines: bool) -> None:
+def test_baseline_matches_committed_file(
+    baseline: Baseline,
+    update_baselines: bool,
+    allow_baseline_growth: bool,
+) -> None:
     """The committed baseline JSON must equal ``derive()`` (CI-mode assertion).
 
     With ``--update-baselines`` (dev only — see ``tests/conftest.py``), the
@@ -1272,7 +1277,7 @@ def test_baseline_matches_committed_file(baseline: Baseline, update_baselines: b
     committed file from ``derive()`` and passes. CI must never set the flag.
     """
     if update_baselines:
-        baseline.write()
+        baseline.write(allow_growth=allow_baseline_growth)
         return
 
     assert baseline.path.is_file(), (

--- a/tests/_guardrails/test_storage_transaction_ratchet.py
+++ b/tests/_guardrails/test_storage_transaction_ratchet.py
@@ -1,12 +1,9 @@
 """Shrink-only ownership gate for bounded and blocking profile transactions.
 
 ADR-0034 PR6 moved the real transaction definition and mechanics into the
-path-owned ``ProfileStore``. PR7A moved two account policy bodies onto its
-bounded primitive; PR7B added browser/remint replacement there; PR7C adds the
-login/import replacement; PR7D adds minted-session replacement. PR11B moves the
-remaining credential write onto ``MasterTokenFile``. The frozen 2 raise / 1 skip /
-2 report outcomes remain exact. Cookie persistence deliberately uses the separate
-blocking primitive.
+path-owned ``ProfileStore``. Policy ownership is now derived into the ADR-0022
+baseline registry instead of being pinned in this module or in a test name.
+Cookie persistence deliberately uses the separate blocking primitive.
 """
 
 from __future__ import annotations
@@ -21,6 +18,8 @@ from notebooklm._auth import profile_store, storage, storage_transaction
 from notebooklm._auth.profile_store import ProfileStore
 from notebooklm._auth.storage_lock import LockState
 from notebooklm.exceptions import LockUnavailableError
+from tests._baselines.registry import baseline_by_name
+from tests._baselines.storage_transaction_policy import derive_storage_transaction_policy
 
 pytestmark = pytest.mark.repo_lint
 
@@ -30,23 +29,6 @@ STORE_PATH = AUTH_ROOT / "profile_store.py"
 TOKEN_FILE_PATH = AUTH_ROOT / "master_token_file.py"
 
 _UNCONVERTED: frozenset[str] = frozenset()
-
-_POLICY_CALLERS: dict[str, frozenset[str]] = {
-    "raise_on_lock_unavailable": frozenset(
-        {
-            "profile_store.ProfileStore._update_account_if_document_unchanged",
-            "profile_store.ProfileStore.update_account",
-            "profile_store.ProfileStore.replace_minted_session",
-        }
-    ),
-    "skip_on_lock_unavailable": frozenset({"profile_store.ProfileStore.clear_account"}),
-    "report_on_lock_unavailable": frozenset(
-        {
-            "profile_store.ProfileStore.replace_from_login",
-            "profile_store.ProfileStore.replace_from_remint",
-        }
-    ),
-}
 
 _STORAGE_TRANSACTION_CALLERS: frozenset[str] = frozenset()
 
@@ -142,23 +124,13 @@ def test_storage_policy_body_routes_through_the_template_exactly() -> None:
     assert frozenset() == _UNCONVERTED
 
 
-def _qualified_callers(target: str) -> set[str]:
-    callers: set[str] = set()
-    for path in (STORE_PATH, STORAGE_PATH):
-        for owner, node in _owned_functions(path).items():
-            if target in _bare_calls(node):
-                callers.add(owner)
-    return callers
-
-
-def test_lock_unavailable_policy_ownership_is_exact_3_1_2() -> None:
-    actual = {policy: _qualified_callers(policy) for policy in _POLICY_CALLERS}
-    assert actual == {policy: set(callers) for policy, callers in _POLICY_CALLERS.items()}
-    assert {policy: len(callers) for policy, callers in actual.items()} == {
-        "raise_on_lock_unavailable": 3,
-        "skip_on_lock_unavailable": 1,
-        "report_on_lock_unavailable": 2,
-    }
+def test_lock_unavailable_policy_ownership_matches_registered_baseline() -> None:
+    committed = baseline_by_name("storage_transaction_policy").load()
+    assert derive_storage_transaction_policy() == committed, (
+        "Lock-unavailable policy ownership changed. Regenerate with "
+        "`python scripts/regen_baselines.py`; new callers additionally require "
+        "`--allow-growth`."
+    )
 
 
 def _is_lock_request_call(node: ast.AST) -> bool:

--- a/tests/_guardrails/test_type_boundaries.py
+++ b/tests/_guardrails/test_type_boundaries.py
@@ -13,13 +13,13 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from scripts._tracked_files import tracked_files
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = PROJECT_ROOT / "src" / "notebooklm"
 TYPES_PATH = SRC_ROOT / "types.py"
 PRIVATE_TYPES_ROOT = SRC_ROOT / "_types"
 CLI_ROOT = SRC_ROOT / "cli"
-PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
 INTERNAL_ARCHITECTURE_DOCS = {
     PROJECT_ROOT / "docs" / "development.md",
     PROJECT_ROOT / "docs" / "rpc-development.md",
@@ -99,15 +99,14 @@ def _cli_private_types_import_offenders(path: Path) -> list[str]:
 
 
 def _iter_public_docs() -> list[Path]:
-    docs: list[Path] = []
-    for root in PUBLIC_DOC_ROOTS:
-        if root.is_file():
-            docs.append(root)
-        elif root.is_dir():
-            docs.extend(
-                path for path in root.rglob("*.md") if path not in INTERNAL_ARCHITECTURE_DOCS
-            )
-    return sorted(docs)
+    tracked = tracked_files(PROJECT_ROOT, fallback_globs=("README.md", "docs/**/*.md"))
+    return sorted(
+        path
+        for path in tracked
+        if path.suffix == ".md"
+        and (path == PROJECT_ROOT / "README.md" or path.is_relative_to(PROJECT_ROOT / "docs"))
+        and path not in INTERNAL_ARCHITECTURE_DOCS
+    )
 
 
 def _public_docs_private_import_offenders() -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,15 @@ def pytest_addoption(parser):
         ),
     )
     parser.addoption(
+        "--allow-growth",
+        action="store_true",
+        default=False,
+        help=(
+            "DEV ONLY: explicitly acknowledge growth in shrink-only baselines. "
+            "Valid only together with --update-baselines."
+        ),
+    )
+    parser.addoption(
         "--require-reality",
         action="store_true",
         default=False,
@@ -282,8 +291,23 @@ def update_baselines(request) -> bool:
     return requested
 
 
+@pytest.fixture
+def allow_baseline_growth(request) -> bool:
+    """Whether shrink-only baseline growth was explicitly acknowledged."""
+    return bool(request.config.getoption("--allow-growth"))
+
+
 def pytest_configure(config):
     """Register custom markers and configure test environment."""
+    allow_growth = bool(config.getoption("--allow-growth"))
+    if allow_growth and not config.getoption("--update-baselines"):
+        raise pytest.UsageError("--allow-growth requires --update-baselines")
+    if allow_growth and os.environ.get("CI", "").strip():
+        raise pytest.UsageError(
+            "--allow-growth must not be used in CI: growth acknowledgement is a local, "
+            "reviewed baseline-regeneration action (ADR-0022)."
+        )
+
     xdist_active = (
         config.getoption("numprocesses", default=None) not in (None, 0)
         or config.getoption("dist", default="no") != "no"

--- a/tests/fixtures/baselines/guardrail_inline_literals.json
+++ b/tests/fixtures/baselines/guardrail_inline_literals.json
@@ -1,0 +1,117 @@
+{
+  "tests/_guardrails/_public_import_manifest.py": {
+    "_DOCUMENTED_PUBLIC_IMPORTS": 49
+  },
+  "tests/_guardrails/_wire_contract.py": {
+    "ENUM_BINDINGS": 156,
+    "ENUM_GAPS": 34,
+    "MAPPINGS": 669,
+    "PINNED": 114,
+    "UNMAPPED": 267
+  },
+  "tests/_guardrails/test_auth_cold_recovery_coordinator_boundary.py": {
+    "_EXPECTED_IMPORTS": 225
+  },
+  "tests/_guardrails/test_auth_cookie_docs.py": {
+    "AUTH_COOKIE_DEPRECATION_ROWS": 25
+  },
+  "tests/_guardrails/test_auth_cookie_filter_boundary.py": {
+    "_EXPECTED_IMPORTS": 25
+  },
+  "tests/_guardrails/test_auth_cookie_merge_boundary.py": {
+    "_EXPECTED_IMPORTS": 60
+  },
+  "tests/_guardrails/test_auth_master_token_bootstrap_boundary.py": {
+    "_ADAPTER_HASHES": 20,
+    "_EXPECTED_IMPORTS": 120,
+    "_METHOD_HASHES": 26
+  },
+  "tests/_guardrails/test_auth_master_token_file_boundary.py": {
+    "_EXPECTED_IMPORTS": 95
+  },
+  "tests/_guardrails/test_auth_master_token_types_boundary.py": {
+    "_EXPECTED_IMPORTS": 20
+  },
+  "tests/_guardrails/test_auth_mint_service_boundary.py": {
+    "_EXPECTED_IMPORTS": 55
+  },
+  "tests/_guardrails/test_auth_phase12c_boundaries.py": {
+    "_MODULE_HASHES": 34,
+    "_NODE_HASHES": 108
+  },
+  "tests/_guardrails/test_auth_profile_document_boundary.py": {
+    "_ALLOWED_IMPORTS": 52
+  },
+  "tests/_guardrails/test_auth_profile_store_boundary.py": {
+    "_EXPECTED_IMPORTS": 225,
+    "_NATIVE_REPLACE_CALLER_TESTS": 33
+  },
+  "tests/_guardrails/test_auth_storage_compatibility.py": {
+    "EXPECTED_ALIAS_CALLERS": 55,
+    "EXPECTED_DIRECT_CALLERS": 54,
+    "EXPECTED_SIGNATURES": 558,
+    "FACADE_INVENTORY_IDENTITIES": 23,
+    "LIVE_SIGNATURES": 61
+  },
+  "tests/_guardrails/test_auth_storage_lock_boundary.py": {
+    "_EXPECTED_IMPORTS": 95
+  },
+  "tests/_guardrails/test_auth_stored_auth_boundary.py": {
+    "_FORBIDDEN_TOKEN_CAPABILITIES": 35,
+    "_VALUE_FIELDS": 22
+  },
+  "tests/_guardrails/test_authtokens_jar_sync.py": {
+    "_COOKIE_SHADOW_INVENTORY": 96,
+    "_NON_AUTHTOKENS_CANDIDATES": 30
+  },
+  "tests/_guardrails/test_classify_error_handler_consistency.py": {
+    "_EXEMPLARS": 22
+  },
+  "tests/_guardrails/test_cli_boundary.py": {
+    "HELPERS_FACADE_ALLOWED_DEFS": 38
+  },
+  "tests/_guardrails/test_cli_vcr_coverage.py": {
+    "GROUP_COVERAGE": 24
+  },
+  "tests/_guardrails/test_error_contract_catch_ordering.py": {
+    "EXCLUDED_FROM_REQUIRED": 28
+  },
+  "tests/_guardrails/test_generation_kind_exhaustiveness.py": {
+    "EXPECTED_DURATION_HINT_BEHAVIOR": 22,
+    "KIND_TO_PAYLOAD_BUILDERS": 23,
+    "LOC": 42,
+    "_EXECUTOR_RAW_ARGS": 32
+  },
+  "tests/_guardrails/test_golden_decode_coverage.py": {
+    "GOLDEN_COVERAGE": 40
+  },
+  "tests/_guardrails/test_login_package_dag.py": {
+    "ALLOWED_EDGES": 43
+  },
+  "tests/_guardrails/test_mcp_classify_consistency.py": {
+    "_EXEMPLARS": 22
+  },
+  "tests/_guardrails/test_no_facade_reach_in.py": {
+    "_FORBIDDEN_PRIVATE_SERVICE_RUNTIME_IMPORT_MODULES": 25
+  },
+  "tests/_guardrails/test_no_session_compat_bridges.py": {
+    "CARVE_OUT_MODULES": 21
+  },
+  "tests/_guardrails/test_public_surface.py": {
+    "AUTH_CROSS_BOUNDARY_NAMES": 23,
+    "_AUTH_DEBLESSED_KEEP_IMPORTABLE": 40
+  },
+  "tests/_guardrails/test_public_surface_manifest.py": {
+    "_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES": 32,
+    "_REEXPORTED_RPC_ENUMS": 24,
+    "_RPC_LEGACY_REEXPORTS": 47,
+    "_TOP_LEVEL_EXCEPTION_EXPORTS": 50,
+    "_TOP_LEVEL_TYPE_EXPORTS": 60
+  },
+  "tests/_guardrails/test_server_classify_consistency.py": {
+    "_EXEMPLARS": 22
+  },
+  "tests/_guardrails/test_studio_enum_manifest.py": {
+    "_RPC_ENUM_SNAPSHOT": 290
+  }
+}

--- a/tests/fixtures/baselines/module_size.json
+++ b/tests/fixtures/baselines/module_size.json
@@ -1,0 +1,12 @@
+{
+  "allowlisted_ceilings": {
+    "exceptions.py": 1575
+  },
+  "budget": 1500,
+  "shrink_locked_ceilings": {
+    "_auth/browser_capture.py": 1445,
+    "_auth/psidts_recovery.py": 1214,
+    "_auth/refresh.py": 1184,
+    "_auth/storage.py": 1089
+  }
+}

--- a/tests/fixtures/baselines/storage_transaction_policy.json
+++ b/tests/fixtures/baselines/storage_transaction_policy.json
@@ -1,0 +1,14 @@
+{
+  "raise_on_lock_unavailable": [
+    "profile_store.ProfileStore._update_account_if_document_unchanged",
+    "profile_store.ProfileStore.replace_minted_session",
+    "profile_store.ProfileStore.update_account"
+  ],
+  "report_on_lock_unavailable": [
+    "profile_store.ProfileStore.replace_from_login",
+    "profile_store.ProfileStore.replace_from_remint"
+  ],
+  "skip_on_lock_unavailable": [
+    "profile_store.ProfileStore.clear_account"
+  ]
+}

--- a/tests/unit/test_baseline_registry.py
+++ b/tests/unit/test_baseline_registry.py
@@ -1,0 +1,55 @@
+"""Focused tests for ADR-0022 baseline growth acknowledgement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._baselines import module_size
+from tests._baselines.registry import Baseline
+
+
+def _new_items(previous: object, current: object) -> list[str]:
+    assert isinstance(previous, list)
+    assert isinstance(current, list)
+    return [f"new item {item}" for item in current if item not in previous]
+
+
+def test_shrink_only_baseline_write_requires_explicit_growth(tmp_path: Path) -> None:
+    path = tmp_path / "baseline.json"
+    state = [["existing"]]
+    baseline = Baseline(
+        name="synthetic",
+        path=path,
+        derive=lambda: state[0],
+        growth_check=_new_items,
+    )
+    baseline.write()
+
+    state[0] = ["existing", "added"]
+    with pytest.raises(RuntimeError, match="--allow-growth"):
+        baseline.write()
+    assert baseline.load() == ["existing"]
+
+    baseline.write(allow_growth=True)
+    assert baseline.load() == ["existing", "added"]
+
+
+def test_baseline_write_still_refuses_all_regeneration_in_ci(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    baseline = Baseline(name="synthetic", path=tmp_path / "baseline.json", derive=list)
+    monkeypatch.setenv("CI", "1")
+
+    with pytest.raises(RuntimeError, match="refusing to regenerate baselines in CI"):
+        baseline.write(allow_growth=True)
+
+
+def test_module_size_exemptions_require_authored_reasons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(module_size.OVER_BUDGET_EXEMPTIONS, "exceptions.py", " ")
+
+    with pytest.raises(RuntimeError, match="durable authored reason"):
+        module_size.derive_module_size()

--- a/tests/unit/test_baseline_registry.py
+++ b/tests/unit/test_baseline_registry.py
@@ -16,7 +16,13 @@ def _new_items(previous: object, current: object) -> list[str]:
     return [f"new item {item}" for item in current if item not in previous]
 
 
-def test_shrink_only_baseline_write_requires_explicit_growth(tmp_path: Path) -> None:
+def test_shrink_only_baseline_write_requires_explicit_growth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Exercise the developer-only growth seam even when the surrounding test
+    # runner (for example GitHub Actions) exports CI=true. The next test keeps
+    # the fail-closed CI behavior covered independently.
+    monkeypatch.delenv("CI", raising=False)
     path = tmp_path / "baseline.json"
     state = [["existing"]]
     baseline = Baseline(

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -159,7 +159,7 @@ def test_verify_package_e2e_retry_is_scoped_to_last_failed_e2e_tests():
 
 
 def test_coverage_thresholds_passes_on_real_state():
-    """Current pyproject.toml + test.yml agree on the coverage threshold."""
+    """Current pyproject.toml + nightly.yml agree on the coverage threshold."""
     result = _run([str(SCRIPTS / "check_coverage_thresholds.py")])
     assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
 
@@ -197,7 +197,7 @@ def test_coverage_thresholds_ignores_commented_cov_fail_under(tmp_path):
 
 
 def test_coverage_thresholds_catches_divergent_second_occurrence(tmp_path):
-    """Multiple --cov-fail-under occurrences must all match (not just the first)."""
+    """A nonzero divergent occurrence cannot hide behind a matching first one."""
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[tool.coverage.report]\nfail_under = 90\n")
     workflow = tmp_path / "test.yml"
@@ -219,6 +219,44 @@ def test_coverage_thresholds_catches_divergent_second_occurrence(tmp_path):
     assert result.returncode == 1
     assert "DRIFT" in result.stderr
     assert "--cov-fail-under=70" in result.stderr
+
+
+def test_coverage_thresholds_allows_zero_only_for_intermediate_collection(tmp_path):
+    """Split coverage may defer the floor, but a later command must enforce it."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.coverage.report]\nfail_under = 90\n")
+    workflow = tmp_path / "test.yml"
+    workflow.write_text(
+        "jobs:\n"
+        "  coverage:\n"
+        "    steps:\n"
+        "      - run: pytest --cov-fail-under=0\n"
+        "      - run: pytest --cov-append --cov-fail-under=90\n"
+    )
+
+    result = _run(
+        [
+            str(SCRIPTS / "check_coverage_thresholds.py"),
+            "--pyproject",
+            str(pyproject),
+            "--workflow",
+            str(workflow),
+        ]
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    workflow.write_text("jobs:\n  coverage:\n    steps:\n      - run: pytest --cov-fail-under=0\n")
+    result = _run(
+        [
+            str(SCRIPTS / "check_coverage_thresholds.py"),
+            "--pyproject",
+            str(pyproject),
+            "--workflow",
+            str(workflow),
+        ]
+    )
+    assert result.returncode == 1
+    assert "only defers coverage enforcement" in result.stderr
 
 
 def test_coverage_thresholds_detects_drift(tmp_path):

--- a/tests/unit/test_ci_test_matrix.py
+++ b/tests/unit/test_ci_test_matrix.py
@@ -10,14 +10,21 @@ import yaml
 pytestmark = pytest.mark.repo_lint
 
 WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "test.yml"
+NIGHTLY_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "nightly.yml"
 
 
-def test_test_matrix_is_independent_and_preserves_ci_contract():
-    """The test matrix must remain an independent 3-by-5 required check."""
+def _step(job: dict[str, object], name: str) -> dict[str, object]:
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return next(step for step in steps if isinstance(step, dict) and step.get("name") == name)
+
+
+def test_test_matrix_is_independent_and_preserves_ci_contract() -> None:
+    """The required matrix covers every Python plus one secondary-OS cell."""
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
 
-    assert {"quality", "test"} <= set(jobs)
+    assert {"quality", "test", "repo-lint"} <= set(jobs)
     assert jobs["quality"]["name"] == "Code Quality"
     assert jobs["test"]["name"] == "Test (${{ matrix.os }}, Python ${{ matrix.python-version }})"
     assert "needs" not in jobs["test"]
@@ -25,6 +32,254 @@ def test_test_matrix_is_independent_and_preserves_ci_contract():
 
     matrix = jobs["test"]["strategy"]["matrix"]
     assert matrix == {
-        "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-        "python-version": ["3.10", "3.11", "3.12", "3.13", "3.14"],
+        "include": [
+            {
+                "os": "ubuntu-latest",
+                "python-version": "3.10",
+                "canonical": False,
+                "windows_playwright": False,
+            },
+            {
+                "os": "ubuntu-latest",
+                "python-version": "3.11",
+                "canonical": False,
+                "windows_playwright": False,
+            },
+            {
+                "os": "ubuntu-latest",
+                "python-version": "3.12",
+                "canonical": True,
+                "windows_playwright": False,
+            },
+            {
+                "os": "ubuntu-latest",
+                "python-version": "3.13",
+                "canonical": False,
+                "windows_playwright": False,
+            },
+            {
+                "os": "ubuntu-latest",
+                "python-version": "3.14",
+                "canonical": False,
+                "windows_playwright": False,
+            },
+            {
+                "os": "macos-latest",
+                "python-version": "3.12",
+                "canonical": False,
+                "windows_playwright": False,
+            },
+            {
+                "os": "windows-latest",
+                "python-version": "3.12",
+                "canonical": False,
+                "windows_playwright": True,
+            },
+        ]
     }
+
+
+def test_pr_matrix_runs_once_without_coverage_and_canonical_owns_reality() -> None:
+    """Every cell runs the suite once; canonical alone owns browser contracts."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    test_job = workflow["jobs"]["test"]
+
+    marker_filter = "not repo_lint and not requires_playwright and not requires_chromium"
+    suite_step = _step(test_job, "Run tests without coverage")
+    suite_command = str(suite_step["run"])
+    assert "if" not in suite_step
+    assert marker_filter in suite_command
+    assert "-n auto" in suite_command
+    assert "--dist loadgroup" in suite_command
+    assert "--no-cov" in suite_command
+
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    assert "--cov" not in workflow_text
+    step_names = {step.get("name") for step in test_job["steps"]}
+    assert "Run tests with coverage" not in step_names
+    assert "Run compatibility tests without coverage" not in step_names
+    assert "Assert per-file coverage floors" not in step_names
+
+    canonical_steps = {
+        "Get Playwright version",
+        "Cache Playwright browsers",
+        "Install Playwright browsers",
+        "Install Playwright system dependencies (Linux)",
+        "Run required external-reality probes",
+        "Run Playwright-dependent unit tests serially",
+        "Run critical contract guards",
+    }
+    for name in canonical_steps:
+        assert _step(test_job, name)["if"] == "matrix.canonical"
+
+    reality_command = str(_step(test_job, "Run required external-reality probes")["run"])
+    assert "-m reality" in reality_command
+    assert "--require-reality" in reality_command
+
+    playwright_command = str(_step(test_job, "Run Playwright-dependent unit tests serially")["run"])
+    assert "tests/unit" in playwright_command
+    assert "(requires_playwright or requires_chromium) and not reality" in playwright_command
+    assert "-n 0" in playwright_command
+    assert "--no-cov" in playwright_command
+
+    critical_command = str(_step(test_job, "Run critical contract guards")["run"])
+    assert "-n auto" in critical_command
+    assert "--timeout=180" in critical_command
+    assert "--no-cov" in critical_command
+    assert "test_baseline_registry_is_non_trivial" in critical_command
+    assert "test_baseline_matches_committed_file" in critical_command
+    assert "test_no_flat_cookie_projection_reaches_an_http_request" in critical_command
+    assert "test_no_cli_module_imports_minting_primitives" in critical_command
+    assert "test_no_bare_master_token_derivation_outside_paths_module" in critical_command
+    assert "test_raw_sync_playwright_is_confined_to_policy_gateway" in critical_command
+    assert "tests/unit/test_ci_test_matrix.py" in critical_command
+
+    smoke = _step(test_job, "Run Windows Playwright compatibility smoke serially")
+    assert smoke["if"] == "matrix.windows_playwright"
+    smoke_command = str(smoke["run"])
+    assert (
+        "tests/unit/test_windows_compatibility.py::TestPlaywrightSmokeTest::"
+        "test_playwright_initializes_with_context_manager"
+    ) in smoke_command
+    assert "-m requires_playwright" in smoke_command
+    assert "-n 0" in smoke_command
+    assert "--no-cov" in smoke_command
+
+
+def test_nightly_coverage_is_sha_pinned_secret_free_and_enforces_floors() -> None:
+    """Scheduled/manual nightly owns global and per-file coverage enforcement."""
+    workflow = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    triggers = workflow.get("on", workflow.get(True))
+    assert set(triggers) == {"schedule", "workflow_dispatch"}
+
+    resolve_job = workflow["jobs"]["resolve-branch"]
+    resolve_checkout = next(
+        step
+        for step in resolve_job["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert resolve_checkout["with"] == {
+        "ref": "refs/heads/${{ steps.resolve.outputs.branch }}",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+    }
+
+    job = workflow["jobs"]["coverage"]
+    assert job["needs"] == "resolve-branch"
+    assert job["if"] == "needs.resolve-branch.outputs.is_standard == 'true'"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert "environment" not in job
+    assert "secrets." not in str(job)
+
+    checkout = next(
+        step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert checkout["uses"] == "actions/checkout@v7"
+    assert checkout["with"] == {
+        "ref": "${{ needs.resolve-branch.outputs.sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+    }
+
+    e2e_checkout = next(
+        step
+        for step in workflow["jobs"]["e2e"]["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert e2e_checkout["with"] == checkout["with"]
+
+    setup_python = _step(job, "Set up Python")
+    assert setup_python["uses"] == "actions/setup-python@v7"
+    assert setup_python["with"]["python-version"] == "3.12"
+    assert _step(job, "Install uv")["uses"] == (
+        "astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78"
+    )
+
+    install_command = str(_step(job, "Install dependencies")["run"])
+    assert "uv sync --frozen" in install_command
+    for extra in {"browser", "dev", "markdown", "mcp", "server", "impersonate", "cookies"}:
+        assert f"--extra {extra}" in install_command
+
+    assert _step(job, "Install Playwright browsers")["run"] == (
+        "uv run playwright install chromium"
+    )
+    assert _step(job, "Install Playwright system dependencies (Linux)")["run"] == (
+        "uv run playwright install-deps chromium"
+    )
+
+    ordinary_step = _step(job, "Run ordinary tests with coverage")
+    ordinary_command = str(ordinary_step["run"])
+    assert "-n auto" in ordinary_command
+    assert "--dist loadgroup" in ordinary_command
+    assert "not repo_lint and not requires_playwright and not requires_chromium" in ordinary_command
+    assert "--cov=src/notebooklm" in ordinary_command
+    assert "--cov-report=" in ordinary_command
+    assert "--cov-fail-under=0" in ordinary_command
+
+    playwright_step = _step(job, "Append Playwright-dependent unit coverage")
+    playwright_command = str(playwright_step["run"])
+    assert "tests/unit" in playwright_command
+    assert "(requires_playwright or requires_chromium) and not reality" in playwright_command
+    assert "-n 0" in playwright_command
+    assert "--cov=src/notebooklm" in playwright_command
+    assert "--cov-append" in playwright_command
+    assert "--cov-report=json:coverage.json" in playwright_command
+    assert "--cov-fail-under=90" in playwright_command
+
+    floor_step = _step(job, "Assert per-file coverage floors")
+    assert floor_step["run"] == (
+        "uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json"
+    )
+    assert job["steps"].index(ordinary_step) < job["steps"].index(playwright_step)
+    assert job["steps"].index(playwright_step) < job["steps"].index(floor_step)
+
+
+def test_repository_lint_is_a_bounded_manual_only_job() -> None:
+    """Deep repo audits have one manual lane, not one per compatibility cell."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["repo-lint"]
+
+    assert job["name"] == "Repository Lint (manual)"
+    assert job["if"] == "github.event_name == 'workflow_dispatch'"
+    assert "needs" not in job
+
+    command = str(_step(job, "Run repository lint tests")["run"])
+    assert "-m repo_lint" in command
+    assert "-n auto" in command
+    assert "--timeout=180" in command
+    assert "--no-cov" in command
+    assert "--cov=" not in command
+
+
+def test_repository_lint_is_scheduled_once_in_nightly() -> None:
+    """AST-heavy audits run automatically once against the resolved nightly SHA."""
+    workflow = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["repo-lint"]
+
+    assert job["needs"] == "resolve-branch"
+    assert job["if"] == "needs.resolve-branch.outputs.is_standard == 'true'"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert "environment" not in job
+    assert "secrets." not in str(job)
+
+    checkout = next(
+        step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert checkout["with"]["ref"] == "${{ needs.resolve-branch.outputs.sha }}"
+
+    command = str(_step(job, "Run repository lint tests")["run"])
+    assert "-m repo_lint" in command
+    assert "-n auto" in command
+    assert "--timeout=180" in command
+    assert "--no-cov" in command
+
+
+def test_cassette_and_fixture_scans_run_once_in_quality() -> None:
+    """Portable secret scans are not repeated across compatibility cells."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    quality_names = {step.get("name") for step in workflow["jobs"]["quality"]["steps"]}
+    test_names = {step.get("name") for step in workflow["jobs"]["test"]["steps"]}
+    scans = {"Assert cassettes are sanitized", "Check fixtures for credential leaks"}
+
+    assert scans <= quality_names
+    assert scans.isdisjoint(test_names)

--- a/tests/unit/test_tracked_files.py
+++ b/tests/unit/test_tracked_files.py
@@ -1,0 +1,20 @@
+"""Tests for repository scans that must ignore untracked local scratch."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts._tracked_files import tracked_files
+
+
+def test_tracked_files_excludes_untracked_scratch(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    tracked = tmp_path / "docs" / "tracked.md"
+    scratch = tmp_path / "docs" / "scratch.md"
+    tracked.parent.mkdir()
+    tracked.write_text("tracked\n", encoding="utf-8")
+    scratch.write_text("untracked\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "docs/tracked.md"], check=True)
+
+    assert tracked_files(tmp_path, fallback_globs=("docs/**/*.md",)) == [tracked]


### PR DESCRIPTION
## Summary

- migrate the remaining module-size and storage-policy snapshots into the ADR-0022 derive/store/compare/regen registry, with explicit shrink-only growth acknowledgement
- add an inventory gate for large inline guardrail literals, including helper modules and wrapped containers, and preserve authored module-size exemptions with required rationale
- reuse the focused CI shape from #2261: reduce the PR compatibility matrix, move coverage and AST-heavy repository audits to nightly/manual lanes, and retain critical contracts on every PR
- keep all Playwright-dependent unit tests in one canonical serial PR lane and append them to nightly coverage before enforcing global and per-file floors
- make documentation scans operate on Git-tracked files and expose the repository gates through `make gates`

Closes #2177

## Test plan

- `make gates` (1795 passed, 1 xfailed)
- `uv run pytest -n auto --dist loadgroup -m "not repo_lint and not requires_playwright and not requires_chromium" --no-cov` (14913 passed, 63 skipped)
- `uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0 --no-cov` (84 passed, 1 skipped)
- `uv run pre-commit run --all-files`
- `uv run ruff check .`
- `uv run mypy src/notebooklm`
- baseline regeneration idempotence check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nightly coverage enforcement and expanded repository quality checks.
  * Added a convenient `make gates` command for running repository lint checks locally.
  * Added safeguards for documentation links, module size, policy ownership, and oversized inline configuration.

* **Improvements**
  * Streamlined pull-request test execution across supported operating systems and Python versions.
  * Improved baseline regeneration controls to prevent unreviewed growth.
  * Updated development documentation with new quality and baseline workflows.

* **Tests**
  * Expanded validation for CI workflows, coverage thresholds, tracked files, and baseline protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->