### PR TITLE
fix(types): fix Studio format table drift and classify canary RPCs (#2313)

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -265,12 +265,22 @@ PLACEHOLDER_FAIL_METHODS: set[RPCMethod] = set()
 FULL_MODE_ONLY_METHODS = {
     # Create operations
     RPCMethod.CREATE_NOTEBOOK,
+    RPCMethod.COPY_NOTEBOOK,
     RPCMethod.ADD_SOURCE,
     RPCMethod.ADD_SOURCE_FILE,  # Registers file source intent (no upload needed)
+    RPCMethod.ADD_SOURCES_ASYNC,
+    RPCMethod.APPEND_SOURCE,
+    RPCMethod.COPY_SOURCES,
+    RPCMethod.CREATE_LABEL,
+    RPCMethod.UPDATE_LABEL,
+    RPCMethod.DELETE_LABEL,
     RPCMethod.CREATE_NOTE,
     RPCMethod.CREATE_ARTIFACT,  # Main RPC for all artifacts - test with flashcards (fast)
+    RPCMethod.COPY_ARTIFACTS,
     RPCMethod.START_FAST_RESEARCH,  # Starts research (verify RPC ID, don't wait)
     RPCMethod.DISCOVER_SOURCES,  # Synchronous discovery (~8 s; also records a job)
+    RPCMethod.CANCEL_RESEARCH,
+    RPCMethod.CANCEL_GENERATION,
     # Delete operations (tested after creates)
     RPCMethod.DELETE_NOTE,
     RPCMethod.DELETE_SOURCE,
@@ -283,6 +293,8 @@ FULL_MODE_ONLY_METHODS = {
 ALWAYS_SKIP_METHODS = {
     # Takes too long
     RPCMethod.START_DEEP_RESEARCH,
+    # Account-scoped to Play Books library; empty on canary account (#2292)
+    RPCMethod.LIST_EXPERT_INTELLIGENCE_CONTENT,
 }
 
 

--- a/src/notebooklm/_android/artifact_creation.py
+++ b/src/notebooklm/_android/artifact_creation.py
@@ -127,15 +127,16 @@ def normalize_creation_options(family: str, **options: Any) -> dict[str, Any]:
     if family in {"video", "cinematic_video"}:
         language = _language(options.get("language"))
         instructions = _optional_string(options.get("instructions"), "instructions")
-        video_format = (
-            VideoFormat.CINEMATIC if family == "cinematic_video" else options.get("video_format")
-        )
-        format_code = _enum_code(
-            video_format,
-            VideoFormat,
-            "video_format",
-            VideoFormat.EXPLAINER.value,
-        )
+        if family == "cinematic_video":
+            format_code = 3
+        else:
+            video_format = options.get("video_format")
+            format_code = _enum_code(
+                video_format,
+                VideoFormat,
+                "video_format",
+                VideoFormat.EXPLAINER.value,
+            )
         video_style = options.get("video_style")
         style_code = _enum_code(
             video_style,
@@ -145,7 +146,7 @@ def normalize_creation_options(family: str, **options: Any) -> dict[str, Any]:
         )
         style_prompt = _optional_string(options.get("style_prompt"), "style_prompt")
         style_prompt = style_prompt.strip() if style_prompt is not None else None
-        if format_code == VideoFormat.CINEMATIC.value:
+        if format_code == 3:
             if style_prompt:
                 raise ValidationError("style_prompt is not supported for cinematic videos")
             style_code = 0

--- a/src/notebooklm/_app/generate_plans.py
+++ b/src/notebooklm/_app/generate_plans.py
@@ -144,7 +144,6 @@ _AUDIO_LENGTH_MAP: Mapping[str, AudioLength] = {
 _VIDEO_FORMAT_MAP: Mapping[str, VideoFormat] = {
     "explainer": VideoFormat.EXPLAINER,
     "brief": VideoFormat.BRIEF,
-    "cinematic": VideoFormat.CINEMATIC,
     # "short" rides the standard build_video_artifact_params (not the cinematic
     # special-case builder), but has a FIXED visual style — the server ignores
     # style codes, so _build_video_plan_for_kind rejects an explicit style for

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -253,8 +253,6 @@ class ArtifactsAPI(ABC):
         """Generate a Video Overview."""
         language = self._resolve_language(language)
         normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
-        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
-            raise ValidationError("style_prompt is not supported for cinematic videos")
         if video_format == VideoFormat.SHORT and (
             (video_style is not None and video_style != VideoStyle.AUTO_SELECT)
             or normalized_style_prompt

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -111,7 +111,7 @@ def get_base_host() -> str:
 # it isn't, which is why :data:`BUILD_LABEL_STALE_AFTER_DAYS` exists and the
 # nightly canary's build-label lane (``scripts/check_rpc_health.py``) watches the
 # gap instead of leaving this constant unattended.
-DEFAULT_BL = "boq_labs-tailwind-frontend_20260802.02_p0"
+DEFAULT_BL = "boq_labs-tailwind-frontend_20260831.16_p0"
 
 # How far behind the served label this pin may fall before the canary calls it
 # stale. Wide on purpose: Google ships a new build roughly weekly, so a tighter

--- a/src/notebooklm/_types/enums.py
+++ b/src/notebooklm/_types/enums.py
@@ -232,7 +232,6 @@ class VideoFormat(int, Enum):
 
     EXPLAINER = 1
     BRIEF = 2
-    CINEMATIC = 3
     SHORT = 4  # vertical short-form video (bundle label "Short"); fixed style
 
 

--- a/src/notebooklm/_web/artifact/generation.py
+++ b/src/notebooklm/_web/artifact/generation.py
@@ -129,8 +129,6 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
-        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
-            raise ValidationError("style_prompt is not supported for cinematic videos")
         # Short videos have a FIXED visual style — the server silently ignores any
         # style code (live-verified: anime vs watercolor render identically). Reject
         # an explicit style/style_prompt rather than pretend it takes effect (#1805).

--- a/src/notebooklm/_web/params/artifacts.py
+++ b/src/notebooklm/_web/params/artifacts.py
@@ -200,7 +200,7 @@ def build_cinematic_video_artifact_params(
                     language,
                     instructions,
                     None,
-                    VideoFormat.CINEMATIC.value,
+                    3,  # Cinematic format code (separate endpoint from standard video options)
                 ],
             ],
         ],

--- a/tests/_guardrails/test_studio_enum_manifest.py
+++ b/tests/_guardrails/test_studio_enum_manifest.py
@@ -167,7 +167,7 @@ _RPC_ENUM_SNAPSHOT: dict[str, dict[str, int]] = {
         "DEEP_RESEARCH": 5,
         "LITE_LLM_SEARCH": 6,
     },
-    "VideoFormat": {"EXPLAINER": 1, "BRIEF": 2, "CINEMATIC": 3, "SHORT": 4},
+    "VideoFormat": {"EXPLAINER": 1, "BRIEF": 2, "SHORT": 4},
     "VideoStyle": {
         "AUTO_SELECT": 1,
         "CUSTOM": 0,

--- a/tests/fixtures/baselines/guardrail_inline_literals.json
+++ b/tests/fixtures/baselines/guardrail_inline_literals.json
@@ -121,6 +121,6 @@
     "_EXEMPLARS": 22
   },
   "tests/_guardrails/test_studio_enum_manifest.py": {
-    "_RPC_ENUM_SNAPSHOT": 290
+    "_RPC_ENUM_SNAPSHOT": 288
   }
 }

--- a/tests/unit/android/test_artifacts.py
+++ b/tests/unit/android/test_artifacts.py
@@ -21,6 +21,7 @@ from tests._helpers.android_supervisor import SupervisedAndroidTransport
 from notebooklm._android import artifact_outputs
 from notebooklm._android import artifacts as android_artifacts
 from notebooklm._android import notes as android_notes
+from notebooklm._android.artifact_creation import normalize_creation_options
 from notebooklm._android.artifact_outputs import report_doc_markdown, write_text_atomic
 from notebooklm._android.artifacts import (
     ACT_ON_SOURCES_METHOD,
@@ -870,22 +871,13 @@ async def test_generate_video_families_use_exact_mobile_options() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("through_video_format", [False, True])
-async def test_cinematic_video_uses_mobile_template_code_three(
-    through_video_format: bool,
-) -> None:
+async def test_cinematic_video_uses_mobile_template_code_three() -> None:
     session, notebooks, _, _, api = _graph()
     session.responses[CREATE_ARTIFACT_METHOD] = _PROTO.CreateArtifactResponse(
         artifact=_artifact("cinematic", type_code=_PROTO.ARTIFACT_TYPE_EXPLAINER_VIDEO)
     )
 
-    if through_video_format:
-        status = await api.generate_video(
-            "notebook-1",
-            video_format=VideoFormat.CINEMATIC,
-        )
-    else:
-        status = await api.generate_cinematic_video("notebook-1")
+    status = await api.generate_cinematic_video("notebook-1")
 
     assert status.task_id == "cinematic"
     options = session.calls[0][1].artifact.explainer_video.generation_options
@@ -896,18 +888,13 @@ async def test_cinematic_video_uses_mobile_template_code_three(
 
 @pytest.mark.asyncio
 async def test_cinematic_video_rejects_style_prompt_before_io() -> None:
-    session, notebooks, _, _, api = _graph()
-
     with pytest.raises(ValidationError, match="cinematic"):
-        await api.generate_video(
-            "notebook-1",
-            video_format=VideoFormat.CINEMATIC,
+        normalize_creation_options(
+            "cinematic_video",
+            language="en",
             video_style=VideoStyle.CUSTOM,
             style_prompt="Use hand-drawn diagrams",
         )
-
-    assert session.calls == []
-    assert notebooks.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -520,7 +520,7 @@ class TestChatBlOverride:
         )
         assert (
             _extract_query_param(str(request.url), "bl")
-            == "boq_labs-tailwind-frontend_20260802.02_p0"
+            == "boq_labs-tailwind-frontend_20260831.16_p0"
         )
 
 

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -871,7 +871,7 @@ _OPTS = [2, None, None, [1, None, None, None, None, None, None, None, None, None
 _LIVE_TABLE: list[Any] = [
     [
         [[[1, "Deep Dive", "d"], [2, "Brief", "d"], [3, "Critique", "d"], [4, "Debate", "d"]]],
-        [[[1, "Explainer", "d"], [2, "Brief", "d"], [3, "Cinematic", "d"], [4, "Short", "d"]]],
+        [[[1, "Explainer", "d"], [2, "Brief", "d"], [4, "Short", "d"]]],
         [[[1, "Detailed Deck", "d"], [2, "Presenter Slides", "d"]]],
         [[["Briefing Doc", "d", "directive"]]],
     ]
@@ -943,7 +943,7 @@ def test_compare_customization_choices_drifts_on_a_new_code() -> None:
 def test_compare_customization_choices_drifts_on_a_dropped_member_only() -> None:
     """Codes decide DRIFT; a label rename is reported but is not drift on its own."""
     table = json.loads(json.dumps(_LIVE_TABLE))
-    del table[0][1][0][3]  # video: Short (4) no longer served
+    del table[0][1][0][2]  # video: Short (4) no longer served
     status, detail = compare_customization_choices(table)
     assert status is CustomizationStatus.DRIFT
     assert "video: modelled codes not served [(4, 'SHORT')]" in detail
@@ -953,7 +953,7 @@ def test_compare_customization_choices_drifts_on_a_dropped_member_only() -> None
 def test_compare_customization_choices_reports_a_label_rename_without_drift() -> None:
     """Labels follow ``hl`` and Google's copy; only the codes are load-bearing (#1597)."""
     table = json.loads(json.dumps(_LIVE_TABLE))
-    table[0][1][0][3] = [4, "Panel", "d"]  # video: Short renamed, code unchanged
+    table[0][1][0][2] = [4, "Panel", "d"]  # video: Short renamed, code unchanged
     status, detail = compare_customization_choices(table)
     assert status is CustomizationStatus.MATCH
     assert "video: label differs from member name [(4, 'Panel', 'SHORT')]" in detail

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -593,7 +593,7 @@ class TestArtifactsSourceSelection:
             )
 
     @pytest.mark.asyncio
-    async def test_generate_video_cinematic_rejects_style_prompt(
+    async def test_generate_video_short_rejects_style_prompt(
         self, mock_core, mock_mind_map_service
     ):
         api = WebArtifactsAPI(
@@ -603,11 +603,11 @@ class TestArtifactsSourceSelection:
             **mock_mind_map_service,
         )
 
-        with pytest.raises(ValidationError, match="cinematic"):
+        with pytest.raises(ValidationError, match="short"):
             await api.generate_video(
                 notebook_id="nb_123",
                 source_ids=["src_a"],
-                video_format=VideoFormat.CINEMATIC,
+                video_format=VideoFormat.SHORT,
                 style_prompt="Use hand-drawn diagrams",
             )
 


### PR DESCRIPTION
## Summary

Fixes #2313.

- **Studio format table drift (`VideoFormat`):** Re-capture `sqTeoe` format enums by removing `CINEMATIC = 3` from `VideoFormat` (matching the live table `[(1, 'EXPLAINER'), (2, 'BRIEF'), (4, 'SHORT')]`). Cinematic generation remains available via dedicated `generate_cinematic_video()` APIs.
- **Build label bump:** Updated `DEFAULT_BL` to `boq_labs-tailwind-frontend_20260831.16_p0`.
- **Canary RPC health check classifications:**
  - Added mutating/cleanup RPCs to `FULL_MODE_ONLY_METHODS`: `COPY_NOTEBOOK`, `ADD_SOURCES_ASYNC`, `APPEND_SOURCE`, `COPY_SOURCES`, `CREATE_LABEL`, `UPDATE_LABEL`, `DELETE_LABEL`, `COPY_ARTIFACTS`, `CANCEL_RESEARCH`, `CANCEL_GENERATION`.
  - Added `LIST_EXPERT_INTELLIGENCE_CONTENT` to `ALWAYS_SKIP_METHODS` (Play Books library; empty on canary account).
- **Guardrail manifests & baselines:** Updated frozen `VideoFormat` snapshot in `test_studio_enum_manifest.py` and regenerated baseline literals.

## Verification

```bash
uv run pytest
uv run ruff check .
uv run ruff format --check .
uv run mypy src/notebooklm
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cinematic videos now support custom style prompts.

* **Changes**
  * Cinematic video is handled through its dedicated generation flow rather than standard video format options.
  * Updated the app shell build version.

* **Bug Fixes**
  * Improved RPC health checks by covering additional full-mode-only methods and excluding account-scoped content checks.

* **Tests**
  * Updated video validation, service-shape, and cinematic generation coverage for the latest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->