### PR TITLE
docs: correct what PR CI runs for repo_lint and coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ at **84.39%** coverage and fails the 90% gate, while CI's set runs **15,478** at
 **96.61%** and passes. That ~1,500-test blind spot hid a real MCP-adapter defect
 through eight red CI jobs on #2198.
 
-To reproduce the nightly coverage run exactly (`.github/workflows/nightly.yml`; PR cells run the same suite without coverage):
+To approximate the nightly coverage gate (`.github/workflows/nightly.yml` — nightly actually splits coverage into a marker-filtered xdist pass plus a serial Playwright `--cov-append` pass and checks per-file floors via `scripts/check_coverage_thresholds.py`; PR cells run the same suite without coverage):
 
 ```bash
 uv run pytest -n auto --dist loadgroup --cov=src/notebooklm \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ at **84.39%** coverage and fails the 90% gate, while CI's set runs **15,478** at
 **96.61%** and passes. That ~1,500-test blind spot hid a real MCP-adapter defect
 through eight red CI jobs on #2198.
 
-To reproduce a CI test run exactly (`.github/workflows/test.yml`):
+To reproduce the nightly coverage run exactly (`.github/workflows/nightly.yml`; PR cells run the same suite without coverage):
 
 ```bash
 uv run pytest -n auto --dist loadgroup --cov=src/notebooklm \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ pre-commit run --all-files                      # manual run on the whole tree (
 
 > **Caveat:** if `pre-commit install` errors with `Cowardly refusing to install hooks with core.hooksPath set`, your git is configured to use a custom hooks directory (common with Husky / nx / shared dev configs). Workaround: `git config --unset core.hooksPath` then re-run `pre-commit install`, or run `pre-commit run --all-files` manually before each commit. CI runs the same hook either way, so a clean local hook is convenience, not correctness.
 
-> **CI parity.** The local pre-commit one-liner above matches the CI **lint gate** (`uv run pre-commit run --all-files` in `.github/workflows/test.yml`). CI additionally runs the full test matrix on multiple Python versions (3.10–3.14) and asserts a 90% coverage floor (`pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`). The lint+test failure modes are caught locally; the multi-Python-version drift is not — `uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90` here uses your local Python version only.
+> **CI parity.** The local pre-commit one-liner above matches the CI **lint gate** (`uv run pre-commit run --all-files` in `.github/workflows/test.yml`). CI additionally runs the full test matrix on multiple Python versions (3.10–3.14) without coverage; the 90% coverage floor (`pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`) is asserted by the nightly workflow. The lint+test failure modes are caught locally; the multi-Python-version drift is not — `uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90` here uses your local Python version only.
 
 ### Pull Request Process
 
@@ -132,9 +132,14 @@ uv run pytest tests/unit tests/integration -m "not repo_lint"
 uv run pytest tests/unit tests/integration -m "repo_lint"
 ```
 
-Run the full suite (including `repo_lint`) before pushing — CI runs everything
-by default, so `repo_lint` failures still block merge. The default
-`uv run pytest` invocation does not filter the marker out.
+Run the full suite (including `repo_lint`) before pushing. PR CI does **not**
+run `repo_lint` in bulk: every matrix cell passes `-m "not repo_lint"`, and only
+the guards named by node id in the `Run critical contract guards` step of
+`.github/workflows/test.yml` block merge. The rest of the marker runs in the
+manual `repo-lint` job (`workflow_dispatch`) and nightly, so a `repo_lint`
+failure you skip locally can reach `main` unnoticed until the next nightly. The
+default `uv run pytest` invocation does not filter the marker out; `make gates`
+runs the marker with CI's shape.
 
 Quick guidance:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,11 +133,14 @@ uv run pytest tests/unit tests/integration -m "repo_lint"
 ```
 
 Run the full suite (including `repo_lint`) before pushing. PR CI does **not**
-run `repo_lint` in bulk: every matrix cell passes `-m "not repo_lint"`, and only
-the guards named by node id in the `Run critical contract guards` step of
-`.github/workflows/test.yml` block merge. The rest of the marker runs in the
-manual `repo-lint` job (`workflow_dispatch`) and nightly, so a `repo_lint`
-failure you skip locally can reach `main` unnoticed until the next nightly. The
+run `repo_lint` in bulk: every matrix cell passes `-m "not repo_lint"`, so of
+the marker itself only the guards named by node id in the `Run critical
+contract guards` step of `.github/workflows/test.yml` are merge-blocking (the
+ordinary non-`repo_lint` suite blocks merge as always, and the Code Quality job
+independently runs some of the same scripts several `repo_lint` tests wrap).
+The rest of the marker runs in the manual `repo-lint` job (`workflow_dispatch`)
+and nightly, so a `repo_lint` failure with no promoted node id and no
+Code-Quality mirror can reach `main` unnoticed until the next nightly. The
 default `uv run pytest` invocation does not filter the marker out; `make gates`
 runs the marker with CI's shape.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -555,9 +555,9 @@ uv run pytest
 uv run pytest -n auto --dist loadgroup
 
 # Fast local loop — skip repo-wide audit / release-gate checks (~40s saved).
-# PR CI skips these too (only node ids named in the critical-guard step run);
-# the manual repo-lint job and nightly run the full marker. Run `make gates`
-# before pushing a change that could trip one.
+# PR CI also skips the bulk repo_lint marker (of it, only node ids named in
+# the critical-guard step run); the manual repo-lint job and nightly run the
+# full marker. Run `make gates` before pushing a change that could trip one.
 uv run pytest tests/unit tests/integration -m "not repo_lint"
 
 # E2E tests (requires auth + test notebook)

--- a/docs/development.md
+++ b/docs/development.md
@@ -555,7 +555,9 @@ uv run pytest
 uv run pytest -n auto --dist loadgroup
 
 # Fast local loop — skip repo-wide audit / release-gate checks (~40s saved).
-# CI still runs these; the marker just lets you iterate quickly.
+# PR CI skips these too (only node ids named in the critical-guard step run);
+# the manual repo-lint job and nightly run the full marker. Run `make gates`
+# before pushing a change that could trip one.
 uv run pytest tests/unit tests/integration -m "not repo_lint"
 
 # E2E tests (requires auth + test notebook)


### PR DESCRIPTION
## Summary

Follow-up to #2287. Three contributor-facing statements describe a CI layout that no longer exists, and #2287's own docstring now contradicts them.

## Changes

| File | Before | Reality |
| --- | --- | --- |
| `CONTRIBUTING.md` (fast-loop section) | "CI runs everything by default, so `repo_lint` failures still block merge." | Every PR matrix cell passes `-m "not repo_lint"`; only guards named by node id in `Run critical contract guards` block merge. The rest of the marker runs in the manual `repo-lint` job and nightly. This gap is how #2266 shipped green. |
| `docs/development.md` (fast-loop comment) | "CI still runs these; the marker just lets you iterate quickly." | Same falsehood. |
| `CONTRIBUTING.md` (CI parity note), `CLAUDE.md` | PR matrix "asserts a 90% coverage floor" / "reproduce a CI test run exactly (`test.yml`)" | `test.yml` runs no `--cov` at all; the floor is asserted in `nightly.yml`. |

`pyproject.toml:192` (marker description) and the `Makefile` `gates` target already state the correct model, so the tree was contradicting itself. The new wording points contributors at `make gates` before pushing anything that could trip a `repo_lint` guard.

## Related Issue

None — surfaced while reviewing #2287.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass — `pytest -n auto --dist loadgroup -m repo_lint --timeout=180 --no-cov` (doc-sync guards live here): 1916 passed, 1 skipped, 1 xfailed
- [x] Linting and formatting pass — `pre-commit run --all-files`
- [x] Type checking passes — N/A, docs only
- [ ] If this PR changes architectural shape, an ADR has been added or updated. *(N/A — docs only.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188GkHrBFM9TbzktngA6mTq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how local test commands compare with PR CI and nightly coverage checks.
  * Documented coverage thresholds and split coverage workflows more accurately.
  * Updated guidance on `repo_lint`, including which checks block merges and when full lint validation runs.
  * Clarified that PR test matrix runs do not include coverage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->