### PR TITLE
test(rpc): cover recent RPC additions end to end

### DIFF
--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -627,7 +627,10 @@ def wait_for_login_landing(
                 )
             # Re-arm on what is actually left, never on a fresh full timeout:
             # the caller's budget has to survive any number of tolerated hops.
-            remaining_ms = (deadline - time.monotonic()) * 1000
+            # Clamp against the previous value as well as the deadline. At
+            # large monotonic readings, floating-point cancellation can make
+            # ``deadline - now`` a fraction larger than the original timeout.
+            remaining_ms = min(remaining_ms, (deadline - time.monotonic()) * 1000)
 
 
 # ---------------------------------------------------------------------------

--- a/src/notebooklm/_auth/browser_capture.py
+++ b/src/notebooklm/_auth/browser_capture.py
@@ -625,11 +625,8 @@ def wait_for_login_landing(
                 io.emit(
                     f"[yellow]A navigation failed{detail}; still waiting for sign-in...[/yellow]"
                 )
-            # Re-arm on what is actually left, never on a fresh full timeout:
-            # the caller's budget has to survive any number of tolerated hops.
-            # Clamp against the previous value as well as the deadline. At
-            # large monotonic readings, floating-point cancellation can make
-            # ``deadline - now`` a fraction larger than the original timeout.
+            # Re-arm on what is left, clamped so floating cancellation cannot
+            # grow the caller's budget during any number of tolerated hops.
             remaining_ms = min(remaining_ms, (deadline - time.monotonic()) * 1000)
 
 

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -155,11 +155,10 @@ class RPCMethod(str, Enum):
     # -> ListExpertIntelligenceContent. Lists the account's Google Play Books
     # library eligible to be added as sources ("Expert Intelligence", US/18+).
     # Web-verified live 2026-09-01; the Android tier serves the same method over
-    # gRPC. Adding a listed book rides ADD_SOURCE / ADD_SOURCES_ASYNC with an
-    # ExpertIntelligenceContent spec (see _web.params.sources) — no add method
-    # of its own. The Android write path additionally requires a per-account
-    # Phenotype experiment header the client cannot synthesize, so add is
-    # web-only (#2292).
+    # gRPC. Adding a listed book rides ADD_SOURCE / ADD_SOURCES_ASYNC on Web
+    # and AddSources on Android with an ExpertIntelligenceContent spec — no add
+    # method of its own. Android obtains a per-account Phenotype experiment
+    # token and sends it in the required gRPC metadata (#2292).
     LIST_EXPERT_INTELLIGENCE_CONTENT = "mVtEUb"
 
     # Source label operations (AI topic grouping).

--- a/tests/_helpers/android_grpc_cassette.py
+++ b/tests/_helpers/android_grpc_cassette.py
@@ -571,20 +571,22 @@ class GrpcInteraction:
         shape = value["shape"]
         response_type = value["response_protobuf_type"]
         responses = value["responses"]
-        metadata_keys = value.get("application_metadata_keys")
+        metadata_keys: tuple[str, ...] | None = None
+        if "application_metadata_keys" in value:
+            raw_metadata_keys = value["application_metadata_keys"]
+            if not isinstance(raw_metadata_keys, list) or not all(
+                isinstance(item, str) for item in raw_metadata_keys
+            ):
+                raise AndroidGrpcCassetteError(
+                    f"{location}.application_metadata_keys must be a list of text keys"
+                )
+            metadata_keys = tuple(raw_metadata_keys)
         if not all(isinstance(item, str) for item in (method, shape, response_type)):
             raise AndroidGrpcCassetteError(
                 f"{location} method, shape, and response type must be text"
             )
         if not isinstance(responses, list):
             raise AndroidGrpcCassetteError(f"{location}.responses must be a list")
-        if metadata_keys is not None and (
-            not isinstance(metadata_keys, list)
-            or not all(isinstance(item, str) for item in metadata_keys)
-        ):
-            raise AndroidGrpcCassetteError(
-                f"{location}.application_metadata_keys must be a list of text keys"
-            )
         return cls(
             method=method,
             shape=cast(RpcShape, shape),
@@ -594,7 +596,7 @@ class GrpcInteraction:
                 ProtoPayload.from_json(item, location=f"{location}.responses[{response_index}]")
                 for response_index, item in enumerate(responses)
             ),
-            application_metadata_keys=(None if metadata_keys is None else tuple(metadata_keys)),
+            application_metadata_keys=metadata_keys,
         )
 
 
@@ -886,13 +888,12 @@ class _Player:
                 f"{self.cursor}"
             )
         expected_metadata = interaction.application_metadata_keys
-        if expected_metadata is not None:
-            actual_metadata = _application_metadata_keys(metadata)
-            if actual_metadata != expected_metadata:
-                raise AndroidGrpcCassetteMismatch(
-                    "Android gRPC cassette application metadata mismatch at interaction "
-                    f"{self.cursor}: expected {expected_metadata!r}, got {actual_metadata!r}"
-                )
+        actual_metadata = _application_metadata_keys(metadata)
+        if actual_metadata != expected_metadata:
+            raise AndroidGrpcCassetteMismatch(
+                "Android gRPC cassette application metadata mismatch at interaction "
+                f"{self.cursor}: expected {expected_metadata!r}, got {actual_metadata!r}"
+            )
         self.cursor += 1
         return interaction
 

--- a/tests/_helpers/android_grpc_cassette.py
+++ b/tests/_helpers/android_grpc_cassette.py
@@ -5,11 +5,13 @@ whereas ``grpc.aio`` performs I/O in gRPC C-core.  These adapters implement the
 small channel surface used by :class:`notebooklm._android.session.AndroidSession`
 and are injected through its existing ``grpc_loader`` seam.
 
-The persisted format contains protobuf messages only.  Call metadata (including
-the bearer) is never copied into the cassette model. Recording requires an
-explicit application-level sanitizer, then always applies
-:class:`ProtoRedactor` as the final security boundary. It replaces every
-user-controlled scalar while preserving message shape and enum values.
+The persisted format contains redacted protobuf messages and, for explicitly
+allowlisted application headers, metadata *key names* only. Credential metadata
+and every metadata value (including the bearer and experiment token) are never
+copied into the cassette model. Recording requires an explicit
+application-level sanitizer, then always applies :class:`ProtoRedactor` as the
+final security boundary. It replaces every user-controlled scalar while
+preserving message shape and enum values.
 """
 
 from __future__ import annotations
@@ -30,6 +32,7 @@ from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
 
 from notebooklm._android.auth import BearerCredential
+from notebooklm._android.phenotype import CLIENT_TYPE_HEADER, EXPERIMENT_TOKEN_HEADER
 from notebooklm._android.session import ANDROID_GRPC_TARGET
 from notebooklm._loop_bound import LoopBoundPrimitive
 
@@ -51,6 +54,7 @@ _SAFE_BYTES_RE = re.compile(rb"^SCRUBBED_(BYTES|REQUEST_BYTES)_[0-9]{4}$")
 # (field 1, length 36): GetLabels source members arrive in this shape.
 _WRAPPED_UUID_RE = re.compile(rb"^\x0a\x24([0-9a-fA-F-]{36})$")
 _SAFE_URL_PREFIX = "https://example.invalid/grpc-cassette/url-"
+_RECORDED_APPLICATION_METADATA_KEYS = frozenset({CLIENT_TYPE_HEADER, EXPERIMENT_TOKEN_HEADER})
 # Integer fields that carry a schema-defined status code rather than data.
 # The recovered proto declares them as ``int32`` instead of an enum; their
 # meaning is pinned in ``notebooklm._types.research`` (RESEARCH_STATUS_CODE_*).
@@ -128,6 +132,21 @@ def _deserializer_type(deserializer: Callable[[bytes], Message]) -> str:
             "AndroidSession response deserializer does not expose a protobuf FQN"
         )
     return type_name
+
+
+def _application_metadata_keys(metadata: Any) -> tuple[str, ...] | None:
+    """Return safe application metadata key names, never values or credentials."""
+
+    if metadata is None:
+        return None
+    keys = sorted(
+        str(item[0]).casefold()
+        for item in metadata
+        if isinstance(item, (tuple, list))
+        and len(item) == 2
+        and str(item[0]).casefold() in _RECORDED_APPLICATION_METADATA_KEYS
+    )
+    return tuple(keys) or None
 
 
 _PLACEHOLDER_BUDGET = 9999
@@ -493,6 +512,7 @@ class GrpcInteraction:
     request: ProtoPayload
     response_type: str
     responses: tuple[ProtoPayload, ...]
+    application_metadata_keys: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if not _METHOD_RE.fullmatch(self.method):
@@ -507,36 +527,64 @@ class GrpcInteraction:
             raise AndroidGrpcCassetteError(
                 "Interaction response payload type does not match its pinned protobuf type"
             )
+        if self.application_metadata_keys is not None:
+            if not self.application_metadata_keys or (
+                tuple(sorted(set(self.application_metadata_keys))) != self.application_metadata_keys
+            ):
+                raise AndroidGrpcCassetteError(
+                    "Interaction application metadata keys must be non-empty, sorted, and unique"
+                )
+            if any(
+                key not in _RECORDED_APPLICATION_METADATA_KEYS
+                for key in self.application_metadata_keys
+            ):
+                raise AndroidGrpcCassetteError(
+                    "Interaction carries a non-allowlisted application metadata key"
+                )
 
     def to_json(self) -> dict[str, Any]:
-        return {
+        value: dict[str, Any] = {
             "method": self.method,
             "request": self.request.to_json(),
             "response_protobuf_type": self.response_type,
             "responses": [response.to_json() for response in self.responses],
             "shape": self.shape,
         }
+        if self.application_metadata_keys is not None:
+            value["application_metadata_keys"] = list(self.application_metadata_keys)
+        return value
 
     @classmethod
     def from_json(cls, value: Any, *, index: int) -> GrpcInteraction:
         location = f"interactions[{index}]"
         if not isinstance(value, dict):
             raise AndroidGrpcCassetteError(f"{location} must be an object")
-        _exact_keys(
-            value,
-            {"method", "request", "response_protobuf_type", "responses", "shape"},
-            location=location,
-        )
+        required_keys = {"method", "request", "response_protobuf_type", "responses", "shape"}
+        actual_keys = set(value)
+        allowed_keys = required_keys | {"application_metadata_keys"}
+        if not required_keys <= actual_keys or not actual_keys <= allowed_keys:
+            raise AndroidGrpcCassetteError(
+                f"{location} keys must be {sorted(required_keys)!r} with optional "
+                "'application_metadata_keys'"
+            )
         method = value["method"]
         shape = value["shape"]
         response_type = value["response_protobuf_type"]
         responses = value["responses"]
+        metadata_keys = value.get("application_metadata_keys")
         if not all(isinstance(item, str) for item in (method, shape, response_type)):
             raise AndroidGrpcCassetteError(
                 f"{location} method, shape, and response type must be text"
             )
         if not isinstance(responses, list):
             raise AndroidGrpcCassetteError(f"{location}.responses must be a list")
+        if metadata_keys is not None and (
+            not isinstance(metadata_keys, list)
+            or not all(isinstance(item, str) for item in metadata_keys)
+        ):
+            raise AndroidGrpcCassetteError(
+                f"{location}.application_metadata_keys must be a list of text keys"
+            )
         return cls(
             method=method,
             shape=cast(RpcShape, shape),
@@ -546,6 +594,7 @@ class GrpcInteraction:
                 ProtoPayload.from_json(item, location=f"{location}.responses[{response_index}]")
                 for response_index, item in enumerate(responses)
             ),
+            application_metadata_keys=(None if metadata_keys is None else tuple(metadata_keys)),
         )
 
 
@@ -670,6 +719,7 @@ class _RecordingStreamCall:
         method: str,
         request: ProtoPayload,
         response_type: str,
+        application_metadata_keys: tuple[str, ...] | None,
     ) -> None:
         self._call = call
         self._iterator = call.__aiter__()
@@ -677,6 +727,7 @@ class _RecordingStreamCall:
         self._method = method
         self._request = request
         self._response_type = response_type
+        self._application_metadata_keys = application_metadata_keys
         self._responses: list[ProtoPayload] = []
         self._complete = False
 
@@ -695,6 +746,7 @@ class _RecordingStreamCall:
                         request=self._request,
                         response_type=self._response_type,
                         responses=tuple(self._responses),
+                        application_metadata_keys=self._application_metadata_keys,
                     )
                 )
                 self._complete = True
@@ -726,6 +778,7 @@ class _RecordingChannel:
 
         async def invoke(request: Message, *, metadata: Any, timeout: float | None) -> Message:
             request_payload = self._recorder.payload(method, "request", request)
+            application_metadata_keys = _application_metadata_keys(metadata)
             response = await live(request, metadata=metadata, timeout=timeout)
             response_payload = self._recorder.payload(method, "response", response)
             if response_payload.type_name != response_type:
@@ -739,6 +792,7 @@ class _RecordingChannel:
                     request=request_payload,
                     response_type=response_type,
                     responses=(response_payload,),
+                    application_metadata_keys=application_metadata_keys,
                 )
             )
             return response
@@ -757,6 +811,7 @@ class _RecordingChannel:
 
         def invoke(request: Message, *, metadata: Any, timeout: float | None) -> Any:
             request_payload = self._recorder.payload(method, "request", request)
+            application_metadata_keys = _application_metadata_keys(metadata)
             call = live(request, metadata=metadata, timeout=timeout)
             return _RecordingStreamCall(
                 call,
@@ -764,6 +819,7 @@ class _RecordingChannel:
                 method,
                 request_payload,
                 response_type,
+                application_metadata_keys,
             )
 
         return invoke
@@ -809,6 +865,7 @@ class _Player:
         shape: RpcShape,
         request: Message,
         response_type: str,
+        metadata: Any,
     ) -> GrpcInteraction:
         if self.cursor >= len(self.cassette.interactions):
             raise AndroidGrpcCassetteMismatch("Android gRPC cassette is exhausted")
@@ -828,6 +885,14 @@ class _Player:
                 "Android gRPC cassette response protobuf type mismatch at interaction "
                 f"{self.cursor}"
             )
+        expected_metadata = interaction.application_metadata_keys
+        if expected_metadata is not None:
+            actual_metadata = _application_metadata_keys(metadata)
+            if actual_metadata != expected_metadata:
+                raise AndroidGrpcCassetteMismatch(
+                    "Android gRPC cassette application metadata mismatch at interaction "
+                    f"{self.cursor}: expected {expected_metadata!r}, got {actual_metadata!r}"
+                )
         self.cursor += 1
         return interaction
 
@@ -890,8 +955,8 @@ class _ReplayChannel:
         response_type = _deserializer_type(response_deserializer)
 
         async def invoke(request: Message, *, metadata: Any, timeout: float | None) -> Message:
-            del metadata, timeout
-            interaction = self._player.take(method, "unary_unary", request, response_type)
+            del timeout
+            interaction = self._player.take(method, "unary_unary", request, response_type, metadata)
             return response_deserializer(interaction.responses[0].wire_bytes)
 
         return invoke
@@ -903,8 +968,10 @@ class _ReplayChannel:
         response_type = _deserializer_type(response_deserializer)
 
         def invoke(request: Message, *, metadata: Any, timeout: float | None) -> _ReplayStreamCall:
-            del metadata, timeout
-            interaction = self._player.take(method, "unary_stream", request, response_type)
+            del timeout
+            interaction = self._player.take(
+                method, "unary_stream", request, response_type, metadata
+            )
             return _ReplayStreamCall(
                 tuple(
                     response_deserializer(response.wire_bytes) for response in interaction.responses

--- a/tests/_helpers/android_grpc_harness.py
+++ b/tests/_helpers/android_grpc_harness.py
@@ -31,6 +31,7 @@ import pytest
 
 from notebooklm import AuthTokens, NotebookLMClient
 from notebooklm._android import auth as android_auth
+from notebooklm._android import phenotype as android_phenotype
 from notebooklm._android import session as android_session
 
 from .android_grpc_cassette import (
@@ -237,6 +238,7 @@ async def android_cassette_client(
     monkeypatch: pytest.MonkeyPatch,
     scratch: ScratchNotebook | None,
     question: str = QUESTION,
+    phenotype_cassette_path: Path | None = None,
     on_recorded: RecordedCallback | None = None,
 ) -> AsyncIterator[tuple[NotebookLMClient, CassetteValues]]:
     """Open the public Android client bound to ``cassette_path`` in the current mode.
@@ -249,7 +251,28 @@ async def android_cassette_client(
     """
 
     redactor = ProtoRedactor(trust_placeholders=True)
-    if is_record_mode():
+    record = is_record_mode()
+    phenotype_staging_path: Path | None = None
+    phenotype_http_post: Any | None = None
+    if phenotype_cassette_path is not None:
+        from .android_phenotype_http_cassette import build_phenotype_http_post
+
+        provider_type = android_phenotype.PhenotypeTokenProvider
+        phenotype_capture_path = phenotype_cassette_path
+        if record:
+            phenotype_staging_path = phenotype_cassette_path.with_name(
+                phenotype_cassette_path.name + ".recording"
+            )
+            discard_recording(phenotype_staging_path)
+            phenotype_capture_path = phenotype_staging_path
+        phenotype_http_post = build_phenotype_http_post(phenotype_capture_path)
+
+        def cassette_provider(*args: Any, **kwargs: Any) -> Any:
+            kwargs["http_post"] = phenotype_http_post
+            return provider_type(*args, **kwargs)
+
+        monkeypatch.setattr(android_phenotype, "PhenotypeTokenProvider", cassette_provider)
+    if record:
         if scratch is None:
             raise RuntimeError("Recording requires the android_record_scratch fixture")
         values = bind_values(
@@ -281,13 +304,26 @@ async def android_cassette_client(
             async with _live_client() as client:
                 assert set(client.backends.values()) == {"android"}
                 yield client, values
+            if phenotype_http_post is not None:
+                phenotype_http_post.assert_consumed()
         except BaseException:
             discard_recording(staging_path)
+            if phenotype_staging_path is not None:
+                discard_recording(phenotype_staging_path)
             raise
-        if on_recorded is None:
-            promote_recording(staging_path, cassette_path)
-        else:
-            on_recorded(staging_path, cassette_path)
+        recordings = [(staging_path, cassette_path)]
+        if phenotype_staging_path is not None and phenotype_cassette_path is not None:
+            recordings.append((phenotype_staging_path, phenotype_cassette_path))
+        missing = [target.name for staging, target in recordings if not staging.exists()]
+        if missing:
+            for staging, _target in recordings:
+                discard_recording(staging)
+            raise RuntimeError(f"Recording captured no interactions for: {', '.join(missing)}")
+        for finished_path, target_path in recordings:
+            if on_recorded is None:
+                promote_recording(finished_path, target_path)
+            else:
+                on_recorded(finished_path, target_path)
         return
 
     values = bind_values(
@@ -314,6 +350,8 @@ async def android_cassette_client(
     async with NotebookLMClient(auth, backend="android") as client:
         assert set(client.backends.values()) == {"android"}
         yield client, values
+    if phenotype_http_post is not None:
+        phenotype_http_post.assert_consumed()
     replay.assert_consumed()
     assert bearer.gets, "replay never consulted the non-secret bearer"
     assert replay.secure_channel_calls == 1

--- a/tests/_helpers/android_phenotype_http_cassette.py
+++ b/tests/_helpers/android_phenotype_http_cassette.py
@@ -1,0 +1,181 @@
+"""HTTP cassette seam for the Android Phenotype protobuf POST.
+
+The Android gRPC cassette records NotebookLM C-core calls. Play Books add has
+one auxiliary HTTP request to ``getExperimentsAndConfigs`` before ``AddSources``;
+this helper scopes VCR.py to that one POST so OAuth minting and profile traffic
+cannot accidentally enter the cassette. Both protobuf bodies are decoded,
+exhaustively scalar-redacted, and reserialized before persistence.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import vcr
+
+from notebooklm._android import phenotype
+
+from .android_grpc_cassette import ProtoRedactor
+
+_PHENOTYPE_METHOD = "/notebooklm.experiments.v1.PhenotypeHttp/GetExperimentsAndConfigs"
+_SAFE_REQUEST_HEADERS = frozenset({"content-length", "content-type", "user-agent"})
+_SAFE_RESPONSE_HEADERS = frozenset({"content-length", "content-type"})
+
+
+def _body_bytes(value: Any, *, location: str) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("latin1")
+    raise TypeError(f"{location} must be bytes or text")
+
+
+def _set_content_length(headers: Any, length: int) -> None:
+    for key in tuple(headers):
+        if str(key).casefold() == "content-length":
+            headers[key] = [str(length)] if isinstance(headers[key], list) else str(length)
+            return
+
+
+def _retain_headers(headers: Any, allowed: frozenset[str]) -> None:
+    for key in tuple(headers):
+        if str(key).casefold() not in allowed:
+            del headers[key]
+
+
+def _normalize_user_agent(headers: Any) -> None:
+    safe_value = phenotype.AndroidDeviceProfile().user_agent
+    for key in tuple(headers):
+        if str(key).casefold() == "user-agent":
+            headers[key] = [safe_value] if isinstance(headers[key], list) else safe_value
+
+
+def _validate_phenotype_request(message: Any) -> None:
+    """Pin non-secret protocol constants before generic scalar redaction."""
+
+    if (
+        message.fetch_reason != phenotype._FETCH_REASON
+        or message.config_class != phenotype._CONFIG_CLASS
+        or message.package_name != phenotype._HOST_PACKAGE
+        or message.header.clearcut_logger_header.log_source != 4
+        or len(message.data) != 1
+    ):
+        raise ValueError("Phenotype cassette refused unexpected request constants")
+    details = message.data[0].package_details
+    if (
+        details.package_name != phenotype._MENDEL_PACKAGE
+        or details.version != phenotype._MENDEL_VERSION
+        or not details.HasField("auth_token_index")
+        or details.auth_token_index.index != 0
+    ):
+        raise ValueError("Phenotype cassette refused unexpected package registration")
+
+
+def _scrub_phenotype_request(request: Any) -> Any:
+    from notebooklm._android.proto.notebooklm.experiments.v1 import exptsandconfigs_pb2
+
+    message = exptsandconfigs_pb2.HeterodyneRequest.FromString(
+        _body_bytes(request.body, location="Phenotype request body")
+    )
+    clean = ProtoRedactor(trust_placeholders=True)(
+        _PHENOTYPE_METHOD,
+        "request",
+        message,
+    )
+    request.body = clean.SerializeToString(deterministic=True)
+    _retain_headers(request.headers, _SAFE_REQUEST_HEADERS)
+    _normalize_user_agent(request.headers)
+    _set_content_length(request.headers, len(request.body))
+    return request
+
+
+def _scrub_phenotype_response(response: dict[str, Any]) -> dict[str, Any]:
+    from notebooklm._android.proto.notebooklm.experiments.v1 import exptsandconfigs_pb2
+
+    body = response.get("body", {})
+    status = response.get("status", {}).get("code")
+    if status != 200:
+        body["string"] = b""
+        _retain_headers(response.get("headers", {}), _SAFE_RESPONSE_HEADERS)
+        _set_content_length(response.get("headers", {}), 0)
+        return response
+    content = _body_bytes(body.get("string", b""), location="Phenotype response body")
+    message = exptsandconfigs_pb2.HeterodyneResponse.FromString(content)
+    clean = ProtoRedactor(trust_placeholders=True)(
+        _PHENOTYPE_METHOD,
+        "response",
+        message,
+    )
+    body["string"] = clean.SerializeToString(deterministic=True)
+    _retain_headers(response.get("headers", {}), _SAFE_RESPONSE_HEADERS)
+    _set_content_length(response.get("headers", {}), len(body["string"]))
+    return response
+
+
+class PhenotypeHttpPost:
+    """One-use HTTP callback bound to a sanitized Phenotype cassette."""
+
+    def __init__(self, recorder: vcr.VCR, cassette_name: str) -> None:
+        self._recorder = recorder
+        self._cassette_name = cassette_name
+        self._used = False
+
+    async def __call__(self, url: str, body: bytes, headers: dict[str, str]) -> tuple[int, bytes]:
+        if url != phenotype._ENDPOINT:
+            raise ValueError("Phenotype cassette refused an unexpected endpoint")
+        from notebooklm._android.proto.notebooklm.experiments.v1 import exptsandconfigs_pb2
+
+        _validate_phenotype_request(exptsandconfigs_pb2.HeterodyneRequest.FromString(body))
+        normalized_headers = {key.casefold(): value for key, value in headers.items()}
+        if set(normalized_headers) != {"authorization", "content-type", "user-agent"}:
+            raise ValueError("Phenotype cassette refused unexpected request headers")
+        if (
+            not normalized_headers["authorization"].startswith("Bearer ")
+            or normalized_headers["authorization"] == "Bearer "
+            or normalized_headers["content-type"] != "application/x-protobuf"
+            or not normalized_headers["user-agent"]
+        ):
+            raise ValueError("Phenotype cassette refused malformed request headers")
+        if self._used:
+            raise RuntimeError("Phenotype cassette permits exactly one HTTP interaction")
+        self._used = True
+        with self._recorder.use_cassette(self._cassette_name):
+            return await phenotype._default_http_post(url, body, headers)
+
+    def assert_consumed(self) -> None:
+        if not self._used:
+            raise AssertionError("Phenotype cassette expected exactly one HTTP interaction")
+
+
+def build_phenotype_http_post(cassette_path: Path) -> PhenotypeHttpPost:
+    """Return an HTTP callback bound only to one sanitized Phenotype cassette."""
+
+    record = os.environ.get("NOTEBOOKLM_ANDROID_GRPC_RECORD", "").casefold() in {
+        "1",
+        "true",
+        "yes",
+    }
+    recorder = vcr.VCR(
+        cassette_library_dir=str(cassette_path.parent),
+        record_mode="all" if record else "none",
+        match_on=[
+            "method",
+            "scheme",
+            "host",
+            "port",
+            "path",
+            "query",
+            "body",
+            "headers",
+        ],
+        before_record_request=_scrub_phenotype_request,
+        before_record_response=_scrub_phenotype_response,
+        filter_headers=["Authorization"],
+        decode_compressed_response=True,
+    )
+    return PhenotypeHttpPost(recorder, cassette_path.name)
+
+
+__all__ = ["PhenotypeHttpPost", "build_phenotype_http_post"]

--- a/tests/_helpers/android_phenotype_http_cassette.py
+++ b/tests/_helpers/android_phenotype_http_cassette.py
@@ -121,6 +121,7 @@ class PhenotypeHttpPost:
         self._recorder = recorder
         self._cassette_name = cassette_name
         self._used = False
+        self._interaction_count: int | None = None
 
     async def __call__(self, url: str, body: bytes, headers: dict[str, str]) -> tuple[int, bytes]:
         if url != phenotype._ENDPOINT:
@@ -141,12 +142,19 @@ class PhenotypeHttpPost:
         if self._used:
             raise RuntimeError("Phenotype cassette permits exactly one HTTP interaction")
         self._used = True
-        with self._recorder.use_cassette(self._cassette_name):
-            return await phenotype._default_http_post(url, body, headers)
+        with self._recorder.use_cassette(self._cassette_name) as cassette:
+            response = await phenotype._default_http_post(url, body, headers)
+            self._interaction_count = len(cassette)
+            return response
 
     def assert_consumed(self) -> None:
         if not self._used:
             raise AssertionError("Phenotype cassette expected exactly one HTTP interaction")
+        if self._interaction_count != 1:
+            raise AssertionError(
+                "Phenotype cassette expected exactly one HTTP interaction, "
+                f"found {self._interaction_count}"
+            )
 
 
 def build_phenotype_http_post(cassette_path: Path) -> PhenotypeHttpPost:

--- a/tests/_helpers/play_book_http_cassette.py
+++ b/tests/_helpers/play_book_http_cassette.py
@@ -10,6 +10,7 @@ from tests.vcr_config import ResourceIdCassetteScrubber
 
 _LIST_RPC_ID = "mVtEUb"
 _ADD_RPC_ID = "X1snv"
+_SYNTHETIC_SOURCE_ID = "00000000-0000-4000-8000-000000000002"
 
 SYNTHETIC_BOOK_ROWS: list[list[Any]] = [
     [
@@ -67,14 +68,27 @@ def _set_content_length(headers: Any, length: int) -> None:
             headers[key] = [str(length)] if isinstance(headers[key], list) else str(length)
 
 
-def _synthetic_list_body() -> str:
-    result = json.dumps([SYNTHETIC_BOOK_ROWS], separators=(",", ":"), ensure_ascii=True)
+def _synthetic_rpc_body(rpc_id: str, result: Any) -> str:
+    result_text = json.dumps(result, separators=(",", ":"), ensure_ascii=True)
     payload = json.dumps(
-        [["wrb.fr", _LIST_RPC_ID, result, None, None, None, "generic"]],
+        [["wrb.fr", rpc_id, result_text, None, None, None, "generic"]],
         separators=(",", ":"),
         ensure_ascii=True,
     )
     return f")]}}'\n\n{len(payload.encode('utf-8'))}\n{payload}\n"
+
+
+def _synthetic_list_body() -> str:
+    return _synthetic_rpc_body(_LIST_RPC_ID, [SYNTHETIC_BOOK_ROWS])
+
+
+def _synthetic_add_body() -> str:
+    source_stub = [
+        [_SYNTHETIC_SOURCE_ID],
+        SYNTHETIC_BOOK_ROWS[0][2],
+        [None, None, None, None, 20],
+    ]
+    return _synthetic_rpc_body(_ADD_RPC_ID, [[source_stub], None, [[source_stub, 0]]])
 
 
 def _rewrite_add_body(body: str | bytes) -> str | bytes:
@@ -133,9 +147,12 @@ class PlayBookHttpCassetteScrubber:
         if content is None:
             return response
         text = content.decode("utf-8") if isinstance(content, bytes) else content
-        if f'"{_LIST_RPC_ID}"' not in text:
+        if f'"{_LIST_RPC_ID}"' in text:
+            synthetic = _synthetic_list_body()
+        elif f'"{_ADD_RPC_ID}"' in text:
+            synthetic = _synthetic_add_body()
+        else:
             return response
-        synthetic = _synthetic_list_body()
         body["string"] = synthetic.encode("utf-8") if isinstance(content, bytes) else synthetic
         _set_content_length(response.get("headers", {}), len(synthetic.encode("utf-8")))
         return response

--- a/tests/_helpers/play_book_http_cassette.py
+++ b/tests/_helpers/play_book_http_cassette.py
@@ -1,0 +1,144 @@
+"""Privacy-preserving VCR hooks for the Web Play Books add workflow."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import parse_qsl, urlencode
+
+from tests.vcr_config import ResourceIdCassetteScrubber
+
+_LIST_RPC_ID = "mVtEUb"
+_ADD_RPC_ID = "X1snv"
+
+SYNTHETIC_BOOK_ROWS: list[list[Any]] = [
+    [
+        "EIBOOK00000001",
+        1,
+        "Placeholder ebook 001",
+        "<p>public-domain placeholder 001</p>",
+        "https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000001",
+        False,
+        None,
+        ["author 001"],
+        4.5,
+        [1],
+    ],
+    [
+        "EIBOOK00000002",
+        1,
+        "Placeholder ebook 002",
+        "<p>public-domain placeholder 002</p>",
+        "https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000002",
+        False,
+        None,
+        ["author 002"],
+        4.2,
+        [1],
+    ],
+    [
+        "EIBOOK00000003",
+        1,
+        "Placeholder ebook 003",
+        "<p>blocked placeholder 003</p>",
+        "https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000003",
+        True,
+        1,
+        ["author 003"],
+        None,
+        [1],
+    ],
+]
+
+_SYNTHETIC_ADD_SPEC = [
+    1,
+    SYNTHETIC_BOOK_ROWS[0][0],
+    SYNTHETIC_BOOK_ROWS[0][2],
+    SYNTHETIC_BOOK_ROWS[0][3],
+    SYNTHETIC_BOOK_ROWS[0][4],
+    SYNTHETIC_BOOK_ROWS[0][8],
+    SYNTHETIC_BOOK_ROWS[0][7],
+]
+
+
+def _set_content_length(headers: Any, length: int) -> None:
+    for key in tuple(headers):
+        if str(key).casefold() == "content-length":
+            headers[key] = [str(length)] if isinstance(headers[key], list) else str(length)
+
+
+def _synthetic_list_body() -> str:
+    result = json.dumps([SYNTHETIC_BOOK_ROWS], separators=(",", ":"), ensure_ascii=True)
+    payload = json.dumps(
+        [["wrb.fr", _LIST_RPC_ID, result, None, None, None, "generic"]],
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return f")]}}'\n\n{len(payload.encode('utf-8'))}\n{payload}\n"
+
+
+def _rewrite_add_body(body: str | bytes) -> str | bytes:
+    as_bytes = isinstance(body, bytes)
+    text = body.decode("utf-8") if as_bytes else body
+    rewritten: list[tuple[str, str]] = []
+    found = False
+    for key, value in parse_qsl(text, keep_blank_values=True):
+        if key != "f.req":
+            rewritten.append((key, value))
+            continue
+        outer = json.loads(value)
+        for batch in outer:
+            for entry in batch:
+                if not isinstance(entry, list) or not entry or entry[0] != _ADD_RPC_ID:
+                    continue
+                args = json.loads(entry[1])
+                try:
+                    source_spec = args[0][0]
+                    expert_spec = source_spec[15]
+                except (IndexError, TypeError) as exc:
+                    raise ValueError("Unexpected Play Books add request shape") from exc
+                if len(source_spec) != 16 or not isinstance(expert_spec, list):
+                    raise ValueError("Unexpected Play Books add request shape")
+                clean_source_spec: list[Any] = [None] * 16
+                clean_source_spec[10] = 1
+                clean_source_spec[15] = list(_SYNTHETIC_ADD_SPEC)
+                args[0][0] = clean_source_spec
+                entry[1] = json.dumps(args, separators=(",", ":"), ensure_ascii=True)
+                found = True
+        rewritten.append((key, json.dumps(outer, separators=(",", ":"), ensure_ascii=True)))
+    if not found:
+        raise ValueError("Play Books add cassette request did not contain X1snv")
+    encoded = urlencode(rewritten)
+    return encoded.encode("utf-8") if as_bytes else encoded
+
+
+class PlayBookHttpCassetteScrubber:
+    """Remove both resource IDs and account library details from a cassette."""
+
+    def __init__(self) -> None:
+        self._resource_ids = ResourceIdCassetteScrubber()
+
+    def scrub_request(self, request: Any) -> Any:
+        request = self._resource_ids.scrub_request(request)
+        if request.uri and f"rpcids={_ADD_RPC_ID}" in request.uri:
+            if not request.body:
+                raise ValueError("Play Books add cassette request has no body")
+            request.body = _rewrite_add_body(request.body)
+        return request
+
+    def scrub_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        response = self._resource_ids.scrub_response(response)
+        body = response.get("body", {})
+        content = body.get("string")
+        if content is None:
+            return response
+        text = content.decode("utf-8") if isinstance(content, bytes) else content
+        if f'"{_LIST_RPC_ID}"' not in text:
+            return response
+        synthetic = _synthetic_list_body()
+        body["string"] = synthetic.encode("utf-8") if isinstance(content, bytes) else synthetic
+        _set_content_length(response.get("headers", {}), len(synthetic.encode("utf-8")))
+        return response
+
+
+__all__ = ["PlayBookHttpCassetteScrubber", "SYNTHETIC_BOOK_ROWS"]

--- a/tests/cassettes/README.md
+++ b/tests/cassettes/README.md
@@ -21,8 +21,9 @@ tests/cassettes/
 │   │   └── *.yaml                          (derived replay fixtures for gzip coverage)
 │   └── examples/
 │       └── example_<description>.yaml      (illustrative fixtures, not recordings)
-└── android/                                Android gRPC (sanitized protobuf JSON)
-    └── *.grpc.json
+└── android/                                Android protocol captures
+    ├── *.grpc.json                         sanitized protobuf gRPC interactions
+    └── *_phenotype.yaml                    auxiliary protobuf-over-HTTP (VCR.py)
 ```
 
 `web/` is the VCR `cassette_library_dir` (`tests/vcr_config.py`), so cassette
@@ -33,10 +34,12 @@ names in test code are **relative to `web/`** and carry no tier prefix:
 @notebooklm_vcr.use_cassette("examples/example_scrubbed_cookies.yaml")
 ```
 
-`android/` is not a vcrpy corpus at all — it replays through a consumer-owned
-gRPC channel seam (`tests/unit/android/test_grpc_cassette.py`,
+Android gRPC JSON replays through a consumer-owned channel seam
+(`tests/unit/android/test_grpc_cassette.py`,
 `tests/integration/test_android_grpc_cassette.py`), which resolves those paths
-itself.
+itself. The narrowly scoped `*_phenotype.yaml` exception captures the separate
+protobuf-over-HTTP call needed to obtain Play Books experiment metadata; it is
+never used to capture gRPC.
 
 ## Naming convention
 
@@ -101,6 +104,14 @@ Sanitized protobuf captures replayed through the test-only gRPC channel seam
 (`@pytest.mark.grpc_cassette`). They are JSON, not YAML, and are never loaded
 by vcrpy. See [docs/development.md](../../docs/development.md) for the Android
 recording workflow.
+
+### Android auxiliary HTTP — `android/*_phenotype.yaml`
+
+The Play Books write path obtains an experiment token through an HTTPS
+protobuf request before invoking gRPC. Its integration test captures that one
+HTTP exchange with VCR.py and protobuf-aware body redaction. Authorization and
+token values are never committed; the corresponding gRPC cassette pins only
+the required application metadata key names.
 
 ## When to add a cassette
 

--- a/tests/cassettes/android/chat_session_control_recorded.grpc.json
+++ b/tests/cassettes/android/chat_session_control_recorded.grpc.json
@@ -1,0 +1,131 @@
+{
+  "format": "notebooklm.android.grpc-cassette",
+  "interactions": [
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetProject",
+      "request": {
+        "protobuf_b64": "CiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEQAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectRequest"
+      },
+      "response_protobuf_type": "notebooklm.internal.android.wire.v1.WireGetProjectResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CqIBChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMhIUU0NSVUJCRURfU1RSSU5HXzAwMjYaAigEIgIQAhokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAxMggIAUoECAEQAVIGCAEQARgBWgoIARABGAEgASgB",
+          "protobuf_type": "notebooklm.internal.android.wire.v1.WireGetProjectResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/ListChatSessions",
+      "request": {
+        "protobuf_b64": "GiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDE=",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMw==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/ListChatSessions",
+      "request": {
+        "protobuf_b64": "GiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDE=",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMw==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatSessionsResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/ListChatTurns",
+      "request": {
+        "protobuf_b64": "IiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDM=",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatTurnsRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatTurnsResponse",
+      "responses": [
+        {
+          "protobuf_b64": "",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListChatTurnsResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed",
+      "request": {
+        "protobuf_b64": "CigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyEhRTQ1JVQkJFRF9TVFJJTkdfMDAwMSI8CAISFwoVU0NSVUJCRURfUkVRVUVTVF8wMDAxIh8IAVobCAIQARoVU0NSVUJCRURfUkVRVUVTVF8wMDAxQiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDFIAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse",
+      "responses": [
+        {
+          "protobuf_b64": "Cp8EChRTQ1JVQkJFRF9TVFJJTkdfMDAyNxpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKrYDCogCCoUBEAEagAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzMQo0UjIKFFNDUlVCQkVEX1NUUklOR18wMDMyEhoKGAoUU0NSVUJCRURfU1RSSU5HXzAwMzMSAAoYWhYKFFNDUlVCQkVEX1NUUklOR18wMDMyEi4KJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDA1EgQQARgBIqYBCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNRJ8IgIYASoiCiAQARocChoQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNDIqCigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyOiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNSgB",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        },
+        {
+          "protobuf_b64": "CrUFChRTQ1JVQkJFRF9TVFJJTkdfMDAzNRpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKswECp4DCsUBEAEawAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNgogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAzNxICCAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzgKJAgBEAEaHgocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzOQo0UjIKFFNDUlVCQkVEX1NUUklOR18wMDMyEhoKGAoUU0NSVUJCRURfU1RSSU5HXzAwMzMSAAoYWhYKFFNDUlVCQkVEX1NUUklOR18wMDMyEi4KJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDA2EgQQARgBEi4KJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDA2EgQQARgBIqYBCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNhJ8IgIYASoiCiAQARocChoQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNDIqCigKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyOiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNigB",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        },
+        {
+          "protobuf_b64": "CvUFChRTQ1JVQkJFRF9TVFJJTkdfMDA0MBpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKowFCt4DCsUBEAEawAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNgogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAzNxICCAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzgKZAgBEAEaXgocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDA0MQogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAyORICQAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwNDIKNFIyChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIaChgKFFNDUlVCQkVEX1NUUklOR18wMDMzEgAKGFoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNxIEEAEYARIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNxIEEAEYASKmAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDcSfCICGAEqIgogEAEaHAoaEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzQyKgooCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMjomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDcoAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        },
+        {
+          "protobuf_b64": "CvUFChRTQ1JVQkJFRF9TVFJJTkdfMDA0MxpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKowFCt4DCsUBEAEawAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNgogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAzNxICCAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzgKZAgBEAEaXgocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDA0MQogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAyORICQAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwNDQKNFIyChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIaChgKFFNDUlVCQkVEX1NUUklOR18wMDMzEgAKGFoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYARIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYASKmAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgSfCICGAEqIgogEAEaHAoaEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzQyKgooCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMjomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgoAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        },
+        {
+          "protobuf_b64": "CvUFChRTQ1JVQkJFRF9TVFJJTkdfMDA0MxpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKowFCt4DCsUBEAEawAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNgogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAzNxICCAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzgKZAgBEAEaXgocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDA0MQogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAyORICQAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwNDQKNFIyChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIaChgKFFNDUlVCQkVEX1NUUklOR18wMDMzEgAKGFoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYARIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYASKmAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgSfCICGAEqIgogEAEaHAoaEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzQyKgooCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMjomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgoAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        },
+        {
+          "protobuf_b64": "CvUFChRTQ1JVQkJFRF9TVFJJTkdfMDA0MxpOCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDMSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwNBgBKowFCt4DCsUBEAEawAEKGhABGhYKFFNDUlVCQkVEX1NUUklOR18wMDI4CiIIARABGhwKFFNDUlVCQkVEX1NUUklOR18wMDI5EgQIAUABCiAIARABGhoKFFNDUlVCQkVEX1NUUklOR18wMDMwEgIIAQocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzNgogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAzNxICCAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzgKZAgBEAEaXgocCAEQARoWChRTQ1JVQkJFRF9TVFJJTkdfMDA0MQogCAEQARoaChRTQ1JVQkJFRF9TVFJJTkdfMDAyORICQAEKHAgBEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwNDQKNFIyChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIaChgKFFNDUlVCQkVEX1NUUklOR18wMDMzEgAKGFoWChRTQ1JVQkJFRF9TVFJJTkdfMDAzMhIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYARIuCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwOBIEEAEYASKmAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgSfCICGAEqIgogEAEaHAoaEAEaFgoUU0NSVUJCRURfU1RSSU5HXzAwMzQyKgooCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMjomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDgoASgBMk4KGAoUU0NSVUJCRURfU1RSSU5HXzAwNDUQCQoYChRTQ1JVQkJFRF9TVFJJTkdfMDA0NhAJChgKFFNDUlVCQkVEX1NUUklOR18wMDQ3EAk=",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GenerateFreeFormStreamedResponse"
+        }
+      ],
+      "shape": "unary_stream"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetChatSessionStatus",
+      "request": {
+        "protobuf_b64": "CjwIAhIXChVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEiHwgBWhsIAhABGhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDESJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMw==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetChatSessionStatusRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetChatSessionStatusResponse",
+      "responses": [
+        {
+          "protobuf_b64": "EAE=",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetChatSessionStatusResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/CancelGeneration",
+      "request": {
+        "protobuf_b64": "CjwIAhIXChVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEiHwgBWhsIAhABGhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDESJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMw==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.CancelGenerationRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.CancelGenerationResponse",
+      "responses": [
+        {
+          "protobuf_b64": "",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.CancelGenerationResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    }
+  ],
+  "version": 1
+}

--- a/tests/cassettes/android/play_books_phenotype.yaml
+++ b/tests/cassettes/android/play_books_phenotype.yaml
@@ -1,0 +1,33 @@
+interactions:
+- request:
+    body: !!binary |
+      CtYCItMCCAESzAIIARgBIhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEqFVNDUlVCQkVEX1JFUVVFU1Rf
+      MDAwMjIVU0NSVUJCRURfUkVRVUVTVF8wMDAzOhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDRCFVNDUlVC
+      QkVEX1JFUVVFU1RfMDAwMkoVU0NSVUJCRURfUkVRVUVTVF8wMDAyWhVTQ1JVQkJFRF9SRVFVRVNU
+      XzAwMDViFVNDUlVCQkVEX1JFUVVFU1RfMDAwNmoVU0NSVUJCRURfUkVRVUVTVF8wMDA3chVTQ1JV
+      QkJFRF9SRVFVRVNUXzAwMDh6FVNDUlVCQkVEX1JFUVVFU1RfMDAwMoIBFVNDUlVCQkVEX1JFUVVF
+      U1RfMDAwOYoBFVNDUlVCQkVEX1JFUVVFU1RfMDAxMJgBAdIBFVNDUlVCQkVEX1JFUVVFU1RfMDAx
+      MWABEh8KHQoVU0NSVUJCRURfUkVRVUVTVF8wMDEyEAEaAggBIAEoAToVU0NSVUJCRURfUkVRVUVT
+      VF8wMDEz
+    headers:
+      content-length:
+      - '405'
+      content-type:
+      - application/x-protobuf
+      user-agent:
+      - com.google.android.gms/253434035 (Linux; U; Android 34; en_US; Pixel 8; Build/AP2A.240905.003)
+    method: POST
+    uri: https://www.googleapis.com/experimentsandconfigs/v1/getExperimentsAndConfigs?r=8&c=1
+  response:
+    body:
+      string: !!binary |
+        CjAKGAoUU0NSVUJCRURfU1RSSU5HXzAwMDEQASIUU0NSVUJCRURfU1RSSU5HXzAwMDIgAQ==
+    headers:
+      content-length:
+      - '52'
+      content-type:
+      - application/octet-stream
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/android/play_books_recorded.grpc.json
+++ b/tests/cassettes/android/play_books_recorded.grpc.json
@@ -1,0 +1,115 @@
+{
+  "format": "notebooklm.android.grpc-cassette",
+  "interactions": [
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/ListExpertIntelligenceContent",
+      "request": {
+        "protobuf_b64": "CjwIAxIXChVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEiHwgBWhsIAhABGhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEQAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentResponse",
+      "responses": [
+        {
+          "protobuf_b64": "Co4BChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRABGhRTQ1JVQkJFRF9TVFJJTkdfMDAyNiIUU0NSVUJCRURfU1RSSU5HXzAwMjcqLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDJCFFNDUlVCQkVEX1NUUklOR18wMDI4UgIIAQqOAQoUU0NSVUJCRURfU1RSSU5HXzAwMjkQARoUU0NSVUJCRURfU1RSSU5HXzAwMzAiFFNDUlVCQkVEX1NUUklOR18wMDMxKi5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDAzQhRTQ1JVQkJFRF9TVFJJTkdfMDAzMlICCAEKjgEKFFNDUlVCQkVEX1NUUklOR18wMDMzEAEaFFNDUlVCQkVEX1NUUklOR18wMDM0IhRTQ1JVQkJFRF9TVFJJTkdfMDAzNSouaHR0cHM6Ly9leGFtcGxlLmludmFsaWQvZ3JwYy1jYXNzZXR0ZS91cmwtMDAwNEIUU0NSVUJCRURfU1RSSU5HXzAwMzJSAggBCo4BChRTQ1JVQkJFRF9TVFJJTkdfMDAzNhABGhRTQ1JVQkJFRF9TVFJJTkdfMDAzNyIUU0NSVUJCRURfU1RSSU5HXzAwMzgqLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDVCFFNDUlVCQkVEX1NUUklOR18wMDM5UgIIAQqUAQoUU0NSVUJCRURfU1RSSU5HXzAwNDAQARoUU0NSVUJCRURfU1RSSU5HXzAwNDEiFFNDUlVCQkVEX1NUUklOR18wMDQyKi5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDA2MAE4AUIUU0NSVUJCRURfU1RSSU5HXzAwNDNSBAgBEAEKkgEKFFNDUlVCQkVEX1NUUklOR18wMDQ0EAEaFFNDUlVCQkVEX1NUUklOR18wMDQ1IhRTQ1JVQkJFRF9TVFJJTkdfMDA0NiouaHR0cHM6Ly9leGFtcGxlLmludmFsaWQvZ3JwYy1jYXNzZXR0ZS91cmwtMDAwNzABOAFCFFNDUlVCQkVEX1NUUklOR18wMDQ3UgIIAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/ListExpertIntelligenceContent",
+      "request": {
+        "protobuf_b64": "CjwIAxIXChVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEiHwgBWhsIAhABGhVTQ1JVQkJFRF9SRVFVRVNUXzAwMDEQAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentResponse",
+      "responses": [
+        {
+          "protobuf_b64": "Co4BChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRABGhRTQ1JVQkJFRF9TVFJJTkdfMDAyNiIUU0NSVUJCRURfU1RSSU5HXzAwMjcqLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDJCFFNDUlVCQkVEX1NUUklOR18wMDI4UgIIAQqOAQoUU0NSVUJCRURfU1RSSU5HXzAwMjkQARoUU0NSVUJCRURfU1RSSU5HXzAwMzAiFFNDUlVCQkVEX1NUUklOR18wMDMxKi5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDAzQhRTQ1JVQkJFRF9TVFJJTkdfMDAzMlICCAEKjgEKFFNDUlVCQkVEX1NUUklOR18wMDMzEAEaFFNDUlVCQkVEX1NUUklOR18wMDM0IhRTQ1JVQkJFRF9TVFJJTkdfMDAzNSouaHR0cHM6Ly9leGFtcGxlLmludmFsaWQvZ3JwYy1jYXNzZXR0ZS91cmwtMDAwNEIUU0NSVUJCRURfU1RSSU5HXzAwMzJSAggBCo4BChRTQ1JVQkJFRF9TVFJJTkdfMDAzNhABGhRTQ1JVQkJFRF9TVFJJTkdfMDAzNyIUU0NSVUJCRURfU1RSSU5HXzAwMzgqLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDVCFFNDUlVCQkVEX1NUUklOR18wMDM5UgIIAQqUAQoUU0NSVUJCRURfU1RSSU5HXzAwNDAQARoUU0NSVUJCRURfU1RSSU5HXzAwNDEiFFNDUlVCQkVEX1NUUklOR18wMDQyKi5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDA2MAE4AUIUU0NSVUJCRURfU1RSSU5HXzAwNDNSBAgBEAEKkgEKFFNDUlVCQkVEX1NUUklOR18wMDQ0EAEaFFNDUlVCQkVEX1NUUklOR18wMDQ1IhRTQ1JVQkJFRF9TVFJJTkdfMDA0NiouaHR0cHM6Ly9leGFtcGxlLmludmFsaWQvZ3JwYy1jYXNzZXR0ZS91cmwtMDAwNzABOAFCFFNDUlVCQkVEX1NUUklOR18wMDQ3UgIIAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.ListExpertIntelligenceContentResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/AddTentativeSources",
+      "request": {
+        "protobuf_b64": "ChYKFFNDUlVCQkVEX1NUUklOR18wMDAzEiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDE=",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddTentativeSourcesRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddTentativeSourcesResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CkAKJgokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAyEhRTQ1JVQkJFRF9TVFJJTkdfMDAwMxoA",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddTentativeSourcesResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "application_metadata_keys": [
+        "x-goog-ext-174067345-bin",
+        "x-goog-ext-202964622-bin"
+      ],
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/AddSources",
+      "request": {
+        "protobuf_b64": "CrYBSiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMoIBigEIARIUU0NSVUJCRURfU1RSSU5HXzAwMjUaFFNDUlVCQkVEX1NUUklOR18wMDI2IhRTQ1JVQkJFRF9TVFJJTkdfMDAyNyouaHR0cHM6Ly9leGFtcGxlLmludmFsaWQvZ3JwYy1jYXNzZXR0ZS91cmwtMDAwMjoUU0NSVUJCRURfU1RSSU5HXzAwMjgSJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMRo8CAMSFwoVU0NSVUJCRURfUkVRVUVTVF8wMDAxIh8IAVobCAIQARoVU0NSVUJCRURfUkVRVUVTVF8wMDAx",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddSourcesRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddSourcesResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CtMBCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMhIUU0NSVUJCRURfU1RSSU5HXzAwMjYajgEoFJoBiAEKFFNDUlVCQkVEX1NUUklOR18wMDI1GhRTQ1JVQkJFRF9TVFJJTkdfMDAyNiIUU0NSVUJCRURfU1RSSU5HXzAwMjgqLmh0dHBzOi8vZXhhbXBsZS5pbnZhbGlkL2dycGMtY2Fzc2V0dGUvdXJsLTAwMDIyFFNDUlVCQkVEX1NUUklOR18wMDI3IgIQAg==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.AddSourcesResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetProject",
+      "request": {
+        "protobuf_b64": "CiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEQAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CpADChRTQ1JVQkJFRF9TVFJJTkdfMDA0OBJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMxIUU0NSVUJCRURfU1RSSU5HXzAwNDkaAigEIgIQAhLVAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDISFFNDUlVCQkVEX1NUUklOR18wMDI2Go4BKBSaAYgBChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRoUU0NSVUJCRURfU1RSSU5HXzAwMjYiFFNDUlVCQkVEX1NUUklOR18wMDI4Ki5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDAyMhRTQ1JVQkJFRF9TVFJJTkdfMDAyNyIEEAIgAxokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAxIhRTQ1JVQkJFRF9TVFJJTkdfMDA1MDIICAFKBAgBEAFSBggBEAEYAVoKCAEQARgBIAEoAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GetProject",
+      "request": {
+        "protobuf_b64": "CiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDEQAQ==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectRequest"
+      },
+      "response_protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse",
+      "responses": [
+        {
+          "protobuf_b64": "CpADChRTQ1JVQkJFRF9TVFJJTkdfMDA0OBJGCiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMxIUU0NSVUJCRURfU1RSSU5HXzAwNDkaAigEIgIQAhLVAQomCiQwMDAwMDAwMC0wMDAwLTQwMDAtODAwMC0wMDAwMDAwMDAwMDISFFNDUlVCQkVEX1NUUklOR18wMDI2Go4BKBSaAYgBChRTQ1JVQkJFRF9TVFJJTkdfMDAyNRoUU0NSVUJCRURfU1RSSU5HXzAwMjYiFFNDUlVCQkVEX1NUUklOR18wMDI4Ki5odHRwczovL2V4YW1wbGUuaW52YWxpZC9ncnBjLWNhc3NldHRlL3VybC0wMDAyMhRTQ1JVQkJFRF9TVFJJTkdfMDAyNyIEEAIgAxokMDAwMDAwMDAtMDAwMC00MDAwLTgwMDAtMDAwMDAwMDAwMDAxIhRTQ1JVQkJFRF9TVFJJTkdfMDA1MDIICAFKBAgBEAFSBggBEAEYAVoKCAEQARgBIAEoAQ==",
+          "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.GetProjectResponse"
+        }
+      ],
+      "shape": "unary_unary"
+    },
+    {
+      "method": "/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/DeleteSources",
+      "request": {
+        "protobuf_b64": "CiYKJDAwMDAwMDAwLTAwMDAtNDAwMC04MDAwLTAwMDAwMDAwMDAwMg==",
+        "protobuf_type": "google.internal.labs.tailwind.orchestration.v1.DeleteSourcesRequest"
+      },
+      "response_protobuf_type": "google.protobuf.Empty",
+      "responses": [
+        {
+          "protobuf_b64": "",
+          "protobuf_type": "google.protobuf.Empty"
+        }
+      ],
+      "shape": "unary_unary"
+    }
+  ],
+  "version": 1
+}

--- a/tests/cassettes/web/sources_play_book_add.yaml
+++ b/tests/cassettes/web/sources_play_book_add.yaml
@@ -218,13 +218,9 @@ interactions:
       string: ')]}''
 
 
-        292
+        254
 
-        [["wrb.fr","X1snv","[[[[\"00000000-0000-4000-8000-000000000002\"],\"SCRUBBED_NAME\",[null,null,null,null,20]]],null,[[[[\"00000000-0000-4000-8000-000000000002\"],\"SCRUBBED_NAME\",[null,null,null,null,20]],0]]]",null,null,null,"generic"],["di",633],["af.httprm",633,"2703687566713757060",14]]
-
-        23
-
-        [["e",4,null,null,324]]
+        [["wrb.fr","X1snv","[[[[\"00000000-0000-4000-8000-000000000002\"],\"Placeholder ebook 001\",[null,null,null,null,20]]],null,[[[[\"00000000-0000-4000-8000-000000000002\"],\"Placeholder ebook 001\",[null,null,null,null,20]],0]]]",null,null,null,"generic"]]
 
         '
     headers:
@@ -238,7 +234,7 @@ interactions:
       content-disposition:
       - attachment; filename="response.bin"; filename*=UTF-8''response.bin
       content-length:
-      - '324'
+      - '265'
       content-security-policy:
       - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
       content-type:

--- a/tests/cassettes/web/sources_play_book_add.yaml
+++ b/tests/cassettes/web/sources_play_book_add.yaml
@@ -1,0 +1,285 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22mVtEUb%22%2C%22%5Bnull%2C1%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788321590819&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '131'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED;
+        APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED; __Secure-3PAPISID=SCRUBBED; NID=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; AEC=SCRUBBED; __Secure-1PSIDTS=SCRUBBED;
+        __Secure-3PSIDTS=SCRUBBED; OSID=SCRUBBED; __Secure-OSID=SCRUBBED
+      host:
+      - notebook.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=mVtEUb&source-path=%2F&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
+  response:
+    body:
+      string: ')]}''
+
+
+        676
+
+        [["wrb.fr","mVtEUb","[[[\"EIBOOK00000001\",1,\"Placeholder ebook 001\",\"<p>public-domain placeholder
+        001</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000001\",false,null,[\"author
+        001\"],4.5,[1]],[\"EIBOOK00000002\",1,\"Placeholder ebook 002\",\"<p>public-domain placeholder
+        002</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000002\",false,null,[\"author
+        002\"],4.2,[1]],[\"EIBOOK00000003\",1,\"Placeholder ebook 003\",\"<p>blocked placeholder 003</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000003\",true,1,[\"author
+        003\"],null,[1]]]]",null,null,null,"generic"]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Model,
+        Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '687'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Wed, 02 Sep 2026 03:59:52 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*, ch-ua-model=*,
+        ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22mVtEUb%22%2C%22%5Bnull%2C1%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788321590819&
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '131'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED;
+        APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED; __Secure-3PAPISID=SCRUBBED; NID=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; AEC=SCRUBBED; __Secure-1PSIDTS=SCRUBBED;
+        __Secure-3PSIDTS=SCRUBBED; OSID=SCRUBBED; __Secure-OSID=SCRUBBED
+      host:
+      - notebook.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=mVtEUb&source-path=%2F&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
+  response:
+    body:
+      string: ')]}''
+
+
+        676
+
+        [["wrb.fr","mVtEUb","[[[\"EIBOOK00000001\",1,\"Placeholder ebook 001\",\"<p>public-domain placeholder
+        001</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000001\",false,null,[\"author
+        001\"],4.5,[1]],[\"EIBOOK00000002\",1,\"Placeholder ebook 002\",\"<p>public-domain placeholder
+        002</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000002\",false,null,[\"author
+        002\"],4.2,[1]],[\"EIBOOK00000003\",1,\"Placeholder ebook 003\",\"<p>blocked placeholder 003</p>\",\"https://play.google.com/books/publisher/content/images/frontcover/EIBOOK00000003\",true,1,[\"author
+        003\"],null,[1]]]]",null,null,null,"generic"]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Model,
+        Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '687'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-security-policy-report-only:
+      - script-src 'unsafe-inline';report-uri https://csp.withgoogle.com/csp/script-inclusions/a00d54fdef4a77536baac3725d1409f8
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Wed, 02 Sep 2026 03:59:52 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*, ch-ua-model=*,
+        ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:52 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22X1snv%22%2C%22%5B%5B%5Bnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C1%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%2C%5C%22EIBOOK00000001%5C%22%2C%5C%22Placeholder+ebook+001%5C%22%2C%5C%22%3Cp%3Epublic-domain+placeholder+001%3C%2Fp%3E%5C%22%2C%5C%22https%3A%2F%2Fplay.google.com%2Fbooks%2Fpublisher%2Fcontent%2Fimages%2Ffrontcover%2FEIBOOK00000001%5C%22%2C4.5%2C%5B%5C%22author+001%5C%22%5D%5D%5D%5D%2C%5C%2200000000-0000-4000-8000-000000000001%5C%22%2C%5B2%2Cnull%2Cnull%2C%5B1%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B1%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788321590819
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1945'
+      content-type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      cookie:
+      - SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED;
+        APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED; __Secure-3PAPISID=SCRUBBED; NID=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; AEC=SCRUBBED; __Secure-1PSIDTS=SCRUBBED;
+        __Secure-3PSIDTS=SCRUBBED; OSID=SCRUBBED; __Secure-OSID=SCRUBBED
+      host:
+      - notebook.google.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=X1snv&source-path=%2Fnotebook%2F00000000-0000-4000-8000-000000000001&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
+  response:
+    body:
+      string: ')]}''
+
+
+        292
+
+        [["wrb.fr","X1snv","[[[[\"00000000-0000-4000-8000-000000000002\"],\"SCRUBBED_NAME\",[null,null,null,null,20]]],null,[[[[\"00000000-0000-4000-8000-000000000002\"],\"SCRUBBED_NAME\",[null,null,null,null,20]],0]]]",null,null,null,"generic"],["di",633],["af.httprm",633,"2703687566713757060",14]]
+
+        23
+
+        [["e",4,null,null,324]]
+
+        '
+    headers:
+      accept-ch:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Model,
+        Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform, Sec-CH-UA-Platform-Version
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      content-disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      content-length:
+      - '324'
+      content-security-policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      content-type:
+      - application/json; charset=utf-8
+      cross-origin-opener-policy:
+      - same-origin-allow-popups
+      cross-origin-resource-policy:
+      - same-site
+      date:
+      - Wed, 02 Sep 2026 03:59:53 GMT
+      expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      permissions-policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*, ch-ua-model=*,
+        ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      pragma:
+      - no-cache
+      server:
+      - ESF
+      set-cookie:
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com; priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Thu, 02-Sep-2027 03:59:53 GMT; path=/; domain=.google.com;
+        Secure; HttpOnly; priority=high; SameSite=none
+      transfer-encoding:
+      - chunked
+      vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/web/sources_search.yaml
+++ b/tests/cassettes/web/sources_search.yaml
@@ -2312,7 +2312,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22ASU5Oe%22%2C%22%5B%5C%22e7626843-661e-4e4d-b0a9-2bc4692f8a7f%5C%22%2C%5C%22Python%20functions%5C%22%2Cnull%2C%5B1%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788314194121&
+    body: f.req=%5B%5B%5B%22ASU5Oe%22%2C%22%5B%5C%2200000000-0000-4000-8000-000000000001%5C%22%2C%5C%22Python%20functions%5C%22%2Cnull%2C%5B1%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788314194121&
     headers:
       accept:
       - '*/*'
@@ -2335,7 +2335,7 @@ interactions:
       user-agent:
       - python-httpx/0.28.1
     method: POST
-    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=ASU5Oe&source-path=%2Fnotebook%2Fe7626843-661e-4e4d-b0a9-2bc4692f8a7f&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
+    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=ASU5Oe&source-path=%2Fnotebook%2F00000000-0000-4000-8000-000000000001&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
   response:
     body:
       string: ')]}''
@@ -2431,7 +2431,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: f.req=%5B%5B%5B%22ASU5Oe%22%2C%22%5B%5C%22e7626843-661e-4e4d-b0a9-2bc4692f8a7f%5C%22%2C%5C%22Python%20functions%5C%22%2Cnull%2C%5B1%5D%2C%5B%5B%5B%5C%228812c279-6a91-4a20-a2a8-9629ff949b95%5C%22%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788314194121&
+    body: f.req=%5B%5B%5B%22ASU5Oe%22%2C%22%5B%5C%2200000000-0000-4000-8000-000000000001%5C%22%2C%5C%22Python%20functions%5C%22%2Cnull%2C%5B1%5D%2C%5B%5B%5B%5C%2200000000-0000-4000-8000-000000000005%5C%22%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1788314194121&
     headers:
       accept:
       - '*/*'
@@ -2454,7 +2454,7 @@ interactions:
       user-agent:
       - python-httpx/0.28.1
     method: POST
-    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=ASU5Oe&source-path=%2Fnotebook%2Fe7626843-661e-4e4d-b0a9-2bc4692f8a7f&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
+    uri: https://notebook.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=ASU5Oe&source-path=%2Fnotebook%2F00000000-0000-4000-8000-000000000001&f.sid=SCRUBBED&hl=en&rt=c&authuser=SCRUBBED_EMAIL%40example.com
   response:
     body:
       string: ')]}''

--- a/tests/e2e/test_rpc_additions.py
+++ b/tests/e2e/test_rpc_additions.py
@@ -1,0 +1,142 @@
+"""Live public-client coverage for RPCs added after v0.8.1.
+
+Every mutation is confined to disposable notebooks. The tests intentionally
+call the public APIs rather than wire services so they qualify the same facade
+and backend assembly users exercise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from notebooklm import (
+    ArtifactCustomizationChoices,
+    ChatSessionStatus,
+    CopiedArtifact,
+    CopiedSource,
+    NextStepSuggestion,
+    RelevantChunk,
+    ResearchStatus,
+    SourceType,
+)
+
+from .conftest import requires_auth
+
+pytestmark = [pytest.mark.e2e, requires_auth]
+
+
+@pytest.mark.asyncio
+async def test_ranked_search_suggestions_and_customization_choices(client, temp_notebook) -> None:
+    chunks = await client.sources.search(
+        temp_notebook.id,
+        "artificial intelligence and machine learning",
+        limit=2,
+    )
+    assert chunks and all(isinstance(chunk, RelevantChunk) for chunk in chunks)
+    filtered = await client.sources.search(
+        temp_notebook.id,
+        "artificial intelligence and machine learning",
+        source_ids=[chunks[0].source_id],
+    )
+    assert filtered and all(chunk.source_id == chunks[0].source_id for chunk in filtered)
+
+    suggestions = await client.notebooks.suggest_next_steps(temp_notebook.id)
+    assert suggestions and all(isinstance(item, NextStepSuggestion) for item in suggestions)
+
+    choices = await client.artifacts.get_customization_choices(temp_notebook.id)
+    assert isinstance(choices, ArtifactCustomizationChoices)
+    assert choices.audio and choices.video and choices.slide_deck and choices.reports
+
+
+@pytest.mark.asyncio
+async def test_synchronous_research_discovery(client, temp_notebook) -> None:
+    task = await client.research.discover(temp_notebook.id, "history of machine learning")
+    assert task.status is ResearchStatus.COMPLETED
+    assert task.task_id and task.summary and task.sources
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(300)
+async def test_notebook_and_source_transfer_lifecycle(
+    client,
+    temp_notebook,
+    created_notebooks,
+) -> None:
+    copied_notebook = await client.notebooks.copy(
+        temp_notebook.id,
+        f"E2E RPC copy {uuid4().hex[:8]}",
+    )
+    created_notebooks.append(copied_notebook.id)
+    assert copied_notebook.id != temp_notebook.id
+
+    target = await client.notebooks.create(f"E2E RPC transfer {uuid4().hex[:8]}")
+    created_notebooks.append(target.id)
+
+    queued = await client.sources.add_urls_async(temp_notebook.id, ["https://example.com/"])
+    assert len(queued) == 1 and queued[0].id
+    await client.sources.wait_until_ready(temp_notebook.id, queued[0].id, timeout=120)
+
+    sources = await client.sources.list(temp_notebook.id)
+    seed = next(source for source in sources if source.id != queued[0].id)
+    before = await client.sources.get_fulltext(temp_notebook.id, seed.id)
+    marker = f"E2E append marker {uuid4().hex}"
+    await client.sources.append_text(temp_notebook.id, seed.id, marker, header="E2E")
+    deadline = asyncio.get_running_loop().time() + 30
+    while True:
+        after = await client.sources.get_fulltext(temp_notebook.id, seed.id)
+        if marker in after.content:
+            break
+        if asyncio.get_running_loop().time() >= deadline:
+            pytest.fail("AppendSource content was not visible within 30 seconds")
+        await asyncio.sleep(1)
+    assert len(after.content) > len(before.content)
+
+    copied_sources = await client.sources.copy(temp_notebook.id, [seed.id], target.id)
+    assert len(copied_sources) == 1
+    assert isinstance(copied_sources[0], CopiedSource)
+    assert copied_sources[0].original_id == seed.id
+
+
+@pytest.mark.asyncio
+async def test_completed_artifact_copy(client, read_only_notebook_id, temp_notebook) -> None:
+    artifacts = await client.artifacts.list(read_only_notebook_id)
+    donor = next((artifact for artifact in artifacts if artifact.is_completed), None)
+    if donor is None:
+        pytest.fail("read-only E2E notebook must contain a completed artifact to copy")
+
+    copied = await client.artifacts.copy(read_only_notebook_id, [donor.id], temp_notebook.id)
+    assert len(copied) == 1
+    assert isinstance(copied[0], CopiedArtifact)
+    assert copied[0].original_id == donor.id
+    assert copied[0].artifact.id != donor.id
+
+
+@pytest.mark.asyncio
+async def test_play_books_list_and_add(client, temp_notebook) -> None:
+    books = await client.sources.list_play_books()
+    exportable = next((book for book in books if not book.export_disabled), None)
+    if exportable is None:
+        pytest.skip("E2E account has no exportable Google Play Book")
+
+    source = await client.sources.add_play_book(
+        temp_notebook.id,
+        exportable.content_id,
+        wait=False,
+    )
+    assert source.id
+    assert source.kind is SourceType.EXPERT_INTELLIGENCE
+
+
+@pytest.mark.asyncio
+async def test_chat_session_status_and_cancel(client, temp_notebook) -> None:
+    answer = await client.chat.ask(temp_notebook.id, "Summarize this notebook briefly.")
+
+    status = await client.chat.session_status(temp_notebook.id, answer.conversation_id)
+    assert isinstance(status, ChatSessionStatus)
+    assert status.generating is False
+    assert status.token is None
+
+    assert await client.chat.cancel(temp_notebook.id, answer.conversation_id) is None

--- a/tests/e2e/test_rpc_additions.py
+++ b/tests/e2e/test_rpc_additions.py
@@ -8,6 +8,7 @@ and backend assembly users exercise.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from uuid import uuid4
 
 import pytest
@@ -131,12 +132,45 @@ async def test_play_books_list_and_add(client, temp_notebook) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(120)
 async def test_chat_session_status_and_cancel(client, temp_notebook) -> None:
-    answer = await client.chat.ask(temp_notebook.id, "Summarize this notebook briefly.")
+    seed = await client.chat.ask(temp_notebook.id, "Summarize this notebook briefly.")
+    generation = asyncio.create_task(
+        client.chat.ask(
+            temp_notebook.id,
+            "Write a detailed, exhaustive explanation of every source in this notebook.",
+            conversation_id=seed.conversation_id,
+        )
+    )
+    try:
+        deadline = asyncio.get_running_loop().time() + 30
+        while True:
+            active = await client.chat.session_status(temp_notebook.id, seed.conversation_id)
+            if active.generating:
+                break
+            if generation.done():
+                await generation
+                pytest.fail("Chat generation completed before an active status was observable")
+            if asyncio.get_running_loop().time() >= deadline:
+                pytest.fail("Chat session did not enter the generating state within 30 seconds")
+            await asyncio.sleep(0.1)
 
-    status = await client.chat.session_status(temp_notebook.id, answer.conversation_id)
-    assert isinstance(status, ChatSessionStatus)
-    assert status.generating is False
-    assert status.token is None
+        assert isinstance(active, ChatSessionStatus)
+        assert active.token
+        assert await client.chat.cancel(temp_notebook.id, seed.conversation_id) is None
 
-    assert await client.chat.cancel(temp_notebook.id, answer.conversation_id) is None
+        deadline = asyncio.get_running_loop().time() + 30
+        while True:
+            terminal = await client.chat.session_status(temp_notebook.id, seed.conversation_id)
+            if not terminal.generating:
+                break
+            if asyncio.get_running_loop().time() >= deadline:
+                pytest.fail("Cancelled chat session did not become idle within 30 seconds")
+            await asyncio.sleep(0.25)
+
+        assert isinstance(terminal, ChatSessionStatus)
+        assert terminal.token is None
+    finally:
+        generation.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await generation

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -36,21 +36,24 @@ violating node IDs.
 Android cassettes live in `tests/cassettes/android/` and intentionally use the
 `.grpc.json` suffix rather than vcrpy's YAML format. Each interaction pins the
 full method path, unary-unary versus unary-stream shape, deterministic request
-protobuf FQN/bytes, and deterministic response protobuf FQN/bytes. Metadata is
-not part of the model, so bearer credentials cannot be serialized. Recording
-requires an explicit application-level sanitizer and then unconditionally runs
-the generalized protobuf redactor as its final security boundary. The redactor
+protobuf FQN/bytes, and deterministic response protobuf FQN/bytes. The model
+can pin an allowlisted set of application metadata key names, but never stores
+metadata values or bearer credentials. Recording requires an explicit
+application-level sanitizer and then unconditionally runs the generalized
+protobuf redactor as its final security boundary. The redactor
 discards unknown fields, replaces every string and byte string, and maps
 integers/floats to safe non-zero placeholders while preserving scalar presence,
 message structure, booleans, and schema-defined enum values. Replay injects an
 in-memory channel and a non-secret bearer provider; it must never construct a
 live gRPC channel or mint OAuth credentials.
 
-Set `NOTEBOOKLM_ANDROID_GRPC_RECORD=1` only for an explicitly reviewed,
-read-only recording test. In that mode, `@pytest.mark.grpc_cassette` keeps the
-real profile home available. Replay remains isolated from the developer's
-profile. Hand-built fixtures must be named `*_synthetic.grpc.json`; do not call
-them recorded traffic.
+Set `NOTEBOOKLM_ANDROID_GRPC_RECORD=1` only for an explicitly reviewed recording
+test. In that mode, `@pytest.mark.grpc_cassette` keeps the real profile home
+available. Replay remains isolated from the developer's profile. The Play Books
+family also records its auxiliary Phenotype protobuf-over-HTTP exchange through
+VCR.py into `play_books_phenotype.yaml`; the HTTP cassette strips authorization
+and redacts both protobuf bodies. Hand-built fixtures must be named
+`*_synthetic.grpc.json`; do not call them recorded traffic.
 
 ### Recorded families
 
@@ -64,6 +67,7 @@ records and replays (`tests/_helpers/android_grpc_harness.py`):
 | `get_or_create_account` | `settings.get_user_settings()` | `GetOrCreateAccount` |
 | `get_project_rich` | `notebooks.get()`, `sources.list()` | `GetProject` ×2 |
 | `load_source` | `sources.get_fulltext()` | `GetProject` ×2, `LoadSource` |
+| `retrieve_relevant_chunks` | `sources.search()`, `sources.search(..., source_ids=...)` | `GetProject`, `RetrieveRelevantChunks` ×2 |
 | `list_artifacts_get_notes` | `artifacts.list()`, `notes.list()` | `ListArtifacts`, `GetNotes` ×2 |
 | `get_labels` | `labels.list()`, `collections.create()`, `collections.list()`, `collections.delete()` | `GetLabels` ×5, `CreateLabel`, `DeleteLabels` |
 | `list_discover_sources_job` | `research.poll()` | `ListDiscoverSourcesJob` |
@@ -71,6 +75,7 @@ records and replays (`tests/_helpers/android_grpc_harness.py`):
 | `get_project_details` | `sharing.get_status()` | `GetProjectDetails` |
 | `generate_free_form_streamed` | `chat.ask()` | `GetProject`, `ListChatSessions` ×2, `ListChatTurns`, `GenerateFreeFormStreamed (stream)` |
 | `list_chat_sessions_turns` | `chat.ask()`, `chat.get_conversation_id()`, `chat.get_history()` | `GetProject`, `ListChatSessions` ×5, `ListChatTurns` ×2, `GenerateFreeFormStreamed (stream)` |
+| `chat_session_control` | `chat.ask()`, `chat.session_status()`, `chat.cancel()` | `GetProject`, `ListChatSessions` ×2, `ListChatTurns`, `GenerateFreeFormStreamed (stream)`, `GetChatSessionStatus`, `CancelGeneration` |
 | `notebook_lifecycle` | `notebooks.create/rename/set_emoji/list/copy/delete()` | `ListRecentlyViewedProjects` ×2, `CreateProject`, `MutateProject` ×2, `CopyProject`, `DeleteProjects` ×2 |
 | `generate_notebook_guide` | `notebooks.get_description()`, `notebooks.get_summary()` | `GenerateNotebookGuide` ×2 |
 | `source_lifecycle` | `sources.add_text/add_url/wait_until_ready/rename/get_guide/check_freshness/refresh/delete()` | `AddTentativeSources` ×2, `AddSources` ×2, `GetProject` ×10, `MutateSource`, `GenerateDocumentGuides`, `CheckSourceFreshness` ×2, `DeleteSources` ×2 |
@@ -85,6 +90,7 @@ records and replays (`tests/_helpers/android_grpc_harness.py`):
 | `generate_report_suggestions` | `artifacts.suggest_reports()` | `GenerateReportSuggestions` |
 | `next_step_suggestions` | `notebooks.suggest_next_steps()`, `artifacts.get_customization_choices()` | `NextStepSuggestions` ×2, `GetArtifactCustomizationChoices` |
 | `source_transfers` | `notebooks.create()`, `sources.add_urls_async/wait_until_ready/append_text/get_fulltext/copy()`, `notebooks.delete()` | `CreateProject`, `AddSourcesAsync`, `GetProject` ×N, `AppendSource`, `LoadSource` ×2, `CopySourcesAsync`, `DeleteProjects` |
+| `play_books` | `sources.list_play_books()`, `sources.add_play_book()`, `sources.delete()` | `ListExpertIntelligenceContent` ×2, `AddTentativeSources`, `AddSources`, `GetProject` ×2, `DeleteSources` |
 | `artifact_copy` | `artifacts.generate_flashcards/poll_status()`, `notebooks.create()`, `artifacts.copy()`, `artifacts.delete()`, `notebooks.delete()` | `GetProject`, `CreateArtifact`, `ListArtifacts` ×N, `CreateProject`, `CopyArtifactsAsync`, `DeleteArtifact`, `DeleteProjects` |
 | `research_fast_cancel` | `research.start(mode="fast")`, `research.cancel()`, `research.poll()` | `DiscoverSourcesManifold`, `ListDiscoverSourcesJob` ×2, `CancelDiscoverSourcesJob` |
 | `research_fast_import` | `research.start(mode="fast")`, `research.poll()`, `research.import_sources()` | `DiscoverSourcesManifold`, `ListDiscoverSourcesJob`, `FinishDiscoverSourcesRun` |
@@ -92,7 +98,7 @@ records and replays (`tests/_helpers/android_grpc_harness.py`):
 | `generate_flashcards` | `artifacts.generate_flashcards/poll_status/get/delete/get_or_none()` | `GetProject`, `CreateArtifact`, `ListArtifacts` ×6, `GetArtifact` ×3, `GetNotes` ×2, `DeleteArtifact` |
 | `generate_audio` | `artifacts.generate_audio/poll_status/get/delete/get_or_none()` | `GetProject`, `CreateArtifact`, `ListArtifacts` ×23, `GetArtifact` ×20, `GetNotes` ×2, `DeleteArtifact` |
 
-26 families, 228 interactions. Re-record everything (creates one disposable scratch notebook with a text
+33 families, 281 interactions. Re-record everything (creates one disposable scratch notebook with a text
 source and a note through an *unrecorded* client, records, then deletes it):
 
 ```bash

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -90,12 +90,15 @@ def android_grpc_cassette(
 
     recorded: list[tuple[Path, Path]] = []
 
-    def bind(name: str) -> Any:
+    def bind(name: str, *, phenotype_http: bool = False) -> Any:
         path = ANDROID_CASSETTES_DIR / f"{name}_recorded.grpc.json"
         return android_cassette_client(
             path,
             monkeypatch=monkeypatch,
             scratch=android_record_scratch,
+            phenotype_cassette_path=(
+                ANDROID_CASSETTES_DIR / f"{name}_phenotype.yaml" if phenotype_http else None
+            ),
             on_recorded=lambda staging, target: recorded.append((staging, target)),
         )
 

--- a/tests/integration/test_android_grpc_cassette.py
+++ b/tests/integration/test_android_grpc_cassette.py
@@ -12,19 +12,30 @@ sanitized placeholders while replaying. Re-record with::
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 import grpc
 import httpx
 import pytest
 
-from notebooklm.types import Notebook, RelevantChunk, ShareStatus, Source, UserSettings
+from notebooklm.types import (
+    ChatSessionStatus,
+    Notebook,
+    PlayBook,
+    RelevantChunk,
+    ShareStatus,
+    Source,
+    SourceType,
+    UserSettings,
+)
 from tests._helpers.android_grpc_harness import SCRATCH_NOTE_TITLE, is_record_mode
 
 pytestmark = pytest.mark.grpc_cassette
 
-CassetteBinder = Callable[[str], Any]
+
+class CassetteBinder(Protocol):
+    def __call__(self, name: str, *, phenotype_http: bool = False) -> Any: ...
+
 
 replay_only = pytest.mark.skipif(
     is_record_mode(), reason="the unbound-channel guards are lifted while recording"
@@ -116,6 +127,28 @@ async def test_source_search_over_retrieve_relevant_chunks(
     assert chunks[0].source_id == source.id
     assert chunks[0].text
     assert filtered and all(chunk.source_id == source.id for chunk in filtered)
+
+
+@pytest.mark.asyncio
+async def test_play_books_list_and_add_with_phenotype_metadata(
+    android_grpc_cassette: CassetteBinder,
+) -> None:
+    async with android_grpc_cassette("play_books", phenotype_http=True) as (client, values):
+        books = await client.sources.list_play_books()
+        assert books and all(isinstance(book, PlayBook) for book in books)
+        exportable = next((book for book in books if not book.export_disabled), None)
+        assert exportable is not None, "recording account needs one exportable Play Book"
+
+        added = await client.sources.add_play_book(
+            values.notebook_id,
+            exportable.content_id,
+            wait=False,
+        )
+        try:
+            assert added.kind is SourceType.EXPERT_INTELLIGENCE
+            assert added.id
+        finally:
+            await client.sources.delete(values.notebook_id, added.id)
 
 
 # --- 4. ListArtifacts plus GetNotes ------------------------------------------
@@ -219,6 +252,22 @@ async def test_chat_history_over_list_chat_sessions_and_turns(
     # collapses, so only its type is asserted here (see tests/integration/README.md).
     assert [question for question, _answer in history] == [values.question]
     assert all(isinstance(answer, str) for _question, answer in history)
+
+
+@pytest.mark.asyncio
+async def test_chat_session_status_and_cancel(
+    android_grpc_cassette: CassetteBinder,
+) -> None:
+    async with android_grpc_cassette("chat_session_control") as (client, values):
+        answer = await client.chat.ask(values.notebook_id, values.question)
+        status = await client.chat.session_status(
+            values.notebook_id,
+            answer.conversation_id,
+        )
+        await client.chat.cancel(values.notebook_id, answer.conversation_id)
+    assert isinstance(status, ChatSessionStatus)
+    assert status.generating is False
+    assert status.token is None
 
 
 # =============================================================================

--- a/tests/integration/test_play_books_vcr.py
+++ b/tests/integration/test_play_books_vcr.py
@@ -1,8 +1,9 @@
 """Cassette-backed coverage for ``client.sources.list_play_books`` (#2292).
 
-Exercises the ``LIST_EXPERT_INTELLIGENCE_CONTENT`` (``mVtEUb``) list path against
-real recorded wire data — a read-only call, so the cassette is minimal and
-mutates nothing.
+Exercises the ``LIST_EXPERT_INTELLIGENCE_CONTENT`` (``mVtEUb``) list path and
+the ``ADD_SOURCES_ASYNC`` (``X1snv``) add path against recorded wire data. The
+mutation recording creates and deletes a disposable notebook outside the VCR
+boundary.
 
 Recording
 ---------
@@ -17,20 +18,25 @@ After recording, re-run the repo's cassette sanitizer (cookies/tokens).
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 
 import pytest
 
 from notebooklm import NotebookLMClient
 from notebooklm.rpc.types import RPCMethod
-from notebooklm.types import PlayBookExportReason
-from tests.integration.conftest import get_vcr_auth, skip_no_cassettes
+from notebooklm.types import PlayBookExportReason, SourceType
+from tests._helpers.play_book_http_cassette import PlayBookHttpCassetteScrubber
+from tests.integration.conftest import _vcr_record_mode, get_vcr_auth, skip_no_cassettes
 from tests.vcr_config import notebooklm_vcr
 
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
 
 CASSETTE_NAME = "sources_play_books.yaml"
 CASSETTE_PATH = Path(__file__).parent.parent / "cassettes" / "web" / CASSETTE_NAME
+ADD_CASSETTE_NAME = "sources_play_book_add.yaml"
+ADD_CASSETTE_PATH = Path(__file__).parent.parent / "cassettes" / "web" / ADD_CASSETTE_NAME
+_PLAY_BOOKS = PlayBookHttpCassetteScrubber()
 
 
 class TestListPlayBooksCassette:
@@ -59,3 +65,50 @@ class TestListPlayBooksCassette:
         """The cassette must contain the LIST_EXPERT_INTELLIGENCE_CONTENT RPC id."""
         body = CASSETTE_PATH.read_text(encoding="utf-8")
         assert RPCMethod.LIST_EXPERT_INTELLIGENCE_CONTENT.value in body
+
+
+class TestAddPlayBookCassette:
+    @pytest.mark.asyncio
+    async def test_add_play_book_records_expert_intelligence_add(self) -> None:
+        """Record the book-specific ``mVtEUb`` -> ``X1snv`` public workflow."""
+
+        auth = await get_vcr_auth()
+        async with NotebookLMClient(auth) as client:
+            scratch_id = "00000000-0000-4000-8000-000000000001"
+            if _vcr_record_mode:
+                scratch = await client.notebooks.create(
+                    f"play-book-vcr-scratch-{uuid.uuid4().hex[:12]}"
+                )
+                scratch_id = scratch.id
+            try:
+                with notebooklm_vcr.use_cassette(
+                    ADD_CASSETTE_NAME,
+                    before_record_request=_PLAY_BOOKS.scrub_request,
+                    before_record_response=_PLAY_BOOKS.scrub_response,
+                ):
+                    books = await client.sources.list_play_books()
+                    exportable = next((book for book in books if not book.export_disabled), None)
+                    assert exportable is not None, (
+                        "recording account needs one exportable Play Book"
+                    )
+                    source = await client.sources.add_play_book(
+                        scratch_id,
+                        exportable.content_id,
+                        wait=False,
+                    )
+            finally:
+                if _vcr_record_mode:
+                    await client.notebooks.delete(scratch_id)
+
+        assert source.id
+        assert source.kind is SourceType.EXPERT_INTELLIGENCE
+        assert source.title
+
+    @pytest.mark.skipif(
+        _vcr_record_mode,
+        reason="cassette assertions run after the record-mode test writes the file",
+    )
+    def test_add_cassette_records_list_and_add_rpcs(self) -> None:
+        body = ADD_CASSETTE_PATH.read_text(encoding="utf-8")
+        assert RPCMethod.LIST_EXPERT_INTELLIGENCE_CONTENT.value in body
+        assert RPCMethod.ADD_SOURCES_ASYNC.value in body

--- a/tests/scripts/check_cassettes_clean.py
+++ b/tests/scripts/check_cassettes_clean.py
@@ -70,6 +70,12 @@ DEFAULT_CASSETTE_DIR = _REPO_ROOT / "tests" / "cassettes"
 _SECRETS_ONLY_EXTENSIONS: tuple[str, ...] = (".yaml", ".yml", ".json", ".html", ".txt")
 DEFAULT_ALLOWLIST = _REPO_ROOT / "tests" / "scripts" / "cassette_repair_allowlist.txt"
 _ANDROID_GRPC_FORMAT = "notebooklm.android.grpc-cassette"
+_ANDROID_SAFE_METADATA_KEYS = frozenset(
+    {
+        "x-goog-ext-174067345-bin",
+        "x-goog-ext-202964622-bin",
+    }
+)
 _PROTOBUF_ASCII_TOKEN = re.compile(rb"[A-Za-z0-9_+\-/=]{40,}")
 
 
@@ -275,8 +281,20 @@ def _scan_android_grpc_cassette(path: Path) -> list[tuple[int, str]]:
     payloads: list[str] = []
     for interaction in data["interactions"]:
         expected = {"method", "request", "response_protobuf_type", "responses", "shape"}
-        if not isinstance(interaction, dict) or set(interaction) != expected:
+        if not isinstance(interaction, dict) or set(interaction) not in (
+            expected,
+            expected | {"application_metadata_keys"},
+        ):
             return [(1, "Leak (invalid Android gRPC cassette): unexpected interaction schema")]
+        metadata_keys = interaction.get("application_metadata_keys")
+        if metadata_keys is not None and (
+            not isinstance(metadata_keys, list)
+            or not metadata_keys
+            or any(not isinstance(key, str) for key in metadata_keys)
+            or metadata_keys != sorted(set(metadata_keys))
+            or not set(metadata_keys) <= _ANDROID_SAFE_METADATA_KEYS
+        ):
+            return [(1, "Leak (invalid Android gRPC cassette): unsafe application metadata keys")]
         request = interaction["request"]
         responses = interaction["responses"]
         if not isinstance(request, dict) or set(request) != {"protobuf_b64", "protobuf_type"}:

--- a/tests/scripts/check_cassettes_clean.py
+++ b/tests/scripts/check_cassettes_clean.py
@@ -287,7 +287,7 @@ def _scan_android_grpc_cassette(path: Path) -> list[tuple[int, str]]:
         ):
             return [(1, "Leak (invalid Android gRPC cassette): unexpected interaction schema")]
         metadata_keys = interaction.get("application_metadata_keys")
-        if metadata_keys is not None and (
+        if "application_metadata_keys" in interaction and (
             not isinstance(metadata_keys, list)
             or not metadata_keys
             or any(not isinstance(key, str) for key in metadata_keys)

--- a/tests/unit/android/test_grpc_cassette.py
+++ b/tests/unit/android/test_grpc_cassette.py
@@ -24,6 +24,7 @@ from tests._helpers.android_grpc_cassette import (
 from tests.cassette_patterns import _CREDENTIAL_DETECTORS
 
 from notebooklm._android.auth import BearerCredential
+from notebooklm._android.phenotype import CLIENT_TYPE_HEADER, EXPERIMENT_TOKEN_HEADER
 from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
     account_pb2,
     artifacts_pb2,
@@ -95,6 +96,10 @@ _CASSETTE_MESSAGE_TYPES = (
     # 8. ListChatSessions plus ListChatTurns
     chat_pb2.ListChatSessionsRequest,
     chat_pb2.ListChatSessionsResponse,
+    chat_pb2.GetChatSessionStatusRequest,
+    chat_pb2.GetChatSessionStatusResponse,
+    chat_pb2.CancelGenerationRequest,
+    chat_pb2.CancelGenerationResponse,
     chat_pb2.ListChatTurnsRequest,
     chat_pb2.ListChatTurnsResponse,
     # 9. server-streaming GenerateFreeFormStreamed
@@ -119,6 +124,8 @@ _CASSETTE_MESSAGE_TYPES = (
     sources_pb2.AddTentativeSourcesResponse,
     sources_pb2.AddSourcesRequest,
     sources_pb2.AddSourcesResponse,
+    sources_pb2.ListExpertIntelligenceContentRequest,
+    sources_pb2.ListExpertIntelligenceContentResponse,
     sources_pb2.MutateSourceRequest,
     sources_pb2.MutateSourceResponse,
     sources_pb2.GenerateDocumentGuidesRequest,
@@ -395,6 +402,69 @@ async def test_recording_serializes_redacted_deterministic_unary_protobuf(tmp_pa
     cassette.dump(cassette_path)
     assert cassette_path.read_bytes() == before
     assert json.loads(raw_cassette)["format"] == "notebooklm.android.grpc-cassette"
+
+
+@pytest.mark.asyncio
+async def test_recording_pins_allowlisted_application_metadata_keys_without_values(
+    tmp_path: Path,
+) -> None:
+    cassette_path = tmp_path / "application-metadata.grpc.json"
+    recorder = RecordingGrpcModule(
+        _LiveGrpc(_LiveChannel(_response())),
+        cassette_path,
+        sanitizer=ProtoRedactor(),
+    )
+    session, supervisor = await _open_session(recorder, _LeaseBearer([]))
+
+    async def application_metadata(_bearer: str) -> tuple[tuple[str, bytes], ...]:
+        return (
+            (CLIENT_TYPE_HEADER, b"private-client-marker"),
+            (EXPERIMENT_TOKEN_HEADER, b"private-experiment-token"),
+        )
+
+    await session.unary(
+        METHOD,
+        read_pb2.GetProjectRequest(project_id=RAW_PROJECT_ID),
+        replay_safe=True,
+        response_type=read_pb2.GetProjectResponse,
+        metadata_augmentor=application_metadata,
+    )
+    await _close_session(session, supervisor)
+
+    raw = cassette_path.read_text(encoding="utf-8")
+    [interaction] = AndroidGrpcCassette.load(cassette_path).interactions
+    assert interaction.application_metadata_keys == (
+        CLIENT_TYPE_HEADER,
+        EXPERIMENT_TOKEN_HEADER,
+    )
+    assert "private-client-marker" not in raw
+    assert "private-experiment-token" not in raw
+    assert "authorization" not in raw.casefold()
+
+    mismatch = ReplayGrpcModule(cassette_path)
+    invoke = mismatch.secure_channel(ANDROID_GRPC_TARGET, object()).unary_unary(
+        METHOD,
+        request_serializer=lambda message: message.SerializeToString(),
+        response_deserializer=read_pb2.GetProjectResponse.FromString,
+    )
+    with pytest.raises(AndroidGrpcCassetteMismatch, match="application metadata mismatch"):
+        await invoke(
+            read_pb2.GetProjectRequest(project_id=SAFE_PROJECT_ID),
+            metadata=(("authorization", "Bearer ignored"),),
+            timeout=None,
+        )
+
+    replay = ReplayGrpcModule(cassette_path)
+    replay_session, replay_supervisor = await _open_session(replay, ReplayBearer())
+    await replay_session.unary(
+        METHOD,
+        read_pb2.GetProjectRequest(project_id=SAFE_PROJECT_ID),
+        replay_safe=True,
+        response_type=read_pb2.GetProjectResponse,
+        metadata_augmentor=application_metadata,
+    )
+    replay.assert_consumed()
+    await _close_session(replay_session, replay_supervisor)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/android/test_grpc_cassette.py
+++ b/tests/unit/android/test_grpc_cassette.py
@@ -15,6 +15,7 @@ from google.protobuf.empty_pb2 import Empty
 from google.protobuf.timestamp_pb2 import Timestamp
 from tests._helpers.android_grpc_cassette import (
     AndroidGrpcCassette,
+    AndroidGrpcCassetteError,
     AndroidGrpcCassetteMismatch,
     ProtoRedactor,
     RecordingGrpcModule,
@@ -403,6 +404,22 @@ async def test_recording_serializes_redacted_deterministic_unary_protobuf(tmp_pa
     assert cassette_path.read_bytes() == before
     assert json.loads(raw_cassette)["format"] == "notebooklm.android.grpc-cassette"
 
+    mismatch = ReplayGrpcModule(cassette_path)
+    invoke = mismatch.secure_channel(ANDROID_GRPC_TARGET, object()).unary_unary(
+        METHOD,
+        request_serializer=lambda message: message.SerializeToString(),
+        response_deserializer=read_pb2.GetProjectResponse.FromString,
+    )
+    with pytest.raises(AndroidGrpcCassetteMismatch, match="application metadata mismatch"):
+        await invoke(
+            read_pb2.GetProjectRequest(
+                project_id=SAFE_PROJECT_ID,
+                include_audio_overview_ids=True,
+            ),
+            metadata=((CLIENT_TYPE_HEADER, b"unexpected-propagation"),),
+            timeout=None,
+        )
+
 
 @pytest.mark.asyncio
 async def test_recording_pins_allowlisted_application_metadata_keys_without_values(
@@ -465,6 +482,17 @@ async def test_recording_pins_allowlisted_application_metadata_keys_without_valu
     )
     replay.assert_consumed()
     await _close_session(replay_session, replay_supervisor)
+
+
+def test_cassette_loader_rejects_explicit_null_application_metadata(tmp_path: Path) -> None:
+    source = ANDROID_CASSETTES / "chat_session_control_recorded.grpc.json"
+    data = json.loads(source.read_text(encoding="utf-8"))
+    data["interactions"][0]["application_metadata_keys"] = None
+    cassette = tmp_path / "null-metadata.grpc.json"
+    cassette.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(AndroidGrpcCassetteError, match="must be a list of text keys"):
+        AndroidGrpcCassette.load(cassette)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/android/test_phenotype.py
+++ b/tests/unit/android/test_phenotype.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+import yaml
 from tests._helpers.android_phenotype_http_cassette import (
     _scrub_phenotype_request,
     _scrub_phenotype_response,
@@ -187,6 +189,7 @@ async def test_phenotype_cassette_replays_exactly_one_pinned_request(
 
     assert status == 200
     assert response
+    post.assert_consumed()
     with pytest.raises(RuntimeError, match="exactly one HTTP interaction"):
         await post(_ENDPOINT, body, headers)
 
@@ -195,6 +198,30 @@ def test_phenotype_cassette_rejects_an_unconsumed_interaction(tmp_path) -> None:
     post = build_phenotype_http_post(tmp_path / "phenotype.yaml")
 
     with pytest.raises(AssertionError, match="expected exactly one HTTP interaction"):
+        post.assert_consumed()
+
+
+@pytest.mark.asyncio
+async def test_phenotype_cassette_rejects_surplus_interactions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NOTEBOOKLM_ANDROID_GRPC_RECORD", raising=False)
+    source = Path(__file__).parents[2] / "cassettes" / "android" / "play_books_phenotype.yaml"
+    data = yaml.safe_load(source.read_text(encoding="utf-8"))
+    data["interactions"].append(copy.deepcopy(data["interactions"][0]))
+    duplicate = tmp_path / "phenotype.yaml"
+    duplicate.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    post = build_phenotype_http_post(duplicate)
+    headers = {
+        "Authorization": "Bearer replay",
+        "Content-Type": "application/x-protobuf",
+        "User-Agent": AndroidDeviceProfile().user_agent,
+    }
+
+    await post(_ENDPOINT, _build_request(AndroidDeviceProfile()), headers)
+
+    with pytest.raises(AssertionError, match="found 2"):
         post.assert_consumed()
 
 

--- a/tests/unit/android/test_phenotype.py
+++ b/tests/unit/android/test_phenotype.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from tests._helpers.android_phenotype_http_cassette import (
+    _scrub_phenotype_request,
+    _scrub_phenotype_response,
+    build_phenotype_http_post,
+)
 
 from notebooklm._android.phenotype import (
+    _ENDPOINT,
     CLIENT_TYPE_HEADER,
     EXPERIMENT_TOKEN_HEADER,
     AndroidDeviceProfile,
@@ -81,6 +89,113 @@ def test_wrap_and_decode_server_token_roundtrip() -> None:
     assert wrapped[0] == 0x0A  # field 1, length-delimited
     assert wrapped[2:] == _SERVER_TOKEN_MSG
     assert _decode_server_token(_SERVER_TOKEN_B64URL) == _SERVER_TOKEN_MSG
+
+
+def test_phenotype_vcr_hooks_redact_both_protobuf_bodies() -> None:
+    request_body = _build_request(AndroidDeviceProfile())
+    request = SimpleNamespace(
+        body=request_body,
+        headers={
+            "Authorization": "Bearer private",
+            "Content-Length": str(len(request_body)),
+            "Content-Type": "application/x-protobuf",
+            "User-Agent": "fixed-agent",
+            "X-Future-Secret": "private-value",
+        },
+    )
+    _scrub_phenotype_request(request)
+    clean_request = pb.HeterodyneRequest.FromString(request.body)
+    assert clean_request.header.clearcut_logger_header.timestamp_millis == 1
+    assert clean_request.data[0].package_details.package_name.startswith("SCRUBBED_")
+    assert request.headers["Content-Length"] == str(len(request.body))
+    assert set(request.headers) == {"Content-Length", "Content-Type", "User-Agent"}
+    assert request.headers["User-Agent"] == AndroidDeviceProfile().user_agent
+
+    response = {
+        "body": {"string": _response_bytes()},
+        "headers": {
+            "content-length": [str(len(_response_bytes()))],
+            "content-type": ["application/octet-stream"],
+            "set-cookie": ["SID=private"],
+            "x-future-secret": ["private-value"],
+        },
+        "status": {"code": 200, "message": "OK"},
+    }
+    _scrub_phenotype_response(response)
+    clean_body = response["body"]["string"]
+    clean_response = pb.HeterodyneResponse.FromString(clean_body)
+    clean_token = clean_response.heterodyne_config[0].server_token
+    assert _SERVER_TOKEN_B64URL.encode() not in clean_body
+    assert clean_token.startswith("SCRUBBED_")
+    assert _decode_server_token(clean_token)
+    assert response["headers"]["content-length"] == [str(len(clean_body))]
+    assert set(response["headers"]) == {"content-length", "content-type"}
+
+
+@pytest.mark.asyncio
+async def test_phenotype_cassette_rejects_semantically_wrong_request_constants(
+    tmp_path,
+) -> None:
+    body = pb.HeterodyneRequest.FromString(_build_request(AndroidDeviceProfile()))
+    body.fetch_reason = 999
+    post = build_phenotype_http_post(tmp_path / "phenotype.yaml")
+    headers = {
+        "Authorization": "Bearer replay",
+        "Content-Type": "application/x-protobuf",
+        "User-Agent": AndroidDeviceProfile().user_agent,
+    }
+
+    with pytest.raises(ValueError, match="unexpected request constants"):
+        await post(_ENDPOINT, body.SerializeToString(), headers)
+
+
+@pytest.mark.asyncio
+async def test_phenotype_cassette_rejects_wrong_endpoint_and_headers(tmp_path) -> None:
+    post = build_phenotype_http_post(tmp_path / "phenotype.yaml")
+    body = _build_request(AndroidDeviceProfile())
+    headers = {
+        "Authorization": "Bearer replay",
+        "Content-Type": "application/x-protobuf",
+        "User-Agent": "fixed-agent",
+    }
+
+    with pytest.raises(ValueError, match="unexpected endpoint"):
+        await post("https://example.invalid/phenotype", body, headers)
+    with pytest.raises(ValueError, match="unexpected request headers"):
+        await post(
+            "https://www.googleapis.com/experimentsandconfigs/v1/getExperimentsAndConfigs?r=8&c=1",
+            body,
+            {**headers, "X-Future-Secret": "private"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_phenotype_cassette_replays_exactly_one_pinned_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NOTEBOOKLM_ANDROID_GRPC_RECORD", raising=False)
+    cassette = Path(__file__).parents[2] / "cassettes" / "android" / "play_books_phenotype.yaml"
+    post = build_phenotype_http_post(cassette)
+    body = _build_request(AndroidDeviceProfile())
+    headers = {
+        "Authorization": "Bearer replay",
+        "Content-Type": "application/x-protobuf",
+        "User-Agent": AndroidDeviceProfile().user_agent,
+    }
+
+    status, response = await post(_ENDPOINT, body, headers)
+
+    assert status == 200
+    assert response
+    with pytest.raises(RuntimeError, match="exactly one HTTP interaction"):
+        await post(_ENDPOINT, body, headers)
+
+
+def test_phenotype_cassette_rejects_an_unconsumed_interaction(tmp_path) -> None:
+    post = build_phenotype_http_post(tmp_path / "phenotype.yaml")
+
+    with pytest.raises(AssertionError, match="expected exactly one HTTP interaction"):
+        post.assert_consumed()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -594,30 +594,36 @@ def test_python_guard_secrets_only_ignores_placeholder_content(tmp_path: Path) -
     assert "0 leaks found" in res.stdout
 
 
-def _write_android_grpc_cassette(path: Path, response_wire: bytes) -> None:
+def _write_android_grpc_cassette(
+    path: Path,
+    response_wire: bytes,
+    *,
+    application_metadata_keys: list[str] | None = None,
+) -> None:
     empty_wire = base64.b64encode(b"").decode("ascii")
     response_b64 = base64.b64encode(response_wire).decode("ascii")
+    interaction = {
+        "method": "/example.Service/GetValue",
+        "request": {
+            "protobuf_b64": empty_wire,
+            "protobuf_type": "example.GetValueRequest",
+        },
+        "response_protobuf_type": "example.GetValueResponse",
+        "responses": [
+            {
+                "protobuf_b64": response_b64,
+                "protobuf_type": "example.GetValueResponse",
+            }
+        ],
+        "shape": "unary_unary",
+    }
+    if application_metadata_keys is not None:
+        interaction["application_metadata_keys"] = application_metadata_keys
     path.write_text(
         json.dumps(
             {
                 "format": "notebooklm.android.grpc-cassette",
-                "interactions": [
-                    {
-                        "method": "/example.Service/GetValue",
-                        "request": {
-                            "protobuf_b64": empty_wire,
-                            "protobuf_type": "example.GetValueRequest",
-                        },
-                        "response_protobuf_type": "example.GetValueResponse",
-                        "responses": [
-                            {
-                                "protobuf_b64": response_b64,
-                                "protobuf_type": "example.GetValueResponse",
-                            }
-                        ],
-                        "shape": "unary_unary",
-                    }
-                ],
+                "interactions": [interaction],
                 "version": 1,
             },
             indent=2,
@@ -636,6 +642,34 @@ def test_python_guard_scans_grpc_payload_instead_of_base64_envelope(tmp_path: Pa
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "0 leaks found" in result.stdout
+
+
+def test_python_guard_allows_only_pinned_grpc_application_metadata_keys(
+    tmp_path: Path,
+) -> None:
+    cassette = tmp_path / "metadata_synthetic.grpc.json"
+    _write_android_grpc_cassette(
+        cassette,
+        b"",
+        application_metadata_keys=[
+            "x-goog-ext-174067345-bin",
+            "x-goog-ext-202964622-bin",
+        ],
+    )
+
+    clean = _run_guard(str(cassette))
+
+    assert clean.returncode == 0, clean.stdout + clean.stderr
+
+    _write_android_grpc_cassette(
+        cassette,
+        b"",
+        application_metadata_keys=["authorization"],
+    )
+    unsafe = _run_guard(str(cassette))
+
+    assert unsafe.returncode == 1
+    assert "unsafe application metadata keys" in unsafe.stdout
 
 
 def test_python_guard_detects_novel_token_inside_grpc_protobuf(tmp_path: Path) -> None:

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -671,6 +671,14 @@ def test_python_guard_allows_only_pinned_grpc_application_metadata_keys(
     assert unsafe.returncode == 1
     assert "unsafe application metadata keys" in unsafe.stdout
 
+    data = json.loads(cassette.read_text(encoding="utf-8"))
+    data["interactions"][0]["application_metadata_keys"] = None
+    cassette.write_text(json.dumps(data), encoding="utf-8")
+    explicit_null = _run_guard(str(cassette))
+
+    assert explicit_null.returncode == 1
+    assert "unsafe application metadata keys" in explicit_null.stdout
+
 
 def test_python_guard_detects_novel_token_inside_grpc_protobuf(tmp_path: Path) -> None:
     novel = "kJ8sLm2NpQr5" + "TvWxYz0AbCdEf" + "GhIjKlMnOpQrSt" + "UvWxYz12345678"

--- a/tests/unit/test_login_wait_navigation_failure.py
+++ b/tests/unit/test_login_wait_navigation_failure.py
@@ -354,6 +354,20 @@ def test_the_budget_shrinks_and_is_never_restarted() -> None:
     assert all(t <= 300 * 1000 for t in page.timeouts)
 
 
+def test_deadline_rounding_cannot_grow_the_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A large fractional clock reading can round a re-arm above the original."""
+    err = _playwright_error(ABORTED)
+    page = _ClockedPage([(0.0, err), (0.0, LANDED)])
+    page.now = 33_554_361.3682
+    monkeypatch.setattr("time.monotonic", page.monotonic)
+
+    # Pin the platform-independent IEEE-754 edge that failed on Windows CI.
+    assert ((page.now + 300) - page.now) * 1000 > 300 * 1000
+    wait_for_login_landing(page, timeout_s=300)
+
+    assert page.timeouts == [300 * 1000, 300 * 1000]
+
+
 def test_a_page_failing_in_a_loop_is_bounded_not_spun_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_play_book_http_cassette.py
+++ b/tests/unit/test_play_book_http_cassette.py
@@ -53,7 +53,8 @@ def test_play_book_response_scrubber_replaces_the_entire_private_library() -> No
     private_result = json.dumps(
         [[["PRIVATE_CONTENT_ID", 1, "Private library title", "Private description"]]]
     )
-    live_body = f')]}}\'\n\n1\n[["wrb.fr","mVtEUb",{json.dumps(private_result)}]]\n'
+    payload = json.dumps([["wrb.fr", "mVtEUb", private_result]])
+    live_body = f")]}}'\n\n1\n{payload}\n"
     response = {
         "body": {"string": live_body},
         "headers": {"content-length": [str(len(live_body.encode()))]},
@@ -68,4 +69,28 @@ def test_play_book_response_scrubber_replaces_the_entire_private_library() -> No
     payload = next(line for line in clean_body.splitlines() if line.startswith("[["))
     frame = json.loads(payload)
     assert json.loads(frame[0][2]) == [SYNTHETIC_BOOK_ROWS]
+    assert response["headers"]["content-length"] == [str(len(clean_body.encode()))]
+
+
+def test_play_book_response_scrubber_replaces_the_private_add_response() -> None:
+    private_stub = [["PRIVATE_SOURCE_ID"], "7", ["PRIVATE_UNMODELED_DATA", None, None, None, 20]]
+    private_result = json.dumps([[private_stub], None, [[private_stub, 0]]])
+    payload = json.dumps([["wrb.fr", "X1snv", private_result]])
+    live_body = f")]}}'\n\n1\n{payload}\n"
+    response = {
+        "body": {"string": live_body},
+        "headers": {"content-length": [str(len(live_body.encode()))]},
+        "status": {"code": 200, "message": "OK"},
+    }
+
+    PlayBookHttpCassetteScrubber().scrub_response(response)
+
+    clean_body = response["body"]["string"]
+    assert "PRIVATE_SOURCE_ID" not in clean_body
+    assert "PRIVATE_UNMODELED_DATA" not in clean_body
+    payload = next(line for line in clean_body.splitlines() if line.startswith("[["))
+    frame = json.loads(payload)
+    result = json.loads(frame[0][2])
+    assert result[0][0][0][0] == "00000000-0000-4000-8000-000000000002"
+    assert result[0][0][1] == "Placeholder ebook 001"
     assert response["headers"]["content-length"] == [str(len(clean_body.encode()))]

--- a/tests/unit/test_play_book_http_cassette.py
+++ b/tests/unit/test_play_book_http_cassette.py
@@ -1,0 +1,71 @@
+"""Privacy boundary tests for the Web Play Books VCR hooks."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlencode
+
+from tests._helpers.play_book_http_cassette import (
+    SYNTHETIC_BOOK_ROWS,
+    PlayBookHttpCassetteScrubber,
+)
+
+
+def _live_add_body() -> str:
+    source_spec = [None] * 16
+    source_spec[0] = "PRIVATE_UNMODELED_ACCOUNT_DATA"
+    source_spec[10] = 1
+    source_spec[15] = [
+        1,
+        "PRIVATE_CONTENT_ID",
+        "Private library title",
+        "Private library description",
+        "https://private.example/cover",
+        4.9,
+        ["Private author"],
+    ]
+    args = [[source_spec], "11111111-1111-4111-8111-111111111111", [2]]
+    envelope = [[["X1snv", json.dumps(args), None, "generic"]]]
+    return urlencode({"f.req": json.dumps(envelope), "at": "SCRUBBED_CSRF:1"})
+
+
+def test_play_book_request_scrubber_replaces_private_library_fields() -> None:
+    request = SimpleNamespace(
+        uri="https://notebook.google.com/batchexecute?rpcids=X1snv",
+        body=_live_add_body(),
+        headers={},
+    )
+
+    PlayBookHttpCassetteScrubber().scrub_request(request)
+
+    assert "PRIVATE_CONTENT_ID" not in request.body
+    assert "Private library" not in request.body
+    assert "PRIVATE_UNMODELED_ACCOUNT_DATA" not in request.body
+    outer = json.loads(parse_qs(request.body)["f.req"][0])
+    args = json.loads(outer[0][0][1])
+    assert args[0][0][15][1] == "EIBOOK00000001"
+    assert args[0][0][15][2] == "Placeholder ebook 001"
+    assert args[1] == "00000000-0000-4000-8000-000000000001"
+
+
+def test_play_book_response_scrubber_replaces_the_entire_private_library() -> None:
+    private_result = json.dumps(
+        [[["PRIVATE_CONTENT_ID", 1, "Private library title", "Private description"]]]
+    )
+    live_body = f')]}}\'\n\n1\n[["wrb.fr","mVtEUb",{json.dumps(private_result)}]]\n'
+    response = {
+        "body": {"string": live_body},
+        "headers": {"content-length": [str(len(live_body.encode()))]},
+        "status": {"code": 200, "message": "OK"},
+    }
+
+    PlayBookHttpCassetteScrubber().scrub_response(response)
+
+    clean_body = response["body"]["string"]
+    assert "PRIVATE_CONTENT_ID" not in clean_body
+    assert "Private library" not in clean_body
+    payload = next(line for line in clean_body.splitlines() if line.startswith("[["))
+    frame = json.loads(payload)
+    assert json.loads(frame[0][2]) == [SYNTHETIC_BOOK_ROWS]
+    assert response["headers"]["content-length"] == [str(len(clean_body.encode()))]

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -58,6 +58,7 @@ _vcr_config = _load_by_path("tests_vcr_config", "vcr_config.py")
 _freq_body_matcher: Callable[[Any, Any], bool] = _vcr_config._freq_body_matcher
 recompute_chunk_prefix: Callable[[str], str] = _cassette_patterns.recompute_chunk_prefix
 scrub_response: Callable[[dict[str, Any]], dict[str, Any]] = _vcr_config.scrub_response
+ResourceIdCassetteScrubber = _vcr_config.ResourceIdCassetteScrubber
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +75,19 @@ class _StubRequest:
 
     def __init__(self, body: Any) -> None:
         self.body = body
+
+
+def test_resource_id_scrubber_replaces_uuid_inside_percent_encoded_request() -> None:
+    """Encoded delimiters must not defeat request-side UUID redaction."""
+
+    scrubber = ResourceIdCassetteScrubber()
+    resource_id = "e7626843-661e-4e4d-b0a9-2bc4692f8a7f"
+    encoded = f"f.req=%22{resource_id}%5C&source-path=%2Fnotebook%2F{resource_id}"
+
+    scrubbed = scrubber.scrub_text(encoded)
+
+    assert resource_id not in scrubbed
+    assert scrubbed.count("00000000-0000-4000-8000-000000000001") == 2
 
 
 def _build_freq_body(params: list[Any]) -> str:

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -372,13 +372,15 @@ _FREQ_VOLATILE_KEYS: frozenset[str] = frozenset(
 # this placeholder in a cassette flags only the normalization, not real data.
 _UUID_PLACEHOLDER = "00000000-0000-0000-0000-_NORMALIZED"
 
-# Canonical UUID v4 string regex. Matches the 8-4-4-4-12 hex layout used by
-# every UUID NotebookLM emits (notebook IDs, source IDs, artifact IDs, project
-# IDs, conversation IDs all share this shape). Anchored to word boundaries so a
-# UUID embedded in a larger string still normalizes but a hex string of similar
-# length (e.g. a session token) does not accidentally match.
+# Canonical UUID string regex. Matches the 8-4-4-4-12 hex layout used by every
+# UUID NotebookLM emits (notebook IDs, source IDs, artifact IDs, project IDs,
+# conversation IDs all share this shape). Deliberately do not use word
+# boundaries: form and URL encoding puts hexadecimal characters immediately
+# beside an identifier (for example ``%22<uuid>%5C``), so ``\b`` misses the
+# request-side copy while still scrubbing the decoded response. The four
+# hyphens make this specific enough to find safely inside a larger string.
 _UUID_RE = re.compile(
-    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
 )
 
 


### PR DESCRIPTION
## Summary

Backfills transport-level integration recordings and live E2E coverage for all 12 RPCs added since v0.8.1. It keeps gRPC traffic in the repository's existing custom protobuf cassette framework, adds the missing Web/Phenotype HTTP VCR fixtures, and hardens every new recording path against credential and account-data disclosure.

## Related Issue

Follow-up coverage for #2291, #2292, #2299, #2300, #2305, and #2306.

## Changes

- Add public-client Android gRPC cassette coverage for ranked source search, Google Play Books, chat session status, and generation cancellation.
- Add the missing Play Books Web VCR flow and its narrowly scoped auxiliary Phenotype protobuf-over-HTTP cassette.
- Add live E2E coverage for the recent search, suggestion, research, transfer, copy, Play Books, and chat-control APIs.
- Register the new protobuf payload types and safely capture only allowlisted application-metadata key names; metadata values are never persisted.
- Add fail-closed Phenotype and Play Books scrubbers that replace account-specific payloads with deterministic synthetic data, strip authorization and unknown headers, and enforce exact request semantics/consumption.
- Strengthen cassette cleanliness checks, URL-encoded UUID scrubbing, canonical protobuf replay checks, and recording documentation.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90`)
- [x] Linting and formatting pass (`uv run pre-commit run --all-files`)
- [x] Type checking passes (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] If this PR changes architectural shape, an ADR has been added or updated. (No production architecture change.)

Exact coverage run with CI extras: 18,789 passed, 73 skipped, 1 xfailed; 93.46% total coverage.

## Notes

- Android NotebookLM gRPC remains captured by `*.grpc.json`; no second gRPC recorder was introduced. VCR.py is used only for Web batchexecute traffic and the separate Phenotype HTTP exchange.
- Final corpus: 33 Android gRPC families / 281 interactions.
- Strict secret scan: 184 cassettes scanned, 0 leaks. The canonicality guard decodes and re-redacts every committed protobuf frame byte-for-byte.
- Independent code, coverage, and security review agents all completed clean final passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google Play Books support for browsing available books and adding a selected book as notebook content.
  - Added chat session controls to check generation status and cancel active generation.

- **Bug Fixes**
  - Improved handling of identifiers in recorded workflows, including encoded requests.
  - Prevented login navigation timeouts from exceeding the configured wait period.

- **Tests**
  - Expanded coverage for source management, research, artifacts, notebook operations, Play Books, and chat controls.
  - Strengthened privacy protections for recorded requests and responses by removing sensitive account data and credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->