### PR TITLE
feat(cli): add ranked source search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Android route were live-verified independently; the Android protobuf overlay,
   public-client cassettes, and lazy-module-aware RPC drift classification pin the
   recovered contract (#2283).
+- `notebooklm source search QUERY` exposes ranked passage retrieval in the CLI,
+  with repeatable `-s/--source` filters (including unique ID prefixes), an
+  optional `--limit`, a human-readable rank/source/span/text table, and the full
+  `RelevantChunk` array under `--json`.
 - **Google Play Books ("Expert Intelligence") sources** (#2292), initially on
   the web backend: `sources.list_play_books()` lists the account's Play Books library as
   `PlayBook` rows (content id, title, authors, `export_disabled` + `reason`),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -158,6 +158,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | Command | Arguments | Options | Example |
 |---------|-----------|---------|---------|
 | `list` | - | `--json`, `--limit N`, `--no-truncate`, `--label`, `--status` | `source list --limit 20 --no-truncate` |
+| `search <query>` | Passage-search query | `-s/--source ID` (repeatable), `--limit N`, `--json` | `source search "revenue growth" --limit 5` |
 | `add <content>` | URL/file/text (use `-` for stdin) | `--title`, `--type`, `--timeout`, `--follow-symlinks`, `--allow-internal` (URL sources only), `--json` (file-source `--mime-type` overrides extension inference — see [detailed section](#source-add-mime-type-file-sources)) | `source add "https://..." --timeout 90` |
 | `add-drive <id> <title>` | Drive file ID, title | `--mime-type [google-doc\|google-slides\|google-sheets\|pdf]`, `--json` | `source add-drive abc123 "Doc" --mime-type google-slides` |
 | `add-drive-file <id>` | Drive file ID or share URL | `--title`, `--wait`, `--json` | `source add-drive-file abc123 --title "Notes" --wait` |
@@ -179,6 +180,27 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `copy <id>... --to <notebook>` | Source IDs (or prefixes), target notebook id/prefix | `--to` (required), `--json` | `source copy src1 src2 --to 1a2b3c` — copies into another notebook; prints original → copy pairs. A partial copy lists the ids left behind (`not_copied` under `--json`) and exits 1 |
 
 All `source` subcommands also accept `-n/--notebook ID` (resolves via flag > `NOTEBOOKLM_NOTEBOOK` env > active context).
+
+`source search <query>` searches the indexed passages of every source in the
+notebook and orders matches by global relevance rank (lower is better). Repeat
+`-s/--source ID` to restrict the search; full IDs and unique prefixes are both
+accepted. The optional `--limit` is applied after global ranking. Text mode
+shows rank, source ID, source-relative span, and passage text. `--json` emits
+the full result array directly:
+
+```json
+[
+  {
+    "source_id": "source-uuid",
+    "text": "The matching passage text...",
+    "rank": 1,
+    "start": 14202,
+    "end": 14733
+  }
+]
+```
+
+`start` and `end` are `null` when the backend provides no usable span.
 
 `source delete <id>` accepts only full source IDs or unique partial-ID prefixes. To delete by exact source title, use `source delete-by-title "<title>"`.
 

--- a/src/notebooklm/cli/_source_render.py
+++ b/src/notebooklm/cli/_source_render.py
@@ -9,7 +9,7 @@ few wrappers remain explicit test patch points.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 from rich.markup import escape as escape_markup
@@ -54,14 +54,49 @@ from .services.source_mutations import (
 )
 from .services.source_research import SourceAddResearchResult
 from .services.source_serializers import (
+    relevant_chunk_payload,
     source_fulltext_payload,
     source_kind_value,
     source_row_payload,
     source_summary_payload,
 )
 
+if TYPE_CHECKING:
+    from ..types import RelevantChunk
+
 # Compatibility wrappers — tests patch these names on this module. Each
 # one is a one-liner forwarder to the canonical service-layer home.
+
+
+def _render_source_search_result(
+    chunks: list[RelevantChunk],
+    *,
+    json_output: bool,
+    ctx: click.Context,
+) -> None:
+    """Render ranked passage search results as JSON or a readable table."""
+    if json_output:
+        json_output_response([relevant_chunk_payload(chunk) for chunk in chunks])
+        return
+
+    if not chunks:
+        cli_print("No relevant passages found.", ctx=ctx)
+        return
+
+    table = Table(title=f"{len(chunks)} relevant passage(s)")
+    table.add_column("Rank", justify="right", no_wrap=True)
+    table.add_column("Source ID", style="cyan", overflow="fold")
+    table.add_column("Span", no_wrap=True)
+    table.add_column("Text", overflow="fold")
+    for chunk in chunks:
+        span = f"{chunk.start}:{chunk.end}" if chunk.start is not None else "-"
+        table.add_row(
+            str(chunk.rank),
+            escape_markup(chunk.source_id),
+            span,
+            escape_markup(chunk.text),
+        )
+    console.print(table)
 
 
 def _looks_like_path(content: str) -> bool:

--- a/src/notebooklm/cli/services/source_serializers.py
+++ b/src/notebooklm/cli/services/source_serializers.py
@@ -8,12 +8,23 @@ from ..._app.serialize import source_summary
 from ...types import drive_source_status_to_str, source_status_to_str
 
 if TYPE_CHECKING:
-    from ...types import Source, SourceFulltext, SourceType
+    from ...types import RelevantChunk, Source, SourceFulltext, SourceType
 
 
 def source_kind_value(kind: SourceType | None) -> str | None:
     """Return the public JSON value for a source kind."""
     return kind.value if kind is not None else None
+
+
+def relevant_chunk_payload(chunk: RelevantChunk) -> dict[str, Any]:
+    """Return the stable JSON shape for one ranked source-search result."""
+    return {
+        "source_id": chunk.source_id,
+        "text": chunk.text,
+        "rank": chunk.rank,
+        "start": chunk.start,
+        "end": chunk.end,
+    }
 
 
 def source_summary_payload(src: Source) -> dict[str, Any]:

--- a/src/notebooklm/cli/source_cmd.py
+++ b/src/notebooklm/cli/source_cmd.py
@@ -67,6 +67,7 @@ from ._source_render import (  # noqa: F401
     _render_source_guide_result,
     _render_source_refresh_result,
     _render_source_rename_result,
+    _render_source_search_result,
     _render_source_stale_result,
     _render_source_wait_outcome,
     _resolve_source_fulltext_output_path,
@@ -80,6 +81,7 @@ from .options import (
     _complete_sources,
     json_option,
     list_options,
+    multi_source_option,
     notebook_option,
     prompt_file_option,
     wait_polling_options,
@@ -133,6 +135,7 @@ def source():
     \b
     Commands:
       list             List sources in a notebook
+      search           Search ranked passages across notebook sources
       add              Add a source (url, text, file, youtube)
       add-drive        Add a Google Drive document (native Docs/Slides/Sheets + PDF)
       add-drive-file   Add an upload-only Drive file (epub/docx/txt/...) via download
@@ -226,6 +229,60 @@ def source_list(
                 )
                 raise AssertionError("unreachable") from None  # pragma: no cover
             render_list(render)
+
+    return _run()
+
+
+@source.command("search")
+@click.argument("query")
+@notebook_option
+@multi_source_option
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Maximum number of globally ranked passages to return.",
+)
+@json_option
+@with_client
+def source_search(ctx, query, notebook_id, source_ids, limit, json_output, client_auth):
+    """Search indexed passages across notebook sources.
+
+    Results are globally ordered by relevance rank. Repeat ``--source`` to
+    restrict the search to selected source IDs or unique ID prefixes.
+
+    \b
+    Examples:
+      notebooklm source search "revenue growth" --limit 5
+      notebooklm source search "revenue growth" -s src1 -s src2 --json
+    """
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with resolve_client_factory(ctx)(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            resolved_source_ids = await resolve_source_ids(
+                client,
+                nb_id_resolved,
+                tuple(source_ids),
+                json_output=json_output,
+            )
+            if json_output:
+                chunks = await client.sources.search(
+                    nb_id_resolved,
+                    query,
+                    source_ids=resolved_source_ids,
+                    limit=limit,
+                )
+            else:
+                with cli_status("Searching source passages...", ctx=ctx):
+                    chunks = await client.sources.search(
+                        nb_id_resolved,
+                        query,
+                        source_ids=resolved_source_ids,
+                        limit=limit,
+                    )
+            _render_source_search_result(chunks, json_output=json_output, ctx=ctx)
 
     return _run()
 

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -135,6 +135,7 @@
       "list",
       "refresh",
       "rename",
+      "search",
       "stale",
       "wait"
     ]
@@ -10220,6 +10221,7 @@
         "list",
         "refresh",
         "rename",
+        "search",
         "stale",
         "wait"
       ],
@@ -11772,6 +11774,98 @@
         }
       ],
       "short_help": "Rename a source."
+    },
+    "source search": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "query",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "has_custom_shell_complete": true,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Maximum number of globally ranked passages to return.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Search indexed passages across notebook..."
     },
     "source stale": {
       "class": "Command",

--- a/tests/unit/cli/test_source_search.py
+++ b/tests/unit/cli/test_source_search.py
@@ -1,0 +1,179 @@
+"""CLI coverage for ranked passage search over ``SourcesAPI.search``."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import RelevantChunk, Source
+
+from .conftest import create_mock_client, inject_client
+
+NB = "nb_123"
+SRC_A = "5777b434-46fd-4f4a-bf28-577b26ead71b"
+SRC_B = "f6e549bc-7593-4146-ab8f-ce01094d1387"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _cli_auth(mock_auth, mock_fetch_tokens):
+    """Every command opens the injected client; reuse the shared auth patches."""
+    yield
+
+
+def _invoke(runner: CliRunner, client, args: list[str]):
+    return runner.invoke(cli, args, obj=inject_client(client))
+
+
+class TestSourceSearch:
+    def test_json_returns_the_direct_relevant_chunk_array(self, runner: CliRunner) -> None:
+        client = create_mock_client()
+        client.sources.search = AsyncMock(
+            return_value=[
+                RelevantChunk(SRC_A, "First passage", 1, 10, 23),
+                RelevantChunk(SRC_B, "Passage without a span", 2),
+            ]
+        )
+
+        result = _invoke(
+            runner,
+            client,
+            ["source", "search", "revenue growth", "-n", NB, "--json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == [
+            {
+                "source_id": SRC_A,
+                "text": "First passage",
+                "rank": 1,
+                "start": 10,
+                "end": 23,
+            },
+            {
+                "source_id": SRC_B,
+                "text": "Passage without a span",
+                "rank": 2,
+                "start": None,
+                "end": None,
+            },
+        ]
+        client.sources.search.assert_awaited_once_with(
+            NB,
+            "revenue growth",
+            source_ids=None,
+            limit=None,
+        )
+        client.sources.list.assert_not_awaited()
+
+    def test_repeatable_source_filters_resolve_prefixes_once(self, runner: CliRunner) -> None:
+        client = create_mock_client()
+        client.sources.list = AsyncMock(
+            return_value=[
+                Source(id=SRC_A, title="Revenue"),
+                Source(id=SRC_B, title="Forecast"),
+            ]
+        )
+        client.sources.search = AsyncMock(return_value=[])
+
+        result = _invoke(
+            runner,
+            client,
+            [
+                "source",
+                "search",
+                "growth",
+                "-n",
+                NB,
+                "-s",
+                SRC_A[:12],
+                "--source",
+                SRC_B[:12],
+                "--limit",
+                "2",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout) == []
+        assert result.stderr.count("Matched:") == 2
+        client.sources.list.assert_awaited_once_with(NB)
+        client.sources.search.assert_awaited_once_with(
+            NB,
+            "growth",
+            source_ids=[SRC_A, SRC_B],
+            limit=2,
+        )
+
+    def test_text_mode_renders_rank_source_span_and_literal_text(self, runner: CliRunner) -> None:
+        client = create_mock_client()
+        client.sources.search = AsyncMock(
+            return_value=[
+                RelevantChunk(SRC_A, "Revenue [grew] quickly", 1, 4, 26),
+                RelevantChunk(SRC_B, "No coordinates", 2),
+            ]
+        )
+
+        result = _invoke(
+            runner,
+            client,
+            ["source", "search", "revenue", "-n", NB],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "2 relevant passage(s)" in result.output
+        assert "Rank" in result.output
+        assert "Source ID" in result.output
+        assert "Span" in result.output
+        assert SRC_A in result.output
+        assert "4:26" in result.output
+        assert "Revenue [grew] quickly" in result.output
+        assert "No coordinates" in result.output
+
+    @pytest.mark.parametrize("json_output", [False, True])
+    def test_empty_results_have_a_stable_output(self, runner: CliRunner, json_output: bool) -> None:
+        client = create_mock_client()
+        client.sources.search = AsyncMock(return_value=[])
+        args = ["source", "search", "missing", "-n", NB]
+        if json_output:
+            args.append("--json")
+
+        result = _invoke(runner, client, args)
+
+        assert result.exit_code == 0, result.output
+        if json_output:
+            assert json.loads(result.output) == []
+        else:
+            assert "No relevant passages found." in result.output
+
+    def test_non_positive_limit_is_rejected_before_client_io(self, runner: CliRunner) -> None:
+        client = create_mock_client()
+        client.sources.search = AsyncMock(return_value=[])
+
+        result = _invoke(
+            runner,
+            client,
+            ["source", "search", "query", "-n", NB, "--limit", "0"],
+        )
+
+        assert result.exit_code == 2
+        assert "Invalid value for '--limit'" in result.output
+        client.sources.search.assert_not_awaited()
+
+    def test_help_documents_filters_limit_and_json(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["source", "search", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "Search indexed passages" in result.output
+        assert "-s, --source TEXT" in result.output
+        assert "--limit INTEGER RANGE" in result.output
+        assert "--json" in result.output

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -257,6 +257,10 @@ def _fail_source_list(client: MagicMock) -> None:
     client.sources.list = AsyncMock(side_effect=RuntimeError("net down"))
 
 
+def _fail_source_search(client: MagicMock) -> None:
+    client.sources.search = AsyncMock(side_effect=RuntimeError("net down"))
+
+
 def _fail_note_list(client: MagicMock) -> None:
     client.notes.list = AsyncMock(side_effect=RuntimeError("net down"))
 
@@ -402,6 +406,11 @@ def _fail_notebook_create(client: MagicMock) -> None:
 JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
     # source group: client raises -> @with_client routes to json_error_response.
     ("source_list_unauthorized", ["source", "list", "-n", "abc", "--json"], _fail_source_list),
+    (
+        "source_search_failure",
+        ["source", "search", "ranked passage", "-n", "abc", "--json"],
+        _fail_source_search,
+    ),
     # artifact group
     (
         "artifact_list_unauthorized",

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -49,6 +49,7 @@ from notebooklm.types import (
     Notebook,
     PlayBook,
     PromptSuggestion,
+    RelevantChunk,
     ReportPreset,
     ResearchSource,
     ResearchStart,
@@ -408,6 +409,20 @@ def _customize_source_fulltext(client: MagicMock) -> None:
     )
 
 
+def _customize_source_search(client: MagicMock) -> None:
+    client.sources.search = AsyncMock(
+        return_value=[
+            RelevantChunk(
+                source_id="src123def456ghi789jkl",
+                text="Ranked passage",
+                rank=1,
+                start=10,
+                end=24,
+            )
+        ]
+    )
+
+
 def _customize_source_guide(client: MagicMock) -> None:
     client.sources.get_guide = AsyncMock(
         return_value=SourceGuide(summary="a summary", keywords=["k1", "k2"])
@@ -599,6 +614,11 @@ _FS_SETUPS = {
 JSON_COMMANDS: list[tuple[str, list[str], object]] = [
     # source group
     ("source_list", ["source", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
+    (
+        "source_search",
+        ["source", "search", "ranked passage", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_source_search,
+    ),
     (
         "source_fulltext",
         [


### PR DESCRIPTION
## Summary

- expose SourcesAPI.search as notebooklm source search QUERY
- support repeatable source filters with unique-prefix resolution and an optional global result limit
- render ranked passages as a human-readable table or a direct RelevantChunk JSON array
- document the command and cover CLI contracts, JSON purity, failures, and rendering

Follow-up to #2305.

## Testing

- uv run pytest -n auto --dist=worksteal tests/unit tests/_guardrails -qq --disable-warnings
- uv run mypy src/notebooklm
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `source search QUERY` command for ranked passage searches across notebook sources.
  - Supports repeatable source filters, result limits, human-readable output, and JSON output.
  - Displays result rank, source, span, and matching passage text.
  - Provides clear output when no matches are found.

- **Documentation**
  - Added command usage, options, output details, and JSON format to the CLI reference.

- **Tests**
  - Added coverage for filtering, limits, text and JSON output, empty results, help text, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->