### PR TITLE
docs: publish diagram viewers with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy architecture diagrams
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pages.yml"
+      - "docs/diagrams/*.html"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Pages artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Stage standalone diagram viewers
+        shell: bash
+        run: |
+          mkdir -p _site/diagrams
+
+          viewer_count=$(find docs/diagrams -maxdepth 1 -type f -name '[0-9][0-9]-*.html' | wc -l | tr -d ' ')
+          source_count=$(find docs/diagrams -maxdepth 1 -type f -name '[0-9][0-9]-*.json' | wc -l | tr -d ' ')
+
+          test "$viewer_count" -gt 0
+          test "$viewer_count" = "$source_count"
+
+          cp docs/diagrams/[0-9][0-9]-*.html _site/diagrams/
+          cp docs/diagrams/01-system-overview.html _site/index.html
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/android/README.md
+++ b/docs/android/README.md
@@ -6,12 +6,12 @@ services. The mobile protobuf surface is also a useful oracle for Web's
 positional payloads. This directory combines the Android user entry point with
 the protocol contracts and evidence used to maintain both transports.
 
-Start with the [Web/Android comparison](../diagrams/06-backends-web-and-android.html), then open the
-[Android subsystem](../diagrams/14-android-backend.html) and
-[call sequence](../diagrams/15-android-call-path.html). Profile/backend precedence and
+Start with the [Web/Android comparison](https://teng-lin.github.io/notebooklm-py/diagrams/06-backends-web-and-android.html), then open the
+[Android subsystem](https://teng-lin.github.io/notebooklm-py/diagrams/14-android-backend.html) and
+[call sequence](https://teng-lin.github.io/notebooklm-py/diagrams/15-android-call-path.html). Profile/backend precedence and
 credential-scoped transfers are covered by diagrams
-[28](../diagrams/28-profile-auth-backend-selection.workflow.html) and
-[30](../diagrams/30-transfer-security-boundaries.dataflow.html).
+[28](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) and
+[30](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html).
 
 ## Using the Android backend
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,9 @@ this layering) lives in [`docs/refactor-history.md`](./refactor-history.md).
 
 ## System shape
 
-Start with the explorable [system overview](./diagrams/01-system-overview.html).
-The [adapter view](./diagrams/02-adapters-and-app-layer.html) expands the frontend
-boundary, and the [backend split](./diagrams/06-backends-web-and-android.html) shows
+Start with the explorable [system overview](https://teng-lin.github.io/notebooklm-py/diagrams/01-system-overview.html).
+The [adapter view](https://teng-lin.github.io/notebooklm-py/diagrams/02-adapters-and-app-layer.html) expands the frontend
+boundary, and the [backend split](https://teng-lin.github.io/notebooklm-py/diagrams/06-backends-web-and-android.html) shows
 where the Web and Android graphs stop sharing implementation. The complete visual index is in
 [`docs/diagrams/README.md`](./diagrams/README.md).
 
@@ -29,7 +29,7 @@ explicit, construction-time alternative that installs Android implementations fo
 typed namespaces. The graphs share public contracts, root lifecycle, admission, and telemetry,
 but not their wire transport, as decided in
 [ADR-0035](./adr/0035-mobile-resilience-transport.md). See the
-[selection workflow](./diagrams/28-profile-auth-backend-selection.workflow.html) for the exact
+[selection workflow](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) for the exact
 argument/environment/profile precedence.
 
 | Adapter | Package | Transport | Console script | Install | Failure projection |
@@ -55,7 +55,7 @@ sibling packages — with the boundary lint-enforced
 `notebooklm.exceptions` hierarchy, with `_app.errors.classify` as the single
 neutral source of the failure-category decision each adapter projects onto its
 own codes (CLI exit codes, MCP error shapes, REST HTTP statuses). See ADR-0021.
-The [exception hierarchy](./diagrams/09-exception-hierarchy.html) shows that shared
+The [exception hierarchy](https://teng-lin.github.io/notebooklm-py/diagrams/09-exception-hierarchy.html) shows that shared
 failure vocabulary and its transport-specific projections.
 The per-module index and the full tree are in [File map](#file-map) below.
 
@@ -79,10 +79,10 @@ advanced `client.rpc_call(...)` escape hatch is deliberately different: its
 `RPCMethod` values are Web batchexecute IDs, so it remains Web-specific under
 either namespace selection.
 
-Use the [runtime and transport view](./diagrams/03-client-runtime-and-transport.html)
-for ownership, the [RPC sequence](./diagrams/07-rpc-call-path.html) for call order, and
-the [runtime class model](./diagrams/23-runtime-class-model.html) for constructor
-relationships. The [capability-contract map](./diagrams/27-capability-contracts.html)
+Use the [runtime and transport view](https://teng-lin.github.io/notebooklm-py/diagrams/03-client-runtime-and-transport.html)
+for ownership, the [RPC sequence](https://teng-lin.github.io/notebooklm-py/diagrams/07-rpc-call-path.html) for call order, and
+the [runtime class model](https://teng-lin.github.io/notebooklm-py/diagrams/23-runtime-class-model.html) for constructor
+relationships. The [capability-contract map](https://teng-lin.github.io/notebooklm-py/diagrams/27-capability-contracts.html)
 shows why feature APIs receive narrow collaborators instead of the whole client runtime.
 
 ### Web batchexecute path
@@ -173,8 +173,8 @@ pipeline.
 With `backend="android"`, the same typed namespace calls terminate in Android
 adapters instead of `RpcExecutor`:
 
-The [Android backend view](./diagrams/14-android-backend.html) identifies its
-participants, while the [Android call sequence](./diagrams/15-android-call-path.html)
+The [Android backend view](https://teng-lin.github.io/notebooklm-py/diagrams/14-android-backend.html) identifies its
+participants, while the [Android call sequence](https://teng-lin.github.io/notebooklm-py/diagrams/15-android-call-path.html)
 shows lazy bearer acquisition, channel creation, and result projection.
 
 ```text
@@ -203,8 +203,8 @@ turn-number orchestration. Its single Web send/decode seam,
 pure `RpcExecutor` shape. Streaming chat has a custom request body and
 chat-flavored error mapping, so the first ask POST goes through:
 
-For a compact view, see the [chat sequence](./diagrams/11-chat-ask-sequence.html) and
-the [chat/notes class model](./diagrams/26-chat-notes-class-model.html).
+For a compact view, see the [chat sequence](https://teng-lin.github.io/notebooklm-py/diagrams/11-chat-ask-sequence.html) and
+the [chat/notes class model](https://teng-lin.github.io/notebooklm-py/diagrams/26-chat-notes-class-model.html).
 
 ```text
 +----------------------------------------------------------------+
@@ -277,9 +277,9 @@ operations use native unary gRPC methods. It does not traverse
 
 Some feature workflows intentionally combine RPC with non-RPC HTTP work:
 
-The [source-ingest data flow](./diagrams/12-source-ingest-dataflow.html),
-[artifact lifecycle](./diagrams/13-artifact-lifecycle.html), and
-[transfer security boundaries](./diagrams/30-transfer-security-boundaries.dataflow.html) provide
+The [source-ingest data flow](https://teng-lin.github.io/notebooklm-py/diagrams/12-source-ingest-dataflow.html),
+[artifact lifecycle](https://teng-lin.github.io/notebooklm-py/diagrams/13-artifact-lifecycle.html), and
+[transfer security boundaries](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html) provide
 the visual counterparts to the detailed ownership table below.
 
 | Flow | Runtime shape |
@@ -295,9 +295,9 @@ the visual counterparts to the detailed ownership table below.
 Three policies thread through the layers above and are easy to violate by
 accident. Each is pinned by an ADR.
 
-The [client resource lifecycle](./diagrams/19-client-resource-lifecycle.html) shows
+The [client resource lifecycle](https://teng-lin.github.io/notebooklm-py/diagrams/19-client-resource-lifecycle.html) shows
 open, drain, close, and rollback states. The
-[retry-policy workflow](./diagrams/20-retry-policy-workflow.html) complements the
+[retry-policy workflow](https://teng-lin.github.io/notebooklm-py/diagrams/20-retry-policy-workflow.html) complements the
 idempotency discussion by showing the decision path for one call.
 
 ### Loop affinity (ADR-0004)
@@ -585,11 +585,11 @@ work:
 
 Beyond the client-owned runtime graph, several feature APIs are implemented via dedicated domain services and helper modules:
 
-The [feature-service map](./diagrams/05-feature-services.html) is the compact index;
-the [artifact class model](./diagrams/08-artifacts-class-model.html) and
-[sources class model](./diagrams/25-sources-class-model.html) expand its two densest
-resource domains. The [deep-research lifecycle](./diagrams/21-deep-research-lifecycle.html)
-and [organization/sharing map](./diagrams/29-organization-and-sharing.architecture.html) cover the
+The [feature-service map](https://teng-lin.github.io/notebooklm-py/diagrams/05-feature-services.html) is the compact index;
+the [artifact class model](https://teng-lin.github.io/notebooklm-py/diagrams/08-artifacts-class-model.html) and
+[sources class model](https://teng-lin.github.io/notebooklm-py/diagrams/25-sources-class-model.html) expand its two densest
+resource domains. The [deep-research lifecycle](https://teng-lin.github.io/notebooklm-py/diagrams/21-deep-research-lifecycle.html)
+and [organization/sharing map](https://teng-lin.github.io/notebooklm-py/diagrams/29-organization-and-sharing.architecture.html) cover the
 remaining multi-step and cross-scope relationships.
 
 | Service / Module | Module | Responsibility |
@@ -619,9 +619,9 @@ only remaining `auth.py` function body because it binds `_poke_session` as
 the default dependency.
 
 Three visuals separate concerns that are easy to conflate: the
-[authentication architecture](./diagrams/04-authentication.html) shows ownership,
-the [login workflow](./diagrams/10-login-workflow.html) shows credential acquisition,
-and the [auth class model](./diagrams/24-auth-class-model.html) shows the storage and
+[authentication architecture](https://teng-lin.github.io/notebooklm-py/diagrams/04-authentication.html) shows ownership,
+the [login workflow](https://teng-lin.github.io/notebooklm-py/diagrams/10-login-workflow.html) shows credential acquisition,
+and the [auth class model](https://teng-lin.github.io/notebooklm-py/diagrams/24-auth-class-model.html) shows the storage and
 recovery owners. ADR-0031 names the credential tiers; ADR-0032 introduces the domain values;
 ADR-0033 constrains consolidation; and ADR-0034 defines the current storage object model.
 
@@ -709,7 +709,7 @@ workflow logic lives in
 [`src/notebooklm/cli/services/`](../src/notebooklm/cli/services). This
 separation is the [ADR-0008](./adr/0008-cli-services-extraction-pattern.md)
 extraction pattern.
-See the [CLI subsystem diagram](./diagrams/16-cli-subsystem.html) for the command,
+See the [CLI subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/16-cli-subsystem.html) for the command,
 service, `_app`, client, and rendering boundaries.
 
 The console-script entry point is
@@ -839,7 +839,7 @@ preview unless called with `confirm=true`). `notebooklm mcp install <client>`
 wires it into Claude Desktop/Code, Cursor, or Windsurf, and `desktop-extension/`
 packages a one-click `.mcpb` bundle. Full guide:
 [`docs/mcp-guide.md`](./mcp-guide.md).
-The [MCP subsystem diagram](./diagrams/17-mcp-subsystem.html) shows the adapter,
+The [MCP subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/17-mcp-subsystem.html) shows the adapter,
 application-core, client, and remote-transfer boundaries together.
 
 ## REST server (`server/`)
@@ -862,7 +862,7 @@ Expensive route groups have lifespan-owned concurrency limiters, tuned by
 `NOTEBOOKLM_SERVER_*_CONCURRENCY` env vars, so source mutation/wait, artifact
 generation/download, research, and blocking chat work cannot unboundedly starve
 cheap reads or `/healthz`.
-The [REST subsystem diagram](./diagrams/18-rest-server-subsystem.html) shows the
+The [REST subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/18-rest-server-subsystem.html) shows the
 lifespan-owned client, route guards, application cores, and response projection.
 
 ## Middleware chain (ADR-0009)
@@ -947,7 +947,7 @@ factory.
 ## Testing patterns
 
 Two policies define how tests interact with the architecture above.
-The [testing and guardrails view](./diagrams/22-testing-and-guardrails.html) maps the
+The [testing and guardrails view](https://teng-lin.github.io/notebooklm-py/diagrams/22-testing-and-guardrails.html) maps the
 suite taxonomy to the boundaries each tier protects.
 
 ### Constructor-injection fixtures (ADR-0007)

--- a/docs/auth-cookie-lifecycle.md
+++ b/docs/auth-cookie-lifecycle.md
@@ -12,9 +12,9 @@ send it to third parties, or expose it in logs. Keep profile directories and
 credential files readable only by the account that runs the client.
 
 For the component-level view, open the
-[authentication architecture](./diagrams/04-authentication.html), then use the
-[login workflow](./diagrams/10-login-workflow.html) and
-[auth class model](./diagrams/24-auth-class-model.html) for acquisition and storage
+[authentication architecture](https://teng-lin.github.io/notebooklm-py/diagrams/04-authentication.html), then use the
+[login workflow](https://teng-lin.github.io/notebooklm-py/diagrams/10-login-workflow.html) and
+[auth class model](https://teng-lin.github.io/notebooklm-py/diagrams/24-auth-class-model.html) for acquisition and storage
 ownership respectively.
 
 ## Choose an authentication method

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,9 +5,9 @@
 
 Complete command reference for the `notebooklm` CLI—providing full programmatic access to all NotebookLM features, including capabilities not exposed in the web UI.
 
-The [CLI subsystem diagram](./diagrams/16-cli-subsystem.html) explains how commands,
+The [CLI subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/16-cli-subsystem.html) explains how commands,
 services, the transport-neutral application layer, and output rendering fit together. The
-[selection workflow](./diagrams/28-profile-auth-backend-selection.workflow.html) shows how profile,
+[selection workflow](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) shows how profile,
 credential, and backend options are resolved.
 
 > **Exit codes:** every command follows the convention documented in [CLI Exit-Code Convention](cli-exit-codes.md) (`0` success, `1` user/app error, `2` system/unexpected, `130` SIGINT). Two commands intentionally deviate for shell control-flow use (`source stale --exit-on-stale` opts into an inverted predicate; `source wait` is three-way); see the doc for details.

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,8 +19,8 @@ This guide covers everything you need to contribute to `notebooklm-py`: architec
 > remains as the contributor on-ramp (package layout + adding-features
 > guidance) and links out to the architecture doc rather than duplicating it.
 
-Use the [system overview](./diagrams/01-system-overview.html) while orienting to the packages and
-the [testing/guardrails map](./diagrams/22-testing-and-guardrails.html)
+Use the [system overview](https://teng-lin.github.io/notebooklm-py/diagrams/01-system-overview.html) while orienting to the packages and
+the [testing/guardrails map](https://teng-lin.github.io/notebooklm-py/diagrams/22-testing-and-guardrails.html)
 when deciding which boundary a change must exercise.
 
 ### Package Structure

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,58 +1,69 @@
 # Architecture diagram catalog
 
-These diagrams are the visual companion to [`docs/architecture.md`](../architecture.md). Open
-the HTML file for the explorable light/dark viewer, guided focus modes, search, and export. The
-JSON file beside it is the editable source of truth; do not hand-edit generated HTML.
+These diagrams are the visual companion to [`docs/architecture.md`](../architecture.md). After the
+first successful GitHub Pages deployment, each **Explore** link opens the hosted viewer with
+light/dark themes, guided focus modes, search, and export. Pages reflects the latest successful
+deployment from `main`; the adjacent **Source** link opens the editable JSON source in GitHub. Do
+not hand-edit generated HTML.
+
+## Hosting
+
+The [`pages.yml`](../../.github/workflows/pages.yml) workflow publishes only the numbered HTML
+viewers after changes reach `main`; pull requests never deploy over the public site. A repository
+administrator must select **Settings → Pages → Build and deployment → Source: GitHub Actions** once
+before the first deployment. Until that deployment succeeds, or if Pages is temporarily
+unavailable, open the committed HTML viewer from a local checkout. The workflow also serves the
+system overview at the [Pages site root](https://teng-lin.github.io/notebooklm-py/).
 
 ## System and boundaries
 
 | # | Diagram | What it answers | Files |
 | --- | --- | --- | --- |
-| 01 | System overview | How do library calls and the CLI, MCP, and REST adapters reach the two backends? | [Explore](./01-system-overview.html) · [Source](./01-system-overview.architecture.json) |
-| 02 | Adapters and application layer | Which responsibilities belong to frontend adapters and `_app/`? | [Explore](./02-adapters-and-app-layer.html) · [Source](./02-adapters-and-app-layer.architecture.json) |
-| 03 | Client runtime and transport | How does the Web runtime separate execution, middleware, transport, and HTTP? | [Explore](./03-client-runtime-and-transport.html) · [Source](./03-client-runtime-and-transport.architecture.json) |
-| 05 | Feature services | Which stateful services sit behind sources, artifacts, and chat? | [Explore](./05-feature-services.html) · [Source](./05-feature-services.architecture.json) |
-| 06 | Web and Android backends | Where do the backend graphs share contracts and where do their wire paths split? | [Explore](./06-backends-web-and-android.html) · [Source](./06-backends-web-and-android.architecture.json) |
-| 22 | Tests and guardrails | Which test suites and architectural gates protect each layer? | [Explore](./22-testing-and-guardrails.html) · [Source](./22-testing-and-guardrails.architecture.json) |
-| 23 | Runtime class model | Which client-owned runtime collaborators satisfy the narrow protocols? | [Explore](./23-runtime-class-model.html) · [Source](./23-runtime-class-model.architecture.json) |
-| 27 | Capability contracts | Which implementations satisfy the RPC, loop, and single-consumer contracts? | [Explore](./27-capability-contracts.html) · [Source](./27-capability-contracts.architecture.json) |
-| 28 | Profile, auth, and backend selection | Which explicit arguments and environment settings win at construction and open? | [Explore](./28-profile-auth-backend-selection.workflow.html) · [Source](./28-profile-auth-backend-selection.workflow.json) |
-| 29 | Organization and sharing | How do notebooks, sharing, settings, labels, and collections divide their scopes? | [Explore](./29-organization-and-sharing.architecture.html) · [Source](./29-organization-and-sharing.architecture.json) |
-| 30 | Transfer security boundaries | Where are upload and download URLs validated, credentials scoped, and files published? | [Explore](./30-transfer-security-boundaries.dataflow.html) · [Source](./30-transfer-security-boundaries.dataflow.json) |
+| 01 | System overview | How do library calls and the CLI, MCP, and REST adapters reach the two backends? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/01-system-overview.html) · [Source](./01-system-overview.architecture.json) |
+| 02 | Adapters and application layer | Which responsibilities belong to frontend adapters and `_app/`? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/02-adapters-and-app-layer.html) · [Source](./02-adapters-and-app-layer.architecture.json) |
+| 03 | Client runtime and transport | How does the Web runtime separate execution, middleware, transport, and HTTP? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/03-client-runtime-and-transport.html) · [Source](./03-client-runtime-and-transport.architecture.json) |
+| 05 | Feature services | Which stateful services sit behind sources, artifacts, and chat? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/05-feature-services.html) · [Source](./05-feature-services.architecture.json) |
+| 06 | Web and Android backends | Where do the backend graphs share contracts and where do their wire paths split? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/06-backends-web-and-android.html) · [Source](./06-backends-web-and-android.architecture.json) |
+| 22 | Tests and guardrails | Which test suites and architectural gates protect each layer? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/22-testing-and-guardrails.html) · [Source](./22-testing-and-guardrails.architecture.json) |
+| 23 | Runtime class model | Which client-owned runtime collaborators satisfy the narrow protocols? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/23-runtime-class-model.html) · [Source](./23-runtime-class-model.architecture.json) |
+| 27 | Capability contracts | Which implementations satisfy the RPC, loop, and single-consumer contracts? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/27-capability-contracts.html) · [Source](./27-capability-contracts.architecture.json) |
+| 28 | Profile, auth, and backend selection | Which explicit arguments and environment settings win at construction and open? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) · [Source](./28-profile-auth-backend-selection.workflow.json) |
+| 29 | Organization and sharing | How do notebooks, sharing, settings, labels, and collections divide their scopes? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/29-organization-and-sharing.architecture.html) · [Source](./29-organization-and-sharing.architecture.json) |
+| 30 | Transfer security boundaries | Where are upload and download URLs validated, credentials scoped, and files published? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html) · [Source](./30-transfer-security-boundaries.dataflow.json) |
 
 ## Authentication
 
 | # | Diagram | What it answers | Files |
 | --- | --- | --- | --- |
-| 04 | Authentication | How do cookie rotation, recovery, and persistence cooperate? | [Explore](./04-authentication.html) · [Source](./04-authentication.architecture.json) |
-| 10 | Login workflow | How do interactive login, browser-cookie import, and master-token bootstrap differ? | [Explore](./10-login-workflow.html) · [Source](./10-login-workflow.workflow.json) |
-| 24 | Authentication class model | Which immutable values, stores, and coordinators own credential state? | [Explore](./24-auth-class-model.html) · [Source](./24-auth-class-model.architecture.json) |
+| 04 | Authentication | How do cookie rotation, recovery, and persistence cooperate? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/04-authentication.html) · [Source](./04-authentication.architecture.json) |
+| 10 | Login workflow | How do interactive login, browser-cookie import, and master-token bootstrap differ? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/10-login-workflow.html) · [Source](./10-login-workflow.workflow.json) |
+| 24 | Authentication class model | Which immutable values, stores, and coordinators own credential state? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/24-auth-class-model.html) · [Source](./24-auth-class-model.architecture.json) |
 
 ## Calls, data flows, and lifecycles
 
 | # | Diagram | What it answers | Files |
 | --- | --- | --- | --- |
-| 07 | Web RPC call path | What happens between a typed Web API call and decoded result? | [Explore](./07-rpc-call-path.html) · [Source](./07-rpc-call-path.sequence.json) |
-| 11 | Chat ask sequence | Which component owns locks, streaming, conversation recovery, and result assembly? | [Explore](./11-chat-ask-sequence.html) · [Source](./11-chat-ask-sequence.sequence.json) |
-| 12 | Source ingest | How do file bytes and no-byte inputs become ready grounding sources? | [Explore](./12-source-ingest-dataflow.html) · [Source](./12-source-ingest-dataflow.dataflow.json) |
-| 13 | Artifact lifecycle | How does generation move through pending, complete, failed, and retry states? | [Explore](./13-artifact-lifecycle.html) · [Source](./13-artifact-lifecycle.lifecycle.json) |
-| 15 | Android call path | What happens between an Android namespace call and protobuf projection? | [Explore](./15-android-call-path.html) · [Source](./15-android-call-path.sequence.json) |
-| 19 | Client resource lifecycle | How do open, bind, drain, close, and reopen affect owned resources? | [Explore](./19-client-resource-lifecycle.html) · [Source](./19-client-resource-lifecycle.lifecycle.json) |
-| 20 | Retry policy | How does the Web executor decide whether an RPC can be replayed? | [Explore](./20-retry-policy-workflow.html) · [Source](./20-retry-policy-workflow.workflow.json) |
-| 21 | Deep research lifecycle | How do research tasks progress from start through import or cancellation? | [Explore](./21-deep-research-lifecycle.html) · [Source](./21-deep-research-lifecycle.lifecycle.json) |
+| 07 | Web RPC call path | What happens between a typed Web API call and decoded result? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/07-rpc-call-path.html) · [Source](./07-rpc-call-path.sequence.json) |
+| 11 | Chat ask sequence | Which component owns locks, streaming, conversation recovery, and result assembly? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/11-chat-ask-sequence.html) · [Source](./11-chat-ask-sequence.sequence.json) |
+| 12 | Source ingest | How do file bytes and no-byte inputs become ready grounding sources? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/12-source-ingest-dataflow.html) · [Source](./12-source-ingest-dataflow.dataflow.json) |
+| 13 | Artifact lifecycle | How does generation move through pending, complete, failed, and retry states? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/13-artifact-lifecycle.html) · [Source](./13-artifact-lifecycle.lifecycle.json) |
+| 15 | Android call path | What happens between an Android namespace call and protobuf projection? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/15-android-call-path.html) · [Source](./15-android-call-path.sequence.json) |
+| 19 | Client resource lifecycle | How do open, bind, drain, close, and reopen affect owned resources? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/19-client-resource-lifecycle.html) · [Source](./19-client-resource-lifecycle.lifecycle.json) |
+| 20 | Retry policy | How does the Web executor decide whether an RPC can be replayed? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/20-retry-policy-workflow.html) · [Source](./20-retry-policy-workflow.workflow.json) |
+| 21 | Deep research lifecycle | How do research tasks progress from start through import or cancellation? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/21-deep-research-lifecycle.html) · [Source](./21-deep-research-lifecycle.lifecycle.json) |
 
 ## Domain models and adapters
 
 | # | Diagram | What it answers | Files |
 | --- | --- | --- | --- |
-| 08 | Artifacts class model | How do artifact contracts, services, polling, and public result types relate? | [Explore](./08-artifacts-class-model.html) · [Source](./08-artifacts-class-model.architecture.json) |
-| 09 | Exception hierarchy | Which public exceptions callers can catch and adapters can classify? | [Explore](./09-exception-hierarchy.html) · [Source](./09-exception-hierarchy.architecture.json) |
-| 14 | Android subsystem | Which sessions, credentials, transports, and adapters make up the Android backend? | [Explore](./14-android-backend.html) · [Source](./14-android-backend.architecture.json) |
-| 16 | CLI subsystem | How do Click commands, services, `_app/`, and renderers divide work? | [Explore](./16-cli-subsystem.html) · [Source](./16-cli-subsystem.architecture.json) |
-| 17 | MCP subsystem | How do MCP tools share the neutral core and mutation confirmation policy? | [Explore](./17-mcp-subsystem.html) · [Source](./17-mcp-subsystem.architecture.json) |
-| 18 | REST subsystem | How do routes, authentication, limits, pending state, and the client lifespan fit together? | [Explore](./18-rest-server-subsystem.html) · [Source](./18-rest-server-subsystem.architecture.json) |
-| 25 | Sources class model | How do source contracts, upload/add services, and public source values relate? | [Explore](./25-sources-class-model.html) · [Source](./25-sources-class-model.architecture.json) |
-| 26 | Chat, notes, and mind maps | How do the conversation and note-backed/interactive surfaces compose? | [Explore](./26-chat-notes-class-model.html) · [Source](./26-chat-notes-class-model.architecture.json) |
+| 08 | Artifacts class model | How do artifact contracts, services, polling, and public result types relate? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/08-artifacts-class-model.html) · [Source](./08-artifacts-class-model.architecture.json) |
+| 09 | Exception hierarchy | Which public exceptions callers can catch and adapters can classify? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/09-exception-hierarchy.html) · [Source](./09-exception-hierarchy.architecture.json) |
+| 14 | Android subsystem | Which sessions, credentials, transports, and adapters make up the Android backend? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/14-android-backend.html) · [Source](./14-android-backend.architecture.json) |
+| 16 | CLI subsystem | How do Click commands, services, `_app/`, and renderers divide work? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/16-cli-subsystem.html) · [Source](./16-cli-subsystem.architecture.json) |
+| 17 | MCP subsystem | How do MCP tools share the neutral core and mutation confirmation policy? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/17-mcp-subsystem.html) · [Source](./17-mcp-subsystem.architecture.json) |
+| 18 | REST subsystem | How do routes, authentication, limits, pending state, and the client lifespan fit together? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/18-rest-server-subsystem.html) · [Source](./18-rest-server-subsystem.architecture.json) |
+| 25 | Sources class model | How do source contracts, upload/add services, and public source values relate? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/25-sources-class-model.html) · [Source](./25-sources-class-model.architecture.json) |
+| 26 | Chat, notes, and mind maps | How do the conversation and note-backed/interactive surfaces compose? | [Explore](https://teng-lin.github.io/notebooklm-py/diagrams/26-chat-notes-class-model.html) · [Source](./26-chat-notes-class-model.architecture.json) |
 
 ## Coverage policy
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -66,7 +66,7 @@ short-lived mobile bearer tokens from `master_token.json`; typed namespace
 operations do not use Web cookies or fall back to the Web transport. Android
 dependencies are excluded from `[all]`. See the
 [Android backend guide](android/README.md) for setup and security details.
-The [selection workflow](diagrams/28-profile-auth-backend-selection.workflow.html) summarizes the
+The [selection workflow](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) summarizes the
 argument, environment, and profile precedence used by every frontend.
 
 ---
@@ -416,7 +416,7 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 
 A single-tenant, localhost REST API over the same transport-neutral core as the CLI — the natural shape for scripting and agent automation (feed a notebook, generate an artifact, pull it down) without spawning a CLI process per call.
 
-The [REST subsystem diagram](diagrams/18-rest-server-subsystem.html) shows its
+The [REST subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/18-rest-server-subsystem.html) shows its
 lifespan-owned client, route guards, concurrency limits, and response projection.
 
 <!-- not mirrored: the server extra is end-user/automation tooling, not part of the contributor `uv sync` flow; CONTRIBUTING.md tracks only browser/dev/markdown. -->

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -13,9 +13,9 @@ notebooks and sources, chat over a notebook's sources, generate and download stu
 and run deep research. It is a thin adapter over the same business logic the CLI uses, so it
 behaves identically to `notebooklm <command>`.
 
-See the [MCP subsystem diagram](./diagrams/17-mcp-subsystem.html) for process and
+See the [MCP subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/17-mcp-subsystem.html) for process and
 application boundaries. Remote file movement is expanded in the
-[transfer-security data flow](./diagrams/30-transfer-security-boundaries.dataflow.html).
+[transfer-security data flow](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html).
 
 ## Install
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -151,9 +151,9 @@ only `web` and `android` are accepted.
 Web cookies are not Android credentials. Install the runtime and bootstrap the
 same profile the client will open:
 
-The [backend comparison](./diagrams/06-backends-web-and-android.html) shows the shared
+The [backend comparison](https://teng-lin.github.io/notebooklm-py/diagrams/06-backends-web-and-android.html) shows the shared
 public contract and separate wire graphs; the
-[selection workflow](./diagrams/28-profile-auth-backend-selection.workflow.html) shows precedence.
+[selection workflow](https://teng-lin.github.io/notebooklm-py/diagrams/28-profile-auth-backend-selection.workflow.html) shows precedence.
 
 ```bash
 pip install "notebooklm-py[android,browser]"

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,9 +13,9 @@ the same account also uses Web. Protect each as described below. Android and
 Web are both unofficial integrations over undocumented Google services, so
 backend selection does not change the security or availability guarantees.
 
-The [authentication architecture](./diagrams/04-authentication.html) maps credential
+The [authentication architecture](https://teng-lin.github.io/notebooklm-py/diagrams/04-authentication.html) maps credential
 owners and recovery, while the
-[transfer-security data flow](./diagrams/30-transfer-security-boundaries.dataflow.html) shows URL
+[transfer-security data flow](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html) shows URL
 validation, per-hop credential stripping, bounded reads, and atomic publication.
 
 ## Credential boundaries


### PR DESCRIPTION
## Summary

- publish the 30 standalone architecture diagram viewers with GitHub Pages after changes land on main
- update every Markdown diagram link to open the hosted viewer instead of GitHub source view
- retain GitHub links to editable JSON sources and document the local-checkout fallback

## Repository setup

After merge, a repository administrator must select Settings → Pages → Build and deployment → Source: GitHub Actions once. The public Pages URLs currently return 404 until that setup and the first successful deployment.

## Validation

- uv run --frozen --extra dev pre-commit run --all-files
- uv run --frozen --extra dev pytest tests/_guardrails/test_install_docs.py -q (10 passed)
- workflow permission, secret-gate, action-pinning, and CI-install-parity checks
- all 80 Markdown references resolve to the 30 published HTML viewers
- local project-site simulation returned HTTP 200 for all 30 viewer URLs and the root index
- no visual-check artifacts added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Architecture diagrams are now published and browsable through the project’s documentation site.
  - Diagram pages are automatically refreshed after relevant updates and can also be deployed manually.
  - A hosted system overview and standalone diagram viewers are available.

- **Documentation**
  - Documentation pages now link directly to the hosted diagram viewers.
  - Added guidance on diagram hosting, deployment timing, and local fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->