### PR TITLE
fix(android): stop policing existence in derived source reads (#2278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   round-trip from every call. Note both backends' underlying RPCs are
   notebook-agnostic, so neither validates that the source belongs to the
   notebook you name.
-- `sources.get_guide()` on the Android backend no longer raises `DecodingError`.
-  `GenerateDocumentGuides` labels a returned guide with the requested source id
-  on the *first* response for a source and omits the label on every repeat
-  call, so the strict echo check rejected guides the server really had returned
-  for all but each source's first read. A
-  populated-but-different echo is still a hard failure, and the rejection paths
-  now report the requested id, every observed echo, the guide count, and each
-  guide's protobuf field tags.
+- `sources.get_guide()` on the Android backend no longer raises `DecodingError`
+  for a sole guide that carries no source-id echo. `GenerateDocumentGuides`
+  labels a returned guide with the requested source id on the *first* response
+  for a source and omits the label on every repeat call, so the strict echo
+  check rejected guides the server really had returned for all but each
+  source's first read. A populated-but-different echo, and an ambiguous
+  multi-guide response, are both still `DecodingError`; those paths now report
+  the requested id, every observed echo, the guide count, and each guide's
+  protobuf field tags.
 
 ## [0.8.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `sources.get_guide()` on the Android backend no longer raises `DecodingError`
-  for URL sources. `GenerateDocumentGuides` labels a returned guide with the
-  requested source id for text sources but omits the label entirely for URL
-  sources, and the strict echo check rejected guides the server really had
-  returned. A populated-but-different echo is still a hard failure, and the
-  rejection paths now report the requested id, every observed echo, the guide
-  count, and each guide's protobuf field tags.
+- **Behaviour change (Android backend):** `sources.get_guide()` and
+  `sources.check_freshness()` no longer raise `SourceNotFoundError` for a
+  source that is absent or not yet summarised. Per ADR-0019 these are *derived
+  reads* that must not police parent existence, and the web backend already
+  returned `SourceGuide("", ())` / `True` for the same inputs — Android now
+  matches it. Existence remains `get()`'s job: the MCP tool and REST route
+  already run their own guard, and the CLI resolves ids against
+  `sources.list()`. Dropping the pre-flight also removes a `GetProject`
+  round-trip from every call. Note both backends' underlying RPCs are
+  notebook-agnostic, so neither validates that the source belongs to the
+  notebook you name.
+- `sources.get_guide()` on the Android backend no longer raises `DecodingError`.
+  `GenerateDocumentGuides` labels a returned guide with the requested source id
+  on the *first* response for a source and omits the label on every repeat
+  call, so the strict echo check rejected guides the server really had returned
+  for all but each source's first read. A
+  populated-but-different echo is still a hard failure, and the rejection paths
+  now report the requested id, every observed echo, the guide count, and each
+  guide's protobuf field tags.
 
 ## [0.8.1] - 2026-08-14
 

--- a/docs/android/endpoints.md
+++ b/docs/android/endpoints.md
@@ -3,7 +3,7 @@
 **Status:** Recovered from capture, schema-level (field numbers + wire types), not
 field-named by Google
 
-**Last verified:** 2026-08-31 (`1.46.7` capture snapshot plus `1.55.10` binary delta; `GenerateDocumentGuides` response re-probed live)
+**Last verified:** 2026-08-31 (`1.46.7` capture snapshot plus `1.55.10` binary delta; `GenerateDocumentGuides` echo re-probed live across repeat calls)
 
 **Scope:** the original `1.46.7.940945420` **49-method surface** (4 gRPC services) is enumerated
 and cross-referenced to the 48-method Web registry used for that audit. The newer Google-signed
@@ -540,25 +540,26 @@ questions):
 ```text
 request:  #1 { #1 str[36] }   # source_id, wrapped   + #2 context
 response: #1 {
-  #1 { #1 { #1 str[36] } }    # source_id — omitted entirely for URL sources
+  #1 { #1 { #1 str[36] } }    # source_id — present on a source's FIRST response only
   #2 { #1 str }               # summary text
   #3 { #1 (repeated) str }    # main ideas / keywords (this capture guessed "suggested questions")
   #4 { }                      # always zero-length in probed responses
 }
 ```
 
-Two readings in this capture were settled by a live probe on 2026-08-31 (issue #2276), which
-requested guides one source at a time for three URL and three pasted-text sources:
+Two readings in this capture were settled by live probes on 2026-08-31 (issues #2276, #2278):
 
-- Response `#1` is **optional**. Text sources echo the requested id; URL sources omit `#1` from
-  the wire altogether, with no substitute identifier anywhere in the message. `sources.get_guide`
-  accordingly treats an absent echo as unlabelled rather than as a mismatch.
+- Response `#1` is **optional, by call ordinal**. Reading the same source three times in a row
+  returns the id on call 1 and omits `#1` from the wire on calls 2 and 3, with identical summary
+  bytes and no substitute identifier anywhere in the message. Source type does *not* predict it —
+  an earlier reading here that credited the split to URL-vs-text was confounded by call ordinal.
+  `sources.get_guide` accordingly treats an absent echo as unlabelled rather than as a mismatch.
 - Response `#3` carries **keywords / main ideas**, not suggested questions: every probed source
   returned five short noun phrases, none interrogative. The proto's own `main_ideas` name agrees.
 
 The client sends no `#2 context` and the probe succeeded without it, so the modelled-vs-captured
 gap on the request side is not load-bearing for this method. The endpoint is single-source: a
-two-source request is rejected with `INVALID_ARGUMENT`. Full table in
+two-source request is rejected with `INVALID_ARGUMENT`. Full tables in
 [proto-evidence-ledger.md](proto-evidence-ledger.md#document-guide-source-echo).
 
 ## Write / mutation RPCs

--- a/docs/android/proto-evidence-ledger.md
+++ b/docs/android/proto-evidence-ledger.md
@@ -3,7 +3,7 @@
 **Status:** admitted read, notebook, source/upload, artifact, chat, notes/sharing,
 organization, Research, and public account-settings contracts
 
-**Evidence snapshot:** 2026-08-31 (`GenerateDocumentGuides` source echo re-probed live)
+**Evidence snapshot:** 2026-08-31 (`GenerateDocumentGuides` echo and derived-read existence policing re-probed live)
 
 **Scope:** project/source reads; notebook operations; URL, maintenance, content, and generic file
 source operations; artifact list/get/create/derive/update/delete, native note-backed mind-map
@@ -111,7 +111,7 @@ fixtures. Hashes prevent a later local checkout from silently changing what was 
 | [`artifact-contracts-and-live-validation.md`](artifact-contracts-and-live-validation.md) | `58af0bbeebdfa6a6a7366577d90a5479bdf971a1ed76fe3d6d7d0b8420f8454d` | consolidated artifact generation, representation, data-table, retry/export, mind-map, and transfer evidence; preserves all four source-report hashes and cleanup qualifications |
 | [`file-transfer-evidence.md`](file-transfer-evidence.md) | `f09a518c398f7355f7ab55c69d6e990037c806a9cc3e3f1291de5efd4971a6a5` | official-app/headless PDF upload request, qualified CSV/DOCX compatibility boundary, and live artifact representation/direct infographic/slide transfer |
 | [`resource-lifecycle-and-public-qualification.md`](resource-lifecycle-and-public-qualification.md) | `7e21ddb46ff851b9ae27c38c7ce6d18cfc6e4589f3730fe30160ef8f7dfcf585` | consolidated notebook copy/metadata, note/mind-map, label/collection, membership, cleanup, and public-qualification evidence; preserves all four source-report hashes |
-| [`endpoints.md`](endpoints.md) | `c4ed059c6812c5e7714366649592c41a1301cb83507770c37dc80df94600c8dd` | live request/response envelopes, route results, version-scoped APK inventories, captured note/sharing bytes, and the account-bootstrap replay boundary |
+| [`endpoints.md`](endpoints.md) | `e1dbbd0b98f6a65bb7a76ce3597282b15d4c884987f806b0744cf17ecbfb4248` | live request/response envelopes, route results, version-scoped APK inventories, captured note/sharing bytes, and the account-bootstrap replay boundary |
 
 The recovery method and the warning about duplicate packages are committed in
 [`README.md`](README.md#caveats-that-will-bite-you). Live request/response shapes are documented in
@@ -731,27 +731,38 @@ Blutter's generated-client binding proves `DeleteSources` returns
 ### Document-guide source echo
 
 `DocumentGuide.source #1` is **optional in practice**, so requested-vs-echoed identity on
-`GenerateDocumentGuides` is a *leak* check, not a *presence* check. A current authenticated probe
-(2026-08-31, issue #2276) requested one guide at a time for three URL sources and three
-pasted-text sources:
+`GenerateDocumentGuides` is a *leak* check, not a *presence* check. Two current authenticated probes
+(2026-08-31, issue #2276 then #2278) establish what governs it:
 
-| Source kind | `DocumentGuide` fields on the wire | Echo |
+| Call | `DocumentGuide` fields on the wire | Echo |
 |---|---|---|
-| pasted text / markdown | `#1`, `#2`, `#3`, empty `#4` | `#1.source_id.id` equals the requested id |
-| URL / web page | `#2`, `#3`, empty `#4` — **no `#1`** | absent |
+| first response for a source | `#1`, `#2`, `#3`, empty `#4` | `#1.source_id.id` equals the requested id |
+| every repeat call | `#2`, `#3`, empty `#4` — **no `#1`** | absent |
 
-The URL responses omit field `#1` from the serialized message entirely; the only other field
-present is a zero-length `#4`, which carries no identifier. That rules out the competing reading
-in which the server labels URL guides through an unmodelled `InputSource` branch (a crawled-document
-or web-content id) that our parser would report as `HasField("source_id") == False` — there is no
-such branch on the wire to miss. The same probe found that a two-source request is rejected with
-`INVALID_ARGUMENT`, so the endpoint is single-source and a lone unlabelled guide can only describe
-the source that was asked about.
+The second probe called `GenerateDocumentGuides` three times in a row for each of three
+never-before-read sources: every one returned the label on call 1 and omitted it on calls 2 and 3,
+with byte-identical summary lengths (930 / 1062 / 798 chars). The unlabelled form is therefore the
+steady state, and the labelled form is the exception.
+
+**Source type does not predict it**, contrary to the first reading recorded here. The initial probe
+compared three URL sources in a long-read notebook against three pasted-text sources in a fresh one
+and attributed the split to type; re-probing the same text sources hours later returned them
+*unlabelled*, and a URL source read for the first time returned *labelled*. Type, age and notebook
+were all confounded with call ordinal. Both shapes are now pinned against recorded bytes in
+`tests/cassettes/android/source_lifecycle_recorded.grpc.json` (interactions 10 and 11: the same
+source, read twice).
+
+The repeat responses omit field `#1` from the serialized message entirely; the only other field
+present is a zero-length `#4`, which carries no identifier. That rules out the competing reading in
+which the server relocates the label into an unmodelled `InputSource` branch that our parser would
+report as `HasField("source_id") == False` — there is no such branch on the wire to miss. The same
+probe found that a two-source request is rejected with `INVALID_ARGUMENT`, so the endpoint is
+single-source and a lone unlabelled guide can only describe the source that was asked about.
 
 `sources.get_guide` therefore accepts a sole unlabelled guide, keeps the hard failure for a
 *populated and different* echo, and still requires an exact match once more than one guide is
 returned — the same `if echoed_id and echoed_id != source_id` convention already used by
-`refresh` and `check_freshness`. The rejection paths now carry the requested id, every observed
+`refresh` and `check_freshness`. The rejection paths carry the requested id, every observed
 echo, the guide count, and each guide's field tags, because the original error carried none of
 them and could not be diagnosed from CI logs. The tags are reported instead of a wire-byte preview:
 an unlabelled guide's payload begins with `#2 snippet`, so any prefix would carry the start of a
@@ -759,12 +770,34 @@ model-written summary of the user's source into an error string that `NOTEBOOKLM
 untruncated.
 
 The probe also corroborates the `main_ideas #3` projection against the alternative reading of the
-captured app traffic (which annotates response `#3` as "(inferred) suggested questions"): all six
-sources returned five short noun phrases — `"Model Context Protocol"`, `"Centralised
-Authentication"`, `"Python Programming"` — none of them interrogative. `LoadSource` echoed the
-requested id on every probed source including the URL ones, so its sibling check is not affected;
-its unlabelled branch nonetheless now defers to `decode_source`, which reports missing-identifier
-drift instead of claiming the source does not exist.
+captured app traffic (which annotates response `#3` as "(inferred) suggested questions"): every
+probed source returned five short noun phrases — `"Model Context Protocol"`, `"Centralised
+Authentication"`, `"Python Programming"` — none of them interrogative.
+
+`LoadSource` echoed the requested id on every probed source and call, so its sibling check is not
+affected; its unlabelled branch nonetheless defers to `decode_source`, which reports
+missing-identifier drift instead of claiming the source does not exist.
+
+### Derived-read existence policing
+
+`get_guide` and `check_freshness` are **derived reads** under
+[ADR-0019](../adr/0019-error-and-return-contract.md): they do not police parent existence. Both
+Android RPCs are notebook-agnostic — they carry a source id and no project id — and a live probe
+(2026-08-31, issue #2278) confirmed the web backend is too: asked for a source of notebook B while
+naming notebook A, both backends returned B's guide. The adapter previously ran a `GetProject`
+pre-flight that raised `SourceNotFoundError`, which made the `notebook_id` argument meaningful on
+Android alone while diverging from web and costing a round-trip per call.
+
+The same probe pinned the target behaviour for a nonexistent source id:
+
+| | web | Android raw RPC | Android adapter (now) |
+|---|---|---|---|
+| `get_guide` | `SourceGuide("", ())` | `GenerateDocumentGuides` → `NOT_FOUND` | `SourceGuide("", ())` |
+| `check_freshness` | `True` | `CheckSourceFreshness` → **empty response** | `True` |
+
+`check_freshness` needed no mapping: the backend answers a bogus id with an empty
+`CheckSourceFreshness` response, which the existing decode already reads as fresh. `refresh` keeps
+its ownership check — mutating a missing source must still raise.
 
 The admitted source overlay also carries the public text, YouTube, and Drive-reference branches used
 by `add_text`, YouTube `add_url`, and `add_drive`; their exact fields are exercised by focused

--- a/src/notebooklm/_android/codecs/sources.py
+++ b/src/notebooklm/_android/codecs/sources.py
@@ -330,13 +330,16 @@ def _skip_value(payload: bytes, offset: int, wire_type: int) -> int:
 def select_document_guide(response: Any, *, source_id: str, method_id: str) -> Any:
     """Pick the ``DocumentGuide`` describing ``source_id`` from a non-empty response.
 
-    ``DocumentGuide.source #1`` is optional in practice: a live probe on
-    2026-08-31 (issue #2276) found text sources echo the requested id while URL
-    sources omit field #1 from the wire entirely, with no substitute identifier
-    elsewhere in the message. The same probe found the endpoint rejects a
-    two-source request with ``INVALID_ARGUMENT``, so a lone unlabelled guide can
-    only describe the source that was asked about. Treating the missing echo as
-    a mismatch therefore rejected guides the server really had returned.
+    ``DocumentGuide.source #1`` is optional in practice. A live probe on
+    2026-08-31 (issue #2276) found the backend labels a guide with the
+    requested id on the **first** response for a source and omits field #1
+    from the wire on every repeat call -- same summary bytes, no substitute
+    identifier anywhere in the message. Source type does not predict it; the
+    unlabelled form is simply the steady state, so requiring the echo rejected
+    guides the server really had returned for all but each source's first
+    read. The same probe found the endpoint rejects a two-source request with
+    ``INVALID_ARGUMENT``, so a lone unlabelled guide can only describe the
+    source that was asked about.
 
     The rule matches ``refresh``/``check_freshness``: only a *populated* and
     *different* echo is a decoding failure. Past one guide the response is

--- a/src/notebooklm/_android/proto_src/google/internal/labs/tailwind/orchestration/v1/sources.proto
+++ b/src/notebooklm/_android/proto_src/google/internal/labs/tailwind/orchestration/v1/sources.proto
@@ -24,7 +24,8 @@ message MainIdeas {
 }
 
 message DocumentGuide {
-  // Optional on the wire: populated for text sources, omitted for URL sources.
+  // Optional on the wire: populated on a source's first guide response,
+  // omitted on every repeat call.
   InputSource source = 1; // evidence: docs/android/proto-evidence-ledger.md#document-guide-source-echo
   Snippet snippet = 2; // evidence: docs/android/proto-evidence-ledger.md#source-field-ledger
   MainIdeas main_ideas = 3; // evidence: docs/android/proto-evidence-ledger.md#source-field-ledger

--- a/src/notebooklm/_android/sources.py
+++ b/src/notebooklm/_android/sources.py
@@ -1270,13 +1270,17 @@ class AndroidSourcesAPI(SourcesAPI):
                 )
 
     async def check_freshness(self, notebook_id: str, source_id: str) -> bool:
+        """Report whether a source is fresh, without policing its existence.
+
+        The other ADR-0019 derived read on this adapter (see ``get_guide``).
+        No pre-flight is needed to stay web-compatible: a live probe of a
+        nonexistent id returned an *empty* ``CheckSourceFreshness`` response
+        rather than an error, which ``_check_freshness`` already reads as
+        fresh -- the same ``True`` the web backend returns for that input
+        (issue #2278). ``refresh`` keeps its ownership check, because mutating
+        a missing source must still raise.
+        """
         async with self._transport.operation_scope("sources.check_freshness") as lease:
-            await self._require_owned_source(
-                notebook_id,
-                source_id,
-                expected_epoch=lease.epoch,
-                method_id=CHECK_SOURCE_FRESHNESS_METHOD,
-            )
             return await self._check_freshness(source_id, expected_epoch=lease.epoch)
 
     async def _check_freshness(
@@ -1313,16 +1317,23 @@ class AndroidSourcesAPI(SourcesAPI):
         return bool(freshness.is_fresh)
 
     async def get_guide(self, notebook_id: str, source_id: str) -> SourceGuide:
+        """Return the AI summary and keywords for a source, or an empty guide.
+
+        A derived read under ADR-0019: it does not police parent existence.
+        A source that is absent, or present but not yet summarised, yields
+        ``SourceGuide("", ())`` rather than an error -- identical to the web
+        backend, which was live-verified returning exactly that for a
+        nonexistent source id (issue #2278). Existence is ``get()``'s job, and
+        every surface that needs a 404 already asks for one: the MCP tool and
+        the REST route both run ``execute_source_get`` first, and the CLI
+        resolves the id against ``sources.list()``.
+
+        Shape drift still raises ``DecodingError`` via ``select_document_guide``.
+        """
         request = _write_proto().GenerateDocumentGuidesRequest(
             sources=[_write_proto().InputSource(source_id=_read_proto().SourceId(id=source_id))]
         )
         async with self._transport.operation_scope("sources.get_guide") as lease:
-            await self._require_owned_source(
-                notebook_id,
-                source_id,
-                expected_epoch=lease.epoch,
-                method_id=GENERATE_DOCUMENT_GUIDES_METHOD,
-            )
             try:
                 response = await self._transport.unary(
                     GENERATE_DOCUMENT_GUIDES_METHOD,
@@ -1336,12 +1347,14 @@ class AndroidSourcesAPI(SourcesAPI):
             except RPCError as exc:
                 if exc.rpc_code != 5:
                     raise
-                raise SourceNotFoundError(
-                    source_id, method_id=GENERATE_DOCUMENT_GUIDES_METHOD
-                ) from None
+                # NOT_FOUND is how the backend reports "no guide for this id",
+                # whether the source is gone or was never summarised; a live
+                # probe confirmed a nonexistent id lands here. Web returns an
+                # empty guide for the same input.
+                return SourceGuide(summary="", keywords=())
 
         if not response.guides:
-            raise SourceNotFoundError(source_id, method_id=GENERATE_DOCUMENT_GUIDES_METHOD)
+            return SourceGuide(summary="", keywords=())
         guide = select_document_guide(
             response,
             source_id=source_id,

--- a/tests/cassettes/android/source_lifecycle_recorded.grpc.json
+++ b/tests/cassettes/android/source_lifecycle_recorded.grpc.json
@@ -152,16 +152,16 @@
       "shape": "unary_unary"
     },
     {
-      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetProject",
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateDocumentGuides",
       "request": {
-        "protobuf_b64": "CiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEQAQ==",
-        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectRequest"
+        "protobuf_b64": "CigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAy",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateDocumentGuidesRequest"
       },
-      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse",
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateDocumentGuidesResponse",
       "responses": [
         {
-          "protobuf_b64": "CvoCChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMxIUU0NSVUJCRURfU1RSSU5HXzAwMjYaAigEIgIQAhJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMhIUU0NSVUJCRURfU1RSSU5HXzAwMTEaAigEIgIQAhJ4CiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBIUU0NSVUJCRURfU1RSSU5HXzAwMjgaNCgFQjAKLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDEiAhACGiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEiFFNDUlVCQkVEX1NUUklOR18wMDI3MggIAUoECAEQAVIGCAEQARgBWgoIARABGAEgASgB",
-          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse"
+          "protobuf_b64": "CrIBCigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyEhYKFFNDUlVCQkVEX1NUUklOR18wMDI5Gm4KFFNDUlVCQkVEX1NUUklOR18wMDMwChRTQ1JVQkJFRF9TVFJJTkdfMDAzMQoUU0NSVUJCRURfU1RSSU5HXzAwMzIKFFNDUlVCQkVEX1NUUklOR18wMDMzChRTQ1JVQkJFRF9TVFJJTkdfMDAzNA==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateDocumentGuidesResponse"
         }
       ],
       "shape": "unary_unary"
@@ -175,23 +175,8 @@
       "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateDocumentGuidesResponse",
       "responses": [
         {
-          "protobuf_b64": "CrIBCigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyEhYKFFNDUlVCQkVEX1NUUklOR18wMDI5Gm4KFFNDUlVCQkVEX1NUUklOR18wMDExChRTQ1JVQkJFRF9TVFJJTkdfMDAxMAoUU0NSVUJCRURfU1RSSU5HXzAwMzAKFFNDUlVCQkVEX1NUUklOR18wMDMxChRTQ1JVQkJFRF9TVFJJTkdfMDAzMg==",
+          "protobuf_b64": "CogBEhYKFFNDUlVCQkVEX1NUUklOR18wMDI5Gm4KFFNDUlVCQkVEX1NUUklOR18wMDMwChRTQ1JVQkJFRF9TVFJJTkdfMDAzMQoUU0NSVUJCRURfU1RSSU5HXzAwMzIKFFNDUlVCQkVEX1NUUklOR18wMDMzChRTQ1JVQkJFRF9TVFJJTkdfMDAzNA==",
           "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateDocumentGuidesResponse"
-        }
-      ],
-      "shape": "unary_unary"
-    },
-    {
-      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetProject",
-      "request": {
-        "protobuf_b64": "CiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEQAQ==",
-        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectRequest"
-      },
-      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse",
-      "responses": [
-        {
-          "protobuf_b64": "CvoCChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMxIUU0NSVUJCRURfU1RSSU5HXzAwMjYaAigEIgIQAhJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMhIUU0NSVUJCRURfU1RSSU5HXzAwMTEaAigEIgIQAhJ4CiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBIUU0NSVUJCRURfU1RSSU5HXzAwMjgaNCgFQjAKLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDEiAhACGiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEiFFNDUlVCQkVEX1NUUklOR18wMDI3MggIAUoECAEQAVIGCAEQARgBWgoIARABGAEgASgB",
-          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse"
         }
       ],
       "shape": "unary_unary"

--- a/tests/integration/test_android_grpc_cassette.py
+++ b/tests/integration/test_android_grpc_cassette.py
@@ -283,7 +283,13 @@ async def test_source_lifecycle_over_source_mutations(
             values.notebook_id, url_source.id, timeout=120, initial_interval=0.1
         )
         renamed = await client.sources.rename(values.notebook_id, text_source.id, values.texts[2])
+        # Both echo shapes from issue #2276, in order. The backend labels a
+        # guide with the requested source id on the FIRST response for that
+        # source and omits the label on every repeat call, so calling twice is
+        # what pins the relaxed echo rule against recorded bytes -- the second
+        # call is the one that used to raise ``DecodingError``.
         guide = await client.sources.get_guide(values.notebook_id, text_source.id)
+        guide_again = await client.sources.get_guide(values.notebook_id, text_source.id)
         fresh = await client.sources.check_freshness(values.notebook_id, url_source.id)
         await client.sources.refresh(values.notebook_id, url_source.id)
         await client.sources.delete(values.notebook_id, url_source.id)
@@ -292,6 +298,10 @@ async def test_source_lifecycle_over_source_mutations(
     assert text_ready.id == text_source.id and url_ready.id == url_source.id
     assert renamed is not None and renamed.id == text_source.id
     assert isinstance(guide.summary, str)
+    # Same guide either way: only the source-id echo differs between the two
+    # responses, which is exactly what the relaxed rule has to tolerate.
+    assert guide_again.summary == guide.summary
+    assert guide_again.keywords == guide.keywords
     assert fresh is True  # an empty CheckSourceFreshness response means "fresh"
 
 

--- a/tests/unit/android/test_source_writes.py
+++ b/tests/unit/android/test_source_writes.py
@@ -38,6 +38,7 @@ from notebooklm._android.sources import (
     AndroidSourcesAPI,
 )
 from notebooklm._android.upload import AndroidUploadPipeline
+from notebooklm._types.research import SourceGuide
 from notebooklm.exceptions import (
     AuthError,
     DecodingError,
@@ -951,8 +952,6 @@ async def test_delete_and_rename_use_non_replayed_exact_wire_shapes() -> None:
     [
         ("rename", MUTATE_SOURCE_METHOD),
         ("refresh", REFRESH_SOURCE_METHOD),
-        ("check_freshness", CHECK_SOURCE_FRESHNESS_METHOD),
-        ("get_guide", GENERATE_DOCUMENT_GUIDES_METHOD),
         ("get_fulltext", LOAD_SOURCE_METHOD),
     ],
 )
@@ -969,10 +968,6 @@ async def test_global_source_operations_reject_cross_notebook_ids_before_io(
             await api.rename(NOTEBOOK_ID, SOURCE_A, "Renamed")
         elif operation == "refresh":
             await api.refresh(NOTEBOOK_ID, SOURCE_A)
-        elif operation == "check_freshness":
-            await api.check_freshness(NOTEBOOK_ID, SOURCE_A)
-        elif operation == "get_guide":
-            await api.get_guide(NOTEBOOK_ID, SOURCE_A)
         else:
             await api.get_fulltext(NOTEBOOK_ID, SOURCE_A)
 
@@ -1148,7 +1143,7 @@ def _guides_transport(*guides: sources_pb2.DocumentGuide) -> FakeTransport:
 
 @pytest.mark.asyncio
 async def test_guide_accepts_the_sole_unlabelled_guide() -> None:
-    """A URL source's guide omits ``DocumentGuide`` #1 entirely (issue #2276)."""
+    """Repeat guide reads omit ``DocumentGuide`` #1 entirely (issue #2276)."""
     transport = _guides_transport(_guide(source_id=None, summary="URL summary"))
 
     guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
@@ -1287,21 +1282,59 @@ async def test_guide_field_tags_report_fields_the_schema_does_not_model() -> Non
 
 
 @pytest.mark.asyncio
-async def test_guide_maps_an_empty_response_to_source_not_found() -> None:
-    """Pins current Android behaviour, which diverges from ADR-0019.
+async def test_guide_maps_an_empty_response_to_an_empty_guide() -> None:
+    """ADR-0019 derived read: absence is data, not an error (issue #2278).
 
-    ADR-0019 lists ``get_guide`` as a derived read that must not police parent
-    existence, and the web backend returns an empty ``SourceGuide`` for an
-    absent envelope. Android raises instead. That predates issue #2276 and is
-    unchanged by it, so it is recorded here rather than altered in a fix whose
-    subject is the echo check.
+    Live-verified parity: the web backend returns ``SourceGuide("", ())`` for a
+    nonexistent source id, and Android now does the same instead of raising
+    ``SourceNotFoundError``.
     """
     transport = _guides_transport()
 
-    with pytest.raises(SourceNotFoundError) as raised:
-        await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
 
-    assert raised.value.source_id == SOURCE_A
+    assert guide == SourceGuide(summary="", keywords=())
+
+
+@pytest.mark.asyncio
+async def test_guide_maps_backend_not_found_to_an_empty_guide() -> None:
+    """rpc code 5 is "no guide for this id", not "the source is gone".
+
+    A live probe of a nonexistent id returns NOT_FOUND from
+    ``GenerateDocumentGuides`` while web returns an empty guide for the same
+    input, so this is the branch that carries the parity.
+    """
+    transport = FakeTransport()
+    transport.handlers[GENERATE_DOCUMENT_GUIDES_METHOD] = RPCError("gone", rpc_code=5)
+
+    guide = await _api(transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+
+    assert guide == SourceGuide(summary="", keywords=())
+
+
+@pytest.mark.asyncio
+async def test_derived_source_reads_do_not_pre_flight_ownership() -> None:
+    """The two ADR-0019 derived reads issue exactly one RPC and no GetProject.
+
+    Dropping the pre-flight is what makes absence return data rather than
+    raise; it also removes a ``GetProject`` round-trip from every call. Both
+    Android RPCs are notebook-agnostic, and so is web -- a live probe of both
+    backends returned a source's guide when asked under an unrelated notebook
+    id -- so the guard was a client-side-only divergence, not a boundary the
+    protocol enforces.
+    """
+    guide_transport = _guides_transport(_guide(source_id=SOURCE_A))
+    guide_transport.handlers[GET_PROJECT_METHOD] = _project(_source(SOURCE_B))
+    await _api(guide_transport).get_guide(NOTEBOOK_ID, SOURCE_A)
+    assert [method for method, _r, _k in guide_transport.calls] == [GENERATE_DOCUMENT_GUIDES_METHOD]
+
+    fresh_transport = FakeTransport()
+    fresh_transport.handlers[GET_PROJECT_METHOD] = _project(_source(SOURCE_B))
+    fresh_transport.handlers[CHECK_SOURCE_FRESHNESS_METHOD] = (
+        sources_pb2.CheckSourceFreshnessResponse()
+    )
+    assert await _api(fresh_transport).check_freshness(NOTEBOOK_ID, SOURCE_A) is True
+    assert [method for method, _r, _k in fresh_transport.calls] == [CHECK_SOURCE_FRESHNESS_METHOD]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #2278. Also corrects the evidence recorded by #2277.

## The contract bug

ADR-0019 lists `get_guide` and `check_freshness` as **derived reads** that must not police parent existence — *"missing parent → empty / not-ready value; resource existence is `get()`'s job."* Android raised instead. Live probe, same account, both backends, nonexistent source id:

| | web | android (before) | android (now) |
|---|---|---|---|
| `get_guide` | `SourceGuide('', ())` | `SourceNotFoundError` | `SourceGuide('', ())` |
| `check_freshness` | `True` | `SourceNotFoundError` | `True` |

**This was reachable in normal use, not just for a bogus id.** The MCP tool and the REST route each run their own `execute_source_get` guard and *then* call `get_guide`, expecting an empty guide to mean "not summarised yet" — their own comments say exactly that:

> `# Guide RPC → the AI digest (a missing guide returns empty summary/keywords — the existence guard above already ruled out a deleted source, so this is a real "no guide yet", not a false success).`

On Android that path was unreachable: a source that exists but has no guide reported "source not found" immediately after the code confirmed it exists. `_app` even carries a `SourceGuideResult.is_empty` property for an outcome Android could never produce.

`check_freshness` needed no mapping at all — probing a bogus id returns an **empty** `CheckSourceFreshness` response, which the existing decode already reads as fresh. `refresh` keeps its ownership check; mutating a missing source must still raise.

Dropping the pre-flight also removes a `GetProject` round-trip from every call — visible as a deleted interaction in the re-recorded cassette.

## What the guard was also doing

Worth naming explicitly, because it is the one thing this PR gives up. Both Android RPCs carry a source id and **no project id**, so `_require_owned_source` was the only thing making the `notebook_id` argument mean anything. A probe confirmed web is notebook-agnostic too — asked for a source of notebook B while naming notebook A, **both** backends return B's guide.

So this was a client-side-only divergence, not a boundary the protocol enforces, and a guarantee only one backend offers is one cross-backend callers cannot rely on. There is no cross-tenant implication: any source id the caller can name is one they can already read via its real notebook. It came from #2269 with no ADR entry or documented rationale — the same PR whose over-tightening caused #2276. `rename`, `refresh` and `get_fulltext` keep their pre-flight and their coverage in the cross-notebook test; the two derived reads are dropped from it and replaced by a test asserting the single-RPC, no-`GetProject` shape.

## Correcting #2277's evidence

The #2276 fix was right; the mechanism I recorded for it was not. I claimed source type governed the echo. It doesn't — **call ordinal** does:

```
=== 20a5e597… ===  call 1: labelled   call 2: unlabelled   call 3: unlabelled   (930ch each)
=== 81111155… ===  call 1: labelled   call 2: unlabelled   call 3: unlabelled  (1062ch each)
=== fe7b9ef8… ===  call 1: labelled   call 2: unlabelled   call 3: unlabelled   (798ch each)
```

Same summary bytes; only the label differs. Re-probing the "text sources echo" set hours later returned them **unlabelled**, and a URL source read for the first time returned **labelled**. Type, age and notebook were all confounded with call ordinal in the original probe — the same over-generalisation-from-one-shape mistake that caused #2276 in the first place.

The practical consequence is that **#2276 was broader than reported**: `get_guide` failed on the second and every later read of *any* source, not on URL sources. The nightly's read-only notebook had been read before, so it failed every time.

Corrected in `docs/android/proto-evidence-ledger.md`, `docs/android/endpoints.md`, the `select_document_guide` docstring, the `sources.proto` comment, and the CHANGELOG (the 0.8.2 entry is still unreleased, so it is fixed in place rather than annotated).

## Cassette

The cassettes turned out to be on `main` after all, so the item #2276 left open is closed here. `source_lifecycle` now reads one source twice and pins **both** shapes against recorded bytes:

```
interaction 10: leading guide field tag = #1 (labelled)
interaction 11: leading guide field tag = #2 (UNLABELLED)
```

Re-recorded with `NOTEBOOKLM_ANDROID_GRPC_RECORD=1`; scratch notebook verified cleaned up.

## Audit of the other derived reads

All five in the ADR-0019 row were checked; only these two diverged.

| | Android behaviour | Conformant |
|---|---|---|
| `get_summary` | no pre-flight; codec returns `NotebookDescription("", [])` | ✅ |
| `get_description` | as above | ✅ |
| `get_tree` | returns `None` on miss | ✅ |
| `get_guide` | pre-flight + rpc-5 + empty-guides all raised | ❌ → fixed |
| `check_freshness` | pre-flight raised | ❌ → fixed |

`get_fulltext` is deliberately **not** in that ADR row and keeps raising.

## Verification

- Live, both backends: nonexistent id → `SourceGuide('', ())` / `True` on each. Repeat reads of a real source → 3/3 succeed with identical content.
- `tests/e2e/test_sources.py` — **16 passed** on android, **16 passed** on web.
- Cassette re-recorded and replayed green.
- Full CI-equivalent suite: **18192 passed**, 93.60% coverage; `ruff check .`, `ruff format --check` (Python scope), `mypy src/notebooklm scripts/_live_auth_scenarios` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android source guide and freshness checks now handle missing or unsummarized sources without errors.
  * Empty guide results are returned consistently instead of raising an error.
  * Repeated guide requests now work consistently across source types, even when responses omit the source identifier.
  * Guide summaries and keywords remain consistent across repeated requests.

* **Documentation**
  * Updated Android endpoint and protocol documentation to describe repeat-call behavior and empty-result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->