### PR TITLE
fix(android): accept an unlabelled source guide for URL sources (#2276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `sources.get_guide()` on the Android backend no longer raises `DecodingError`
+  for URL sources. `GenerateDocumentGuides` labels a returned guide with the
+  requested source id for text sources but omits the label entirely for URL
+  sources, and the strict echo check rejected guides the server really had
+  returned. A populated-but-different echo is still a hard failure, and the
+  rejection paths now report the requested id, every observed echo, the guide
+  count, and the raw response bytes.
+
 ## [0.8.1] - 2026-08-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources, and the strict echo check rejected guides the server really had
   returned. A populated-but-different echo is still a hard failure, and the
   rejection paths now report the requested id, every observed echo, the guide
-  count, and the raw response bytes.
+  count, and each guide's protobuf field tags.
 
 ## [0.8.1] - 2026-08-14
 

--- a/docs/android/endpoints.md
+++ b/docs/android/endpoints.md
@@ -3,7 +3,7 @@
 **Status:** Recovered from capture, schema-level (field numbers + wire types), not
 field-named by Google
 
-**Last verified:** 2026-08-29 (`1.46.7` capture snapshot plus `1.55.10` binary delta)
+**Last verified:** 2026-08-31 (`1.46.7` capture snapshot plus `1.55.10` binary delta; `GenerateDocumentGuides` response re-probed live)
 
 **Scope:** the original `1.46.7.940945420` **49-method surface** (4 gRPC services) is enumerated
 and cross-referenced to the 48-method Web registry used for that audit. The newer Google-signed
@@ -540,11 +540,26 @@ questions):
 ```text
 request:  #1 { #1 str[36] }   # source_id, wrapped   + #2 context
 response: #1 {
-  #1 { #1 { #1 str[36] } }    # source_id
-  #2 { #1 str }               # (inferred) summary text
-  #3 { #1 (repeated) str }    # (inferred) suggested questions
+  #1 { #1 { #1 str[36] } }    # source_id — omitted entirely for URL sources
+  #2 { #1 str }               # summary text
+  #3 { #1 (repeated) str }    # main ideas / keywords (this capture guessed "suggested questions")
+  #4 { }                      # always zero-length in probed responses
 }
 ```
+
+Two readings in this capture were settled by a live probe on 2026-08-31 (issue #2276), which
+requested guides one source at a time for three URL and three pasted-text sources:
+
+- Response `#1` is **optional**. Text sources echo the requested id; URL sources omit `#1` from
+  the wire altogether, with no substitute identifier anywhere in the message. `sources.get_guide`
+  accordingly treats an absent echo as unlabelled rather than as a mismatch.
+- Response `#3` carries **keywords / main ideas**, not suggested questions: every probed source
+  returned five short noun phrases, none interrogative. The proto's own `main_ideas` name agrees.
+
+The client sends no `#2 context` and the probe succeeded without it, so the modelled-vs-captured
+gap on the request side is not load-bearing for this method. The endpoint is single-source: a
+two-source request is rejected with `INVALID_ARGUMENT`. Full table in
+[proto-evidence-ledger.md](proto-evidence-ledger.md#document-guide-source-echo).
 
 ## Write / mutation RPCs
 

--- a/docs/android/proto-evidence-ledger.md
+++ b/docs/android/proto-evidence-ledger.md
@@ -3,7 +3,7 @@
 **Status:** admitted read, notebook, source/upload, artifact, chat, notes/sharing,
 organization, Research, and public account-settings contracts
 
-**Evidence snapshot:** 2026-08-29
+**Evidence snapshot:** 2026-08-31 (`GenerateDocumentGuides` source echo re-probed live)
 
 **Scope:** project/source reads; notebook operations; URL, maintenance, content, and generic file
 source operations; artifact list/get/create/derive/update/delete, native note-backed mind-map
@@ -111,7 +111,7 @@ fixtures. Hashes prevent a later local checkout from silently changing what was 
 | [`artifact-contracts-and-live-validation.md`](artifact-contracts-and-live-validation.md) | `58af0bbeebdfa6a6a7366577d90a5479bdf971a1ed76fe3d6d7d0b8420f8454d` | consolidated artifact generation, representation, data-table, retry/export, mind-map, and transfer evidence; preserves all four source-report hashes and cleanup qualifications |
 | [`file-transfer-evidence.md`](file-transfer-evidence.md) | `f09a518c398f7355f7ab55c69d6e990037c806a9cc3e3f1291de5efd4971a6a5` | official-app/headless PDF upload request, qualified CSV/DOCX compatibility boundary, and live artifact representation/direct infographic/slide transfer |
 | [`resource-lifecycle-and-public-qualification.md`](resource-lifecycle-and-public-qualification.md) | `7e21ddb46ff851b9ae27c38c7ce6d18cfc6e4589f3730fe30160ef8f7dfcf585` | consolidated notebook copy/metadata, note/mind-map, label/collection, membership, cleanup, and public-qualification evidence; preserves all four source-report hashes |
-| [`endpoints.md`](endpoints.md) | `3d8879eff8427c3c0aac373308f695f8d220b6e4c98f51bfc2b419d367f4fd27` | live request/response envelopes, route results, version-scoped APK inventories, captured note/sharing bytes, and the account-bootstrap replay boundary |
+| [`endpoints.md`](endpoints.md) | `c4ed059c6812c5e7714366649592c41a1301cb83507770c37dc80df94600c8dd` | live request/response envelopes, route results, version-scoped APK inventories, captured note/sharing bytes, and the account-bootstrap replay boundary |
 
 The recovery method and the warning about duplicate packages are committed in
 [`README.md`](README.md#caveats-that-will-bite-you). Live request/response shapes are documented in
@@ -714,7 +714,7 @@ Blutter's generated-client binding proves `DeleteSources` returns
 | `orchestration.v1.InputSource` | `source_id #1` | exact closure; guide request/correlation |
 | `orchestration.v1.Snippet` | `text_snippet #1` | exact closure; guide summary |
 | `orchestration.v1.MainIdeas` | repeated `text_ideas #1` | exact closure; guide keywords |
-| `orchestration.v1.DocumentGuide` | `source #1`, `snippet #2`, `main_ideas #3` | exact closure; exact-ID guide projection |
+| `orchestration.v1.DocumentGuide` | `source #1` (optional on the wire), `snippet #2`, `main_ideas #3` | exact closure; guide projection keyed on an echo the server may omit — see [Document-guide source echo](#document-guide-source-echo) |
 | `orchestration.v1.GenerateDocumentGuidesRequest/Response` | repeated `sources #1` / repeated `guides #1` | exact method closure |
 | `orchestration.v1.TentativeSourceMetadata` | `name #1` | exact closure; bijective correlation key |
 | `orchestration.v1.AddTentativeSourcesRequest` | repeated metadata `#1`, `project_id #2`, `request_context #3`, `provenance #4` | exact closure; URL builders leave #3/#4 absent, file-upload registration populates them |
@@ -727,6 +727,41 @@ Blutter's generated-client binding proves `DeleteSources` returns
 | `orchestration.v1.RefreshSourceRequest/Response` | request `source_id #2`, `request_context #3`; response `source #1` | current-bundle constructor/accessor plus valid stale-Google-Doc Android refresh |
 | `orchestration.v1.PlainTextSourceContent` | `header #1`, `body #2` | exact response closure; flat text uses body |
 | `orchestration.v1.LoadSourceRequest/Response` | `source_id #1` / `source #1`, `plain_text #2`, `markdown_string #3`, `TailwindDoc #4` | exact method closure; current live responses used only `source #1` plus `TailwindDoc #4`, decoded through the local response overlay |
+
+### Document-guide source echo
+
+`DocumentGuide.source #1` is **optional in practice**, so requested-vs-echoed identity on
+`GenerateDocumentGuides` is a *leak* check, not a *presence* check. A current authenticated probe
+(2026-08-31, issue #2276) requested one guide at a time for three URL sources and three
+pasted-text sources:
+
+| Source kind | `DocumentGuide` fields on the wire | Echo |
+|---|---|---|
+| pasted text / markdown | `#1`, `#2`, `#3`, empty `#4` | `#1.source_id.id` equals the requested id |
+| URL / web page | `#2`, `#3`, empty `#4` — **no `#1`** | absent |
+
+The URL responses omit field `#1` from the serialized message entirely; the only other field
+present is a zero-length `#4`, which carries no identifier. That rules out the competing reading
+in which the server labels URL guides through an unmodelled `InputSource` branch (a crawled-document
+or web-content id) that our parser would report as `HasField("source_id") == False` — there is no
+such branch on the wire to miss. The same probe found that a two-source request is rejected with
+`INVALID_ARGUMENT`, so the endpoint is single-source and a lone unlabelled guide can only describe
+the source that was asked about.
+
+`sources.get_guide` therefore accepts a sole unlabelled guide, keeps the hard failure for a
+*populated and different* echo, and still requires an exact match once more than one guide is
+returned — the same `if echoed_id and echoed_id != source_id` convention already used by
+`refresh` and `check_freshness`. The rejection paths now carry the requested id, every observed
+echo, the guide count, and the raw response bytes, because the original error carried none of
+them and could not be diagnosed from CI logs.
+
+The probe also corroborates the `main_ideas #3` projection against the alternative reading of the
+captured app traffic (which annotates response `#3` as "(inferred) suggested questions"): all six
+sources returned five short noun phrases — `"Model Context Protocol"`, `"Centralised
+Authentication"`, `"Python Programming"` — none of them interrogative. `LoadSource` echoed the
+requested id on every probed source including the URL ones, so its sibling check is not affected;
+its unlabelled branch nonetheless now defers to `decode_source`, which reports missing-identifier
+drift instead of claiming the source does not exist.
 
 The admitted source overlay also carries the public text, YouTube, and Drive-reference branches used
 by `add_text`, YouTube `add_url`, and `add_drive`; their exact fields are exercised by focused

--- a/docs/android/proto-evidence-ledger.md
+++ b/docs/android/proto-evidence-ledger.md
@@ -752,8 +752,11 @@ the source that was asked about.
 *populated and different* echo, and still requires an exact match once more than one guide is
 returned — the same `if echoed_id and echoed_id != source_id` convention already used by
 `refresh` and `check_freshness`. The rejection paths now carry the requested id, every observed
-echo, the guide count, and the raw response bytes, because the original error carried none of
-them and could not be diagnosed from CI logs.
+echo, the guide count, and each guide's field tags, because the original error carried none of
+them and could not be diagnosed from CI logs. The tags are reported instead of a wire-byte preview:
+an unlabelled guide's payload begins with `#2 snippet`, so any prefix would carry the start of a
+model-written summary of the user's source into an error string that `NOTEBOOKLM_DEBUG=1` prints
+untruncated.
 
 The probe also corroborates the `main_ideas #3` projection against the alternative reading of the
 captured app traffic (which annotates response `#3` as "(inferred) suggested questions"): all six

--- a/src/notebooklm/_android/codecs/sources.py
+++ b/src/notebooklm/_android/codecs/sources.py
@@ -213,11 +213,6 @@ def decode_sources(
     return decoded
 
 
-# Structural prefix only: enough to see which field leads the first guide
-# without carrying the summary text that follows it.
-_WIRE_PREFIX_BYTES = 24
-
-
 def _document_guide_echo(guide: Any) -> str:
     """Return the source id a ``DocumentGuide`` labels itself with, or ``""``.
 
@@ -251,24 +246,85 @@ def _guide_failure(
     output. The counts and ids go in the *message*, which is what a pytest
     traceback prints in full.
 
-    ``raw_response`` carries only a short structural prefix of the wire bytes --
-    enough to read which field leads the first guide, which is the question
-    these branches exist to answer. It is capped *here* rather than left to
-    ``_truncate_response_preview``: hex-encoding makes the credential shapes
-    that ``scrub_secrets`` looks for unmatchable, and ``NOTEBOOKLM_DEBUG=1``
-    otherwise opts out of truncation entirely, which would splice a whole
-    model-written summary of the user's source into the exception string.
+    ``raw_response`` carries the per-guide **field tags** rather than any wire
+    bytes. Tags answer the question these branches exist to ask -- whether the
+    server labelled the guide at all, and whether it used a field we do not
+    model -- and they carry no content. A byte preview cannot: a guide's
+    payload begins with ``#2 snippet`` exactly when the label is missing, so
+    even a short prefix would capture the start of a model-written summary of
+    the user's source. Hex is reversible and merely hides that text from
+    ``scrub_secrets``, and ``NOTEBOOKLM_DEBUG=1`` opts out of truncation
+    entirely, so there is no safe prefix length.
     """
 
     observed = ", ".join(_guide_echo_diagnostic(echoes)) or "<none>"
-    wire = response.SerializeToString()
     return DecodingError(
-        f"{reason} (requested={source_id}, guides={len(response.guides)}, "
-        f"observed=[{observed}], bytes={len(wire)})",
+        f"{reason} (requested={source_id}, guides={len(response.guides)}, observed=[{observed}])",
         method_id=method_id,
         found_ids=_guide_echo_diagnostic(echoes),
-        raw_response=wire[:_WIRE_PREFIX_BYTES].hex(),
+        raw_response=_guide_field_tags(response),
     )
+
+
+def _guide_field_tags(response: Any) -> str:
+    """Render the field tags present on each guide, e.g. ``"[2,3,4 | 1,2,3]"``.
+
+    Read off the wire rather than from ``ListFields()`` so tags we do not model
+    are reported too -- an unmodelled tag is the shape that would indicate the
+    label had moved rather than been dropped. Only tag numbers are kept; no
+    payload is read.
+    """
+
+    return (
+        "["
+        + " | ".join(
+            ",".join(str(tag) for tag in _top_level_tags(guide.SerializeToString()))
+            for guide in response.guides
+        )
+        + "]"
+    )
+
+
+def _top_level_tags(payload: bytes) -> list[int]:
+    """List the top-level protobuf field numbers in ``payload``, skipping values."""
+
+    tags: list[int] = []
+    offset = 0
+    try:
+        while offset < len(payload):
+            key, offset = _read_varint(payload, offset)
+            tags.append(key >> 3)
+            offset = _skip_value(payload, offset, key & 7)
+    except (IndexError, ValueError):
+        tags.append(-1)  # truncated or unparsable past this point
+    return tags
+
+
+def _read_varint(payload: bytes, offset: int) -> tuple[int, int]:
+    value = shift = 0
+    while True:
+        byte = payload[offset]
+        offset += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, offset
+        shift += 7
+
+
+def _skip_value(payload: bytes, offset: int, wire_type: int) -> int:
+    if wire_type == 0:
+        _, offset = _read_varint(payload, offset)
+        return offset
+    if wire_type == 2:
+        length, offset = _read_varint(payload, offset)
+        if offset + length > len(payload):
+            raise IndexError("length-delimited field runs past the payload")
+        return offset + length
+    if wire_type == 5:
+        return offset + 4
+    if wire_type == 1:
+        return offset + 8
+    raise ValueError(f"unsupported wire type {wire_type}")
 
 
 def select_document_guide(response: Any, *, source_id: str, method_id: str) -> Any:

--- a/src/notebooklm/_android/codecs/sources.py
+++ b/src/notebooklm/_android/codecs/sources.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any, cast
 
 from ...exceptions import DecodingError
@@ -213,4 +213,109 @@ def decode_sources(
     return decoded
 
 
-__all__ = ["decode_source", "decode_sources"]
+# Structural prefix only: enough to see which field leads the first guide
+# without carrying the summary text that follows it.
+_WIRE_PREFIX_BYTES = 24
+
+
+def _document_guide_echo(guide: Any) -> str:
+    """Return the source id a ``DocumentGuide`` labels itself with, or ``""``.
+
+    The label is optional on the wire, so an empty return means *unlabelled*,
+    never *mismatched*.
+    """
+
+    if not guide.HasField("source") or not guide.source.HasField("source_id"):
+        return ""
+    return str(guide.source.source_id.id)
+
+
+def _guide_echo_diagnostic(echoes: Iterable[str]) -> list[str]:
+    """Render observed guide echoes for ``RPCError.found_ids``."""
+
+    return [echo or "<unlabelled>" for echo in echoes]
+
+
+def _guide_failure(
+    reason: str,
+    *,
+    source_id: str,
+    method_id: str,
+    response: Any,
+    echoes: Sequence[str],
+) -> DecodingError:
+    """Build a rejected-guide error that can be diagnosed from a CI log alone.
+
+    The original strict-echo branches reported neither the observed ids nor the
+    guide count, which is why issue #2276 could not be closed from the nightly
+    output. The counts and ids go in the *message*, which is what a pytest
+    traceback prints in full.
+
+    ``raw_response`` carries only a short structural prefix of the wire bytes --
+    enough to read which field leads the first guide, which is the question
+    these branches exist to answer. It is capped *here* rather than left to
+    ``_truncate_response_preview``: hex-encoding makes the credential shapes
+    that ``scrub_secrets`` looks for unmatchable, and ``NOTEBOOKLM_DEBUG=1``
+    otherwise opts out of truncation entirely, which would splice a whole
+    model-written summary of the user's source into the exception string.
+    """
+
+    observed = ", ".join(_guide_echo_diagnostic(echoes)) or "<none>"
+    wire = response.SerializeToString()
+    return DecodingError(
+        f"{reason} (requested={source_id}, guides={len(response.guides)}, "
+        f"observed=[{observed}], bytes={len(wire)})",
+        method_id=method_id,
+        found_ids=_guide_echo_diagnostic(echoes),
+        raw_response=wire[:_WIRE_PREFIX_BYTES].hex(),
+    )
+
+
+def select_document_guide(response: Any, *, source_id: str, method_id: str) -> Any:
+    """Pick the ``DocumentGuide`` describing ``source_id`` from a non-empty response.
+
+    ``DocumentGuide.source #1`` is optional in practice: a live probe on
+    2026-08-31 (issue #2276) found text sources echo the requested id while URL
+    sources omit field #1 from the wire entirely, with no substitute identifier
+    elsewhere in the message. The same probe found the endpoint rejects a
+    two-source request with ``INVALID_ARGUMENT``, so a lone unlabelled guide can
+    only describe the source that was asked about. Treating the missing echo as
+    a mismatch therefore rejected guides the server really had returned.
+
+    The rule matches ``refresh``/``check_freshness``: only a *populated* and
+    *different* echo is a decoding failure. Past one guide the response is
+    ambiguous, so an exact match becomes mandatory again. See
+    ``docs/android/proto-evidence-ledger.md#document-guide-source-echo``.
+    """
+
+    if not response.guides:
+        raise ValueError("select_document_guide requires a non-empty guides list")
+    echoes = [_document_guide_echo(guide) for guide in response.guides]
+    matches = [
+        guide for guide, echo in zip(response.guides, echoes, strict=True) if echo == source_id
+    ]
+    if len(matches) > 1:
+        raise _guide_failure(
+            "Android source guide response contained duplicate source ids",
+            source_id=source_id,
+            method_id=method_id,
+            response=response,
+            echoes=echoes,
+        )
+    if matches:
+        return next(iter(matches))
+    sole_unlabelled = len(response.guides) == 1 and not any(echoes)
+    if not sole_unlabelled:
+        raise _guide_failure(
+            "Android source guide response did not match the requested source id",
+            source_id=source_id,
+            method_id=method_id,
+            response=response,
+            echoes=echoes,
+        )
+    # The sole unlabelled guide: the normal shape for a URL source, not an
+    # anomaly, so this is deliberately not logged.
+    return next(iter(response.guides))
+
+
+__all__ = ["decode_source", "decode_sources", "select_document_guide"]

--- a/src/notebooklm/_android/proto_src/google/internal/labs/tailwind/orchestration/v1/sources.proto
+++ b/src/notebooklm/_android/proto_src/google/internal/labs/tailwind/orchestration/v1/sources.proto
@@ -24,7 +24,8 @@ message MainIdeas {
 }
 
 message DocumentGuide {
-  InputSource source = 1; // evidence: docs/android/proto-evidence-ledger.md#source-field-ledger
+  // Optional on the wire: populated for text sources, omitted for URL sources.
+  InputSource source = 1; // evidence: docs/android/proto-evidence-ledger.md#document-guide-source-echo
   Snippet snippet = 2; // evidence: docs/android/proto-evidence-ledger.md#source-field-ledger
   MainIdeas main_ideas = 3; // evidence: docs/android/proto-evidence-ledger.md#source-field-ledger
 }

--- a/src/notebooklm/_android/sources.py
+++ b/src/notebooklm/_android/sources.py
@@ -39,7 +39,7 @@ from ..exceptions import (
 from ..types import Source, SourceFulltext, SourceStatus, SourceType
 from .codecs.documents import decode_document, tailwind_doc_markdown, tailwind_doc_plain_text
 from .codecs.notebooks import decode_project, map_get_project_error, validate_project_identity
-from .codecs.sources import decode_source, decode_sources
+from .codecs.sources import decode_source, decode_sources, select_document_guide
 from .session import AndroidSession
 from .upload import (
     AndroidUploadPipeline,
@@ -1340,26 +1340,13 @@ class AndroidSourcesAPI(SourcesAPI):
                     source_id, method_id=GENERATE_DOCUMENT_GUIDES_METHOD
                 ) from None
 
-        matches = [
-            guide
-            for guide in response.guides
-            if guide.HasField("source")
-            and guide.source.HasField("source_id")
-            and guide.source.source_id.id == source_id
-        ]
-        if not matches:
-            if not response.guides:
-                raise SourceNotFoundError(source_id, method_id=GENERATE_DOCUMENT_GUIDES_METHOD)
-            raise DecodingError(
-                "Android source guide response did not match the requested source id",
-                method_id=GENERATE_DOCUMENT_GUIDES_METHOD,
-            )
-        if len(matches) != 1:
-            raise DecodingError(
-                "Android source guide response contained duplicate source ids",
-                method_id=GENERATE_DOCUMENT_GUIDES_METHOD,
-            )
-        guide = next(iter(matches))
+        if not response.guides:
+            raise SourceNotFoundError(source_id, method_id=GENERATE_DOCUMENT_GUIDES_METHOD)
+        guide = select_document_guide(
+            response,
+            source_id=source_id,
+            method_id=GENERATE_DOCUMENT_GUIDES_METHOD,
+        )
         summary = guide.snippet.text_snippet if guide.HasField("snippet") else ""
         keywords = tuple(guide.main_ideas.text_ideas) if guide.HasField("main_ideas") else ()
         return SourceGuide(summary=summary, keywords=keywords)
@@ -1408,12 +1395,18 @@ class AndroidSourcesAPI(SourcesAPI):
         if not response.HasField("source"):
             raise SourceNotFoundError(source_id, method_id=LOAD_SOURCE_METHOD)
         raw_id = response.source.source_id.id if response.source.HasField("source_id") else ""
-        if not raw_id:
-            raise SourceNotFoundError(source_id, method_id=LOAD_SOURCE_METHOD)
-        if raw_id != source_id:
+        # An absent echo is not an absent source: ``LoadSource`` was observed
+        # echoing every probed source type (issue #2276), but turning a
+        # hypothetically unlabelled response into ``SourceNotFoundError`` would
+        # misreport a source the server did return. Only a populated and
+        # different id is a decoding failure, as in ``get_guide`` and
+        # ``refresh``.
+        if raw_id and raw_id != source_id:
             raise DecodingError(
-                "Android full-text response did not match the requested source id",
+                "Android full-text response did not match the requested source id "
+                f"(requested={source_id}, observed={raw_id})",
                 method_id=LOAD_SOURCE_METHOD,
+                found_ids=[raw_id],
             )
         source = decode_source(response.source, method_id=LOAD_SOURCE_METHOD)
         document = (

--- a/tests/unit/android/test_source_writes.py
+++ b/tests/unit/android/test_source_writes.py
@@ -1138,12 +1138,6 @@ def _guide(
     return guide
 
 
-def transport_response(transport: FakeTransport) -> Any:
-    """The canned ``GenerateDocumentGuides`` response a fake transport returns."""
-
-    return transport.handlers[GENERATE_DOCUMENT_GUIDES_METHOD]
-
-
 def _guides_transport(*guides: sources_pb2.DocumentGuide) -> FakeTransport:
     transport = FakeTransport()
     transport.handlers[GENERATE_DOCUMENT_GUIDES_METHOD] = (
@@ -1189,11 +1183,8 @@ async def test_guide_rejects_a_populated_mismatched_echo_with_diagnostics() -> N
     assert f"requested={SOURCE_A}" in str(raised.value)
     assert "guides=1" in str(raised.value)
     assert f"observed=[{SOURCE_B}]" in str(raised.value)
-    # The wire preview is capped at the source (24 bytes -> 48 hex chars) so
-    # NOTEBOOKLM_DEBUG=1 cannot splice a whole source summary into str(exc).
-    assert raised.value.raw_response is not None
-    assert len(raised.value.raw_response) == 48
-    assert f"bytes={len(transport_response(transport).SerializeToString())}" in str(raised.value)
+    # Field tags, never wire bytes: guide #1 present, #2 snippet present.
+    assert raised.value.raw_response == "[1,2,3]"
 
 
 @pytest.mark.asyncio
@@ -1207,6 +1198,8 @@ async def test_guide_rejects_multiple_guides_without_an_exact_match() -> None:
     assert raised.value.found_ids == ["<unlabelled>", SOURCE_B]
     assert "guides=2" in str(raised.value)
     assert f"observed=[<unlabelled>, {SOURCE_B}]" in str(raised.value)
+    # The unlabelled guide is reported as missing tag 1, not as bytes.
+    assert raised.value.raw_response == "[2,3 | 1,2,3]"
 
 
 @pytest.mark.asyncio
@@ -1252,6 +1245,45 @@ async def test_guide_rejects_duplicate_matching_echoes() -> None:
 
     assert "duplicate source ids" in str(raised.value)
     assert raised.value.found_ids == [SOURCE_A, SOURCE_A]
+
+
+@pytest.mark.asyncio
+async def test_guide_failure_diagnostics_never_carry_guide_content() -> None:
+    """A rejected guide must not splice source-derived text into the error.
+
+    ``raw_response`` is spliced into ``str()``/``repr()`` of RPC errors and
+    ``NOTEBOOKLM_DEBUG=1`` opts out of its truncation, so a wire-byte preview
+    of any length could disclose a model-written summary of the user's source
+    -- an unlabelled guide's payload starts with ``#2 snippet``. Only field
+    tags are reported.
+    """
+    secret_summary = "PRIVATE SUMMARY OF THE USER SOURCE " * 5
+    transport = _guides_transport(
+        _guide(source_id=None, summary=secret_summary, ideas=("private idea",)),
+        _guide(source_id=SOURCE_B, summary="other"),
+    )
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    rendered = f"{raised.value!s} {raised.value!r} {raised.value.raw_response}"
+    assert "PRIVATE" not in rendered
+    assert "private idea" not in rendered
+    assert raised.value.raw_response == "[2,3 | 1,2,3]"
+
+
+@pytest.mark.asyncio
+async def test_guide_field_tags_report_fields_the_schema_does_not_model() -> None:
+    """An unmodelled tag is how a *moved* label would look, so it must show."""
+    guide = _guide(source_id=None)
+    # Tag 7 is absent from ``DocumentGuide``; protobuf keeps it as unknown.
+    guide.MergeFromString(guide.SerializeToString() + b"\x3a\x00")
+    transport = _guides_transport(guide, _guide(source_id=SOURCE_B))
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert raised.value.raw_response == "[2,3,7 | 1,2,3]"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/android/test_source_writes.py
+++ b/tests/unit/android/test_source_writes.py
@@ -13,6 +13,7 @@ import pytest
 from tests._helpers.android_supervisor import SupervisedAndroidTransport
 
 from notebooklm._android.codecs.documents import decode_document, tailwind_doc_plain_text
+from notebooklm._android.codecs.sources import select_document_guide
 from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
     chat_pb2,
     read_pb2,
@@ -1118,6 +1119,199 @@ async def test_guide_and_fulltext_decode_only_captured_flat_fields() -> None:
         fulltext_call[2]["response_type"].DESCRIPTOR.full_name
         == "notebooklm.internal.android.wire.v1.WireLoadSourceResponse"
     )
+
+
+def _guide(
+    *,
+    source_id: str | None,
+    summary: str = "Summary",
+    ideas: tuple[str, ...] = ("one", "two"),
+) -> sources_pb2.DocumentGuide:
+    """Build a ``DocumentGuide``; ``source_id=None`` omits the optional echo."""
+
+    guide = sources_pb2.DocumentGuide(
+        snippet=sources_pb2.Snippet(text_snippet=summary),
+        main_ideas=sources_pb2.MainIdeas(text_ideas=list(ideas)),
+    )
+    if source_id is not None:
+        guide.source.CopyFrom(sources_pb2.InputSource(source_id=read_pb2.SourceId(id=source_id)))
+    return guide
+
+
+def transport_response(transport: FakeTransport) -> Any:
+    """The canned ``GenerateDocumentGuides`` response a fake transport returns."""
+
+    return transport.handlers[GENERATE_DOCUMENT_GUIDES_METHOD]
+
+
+def _guides_transport(*guides: sources_pb2.DocumentGuide) -> FakeTransport:
+    transport = FakeTransport()
+    transport.handlers[GENERATE_DOCUMENT_GUIDES_METHOD] = (
+        sources_pb2.GenerateDocumentGuidesResponse(guides=list(guides))
+    )
+    return transport
+
+
+@pytest.mark.asyncio
+async def test_guide_accepts_the_sole_unlabelled_guide() -> None:
+    """A URL source's guide omits ``DocumentGuide`` #1 entirely (issue #2276)."""
+    transport = _guides_transport(_guide(source_id=None, summary="URL summary"))
+
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert guide.summary == "URL summary"
+    assert guide.keywords == ("one", "two")
+
+
+@pytest.mark.asyncio
+async def test_guide_accepts_an_unlabelled_guide_whose_echo_is_an_empty_source() -> None:
+    """``source`` present but ``source_id`` absent is still *unlabelled*."""
+    unlabelled = _guide(source_id=None, summary="Empty echo")
+    unlabelled.source.CopyFrom(sources_pb2.InputSource())
+    transport = _guides_transport(unlabelled)
+
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert guide.summary == "Empty echo"
+
+
+@pytest.mark.asyncio
+async def test_guide_rejects_a_populated_mismatched_echo_with_diagnostics() -> None:
+    transport = _guides_transport(_guide(source_id=SOURCE_B))
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert raised.value.method_id == GENERATE_DOCUMENT_GUIDES_METHOD
+    assert raised.value.found_ids == [SOURCE_B]
+    # The counts and ids live in the message, which a CI traceback prints in
+    # full; ``raw_response`` is truncated to 80 characters unless NOTEBOOKLM_DEBUG=1.
+    assert f"requested={SOURCE_A}" in str(raised.value)
+    assert "guides=1" in str(raised.value)
+    assert f"observed=[{SOURCE_B}]" in str(raised.value)
+    # The wire preview is capped at the source (24 bytes -> 48 hex chars) so
+    # NOTEBOOKLM_DEBUG=1 cannot splice a whole source summary into str(exc).
+    assert raised.value.raw_response is not None
+    assert len(raised.value.raw_response) == 48
+    assert f"bytes={len(transport_response(transport).SerializeToString())}" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_guide_rejects_multiple_guides_without_an_exact_match() -> None:
+    """Past one guide the response is ambiguous, so an unlabelled row is fatal."""
+    transport = _guides_transport(_guide(source_id=None), _guide(source_id=SOURCE_B))
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert raised.value.found_ids == ["<unlabelled>", SOURCE_B]
+    assert "guides=2" in str(raised.value)
+    assert f"observed=[<unlabelled>, {SOURCE_B}]" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_guide_prefers_the_exact_match_beside_an_unlabelled_sibling() -> None:
+    """Where the relaxed rule and the multi-guide rule meet, the label wins."""
+    transport = _guides_transport(
+        _guide(source_id=None, summary="unlabelled"),
+        _guide(source_id=SOURCE_A, summary="labelled"),
+    )
+
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert guide.summary == "labelled"
+
+
+@pytest.mark.asyncio
+async def test_guide_accepts_an_echo_populated_with_an_empty_id() -> None:
+    """``SourceId(id="")`` is the third unlabelled shape and reads the same."""
+    empty_id = _guide(source_id="", summary="Empty id")
+    transport = _guides_transport(empty_id)
+
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert guide.summary == "Empty id"
+
+
+def test_select_document_guide_rejects_an_empty_response() -> None:
+    """The zero-guide case is the caller's to map; the codec refuses it."""
+    with pytest.raises(ValueError, match="non-empty guides list"):
+        select_document_guide(
+            sources_pb2.GenerateDocumentGuidesResponse(),
+            source_id=SOURCE_A,
+            method_id=GENERATE_DOCUMENT_GUIDES_METHOD,
+        )
+
+
+@pytest.mark.asyncio
+async def test_guide_rejects_duplicate_matching_echoes() -> None:
+    transport = _guides_transport(_guide(source_id=SOURCE_A), _guide(source_id=SOURCE_A))
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert "duplicate source ids" in str(raised.value)
+    assert raised.value.found_ids == [SOURCE_A, SOURCE_A]
+
+
+@pytest.mark.asyncio
+async def test_guide_maps_an_empty_response_to_source_not_found() -> None:
+    """Pins current Android behaviour, which diverges from ADR-0019.
+
+    ADR-0019 lists ``get_guide`` as a derived read that must not police parent
+    existence, and the web backend returns an empty ``SourceGuide`` for an
+    absent envelope. Android raises instead. That predates issue #2276 and is
+    unchanged by it, so it is recorded here rather than altered in a fix whose
+    subject is the echo check.
+    """
+    transport = _guides_transport()
+
+    with pytest.raises(SourceNotFoundError) as raised:
+        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert raised.value.source_id == SOURCE_A
+
+
+@pytest.mark.asyncio
+async def test_fulltext_reports_an_unlabelled_source_as_drift_not_absence() -> None:
+    """An absent ``LoadSource`` echo must not masquerade as a missing source.
+
+    The server did return a source; what it withheld is the label. Deferring to
+    ``decode_source`` names that precisely instead of claiming the source does
+    not exist (issue #2276, "latent twin").
+    """
+    unlabelled = FakeTransport()
+    source = _source(SOURCE_A, title="Document")
+    source.ClearField("source_id")
+    unlabelled.handlers[LOAD_SOURCE_METHOD] = source_content_pb2.WireLoadSourceResponse(
+        source=source,
+        plain_text=sources_pb2.PlainTextSourceContent(body="plain body"),
+    )
+
+    # Catch broadly and pin the exact type: ``SourceNotFoundError`` is not a
+    # ``DecodingError`` subclass, so ``pytest.raises(DecodingError)`` alone
+    # would let the pre-fix behaviour escape the test rather than fail it.
+    with pytest.raises(Exception) as unlabelled_raised:  # noqa: B017, PT011
+        await _api(unlabelled).get_fulltext(NOTEBOOK_ID, SOURCE_A)
+
+    assert type(unlabelled_raised.value) is DecodingError
+    assert "did not contain a source id" in str(unlabelled_raised.value)
+
+
+@pytest.mark.asyncio
+async def test_fulltext_rejects_a_populated_mismatched_echo_with_diagnostics() -> None:
+    mismatched = FakeTransport()
+    mismatched.handlers[LOAD_SOURCE_METHOD] = source_content_pb2.WireLoadSourceResponse(
+        source=_source(SOURCE_B, title="Other"),
+        plain_text=sources_pb2.PlainTextSourceContent(body="plain body"),
+    )
+
+    with pytest.raises(DecodingError) as raised:
+        await _api(mismatched).get_fulltext(NOTEBOOK_ID, SOURCE_A)
+
+    assert raised.value.method_id == LOAD_SOURCE_METHOD
+    assert raised.value.found_ids == [SOURCE_B]
+    assert f"requested={SOURCE_A}, observed={SOURCE_B}" in str(raised.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #2276.

## What the live probe found

The issue named three mechanisms and said the fork had to be settled with bytes before choosing a fix. A live probe against the `teng-lin-9414` account on 2026-08-31 — three URL sources and three pasted-text sources, one `GenerateDocumentGuides` request each, raw response dumped — settles it as **(a) echo absent**:

| Source kind | `DocumentGuide` fields on the wire | Echo |
|---|---|---|
| pasted text / markdown | `#1`, `#2`, `#3`, empty `#4` | `#1.source_id.id` equals the requested id |
| URL / web page | `#2`, `#3`, empty `#4` — **no `#1`** | absent |

A URL source's guide omits field `#1` from the serialized message entirely. That also rules out mechanism **(c)**: there is no unmodelled `InputSource` branch for our parser to miss, because there is no field `#1` on the wire at all, and the only other field present is a zero-length `#4` carrying no identifier. Decoded prefix of a real URL response:

```
#1 LEN 982 {
  #2 LEN 845 { #1 LEN 842 str='The Model Context Protocol (MCP) team has officially…' }
  #3 LEN 129 { #1 'Model Context Protocol'  #1 'Centralised Authentication'  … }
  #4 LEN 0 <empty>
}
```

Two side questions the issue flagged are settled by the same probe:

- **The endpoint is single-source.** A two-source request is rejected with `INVALID_ARGUMENT`. So a lone unlabelled guide can only describe the source that was asked about — which is what makes relaxing the check safe rather than merely convenient.
- **Response `#3` is keywords, not suggested questions.** `docs/android/endpoints.md` annotated it "(inferred) suggested questions". All six probed sources returned five short noun phrases (`"Model Context Protocol"`, `"Python Programming"`), none interrogative. The `main_ideas` projection is right.
- The `#2 context` request-side gap is **not** load-bearing here: we send no context and the probe succeeded.

## The fix

Guide selection moves into `select_document_guide()` in `_android/codecs/sources.py` and follows the convention `refresh` and `check_freshness` already use — only a *populated* and *different* echo is a decoding failure:

| Guides | Echoes | Result |
|---|---|---|
| 0 | — | `SourceNotFoundError` (unchanged) |
| 1 | matches | that guide |
| 1 | absent, or `source_id` absent, or `id=""` | accepted |
| 1 | populated and different | `DecodingError` |
| >1 | exactly one matches | that guide |
| >1 | none matches, or ≥2 match | `DecodingError` |

**Diagnosability.** The original error carried neither the observed ids nor the guide count, which is why #2276 could not be closed from the nightly logs. The rejection paths now put the requested id, every observed echo, the guide count and the response size in the exception *message* — the part a pytest traceback prints in full:

```
Android source guide response did not match the requested source id
(requested=aaaa…, guides=2, observed=[bbbb…, <unlabelled>], bytes=698)
```

`raw_response` keeps a 24-byte structural prefix of the wire bytes, capped **at the source**. Hex-encoding makes every shape `scrub_secrets` looks for unmatchable, and `NOTEBOOKLM_DEBUG=1` opts out of truncation entirely, so an uncapped hex dump would splice a model-written summary of the user's source into the exception string. 24 bytes answers the only question these branches exist to ask — which field leads the first guide.

**Latent twin.** `get_fulltext` had the identical fail-closed pattern and additionally turned an *absent* echo into `SourceNotFoundError`. The probe found `LoadSource` echoes every source type it was given, including URL sources, so this was latent rather than live — but an absent label is not an absent source. It now defers to `decode_source`, which reports the missing identifier as drift.

## Verification

Pre-fix reproduction and post-fix pass, same command, same notebook, android backend:

```
BEFORE  src/notebooklm/_android/sources.py:1353: DecodingError   ← the exact nightly failure
AFTER   4 passed
```

- `tests/e2e/test_sources.py::TestSourceRetrieval` — **4 passed** on the android backend against a URL-source notebook; **4 passed** on the web backend against the same notebook (no regression).
- Live `get_guide()` over 3 URL + 3 text sources — all six return a non-empty summary and 5 keywords.
- Full CI-equivalent suite: `pytest -n auto --dist loadgroup --cov=src/notebooklm --cov-fail-under=90` → **18046 passed**, 93.58% coverage. `ruff check .`, `ruff format --check` (Python scope), `mypy src/notebooklm scripts/_live_auth_scenarios` all clean.

## Deliberately not in this PR

- **The URL-source cassette** (issue item 3). The Android gRPC cassette harness and `source_lifecycle_recorded.grpc.json` live on the unmerged `test/android-grpc-integration` branch, not on `main`, so there is nothing here to record against. It should be recorded when that branch lands. The unit coverage half of item 3 **is** here: six new tests over the absent / empty-id / mismatched / duplicate / multi-guide / empty-response branches, none of which had any coverage before.
- **An ADR-0019 divergence found while reviewing.** ADR-0019 lists `get_guide` as a derived read that must not police parent existence, and the web backend returns an empty `SourceGuide` for an absent envelope; Android raises `SourceNotFoundError` on an empty `guides` list. That predates this issue and is not made more reachable by this fix — the zero-guide branch was equally reachable before — so it is documented in the test rather than changed in a fix whose subject is the echo check. Filed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android guide retrieval for URL sources that omit source labels.
  * Improved handling of missing, mismatched, or duplicate source identifiers.
  * Added clearer diagnostic details when source or guide responses cannot be matched.
  * Preserved strict validation when a populated source identifier differs from the requested source.
  * Prevented source-derived guide content from appearing in error messages.

* **Documentation**
  * Updated Android endpoint documentation with verified response formats and source-label behavior.
  * Added evidence and probe findings for guide and full-text responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->