### PR TITLE
docs(skill): harden Gemini Notebook automation guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,31 +1,44 @@
 ---
 name: notebooklm
-description: Operate Google Gemini Notebook through notebooklm-py to create notebooks, add sources, chat over content, run research, generate and download artifacts, and use features beyond the web UI. Use when the user names Google Gemini Notebook or asks to use it for podcasts, videos, reports, quizzes, flashcards, slide decks, infographics, mind maps, or source-grounded summaries.
+description: Install, authenticate, troubleshoot, and operate Gemini Notebook through the notebooklm-py CLI or typed async Python API. Use for notebook and source management, grounded chat and research, and artifact generation or download when the user mentions Gemini Notebook, notebooklm-py, the notebooklm CLI, or its Python API. Do not use for the generic Gemini API or unrelated content creation.
 ---
 
-# Google Gemini Notebook Automation
+# Gemini Notebook Automation
 
 Use the `notebooklm` CLI for agent workflows. Prefer `--json` and explicit IDs so every
 operation is inspectable and safe under concurrency. Use the typed async Python API only when the
-user requests application code or the CLI cannot express the workflow.
+user requests application code or the CLI cannot express the workflow. The readiness, identity,
+authorization, and credential-handling rules below apply to both interfaces.
 
 ## Setup and Authentication
 
-Install the package in the user's existing environment; do not create a separate environment unless
-requested:
+Requires Python 3.10+. Install the package in the user's existing environment; do not create a
+separate environment unless requested:
 
 ```bash
 pip install "notebooklm-py[browser]"
 pip install "notebooklm-py[cookies]"  # optional browser-cookie extraction
 ```
 
-In a resettable headless sandbox that reuses a host-generated `storage_state.json` or
-`NOTEBOOKLM_AUTH_JSON`, the base `pip install notebooklm-py` is sufficient. Reusing a
-`master_token.json` requires `pip install "notebooklm-py[headless]"`; `[browser]` is needed for
-interactive login, and `[cookies]` is needed for browser-cookie extraction.
+If system `pip` reports `externally-managed-environment`, do not use `--break-system-packages`.
+For CLI-only use, offer `uv tool install "notebooklm-py[browser]"` or the equivalent `pipx`
+command; for application code, use the user's active project environment.
 
-Use PyPI or a release tag, not an unreleased `main` checkout. For the extras matrix, headless setup,
-CI secrets, skill installation, or the opt-in Android backend, read the
+For unattended or headless work, prefer durable profile-backed master-token auth over a copied
+cookie snapshot. Install `pip install "notebooklm-py[headless]"`; the one-time automatic OAuth
+capture also needs `[browser]`. On a trusted workstation run
+`notebooklm login --master-token --account <email>`, then deploy `master_token.json`, not
+`storage_state.json`, to the selected profile. `NOTEBOOKLM_HOME` selects the private base directory
+and `NOTEBOOKLM_PROFILE` selects its profile; defaults resolve to
+`~/.notebooklm/profiles/default/master_token.json`.
+
+In CI, `NOTEBOOKLM_MASTER_TOKEN_JSON` is a secret-transport convention, not an environment variable
+the package reads directly. Write its exact value to the selected profile's `master_token.json`
+with mode `0600`, unset it, then run `notebooklm auth refresh` to mint `storage_state.json`. A
+sibling master token can automatically re-mint expired file-backed cookies. Inline
+`NOTEBOOKLM_AUTH_JSON` is only a short-lived fallback; it bypasses this recovery path.
+
+Use PyPI or a release tag, not an unreleased `main` checkout. When available, consult the
 [installation guide](https://github.com/teng-lin/notebooklm-py/blob/main/docs/installation.md).
 
 Before a workflow, verify real authentication rather than merely parsing the cookie file:
@@ -34,7 +47,7 @@ Before a workflow, verify real authentication rather than merely parsing the coo
 notebooklm auth check --test --json
 ```
 
-Require both `"status": "ok"` and `"checks.token_fetch": true`. If validation fails:
+Require `.status == "ok"` and `.checks.token_fetch == true`. If validation fails:
 
 - With a display, run `notebooklm login` and validate again.
 - In a headless environment, install `[cookies]` and use
@@ -43,22 +56,29 @@ Require both `"status": "ok"` and `"checks.token_fetch": true`. If validation fa
 - If previously valid cookies became stale, try `notebooklm auth refresh`; use
   `notebooklm auth refresh --browser-cookies <browser>` after signing back into the browser.
 
+The normal `--test` preflight may heal and persist refreshed cookies. Add `--passive` when the
+check must be strictly read-only, including the failure-diagnosis workflow below.
+
 `notebooklm status` reports selected-notebook context, not authentication.
 
-Treat `storage_state.json`, `master_token.json`, and `NOTEBOOKLM_AUTH_JSON` as bearer credentials:
-never print, log, or commit them. Prefer a secret store in CI.
+Treat both auth files as bearer credentials: never print, log, or commit them. A master token is a
+durable full-account credential that survives password changes; use a dedicated account, protect
+it in a secret store and as `0600` on disk, and explicitly revoke it if exposed.
 
 ## Operating Invariants
 
 1. Use `--json` for discovery and mutations, then retain the returned full UUIDs. Important
    envelopes are `.notebook.id` from `create`, `.source.id` from `source add`, and `.task_id` from
    asynchronous generators. `generate mind-map` instead returns `mind_map`, `note_id`, and `kind`;
-   it has no task ID or separate wait step.
+   both kinds return a finished result with no task ID or separate `artifact wait` step.
 2. Pass `-n/--notebook <id>` on every notebook-scoped command in automation or concurrent work.
    Do not rely on `notebooklm use`. For every concurrent run, also set a unique
-   `NOTEBOOKLM_PROFILE=agent-<id>` so authentication recovery and other profile writes are isolated.
-3. After adding sources, wait for every captured source ID before chat or generation. Source JSON
-   states are lowercase: require `status == "ready"`; stop on `"error"`.
+   `NOTEBOOKLM_PROFILE=agent-<id>` so context and profile writes are isolated. A new profile has no
+   credentials: put a `master_token.json` copy in that profile and mint its storage before use.
+   Never share one writable `storage_state.json` across agents.
+3. After adding sources, retain every `.source.id`, then run `source wait` for each before chat or
+   generation. The add envelope has no status. Require wait exit 0 and `status == "ready"`; let the
+   waiter handle media-specific transient `error` rows.
 4. After an asynchronous generator returns a task/artifact ID, pass it positionally to
    `artifact wait` with `-n <notebook_id>`. Download that exact artifact with
    `-a <artifact_id> -n <notebook_id>`; never select the latest visible artifact. Mind-map generation
@@ -84,8 +104,13 @@ Obtain confirmation immediately before an action when it was not already clearly
 - `research wait --import-all`, which imports sources;
 - `ask --save-as-note` and `history --save`, which create notes.
 
-After confirmation, pass `--yes`/`-y` where supported. Do not assume `--json` bypasses destructive
-confirmation.
+User intent, not the presence of a CLI prompt, is the authorization boundary. After authorization,
+pass `--yes`/`-y` where supported. Most destructive JSON commands refuse to prompt without it, but
+some, including `ask --new --json` and `share remove --json`, execute without prompting. Never
+treat prompt absence as consent.
+
+`research cancel` is fire-and-forget. After an authorized cancellation, verify the exact run with
+`notebooklm research status -n <notebook_id> --run-id <research_run_id> --json`.
 
 ## Command Discovery
 
@@ -100,6 +125,9 @@ notebooklm artifact --help
 notebooklm download --help
 ```
 
+Also inspect `notebooklm --version` and drill down to the exact command, such as
+`notebooklm generate audio --help`, whenever its help differs from this skill.
+
 Common operations:
 
 | Goal | Command |
@@ -112,25 +140,28 @@ Common operations:
 | Generate | `notebooklm generate <type> ... -n <nb> --json` |
 | Download | `notebooklm download <type> <path> -n <nb> -a <artifact>` |
 
-For the full surface, consult the installed command help or the
+For the full surface, consult the installed command help or, when available, the
 [CLI reference](https://github.com/teng-lin/notebooklm-py/blob/main/docs/cli-reference.md).
-For application code, read the
+For application code, use the baseline below and, when available, the
 [Python API guide](https://github.com/teng-lin/notebooklm-py/blob/main/docs/python-api.md).
 
 ## Canonical Source-to-Artifact Workflow
 
 Keep `{notebook_id}`, every `{source_id}`, and `{artifact_id}` from JSON output:
 
+An explicit request for this completed workflow authorizes its normal prerequisite waits, requested
+generation, and requested output file. Confirm only work not already authorized by that request.
+
 1. `notebooklm create "Research: topic" --json`
 2. `notebooklm source add <input> -n {notebook_id} --json` for each input.
-3. After confirmation for a foreground wait, run
+3. Once the foreground wait is authorized, run
    `notebooklm source wait {source_id} -n {notebook_id} --timeout 600` for every captured source.
-4. After confirmation, generate the requested type. For audio:
+4. Once generation is authorized, generate the requested type. For audio:
    `notebooklm generate audio "instructions" -n {notebook_id} -s {source_id} --json`.
    Repeat `-s` for each selected source and capture `.task_id` as `{artifact_id}`.
-5. After confirmation for a foreground wait, run
+5. Once the foreground wait is authorized, run
    `notebooklm artifact wait {artifact_id} -n {notebook_id} --timeout 1200`.
-6. After confirmation to write the file, run
+6. Once the output write is authorized, run
    `notebooklm download audio ./podcast.m4a -a {artifact_id} -n {notebook_id}`.
 
 For analysis without generation, replace steps 4-6 with an ID-pinned chat command only after every
@@ -156,7 +187,57 @@ notebooklm research wait -n {notebook_id} --run-id {research_run_id} \
   --import-all --timeout 1800 --json
 ```
 
-Retain imported source IDs and wait for readiness before later chat or generation.
+With `--import-all`, `--timeout` is a per-phase budget for polling and import retry, so this example
+can consume roughly 3600 seconds of host wall time.
+
+Retain newly created source IDs from `.imported_sources[].id` and wait for readiness before later
+chat or generation.
+
+## Python API Baseline
+
+When the full API guide is unavailable, use the installed typed API and its docstrings; do not guess
+method names. Keep the same IDs and readiness gates as the CLI workflow:
+
+```python
+import asyncio
+
+from notebooklm import NotebookLMClient
+
+
+async def main(url: str) -> None:
+    async with NotebookLMClient.from_storage() as client:
+        notebook = await client.notebooks.create("Research: topic")
+        source = await client.sources.add_url(notebook.id, url)
+        await client.sources.wait_until_ready(notebook.id, source.id, timeout=600)
+
+        answer = await client.chat.ask(
+            notebook.id, "Summarize the key arguments", source_ids=[source.id]
+        )
+        print(answer.answer)
+
+        task = await client.artifacts.generate_audio(
+            notebook.id,
+            source_ids=[source.id],
+            instructions="Focus on the key arguments",
+        )
+        final = await client.artifacts.wait_for_completion(
+            notebook.id, task.task_id, timeout=1200
+        )
+        if not final.is_complete:
+            raise RuntimeError(f"Generation ended with {final.status}: {final.error}")
+        await client.artifacts.download_audio(
+            notebook.id, "./podcast.m4a", artifact_id=task.task_id
+        )
+
+
+asyncio.run(main("https://example.com"))
+```
+
+`NotebookLMClient.from_storage()` is an async context manager and is not awaited. A client is
+re-entrant on one event loop but is not thread-safe; create one client per loop. Public namespaces
+include `notebooks`, `sources`, `chat`, `research`, `artifacts`, `mind_maps`, `notes`, `settings`,
+`sharing`, `labels`, and `collections`. Apply the authorization boundaries above before running
+state-changing, long-running, or file-writing calls.
 
 ## Generation Notes
 
@@ -166,8 +247,10 @@ styles, source selection, language, and retry support vary by type.
 
 Keep these non-obvious distinctions:
 
-- Mind map (`--kind interactive`, default) is an asynchronous studio artifact.
-- Mind map (`--kind note-backed`) is synchronous and supports `--instructions`.
+- Mind map (`--kind interactive`, default) is an asynchronous studio artifact internally, but the
+  CLI polls it to completion and returns `{mind_map, note_id, kind}`; do not run `artifact wait`.
+- Mind map (`--kind note-backed`) is server-synchronous. Both kinds accept `--instructions`;
+  interactive applies it reliably, while the server may ignore it for note-backed maps.
 - `generate video --format cinematic` ignores `--style`, requires Google AI Ultra, and can take
   roughly 30-40 minutes.
 - Slide-deck has no orientation flag. Request portrait output in the description (for example,
@@ -175,26 +258,31 @@ Keep these non-obvious distinctions:
 - For a custom report, pass the prompt as the positional description with `--format custom`;
   `--append` applies only to built-in report formats.
 
-For prompts too long or awkward for shell quoting, use `--prompt-file PATH` on `ask`, research, and
-supported generators. It contains prompt text; upload source documents with `source add` instead.
+For prompts too long or awkward for shell quoting, use `--prompt-file PATH` on `ask`,
+`source add-research`, and supported generators. It contains prompt text; upload source documents
+with `source add` instead.
 
 ## Output and Citations
 
 Use JSON structurally rather than parsing human output. Common lifecycle values are:
 
-- sources: `processing` -> `ready` or `error`;
-- artifacts: `pending`/`in_progress` -> `completed`.
+- sources: `unknown`/`preparing`/`processing` -> `ready` or `error`; proceed only on `ready`;
+- artifacts: `pending`/`in_progress` -> `completed`, `failed`, or `removed`; `not_found` may be a
+  brief listing lag. Proceed or download only on `completed`.
 
-Chat JSON includes `answer`, `conversation_id`, and `references[].source_id`. Citation offsets refer
-to Google Gemini Notebook's internal chunks, not raw fulltext offsets. In Python, retrieve source
-fulltext and use `SourceFulltext.find_citation_context()` when exact surrounding text is needed.
+Chat JSON includes `answer`, `conversation_id`, and `references[].source_id`. A reference's
+`start_char`/`end_char` are UTF-16 offsets into the structured source document, not flat
+`SourceFulltext.content`. In Python, use
+`from notebooklm import resolve_chat_reference_passage`, then call
+`await resolve_chat_reference_passage(client, notebook_id, reference)`; it uses the exact document
+range and falls back to `find_citation_context()` when necessary.
 
 ## Failure Handling
 
 On failure, run safe read-only diagnosis first:
 
 ```bash
-notebooklm auth check --test --json
+notebooklm auth check --test --passive --json
 notebooklm list --json
 notebooklm source list -n {notebook_id} --json
 notebooklm artifact list -n {notebook_id} --json
@@ -205,12 +293,16 @@ Inspect only the commands relevant to the failed workflow. Do not mutate state d
 
 - Exit 0 means success. Expected command failures use exit 1. A `source wait` timeout uses exit 2;
   `artifact wait` and `research wait` timeouts use exit 1.
+- Branch on exit code first. Ordinary handled JSON failures use `{error, code, message}`, while wait
+  commands return domain envelopes such as `{"status": "timeout", "error": "..."}`.
 - On auth failure, revalidate `checks.token_fetch`; log in only if it is not `true`.
 - On a wait timeout, report it and inspect the exact source, artifact, or research run.
 - Generation is rate-limited by Google. Preserve the task ID, inspect status, and retry only when the
-  user authorizes it; do not loop indefinitely.
-- On a protocol error, check the installed version and the project's issue tracker before suggesting
-  a workaround.
+  user authorizes it; do not loop indefinitely. For an existing failed Studio artifact, inspect
+  `notebooklm artifact retry <artifact_id> -n {notebook_id} --help` before retrying in place.
+- On a protocol error, record the installed version, exact command, relevant IDs, and redacted
+  error. Check the project's issue tracker when network access exists; do not invent a workaround
+  when it does not.
 
 Keep progress updates brief and include the relevant returned ID. Never expose credential contents.
 
@@ -220,3 +312,4 @@ If this file is already inside an agent skill directory, the skill itself is ins
 
 - `notebooklm skill install` installs or updates supported local skill targets.
 - `notebooklm skill package` builds an uploadable archive for sandboxed agent environments.
+- `notebooklm skill status --json` reports installed versions and `content_mismatch`.

--- a/tests/_guardrails/test_install_docs.py
+++ b/tests/_guardrails/test_install_docs.py
@@ -217,14 +217,34 @@ def test_skill_md_stays_compact() -> None:
 def test_skill_md_workflows_preserve_readiness_identity_and_safe_autonomy() -> None:
     """The compact skill must retain the stateful safety invariants."""
     text = _read(SKILL_MD)
+    setup = _section(text, "## Setup and Authentication", "## Operating Invariants")
+    operating = _section(text, "## Operating Invariants", "## Authorization Boundaries")
     authorization = _section(text, "## Authorization Boundaries", "## Command Discovery")
     workflow = _section(text, "## Canonical Source-to-Artifact Workflow", "## Deep Research")
     deep_research = _section(text, "## Deep Research", "## Generation Notes")
+    python_api = _section(text, "## Python API Baseline", "## Generation Notes")
     generation = _section(text, "## Generation Notes", "## Output and Citations")
+    output = _section(text, "## Output and Citations", "## Failure Handling")
     failure_handling = _section(text, "## Failure Handling", "## Skill Installation")
 
+    assert "Gemini Notebook" in text
+    brand_text = text.replace("NotebookLMClient", "")
+    assert "NotebookLM" not in brand_text
+    assert "Google Gemini Notebook" not in text
+    assert "notebooklm auth check --test --json" in setup
+    assert "may heal and persist refreshed cookies" in setup
+    assert ".checks.token_fetch == true" in setup
+    assert "NOTEBOOKLM_MASTER_TOKEN_JSON" in setup
+    assert "secret-transport convention" in setup
+    assert "not an environment variable" in setup
+    assert "notebooklm auth refresh" in setup
+    assert text.count("NOTEBOOKLM_AUTH_JSON") == 1
     assert "language set" in authorization
     assert "research wait --import-all" in authorization
+    assert "ask --new --json" in authorization
+    assert "prompt absence as consent" in authorization
+    assert "research cancel" in authorization
+    assert "--run-id <research_run_id>" in authorization
     assert 'status == "ready"' in text
     assert "status=READY" not in text
     assert "subagent" not in text.lower()
@@ -232,14 +252,23 @@ def test_skill_md_workflows_preserve_readiness_identity_and_safe_autonomy() -> N
     assert "one sequential job" in text
     assert "only after the wait exits 0" in text
     assert "run safe read-only diagnosis first" in failure_handling
+    assert "notebooklm auth check --test --passive --json" in failure_handling
     assert 'pip install "notebooklm-py[headless]"' in text
     assert "For every concurrent run" in text
+    assert "NOTEBOOKLM_AUTH_JSON" not in operating
+    assert "master_token.json" in operating
+    assert "Never share one writable `storage_state.json`" in operating
     assert "asynchronous generators" in text
-    assert "no task ID or separate wait step" in text
+    assert "no task ID or separate `artifact wait` step" in text
     assert "Mind map (`--kind note-backed`)" in generation
     assert "Mind map (`--kind interactive`, default)" in generation
+    assert "CLI polls it to completion" in generation
+    assert "Both kinds accept `--instructions`" in generation
     assert "A `source wait` timeout uses exit 2" in failure_handling
     assert "`artifact wait` and `research wait` timeouts use exit 1" in failure_handling
+    assert '"status": "timeout"' in failure_handling
+    assert "proceed only on" in output
+    assert "await resolve_chat_reference_passage(client, notebook_id, reference)" in output
 
     assert workflow.index("notebooklm create") < workflow.index("notebooklm source add")
     assert workflow.index("notebooklm source add") < workflow.index("notebooklm source wait")
@@ -255,6 +284,23 @@ def test_skill_md_workflows_preserve_readiness_identity_and_safe_autonomy() -> N
     assert "--run-id {research_run_id}" in deep_research
     assert "--mode deep --no-wait --json" in deep_research
     assert "--import-all --timeout 1800 --json" in deep_research
+    assert ".imported_sources[].id" in deep_research
+    assert "per-phase budget" in deep_research
+
+    assert python_api.index("client.sources.add_url") < python_api.index(
+        "client.sources.wait_until_ready"
+    )
+    assert python_api.index("client.sources.wait_until_ready") < python_api.index("client.chat.ask")
+    assert python_api.index("client.artifacts.generate_audio") < python_api.index(
+        "client.artifacts.wait_for_completion"
+    )
+    assert python_api.index("client.artifacts.wait_for_completion") < python_api.index(
+        "client.artifacts.download_audio"
+    )
+    assert "task.task_id" in python_api
+    assert "artifact_id=task.task_id" in python_api
+    assert "final.is_complete" in python_api
+    assert "not thread-safe" in python_api
 
     workflow_sections = {
         "canonical source-to-artifact": workflow,

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -75,7 +75,7 @@ class TestAgentTemplates:
         content = agent_templates_module.get_agent_source_content("claude")
 
         assert content is not None
-        assert "Google Gemini Notebook Automation" in content
+        assert "Gemini Notebook Automation" in content
 
     def test_codex_reads_repo_root_agents_when_present(self, tmp_path):
         """Codex prefers the repo-root AGENTS.md when running from a checkout."""


### PR DESCRIPTION
## Summary

Expand the compact Gemini Notebook agent skill with an offline-usable CLI and Python baseline while retaining the safety hardening introduced in #2309.

## Related Issue

Follows #2309; does not close it.

## Changes

- promote durable profile-backed master-token authentication for unattended and CI workflows
- document `NOTEBOOKLM_MASTER_TOKEN_JSON` as a CI secret-transport convention and demote inline cookie JSON to a short-lived fallback
- preserve explicit-ID, readiness, authorization, cancellation, lifecycle, and content-mismatch safeguards
- add an offline Python API baseline and version-matched CLI help routing
- standardize the product name as Gemini Notebook
- strengthen guardrails against future content, branding, authentication, and workflow drift

## Test Plan

- [x] `uv run pytest tests/_guardrails/test_install_docs.py tests/unit/app/test_app_skill.py tests/unit/cli/test_skill.py tests/unit/cli/test_agent.py -q` (120 passed)
- [x] `uv run ruff check tests/_guardrails/test_install_docs.py tests/unit/cli/test_agent.py`
- [x] `uv run ruff format --check tests/_guardrails/test_install_docs.py tests/unit/cli/test_agent.py`
- [x] skill `quick_validate.py .`
- [x] parsed the embedded Python example with `ast.parse`
- [x] verified `SKILL.md` remains under the 16 KiB entrypoint budget
- [ ] full `uv run pytest` suite not run
- [ ] `uv run pre-commit run --all-files` not run
- [ ] `uv run mypy src/notebooklm` not run; production Python is unchanged

## Notes

The direct master-token environment path is intentionally not claimed: the package reads `master_token.json` from the selected profile. `NOTEBOOKLM_MASTER_TOKEN_JSON` is materialized with mode `0600` and then unset. Unrelated untracked documentation in the local checkout is excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified authentication, authorization, profile isolation, CI secret handling, and failure recovery guidance.
  - Added `skill status`, passive authentication checks, Python API usage guidance, and explicit workflow authorization steps.
  - Expanded documentation for generation options, source readiness, artifact lifecycle, citations, retries, timeouts, and protocol errors.
  - Updated branding and NotebookLM terminology.

- **Tests**
  - Strengthened documentation guardrails for authentication, authorization, workflows, API ordering, deep research, and failure handling.
  - Updated agent content expectations to use the current NotebookLM branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->