### PR TITLE
fix(annotations): qualify class-body list annotations for Python 3.14

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -1,5 +1,6 @@
 """Backend-neutral notebook operations API."""
 
+import builtins
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -94,7 +95,7 @@ class NotebooksAPI(ABC):
         return None
 
     @abstractmethod
-    async def get_source_ids(self, notebook_id: str) -> list[str]:
+    async def get_source_ids(self, notebook_id: str) -> builtins.list[str]:
         """Return all source IDs in a notebook."""
 
     @abstractmethod
@@ -102,14 +103,14 @@ class NotebooksAPI(ABC):
         self,
         notebook_id: str,
         *,
-        source_ids: list[str] | None = None,
+        source_ids: builtins.list[str] | None = None,
         mode: int = 4,
         query: str | None = None,
-    ) -> list[PromptSuggestion]:
+    ) -> builtins.list[PromptSuggestion]:
         """Return AI-suggested prompts for a notebook."""
 
     @abstractmethod
-    async def list(self) -> list[Notebook]:
+    async def list(self) -> builtins.list[Notebook]:
         """List notebooks in backend-defined recent-first order."""
 
     async def create(self, title: str) -> Notebook:

--- a/src/notebooklm/_web/artifacts.py
+++ b/src/notebooklm/_web/artifacts.py
@@ -134,7 +134,7 @@ class WebArtifactsAPI(ArtifactsAPI):
 
     async def list(
         self, notebook_id: str, artifact_type: ArtifactType | None = None
-    ) -> list[Artifact]:
+    ) -> builtins.list[Artifact]:
         """List all artifacts in a notebook, including mind maps.
 
         Returns all AI-generated content. Note-backed mind maps live in the

--- a/src/notebooklm/_web/notebooks.py
+++ b/src/notebooklm/_web/notebooks.py
@@ -1,5 +1,6 @@
 """Web backend for notebook operations."""
 
+import builtins
 import logging
 import reprlib
 from typing import Any
@@ -259,7 +260,7 @@ class WebNotebooksAPI(NotebooksAPI):
     async def _rpc_call(
         self,
         method: RPCMethod,
-        params: list[Any],
+        params: builtins.list[Any],
         source_path: str = "/",
         allow_null: bool = False,
         _is_retry: bool = False,
@@ -278,7 +279,7 @@ class WebNotebooksAPI(NotebooksAPI):
             operation_variant=operation_variant,
         )
 
-    async def get_source_ids(self, notebook_id: str) -> list[str]:
+    async def get_source_ids(self, notebook_id: str) -> builtins.list[str]:
         """Extract all source IDs from a notebook.
 
         Fetches notebook data and extracts source IDs for use with chat and
@@ -400,10 +401,10 @@ class WebNotebooksAPI(NotebooksAPI):
         self,
         notebook_id: str,
         *,
-        source_ids: list[str] | None = None,
+        source_ids: builtins.list[str] | None = None,
         mode: int = _PROMPT_SUGGESTIONS_DEFAULT_MODE,
         query: str | None = None,
-    ) -> list[PromptSuggestion]:
+    ) -> builtins.list[PromptSuggestion]:
         """Get AI-suggested prompts for a notebook.
 
         Backed by ``GeneratePromptSuggestions`` (``otmP3b``): a *general*
@@ -476,7 +477,7 @@ class WebNotebooksAPI(NotebooksAPI):
             if row.is_well_formed
         ]
 
-    async def list(self) -> list[Notebook]:
+    async def list(self) -> builtins.list[Notebook]:
         """List notebooks (most-recently-viewed first).
 
         .. note::

--- a/src/notebooklm/_web/sources/__init__.py
+++ b/src/notebooklm/_web/sources/__init__.py
@@ -116,7 +116,7 @@ class WebSourcesAPI(SourcesAPI):
     async def _rpc_call(
         self,
         method: RPCMethod,
-        params: list[Any],
+        params: builtins.list[Any],
         source_path: str = "/",
         allow_null: bool = False,
         _is_retry: bool = False,
@@ -142,7 +142,7 @@ class WebSourcesAPI(SourcesAPI):
         strict: bool = False,
         statuses: Collection[SourceStatus] | None = None,
         types: Collection[SourceType] | None = None,
-    ) -> list[Source]:
+    ) -> builtins.list[Source]:
         """List all sources in a notebook.
 
         Args:

--- a/tests/_guardrails/test_builtin_shadowed_annotations.py
+++ b/tests/_guardrails/test_builtin_shadowed_annotations.py
@@ -1,0 +1,116 @@
+"""Guard that a class-body annotation never names a builtin the class shadows.
+
+``WebArtifactsAPI`` defines a method called ``list``, so inside that class body
+the name ``list`` is the method, not the builtin. Until Python 3.14 that was
+invisible: annotations were evaluated eagerly at ``def`` time, before the name
+was bound as a class attribute, so ``-> list[Artifact]`` resolved to the
+builtin and everything worked. PEP 649 defers the evaluation into a synthesized
+``__annotate__`` whose scope includes the class body, so the same annotation now
+resolves *after* the class exists and raises ``TypeError: 'function' object is
+not subscriptable`` the moment anything reads it (#2266).
+
+The repo's answer predates the break: ``builtins.list[...]`` is spelled
+explicitly at ~40 sites across the client classes for exactly this reason. The
+twelve sites #2266 found were the ones that missed the convention, not a
+different design. This lint keeps them from coming back.
+
+**Static on purpose.** It parses rather than imports, so it catches a 3.14-only
+break while running on 3.12 — which is where it will actually run. The failing
+signature check is marked ``repo_lint``, and every compatibility cell in
+``test.yml`` runs ``-m "not repo_lint"``, while both lanes that do execute
+``repo_lint`` pin 3.12. Adding a 3.14 lane would close today's hole on one
+version; parsing closes it on every version, including whichever one breaks
+next.
+
+**Every builtin, not just ``list``.** Only ``list`` is shadowed today. A future
+method named ``type``, ``filter`` or ``id`` fails the same way for the same
+reason, and there is no cost to covering it now.
+
+Modules carrying ``from __future__ import annotations`` are out of scope: their
+annotations are stored as strings and evaluated against module globals, where
+the builtin is still the builtin.
+
+Only annotations evaluated **in the class-body scope** count — method
+signatures and class-level variable annotations. A local annotation inside a
+method body (``source_ids: list[str] = []``) is not evaluated at all, and a
+nested ``def`` resolves in its enclosing function scope, so neither can see the
+class attribute. Flagging those would report a break that cannot happen.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = PROJECT_ROOT / "src" / "notebooklm"
+
+
+def _has_future_annotations(tree: ast.Module) -> bool:
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in tree.body
+    )
+
+
+def _shadowed_builtins(cls: ast.ClassDef) -> set[str]:
+    """Return the builtin names this class body rebinds."""
+    names: set[str] = set()
+    for node in cls.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return {name for name in names if hasattr(builtins, name)}
+
+
+def _class_scope_annotations(cls: ast.ClassDef) -> list[ast.expr]:
+    """Return the annotations evaluated in the class-body scope."""
+    annotations: list[ast.expr] = []
+    for node in cls.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs, args.vararg, args.kwarg]:
+                if arg is not None and arg.annotation is not None:
+                    annotations.append(arg.annotation)
+            if node.returns is not None:
+                annotations.append(node.returns)
+        elif isinstance(node, ast.AnnAssign):
+            annotations.append(node.annotation)
+    return annotations
+
+
+def test_class_body_annotations_do_not_name_a_shadowed_builtin() -> None:
+    offenders: list[str] = []
+
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if _has_future_annotations(tree):
+            continue
+        for cls in [node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]:
+            shadowed = _shadowed_builtins(cls)
+            if not shadowed:
+                continue
+            for annotation in _class_scope_annotations(cls):
+                for node in ast.walk(annotation):
+                    if isinstance(node, ast.Name) and node.id in shadowed:
+                        offenders.append(
+                            f"{path.relative_to(PROJECT_ROOT)}:{node.lineno} "
+                            f"({cls.name} shadows '{node.id}')"
+                        )
+
+    assert not offenders, (
+        "class-body annotation names a builtin the class rebinds, which resolves to the "
+        "class attribute under PEP 649 (#2266). Qualify it as 'builtins."
+        + "<name>[...]', the spelling the rest of the client classes already use:\n  "
+        + "\n  ".join(sorted(set(offenders)))
+    )


### PR DESCRIPTION
## Summary

The twelve class-body `list[...]` annotations PEP 649 breaks on 3.14, spelled `builtins.list[...]` per shape 2 — plus the static guardrail you sketched in option 2.

## Related Issue

Closes #2266

## Changes

- `builtins.list[...]` at the twelve sites: `_notebooks.py` (4), `_web/artifacts.py` (1), `_web/notebooks.py` (5), `_web/sources/__init__.py` (2).
- `import builtins` in `_notebooks.py` and `_web/notebooks.py`; the other two already had it.
- `tests/_guardrails/test_builtin_shadowed_annotations.py`, marked `repo_lint`. It parses rather than imports, so it catches a 3.14 break while running on 3.12, and it covers any builtin a class body rebinds, not just `list`.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass — 3.14.0, `-n auto --dist loadgroup --cov-fail-under=90`: 16,945 passed, 65 skipped, 1 xfailed, 96.54%. `test_backend_abstract_contracts.py` passes; `tests/_guardrails` alone, 2,157 passed.
- [x] Linting and formatting pass — `pre-commit run --all-files`
- [x] Type checking passes — `mypy src/notebooklm`, no issues in 372 source files
- [ ] If this PR changes architectural shape, an ADR has been added or updated. *(N/A — a test and twelve spellings.)*

## Notes

Thanks for the correction on the CI gap. The `repo_lint` marker was the piece I had wrong, and it's what made the static check the obvious shape rather than a version lane.

A first pass over the tree flagged fourteen sites. Two of them (`_web/notebooks.py:306,807`) are local annotations inside method bodies, which never resolve in the class-body scope — the guardrail skips function scopes for that reason. Your twelve are the set.

The guardrail does fail when it should: revert one site by hand and it reports `src/notebooklm/_web/artifacts.py:137 (WebArtifactsAPI shadows 'list')`.

Happy to reshape any of this if you'd rather it looked different.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Note deletion now supports multiple note IDs in a single request.
  * Deleting with an empty list performs no request.

* **Bug Fixes**
  * Improved compatibility with newer Python versions by preventing conflicts between built-in names and type annotations.

* **Tests**
  * Added coverage for batched note deletion, empty-list behavior, and annotation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->