### PR TITLE
feat(cli): add notebook copy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `notebooklm copy <title> [-n <notebook-id>] [--use] [--json]` exposes the
+  existing cross-backend `notebooks.copy()` operation in the CLI. It accepts
+  partial IDs or the active notebook, copies sources and Studio artifacts, and
+  can switch context to the new notebook explicitly with `--use`.
 - `sources.search(notebook_id, query, *, source_ids=None, limit=None)` on **both**
   the Web and Android backends: ranked passage retrieval through
   `RetrieveRelevantChunks` (Web id `ASU5Oe`) with optional source filtering and

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These combine ordinary library primitives — see the [CLI Reference](docs/cli-r
 
 | Category | Capabilities |
 |----------|--------------|
-| **Notebooks** | Create, list, rename, delete |
+| **Notebooks** | Create, copy (including sources and Studio artifacts), list, rename, delete |
 | **Sources** | URLs, YouTube, files (PDF, text, Markdown, Word, EPUB, audio, video, images), Google Drive, pasted text; refresh, get guide/fulltext |
 | **Chat** | Questions, conversation history, custom personas, suggested starter prompts |
 | **Notes** | Create, list, rename, delete, save chat answers, save conversation history |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,6 +108,9 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `create <title>` | Create notebook (does not change active context) | `notebooklm create "Research"` |
 | `create <title> --use` | Create notebook and make it the active context | `notebooklm create "Research" --use` |
 | `create <title> --json` | JSON envelope; with `--use` includes `active_notebook_id` | `notebooklm create "X" --use --json` |
+| `copy <title>` | Copy the current notebook, including sources and Studio artifacts | `notebooklm copy "Research — Copy"` |
+| `copy <title> -n <id>` | Copy a specific notebook (partial IDs accepted) | `notebooklm copy "Research — Copy" -n abc123` |
+| `copy <title> --use --json` | Make the copy active and emit `{source_notebook_id, notebook, active_notebook_id}` | `notebooklm copy "Research — Copy" --use --json` |
 | `delete -n <id>` | Delete notebook (uses current notebook if `-n` omitted) | `notebooklm delete -n abc123` |
 | `delete -n <id> -y` | Skip confirmation | `notebooklm delete -n abc123 -y` |
 | `delete -n <id> --json` | Emit `{notebook_id, success}` envelope (plus `context_cleared: true` when deleting the active notebook); requires `-y` (refuses to prompt in JSON mode) | `notebooklm delete -n abc123 -y --json` |

--- a/src/notebooklm/_app/__init__.py
+++ b/src/notebooklm/_app/__init__.py
@@ -125,10 +125,12 @@ from .labels import (
 )
 from .language import SUPPORTED_LANGUAGES, LanguageConfigStore, is_supported_language, language_name
 from .notebooks import (
+    NotebookCopyResult,
     NotebookCreateResult,
     NotebookDescribeResult,
     NotebookMetadataResult,
     NotebookRenameResult,
+    execute_notebook_copy,
     execute_notebook_create,
     execute_notebook_delete,
     execute_notebook_describe,
@@ -394,10 +396,12 @@ __all__ = [
     "is_supported_language",
     "language_name",
     # notebooks
+    "NotebookCopyResult",
     "NotebookCreateResult",
     "NotebookDescribeResult",
     "NotebookMetadataResult",
     "NotebookRenameResult",
+    "execute_notebook_copy",
     "execute_notebook_create",
     "execute_notebook_delete",
     "execute_notebook_describe",

--- a/src/notebooklm/_app/notebooks.py
+++ b/src/notebooklm/_app/notebooks.py
@@ -1,11 +1,11 @@
 """Transport-neutral notebook business logic.
 
 This is the Click-free core of ``cli/notebook_cmd.py``: it owns the
-``create`` / ``delete`` / ``rename`` / ``describe`` (summary) / ``metadata``
-workflows and returns typed result dataclasses instead of an adapter-shaped
-envelope dict. Every transport adapter (the Click CLI today, the FastMCP
-server / future HTTP later) drives this core and renders the typed result into
-its own surface + exit-code policy.
+``create`` / ``copy`` / ``delete`` / ``rename`` / ``describe`` (summary) /
+``metadata`` workflows and returns typed result dataclasses instead of an
+adapter-shaped envelope dict. Every transport adapter (the Click CLI today,
+the FastMCP server / future HTTP later) drives this core and renders the typed
+result into its own surface + exit-code policy.
 
 Two boundary-imposed seams are worth calling out:
 
@@ -155,6 +155,39 @@ async def _backfill_create_timestamps(
 
 
 # ---------------------------------------------------------------------------
+# notebook copy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NotebookCopyResult:
+    """Outcome of ``notebook copy``."""
+
+    source_notebook_id: str
+    notebook: Notebook
+
+
+async def execute_notebook_copy(
+    client: NotebookLMClient,
+    notebook_id: str,
+    title: str,
+    *,
+    resolve_notebook_id: ResolveNotebookIdFn,
+    json_output: bool = False,
+) -> NotebookCopyResult:
+    """Resolve + copy a notebook, including its sources and Studio artifacts.
+
+    ``notebooks.copy`` deliberately does not retry an ambiguous transport
+    failure because the server may already have committed the copy. That
+    policy lives in the backend implementation; this workflow preserves it by
+    issuing exactly one copy call after resolution.
+    """
+    resolved_id = await resolve_notebook_id(client, notebook_id, json_output=json_output)
+    notebook = await client.notebooks.copy(resolved_id, title)
+    return NotebookCopyResult(source_notebook_id=resolved_id, notebook=notebook)
+
+
+# ---------------------------------------------------------------------------
 # notebook delete
 # ---------------------------------------------------------------------------
 
@@ -263,6 +296,7 @@ async def execute_notebook_metadata(
 
 
 __all__ = [
+    "NotebookCopyResult",
     "NotebookCreateResult",
     "NotebookDescribeResult",
     "NotebookMetadataResult",
@@ -270,6 +304,7 @@ __all__ = [
     "ResolveNotebookIdFn",
     "SUGGEST_SURFACE_MAP",
     "SuggestSurface",
+    "execute_notebook_copy",
     "execute_notebook_create",
     "execute_notebook_delete",
     "execute_notebook_describe",

--- a/src/notebooklm/cli/grouped.py
+++ b/src/notebooklm/cli/grouped.py
@@ -50,7 +50,7 @@ class SectionedGroup(click.Group):
 
     Instead of a flat alphabetical list, commands are grouped by function:
     - Session: login, use, status, clear, doctor, auth, completion
-    - Notebooks: list, create, delete, rename, summary, metadata
+    - Notebooks: list, create, copy, delete, rename, summary, metadata
     - Chat: ask, suggest-prompts, suggest-next-steps, configure, history
     - Command Groups: source, artifact, note, label, collection, share, research,
       profile, agent, skill, language, mcp (show subcommands)
@@ -62,7 +62,7 @@ class SectionedGroup(click.Group):
     command_sections = OrderedDict(
         [
             ("Session", ["login", "use", "status", "clear", "doctor", "auth", "completion"]),
-            ("Notebooks", ["list", "create", "delete", "rename", "summary", "metadata"]),
+            ("Notebooks", ["list", "create", "copy", "delete", "rename", "summary", "metadata"]),
             ("Chat", ["ask", "suggest-prompts", "suggest-next-steps", "configure", "history"]),
         ]
     )

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -194,7 +194,7 @@ def register_notebook_commands(cli):
           notebooklm copy "Research — Copy" -n abc123 --use
           notebooklm copy "Research — Copy" -n abc123 --json
         """
-        source_id = require_notebook(notebook_id)
+        source_id = require_notebook(notebook_id, json_output=json_output)
 
         async def _run():
             async with resolve_client_factory(ctx)(client_auth) as client:

--- a/src/notebooklm/cli/notebook_cmd.py
+++ b/src/notebooklm/cli/notebook_cmd.py
@@ -3,6 +3,7 @@
 Commands:
     list       List all notebooks
     create     Create a new notebook
+    copy       Copy a notebook, including sources and Studio artifacts
     delete     Delete a notebook
     rename     Rename a notebook
     summary    Get notebook summary with AI-generated insights
@@ -14,6 +15,7 @@ Note: Sharing commands moved to 'share' command group.
 import click
 
 from .._app.notebooks import (
+    execute_notebook_copy,
     execute_notebook_create,
     execute_notebook_delete,
     execute_notebook_describe,
@@ -21,7 +23,7 @@ from .._app.notebooks import (
     execute_notebook_rename,
 )
 from .._app.views import notebook_viewed_keys
-from ..types import share_permission_to_str
+from ..types import Notebook, share_permission_to_str
 from .auth_runtime import resolve_client_factory, with_client
 from .context import clear_context, get_current_notebook, set_current_notebook
 from .error_handler import _output_error
@@ -36,6 +38,29 @@ from .rendering import (
 from .resolve import require_notebook, resolve_notebook_id
 from .services.confirming_mutation import MutationPlan, run_confirmed_mutation
 from .services.listing import ListSpec, prepare_list
+
+
+def _notebook_mutation_payload(notebook: Notebook) -> dict:
+    """Serialize the stable notebook shape shared by create/copy JSON output."""
+    return {
+        "id": notebook.id,
+        "title": notebook.title,
+        "role": (share_permission_to_str(notebook.role) if notebook.role is not None else None),
+        "created_at": notebook.created_at.isoformat() if notebook.created_at else None,
+        **notebook_viewed_keys(notebook),
+    }
+
+
+def _set_notebook_context(notebook: Notebook) -> None:
+    """Persist a newly created or copied notebook as the active context."""
+    created = notebook.created_at.strftime("%Y-%m-%d") if notebook.created_at else None
+    set_current_notebook(
+        notebook.id,
+        notebook.title,
+        notebook.is_owner,
+        created,
+        role=(share_permission_to_str(notebook.role) if notebook.role is not None else None),
+    )
 
 
 def register_notebook_commands(cli):
@@ -115,29 +140,12 @@ def register_notebook_commands(cli):
                 nb = (await execute_notebook_create(client, title)).notebook
 
                 if switch_context:
-                    created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
-                    set_current_notebook(
-                        nb.id,
-                        nb.title,
-                        nb.is_owner,
-                        created_str,
-                        role=share_permission_to_str(nb.role) if nb.role is not None else None,
-                    )
+                    _set_notebook_context(nb)
 
                 if json_output:
-                    data: dict = {
-                        "notebook": {
-                            "id": nb.id,
-                            "title": nb.title,
-                            # Kept in step with `list --json` / `use --json` so
-                            # automation sees one notebook shape (#2125).
-                            "role": (
-                                share_permission_to_str(nb.role) if nb.role is not None else None
-                            ),
-                            "created_at": nb.created_at.isoformat() if nb.created_at else None,
-                            **notebook_viewed_keys(nb),
-                        }
-                    }
+                    # Kept in step with `list --json` / `use --json` so
+                    # automation sees one notebook shape (#2125).
+                    data: dict = {"notebook": _notebook_mutation_payload(nb)}
                     # When --use switched the active context, surface the new
                     # active notebook id at the top level so callers can
                     # branch on the field without scraping the "Context set
@@ -150,6 +158,75 @@ def register_notebook_commands(cli):
                 cli_print(f"[green]Created notebook:[/green] {nb.id} - {nb.title}", ctx=ctx)
                 if switch_context:
                     cli_print("[dim]Context set to new notebook[/dim]", ctx=ctx)
+                else:
+                    cli_print(
+                        f"[dim]Tip: pass --use next time, or run 'notebooklm use {nb.id}'.[/dim]",
+                        ctx=ctx,
+                    )
+
+        return _run()
+
+    @cli.command("copy")
+    @click.argument("title")
+    @notebook_option
+    @click.option(
+        "--use",
+        "-u",
+        "switch_context",
+        is_flag=True,
+        help="Set the copied notebook as the current context.",
+    )
+    @json_option
+    @with_client
+    def copy_cmd(ctx, title, notebook_id, switch_context, json_output, client_auth):
+        """Copy a notebook, including its sources and Studio artifacts.
+
+        Uses the current notebook unless ``-n/--notebook`` is supplied. Partial
+        notebook IDs are accepted. The server creates one new notebook with
+        TITLE; pass ``--use`` to make that copy the active context.
+
+        The copy is not automatically retried if the response is lost, because
+        it may already have committed on the server.
+
+        \b
+        Examples:
+          notebooklm copy "Research — Copy"
+          notebooklm copy "Research — Copy" -n abc123 --use
+          notebooklm copy "Research — Copy" -n abc123 --json
+        """
+        source_id = require_notebook(notebook_id)
+
+        async def _run():
+            async with resolve_client_factory(ctx)(client_auth) as client:
+                result = await execute_notebook_copy(
+                    client,
+                    source_id,
+                    title,
+                    resolve_notebook_id=resolve_notebook_id,
+                    json_output=json_output,
+                )
+                nb = result.notebook
+
+                if switch_context:
+                    _set_notebook_context(nb)
+
+                if json_output:
+                    data: dict = {
+                        "source_notebook_id": result.source_notebook_id,
+                        "notebook": _notebook_mutation_payload(nb),
+                    }
+                    if switch_context:
+                        data["active_notebook_id"] = nb.id
+                    json_output_response(data)
+                    return
+
+                cli_print(
+                    f"[green]Copied notebook:[/green] {result.source_notebook_id} -> "
+                    f"{nb.id} - {nb.title}",
+                    ctx=ctx,
+                )
+                if switch_context:
+                    cli_print("[dim]Context set to copied notebook[/dim]", ctx=ctx)
                 else:
                     cli_print(
                         f"[dim]Tip: pass --use next time, or run 'notebooklm use {nb.id}'.[/dim]",

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -17,7 +17,7 @@ from .. import paths as paths_module
 from ..paths import get_context_path
 from . import context as context_helpers
 from . import rendering as rendering_helpers
-from .error_handler import exit_with_code
+from .error_handler import exit_with_code, output_error
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
@@ -122,6 +122,7 @@ def require_notebook(
     *,
     context_path_fn: ContextPathFn | None = None,
     output_console: Console | None = None,
+    json_output: bool = False,
 ) -> str:
     """Get notebook ID from argument, env var, or active context.
 
@@ -140,6 +141,8 @@ def require_notebook(
             wrappers and tests. ``None`` keeps the module-level
             ``get_context_path`` lookup call-time patchable.
         output_console: Console used for the no-notebook diagnostic.
+        json_output: Emit a structured validation error instead of Rich text
+            when no notebook can be resolved.
 
     Returns:
         Notebook ID from argument, env var, or context, validated and stripped.
@@ -162,11 +165,15 @@ def require_notebook(
     if current:
         return validate_id(current, "Notebook")
 
-    output_console = _default_stdout_console(output_console)
-    output_console.print(
-        "[red]No notebook specified. Use 'notebooklm use <id>' to set context, "
-        "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK.[/red]"
+    message = (
+        "No notebook specified. Use 'notebooklm use <id>' to set context, "
+        "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK."
     )
+    if json_output:
+        output_error(message, "VALIDATION_ERROR", json_output=True, exit_code=1)
+
+    output_console = _default_stdout_console(output_console)
+    output_console.print(f"[red]{message}[/red]")
     exit_with_code(1)
 
 

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -6,6 +6,7 @@ Command structure:
   notebooklm status                   # Show current context
   notebooklm list                     # List notebooks
   notebooklm create <title>           # Create notebook
+  notebooklm copy <title>             # Copy current notebook
   notebooklm ask <question>           # Ask the current notebook a question
 
   notebooklm source <command>         # Source operations

--- a/tests/_baselines/cli_contract.py
+++ b/tests/_baselines/cli_contract.py
@@ -56,7 +56,7 @@ CLICK_GROUPS = (
 
 TOP_LEVEL_SURFACES = {
     "session": ("login", "auth", "use", "status", "clear"),
-    "notebook": ("list", "create", "delete", "rename", "metadata", "summary"),
+    "notebook": ("list", "create", "copy", "delete", "rename", "metadata", "summary"),
     "chat": ("ask", "suggest-prompts", "configure", "history"),
 }
 

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -2066,6 +2066,77 @@
       ],
       "short_help": "Configure chat persona and response settings."
     },
+    "copy": {
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Set the copied notebook as the current context.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "switch_context",
+          "opts": [
+            "--use",
+            "-u"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Copy a notebook, including its sources and..."
+    },
     "create": {
       "class": "Command",
       "params": [
@@ -8501,6 +8572,7 @@
         "collection",
         "completion",
         "configure",
+        "copy",
         "create",
         "delete",
         "doctor",
@@ -12200,6 +12272,7 @@
     "collection",
     "completion",
     "configure",
+    "copy",
     "create",
     "delete",
     "doctor",
@@ -12236,6 +12309,7 @@
     "notebook": [
       "list",
       "create",
+      "copy",
       "delete",
       "rename",
       "metadata",

--- a/tests/unit/app/test_app_notebooks.py
+++ b/tests/unit/app/test_app_notebooks.py
@@ -4,11 +4,11 @@ These pin the Click-free notebook workflows at the ``_app`` boundary with a
 ``MagicMock`` client + an injected partial-id resolver (the CLI normally
 injects ``cli.resolve.resolve_notebook_id``):
 
-* ``create`` / ``delete`` / ``rename`` / ``describe`` (summary) / ``metadata``
-  executors delegate to the right ``client.notebooks`` RPC and project the typed
-  result dataclasses,
-* the resolver is threaded through ``rename`` / ``describe`` / ``metadata`` and
-  the resolved id flows into the downstream RPC,
+* ``create`` / ``copy`` / ``delete`` / ``rename`` / ``describe`` (summary) /
+  ``metadata`` executors delegate to the right ``client.notebooks`` RPC and
+  project the typed result dataclasses,
+* the resolver is threaded through ``copy`` / ``rename`` / ``describe`` /
+  ``metadata`` and the resolved id flows into the downstream RPC,
 * ``describe`` tolerates a ``None`` description (the CLI renders both views from
   the typed field).
 
@@ -25,10 +25,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._app.notebooks import (
+    NotebookCopyResult,
     NotebookCreateResult,
     NotebookDescribeResult,
     NotebookMetadataResult,
     NotebookRenameResult,
+    execute_notebook_copy,
     execute_notebook_create,
     execute_notebook_delete,
     execute_notebook_describe,
@@ -184,6 +186,31 @@ async def test_execute_notebook_create_empty_id_skips_reread() -> None:
 
     assert nb.created_at is None
     client.notebooks.get.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# copy — resolver threading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_notebook_copy_resolves_then_copies_once() -> None:
+    client = _client()
+    copied = Notebook(id="nb_copy", title="Copied notebook")
+    client.notebooks.copy = AsyncMock(return_value=copied)
+
+    result = await execute_notebook_copy(
+        client,
+        "nb_part",
+        "Copied notebook",
+        resolve_notebook_id=_resolve_nb,
+        json_output=True,
+    )
+
+    assert isinstance(result, NotebookCopyResult)
+    assert result.source_notebook_id == "full_nb_part"
+    assert result.notebook is copied
+    client.notebooks.copy.assert_awaited_once_with("full_nb_part", "Copied notebook")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_grouped.py
+++ b/tests/unit/cli/test_grouped.py
@@ -33,6 +33,7 @@ class TestSectionedHelp:
         assert "Notebooks:" in result.output
         assert "list" in result.output
         assert "create" in result.output
+        assert "copy" in result.output
         assert "delete" in result.output
         assert "rename" in result.output
         assert "share" in result.output

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -602,6 +602,34 @@ class TestNotebookCopy:
         assert "active_notebook_id" not in data
         assert not mock_context_file.exists()
 
+    def test_notebook_copy_json_missing_source_returns_structured_error(
+        self, runner, mock_auth, mock_context_file, monkeypatch
+    ):
+        monkeypatch.delenv("NOTEBOOKLM_NOTEBOOK", raising=False)
+        mock_client = self._client()
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["copy", "Copied notebook", "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {
+            "error": True,
+            "code": "VALIDATION_ERROR",
+            "message": (
+                "No notebook specified. Use 'notebooklm use <id>' to set context, "
+                "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK."
+            ),
+        }
+        assert result.stderr == ""
+        mock_client.notebooks.copy.assert_not_awaited()
+
     @pytest.mark.parametrize("use_flag", ["--use", "-u"])
     def test_notebook_copy_use_switches_context(
         self, runner, mock_auth, mock_context_file, use_flag

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -529,6 +529,104 @@ class TestNotebookCreate:
 
 
 # =============================================================================
+# NOTEBOOK COPY TESTS
+# =============================================================================
+
+
+class TestNotebookCopy:
+    def _client(self) -> MagicMock:
+        mock_client = create_mock_client()
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[Notebook(id="nb_source_full", title="Source notebook")]
+        )
+        mock_client.notebooks.copy = AsyncMock(
+            return_value=Notebook(
+                id="nb_copy",
+                title="Copied notebook",
+                created_at=datetime(2024, 1, 2),
+                role=SharePermission.OWNER,
+            )
+        )
+        return mock_client
+
+    def test_notebook_copy_uses_and_preserves_current_context(
+        self, runner, mock_auth, mock_context_file
+    ):
+        mock_context_file.write_text(
+            json.dumps({"notebook_id": "nb_source", "title": "Source notebook"})
+        )
+        mock_client = self._client()
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["copy", "Copied notebook"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Copied notebook" in result.output
+        assert "nb_source_full -> nb_copy" in result.output
+        mock_client.notebooks.copy.assert_awaited_once_with("nb_source_full", "Copied notebook")
+        assert json.loads(mock_context_file.read_text())["notebook_id"] == "nb_source"
+
+    def test_notebook_copy_json_output(self, runner, mock_auth, mock_context_file):
+        mock_client = self._client()
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["copy", "Copied notebook", "-n", "nb_source", "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert "Matched:" not in result.stdout
+        assert "Matched:" in result.stderr
+        assert data["source_notebook_id"] == "nb_source_full"
+        assert data["notebook"] == {
+            "id": "nb_copy",
+            "title": "Copied notebook",
+            "role": "owner",
+            "created_at": "2024-01-02T00:00:00",
+            "last_viewed_at": None,
+            "modified_at": None,
+        }
+        assert "active_notebook_id" not in data
+        assert not mock_context_file.exists()
+
+    @pytest.mark.parametrize("use_flag", ["--use", "-u"])
+    def test_notebook_copy_use_switches_context(
+        self, runner, mock_auth, mock_context_file, use_flag
+    ):
+        mock_client = self._client()
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["copy", "Copied notebook", "-n", "nb_source", use_flag, "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data["active_notebook_id"] == "nb_copy"
+        context = json.loads(mock_context_file.read_text())
+        assert context["notebook_id"] == "nb_copy"
+        assert context["title"] == "Copied notebook"
+
+
+# =============================================================================
 # NOTEBOOK DELETE TESTS
 # =============================================================================
 

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -393,6 +393,10 @@ def _fail_notebook_create(client: MagicMock) -> None:
     client.notebooks.create = AsyncMock(side_effect=RuntimeError("notebook quota exceeded"))
 
 
+def _fail_notebook_copy(client: MagicMock) -> None:
+    client.notebooks.copy = AsyncMock(side_effect=RuntimeError("copy response lost"))
+
+
 # ---------------------------------------------------------------------------
 # Parametrized sweep
 # ---------------------------------------------------------------------------
@@ -694,6 +698,11 @@ JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
         "notebook_create_failure",
         ["create", "My Notebook", "--json"],
         _fail_notebook_create,
+    ),
+    (
+        "notebook_copy_failure",
+        ["copy", "My Notebook Copy", "-n", "abc", "--json"],
+        _fail_notebook_copy,
     ),
     # doctor + profile-list: filesystem-driven failures wrapped in the
     # canonical ADR-0015 JSON error envelope.

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -533,6 +533,17 @@ def _customize_notebook_create(client: MagicMock) -> None:
     )
 
 
+def _customize_notebook_copy(client: MagicMock) -> None:
+    client.notebooks.copy = AsyncMock(
+        return_value=Notebook(
+            id="copyxyz123abc456def789",
+            title="My Notebook Copy",
+            created_at=datetime(2024, 1, 2),
+            is_owner=True,
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # Filesystem-driven --json commands (doctor, profile list).
 # These cases bypass NotebookLMClient entirely and read ~/.notebooklm/...,
@@ -879,7 +890,7 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
         ["artifact", "choices", "-n", "abc123def456ghi789jkl", "--json"],
         _customize_artifact_choices,
     ),
-    # doctor / profile / notebook-create coverage (meta-audit G9 + I7 + I9):
+    # doctor / profile / notebook create/copy coverage (meta-audit G9 + I7 + I9):
     # `doctor` and `profile list` read NOTEBOOKLM_HOME directly and don't
     # build a NotebookLMClient — the parametrized test dispatches on these
     # case_ids and uses the ``_setup_fs_<case>`` helpers above instead of
@@ -888,6 +899,11 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
     ("doctor", ["doctor", "--json"], None),
     ("profile_list", ["profile", "list", "--json"], None),
     ("notebook_create", ["create", "My Notebook", "--json"], _customize_notebook_create),
+    (
+        "notebook_copy",
+        ["copy", "My Notebook Copy", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_notebook_copy,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

- add `notebooklm copy TITLE` as the CLI adapter for the existing notebook copy RPC
- support the current notebook or an explicit/partial notebook ID, optional context switching with `--use`, and stable `--json` output
- add the transport-neutral app workflow, CLI contract coverage, unit tests, and user-facing documentation

Follow-up to #2269, which introduced `notebooks.copy()`.

## Testing

- `uv run pytest tests/unit tests/_guardrails -n auto --dist=worksteal -q` (16,183 passed, 81 skipped, 1 xfailed)
- focused app, CLI, contract, JSON, public-surface, and VCR tests (659 passed)
- `uv run ruff check .`
- `uv run mypy src/notebooklm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `notebooklm copy <title>` command.
  - Copy the current notebook or specify a notebook ID, including its sources and Studio artifacts.
  - Optionally switch to the copied notebook with `--use`/`-u`.
  - Added JSON output with source, copied notebook, and active notebook details when applicable.

- **Bug Fixes**
  - Notebook copy errors now produce structured JSON responses when using `--json`.

- **Documentation**
  - Updated CLI reference, command help, and feature coverage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->