### PR TITLE
fix(scripts): parse RPC registrations forward so inline-ctor ids are not dropped

### DIFF
--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -5,12 +5,19 @@ against ``src/notebooklm/rpc/types.py``.
 NotebookLM declares every ``batchexecute`` RPC in its (public, gstatic-served) JS
 bundle as::
 
-    _.fD("<rpc_id>", <RespCtor>, <ReqCtor>, [<flags>, "/<Service>.<Method>"])
+    new _.dC("<rpc_id>", <RespCtor>, <ReqCtor>, [<flags>, "/<Service>.<Method>"])
 
-(The registration helper is currently minified to ``_.fD``; it was ``_.uD`` in an
-earlier bundle. The scraper does **not** depend on the helper name — it anchors on
-the quoted ``"/<Service>.<Method>"`` path — so a future rename of this helper does
-not blank the diff.)
+(The registration helper is currently minified to ``_.dC``; it was ``_.fD`` and
+``_.uD`` in earlier bundles. The scraper does **not** depend on the helper name:
+it parses *forward* from each ``new _.<helper>("<id>"`` call to the first quoted
+``"/<Service>.<Method>"`` path before the next ``new _.`` call, so id and path
+come from the same registration by construction, and falls back to a
+path-anchored backward scan for any path the forward parse did not claim — so a
+rename of the helper, or a change of the ``new`` call form, does not blank the
+diff. The ctor arguments may be *named* (``zKb``) or *inline anonymous classes*
+hundreds of chars long (#2289); neither form affects the parse. Parse coverage —
+registration sites, method paths, fallback- and un-attributed paths — is
+reported so a minifier change that widens a gap shows up as a number.)
 
 The obfuscated ``<rpc_id>`` values are this project's #1 breakage class — they
 rotate without notice and a stale id silently breaks the affected operation. This
@@ -74,6 +81,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 # The NotebookLM web app's gstatic JS namespace. If Google renames the app this
 # pattern must be updated (the script will then report "no bundle URL").
@@ -81,16 +89,26 @@ _APP = "boq-labs-tailwind"
 _BUNDLE_URL_RE = re.compile(rf'https://www\.gstatic\.com/_/mss/{_APP}/_/js/[^"\\\s<>]+')
 
 # A registration's two stable, quoted anchors: the ``/Service.Method`` path and
-# the rpc id. We anchor on the path and scan *backward* for the nearest id, which
-# is robust to nested ``[...]`` in the options array (a single forward regex
-# spanning to the path breaks on the inner ``]``). Quote-agnostic (``"`` or
-# ``'``) so a change in the bundle minifier's quote style doesn't blank the diff.
+# the rpc id. Quote-agnostic (``"`` or ``'``) so a change in the bundle
+# minifier's quote style doesn't blank the diff.
 _METHOD_PATH_RE = re.compile(r"""["'](/[A-Za-z][\w]*\.[A-Za-z][\w]*)["']""")
 _ID_TOKEN_RE = re.compile(r"""["']([A-Za-z0-9]{5,8})["']""")
-# How far back from a path string to scan for its registration id. The
-# ``_.uD(id, ReqCtor, RespCtor, [flags, path])`` form fits well within ~100 chars;
-# 160 leaves headroom for longer minified constructor names.
-_ID_LOOKBACK = 160
+# Primary parse: a registration *site* is a ``new _.<helper>("<id>"`` call whose
+# first argument is a quoted short token. Parsing forward from the site to the
+# next ``new _.<helper>(`` call bounds the registration, so the first path in
+# that span belongs to that id by construction — independent of how long the
+# ctor arguments are (named ctors are ~60 chars; inline anonymous classes run
+# 160–370 chars on the 2026-08-31 bundle, #2289) and immune to stray quoted
+# tokens inside a ctor body. ``new _.BD("…")``-style non-RPC calls also match as
+# sites; they simply carry no path and are not counted.
+_REGISTRATION_SITE_RE = re.compile(r"""new\s+_\.\w+\(\s*(["'])([A-Za-z0-9]{5,8})\1""")
+_REGISTRATION_BOUNDARY_RE = re.compile(r"new\s+_\.\w+\(")
+# Fallback for a path the forward parse did not claim (a change of the ``new
+# _.`` call form): scan *backward* from the path for the nearest quoted short
+# token. 400 chars covers the widest inline-anonymous-ctor registration seen
+# (367) and is where the recovered count plateaus (#2289 sweep: 160 -> 171 ids,
+# 240 -> 183, 320 -> 186, 400+ -> 187).
+_ID_LOOKBACK = 400
 
 # Real obfuscated rpc ids are short alphanumerics; this filter keeps non-id enum
 # constants (e.g. ``blog_post``) out of the diff.
@@ -178,21 +196,79 @@ def parse_ids_from_text(types_text: str) -> dict[str, str]:
     return out
 
 
+class RegistryParse(NamedTuple):
+    """The parsed registry plus the parse-coverage numbers behind it (#2289)."""
+
+    registry: dict[str, str]
+    """``{rpc_id: /Service.Method}`` for every registration attributed to an id."""
+    sites: int
+    """``new _.<helper>("<id>"`` calls the forward parse found a method path in."""
+    paths: int
+    """Distinct quoted ``/Service.Method`` strings in the bundle."""
+    fallback: int
+    """Paths attributed only by the backward path-anchored scan (helper-form drift)."""
+    unclaimed: tuple[str, ...]
+    """Distinct method paths no id could be attributed to — a parser gap to widen."""
+
+
+def parse_registry(bundle: str) -> RegistryParse:
+    """Parse every ``id -> /Service.Method`` registration in the bundle.
+
+    Primary pass — *forward* from each registration site: the span from a
+    ``new _.<helper>("<id>"`` call to the next ``new _.<helper>(`` call is one
+    registration, and the first ``"/Service.Method"`` inside it is that id's
+    path. Id and path therefore come from the same call regardless of how long
+    the ctor arguments between them are (the #2289 inline-anonymous-ctor form
+    that a fixed backward window silently dropped).
+
+    Fallback pass — for any path the forward parse did not claim (e.g. the
+    helper is no longer invoked with ``new``): the nearest preceding quoted
+    short token within :data:`_ID_LOOKBACK` chars, provided that token is not
+    already an id the forward pass attributed (so a stray path never re-maps a
+    known registration). Paths still unattributed after both passes are
+    returned as ``unclaimed`` rather than dropped.
+    """
+    registry: dict[str, str] = {}
+    claimed_paths: set[str] = set()
+    sites = 0
+    for site in _REGISTRATION_SITE_RE.finditer(bundle):
+        boundary = _REGISTRATION_BOUNDARY_RE.search(bundle, site.end())
+        end = boundary.start() if boundary else len(bundle)
+        path = _METHOD_PATH_RE.search(bundle, site.end(), end)
+        if path is None:
+            continue
+        sites += 1
+        registry[site.group(2)] = path.group(1)
+        claimed_paths.add(path.group(1))
+
+    forward_ids = set(registry)
+    fallback = 0
+    seen_paths: set[str] = set()
+    unclaimed: list[str] = []
+    for match in _METHOD_PATH_RE.finditer(bundle):
+        path_str = match.group(1)
+        seen_paths.add(path_str)
+        if path_str in claimed_paths:
+            continue
+        window = bundle[max(0, match.start() - _ID_LOOKBACK) : match.start()]
+        ids = _ID_TOKEN_RE.findall(window)
+        if ids and ids[-1] not in forward_ids:
+            registry[ids[-1]] = path_str
+            claimed_paths.add(path_str)
+            fallback += 1
+        elif path_str not in unclaimed:
+            unclaimed.append(path_str)
+    # A path the fallback claimed at a later occurrence is no longer unclaimed.
+    unclaimed = [p for p in unclaimed if p not in claimed_paths]
+    return RegistryParse(registry, sites, len(seen_paths), fallback, tuple(unclaimed))
+
+
 def extract_registry(bundle: str) -> dict[str, str]:
     """Return ``{rpc_id: /Service.Method}`` for every registration in the bundle.
 
-    Anchored on each ``"/Service.Method"`` path: the rpc id is the nearest
-    preceding quoted short token (the registration's first argument). Scanning
-    backward from the path tolerates nested brackets in the options array that a
-    single forward regex cannot span.
+    Thin wrapper over :func:`parse_registry` for callers that only need the map.
     """
-    out: dict[str, str] = {}
-    for match in _METHOD_PATH_RE.finditer(bundle):
-        window = bundle[max(0, match.start() - _ID_LOOKBACK) : match.start()]
-        ids = _ID_TOKEN_RE.findall(window)
-        if ids:
-            out[ids[-1]] = match.group(1)
-    return out
+    return parse_registry(bundle).registry
 
 
 def diff(ours: dict[str, str], live: dict[str, str], bundle: str) -> dict[str, dict[str, str]]:
@@ -529,9 +605,20 @@ def fetch_bundle() -> str:
     return "\n".join(bodies)
 
 
+def _coverage_counts(parsed: RegistryParse) -> dict[str, int]:
+    """The parse-coverage numbers as reported (a shrinking ``parsed`` or a growing
+    ``fallback``/``unclaimed`` is the minifier-drift signal, #2289)."""
+    return {
+        "registration_sites": parsed.sites,
+        "method_paths": parsed.paths,
+        "parsed": len(parsed.registry),
+        "fallback": parsed.fallback,
+    }
+
+
 def _print_report(
     ours: dict[str, str],
-    live: dict[str, str],
+    parsed: RegistryParse,
     buckets: dict[str, dict[str, str]],
     current_services: set[str],
 ) -> None:
@@ -547,7 +634,18 @@ def _print_report(
         buckets["absent"],
         buckets["unmapped"],
     )
-    print(f"our ids: {len(ours)} | live registrations parsed: {len(live)}")
+    cov = _coverage_counts(parsed)
+    print(f"our ids: {len(ours)} | live registrations parsed: {cov['parsed']}")
+    print(
+        f"parse coverage: registration sites: {cov['registration_sites']}  "
+        f"method paths: {cov['method_paths']}  fallback: {cov['fallback']}  "
+        f"unclaimed: {len(parsed.unclaimed)}"
+    )
+    if parsed.unclaimed:
+        print("UNCLAIMED — method path with no attributable id (parser gap; widen the parser):")
+        for path in parsed.unclaimed:
+            print(f"  {path}")
+    print()
     print(
         f"CONFIRMED: {len(confirmed)}  ABSENT: {len(absent)}  "
         f"PRESENT-UNPARSED: {len(present)}  UNMAPPED: {len(unmapped)}\n"
@@ -741,7 +839,8 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
         return _AUTH_FAILURE_EXIT
-    live = extract_registry(bundle)
+    parsed = parse_registry(bundle)
+    live = parsed.registry
     buckets = diff(ours, live, bundle)
     # Services any CONFIRMED id resolves to are, empirically, serving our cohort.
     current_services = {_service_of(m) for m in buckets["confirmed"].values()}
@@ -768,6 +867,8 @@ def main(argv: list[str] | None = None) -> int:
                         for i, m in buckets["unmapped"].items()
                     },
                     "enums": enum_buckets,
+                    "parse_coverage": _coverage_counts(parsed)
+                    | {"unclaimed": list(parsed.unclaimed)},
                     "quota_codes": {str(code): message for code, message in quota.items()},
                     "proto_assertions": sorted(f"{m}.{f}" for m, f in proto),
                     "counts": {k: len(v) for k, v in buckets.items()}
@@ -779,7 +880,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        _print_report(ours, live, buckets, current_services)
+        _print_report(ours, parsed, buckets, current_services)
         _print_enum_report(enum_buckets, quota, proto)
 
     exit_code = 0

--- a/scripts/capture_rpc_registry.py
+++ b/scripts/capture_rpc_registry.py
@@ -94,15 +94,20 @@ _BUNDLE_URL_RE = re.compile(rf'https://www\.gstatic\.com/_/mss/{_APP}/_/js/[^"\\
 _METHOD_PATH_RE = re.compile(r"""["'](/[A-Za-z][\w]*\.[A-Za-z][\w]*)["']""")
 _ID_TOKEN_RE = re.compile(r"""["']([A-Za-z0-9]{5,8})["']""")
 # Primary parse: a registration *site* is a ``new _.<helper>("<id>"`` call whose
-# first argument is a quoted short token. Parsing forward from the site to the
-# next ``new _.<helper>(`` call bounds the registration, so the first path in
-# that span belongs to that id by construction — independent of how long the
-# ctor arguments are (named ctors are ~60 chars; inline anonymous classes run
-# 160–370 chars on the 2026-08-31 bundle, #2289) and immune to stray quoted
-# tokens inside a ctor body. ``new _.BD("…")``-style non-RPC calls also match as
-# sites; they simply carry no path and are not counted.
+# first argument is a quoted short token. The registration is that call's
+# bracket-balanced argument list, so the first path inside it belongs to that
+# id by construction — independent of how long the ctor arguments are (named
+# ctors are ~60 chars; inline anonymous classes run 160–370 chars on the
+# 2026-08-31 bundle, #2289), immune to stray quoted tokens inside a ctor body,
+# and a ``new _.X("…")`` call nested *inside* a ctor body is part of the outer
+# span, not a site of its own. ``new _.BD("…")``-style non-RPC calls also match
+# as sites; they simply carry no path and are not counted. If the argument
+# list does not balance within ``_SPAN_SCAN_LIMIT`` chars (a string/regex
+# literal the scanner misreads), the span falls back to the next ``new _.``
+# call so a single odd registration cannot swallow the rest of the bundle.
 _REGISTRATION_SITE_RE = re.compile(r"""new\s+_\.\w+\(\s*(["'])([A-Za-z0-9]{5,8})\1""")
 _REGISTRATION_BOUNDARY_RE = re.compile(r"new\s+_\.\w+\(")
+_SPAN_SCAN_LIMIT = 10_000
 # Fallback for a path the forward parse did not claim (a change of the ``new
 # _.`` call form): scan *backward* from the path for the nearest quoted short
 # token. 400 chars covers the widest inline-anonymous-ctor registration seen
@@ -211,55 +216,87 @@ class RegistryParse(NamedTuple):
     """Distinct method paths no id could be attributed to — a parser gap to widen."""
 
 
+def _call_span_end(bundle: str, start: int) -> int:
+    """Return the index just past the ``)`` that closes the call open at ``start``.
+
+    ``start`` is inside the argument list (depth 1). Quoted strings are skipped
+    so brackets inside literals do not count. If the list does not balance
+    within :data:`_SPAN_SCAN_LIMIT` chars, the span ends at the next
+    ``new _.<helper>(`` call instead (or the end of the bundle).
+    """
+    depth = 1
+    i = start
+    limit = min(len(bundle), start + _SPAN_SCAN_LIMIT)
+    while i < limit:
+        char = bundle[i]
+        if char in "\"'`":
+            i += 1
+            while i < limit and bundle[i] != char:
+                i += 2 if bundle[i] == "\\" else 1
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    boundary = _REGISTRATION_BOUNDARY_RE.search(bundle, start)
+    return boundary.start() if boundary else len(bundle)
+
+
 def parse_registry(bundle: str) -> RegistryParse:
     """Parse every ``id -> /Service.Method`` registration in the bundle.
 
-    Primary pass — *forward* from each registration site: the span from a
-    ``new _.<helper>("<id>"`` call to the next ``new _.<helper>(`` call is one
-    registration, and the first ``"/Service.Method"`` inside it is that id's
-    path. Id and path therefore come from the same call regardless of how long
-    the ctor arguments between them are (the #2289 inline-anonymous-ctor form
-    that a fixed backward window silently dropped).
+    Primary pass — *forward* from each registration site: the bracket-balanced
+    argument list of a ``new _.<helper>("<id>"`` call is one registration, and
+    the first ``"/Service.Method"`` inside it is that id's path. Id and path
+    therefore come from the same call regardless of how long the ctor arguments
+    between them are (the #2289 inline-anonymous-ctor form that a fixed
+    backward window silently dropped). A ``new _.X(…)`` call nested inside a
+    ctor body lies within the outer span and is not a site of its own.
 
-    Fallback pass — for any path the forward parse did not claim (e.g. the
-    helper is no longer invoked with ``new``): the nearest preceding quoted
-    short token within :data:`_ID_LOOKBACK` chars, provided that token is not
-    already an id the forward pass attributed (so a stray path never re-maps a
-    known registration). Paths still unattributed after both passes are
-    returned as ``unclaimed`` rather than dropped.
+    Fallback pass — over every path *occurrence* the forward parse did not
+    claim (e.g. the helper is no longer invoked with ``new``): the nearest
+    preceding quoted short token within :data:`_ID_LOOKBACK` chars, provided
+    that token is not already an attributed id (by either pass), so a stray
+    path never re-maps a known registration. An occurrence whose nearest token
+    is already mapped to that same path is a repeat of a known registration
+    and is ignored. Paths still unattributed after both passes are returned as
+    ``unclaimed`` rather than dropped.
     """
     registry: dict[str, str] = {}
-    claimed_paths: set[str] = set()
+    claimed_occurrences: set[int] = set()
     sites = 0
+    span_end = 0
     for site in _REGISTRATION_SITE_RE.finditer(bundle):
-        boundary = _REGISTRATION_BOUNDARY_RE.search(bundle, site.end())
-        end = boundary.start() if boundary else len(bundle)
-        path = _METHOD_PATH_RE.search(bundle, site.end(), end)
+        if site.start() < span_end:
+            continue  # nested inside the registration being parsed
+        span_end = _call_span_end(bundle, site.end())
+        path = _METHOD_PATH_RE.search(bundle, site.end(), span_end)
         if path is None:
             continue
         sites += 1
         registry[site.group(2)] = path.group(1)
-        claimed_paths.add(path.group(1))
+        claimed_occurrences.add(path.start())
 
-    forward_ids = set(registry)
     fallback = 0
     seen_paths: set[str] = set()
     unclaimed: list[str] = []
     for match in _METHOD_PATH_RE.finditer(bundle):
         path_str = match.group(1)
         seen_paths.add(path_str)
-        if path_str in claimed_paths:
+        if match.start() in claimed_occurrences:
             continue
         window = bundle[max(0, match.start() - _ID_LOOKBACK) : match.start()]
         ids = _ID_TOKEN_RE.findall(window)
-        if ids and ids[-1] not in forward_ids:
+        if ids and ids[-1] not in registry:
             registry[ids[-1]] = path_str
-            claimed_paths.add(path_str)
             fallback += 1
-        elif path_str not in unclaimed:
+        elif not (ids and registry[ids[-1]] == path_str) and path_str not in unclaimed:
             unclaimed.append(path_str)
     # A path the fallback claimed at a later occurrence is no longer unclaimed.
-    unclaimed = [p for p in unclaimed if p not in claimed_paths]
+    attributed = set(registry.values())
+    unclaimed = [p for p in unclaimed if p not in attributed]
     return RegistryParse(registry, sites, len(seen_paths), fallback, tuple(unclaimed))
 
 

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -650,6 +650,60 @@ def test_extract_registry_falls_back_to_path_anchor_without_new_form() -> None:
     assert parsed.unclaimed == ()
 
 
+def test_extract_registry_nested_new_inside_ctor_body_is_not_a_boundary() -> None:
+    """A ``new _.X("…")`` call *inside* an inline ctor body belongs to the outer
+    registration: it must neither end the outer span nor claim the path itself."""
+    bundle = (
+        'new _.dC("outerId",class extends _.n{constructor(a){super(a);'
+        'this.x=new _.BD("innerX",[1,2]);this.y=_.q("(",")")}},Q,'
+        '[_.ne,!0,_.me,"/Svc.Outer"]);'
+        'new _.dC("nextId",A,B,[_.ne,!1,_.me,"/Svc.Next"]);'
+    )
+    assert extract_registry(bundle) == {"outerId": "/Svc.Outer", "nextId": "/Svc.Next"}
+    parsed = parse_registry(bundle)
+    assert parsed.sites == 2
+    assert parsed.fallback == 0
+    assert parsed.unclaimed == ()
+
+
+def test_fallback_never_overwrites_an_id_it_already_attributed() -> None:
+    """Two orphan paths whose nearest token is the same id: the second must not
+    silently replace the first's mapping — it is reported as unclaimed."""
+    bundle = '_.fD("legacy",A,B,[_.Ue,!1,_.Se,"/Svc.First"]);x="/Svc.Second";'
+    parsed = parse_registry(bundle)
+    assert parsed.registry == {"legacy": "/Svc.First"}
+    assert parsed.fallback == 1
+    assert parsed.unclaimed == ("/Svc.Second",)
+
+
+def test_same_path_registered_under_two_ids_keeps_both() -> None:
+    """A forward-form and a legacy-form registration of the same method under
+    different ids are both kept: claiming is per path *occurrence*, not value."""
+    bundle = (
+        'new _.dC("newId",A,B,[_.ne,!0,_.me,"/Svc.Same"]);'
+        '_.fD("oldId",A,B,[_.Ue,!1,_.Se,"/Svc.Same"]);'
+    )
+    parsed = parse_registry(bundle)
+    assert parsed.registry == {"newId": "/Svc.Same", "oldId": "/Svc.Same"}
+    assert parsed.sites == 1
+    assert parsed.fallback == 1
+    assert parsed.unclaimed == ()
+
+
+def test_repeated_occurrence_of_a_known_registration_is_not_unclaimed() -> None:
+    """The bundle registers some RPCs twice (once per chunk). A second occurrence
+    whose nearest token is already mapped to the same path is a repeat, not a gap."""
+    bundle = (
+        _NAMED_CTOR + 'r("wXbhsf","/LabsTailwindOrchestrationService.ListRecentlyViewedProjects");'
+    )
+    parsed = parse_registry(bundle)
+    assert parsed.registry == {
+        "wXbhsf": "/LabsTailwindOrchestrationService.ListRecentlyViewedProjects",
+    }
+    assert parsed.fallback == 0
+    assert parsed.unclaimed == ()
+
+
 def test_parse_registry_reports_unclaimed_paths() -> None:
     """A path with no attributable id is surfaced as a count, not silently dropped."""
     bundle = _NAMED_CTOR + 'x="/Svc.Orphan";' + "y" * 500 + 'z="/Svc.Orphan2";'

--- a/tests/unit/test_capture_rpc_registry.py
+++ b/tests/unit/test_capture_rpc_registry.py
@@ -26,6 +26,7 @@ from scripts.capture_rpc_registry import (
     main,
     parse_enum_members_from_text,
     parse_ids_from_text,
+    parse_registry,
 )
 
 # Mixed quote styles on purpose — exercises the quote-agnostic parsing of both
@@ -559,3 +560,132 @@ def test_check_and_check_enums_combine(tmp_path: Path, capsys: pytest.CaptureFix
     assert (
         main(["--bundle-file", str(bundle), "--types", str(types), "--check", "--check-enums"]) == 1
     )
+
+
+# ---------------------------------------------------------------------------
+# Registration-form robustness (#2289)
+# ---------------------------------------------------------------------------
+
+# Verbatim registrations from the 2026-08-31 bundle. Both constructor arguments
+# are *inline anonymous classes*, so the id sits 160+ chars before the path —
+# outside the old 160-char backward window, which silently dropped 16 of 187
+# live registrations (#2289). ``WJkjP`` is the example quoted in the issue;
+# ``OcvKNc`` is the widest gap (232 chars) among the sixteen.
+_INLINE_CTOR_WJKJP = (
+    'new _.dC("WJkjP",class extends _.n{constructor(a){super(a)}},'
+    "class extends _.n{constructor(a){super(a)}Xs(a){return _.io(this,_.Ru,2,a)}"
+    "Lc(){return _.r(this,4)}},"
+    '[_.ne,!0,_.me,"/LabsTailwindOrchestrationService.GetSuggestedArtifactFromChat"]);'
+)
+_INLINE_CTOR_OCVKNC = (
+    'new _.dC("OcvKNc",class extends _.n{constructor(a){super(a)}},'
+    "class extends _.n{constructor(a){super(a)}Lc(){return _.r(this,2)}"
+    "Co(a){return _.Ml(this,zE,3,_.Nl(a))}Fp(a,b){return _.Jl(this,3,zE,a,b)}"
+    "Xs(a){return _.io(this,_.Ru,6,a)}},"
+    '[_.ne,!0,_.me,"/LabsTailwindOrchestrationService.NextStepSuggestions"]);'
+)
+# A *named*-ctor registration (verbatim), the form the old window was sized for.
+_NAMED_CTOR = (
+    "var zKb=class extends _.n{constructor(a){super(a)}};"
+    'new _.dC("wXbhsf",class extends _.n{constructor(a){super(a)}},zKb,'
+    '[_.ne,!0,_.me,"/LabsTailwindOrchestrationService.ListRecentlyViewedProjects"]);'
+)
+
+
+def test_extract_registry_inline_anonymous_ctors() -> None:
+    """Inline anonymous ctor args push the id far from the path; it must still parse."""
+    bundle = _INLINE_CTOR_WJKJP + _INLINE_CTOR_OCVKNC + _NAMED_CTOR
+    assert extract_registry(bundle) == {
+        "WJkjP": "/LabsTailwindOrchestrationService.GetSuggestedArtifactFromChat",
+        "OcvKNc": "/LabsTailwindOrchestrationService.NextStepSuggestions",
+        "wXbhsf": "/LabsTailwindOrchestrationService.ListRecentlyViewedProjects",
+    }
+    parsed = parse_registry(bundle)
+    # All three came from the forward parse (id and path from the same ``new _.``
+    # registration), not from the path-anchored fallback.
+    assert parsed.sites == 3
+    assert parsed.fallback == 0
+    assert parsed.unclaimed == ()
+
+
+def test_extract_registry_adjacent_registrations_do_not_cross_wire() -> None:
+    """Id and path must come from the *same* registration.
+
+    Two traps a naive parse falls into: (1) a non-RPC ``new _.X("<short>", …)``
+    call with no path directly precedes a registration — a forward regex without
+    a ``new _.`` boundary would span into the neighbour and attribute its path to
+    the wrong token; (2) an inline ctor body carries a stray 5–8 char string
+    literal between the id and the path — the nearest-preceding-token backward
+    scan would take *that* as the id.
+    """
+    bundle = (
+        'new _.BD("notRpc",class extends _.n{constructor(a){super(a)}});'
+        'new _.dC("realId",class extends _.n{constructor(a){super(a,"strayS")}},Q,'
+        '[_.ne,!0,_.me,"/Svc.Real"]);'
+        'new _.dC("nextId",A,B,[_.ne,!1,_.me,"/Svc.Next"]);'
+    )
+    assert extract_registry(bundle) == {"realId": "/Svc.Real", "nextId": "/Svc.Next"}
+    parsed = parse_registry(bundle)
+    assert parsed.sites == 2
+    assert parsed.fallback == 0
+    assert parsed.unclaimed == ()
+
+
+def test_extract_registry_falls_back_to_path_anchor_without_new_form() -> None:
+    """A helper-form change (no ``new _.`` prefix) must not blank the registry.
+
+    The path-anchored backward scan stays as a fallback and now tolerates the
+    inline-anonymous-ctor distances too (the window was widened to 400).
+    """
+    bundle = '_.fD("wXbhsf",kF,csb,[_.Ue,!1,_.Se,"/Svc.List"]);' + _INLINE_CTOR_WJKJP.replace(
+        "new _.dC(", "_.dC("
+    )
+    assert extract_registry(bundle) == {
+        "wXbhsf": "/Svc.List",
+        "WJkjP": "/LabsTailwindOrchestrationService.GetSuggestedArtifactFromChat",
+    }
+    parsed = parse_registry(bundle)
+    assert parsed.sites == 0
+    assert parsed.fallback == 2
+    assert parsed.unclaimed == ()
+
+
+def test_parse_registry_reports_unclaimed_paths() -> None:
+    """A path with no attributable id is surfaced as a count, not silently dropped."""
+    bundle = _NAMED_CTOR + 'x="/Svc.Orphan";' + "y" * 500 + 'z="/Svc.Orphan2";'
+    parsed = parse_registry(bundle)
+    assert parsed.registry == {
+        "wXbhsf": "/LabsTailwindOrchestrationService.ListRecentlyViewedProjects",
+    }
+    assert parsed.sites == 1
+    # ``/Svc.Orphan`` is within the fallback window of ``wXbhsf`` but that id is
+    # already claimed by its own registration, so the fallback must not re-map it.
+    assert parsed.unclaimed == ("/Svc.Orphan", "/Svc.Orphan2")
+    assert parsed.fallback == 0
+
+
+def test_main_reports_parse_coverage(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The report and --json carry the parse-coverage numbers (#2289)."""
+    types = tmp_path / "types.py"
+    types.write_text(_TYPES, encoding="utf-8")
+    bundle = tmp_path / "bundle.js"
+    # Three registrations (one an inline-ctor form) plus one orphan path.
+    bundle.write_text(_BUNDLE + _INLINE_CTOR_WJKJP + 'o="/Svc.Orphan";', encoding="utf-8")
+
+    assert main(["--bundle-file", str(bundle), "--types", str(types)]) == 0
+    out = capsys.readouterr().out
+    assert "live registrations parsed: 4" in out
+    assert "registration sites: 4" in out
+    assert "method paths: 5" in out
+    assert "unclaimed: 1" in out
+    assert "/Svc.Orphan" in out
+
+    assert main(["--bundle-file", str(bundle), "--types", str(types), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["parse_coverage"] == {
+        "registration_sites": 4,
+        "method_paths": 5,
+        "parsed": 4,
+        "fallback": 0,
+        "unclaimed": ["/Svc.Orphan"],
+    }


### PR DESCRIPTION
## Summary

Fixes #2289: `scripts/capture_rpc_registry.py` silently dropped **16 of 187** live RPC registrations because `extract_registry()` anchored on each `"/Service.Method"` string and scanned *backward* a fixed `_ID_LOOKBACK = 160` chars for the id. When the bundle inlines both constructor arguments as anonymous classes the id sits 160–370 chars before the path, so those registrations vanished from the UNMAPPED inventory — biased toward exactly the dormant RPCs the inventory exists to find (`OcvKNc NextStepSuggestions`, `JKjuUb ListSources`, `PGIOzd GetNotebookContext`, …). The nearest-token heuristic could also mis-map a stray quoted literal inside a ctor body as the id.

**Parsing change** (issue's approach 1 + 3 + 4):
- **Forward parse** from each `new _.<helper>("<id>"` registration site to the first method path before the next `new _.<helper>(` call. Id and path come from the same registration by construction, so ctor-argument length is irrelevant and stray quoted tokens in ctor bodies cannot be mistaken for the id.
- **Fallback** keeps the path-anchored backward scan for paths the forward parse does not claim (robustness to a change of the `new` call form), with the window widened to 400 (where the #2289 sweep plateaus). It never re-maps an id the forward pass already attributed.
- **Parse-coverage count**: `parse_registry()` returns a `RegistryParse` NamedTuple (`registry`, `sites`, `paths`, `fallback`, `unclaimed`). The report prints `parse coverage: registration sites: N  method paths: N  fallback: N  unclaimed: N` (plus the unclaimed paths), and `--json` carries the same under `parse_coverage`. `extract_registry()` is kept as a thin wrapper.
- Script header docstring updated to describe the strategy (no separate docs page described it).

Against the saved 2026-08-31 bundle:

| | before | after |
|---|---|---|
| registrations parsed | 171 | **187** |
| method paths attributed | 171 / 187 | **187 / 187** |
| registration sites | – | 208 |
| fallback / unclaimed | – | 0 / 0 |

No disagreements with the old parser on the 171 it did find; all 54 of our ids stay CONFIRMED.

Re-running the #2283 inventory and probing the recovered RPCs is a follow-up, not part of this PR.

## Test plan

- [x] 5 new regression tests in `tests/unit/test_capture_rpc_registry.py` (TDD: failed before, pass after):
  - verbatim inline-anonymous-ctor registrations `WJkjP` (160-char gap) and `OcvKNc` (232-char gap) plus a verbatim named-ctor registration → exact `{id: path}`, all via the forward parse
  - adjacent registrations: a non-RPC `new _.BD("…")` directly before a registration and a stray `"strayS"` literal inside a ctor body → no cross-wiring
  - no-`new` helper form → fallback attributes both, `sites == 0`, `fallback == 2`
  - orphan paths → reported as `unclaimed`, and the fallback does not re-map an already-claimed id
  - `main()` report and `--json` carry the coverage numbers
- [x] `uv run ruff format --check . && uv run ruff check .`
- [x] `uv run mypy src/notebooklm scripts/_live_auth_scenarios scripts/capture_rpc_registry.py --ignore-missing-imports`
- [x] `uv run pytest -n auto --dist loadgroup` → 18393 passed, 70 skipped, 1 xfailed (exit 0)
- [x] `--bundle-file` run against the saved 2026-08-31 bundle: 187/187, 0 unclaimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaNaUd3mutrGvnpU5uybDK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC registry parsing for longer and varied registration formats.
  * Prevented incorrect associations between adjacent registrations and duplicate fallback assignments.
  * Added fallback handling for registrations using alternate helper forms.

* **Reporting**
  * Added registry parse-coverage metrics and reporting for unclaimed paths.
  * Included coverage details in standard and JSON command-line output.

* **Tests**
  * Expanded validation for constructor formats, helper forms, fallback parsing, duplicate registrations, and coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->