### PR TITLE
test(android): stop racing the Windows clock in the upload timeout test

### DIFF
--- a/tests/unit/android/test_source_upload.py
+++ b/tests/unit/android/test_source_upload.py
@@ -486,6 +486,14 @@ async def test_waiting_branches_use_one_exact_read_then_optional_no_readback_tit
 @pytest.mark.asyncio
 async def test_error_or_wait_timeout_never_dispatches_title_mutation(tmp_path: Path) -> None:
     path, _ = _write_pdf(tmp_path)
+    # The ERROR leg has to reach its first poll: ``wait_until_registered`` checks
+    # the deadline before looking, and an expiry with nothing observed raises
+    # SourceTimeoutError (no status, no error streak) rather than the terminal
+    # SourceProcessingError this asserts. ``time.monotonic()`` advances in
+    # 15.6 ms steps on Windows before 3.13 (``GetTickCount64``), so a 10 ms
+    # budget can be gone between ``RuntimeDeadline.start()`` and that first
+    # check. Stay above one tick.
+    wait_timeout = 0.05
     for response, expected in [
         (_project(_SETTINGS.SOURCE_STATUS_ERROR), SourceProcessingError),
         (_project(_SETTINGS.SOURCE_STATUS_TENTATIVE), SourceTimeoutError),
@@ -498,7 +506,7 @@ async def test_error_or_wait_timeout_never_dispatches_title_mutation(tmp_path: P
                 NOTEBOOK_ID,
                 path,
                 wait=False,
-                wait_timeout=0.01,
+                wait_timeout=wait_timeout,
                 title="Custom",
             )
         assert MUTATE_SOURCE_METHOD not in [call[0] for call in session.calls]


### PR DESCRIPTION
## Summary

`test_error_or_wait_timeout_never_dispatches_title_mutation` flakes on
`windows-latest` / 3.12: it asserts `SourceProcessingError` and gets
`SourceTimeoutError`. A clock race, not a behaviour bug — I hit it on #2287,
whose diff never touches this path.

## Related Issue

None. Surfaced by that red cell.

## Changes

`wait_timeout` goes from `0.01` to `0.05` in that one test.

`wait_until_registered` checks the deadline before the first `get_source`. On
Windows before 3.13, `time.monotonic()` is `GetTickCount64()` and moves in
15.6 ms steps ([What's New in 3.13][1]), so one tick landing between
`RuntimeDeadline.start(0.01)` and that check spends the budget before anything
is polled. The timeout then carries `last_status=None` — which is why the CI
message stops at `not ready after 0.0s` with no status suffix. A PDF's type
code is terminal, so a poll that did happen would have raised
`SourceProcessingError`, as it does on every other cell.

Reproduced without a Windows runner, feeding the poller a clock that crosses
one tick:

    monotonic = iter([0.0, 0.0156]).__next__

    coarse -> SourceTimeoutError: Source …0201 not ready after 0.0s | polls=0 last_status=None
    fine   -> SourceProcessingError: Source …0201 failed to process | polls=1

The first line is the CI failure character for character. 0.05 clears a tick
with room to spare. The sibling case below keeps `0.01`: it asserts the
timeout, so an early expiry cannot flip it.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass — 3.14.0, `-n auto --dist loadgroup --cov-fail-under=90`: 18,172 passed, 81 skipped, 1 xfailed, 92.98%
- [x] Linting and formatting pass — `pre-commit run --all-files`
- [x] Type checking passes — `mypy src/notebooklm --ignore-missing-imports`, no issues in 418 source files
- [ ] If this PR changes architectural shape, an ADR has been added or updated. *(N/A — one test budget.)*

## Notes

The deeper fix — one guaranteed look before any timeout is declared — would
cover the other sub-tick budgets in the suite (19 spots under 15.6 ms), but it
breaks `test_wait_until_ready_checks_timeout_after_get`,
`test_wait_until_registered_raises_timeout` and
`test_wait_until_ready_timeout_raises`, which pin that order on purpose. Your
call. I'll open an issue if you want it tracked.

[1]: https://docs.python.org/3/whatsnew/3.13.html#time

---

by Carlos Vera  
carlos@braveslab.com<br>
<em>“**For I can do everything through Christ, who gives me strength.**”</em>
<em>Phil 4:13 | NLT</em>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Android upload timeout/error test reliability by allowing sufficient time for the initial status check, including on Windows.
  * Added clarifying comments documenting the timeout requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->