### PR TITLE
test: raise coverage on the lowest-covered modules from the nightly job

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -220,9 +220,7 @@ async def main(url: str) -> None:
             source_ids=[source.id],
             instructions="Focus on the key arguments",
         )
-        final = await client.artifacts.wait_for_completion(
-            notebook.id, task.task_id, timeout=1200
-        )
+        final = await client.artifacts.wait_for_completion(notebook.id, task.task_id, timeout=1200)
         if not final.is_complete:
             raise RuntimeError(f"Generation ended with {final.status}: {final.error}")
         await client.artifacts.download_audio(

--- a/SKILL.md
+++ b/SKILL.md
@@ -220,7 +220,9 @@ async def main(url: str) -> None:
             source_ids=[source.id],
             instructions="Focus on the key arguments",
         )
-        final = await client.artifacts.wait_for_completion(notebook.id, task.task_id, timeout=1200)
+        final = await client.artifacts.wait_for_completion(
+            notebook.id, task.task_id, timeout=1200
+        )
         if not final.is_complete:
             raise RuntimeError(f"Generation ended with {final.status}: {final.error}")
         await client.artifacts.download_audio(

--- a/src/notebooklm/cli/_cookie_import.py
+++ b/src/notebooklm/cli/_cookie_import.py
@@ -23,7 +23,6 @@ from .._app.login_cookie import (
     CookieImportSuccess,
     has_usable_secondary_binding,
     import_cookie_payload,
-    normalize_cookie_payload,
 )
 from ..auth import replace_profile_from_login
 from .services.playwright_login import filter_storage_state_cookies_by_domain_policy
@@ -49,54 +48,6 @@ def _read_auth_json_input(path: str) -> Any:
         raise click.ClickException(  # cli-input-validation: import-cookies JSON read failure
             f"Could not read {path!r}: {exc}"
         ) from None
-
-
-def _coerce_cookie_json_to_storage_state(payload: Any) -> dict[str, Any]:
-    """Normalize supported cookie JSON shapes to Playwright storage_state."""
-    result = None
-    try:
-        result = normalize_cookie_payload(payload)
-        if isinstance(result, CookieImportFailure):
-            raise click.ClickException(result.message) from None  # cli-input-validation: payload
-        return result
-    finally:
-        del payload, result
-
-
-def _normalize_imported_cookie(cookie: Any) -> dict[str, Any]:
-    """Translate common browser-export cookie fields toward storage_state."""
-    result = None
-    try:
-        result = normalize_cookie_payload([cookie])
-        if isinstance(result, CookieImportFailure):
-            raise click.ClickException(result.message) from None  # cli-input-validation: record
-        return result["cookies"][0]
-    finally:
-        del cookie, result
-
-
-def _nonempty_cookie_names(filtered_state: dict[str, Any]) -> set[str]:
-    """Names of ``filtered_state`` cookies that carry a non-empty string value.
-
-    Reads the raw cookie list rather than the flattened
-    ``extract_cookies_from_storage`` dict, so a non-empty cookie is never masked
-    by an empty same-name duplicate — matching the runtime jar, which skips empty
-    rows when building httpx cookies.
-    """
-    cookies = result = None
-    try:
-        cookies = filtered_state.get("cookies", [])
-        result = {
-            cookie["name"]
-            for cookie in cookies
-            if isinstance(cookie, dict)
-            and isinstance(cookie.get("name"), str)
-            and isinstance(cookie.get("value"), str)
-            and cookie["value"]
-        }
-        return result
-    finally:
-        del filtered_state, cookies, result
 
 
 def _has_usable_secondary_binding(filtered_state: dict[str, Any]) -> bool:

--- a/tests/unit/android/test_artifact_outputs.py
+++ b/tests/unit/android/test_artifact_outputs.py
@@ -1,0 +1,606 @@
+"""Unit coverage for the Android artifact decode/render helpers.
+
+``tests/unit/android/test_artifacts.py`` drives these through the full adapter
+graph and covers the happy paths. These cases call the helpers directly to
+reach the rejection branches — malformed mind-map trees, non-typed prefetch
+rows, ragged/headerless tables, and the citation-label variants of
+``report_doc_markdown``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from notebooklm._android import artifact_outputs as outputs
+from notebooklm._android.artifact_outputs import (
+    data_table_csv,
+    decode_interactive_app_data,
+    decode_interactive_mind_map_tree,
+    decode_prefetched_artifacts,
+    report_doc_markdown,
+    select_note_backed_mind_map,
+    select_single_file_media_url,
+    validate_artifact_language,
+    validate_echoed_source_ids,
+    write_text_atomic,
+)
+from notebooklm._android.artifact_proto import ARTIFACTS_PROTO as _PROTO
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
+    chat_pb2,
+)
+from notebooklm._android.proto.notebooklm.internal.android.wire.v1 import (
+    artifacts_pb2 as wire_pb2,
+)
+from notebooklm._types.artifact_content import ArtifactMedia, ArtifactMediaType
+from notebooklm.exceptions import (
+    ArtifactDownloadError,
+    ArtifactParseError,
+    DecodingError,
+    ValidationError,
+)
+from notebooklm.types import Artifact, MindMap, MindMapKind
+
+METHOD_ID = "test-method"
+
+
+def _artifact(artifact_id: str = "art-1", **kwargs: Any) -> Artifact:
+    kwargs.setdefault("_artifact_type", 1)
+    kwargs.setdefault("status", 3)
+    return Artifact(id=artifact_id, title="Title", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Small validators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, 7, "", "   "])
+def test_validate_artifact_language_rejects_blank_and_non_string(value: Any) -> None:
+    with pytest.raises(ValidationError, match="language must be a non-empty string"):
+        validate_artifact_language(value)
+
+
+def test_validate_artifact_language_passes_a_tag_through() -> None:
+    assert validate_artifact_language("fr") == "fr"
+
+
+def test_validate_echoed_source_ids_rejects_a_mismatched_echo() -> None:
+    artifact = _artifact(source_ids=("s1", "s2"))
+
+    with pytest.raises(DecodingError, match="different source ids"):
+        validate_echoed_source_ids(artifact, ["s1"], "report", METHOD_ID)
+
+
+@pytest.mark.parametrize(
+    "source_ids",
+    [pytest.param((), id="empty-echo-is-tolerated"), pytest.param(("s2", "s1"), id="reordered")],
+)
+def test_validate_echoed_source_ids_accepts_matching_or_absent_echoes(
+    source_ids: tuple[str, ...],
+) -> None:
+    validate_echoed_source_ids(_artifact(source_ids=source_ids), ["s1", "s2"], "report", METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# select_single_file_media_url
+# ---------------------------------------------------------------------------
+
+
+def _media(kind: ArtifactMediaType, url: str) -> ArtifactMedia:
+    return ArtifactMedia(url=url, kind=kind)
+
+
+def test_progressive_media_wins_over_download() -> None:
+    artifact = _artifact(
+        media_urls=(
+            _media(ArtifactMediaType.DOWNLOAD, "https://x.invalid/dl"),
+            _media(ArtifactMediaType.PROGRESSIVE, "https://x.invalid/prog"),
+        )
+    )
+
+    assert select_single_file_media_url(artifact) == "https://x.invalid/prog"
+
+
+def test_download_media_is_the_fallback() -> None:
+    artifact = _artifact(media_urls=(_media(ArtifactMediaType.DOWNLOAD, "https://x.invalid/dl"),))
+
+    assert select_single_file_media_url(artifact) == "https://x.invalid/dl"
+
+
+def test_no_admitted_media_representation_returns_none() -> None:
+    assert select_single_file_media_url(_artifact()) is None
+
+
+# ---------------------------------------------------------------------------
+# decode_interactive_mind_map_tree
+# ---------------------------------------------------------------------------
+
+
+def test_mind_map_tree_decodes_a_nested_tree() -> None:
+    payload = {"name": "root", "children": [{"name": "leaf", "children": []}]}
+
+    assert decode_interactive_mind_map_tree(json.dumps(payload), artifact_id="a") == payload
+
+
+def test_mind_map_tree_rejects_invalid_json() -> None:
+    with pytest.raises(ArtifactParseError, match="not valid JSON"):
+        decode_interactive_mind_map_tree("{not json", artifact_id="a")
+
+
+def test_mind_map_tree_rejects_a_non_object_root() -> None:
+    with pytest.raises(ArtifactParseError, match="not a JSON object"):
+        decode_interactive_mind_map_tree("[]", artifact_id="a")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"children": []}, id="missing-name"),
+        pytest.param({"name": "", "children": []}, id="empty-name"),
+        pytest.param({"name": 1, "children": []}, id="non-string-name"),
+        pytest.param({"name": "root", "children": {}}, id="non-list-children"),
+    ],
+)
+def test_mind_map_tree_rejects_invalid_nodes(payload: dict[str, Any]) -> None:
+    with pytest.raises(ArtifactParseError, match="invalid node"):
+        decode_interactive_mind_map_tree(json.dumps(payload), artifact_id="a")
+
+
+def test_mind_map_tree_rejects_a_non_object_child() -> None:
+    payload = {"name": "root", "children": ["leaf"]}
+
+    with pytest.raises(ArtifactParseError, match="structural bounds"):
+        decode_interactive_mind_map_tree(json.dumps(payload), artifact_id="a")
+
+
+def test_mind_map_tree_rejects_nesting_past_the_depth_bound() -> None:
+    node: dict[str, Any] = {"name": "leaf", "children": []}
+    for _ in range(70):
+        node = {"name": "n", "children": [node]}
+
+    with pytest.raises(ArtifactParseError, match="structural bounds"):
+        decode_interactive_mind_map_tree(json.dumps(node), artifact_id="a")
+
+
+def test_mind_map_tree_rejects_more_than_ten_thousand_nodes() -> None:
+    children = [{"name": f"n{index}", "children": []} for index in range(10_001)]
+
+    with pytest.raises(ArtifactParseError, match="structural bounds"):
+        decode_interactive_mind_map_tree(
+            json.dumps({"name": "root", "children": children}), artifact_id="a"
+        )
+
+
+# ---------------------------------------------------------------------------
+# decode_prefetched_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_prefetched_typed_artifacts_pass_through_unchanged() -> None:
+    artifact = _artifact("art-9")
+
+    assert decode_prefetched_artifacts([artifact], method_id=METHOD_ID) == [artifact]
+
+
+def test_prefetched_protobufs_are_decoded() -> None:
+    message = _PROTO.Artifact(artifact_id="art-9", title="Deck")
+
+    [decoded] = decode_prefetched_artifacts([message], method_id=METHOD_ID)
+
+    assert decoded.id == "art-9"
+    assert decoded.title == "Deck"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(["art-9", "Deck"], id="web-wire-list"),
+        pytest.param({"id": "art-9"}, id="mapping"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_prefetched_rows_of_other_shapes_are_rejected(value: Any) -> None:
+    with pytest.raises(ValidationError, match="Android Artifact objects or protobufs"):
+        decode_prefetched_artifacts([value], method_id=METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# select_note_backed_mind_map
+# ---------------------------------------------------------------------------
+
+
+def _mind_map(
+    mind_map_id: str,
+    *,
+    kind: MindMapKind = MindMapKind.NOTE_BACKED,
+    created_at: datetime | None = None,
+) -> MindMap:
+    return MindMap(
+        id=mind_map_id,
+        notebook_id="nb1",
+        title=mind_map_id,
+        kind=kind,
+        created_at=created_at,
+    )
+
+
+def test_select_note_backed_mind_map_rejects_untyped_rows() -> None:
+    with pytest.raises(ValidationError, match="typed MindMap objects"):
+        select_note_backed_mind_map([{"id": "mm-1"}], mind_map_id=None)
+
+
+def test_select_note_backed_mind_map_returns_the_requested_id() -> None:
+    wanted = _mind_map("mm-2")
+
+    selected = select_note_backed_mind_map([_mind_map("mm-1"), wanted], mind_map_id="mm-2")
+
+    assert selected is wanted
+
+
+def test_select_note_backed_mind_map_returns_none_for_an_unknown_id() -> None:
+    assert select_note_backed_mind_map([_mind_map("mm-1")], mind_map_id="absent") is None
+
+
+def test_select_note_backed_mind_map_prefers_the_newest_candidate() -> None:
+    older = _mind_map("mm-1", created_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    newer = _mind_map("mm-2", created_at=datetime(2026, 6, 1, tzinfo=timezone.utc))
+    undated = _mind_map("mm-3")
+
+    assert select_note_backed_mind_map([older, undated, newer], mind_map_id=None) is newer
+
+
+def test_select_note_backed_mind_map_skips_interactive_rows() -> None:
+    interactive = _mind_map("mm-1", kind=MindMapKind.INTERACTIVE)
+
+    assert select_note_backed_mind_map([interactive], mind_map_id=None) is None
+
+
+# ---------------------------------------------------------------------------
+# decode_interactive_app_data
+# ---------------------------------------------------------------------------
+
+
+def test_app_data_json_is_preferred_over_the_embedded_html() -> None:
+    decoded = decode_interactive_app_data(
+        "<html>ignored</html>",
+        '{"cards": 3}',
+        artifact_type="quiz",
+        artifact_id="a",
+    )
+
+    assert decoded == {"cards": 3}
+
+
+def test_app_data_falls_back_to_the_embedded_html_payload() -> None:
+    html = '<div data-app-data="{&quot;cards&quot;: 1}"></div>'
+
+    decoded = decode_interactive_app_data(html, "", artifact_type="quiz", artifact_id="a")
+
+    assert decoded == {"cards": 1}
+
+
+def test_app_data_rejects_unparseable_json() -> None:
+    with pytest.raises(ArtifactParseError, match="Failed to parse"):
+        decode_interactive_app_data("", "{nope", artifact_type="quiz", artifact_id="a")
+
+
+def test_app_data_rejects_html_without_an_embedded_payload() -> None:
+    with pytest.raises(ArtifactParseError, match="Failed to parse"):
+        decode_interactive_app_data(
+            "<html>no payload</html>", "", artifact_type="quiz", artifact_id="a"
+        )
+
+
+def test_app_data_rejects_a_non_object_payload() -> None:
+    with pytest.raises(ArtifactParseError, match="not a JSON object"):
+        decode_interactive_app_data("", "[1, 2]", artifact_type="quiz", artifact_id="a")
+
+
+# ---------------------------------------------------------------------------
+# report_doc_markdown
+# ---------------------------------------------------------------------------
+
+
+def _document_with_body(text: str = "Body") -> chat_pb2.TailwindDoc:
+    document = chat_pb2.TailwindDoc()
+    document.body.content.add().paragraph.elements.add().text_run.content = text
+    return document
+
+
+def test_report_doc_markdown_without_a_body_is_empty() -> None:
+    assert report_doc_markdown(chat_pb2.TailwindDoc()) == ""
+
+
+def test_report_doc_markdown_skips_objects_without_a_citation() -> None:
+    document = _document_with_body()
+    document.objects.add().object_id.id = "obj-1"
+
+    assert report_doc_markdown(document) == "Body"
+
+
+def test_report_doc_markdown_renders_an_attributed_citation() -> None:
+    document = _document_with_body()
+    item = document.objects.add()
+    item.object_id.id = "obj-1"
+    item.citation.fragment.elements.add().paragraph.elements.add().text_run.content = "quoted"
+    item.citation.source_attribution.ingested_source.source.id = "src-7"
+
+    assert report_doc_markdown(document) == ("Body\n\n> **Citation obj-1 (src-7):** quoted")
+
+
+def test_report_doc_markdown_falls_back_to_the_citation_object_id() -> None:
+    document = _document_with_body()
+    item = document.objects.add()
+    item.citation.object_id.id = "cite-2"
+    item.citation.fragment.elements.add().paragraph.elements.add().text_run.content = "quoted"
+
+    assert report_doc_markdown(document) == "Body\n\n> **Citation cite-2:** quoted"
+
+
+def test_report_doc_markdown_labels_an_anonymous_empty_citation() -> None:
+    document = _document_with_body()
+    document.objects.add().citation.SetInParent()
+
+    assert report_doc_markdown(document) == "Body\n\n> **Citation:**"
+
+
+# ---------------------------------------------------------------------------
+# data_table_csv
+# ---------------------------------------------------------------------------
+
+
+def _table_message(rows: list[list[str]]) -> Any:
+    """Build an exact ``Artifact`` carrying a single-table wire projection."""
+    projection = wire_pb2.WireArtifactTableProjection()
+    table = projection.table.document.body.content.add().table
+    for values in rows:
+        row = table.table_rows.add()
+        for value in values:
+            cell = row.table_cells.add()
+            cell.content.add().paragraph.elements.add().text_run.content = value
+    message = _PROTO.Artifact(artifact_id="art-1")
+    message.MergeFromString(projection.SerializeToString())
+    return message
+
+
+def test_data_table_csv_writes_a_bom_prefixed_rfc_table() -> None:
+    message = _table_message([["Name", "Note"], ["Alpha", "one"]])
+
+    assert data_table_csv(message, artifact_id="a") == "﻿Name,Note\r\nAlpha,one\r\n"
+
+
+def test_data_table_csv_rejects_an_artifact_without_a_table_document() -> None:
+    with pytest.raises(ArtifactParseError, match="omitted its table document"):
+        data_table_csv(_PROTO.Artifact(artifact_id="art-1"), artifact_id="a")
+
+
+def test_data_table_csv_rejects_a_ragged_table() -> None:
+    message = _table_message([["Name", "Note"], ["Alpha"]])
+
+    with pytest.raises(ArtifactParseError, match="invalid rectangular table"):
+        data_table_csv(message, artifact_id="a")
+
+
+def test_data_table_csv_rejects_a_table_with_no_columns() -> None:
+    projection = wire_pb2.WireArtifactTableProjection()
+    projection.table.document.body.content.add().table.table_rows.add()
+    message = _PROTO.Artifact(artifact_id="art-1")
+    message.MergeFromString(projection.SerializeToString())
+
+    with pytest.raises(ArtifactParseError, match="invalid rectangular table"):
+        data_table_csv(message, artifact_id="a")
+
+
+@pytest.mark.parametrize(
+    "heading", [pytest.param("", id="empty"), pytest.param("   ", id="whitespace-only")]
+)
+def test_data_table_csv_rejects_a_missing_header_cell(heading: str) -> None:
+    message = _table_message([["Name", heading], ["Alpha", "one"]])
+
+    with pytest.raises(ArtifactParseError, match="missing header cell"):
+        data_table_csv(message, artifact_id="a")
+
+
+def test_data_table_csv_flattens_thought_wrapped_cells() -> None:
+    projection = wire_pb2.WireArtifactTableProjection()
+    table = projection.table.document.body.content.add().table
+    header = table.table_rows.add()
+    header.table_cells.add().content.add().paragraph.elements.add().text_run.content = "Head"
+    thought = table.table_rows.add().table_cells.add().content.add().thought
+    thought.elements.add().paragraph.elements.add().text_run.content = "inner"
+    message = _PROTO.Artifact(artifact_id="art-1")
+    message.MergeFromString(projection.SerializeToString())
+
+    assert data_table_csv(message, artifact_id="a") == "﻿Head\r\ninner\r\n"
+
+
+def test_data_table_csv_rejects_a_non_text_paragraph_element() -> None:
+    projection = wire_pb2.WireArtifactTableProjection()
+    table = projection.table.document.body.content.add().table
+    header = table.table_rows.add()
+    header.table_cells.add().content.add().paragraph.elements.add().text_run.content = "Head"
+    cell = table.table_rows.add().table_cells.add().content.add()
+    cell.paragraph.elements.add().image.url = "https://x.invalid/i"
+    message = _PROTO.Artifact(artifact_id="art-1")
+    message.MergeFromString(projection.SerializeToString())
+
+    with pytest.raises(ArtifactParseError, match="unsupported cell structure"):
+        data_table_csv(message, artifact_id="a")
+
+
+def test_data_table_csv_rejects_an_unsupported_block_variant() -> None:
+    projection = wire_pb2.WireArtifactTableProjection()
+    table = projection.table.document.body.content.add().table
+    header = table.table_rows.add()
+    header.table_cells.add().content.add().paragraph.elements.add().text_run.content = "Head"
+    table.table_rows.add().table_cells.add().content.add().horizontal_rule.SetInParent()
+    message = _PROTO.Artifact(artifact_id="art-1")
+    message.MergeFromString(projection.SerializeToString())
+
+    with pytest.raises(ArtifactParseError, match="unsupported cell structure"):
+        data_table_csv(message, artifact_id="a")
+
+
+# ---------------------------------------------------------------------------
+# write_text_atomic
+# ---------------------------------------------------------------------------
+
+
+def _staging_leftovers(directory: Path) -> list[Path]:
+    return [path for path in directory.iterdir() if path.name.endswith(".tmp")]
+
+
+@pytest.mark.asyncio
+async def test_write_text_atomic_publishes_bytes_verbatim(tmp_path: Path) -> None:
+    """Line endings survive publication — no platform newline translation."""
+    destination = tmp_path / "nested" / "out.csv"
+
+    result = await write_text_atomic(
+        str(destination), "a,b\r\n1,2\r\n", artifact_type="data_table", artifact_id="art-1"
+    )
+
+    assert result == str(destination)
+    assert destination.read_bytes() == b"a,b\r\n1,2\r\n"
+    assert _staging_leftovers(destination.parent) == []
+
+
+@pytest.mark.asyncio
+async def test_write_text_atomic_reports_a_failed_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "out.csv"
+
+    def _failing_replace(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("cross-device link")
+
+    monkeypatch.setattr(outputs.os, "replace", _failing_replace)
+
+    with pytest.raises(ArtifactDownloadError, match="Could not publish"):
+        await write_text_atomic(
+            str(destination), "body", artifact_type="report", artifact_id="art-1"
+        )
+
+    assert not destination.exists()
+    # The staging file is removed rather than left behind as a partial artifact.
+    assert _staging_leftovers(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_write_text_atomic_removes_staging_when_encoding_fails(
+    tmp_path: Path,
+) -> None:
+    """An unencodable payload leaves neither the destination nor a temp file."""
+    destination = tmp_path / "out.md"
+
+    with pytest.raises(ArtifactDownloadError, match="Could not publish"):
+        await write_text_atomic(
+            str(destination), "\ud800", artifact_type="report", artifact_id="art-1"
+        )
+
+    assert not destination.exists()
+    assert _staging_leftovers(tmp_path) == []
+
+
+@pytest.fixture
+def blocking_mkstemp(monkeypatch: pytest.MonkeyPatch):
+    """Hold the worker thread inside ``mkstemp`` until the test releases it."""
+    started = threading.Event()
+    release = threading.Event()
+    real_mkstemp = tempfile.mkstemp
+
+    def _blocking(*args: Any, **kwargs: Any):
+        started.set()
+        release.wait(10)
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(outputs.tempfile, "mkstemp", _blocking)
+    yield started, release
+    release.set()
+
+
+async def _await_worker_started(started: threading.Event) -> None:
+    await asyncio.to_thread(started.wait, 10)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_write_settles_the_worker_and_leaves_no_files(
+    tmp_path: Path, blocking_mkstemp
+) -> None:
+    """Cancellation cannot abandon a live filesystem thread mid-write."""
+    started, release = blocking_mkstemp
+    destination = tmp_path / "out.md"
+    task = asyncio.create_task(
+        write_text_atomic(str(destination), "body", artifact_type="report", artifact_id="art-1")
+    )
+    await _await_worker_started(started)
+
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not destination.exists()
+    assert _staging_leftovers(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_still_settles_the_worker(
+    tmp_path: Path, blocking_mkstemp
+) -> None:
+    """A second cancel during the shielded retry re-enters the wait, not the caller."""
+    started, release = blocking_mkstemp
+    destination = tmp_path / "out.md"
+    task = asyncio.create_task(
+        write_text_atomic(str(destination), "body", artifact_type="report", artifact_id="art-1")
+    )
+    await _await_worker_started(started)
+
+    task.cancel()
+    # Let the coroutine take the first CancelledError and re-enter the shield.
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not destination.exists()
+    assert _staging_leftovers(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_cancellation_racing_a_failed_worker_reports_the_cancellation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker OSError during cancellation does not mask the CancelledError."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def _failing(*_args: Any, **_kwargs: Any):
+        started.set()
+        release.wait(10)
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(outputs.tempfile, "mkstemp", _failing)
+    destination = tmp_path / "out.md"
+    task = asyncio.create_task(
+        write_text_atomic(str(destination), "body", artifact_type="report", artifact_id="art-1")
+    )
+    await _await_worker_started(started)
+
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not destination.exists()

--- a/tests/unit/android/test_chat_codec.py
+++ b/tests/unit/android/test_chat_codec.py
@@ -1,0 +1,346 @@
+"""Unit coverage for the Android chat projection's admission branches.
+
+``tests/unit/android/test_chat.py`` covers the fully-populated decode through
+the adapter. These cases call the projection directly to reach the citation
+rejections, the overlapping-fragment reconstruction, and the history pairing
+rules for rows that arrive without their partner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._android.codecs.chat import (
+    decode_history,
+    decode_references,
+    decode_turn_key,
+)
+from notebooklm._android.codecs.documents import decode_document
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
+    chat_pb2,
+    read_pb2,
+)
+from notebooklm._types.documents import StructuredDocument
+
+
+def _fragment_element(text: str, *, start: int, end: int) -> chat_pb2.StructuralElement:
+    element = chat_pb2.StructuralElement(start_index=start, end_index=end)
+    run = element.paragraph.elements.add(start_index=start, end_index=end)
+    run.text_run.content = text
+    return element
+
+
+def _citation_object(
+    *,
+    object_id: str | None = "c1",
+    source_id: str | None = "src-1",
+    fragment: list[chat_pb2.StructuralElement] | None = None,
+    ranges: list[tuple[int, int]] | None = None,
+    attribution: bool = True,
+) -> chat_pb2.DocumentObject:
+    item = chat_pb2.DocumentObject()
+    if object_id is not None:
+        item.object_id.id = object_id
+    citation = item.citation
+    if attribution:
+        citation.source_attribution.ingested_source.source.CopyFrom(
+            read_pb2.SourceId(id=source_id or "")
+        )
+    if fragment is not None:
+        citation.fragment.elements.extend(fragment)
+    for start, end in ranges or []:
+        citation.ranges.add(start_index=start, end_index=end)
+    return item
+
+
+def _document(*objects: chat_pb2.DocumentObject) -> chat_pb2.TailwindDoc:
+    document = chat_pb2.TailwindDoc()
+    document.objects.extend(objects)
+    return document
+
+
+# ---------------------------------------------------------------------------
+# decode_references
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_response_document_yields_no_references() -> None:
+    assert decode_references(chat_pb2.TailwindDoc(), StructuredDocument()) == []
+
+
+def test_objects_without_a_citation_are_skipped() -> None:
+    document = chat_pb2.TailwindDoc()
+    document.objects.add().object_id.id = "c1"
+
+    assert decode_references(document, StructuredDocument()) == []
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        pytest.param(_citation_object(attribution=False), id="no-source-attribution"),
+        pytest.param(_citation_object(source_id=""), id="empty-source-id"),
+    ],
+)
+def test_citations_without_a_usable_source_are_skipped(item: chat_pb2.DocumentObject) -> None:
+    assert decode_references(_document(item), StructuredDocument()) == []
+
+
+def test_a_partial_attribution_chain_is_skipped() -> None:
+    item = chat_pb2.DocumentObject()
+    item.object_id.id = "c1"
+    # ``source_attribution`` present, but without its ``ingested_source`` arm.
+    item.citation.source_attribution.SetInParent()
+
+    assert decode_references(_document(item), StructuredDocument()) == []
+
+
+def test_a_citation_without_a_fragment_carries_no_text_or_offsets() -> None:
+    [reference] = decode_references(_document(_citation_object()), StructuredDocument())
+
+    assert (reference.cited_text, reference.start_char, reference.end_char) == (None, None, None)
+    assert (reference.source_id, reference.citation_number, reference.chunk_id) == (
+        "src-1",
+        1,
+        "c1",
+    )
+
+
+def test_a_fragment_whose_blocks_all_fail_admission_carries_no_text() -> None:
+    """Inverted block ranges decode to nothing, so the projection stays empty."""
+    item = _citation_object(fragment=[_fragment_element("x", start=9, end=2)])
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert reference.cited_text is None
+
+
+def test_fragment_blocks_are_concatenated_in_offset_order() -> None:
+    item = _citation_object(
+        fragment=[
+            _fragment_element("world", start=5, end=10),
+            _fragment_element("hello", start=0, end=5),
+        ]
+    )
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert reference.cited_text == "helloworld"
+    assert (reference.start_char, reference.end_char) == (0, 10)
+
+
+def test_an_overlapping_fragment_block_is_trimmed_to_the_new_text_only() -> None:
+    """The overlap is measured in UTF-16 units, matching the declared offsets."""
+    item = _citation_object(
+        fragment=[
+            _fragment_element("abcde", start=0, end=5),
+            _fragment_element("cdefg", start=2, end=7),
+        ]
+    )
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert reference.cited_text == "abcdefg"
+
+
+def test_a_fully_contained_fragment_block_contributes_nothing() -> None:
+    item = _citation_object(
+        fragment=[
+            _fragment_element("abcde", start=0, end=5),
+            _fragment_element("bc", start=1, end=3),
+            _fragment_element("fg", start=5, end=7),
+        ]
+    )
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert reference.cited_text == "abcdefg"
+
+
+def test_a_text_less_fragment_falls_back_to_the_plain_rendering() -> None:
+    element = chat_pb2.StructuralElement(start_index=0, end_index=4)
+    element.code_block.content = "code"
+    item = _citation_object(fragment=[element])
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert reference.cited_text == "code"
+
+
+@pytest.mark.parametrize(
+    ("ranges", "expected"),
+    [
+        pytest.param([], (None, None), id="no-declared-ranges"),
+        pytest.param([(3, 9)], (3, 9), id="single-range"),
+        pytest.param([(10, 12), (3, 9)], (3, 12), id="union-of-ranges"),
+        pytest.param([(9, 3)], (None, None), id="inverted-range-rejected"),
+    ],
+)
+def test_declared_fragment_range_is_the_strict_union(
+    ranges: list[tuple[int, int]], expected: tuple[int | None, int | None]
+) -> None:
+    item = _citation_object(ranges=ranges)
+
+    [reference] = decode_references(_document(item), StructuredDocument())
+
+    assert (reference.fragment_start_char, reference.fragment_end_char) == expected
+
+
+def test_answer_anchors_ignore_annotations_past_the_answer_extent() -> None:
+    answer = chat_pb2.TailwindDoc()
+    answer.body.content.add(start_index=0, end_index=5).paragraph.elements.add(
+        start_index=0, end_index=5
+    ).text_run.content = "hello"
+    in_range = answer.body.inline_object_locations.add()
+    in_range.object_id.id = "c1"
+    in_range.content_range.start_index = 1
+    in_range.content_range.end_index = 4
+    out_of_range = answer.body.inline_object_locations.add()
+    out_of_range.object_id.id = "c2"
+    out_of_range.content_range.start_index = 90
+    out_of_range.content_range.end_index = 99
+    answer_document = decode_document(answer)
+
+    references = decode_references(
+        _document(_citation_object(object_id="c1"), _citation_object(object_id="c2")),
+        answer_document,
+    )
+
+    anchored, unanchored = references
+    assert (anchored.answer_anchor_start, anchored.answer_anchor_end) == (1, 4)
+    assert (unanchored.answer_anchor_start, unanchored.answer_anchor_end) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# decode_turn_key
+# ---------------------------------------------------------------------------
+
+
+def test_turn_key_is_absent_without_the_field() -> None:
+    assert decode_turn_key(chat_pb2.AnswerResponse()) is None
+
+
+def test_turn_key_without_a_session_id_is_not_usable() -> None:
+    answer = chat_pb2.AnswerResponse()
+    answer.conversation_turn_key.conversation_id = "turn-1"
+
+    assert decode_turn_key(answer) is None
+
+
+def test_turn_key_projects_the_three_captured_fields() -> None:
+    answer = chat_pb2.AnswerResponse()
+    answer.conversation_turn_key.CopyFrom(
+        chat_pb2.ConversationTurnKey(
+            session_id="sess-1", conversation_id="turn-1", observed_field_3=4
+        )
+    )
+
+    key = decode_turn_key(answer)
+
+    assert key is not None
+    assert (key.session_id, key.turn_id, key.turn_code) == ("sess-1", "turn-1", 4)
+
+
+def test_turn_key_reports_a_missing_conversation_id_as_none() -> None:
+    answer = chat_pb2.AnswerResponse()
+    answer.conversation_turn_key.session_id = "sess-1"
+
+    key = decode_turn_key(answer)
+
+    assert key is not None
+    assert key.turn_id is None
+
+
+# ---------------------------------------------------------------------------
+# decode_history
+# ---------------------------------------------------------------------------
+
+
+def _turns(*turns: chat_pb2.ChatHistoryMessage) -> chat_pb2.ListChatTurnsResponse:
+    return chat_pb2.ListChatTurnsResponse(chat_turns=list(turns))
+
+
+def _answer_turn(
+    text: str = "",
+    *,
+    doc_text: str | None = None,
+    query: str = "",
+) -> chat_pb2.ChatHistoryMessage:
+    turn = chat_pb2.ChatHistoryMessage(observed_event_type=2, user_query_text=query)
+    response = turn.act_on_sources_response.response
+    response.response = text
+    if doc_text is not None:
+        response.response_doc.body.content.add().paragraph.elements.add().text_run.content = (
+            doc_text
+        )
+    return turn
+
+
+def _query_turn(text: str) -> chat_pb2.ChatHistoryMessage:
+    return chat_pb2.ChatHistoryMessage(observed_event_type=1, user_query_text=text)
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_a_non_positive_limit_returns_nothing(limit: int) -> None:
+    assert decode_history(_turns(_query_turn("q")), limit=limit) == []
+
+
+def test_newest_first_rows_are_paired_and_returned_oldest_first() -> None:
+    response = _turns(
+        _answer_turn("a2"),
+        _query_turn("q2"),
+        _answer_turn("a1"),
+        _query_turn("q1"),
+    )
+
+    assert decode_history(response, limit=10) == [("q1", "a1"), ("q2", "a2")]
+
+
+def test_a_combined_row_is_paired_without_inventing_a_second_question() -> None:
+    """A legacy row carrying both halves stays one pair."""
+    response = _turns(_answer_turn("a1", query="q1"))
+
+    assert decode_history(response, limit=10) == [("q1", "a1")]
+
+
+def test_an_answer_falls_back_to_its_response_document() -> None:
+    response = _turns(_answer_turn("", doc_text="from doc"), _query_turn("q1"))
+
+    assert decode_history(response, limit=10) == [("q1", "from doc")]
+
+
+def test_only_the_newest_of_several_orphan_answers_is_retained() -> None:
+    response = _turns(_answer_turn("newest"), _answer_turn("older"), _query_turn("q1"))
+
+    assert decode_history(response, limit=10) == [("q1", "newest")]
+
+
+def test_a_question_without_a_preceding_answer_pairs_with_an_empty_string() -> None:
+    response = _turns(_query_turn("q1"))
+
+    assert decode_history(response, limit=10) == [("q1", "")]
+
+
+def test_a_turn_without_a_response_arm_yields_an_empty_answer() -> None:
+    bare = chat_pb2.ChatHistoryMessage(observed_event_type=2)
+
+    assert decode_history(_turns(bare, _query_turn("q1")), limit=10) == [("q1", "")]
+
+
+def test_rows_of_an_unrecovered_event_type_are_ignored() -> None:
+    unknown = chat_pb2.ChatHistoryMessage(observed_event_type=7, user_query_text="ignored")
+
+    assert decode_history(_turns(unknown, _query_turn("q1")), limit=10) == [("q1", "")]
+
+
+def test_pairing_stops_once_the_limit_is_reached() -> None:
+    response = _turns(
+        _answer_turn("a3"),
+        _query_turn("q3"),
+        _answer_turn("a2"),
+        _query_turn("q2"),
+        _answer_turn("a1"),
+        _query_turn("q1"),
+    )
+
+    assert decode_history(response, limit=2) == [("q2", "a2"), ("q3", "a3")]

--- a/tests/unit/android/test_document_codec.py
+++ b/tests/unit/android/test_document_codec.py
@@ -1,0 +1,544 @@
+"""Edge-case coverage for the shared Android ``TailwindDoc`` codec.
+
+``tests/unit/android/test_chat.py`` pins the happy-path decode of a fully
+populated document. These cases cover the rejection/clamping branches and the
+Markdown/plain-text renderers, which the transport-level suites never reach.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._android.codecs.documents import (
+    decode_blocks,
+    decode_document,
+    structural_element_markdown,
+    structural_elements_plain_text,
+    tailwind_doc_markdown,
+    tailwind_doc_plain_text,
+)
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
+    chat_pb2,
+)
+from notebooklm._types.documents import BlockKind, BlockStyle, ListStyle
+
+
+def _paragraph(
+    text: str,
+    *,
+    start: int = 0,
+    end: int | None = None,
+    style: chat_pb2.TextStyle | None = None,
+    named_style: int | None = None,
+    bullet: chat_pb2.BulletInfo | None = None,
+) -> chat_pb2.StructuralElement:
+    """Build a single-run paragraph element spanning ``text``."""
+    end = start + len(text) if end is None else end
+    run = chat_pb2.TextRun(content=text)
+    if style is not None:
+        run.text_style.CopyFrom(style)
+    paragraph = chat_pb2.Paragraph(
+        elements=[chat_pb2.ParagraphElement(start_index=start, end_index=end, text_run=run)]
+    )
+    if named_style is not None:
+        paragraph.paragraph_style.named_style_type = named_style
+    if bullet is not None:
+        paragraph.bullet_info.CopyFrom(bullet)
+    return chat_pb2.StructuralElement(start_index=start, end_index=end, paragraph=paragraph)
+
+
+def _doc(*elements: chat_pb2.StructuralElement) -> chat_pb2.TailwindDoc:
+    return chat_pb2.TailwindDoc(body=chat_pb2.Body(content=list(elements)))
+
+
+# --------------------------------------------------------------------------
+# _bounded_range rejection / clamping (via decode_blocks)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        pytest.param(-1, 4, id="negative-start"),
+        pytest.param(6, 2, id="end-before-start"),
+    ],
+)
+def test_decode_blocks_drops_structurally_invalid_ranges(start: int, end: int) -> None:
+    element = chat_pb2.StructuralElement(
+        start_index=start,
+        end_index=end,
+        paragraph=chat_pb2.Paragraph(),
+    )
+
+    assert decode_blocks([element]) == ()
+
+
+def test_decode_blocks_sorts_by_declared_offsets() -> None:
+    blocks = decode_blocks(
+        [
+            _paragraph("second", start=10, end=16),
+            _paragraph("first", start=0, end=5),
+        ]
+    )
+
+    assert [(block.start_index, block.end_index) for block in blocks] == [(0, 5), (10, 16)]
+
+
+def test_paragraph_spans_skip_non_text_and_inverted_elements() -> None:
+    paragraph = chat_pb2.Paragraph(
+        elements=[
+            # end < start -> rejected before the text_run check.
+            chat_pb2.ParagraphElement(
+                start_index=5, end_index=1, text_run=chat_pb2.TextRun(content="bad")
+            ),
+            # No text_run -> not a span.
+            chat_pb2.ParagraphElement(
+                start_index=0, end_index=3, image=chat_pb2.Image(url="https://x.invalid/i")
+            ),
+            # No text_style -> the style-less span defaults.
+            chat_pb2.ParagraphElement(
+                start_index=3, end_index=7, text_run=chat_pb2.TextRun(content="ok!!")
+            ),
+        ]
+    )
+    element = chat_pb2.StructuralElement(start_index=0, end_index=7, paragraph=paragraph)
+
+    [block] = decode_blocks([element])
+
+    [span] = block.spans
+    assert (span.start_index, span.end_index, span.text) == (3, 7, "ok!!")
+    assert (span.bold, span.italic, span.underline, span.url) == (False, False, False, None)
+
+
+def test_paragraph_style_and_list_type_out_of_range_fall_back_to_unspecified() -> None:
+    element = _paragraph(
+        "x",
+        named_style=99,
+        bullet=chat_pb2.BulletInfo(list_type=99, nesting_level=1, glyph="*", ordinal=0),
+    )
+
+    [block] = decode_blocks([element])
+
+    assert block.style is BlockStyle.UNSPECIFIED
+    assert block.list_info is not None
+    assert block.list_info.style is ListStyle.UNSPECIFIED
+    # ordinal 0 is "unset" on the wire and normalises to ``None``.
+    assert block.list_info.ordinal is None
+
+
+def test_unknown_structural_variant_decodes_as_unknown_kind() -> None:
+    [block] = decode_blocks([chat_pb2.StructuralElement(start_index=0, end_index=1)])
+
+    assert block.kind is BlockKind.UNKNOWN
+    assert block.spans == ()
+
+
+# --------------------------------------------------------------------------
+# Table decoding: clamping, empty cells, nested content
+# --------------------------------------------------------------------------
+
+
+def test_decode_table_clamps_cells_and_keeps_nested_spans() -> None:
+    table = chat_pb2.Table(
+        table_rows=[
+            # Row entirely outside the block bounds -> dropped.
+            chat_pb2.TableRow(start_index=100, end_index=120),
+            chat_pb2.TableRow(
+                start_index=0,
+                end_index=20,
+                table_cells=[
+                    # Zero-width cell: recorded, but its content is not descended.
+                    chat_pb2.TableCell(
+                        start_index=0,
+                        end_index=0,
+                        content=[_paragraph("ignored", start=0, end=0)],
+                    ),
+                    # Cell whose declared end runs past the row -> clamped to 20.
+                    chat_pb2.TableCell(
+                        start_index=2,
+                        end_index=999,
+                        content=[_paragraph("cell", start=2, end=6)],
+                    ),
+                    # Inverted cell -> dropped.
+                    chat_pb2.TableCell(start_index=9, end_index=4),
+                ],
+            ),
+        ]
+    )
+    element = chat_pb2.StructuralElement(start_index=0, end_index=20, table=table)
+
+    [block] = decode_blocks([element])
+
+    assert block.kind is BlockKind.TABLE
+    [row] = block.table_rows
+    assert [(cell.start_index, cell.end_index) for cell in row] == [(0, 0), (2, 20)]
+    assert [span.text for span in block.spans] == ["cell"]
+
+
+def test_decode_table_skips_cell_children_that_fail_range_admission() -> None:
+    """A child whose declared range escapes its cell contributes no spans."""
+    table = chat_pb2.Table(
+        table_rows=[
+            chat_pb2.TableRow(
+                start_index=0,
+                end_index=10,
+                table_cells=[
+                    chat_pb2.TableCell(
+                        start_index=0,
+                        end_index=10,
+                        content=[
+                            # Inverted child range -> ``_decode_block`` returns None.
+                            _paragraph("dropped", start=9, end=2),
+                            _paragraph("kept", start=0, end=4),
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    element = chat_pb2.StructuralElement(start_index=0, end_index=10, table=table)
+
+    [block] = decode_blocks([element])
+
+    assert [span.text for span in block.spans] == ["kept"]
+
+
+def test_decode_table_drops_rows_whose_cells_are_all_empty() -> None:
+    table = chat_pb2.Table(
+        table_rows=[
+            chat_pb2.TableRow(
+                start_index=0,
+                end_index=10,
+                table_cells=[chat_pb2.TableCell(start_index=0, end_index=0)],
+            )
+        ]
+    )
+    element = chat_pb2.StructuralElement(start_index=0, end_index=10, table=table)
+
+    [block] = decode_blocks([element])
+
+    assert block.table_rows == ()
+
+
+def _nested_tables(depth: int) -> chat_pb2.StructuralElement:
+    """Build ``depth`` table-in-cell levels around a ``deep`` paragraph.
+
+    Built by in-place mutation: the ``chat_pb2.X(...)`` constructors round-trip
+    through the wire format and would trip protobuf's own 100-level recursion
+    limit long before the codec's structural cap.
+    """
+    root = chat_pb2.StructuralElement(start_index=0, end_index=4)
+    element = root
+    for _ in range(depth):
+        row = element.table.table_rows.add(start_index=0, end_index=4)
+        cell = row.table_cells.add(start_index=0, end_index=4)
+        element = cell.content.add(start_index=0, end_index=4)
+    run = element.paragraph.elements.add(start_index=0, end_index=4)
+    run.text_run.content = "deep"
+    return root
+
+
+def test_decode_table_descends_nesting_below_the_structural_depth_cap() -> None:
+    [block] = decode_blocks([_nested_tables(3)])
+
+    assert [span.text for span in block.spans] == ["deep"]
+
+
+def test_decode_table_stops_descending_past_the_structural_depth_cap() -> None:
+    """Beyond 64 levels the codec stops descending instead of recursing."""
+    [block] = decode_blocks([_nested_tables(70)])
+
+    assert block.spans == ()
+
+
+# --------------------------------------------------------------------------
+# decode_document: body guard + annotation admission
+# --------------------------------------------------------------------------
+
+
+def test_decode_document_without_body_is_empty() -> None:
+    decoded = decode_document(chat_pb2.TailwindDoc())
+
+    assert decoded.blocks == ()
+    assert decoded.annotations == ()
+
+
+def test_decode_document_admits_only_well_formed_annotations() -> None:
+    body = chat_pb2.Body(content=[_paragraph("hello")])
+    entries = body.inline_object_locations
+    # No object_id at all.
+    entries.add().content_range.end_index = 4
+    # Empty object id.
+    empty_id = entries.add()
+    empty_id.object_id.id = ""
+    empty_id.content_range.end_index = 4
+    # No content_range.
+    entries.add().object_id.id = "obj-no-range"
+    # Inverted range.
+    inverted = entries.add()
+    inverted.object_id.id = "obj-inverted"
+    inverted.content_range.start_index = 9
+    inverted.content_range.end_index = 2
+    # Admitted.
+    good = entries.add()
+    good.object_id.id = "obj-good"
+    good.content_range.start_index = 1
+    good.content_range.end_index = 4
+
+    decoded = decode_document(chat_pb2.TailwindDoc(body=body))
+
+    assert [(a.object_id, a.start_index, a.end_index) for a in decoded.annotations] == [
+        ("obj-good", 1, 4)
+    ]
+
+
+# --------------------------------------------------------------------------
+# Plain-text rendering
+# --------------------------------------------------------------------------
+
+
+def test_tailwind_doc_plain_text_without_body_is_empty() -> None:
+    assert tailwind_doc_plain_text(chat_pb2.TailwindDoc()) == ""
+
+
+def test_plain_text_renders_every_text_bearing_variant_in_wire_order() -> None:
+    document = _doc(
+        _paragraph("para"),
+        chat_pb2.StructuralElement(
+            table=chat_pb2.Table(
+                table_rows=[
+                    chat_pb2.TableRow(
+                        table_cells=[
+                            chat_pb2.TableCell(content=[_paragraph("cell")]),
+                        ]
+                    )
+                ]
+            )
+        ),
+        chat_pb2.StructuralElement(code_block=chat_pb2.CodeBlock(content="code()")),
+        chat_pb2.StructuralElement(a2ui_block=chat_pb2.A2uiBlock(json='{"a":1}')),
+        chat_pb2.StructuralElement(thought=chat_pb2.Thought(elements=[_paragraph("thinking")])),
+        # Metadata-only leaves contribute nothing.
+        chat_pb2.StructuralElement(image=chat_pb2.Image(url="https://x.invalid/i")),
+        chat_pb2.StructuralElement(horizontal_rule=chat_pb2.HorizontalRule()),
+    )
+
+    assert tailwind_doc_plain_text(document) == 'para\ncell\ncode()\n{"a":1}\nthinking'
+
+
+def test_plain_text_skips_empty_leaf_payloads() -> None:
+    document = _doc(
+        chat_pb2.StructuralElement(code_block=chat_pb2.CodeBlock(content="")),
+        chat_pb2.StructuralElement(a2ui_block=chat_pb2.A2uiBlock(json="")),
+        _paragraph(""),
+    )
+
+    assert tailwind_doc_plain_text(document) == ""
+
+
+def _nested_thoughts(depth: int) -> chat_pb2.StructuralElement:
+    """Build ``depth`` thought-in-thought levels around a ``deep`` paragraph."""
+    root = chat_pb2.StructuralElement()
+    element = root
+    for _ in range(depth):
+        element = element.thought.elements.add()
+    element.paragraph.elements.add().text_run.content = "deep"
+    return root
+
+
+def test_plain_text_descends_nesting_below_the_structural_depth_cap() -> None:
+    assert structural_elements_plain_text([_nested_thoughts(3)]) == "deep"
+
+
+def test_plain_text_stops_at_the_structural_depth_cap() -> None:
+    assert structural_elements_plain_text([_nested_thoughts(70)]) == ""
+
+
+# --------------------------------------------------------------------------
+# Markdown rendering
+# --------------------------------------------------------------------------
+
+
+def test_tailwind_doc_markdown_without_body_is_empty() -> None:
+    assert tailwind_doc_markdown(chat_pb2.TailwindDoc()) == ""
+
+
+def test_inline_markdown_applies_every_admitted_text_style() -> None:
+    style = chat_pb2.TextStyle(
+        bold=True,
+        italic=True,
+        underline=True,
+        code=True,
+        strikethrough=True,
+        math=1,
+        url="https://example.invalid/a",
+    )
+
+    rendered = structural_element_markdown(_paragraph("t", style=style))
+
+    assert rendered == "[$<u>~~***`t`***~~</u>$](https://example.invalid/a)"
+
+
+def test_inline_markdown_leaves_unstyled_runs_verbatim() -> None:
+    """A present-but-empty ``text_style`` adds no wrappers."""
+    rendered = structural_element_markdown(_paragraph("plain", style=chat_pb2.TextStyle()))
+
+    assert rendered == "plain"
+
+
+def test_inline_markdown_renders_image_and_resource_elements() -> None:
+    paragraph = chat_pb2.Paragraph(
+        elements=[
+            chat_pb2.ParagraphElement(image=chat_pb2.Image(url="https://x.invalid/i")),
+            chat_pb2.ParagraphElement(resource=chat_pb2.Resource(id="res-1")),
+            # Empty image/resource payloads are skipped entirely.
+            chat_pb2.ParagraphElement(image=chat_pb2.Image()),
+            chat_pb2.ParagraphElement(resource=chat_pb2.Resource(id="")),
+        ]
+    )
+    element = chat_pb2.StructuralElement(paragraph=paragraph)
+
+    assert structural_element_markdown(element) == "![image](https://x.invalid/i)[resource: res-1]"
+
+
+def test_empty_paragraph_renders_as_empty_string() -> None:
+    assert structural_element_markdown(_paragraph("")) == ""
+
+
+@pytest.mark.parametrize(
+    ("bullet", "expected"),
+    [
+        pytest.param(
+            chat_pb2.BulletInfo(list_type=2, nesting_level=1, absolute_ordinal=7),
+            "  7. item",
+            id="ordered-absolute-ordinal",
+        ),
+        pytest.param(
+            chat_pb2.BulletInfo(list_type=2, ordinal=3),
+            "3. item",
+            id="ordered-falls-back-to-ordinal",
+        ),
+        pytest.param(
+            chat_pb2.BulletInfo(list_type=2),
+            "1. item",
+            id="ordered-defaults-to-one",
+        ),
+        pytest.param(
+            chat_pb2.BulletInfo(list_type=1, nesting_level=2),
+            "    - item",
+            id="unordered-indented",
+        ),
+        pytest.param(
+            chat_pb2.BulletInfo(list_type=1, nesting_level=50),
+            "  " * 12 + "- item",
+            id="indent-clamped-at-twelve",
+        ),
+    ],
+)
+def test_bullet_markdown_variants(bullet: chat_pb2.BulletInfo, expected: str) -> None:
+    assert structural_element_markdown(_paragraph("item", bullet=bullet)) == expected
+
+
+@pytest.mark.parametrize(
+    ("named_style", "expected"),
+    [
+        pytest.param(1, "head", id="normal-text-unprefixed"),
+        pytest.param(2, "# head", id="title"),
+        pytest.param(3, "## head", id="subtitle"),
+        pytest.param(4, "# head", id="heading-1"),
+        pytest.param(9, "###### head", id="heading-6"),
+        pytest.param(42, "head", id="out-of-range-unprefixed"),
+    ],
+)
+def test_named_style_markdown_variants(named_style: int, expected: str) -> None:
+    assert structural_element_markdown(_paragraph("head", named_style=named_style)) == expected
+
+
+def test_table_markdown_pads_ragged_rows_and_escapes_pipes() -> None:
+    table = chat_pb2.Table(
+        table_rows=[
+            chat_pb2.TableRow(
+                table_cells=[
+                    chat_pb2.TableCell(content=[_paragraph("a|b")]),
+                    chat_pb2.TableCell(content=[_paragraph("c"), _paragraph(""), _paragraph("d")]),
+                ]
+            ),
+            chat_pb2.TableRow(table_cells=[chat_pb2.TableCell(content=[_paragraph("e")])]),
+        ]
+    )
+
+    rendered = structural_element_markdown(chat_pb2.StructuralElement(table=table))
+
+    # The short second row is padded out to the widest row.
+    assert rendered == "| a\\|b | c<br>d |\n| --- | --- |\n| e |  |"
+
+
+def test_table_markdown_without_rows_is_empty() -> None:
+    element = chat_pb2.StructuralElement(table=chat_pb2.Table())
+
+    assert structural_element_markdown(element) == ""
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        pytest.param(
+            chat_pb2.StructuralElement(horizontal_rule=chat_pb2.HorizontalRule()),
+            "---",
+            id="horizontal-rule",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(
+                code_block=chat_pb2.CodeBlock(content="x = 1", language_hint="python")
+            ),
+            "```python\nx = 1\n```",
+            id="code-block-with-hint",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(code_block=chat_pb2.CodeBlock(content="x")),
+            "```\nx\n```",
+            id="code-block-without-hint",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(a2ui_block=chat_pb2.A2uiBlock(json="{}")),
+            "```json\n{}\n```",
+            id="a2ui-block",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(image=chat_pb2.Image(url="https://x.invalid/i")),
+            "![image](https://x.invalid/i)",
+            id="image",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(image=chat_pb2.Image()),
+            "",
+            id="image-without-url",
+        ),
+        pytest.param(
+            chat_pb2.StructuralElement(),
+            "",
+            id="unset-variant",
+        ),
+    ],
+)
+def test_leaf_markdown_variants(element: chat_pb2.StructuralElement, expected: str) -> None:
+    assert structural_element_markdown(element) == expected
+
+
+def test_thought_markdown_joins_non_empty_children() -> None:
+    element = chat_pb2.StructuralElement(
+        thought=chat_pb2.Thought(elements=[_paragraph("one"), _paragraph(""), _paragraph("two")])
+    )
+
+    assert structural_element_markdown(element) == "one\n\ntwo"
+
+
+def test_tailwind_doc_markdown_joins_blocks_and_drops_empty_ones() -> None:
+    document = _doc(
+        _paragraph("intro"),
+        _paragraph(""),
+        chat_pb2.StructuralElement(horizontal_rule=chat_pb2.HorizontalRule()),
+        _paragraph("outro"),
+    )
+
+    assert tailwind_doc_markdown(document) == "intro\n\n---\n\noutro"

--- a/tests/unit/android/test_note_codec.py
+++ b/tests/unit/android/test_note_codec.py
@@ -1,0 +1,296 @@
+"""Unit coverage for the Android note codec's admission and failure branches.
+
+The adapter-level suites drive these through ``AndroidNotesAPI``. These cases
+call the codec directly to reach the id guards, the mind-map classifier's
+fallbacks, and the ``DecodingError`` wrapping that turns an unexpected shape
+into a named drift signal instead of an ``AttributeError``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from notebooklm._android.codecs.notes import (
+    build_saved_response_payload,
+    decode_note,
+    decode_note_backed_mind_map_rows,
+    decode_note_backed_mind_maps,
+    decode_note_by_id,
+    decode_note_entries,
+    is_note_backed_mind_map,
+)
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
+    notes_pb2,
+)
+from notebooklm.exceptions import DecodingError
+from notebooklm.types import ChatReference, MindMapKind
+
+METHOD_ID = "test-method"
+NB = "notebook-1"
+
+_MIND_MAP_JSON = json.dumps({"name": "root", "children": [{"name": "leaf"}]})
+
+
+def _note(
+    note_id: str = "note-1",
+    *,
+    name: str = "Title",
+    content: str = "Body",
+    prompt_type: int | None = None,
+) -> Any:
+    note = notes_pb2.ProjectNote(id=note_id, name=name, content=content)
+    if prompt_type is not None:
+        note.metadata.note_prompt_type = prompt_type
+    return note
+
+
+def _response(*notes: Any, include_status_row: bool = False) -> Any:
+    response = notes_pb2.GetNotesResponse()
+    if include_status_row:
+        # A ``NoteOrStatus`` without the note arm: neither a deletion nor an error.
+        response.notes.add()
+    for note in notes:
+        response.notes.add().note.CopyFrom(note)
+    return response
+
+
+class _ExplodingResponse:
+    """Stands in for a response whose shape drifted out from under the codec."""
+
+    @property
+    def notes(self) -> Any:
+        raise AttributeError("notes")
+
+
+# ---------------------------------------------------------------------------
+# decode_note
+# ---------------------------------------------------------------------------
+
+
+def test_decode_note_projects_the_evidenced_fields() -> None:
+    decoded = decode_note(_note(), NB, method_id=METHOD_ID)
+
+    assert (decoded.id, decoded.notebook_id, decoded.title, decoded.content) == (
+        "note-1",
+        NB,
+        "Title",
+        "Body",
+    )
+    # ``last_edit_timestamp`` is not creation time, so it is left unknown.
+    assert decoded.created_at is None
+
+
+def test_decode_note_rejects_a_row_without_an_id() -> None:
+    with pytest.raises(DecodingError, match="did not contain a note id"):
+        decode_note(_note(""), NB, method_id=METHOD_ID)
+
+
+def test_decode_note_wraps_an_unexpected_shape() -> None:
+    with pytest.raises(DecodingError, match="Could not decode Android note response"):
+        decode_note(object(), NB, method_id=METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# decode_note_entries
+# ---------------------------------------------------------------------------
+
+
+def test_decode_note_entries_skips_status_rows_and_mind_maps() -> None:
+    response = _response(
+        _note("note-1"),
+        _note("map-1", content=_MIND_MAP_JSON),
+        include_status_row=True,
+    )
+
+    decoded = decode_note_entries(response, NB, method_id=METHOD_ID)
+
+    assert [note.id for note in decoded] == ["note-1"]
+
+
+def test_decode_note_entries_propagates_a_row_level_decoding_error() -> None:
+    response = _response(_note(""))
+
+    with pytest.raises(DecodingError, match="did not contain a note id"):
+        decode_note_entries(response, NB, method_id=METHOD_ID)
+
+
+def test_decode_note_entries_wraps_an_unexpected_shape() -> None:
+    with pytest.raises(DecodingError, match="Could not decode Android notes response"):
+        decode_note_entries(_ExplodingResponse(), NB, method_id=METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# decode_note_by_id
+# ---------------------------------------------------------------------------
+
+
+def test_decode_note_by_id_returns_an_exact_match_including_a_mind_map() -> None:
+    """``list`` filters mind maps out; an exact id lookup does not."""
+    response = _response(_note("note-1"), _note("map-1", content=_MIND_MAP_JSON))
+
+    decoded = decode_note_by_id(response, NB, "map-1", method_id=METHOD_ID)
+
+    assert decoded is not None
+    assert decoded.id == "map-1"
+
+
+def test_decode_note_by_id_returns_none_when_absent() -> None:
+    response = _response(_note("note-1"), include_status_row=True)
+
+    assert decode_note_by_id(response, NB, "absent", method_id=METHOD_ID) is None
+
+
+def test_decode_note_by_id_propagates_a_row_level_decoding_error() -> None:
+    """A matching row with a blank id cannot be silently reported as absent."""
+
+    class _BlankIdMatch:
+        class _Entry:
+            def HasField(self, _name: str) -> bool:
+                return True
+
+            note = _note("")
+
+        notes = (_Entry(),)
+
+    with pytest.raises(DecodingError):
+        decode_note_by_id(_BlankIdMatch(), NB, "", method_id=METHOD_ID)
+
+
+def test_decode_note_by_id_wraps_an_unexpected_shape() -> None:
+    with pytest.raises(DecodingError, match="exact-id response"):
+        decode_note_by_id(_ExplodingResponse(), NB, "note-1", method_id=METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# is_note_backed_mind_map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("content", "prompt_type", "expected"),
+    [
+        pytest.param("", notes_pb2.MIND_MAP, True, id="android-prompt-enum"),
+        pytest.param(_MIND_MAP_JSON, None, True, id="children-key"),
+        pytest.param('{"nodes": []}', None, True, id="legacy-nodes-key"),
+        pytest.param('{"name": "x"}', None, False, id="object-without-either-key"),
+        pytest.param("[1, 2]", None, False, id="non-object-json"),
+        pytest.param("not json", None, False, id="unparseable"),
+        pytest.param("", None, False, id="empty-content"),
+    ],
+)
+def test_mind_map_classifier_admits_either_exact_signal(
+    content: str, prompt_type: int | None, expected: bool
+) -> None:
+    assert is_note_backed_mind_map(_note(content=content, prompt_type=prompt_type)) is expected
+
+
+# ---------------------------------------------------------------------------
+# decode_note_backed_mind_map_rows / decode_note_backed_mind_maps
+# ---------------------------------------------------------------------------
+
+
+def test_mind_map_rows_carry_only_the_two_evidenced_slots() -> None:
+    response = _response(
+        _note("note-1"),
+        _note("map-1", content=_MIND_MAP_JSON),
+        include_status_row=True,
+    )
+
+    assert decode_note_backed_mind_map_rows(response, method_id=METHOD_ID) == [
+        ["map-1", _MIND_MAP_JSON]
+    ]
+
+
+def test_mind_map_rows_reject_a_row_without_an_id() -> None:
+    response = _response(_note("", content=_MIND_MAP_JSON))
+
+    with pytest.raises(DecodingError, match="did not contain a note id"):
+        decode_note_backed_mind_map_rows(response, method_id=METHOD_ID)
+
+
+def test_mind_map_rows_wrap_an_unexpected_shape() -> None:
+    with pytest.raises(DecodingError, match="mind-map rows"):
+        decode_note_backed_mind_map_rows(_ExplodingResponse(), method_id=METHOD_ID)
+
+
+def test_mind_maps_project_the_parsed_tree_without_guessing_creation_time() -> None:
+    response = _response(
+        _note("note-1"),
+        _note("map-1", name="Concepts", content=_MIND_MAP_JSON),
+        include_status_row=True,
+    )
+
+    [mind_map] = decode_note_backed_mind_maps(response, NB, method_id=METHOD_ID)
+
+    assert (mind_map.id, mind_map.title) == ("map-1", "Concepts")
+    assert mind_map.kind is MindMapKind.NOTE_BACKED
+    assert mind_map.created_at is None
+    assert mind_map.tree == json.loads(_MIND_MAP_JSON)
+
+
+def test_mind_maps_leave_an_unparseable_tree_unset() -> None:
+    response = _response(_note("map-1", content="", prompt_type=notes_pb2.MIND_MAP))
+
+    [mind_map] = decode_note_backed_mind_maps(response, NB, method_id=METHOD_ID)
+
+    assert mind_map.tree is None
+
+
+def test_mind_maps_reject_a_row_without_an_id() -> None:
+    response = _response(_note("", content=_MIND_MAP_JSON))
+
+    with pytest.raises(DecodingError, match="did not contain a note id"):
+        decode_note_backed_mind_maps(response, NB, method_id=METHOD_ID)
+
+
+def test_mind_maps_wrap_an_unexpected_shape() -> None:
+    with pytest.raises(DecodingError, match="note-backed mind maps response"):
+        decode_note_backed_mind_maps(_ExplodingResponse(), NB, method_id=METHOD_ID)
+
+
+# ---------------------------------------------------------------------------
+# build_saved_response_payload
+# ---------------------------------------------------------------------------
+
+
+def _reference(**kwargs: Any) -> ChatReference:
+    kwargs.setdefault("source_id", "src-1")
+    return ChatReference(**kwargs)
+
+
+def test_saved_response_payload_skips_unusable_and_duplicate_chunks() -> None:
+    references = [
+        _reference(chunk_id=None, cited_text="no chunk id"),
+        _reference(chunk_id="", cited_text="empty chunk id"),
+        _reference(chunk_id="c1", cited_text="first", start_char=3, end_char=8),
+        _reference(chunk_id="c1", cited_text="duplicate"),
+    ]
+
+    passages, _document = build_saved_response_payload(references[2].cited_text, references, [])
+
+    assert len(passages) == 1
+
+
+def test_saved_response_payload_zeroes_the_range_of_an_empty_citation() -> None:
+    """A structural anchor carries no text, so its source range collapses."""
+    reference = _reference(chunk_id="c1", cited_text=None, start_char=5, end_char=9)
+
+    _passages, document = build_saved_response_payload("answer", [reference], [])
+
+    [item] = document.objects
+    [range_] = item.citation.ranges
+    assert (range_.start_index, range_.end_index) == (0, 0)
+
+
+def test_saved_response_payload_anchors_only_chunks_it_can_key_on() -> None:
+    anchored = _reference(chunk_id="c1", cited_text="cited")
+    unkeyed = _reference(chunk_id=None, cited_text="cited")
+
+    _passages, document = build_saved_response_payload(
+        "answer", [anchored], [(anchored, 4), (unkeyed, 6)]
+    )
+
+    assert [entry.object_id.id for entry in document.body.inline_object_locations] == ["c1"]

--- a/tests/unit/android/test_organization_adapters.py
+++ b/tests/unit/android/test_organization_adapters.py
@@ -1003,3 +1003,251 @@ def test_strict_codecs_reject_malformed_ids_without_echoing_them() -> None:
     )
     with pytest.raises(DecodingError, match="malformed notebook member ID"):
         decode_collections(response, method_id=GET_LABELS_METHOD)
+
+
+# ---------------------------------------------------------------------------
+# Read-back and write-failure branches shared by both organization adapters
+# ---------------------------------------------------------------------------
+
+
+class _VanishingResourceServer(FakeOrganizationServer):
+    """Drops the mutated label/collection right after the write lands.
+
+    Models a concurrent delete landing between the mutation and the read-back,
+    which is the only way the adapters' post-write ``is None`` guards fire.
+    """
+
+    async def unary(self, method: str, request: Any, **kwargs: Any) -> Any:
+        response = await super().unary(method, request, **kwargs)
+        if method == MUTATE_LABEL_METHOD:
+            self.labels[NB].pop(LABEL_A, None)
+            self.collections.pop(COLLECTION_A, None)
+        return response
+
+
+class _DeleteThenReportMissingServer(FakeOrganizationServer):
+    """Applies the delete, then answers ``NOT_FOUND`` — a benign double-delete."""
+
+    async def unary(self, method: str, request: Any, **kwargs: Any) -> Any:
+        response = await super().unary(method, request, **kwargs)
+        if method == DELETE_LABELS_METHOD:
+            raise RPCError("already deleted", method_id=DELETE_LABELS_METHOD, rpc_code=5)
+        return response
+
+
+async def test_label_get_returns_the_matching_row() -> None:
+    labels, _collections = _apis(FakeOrganizationServer())
+
+    label = await labels.get(NB, LABEL_A)
+
+    assert (label.id, label.name, label.emoji) == (LABEL_A, "Papers", "📄")
+
+
+async def test_collection_get_returns_the_matching_row() -> None:
+    _labels, collections = _apis(FakeOrganizationServer())
+
+    collection = await collections.get(COLLECTION_A)
+
+    assert (collection.id, collection.name) == (COLLECTION_A, "Research")
+
+
+async def test_label_sources_rejects_an_absent_label() -> None:
+    labels, _collections = _apis(FakeOrganizationServer())
+
+    with pytest.raises(LabelNotFoundError):
+        await labels.sources(NB, LABEL_MISSING)
+
+
+async def test_collection_notebooks_rejects_an_absent_collection() -> None:
+    _labels, collections = _apis(FakeOrganizationServer())
+
+    with pytest.raises(CollectionNotFoundError):
+        await collections.notebooks(COLLECTION_MISSING)
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_create_treats_an_undecodable_echo_as_unconfirmed(kind: str) -> None:
+    """A malformed created row cannot be reported as a clean success."""
+    server = FakeOrganizationServer()
+    if kind == "label":
+        server.create_response_override = organization_pb2.CreateLabelResponse(
+            label_and_sources=[organization_pb2.LabelAndSources(label="X", label_id="not-a-uuid")]
+        )
+    else:
+        server.create_response_override = organization_pb2.CreateLabelResponse(
+            notebook_collections=[organization_pb2.NotebookCollection(name="X", id="not-a-uuid")]
+        )
+    labels, collections = _apis(server)
+
+    with pytest.raises(DecodingError) as caught:
+        if kind == "label":
+            await labels.create(NB, "Requested")
+        else:
+            await collections.create("Requested")
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+async def test_label_update_rejects_an_absent_label() -> None:
+    labels, _collections = _apis(FakeOrganizationServer())
+
+    with pytest.raises(LabelNotFoundError):
+        await labels.update(NB, LABEL_MISSING, name="New")
+
+
+async def test_collection_update_rejects_an_absent_collection() -> None:
+    _labels, collections = _apis(FakeOrganizationServer())
+
+    with pytest.raises(CollectionNotFoundError):
+        await collections.rename(COLLECTION_MISSING, "New")
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_property_write_not_found_maps_to_the_typed_miss(kind: str) -> None:
+    """The property write has already proven the resource existed on read."""
+    server = FakeOrganizationServer()
+    server.failures[2] = RPCError("gone", method_id=MUTATE_LABEL_METHOD, rpc_code=5)
+    labels, collections = _apis(server)
+
+    expected = LabelNotFoundError if kind == "label" else CollectionNotFoundError
+    with pytest.raises(expected):
+        if kind == "label":
+            await labels.update(NB, LABEL_A, name="New")
+        else:
+            await collections.rename(COLLECTION_A, "New")
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_property_write_other_rpc_errors_propagate_unchanged(kind: str) -> None:
+    server = FakeOrganizationServer()
+    denied = RPCError("denied", method_id=MUTATE_LABEL_METHOD, rpc_code=7)
+    server.failures[2] = denied
+    labels, collections = _apis(server)
+
+    with pytest.raises(RPCError) as caught:
+        if kind == "label":
+            await labels.update(NB, LABEL_A, name="New")
+        else:
+            await collections.rename(COLLECTION_A, "New")
+
+    assert caught.value is denied
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_property_write_read_back_absence_maps_to_the_typed_miss(kind: str) -> None:
+    labels, collections = _apis(_VanishingResourceServer())
+
+    expected = LabelNotFoundError if kind == "label" else CollectionNotFoundError
+    with pytest.raises(expected):
+        if kind == "label":
+            await labels.update(NB, LABEL_A, name="New")
+        else:
+            await collections.rename(COLLECTION_A, "New")
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_property_write_that_does_not_stick_is_reported_as_drift(kind: str) -> None:
+    server = FakeOrganizationServer()
+    server.ignore_mutations = True
+    labels, collections = _apis(server)
+
+    with pytest.raises(DecodingError, match="did not read back the requested properties"):
+        if kind == "label":
+            await labels.update(NB, LABEL_A, name="Renamed")
+        else:
+            await collections.rename(COLLECTION_A, "Renamed")
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_membership_read_back_absence_maps_to_the_typed_miss(kind: str) -> None:
+    labels, collections = _apis(_VanishingResourceServer())
+
+    expected = LabelNotFoundError if kind == "label" else CollectionNotFoundError
+    with pytest.raises(expected):
+        if kind == "label":
+            await labels.add_sources(NB, LABEL_A, [SOURCE_B])
+        else:
+            await collections.add_notebooks(COLLECTION_A, [NB_B])
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_membership_write_that_does_not_stick_is_reported_as_drift(kind: str) -> None:
+    server = FakeOrganizationServer()
+    server.ignore_mutations = True
+    labels, collections = _apis(server)
+
+    with pytest.raises(DecodingError, match="did not read back the requested state"):
+        if kind == "label":
+            await labels.add_sources(NB, LABEL_A, [SOURCE_B])
+        else:
+            await collections.add_notebooks(COLLECTION_A, [NB_B])
+
+
+async def test_label_membership_other_rpc_errors_skip_the_absence_probe() -> None:
+    """Only ``NOT_FOUND`` is ambiguous — anything else propagates immediately."""
+    server = FakeOrganizationServer()
+    denied = RPCError("denied", method_id=MUTATE_LABEL_METHOD, rpc_code=7)
+    server.failures[1] = denied
+    labels, _collections = _apis(server)
+
+    with pytest.raises(RPCError) as caught:
+        await labels.add_sources(NB, LABEL_A, [SOURCE_B])
+
+    assert caught.value is denied
+    assert [method for method, _request, _kwargs in server.calls] == [MUTATE_LABEL_METHOD]
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_delete_of_only_unknown_ids_issues_no_write(kind: str) -> None:
+    server = FakeOrganizationServer()
+    labels, collections = _apis(server)
+
+    if kind == "label":
+        await labels.delete(NB, [LABEL_MISSING])
+    else:
+        await collections.delete([COLLECTION_MISSING])
+
+    assert [method for method, _request, _kwargs in server.calls] == [GET_LABELS_METHOD]
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_delete_tolerates_a_not_found_answer_once_absence_is_proven(kind: str) -> None:
+    server = _DeleteThenReportMissingServer()
+    labels, collections = _apis(server)
+
+    if kind == "label":
+        await labels.delete(NB, LABEL_A)
+        assert LABEL_A not in server.labels[NB]
+    else:
+        await collections.delete(COLLECTION_A)
+        assert COLLECTION_A not in server.collections
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_delete_propagates_non_not_found_rpc_errors(kind: str) -> None:
+    server = FakeOrganizationServer()
+    denied = RPCError("denied", method_id=DELETE_LABELS_METHOD, rpc_code=7)
+    server.failures[2] = denied
+    labels, collections = _apis(server)
+
+    with pytest.raises(RPCError) as caught:
+        if kind == "label":
+            await labels.delete(NB, LABEL_A)
+        else:
+            await collections.delete(COLLECTION_A)
+
+    assert caught.value is denied
+
+
+@pytest.mark.parametrize("kind", ["label", "collection"])
+async def test_delete_that_does_not_remove_the_row_is_reported_as_drift(kind: str) -> None:
+    """A swallowed ``NOT_FOUND`` still has to prove absence on read-back."""
+    server = FakeOrganizationServer()
+    server.failures[2] = RPCError("gone", method_id=DELETE_LABELS_METHOD, rpc_code=5)
+    labels, collections = _apis(server)
+
+    with pytest.raises(DecodingError, match="did not read back absence"):
+        if kind == "label":
+            await labels.delete(NB, LABEL_A)
+        else:
+            await collections.delete(COLLECTION_A)

--- a/tests/unit/android/test_upload_helpers.py
+++ b/tests/unit/android/test_upload_helpers.py
@@ -1,0 +1,320 @@
+"""Unit coverage for the Android uploader's pure admission helpers.
+
+These sit in front of every byte the adapter sends: the MIME resolution, the
+HTML refusal, the Drive metadata gate, and the timeout projection. The adapter
+suites exercise their accept paths; these cases pin the rejections, which is
+where a regression would silently widen what the client is willing to upload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._android.upload import (
+    _drive_filename,
+    _drive_resource_key_headers,
+    _resolve_upload_content_type,
+    _resolve_upload_timeouts,
+    _validate_drive_metadata,
+    _validate_upload_file_supported,
+)
+from notebooklm._source.drive import DriveRef
+from notebooklm.exceptions import ValidationError
+
+FILE_ID = "1AbCdEf"
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": "paper.pdf", "mimeType": "application/pdf"}
+    metadata.update(overrides)
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# _resolve_upload_content_type
+# ---------------------------------------------------------------------------
+
+
+def test_an_explicit_mime_type_wins_and_is_stripped() -> None:
+    assert _resolve_upload_content_type(Path("notes.md"), "  text/plain  ") == "text/plain"
+
+
+@pytest.mark.parametrize("mime_type", ["", "   "])
+def test_a_blank_explicit_mime_type_is_rejected(mime_type: str) -> None:
+    with pytest.raises(ValidationError, match="cannot be empty or whitespace-only"):
+        _resolve_upload_content_type(Path("notes.md"), mime_type)
+
+
+def test_the_pinned_table_beats_the_platform_mimetypes_database() -> None:
+    """``.docx``/``.pptx`` return nothing from the Windows registry (#2034 note)."""
+    assert _resolve_upload_content_type(Path("NOTES.MD"), None) == "text/markdown"
+    assert _resolve_upload_content_type(Path("deck.pptx"), None) == (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    )
+
+
+def test_an_unpinned_extension_falls_back_to_the_mimetypes_guess() -> None:
+    assert _resolve_upload_content_type(Path("page.json"), None) == "application/json"
+
+
+def test_an_unguessable_extension_falls_back_to_octet_stream() -> None:
+    assert _resolve_upload_content_type(Path("blob.unknownext"), None) == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# _validate_upload_file_supported
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "content_type"),
+    [
+        pytest.param("page.html", "text/plain", id="html-extension"),
+        pytest.param("page.XHTML", "text/plain", id="uppercase-extension"),
+        pytest.param("page.txt", "text/html; charset=utf-8", id="html-content-type"),
+        pytest.param("page.txt", "APPLICATION/XHTML+XML", id="uppercase-content-type"),
+    ],
+)
+def test_html_family_uploads_are_refused(name: str, content_type: str) -> None:
+    with pytest.raises(ValidationError, match="HTML file uploads are not supported"):
+        _validate_upload_file_supported(Path(name), content_type)
+
+
+def test_a_supported_upload_passes_the_gate() -> None:
+    _validate_upload_file_supported(Path("paper.pdf"), "application/pdf")
+
+
+# ---------------------------------------------------------------------------
+# _drive_resource_key_headers
+# ---------------------------------------------------------------------------
+
+
+def test_a_link_shared_file_echoes_its_resource_key() -> None:
+    headers = _drive_resource_key_headers(DriveRef(file_id=FILE_ID, resource_key="rk-1"))
+
+    assert headers == {"X-Goog-Drive-Resource-Keys": f"{FILE_ID}/rk-1"}
+
+
+def test_a_file_without_a_resource_key_sends_no_extra_header() -> None:
+    assert _drive_resource_key_headers(DriveRef(file_id=FILE_ID)) == {}
+
+
+# ---------------------------------------------------------------------------
+# _drive_filename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("paper.pdf", "paper.pdf", id="plain"),
+        pytest.param("  paper.pdf  ", "paper.pdf", id="stripped"),
+        pytest.param("a/b/paper.pdf", "paper.pdf", id="posix-path-stripped"),
+        pytest.param("a\\b\\paper.pdf", "paper.pdf", id="windows-path-stripped"),
+        pytest.param("pa\tper\x7f.pdf", "pa_per_.pdf", id="control-characters-replaced"),
+    ],
+)
+def test_drive_filename_reduces_to_one_safe_leaf(value: str, expected: str) -> None:
+    assert _drive_filename(value, FILE_ID) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param(".", id="dot"),
+        pytest.param("..", id="parent"),
+        pytest.param("dir/", id="trailing-separator"),
+        pytest.param(None, id="not-a-string"),
+        pytest.param(7, id="numeric"),
+    ],
+)
+def test_drive_filename_rejects_unusable_values(value: Any) -> None:
+    with pytest.raises(ValidationError, match="usable filename"):
+        _drive_filename(value, FILE_ID)
+
+
+def test_drive_filename_rejects_an_over_long_name() -> None:
+    with pytest.raises(ValidationError, match="too long to import safely"):
+        _drive_filename("x" * 241 + ".pdf", FILE_ID)
+
+
+def test_drive_filename_measures_length_in_utf8_bytes() -> None:
+    """A multi-byte name under the character cap can still exceed the byte cap."""
+    with pytest.raises(ValidationError, match="too long to import safely"):
+        _drive_filename("é" * 121, FILE_ID)
+
+
+# ---------------------------------------------------------------------------
+# _validate_drive_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_drive_metadata_returns_the_admitted_filename_and_mime() -> None:
+    ref = DriveRef(file_id=FILE_ID)
+
+    assert _validate_drive_metadata(_metadata(), ref) == ("paper.pdf", "application/pdf")
+
+
+def test_drive_metadata_accepts_a_size_under_the_cap() -> None:
+    ref = DriveRef(file_id=FILE_ID)
+
+    assert _validate_drive_metadata(_metadata(size="1024"), ref)[0] == "paper.pdf"
+
+
+def test_drive_metadata_accepts_explicitly_downloadable_files() -> None:
+    ref = DriveRef(file_id=FILE_ID)
+
+    assert _validate_drive_metadata(_metadata(capabilities={"canDownload": True}), ref)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [pytest.param(None, id="none"), pytest.param([], id="list"), pytest.param("{}", id="string")],
+)
+def test_drive_metadata_rejects_a_non_object_payload(metadata: Any) -> None:
+    with pytest.raises(ValidationError, match="malformed metadata"):
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+
+@pytest.mark.parametrize(
+    "mime_type",
+    [pytest.param(None, id="absent"), pytest.param("", id="empty"), pytest.param(7, id="numeric")],
+)
+def test_drive_metadata_requires_a_mime_type(mime_type: Any) -> None:
+    with pytest.raises(ValidationError, match="did not return a MIME type"):
+        _validate_drive_metadata(_metadata(mimeType=mime_type), DriveRef(file_id=FILE_ID))
+
+
+def test_drive_metadata_routes_native_google_documents_elsewhere() -> None:
+    metadata = _metadata(name="doc.pdf", mimeType="application/vnd.google-apps.document")
+
+    with pytest.raises(ValidationError, match="sources.add_drive"):
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+
+def test_drive_metadata_rejects_malformed_capabilities() -> None:
+    with pytest.raises(ValidationError, match="malformed metadata"):
+        _validate_drive_metadata(_metadata(capabilities="yes"), DriveRef(file_id=FILE_ID))
+
+
+def test_drive_metadata_rejects_a_file_this_account_cannot_download() -> None:
+    metadata = _metadata(capabilities={"canDownload": False})
+
+    with pytest.raises(ValidationError, match="not downloadable by this account"):
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+
+def test_drive_metadata_refuses_html_before_the_extension_allowlist() -> None:
+    metadata = _metadata(name="page.html", mimeType="text/html")
+
+    with pytest.raises(ValidationError, match="HTML isn't supported"):
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+
+def test_drive_metadata_rejects_an_unsupported_extension_and_names_the_accepted_set() -> None:
+    metadata = _metadata(name="archive.zip", mimeType="application/zip")
+
+    with pytest.raises(ValidationError, match="unsupported type") as caught:
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+    assert "pdf" in str(caught.value)
+
+
+def test_drive_metadata_rejects_a_file_over_the_download_cap() -> None:
+    metadata = _metadata(size=str(200 * 1024 * 1024 + 1))
+
+    with pytest.raises(ValidationError, match="over the 200 MiB download cap"):
+        _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))
+
+
+@pytest.mark.parametrize(
+    "size", [pytest.param("huge", id="non-numeric"), pytest.param(None, id="absent")]
+)
+def test_drive_metadata_tolerates_an_undeclared_or_unparseable_size(size: Any) -> None:
+    """An unreadable size is not treated as over-cap; the stream cap still applies."""
+    metadata = _metadata()
+    if size is not None:
+        metadata["size"] = size
+
+    assert _validate_drive_metadata(metadata, DriveRef(file_id=FILE_ID))[0] == "paper.pdf"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_upload_timeouts
+# ---------------------------------------------------------------------------
+
+
+def test_an_unset_timeout_uses_the_historical_lifecycle_fence() -> None:
+    assert _resolve_upload_timeouts(None) == (300.0, None)
+
+
+def test_a_numeric_timeout_becomes_the_aggregate_with_no_per_request_override() -> None:
+    assert _resolve_upload_timeouts(45.0) == (45.0, None)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(0.0, id="zero"),
+        pytest.param(-1.0, id="negative"),
+        pytest.param(float("inf"), id="infinite"),
+        pytest.param(float("nan"), id="nan"),
+    ],
+)
+def test_a_non_positive_or_non_finite_numeric_timeout_is_rejected(value: float) -> None:
+    with pytest.raises(ValueError, match="must be a finite positive number"):
+        _resolve_upload_timeouts(value)
+
+
+def test_an_httpx_timeout_is_preserved_and_widens_the_lifecycle_fence() -> None:
+    configured = httpx.Timeout(connect=10.0, read=200.0, write=200.0, pool=10.0)
+
+    aggregate, per_request = _resolve_upload_timeouts(configured)
+
+    assert per_request is configured
+    assert aggregate == 2.0 * (10.0 + 200.0 + 200.0 + 10.0)
+
+
+def test_a_small_httpx_timeout_keeps_the_300_second_floor() -> None:
+    aggregate, per_request = _resolve_upload_timeouts(httpx.Timeout(5.0))
+
+    assert (aggregate, per_request.read) == (300.0, 5.0)
+
+
+def test_a_fully_unbounded_httpx_timeout_keeps_the_historical_fence() -> None:
+    configured = httpx.Timeout(None)
+
+    aggregate, per_request = _resolve_upload_timeouts(configured)
+
+    assert aggregate == 300.0
+    assert per_request is configured
+
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        pytest.param({"connect": 0.0}, id="zero-connect"),
+        pytest.param({"read": -1.0}, id="negative-read"),
+        pytest.param({"write": float("inf")}, id="infinite-write"),
+        pytest.param({"pool": float("nan")}, id="nan-pool"),
+    ],
+)
+def test_an_httpx_timeout_component_must_be_finite_and_positive(
+    component: dict[str, float],
+) -> None:
+    kwargs: dict[str, float | None] = {
+        "connect": 5.0,
+        "read": 5.0,
+        "write": 5.0,
+        "pool": 5.0,
+    }
+    kwargs.update(component)
+
+    with pytest.raises(ValueError, match="components must be finite positive numbers"):
+        _resolve_upload_timeouts(httpx.Timeout(**kwargs))

--- a/tests/unit/app/test_app_login_cookie.py
+++ b/tests/unit/app/test_app_login_cookie.py
@@ -463,9 +463,13 @@ def test_quiet_network_error_is_reraised_same_object(monkeypatch: pytest.MonkeyP
     assert caught.value is error
 
 
+#: ``cookie_import`` was re-pinned when the three helpers left unreferenced by
+#: the ``_app/login_cookie`` extraction (``_coerce_cookie_json_to_storage_state``,
+#: ``_normalize_imported_cookie``, ``_nonempty_cookie_names``) were deleted; the
+#: live logic behind them is unchanged and still lives in ``_app/login_cookie``.
 _SEMANTIC_HASHES = {
     "login_cookie": "ba6c11e67a09365d017b9ec46aed5e37eb7173f864ba45746ca289fc49bed2dd",
-    "cookie_import": "5a50d08f573f05bf6eba1879014d9c6736a152a37456009da8306a9f6f49281f",
+    "cookie_import": "80135a3c19f81812c3486bfab695b9348d63514901e51ac8978bbab00ba6d254",
     "browser_accounts": "0b4278d9971e3522be70481aa98d0dde869455be703aa8f24e61840fb16e79ed",
     "chromium_accounts": "3f7241d07681f66823c212bb3b8292caa59b65a402d022537b134ca3e6995c92",
     "cookie_domains": "a09898adcc9d4e9cba6308fd4bd8a13d36ca9a17bc462834eb27f5854d1e65c3",

--- a/tests/unit/app/test_download_registry_invariants.py
+++ b/tests/unit/app/test_download_registry_invariants.py
@@ -1,0 +1,216 @@
+"""Invariant guards on the canonical download registry.
+
+The registry itself is well-formed, so the ``__post_init__`` and builder
+validations never fire in production. These cases construct malformed rows to
+prove each guard bites — an unenforced invariant is a comment, and this table
+is the single source of truth for every artifact's extension and MIME type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._app import download_specs
+from notebooklm._app.download_specs import (
+    DOWNLOAD_REGISTRY,
+    DownloadFormatSpec,
+    DownloadRegistryEntry,
+)
+from notebooklm.types import ArtifactType
+
+PDF = DownloadFormatSpec(".pdf", "application/pdf")
+PPTX = DownloadFormatSpec(
+    ".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
+
+def _entry(**overrides: object) -> DownloadRegistryEntry:
+    fields: dict[str, object] = {
+        "name": "slide-deck",
+        "kind": ArtifactType.SLIDE_DECK,
+        "default_output": PDF,
+        "default_dir": "./slide-decks",
+        "download_attr": "download_slide_deck",
+    }
+    fields.update(overrides)
+    return DownloadRegistryEntry(**fields)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DownloadFormatSpec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("extension", "mime_type", "message"),
+    [
+        pytest.param("pdf", "application/pdf", "must start with '.'", id="no-leading-dot"),
+        pytest.param(".PDF", "application/pdf", "must be lowercase", id="uppercase"),
+        pytest.param(".pdf", "pdf", "must contain '/'", id="not-a-mime-type"),
+    ],
+)
+def test_format_spec_rejects_malformed_descriptors(
+    extension: str, mime_type: str, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        DownloadFormatSpec(extension, mime_type)
+
+
+# ---------------------------------------------------------------------------
+# DownloadRegistryEntry
+# ---------------------------------------------------------------------------
+
+
+def test_entry_rejects_duplicate_alternate_format_names() -> None:
+    with pytest.raises(ValueError, match="duplicate formats"):
+        _entry(
+            format_default="pdf",
+            alternate_formats=(("pptx", PPTX), ("pptx", PPTX)),
+            format_kwarg="output_format",
+        )
+
+
+def test_entry_rejects_a_default_repeated_among_the_alternates() -> None:
+    with pytest.raises(ValueError, match="is repeated for"):
+        _entry(
+            format_default="pdf",
+            alternate_formats=(("pdf", PDF),),
+            format_kwarg="output_format",
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param(
+            {"format_default": "pdf", "format_kwarg": "output_format"}, id="no-alternates"
+        ),
+        pytest.param(
+            {"alternate_formats": (("pptx", PPTX),), "format_kwarg": "output_format"},
+            id="no-default",
+        ),
+    ],
+)
+def test_entry_requires_a_default_and_alternates_together(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="must define a default and alternate formats together"):
+        _entry(**overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param(
+            {"format_default": "pdf", "alternate_formats": (("pptx", PPTX),)},
+            id="formats-without-kwarg",
+        ),
+        pytest.param({"format_kwarg": "output_format"}, id="kwarg-without-formats"),
+    ],
+)
+def test_entry_requires_a_format_kwarg_with_its_formats(overrides: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="must define its format kwarg with its formats"):
+        _entry(**overrides)
+
+
+def test_a_format_less_entry_cannot_contribute_to_the_legacy_map() -> None:
+    with pytest.raises(ValueError, match="contributes to the legacy format map"):
+        _entry(contributes_to_legacy_format_extensions=True)
+
+
+def test_formats_places_the_default_first() -> None:
+    entry = _entry(
+        format_default="pdf",
+        alternate_formats=(("pptx", PPTX),),
+        format_kwarg="output_format",
+    )
+
+    assert entry.formats == (("pdf", PDF), ("pptx", PPTX))
+
+
+def test_a_format_less_entry_exposes_no_format_axis() -> None:
+    entry = _entry()
+
+    assert entry.formats == ()
+    spec = entry.to_download_type_spec()
+    assert spec.format_choices == ()
+    assert dict(spec.format_extension_map) == {}
+    assert spec.extension == ".pdf"
+
+
+# ---------------------------------------------------------------------------
+# Registry-wide builders
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_names_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(download_specs, "DOWNLOAD_REGISTRY", (_entry(), _entry()))
+
+    with pytest.raises(ValueError, match="duplicate names"):
+        download_specs._build_download_specs()
+
+
+def test_duplicate_artifact_kinds_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        download_specs,
+        "DOWNLOAD_REGISTRY",
+        (_entry(), _entry(name="slide-deck-copy", download_attr="download_slide_deck_copy")),
+    )
+
+    with pytest.raises(ValueError, match="duplicate artifact kinds"):
+        download_specs._build_download_specs()
+
+
+def test_one_extension_may_not_carry_two_mime_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        download_specs,
+        "DOWNLOAD_REGISTRY",
+        (
+            _entry(),
+            _entry(
+                name="report",
+                kind=ArtifactType.REPORT,
+                default_output=DownloadFormatSpec(".pdf", "text/pdf"),
+                download_attr="download_report",
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="conflicting MIME types"):
+        download_specs._build_extension_mime_types()
+
+
+def test_legacy_format_map_rejects_conflicting_extensions() -> None:
+    entries = (
+        _entry(
+            format_default="pdf",
+            alternate_formats=(("pptx", PPTX),),
+            format_kwarg="output_format",
+            contributes_to_legacy_format_extensions=True,
+        ),
+        _entry(
+            name="report",
+            kind=ArtifactType.REPORT,
+            download_attr="download_report",
+            format_default="pdf",
+            alternate_formats=(("md", DownloadFormatSpec(".md", "text/markdown")),),
+            format_kwarg="output_format",
+            contributes_to_legacy_format_extensions=True,
+            default_output=DownloadFormatSpec(".docx", "application/msword"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="conflicting legacy extensions"):
+        download_specs._build_legacy_format_extensions(entries)
+
+
+def test_legacy_format_map_requires_at_least_one_contributor() -> None:
+    with pytest.raises(ValueError, match="no legacy format-map contributors"):
+        download_specs._build_legacy_format_extensions((_entry(),))
+
+
+def test_the_shipped_registry_satisfies_every_builder() -> None:
+    """The guards above only matter if the real table still passes them."""
+    specs = download_specs._build_download_specs()
+
+    assert set(specs) == {entry.name for entry in DOWNLOAD_REGISTRY}
+    assert download_specs._build_extension_mime_types()[".m4a"] == "audio/mp4"
+    assert download_specs._build_legacy_format_extensions(DOWNLOAD_REGISTRY)

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -150,6 +150,37 @@ class TestAuthImportCookiesCommand:
         assert "Invalid JSON" in result.output
         assert not storage_path.exists()
 
+    def test_import_cookies_rejects_a_non_utf8_file(self, runner, tmp_path):
+        """A latin-1 / UTF-16 export names the decode failure, not a JSON error."""
+        input_path = tmp_path / "cookies.json"
+        storage_path = tmp_path / "storage_state.json"
+        input_path.write_bytes(b'{"cookies": [{"name": "SID", "value": "\xff\xfe"}]}')
+
+        result = runner.invoke(
+            cli, ["--storage", str(storage_path), "auth", "import-cookies", str(input_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "as UTF-8" in result.output
+        assert not storage_path.exists()
+
+    def test_import_cookies_reports_an_unreadable_path(self, runner, tmp_path):
+        storage_path = tmp_path / "storage_state.json"
+
+        result = runner.invoke(
+            cli,
+            [
+                "--storage",
+                str(storage_path),
+                "auth",
+                "import-cookies",
+                str(tmp_path / "absent.json"),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert not storage_path.exists()
+
     def test_import_cookies_rejects_unsupported_json_shape(self, runner, tmp_path):
         input_path = tmp_path / "cookies.json"
         storage_path = tmp_path / "storage_state.json"

--- a/tests/unit/mcp/test_content_sanity_orchestration.py
+++ b/tests/unit/mcp/test_content_sanity_orchestration.py
@@ -1,0 +1,158 @@
+"""Task orchestration in the MCP thin-content sanity pass.
+
+``tests/unit/mcp/test_sources.py`` drives the warning classifier end to end
+through ``source_wait``. These cases target the fan-out itself: the web-page
+pre-filter, the in-place annotation contract, and the cancel-and-drain path
+that keeps a failing or cancelled batch from leaking sibling fetches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from notebooklm._types.sources import _SOURCE_TYPE_CODE_MAP, Source, SourceType
+from notebooklm.mcp.tools import _content_sanity
+from notebooklm.mcp.tools._content_sanity import (
+    _annotate_thin_warnings,
+    _thin_content_warning,
+)
+from notebooklm.rpc.types import SourceStatus
+
+pytestmark = pytest.mark.asyncio
+
+
+def _type_code(kind: SourceType) -> int:
+    """Resolve a wire type code from the canonical map, not a magic number."""
+    return next(code for code, value in _SOURCE_TYPE_CODE_MAP.items() if value is kind)
+
+
+_WEB_PAGE_TYPE_CODE = _type_code(SourceType.WEB_PAGE)
+_PASTED_TEXT_TYPE_CODE = _type_code(SourceType.PASTED_TEXT)
+
+
+def _source(source_id: str, *, type_code: int = _WEB_PAGE_TYPE_CODE, ready: bool = True) -> Source:
+    return Source(
+        id=source_id,
+        title=source_id,
+        _type_code=type_code,
+        status=SourceStatus.READY if ready else SourceStatus.PROCESSING,
+    )
+
+
+def _pairs(*sources: Source) -> list[tuple[dict[str, Any], Source]]:
+    return [({"id": source.id}, source) for source in sources]
+
+
+async def test_no_web_page_sources_schedules_no_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-web-page sources are filtered out before any task is created."""
+    calls: list[str] = []
+
+    async def _never(_client, _notebook_id, source):  # noqa: ANN001, ANN202
+        calls.append(source.id)
+        return "warned"
+
+    monkeypatch.setattr(_content_sanity, "_thin_content_warning", _never)
+    pairs = _pairs(_source("s1", type_code=_PASTED_TEXT_TYPE_CODE))
+
+    await _annotate_thin_warnings(object(), "nb1", pairs)
+
+    assert calls == []
+    assert pairs[0][0] == {"id": "s1"}
+
+
+async def test_warnings_are_attached_in_place_to_their_own_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _warn(_client, _notebook_id, source):  # noqa: ANN001, ANN202
+        return None if source.id == "s2" else f"thin:{source.id}"
+
+    monkeypatch.setattr(_content_sanity, "_thin_content_warning", _warn)
+    pairs = _pairs(_source("s1"), _source("s2"), _source("s3"))
+
+    await _annotate_thin_warnings(object(), "nb1", pairs)
+
+    assert [view.get("warning") for view, _source in pairs] == ["thin:s1", None, "thin:s3"]
+
+
+async def test_an_existing_warning_is_never_clobbered(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _warn(_client, _notebook_id, _source):  # noqa: ANN001, ANN202
+        return "thin"
+
+    monkeypatch.setattr(_content_sanity, "_thin_content_warning", _warn)
+    pairs = _pairs(_source("s1"))
+    pairs[0][0]["warning"] = "import failed"
+
+    await _annotate_thin_warnings(object(), "nb1", pairs)
+
+    assert pairs[0][0]["warning"] == "import failed"
+
+
+async def test_a_failing_fetch_cancels_and_drains_its_siblings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No sibling coroutine is left running when the batch escapes."""
+    started = asyncio.Event()
+    sibling_cancelled = False
+
+    async def _warn(_client, _notebook_id, source):  # noqa: ANN001, ANN202
+        nonlocal sibling_cancelled
+        if source.id == "boom":
+            await started.wait()
+            raise RuntimeError("fetch exploded")
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            sibling_cancelled = True
+            raise
+        return None
+
+    monkeypatch.setattr(_content_sanity, "_thin_content_warning", _warn)
+    pairs = _pairs(_source("boom"), _source("slow"))
+
+    with pytest.raises(RuntimeError, match="fetch exploded"):
+        await _annotate_thin_warnings(object(), "nb1", pairs)
+
+    assert sibling_cancelled is True
+    assert "warning" not in pairs[1][0]
+
+
+async def test_caller_cancellation_drains_the_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    running = asyncio.Event()
+    cancelled = 0
+
+    async def _warn(_client, _notebook_id, _source):  # noqa: ANN001, ANN202
+        nonlocal cancelled
+        running.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cancelled += 1
+            raise
+        return None
+
+    monkeypatch.setattr(_content_sanity, "_thin_content_warning", _warn)
+    pairs = _pairs(_source("s1"), _source("s2"))
+    task = asyncio.create_task(_annotate_thin_warnings(object(), "nb1", pairs))
+    await running.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancelled == 2
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(_source("s1", ready=False), id="not-ready"),
+        pytest.param(_source("s1", type_code=_PASTED_TEXT_TYPE_CODE), id="not-a-web-page"),
+    ],
+)
+async def test_the_classifier_refuses_sources_it_must_never_flag(source: Source) -> None:
+    """Short pasted text is legitimate; an unfinished source has nothing to read."""
+    assert await _thin_content_warning(object(), "nb1", source) is None

--- a/tests/unit/test_artifact_generation_service.py
+++ b/tests/unit/test_artifact_generation_service.py
@@ -1,0 +1,433 @@
+"""Direct coverage for :class:`ArtifactGenerationService`.
+
+The facade-level suites drive ``ArtifactsAPI`` and stop at the happy path.
+These cases exercise the service's own seams: the ``language=None`` /
+``source_ids=None`` resolution shared by every ``generate_*`` entry point, the
+``generate_video`` option-compatibility rules, the mind-map JSON leaf handling,
+and the row-shape guards in ``_parse_generation_result``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from notebooklm._types.notes import Note
+from notebooklm._types.research import MindMapResult
+from notebooklm._web.artifact.generation import ArtifactGenerationService
+from notebooklm.exceptions import (
+    ArtifactFeatureUnavailableError,
+    DecodingError,
+    ValidationError,
+)
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import VideoFormat, VideoStyle
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _RecordedCall:
+    method: RPCMethod
+    params: list[Any]
+    kwargs: dict[str, Any]
+
+
+class _FakeRpc:
+    """Records dispatches and replays a scripted result per method."""
+
+    def __init__(self, results: dict[RPCMethod, Any] | None = None) -> None:
+        self._results = results or {}
+        self.calls: list[_RecordedCall] = []
+
+    async def rpc_call(self, method, params, source_path="/", **kwargs):  # noqa: ANN001
+        self.calls.append(_RecordedCall(method, params, {"source_path": source_path, **kwargs}))
+        # An unscripted method answers with the standard accepted-task row.
+        return self._results.get(method, [["artifact-1", None, None, None, 2]])
+
+    @property
+    def only(self) -> _RecordedCall:
+        [call] = self.calls
+        return call
+
+
+@dataclass
+class _FakeNotebooks:
+    source_ids: list[str] = field(default_factory=lambda: ["resolved-src"])
+    asked: list[str] = field(default_factory=list)
+
+    async def get_source_ids(self, notebook_id: str) -> list[str]:
+        self.asked.append(notebook_id)
+        return list(self.source_ids)
+
+
+@dataclass
+class _FakeNoteService:
+    note: Note | None = None
+    created: list[tuple[str, str, str]] = field(default_factory=list)
+
+    async def create_note(self, notebook_id: str, *, title: str, content: str) -> Note:
+        self.created.append((notebook_id, title, content))
+        if self.note is not None:
+            return self.note
+        return Note(
+            id="note-1",
+            notebook_id=notebook_id,
+            title=title,
+            content=content,
+            created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        )
+
+
+def _service(
+    *,
+    rpc: _FakeRpc | None = None,
+    notebooks: _FakeNotebooks | None = None,
+    notes: _FakeNoteService | None = None,
+) -> tuple[ArtifactGenerationService, _FakeRpc, _FakeNotebooks, _FakeNoteService]:
+    rpc = rpc or _FakeRpc()
+    notebooks = notebooks or _FakeNotebooks()
+    notes = notes or _FakeNoteService()
+    service = ArtifactGenerationService(rpc=rpc, notebooks=notebooks, note_service=notes)
+    return service, rpc, notebooks, notes
+
+
+# ---------------------------------------------------------------------------
+# Shared language / source-id resolution
+# ---------------------------------------------------------------------------
+
+#: ``(method name, extra kwargs)`` for every entry point that resolves both
+#: ``language=None`` (via ``NOTEBOOKLM_HL``) and ``source_ids=None``.
+_LANGUAGE_AWARE = [
+    ("generate_audio", {}),
+    ("generate_video", {}),
+    ("generate_cinematic_video", {}),
+    ("generate_report", {}),
+    ("generate_study_guide", {}),
+    ("generate_infographic", {}),
+    ("generate_slide_deck", {}),
+    ("generate_data_table", {}),
+    ("generate_mind_map", {}),
+]
+
+#: Entry points with no ``language`` parameter — source-id resolution only.
+_SOURCE_ONLY = [("generate_quiz", {}), ("generate_flashcards", {})]
+
+
+@pytest.mark.parametrize("name", [n for n, _ in _LANGUAGE_AWARE])
+async def test_language_none_resolves_from_the_environment(
+    name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_HL", "fr")
+    service, rpc, _, _ = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [[None]]}))
+
+    await getattr(service, name)("nb1", language=None)
+
+    # The resolved tag reaches the wire params rather than a literal ``None``.
+    assert "fr" in repr(rpc.only.params)
+
+
+@pytest.mark.parametrize("name", [n for n, _ in _LANGUAGE_AWARE + _SOURCE_ONLY])
+async def test_source_ids_none_resolves_from_the_notebook(name: str) -> None:
+    service, rpc, notebooks, _ = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [[None]]}))
+
+    await getattr(service, name)("nb1", source_ids=None)
+
+    assert notebooks.asked == ["nb1"]
+    assert "resolved-src" in repr(rpc.only.params)
+
+
+@pytest.mark.parametrize("name", [n for n, _ in _LANGUAGE_AWARE + _SOURCE_ONLY])
+async def test_explicit_source_ids_skip_the_notebook_lookup(name: str) -> None:
+    service, rpc, notebooks, _ = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [[None]]}))
+
+    await getattr(service, name)("nb1", source_ids=["explicit-src"])
+
+    assert notebooks.asked == []
+    assert "explicit-src" in repr(rpc.only.params)
+
+
+async def test_generate_study_guide_delegates_to_generate_report() -> None:
+    service, rpc, _, _ = _service()
+
+    await service.generate_study_guide("nb1", source_ids=["s1"], extra_instructions="focus")
+
+    assert rpc.only.method is RPCMethod.CREATE_ARTIFACT
+    assert rpc.only.kwargs["source_path"] == "/notebook/nb1"
+
+
+# ---------------------------------------------------------------------------
+# generate_video option compatibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        pytest.param(
+            {"video_format": VideoFormat.CINEMATIC, "style_prompt": "noir"},
+            "style_prompt is not supported for cinematic videos",
+            id="cinematic-rejects-style-prompt",
+        ),
+        pytest.param(
+            {"video_format": VideoFormat.SHORT, "video_style": VideoStyle.ANIME},
+            "short has a fixed visual style",
+            id="short-rejects-style",
+        ),
+        pytest.param(
+            {"video_format": VideoFormat.SHORT, "style_prompt": "noir"},
+            "short has a fixed visual style",
+            id="short-rejects-style-prompt",
+        ),
+        pytest.param(
+            {"video_style": VideoStyle.CUSTOM},
+            "style_prompt is required when video_style is CUSTOM",
+            id="custom-requires-style-prompt",
+        ),
+        pytest.param(
+            {"video_style": VideoStyle.CUSTOM, "style_prompt": "   "},
+            "style_prompt is required when video_style is CUSTOM",
+            id="custom-rejects-whitespace-only-style-prompt",
+        ),
+        pytest.param(
+            {"video_style": VideoStyle.ANIME, "style_prompt": "noir"},
+            "style_prompt requires video_style=VideoStyle.CUSTOM",
+            id="style-prompt-requires-custom",
+        ),
+    ],
+)
+async def test_generate_video_rejects_incompatible_options(
+    kwargs: dict[str, Any], message: str
+) -> None:
+    service, rpc, _, _ = _service()
+
+    with pytest.raises(ValidationError, match=message):
+        await service.generate_video("nb1", source_ids=["s1"], **kwargs)
+
+    # Rejection happens before any dispatch.
+    assert rpc.calls == []
+
+
+async def test_generate_video_accepts_short_with_auto_select_style() -> None:
+    """``AUTO_SELECT`` is the short format's own default, not an override."""
+    service, rpc, _, _ = _service()
+
+    await service.generate_video(
+        "nb1",
+        source_ids=["s1"],
+        video_format=VideoFormat.SHORT,
+        video_style=VideoStyle.AUTO_SELECT,
+    )
+
+    assert rpc.only.method is RPCMethod.CREATE_ARTIFACT
+
+
+async def test_generate_video_strips_the_custom_style_prompt() -> None:
+    service, rpc, _, _ = _service()
+
+    await service.generate_video(
+        "nb1",
+        source_ids=["s1"],
+        video_style=VideoStyle.CUSTOM,
+        style_prompt="  neon skyline  ",
+    )
+
+    assert "neon skyline" in repr(rpc.only.params)
+    assert "  neon skyline  " not in repr(rpc.only.params)
+
+
+# ---------------------------------------------------------------------------
+# revise_slide / retry_failed
+# ---------------------------------------------------------------------------
+
+
+async def test_revise_slide_rejects_a_negative_index() -> None:
+    service, rpc, _, _ = _service()
+
+    with pytest.raises(ValidationError, match="slide_index must be >= 0"):
+        await service.revise_slide("nb1", "art-1", -1, "brighter")
+
+    assert rpc.calls == []
+
+
+async def test_revise_slide_raises_when_the_server_returns_no_row() -> None:
+    service, _, _, _ = _service(rpc=_FakeRpc({RPCMethod.REVISE_SLIDE: None}))
+
+    with pytest.raises(ArtifactFeatureUnavailableError):
+        await service.revise_slide("nb1", "art-1", 0, "brighter")
+
+
+async def test_revise_slide_returns_the_accepted_task() -> None:
+    service, rpc, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.REVISE_SLIDE: [["art-1", None, None, None, 2]]})
+    )
+
+    status = await service.revise_slide("nb1", "art-1", 2, "brighter")
+
+    assert status.task_id == "art-1"
+    assert rpc.only.kwargs["raise_on_null_status"] is True
+
+
+async def test_retry_failed_raises_when_the_server_returns_no_row() -> None:
+    service, _, _, _ = _service(rpc=_FakeRpc({RPCMethod.RETRY_ARTIFACT: None}))
+
+    with pytest.raises(ArtifactFeatureUnavailableError) as excinfo:
+        await service.retry_failed("nb1", "art-1")
+
+    assert excinfo.value.method_id == RPCMethod.RETRY_ARTIFACT.value
+
+
+async def test_retry_failed_rejects_a_row_with_an_empty_artifact_id() -> None:
+    """#1342: a row that created no task raises rather than reporting failure."""
+    service, _, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.RETRY_ARTIFACT: [["", None, None, None, 2]]})
+    )
+
+    with pytest.raises(DecodingError, match="No artifact id"):
+        await service.retry_failed("nb1", "art-1")
+
+
+async def test_retry_failed_reports_a_null_artifact_id_as_feature_gated() -> None:
+    service, _, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.RETRY_ARTIFACT: [[None, None, None, None, 2]]})
+    )
+
+    with pytest.raises(ArtifactFeatureUnavailableError) as excinfo:
+        await service.retry_failed("nb1", "art-1")
+
+    assert excinfo.value.method_id == RPCMethod.RETRY_ARTIFACT.value
+
+
+async def test_retry_failed_returns_the_requeued_artifact_id() -> None:
+    service, rpc, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.RETRY_ARTIFACT: [["art-1", None, None, None, 1]]})
+    )
+
+    status = await service.retry_failed("nb1", "art-1")
+
+    assert status.task_id == "art-1"
+    assert status.status == "pending"
+    assert rpc.only.kwargs["source_path"] == "/notebook/nb1"
+
+
+# ---------------------------------------------------------------------------
+# _call_generate / _parse_generation_result
+# ---------------------------------------------------------------------------
+
+
+async def test_null_result_names_the_requested_artifact_type() -> None:
+    service, _, _, _ = _service(rpc=_FakeRpc({RPCMethod.CREATE_ARTIFACT: None}))
+
+    with pytest.raises(ArtifactFeatureUnavailableError, match="Quiz generation is unavailable"):
+        await service.generate_quiz("nb1", source_ids=["s1"])
+
+
+async def test_null_artifact_id_raises_feature_unavailable() -> None:
+    service, _, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.CREATE_ARTIFACT: [[None, None, None, None, 2]]})
+    )
+
+    with pytest.raises(ArtifactFeatureUnavailableError, match="Artifact generation is unavailable"):
+        await service.generate_audio("nb1", source_ids=["s1"])
+
+
+async def test_empty_artifact_id_raises_decoding_error() -> None:
+    """A present-but-empty id is drift, not a gated feature."""
+    service, _, _, _ = _service(
+        rpc=_FakeRpc({RPCMethod.CREATE_ARTIFACT: [["", None, None, None, 2]]})
+    )
+
+    with pytest.raises(DecodingError, match="No artifact id"):
+        await service.generate_audio("nb1", source_ids=["s1"])
+
+
+async def test_generation_debug_label_tolerates_a_short_param_list(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The debug label is best-effort: a short descriptor logs ``unknown``."""
+    service, _, _, _ = _service()
+
+    with caplog.at_level("DEBUG", logger="notebooklm._artifact.generation"):
+        await service._call_generate("nb1", ["ctx", "nb1"])
+
+    assert "type=unknown" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# generate_mind_map
+# ---------------------------------------------------------------------------
+
+
+async def test_mind_map_absent_leaf_returns_an_empty_result() -> None:
+    service, _, _, notes = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: []}))
+
+    result = await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    assert result == MindMapResult(mind_map=None, note_id=None)
+    assert notes.created == []
+
+
+async def test_mind_map_json_leaf_is_parsed_and_titled_from_its_root_name() -> None:
+    service, _, _, notes = _service(
+        rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [['{"name": "Photosynthesis"}']]})
+    )
+
+    result = await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    assert result.mind_map == {"name": "Photosynthesis"}
+    assert result.note_id == "note-1"
+    assert notes.created == [("nb1", "Photosynthesis", '{"name": "Photosynthesis"}')]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param('{"name": ""}', id="empty-name"),
+        pytest.param('{"name": 7}', id="non-string-name"),
+        pytest.param('{"nodes": []}', id="no-name-key"),
+        pytest.param("[1, 2]", id="non-dict-root"),
+    ],
+)
+async def test_mind_map_falls_back_to_the_default_title(payload: str) -> None:
+    """#1270: only a non-empty ``str`` name may become the note title."""
+    service, _, _, notes = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [[payload]]}))
+
+    await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    [(_, title, _content)] = notes.created
+    assert title == "Mind Map"
+
+
+async def test_mind_map_unparseable_json_is_stored_verbatim() -> None:
+    service, _, _, notes = _service(
+        rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [["not json at all"]]})
+    )
+
+    result = await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    assert result.mind_map == "not json at all"
+    assert notes.created == [("nb1", "Mind Map", "not json at all")]
+
+
+async def test_mind_map_non_string_leaf_is_reserialised_for_the_note_body() -> None:
+    service, _, _, notes = _service(
+        rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [[{"name": "Tree"}]]})
+    )
+
+    result = await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    assert result.mind_map == {"name": "Tree"}
+    assert notes.created == [("nb1", "Tree", '{"name": "Tree"}')]
+
+
+async def test_mind_map_note_without_an_id_reports_note_id_none() -> None:
+    """Defensive: the public contract says ``note_id is None`` means unsaved."""
+    notes = _FakeNoteService(note=Note(id="", notebook_id="nb1", title="Mind Map", content="{}"))
+    service, _, _, _ = _service(rpc=_FakeRpc({RPCMethod.GENERATE_MIND_MAP: [["{}"]]}), notes=notes)
+
+    result = await service.generate_mind_map("nb1", source_ids=["s1"])
+
+    assert result.note_id is None

--- a/tests/unit/test_lazy_package_exports.py
+++ b/tests/unit/test_lazy_package_exports.py
@@ -1,0 +1,171 @@
+"""Lazy package-export resolution for ``_artifact`` and ``_source``.
+
+Both packages keep historical package-level names that now live in the web
+backend, resolved through a module ``__getattr__`` so importing the neutral
+package never pulls ``_web`` in. These cases pin every advertised name, the
+caching that follows the first access, and the ``AttributeError`` for anything
+else — a silently-broken lazy branch would surface as an import error only in
+whichever adapter still used the old spelling.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import json
+import subprocess
+import sys
+
+import pytest
+
+from notebooklm import _artifact, _source
+
+_ARTIFACT_LAZY = (
+    "ArtifactDownloadService",
+    "ArtifactListingService",
+    "find_artifact_row_by_id",
+    "iter_artifact_rows",
+    "generation",
+    "listing",
+    "payloads",
+)
+
+
+@pytest.mark.parametrize("name", _ARTIFACT_LAZY)
+def test_artifact_lazy_names_resolve_to_their_web_owners(name: str) -> None:
+    value = getattr(_artifact, name)
+
+    assert value is not None
+    # Resolution is memoised into the module globals, so a second access is a
+    # plain attribute read rather than another import.
+    assert _artifact.__dict__[name] is value
+    assert getattr(_artifact, name) is value
+
+
+def test_artifact_lazy_names_match_the_modules_they_delegate_to() -> None:
+    from notebooklm._web.artifact import generation, listing
+    from notebooklm._web.artifact.downloads import ArtifactDownloadService
+    from notebooklm._web.params import artifacts
+
+    assert _artifact.generation is generation
+    assert _artifact.listing is listing
+    assert _artifact.payloads is artifacts
+    assert _artifact.ArtifactDownloadService is ArtifactDownloadService
+    assert _artifact.ArtifactListingService is listing.ArtifactListingService
+    assert _artifact.find_artifact_row_by_id is listing.find_artifact_row_by_id
+    assert _artifact.iter_artifact_rows is listing.iter_artifact_rows
+
+
+def test_artifact_rejects_an_unknown_attribute() -> None:
+    missing = "nope"
+    with pytest.raises(AttributeError, match="has no attribute 'nope'"):
+        getattr(_artifact, missing)
+
+
+def test_artifact_all_is_fully_resolvable() -> None:
+    """Every advertised name must actually resolve, eager or lazy."""
+    for name in _artifact.__all__:
+        assert getattr(_artifact, name) is not None
+
+
+#: ``notebooklm._source.batch`` is a real neutral submodule, so once anything
+#: imports it (production does, for ``SourceUrlBatchItem``) normal attribute
+#: lookup finds it and ``__getattr__`` is never consulted for that name. Its
+#: ``_MODULE_EXPORTS`` entry pointing at the web module is therefore shadowed;
+#: covered separately below rather than asserted as a lazy alias.
+_SOURCE_SHADOWED_BY_A_REAL_SUBMODULE = frozenset({"batch"})
+
+
+@pytest.mark.parametrize(
+    "name", sorted(set(_source._MODULE_EXPORTS) - _SOURCE_SHADOWED_BY_A_REAL_SUBMODULE)
+)
+def test_source_module_exports_resolve_to_the_named_module(name: str) -> None:
+    value = getattr(_source, name)
+
+    assert value is importlib.import_module(_source._MODULE_EXPORTS[name])
+    assert _source.__dict__[name] is value
+
+
+def test_a_real_submodule_shadows_its_lazy_alias() -> None:
+    """``_source.batch`` is the neutral module, not the web one the map names.
+
+    Characterization, not endorsement: the answer depends on whether anything
+    has imported ``notebooklm._source.batch`` yet, and production always has.
+    """
+    import notebooklm._source.batch as neutral_batch
+
+    assert _source.batch is neutral_batch
+    assert _source._MODULE_EXPORTS["batch"] == "notebooklm._web.sources.batch"
+
+
+@pytest.mark.parametrize("name", sorted(_source._SYMBOL_EXPORTS))
+def test_source_symbol_exports_resolve_to_the_named_attribute(name: str) -> None:
+    module_name, attribute = _source._SYMBOL_EXPORTS[name]
+
+    value = getattr(_source, name)
+
+    assert value is getattr(importlib.import_module(module_name), attribute)
+    assert _source.__dict__[name] is value
+
+
+def test_source_rejects_an_unknown_attribute() -> None:
+    missing = "nope"
+    with pytest.raises(AttributeError, match="has no attribute 'nope'"):
+        getattr(_source, missing)
+
+
+def test_source_dir_advertises_the_lazy_exports() -> None:
+    listed = dir(_source)
+
+    assert set(_source._MODULE_EXPORTS) <= set(listed)
+    assert set(_source._SYMBOL_EXPORTS) <= set(listed)
+    assert listed == sorted(listed)
+
+
+def test_source_all_is_fully_resolvable() -> None:
+    for name in _source.__all__:
+        assert getattr(_source, name) is not None
+
+
+def test_importing_the_neutral_source_package_adds_no_web_modules() -> None:
+    """Importing ``_source`` itself must not pull ``_web.sources`` in.
+
+    Measured as a delta against ``import notebooklm``, which eagerly loads the
+    web backend on its own — the lazy map only buys isolation for this
+    submodule, and asserting more would pass for the wrong reason.
+
+    Runs in a subprocess: evicting ``notebooklm._web*`` from this process's
+    ``sys.modules`` to measure it in-process would hand every later test a
+    second copy of those classes and silently break unrelated ``isinstance``
+    checks elsewhere in the suite.
+    """
+    probe = (
+        "import sys, json; import notebooklm; "
+        "before = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
+        "import notebooklm._source; "
+        "after = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
+        "print(json.dumps(sorted(after - before)))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert json.loads(result.stdout) == []
+
+
+def test_the_neutral_source_package_has_no_static_web_import() -> None:
+    """The lazy map exists so this file names ``_web`` only inside strings."""
+    tree = ast.parse(inspect.getsource(_source))
+
+    imported = {
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module
+    } | {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+
+    assert not [name for name in imported if "_web" in name]

--- a/tests/unit/test_polling_service.py
+++ b/tests/unit/test_polling_service.py
@@ -79,3 +79,62 @@ async def test_status_with_elapsed_json_output_is_no_op() -> None:
 
     assert entered is True
     status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_until_returns_immediately_when_the_first_fetch_is_terminal() -> None:
+    """The happy path costs exactly one fetch and never sleeps."""
+    sleeps: list[float] = []
+
+    async def fetch() -> str:
+        return "completed"
+
+    with patch.object(polling.asyncio, "sleep", side_effect=lambda d: sleeps.append(d)):
+        result = await poll_until(
+            fetch, lambda value: value == "completed", timeout=10.0, interval=1.0
+        )
+
+    assert (result.value, result.attempts, result.timed_out) == ("completed", 1, False)
+    assert result.elapsed >= 0.0
+    assert sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_poll_until_still_fetches_once_with_a_zero_timeout() -> None:
+    """``timeout=0`` is a single-shot poll, not a refusal."""
+    attempts = 0
+
+    async def fetch() -> str:
+        nonlocal attempts
+        attempts += 1
+        return "pending"
+
+    result = await poll_until(fetch, lambda value: value == "done", timeout=0.0, interval=1.0)
+
+    assert (attempts, result.attempts, result.timed_out) == (1, 1, True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        pytest.param({"timeout": -1.0, "interval": 1.0}, "non-negative", id="negative-timeout"),
+        pytest.param({"timeout": 1.0, "interval": 0.0}, "must be positive", id="zero-interval"),
+        pytest.param(
+            {"timeout": 1.0, "interval": -1.0}, "must be positive", id="negative-interval"
+        ),
+    ],
+)
+async def test_poll_until_rejects_unusable_budgets(kwargs: dict, message: str) -> None:
+    """Rejection happens before the first fetch."""
+    called = False
+
+    async def fetch() -> str:
+        nonlocal called
+        called = True
+        return "pending"
+
+    with pytest.raises(ValueError, match=message):
+        await poll_until(fetch, lambda _value: True, **kwargs)
+
+    assert called is False

--- a/tests/unit/test_semaphore_middleware.py
+++ b/tests/unit/test_semaphore_middleware.py
@@ -1,0 +1,161 @@
+"""Direct characterization tests for :class:`SemaphoreMiddleware`.
+
+B0 moved the live RPC gate to ``CallSupervisor``; the module docstring says
+this helper stays "for direct middleware compatibility tests", and until now
+there were none. These pin what a caller composing it directly still gets:
+
+- the slot is held for exactly the inner leg (``next_call``), including any
+  retries a middleware nested inside it performs — the "one slot per logical
+  RPC" backpressure contract;
+- the slot is released when ``next_call`` raises, so a failing call cannot
+  leak capacity;
+- the measured queue wait is written to the shared request context under the
+  documented key, so a host can forward it to ``ClientMetrics`` without the
+  middleware knowing metric names.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import httpx
+import pytest
+
+from notebooklm._web.transport.middleware.core import (
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._web.transport.middleware.semaphore import (
+    RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS,
+    RPC_QUEUE_WAIT_CONTEXT_KEY,
+    SemaphoreMiddleware,
+)
+from tests._fixtures.chain import make_request
+
+pytestmark = pytest.mark.asyncio
+
+
+def _terminal(on_call: NextCall | None = None) -> NextCall:
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        if on_call is not None:
+            await on_call(request)
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b"ok"),
+            context=request.context,
+        )
+
+    return terminal
+
+
+async def test_the_legacy_key_alias_still_points_at_the_canonical_context_key() -> None:
+    assert RPC_QUEUE_WAIT_CONTEXT_KEY == RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS
+
+
+async def test_a_no_op_gate_passes_the_response_through_and_records_a_wait() -> None:
+    chain = build_chain(
+        [SemaphoreMiddleware(contextlib.nullcontext)],
+        _terminal(),
+    )
+    request = make_request()
+
+    result = await chain(request)
+
+    assert result.response.status_code == 200
+    recorded = request.context[RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS]
+    assert isinstance(recorded, float)
+    assert recorded >= 0.0
+
+
+async def test_the_slot_is_held_for_the_whole_inner_leg() -> None:
+    """A one-slot gate serializes two concurrent calls end to end."""
+    semaphore = asyncio.Semaphore(1)
+    concurrent = 0
+    peak = 0
+    release = asyncio.Event()
+
+    async def observing(_request: RpcRequest) -> None:
+        nonlocal concurrent, peak
+        concurrent += 1
+        peak = max(peak, concurrent)
+        await release.wait()
+        concurrent -= 1
+
+    chain = build_chain([SemaphoreMiddleware(lambda: semaphore)], _terminal(observing))
+    first = asyncio.create_task(chain(make_request()))
+    second = asyncio.create_task(chain(make_request()))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert peak == 1
+    assert semaphore.locked()
+
+    release.set()
+    await asyncio.gather(first, second)
+    assert peak == 1
+    assert not semaphore.locked()
+
+
+async def test_retries_inside_the_gate_do_not_release_the_slot() -> None:
+    """A nested retry re-enters the inner chain without re-queueing."""
+    semaphore = asyncio.Semaphore(1)
+    attempts = 0
+    locked_during_attempts: list[bool] = []
+
+    async def retrying(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        nonlocal attempts
+        for _ in range(3):
+            attempts += 1
+            locked_during_attempts.append(semaphore.locked())
+        return await next_call(request)
+
+    chain = build_chain(
+        [SemaphoreMiddleware(lambda: semaphore), retrying],
+        _terminal(),
+    )
+
+    await chain(make_request())
+
+    assert attempts == 3
+    assert locked_during_attempts == [True, True, True]
+    assert not semaphore.locked()
+
+
+async def test_a_failing_call_still_releases_the_slot() -> None:
+    semaphore = asyncio.Semaphore(1)
+
+    async def failing(_request: RpcRequest) -> RpcResponse:
+        raise RuntimeError("transport blew up")
+
+    chain = build_chain([SemaphoreMiddleware(lambda: semaphore)], failing)
+
+    with pytest.raises(RuntimeError, match="transport blew up"):
+        await chain(make_request())
+
+    assert not semaphore.locked()
+
+
+async def test_the_recorded_wait_reflects_time_spent_queued() -> None:
+    semaphore = asyncio.Semaphore(1)
+    release = asyncio.Event()
+    first_context: dict = {}
+    second_context: dict = {}
+
+    async def holding(_request: RpcRequest) -> None:
+        await release.wait()
+
+    chain = build_chain([SemaphoreMiddleware(lambda: semaphore)], _terminal(holding))
+    first = asyncio.create_task(chain(make_request(context=first_context)))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(chain(make_request(context=second_context)))
+    await asyncio.sleep(0.02)
+    release.set()
+    await asyncio.gather(first, second)
+
+    # The queued call waited for the holder; the holder did not.
+    assert (
+        second_context[RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS]
+        > first_context[RPC_CONTEXT_RPC_QUEUE_WAIT_SECONDS]
+    )

--- a/tests/unit/test_source_markdown.py
+++ b/tests/unit/test_source_markdown.py
@@ -6,7 +6,14 @@ import pytest
 
 pytest.importorskip("markdownify")
 
-from notebooklm._source.markdown import html_to_markdown  # noqa: E402
+from markdownify import MarkdownConverter  # noqa: E402
+
+from notebooklm._source.markdown import (  # noqa: E402
+    _repair_mangled_math,
+    _SourceHtmlConverter,
+    _SourceMarkdownConverter,
+    html_to_markdown,
+)
 
 
 def test_html_table_cell_break_is_preserved() -> None:
@@ -84,3 +91,71 @@ def test_non_target_dollar_text_is_preserved(html: str, expected: str) -> None:
     output = html_to_markdown(html)
 
     assert output == expected
+
+
+# ---------------------------------------------------------------------------
+# Escaping and math-repair branches
+# ---------------------------------------------------------------------------
+
+
+def test_html_escape_of_empty_text_short_circuits() -> None:
+    converter = _SourceHtmlConverter(heading_style="ATX")
+
+    assert converter.escape("") == ""
+    assert converter.escape(None) == ""
+
+
+def test_markdown_source_escape_never_re_escapes() -> None:
+    """An imported Markdown rendition is already Markdown; escaping would double it."""
+    converter = _SourceMarkdownConverter(heading_style="ATX")
+
+    assert converter.escape("a_b *c*") == "a_b *c*"
+    assert converter.escape("") == ""
+
+
+def test_html_escape_falls_back_to_the_single_argument_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older markdownify releases take ``escape(text)`` with no ``parent_tags``."""
+    seen: list[tuple] = []
+
+    def _one_argument_escape(self, text, *extra):  # noqa: ANN001, ANN202
+        seen.append(extra)
+        if extra:
+            raise TypeError("escape() takes 2 positional arguments but 3 were given")
+        return text
+
+    monkeypatch.setattr(MarkdownConverter, "escape", _one_argument_escape, raising=True)
+    converter = _SourceHtmlConverter(heading_style="ATX")
+
+    assert converter.escape("plain") == "plain"
+    # First the two-argument call, then the retry without ``parent_tags``.
+    assert seen == [(None,), ()]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param("$x + 1$", "$x + 1$", id="no-surrounding-emphasis"),
+        pytest.param("*$plain$*", "*$plain$*", id="no-math-signal-in-body"),
+        pytest.param(r"*$a\_b$*", "*$a_b$*", id="emphasis-on-both-sides"),
+        pytest.param(r"*$a\_b*$", "$a_b$", id="lead-only-marker-trapped-in-body"),
+        pytest.param(r"$*a\_b$*", "$a_b$", id="trail-only-marker-trapped-in-body"),
+        pytest.param("**$x^2$**", "**$x^2$**", id="double-emphasis-preserved"),
+        pytest.param("costs $5 and $10", "costs $5 and $10", id="currency-untouched"),
+    ],
+)
+def test_mangled_math_repair_is_narrow(text: str, expected: str) -> None:
+    assert _repair_mangled_math(text) == expected
+
+
+def test_math_spans_survive_html_escaping() -> None:
+    output = html_to_markdown(r"<p>Let $a\_b$ be given.</p>")
+
+    assert r"$a\_b$" in output
+
+
+def test_a_dollar_span_without_math_signal_is_escaped_like_prose() -> None:
+    output = html_to_markdown("<p>Between $a$ and $b$ there is a_gap.</p>")
+
+    assert r"a\_gap" in output

--- a/tests/unit/test_version_info.py
+++ b/tests/unit/test_version_info.py
@@ -8,6 +8,12 @@ independent of whether the test runs from a checkout or an installed wheel.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
 from notebooklm import _version_info as vi
 
 
@@ -44,3 +50,95 @@ def test_bare_version_when_no_commit(monkeypatch) -> None:
 
 def _must_not_be_called():  # pragma: no cover - only runs if the guard fails
     raise AssertionError("_live_commit must not be called when a commit is embedded")
+
+
+# ---------------------------------------------------------------------------
+# The two commit sources themselves
+# ---------------------------------------------------------------------------
+
+
+def test_embedded_commit_is_none_without_a_build_stamped_module(monkeypatch) -> None:
+    """A source checkout has no ``_commit.py``; the import failure is expected."""
+    monkeypatch.setitem(sys.modules, "notebooklm._commit", None)
+
+    assert vi._embedded_commit() is None
+
+
+def test_embedded_commit_treats_an_empty_stamp_as_absent(monkeypatch) -> None:
+    """A build that saw no git writes an empty ``COMMIT`` rather than omitting it."""
+    module = type(sys)("notebooklm._commit")
+    module.COMMIT = ""
+    monkeypatch.setitem(sys.modules, "notebooklm._commit", module)
+
+    assert vi._embedded_commit() is None
+
+
+def test_embedded_commit_returns_the_stamped_value(monkeypatch) -> None:
+    module = type(sys)("notebooklm._commit")
+    module.COMMIT = "abc12345"
+    monkeypatch.setitem(sys.modules, "notebooklm._commit", module)
+
+    assert vi._embedded_commit() == "abc12345"
+
+
+@pytest.mark.parametrize(
+    "repo_root",
+    [pytest.param(None, id="install-too-shallow"), pytest.param("missing", id="no-dot-git")],
+)
+def test_live_commit_is_none_without_a_checkout(monkeypatch, tmp_path, repo_root) -> None:
+    root = None if repo_root is None else tmp_path / "no-git"
+    if root is not None:
+        root.mkdir()
+    monkeypatch.setattr(vi, "_REPO_ROOT", root)
+
+    assert vi._live_commit() is None
+
+
+def _checkout(tmp_path: Path) -> Path:
+    root = tmp_path / "checkout"
+    (root / ".git").mkdir(parents=True)
+    return root
+
+
+def test_live_commit_returns_the_short_hash(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(vi, "_REPO_ROOT", _checkout(tmp_path))
+    monkeypatch.setattr(
+        vi.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            [], 0, stdout="5d748a26\n", stderr=""
+        ),
+    )
+
+    assert vi._live_commit() == "5d748a26"
+
+
+def test_live_commit_treats_empty_git_output_as_unknown(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(vi, "_REPO_ROOT", _checkout(tmp_path))
+    monkeypatch.setattr(
+        vi.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout="  \n", stderr=""),
+    )
+
+    assert vi._live_commit() is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(FileNotFoundError("git"), id="git-not-installed"),
+        pytest.param(subprocess.TimeoutExpired("git", 2), id="timed-out"),
+        pytest.param(subprocess.CalledProcessError(128, "git"), id="not-a-repository"),
+    ],
+)
+def test_live_commit_swallows_every_git_failure(monkeypatch, tmp_path, error) -> None:
+    """Version reporting must never fail because git did."""
+    monkeypatch.setattr(vi, "_REPO_ROOT", _checkout(tmp_path))
+
+    def _raise(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(vi.subprocess, "run", _raise)
+
+    assert vi._live_commit() is None


### PR DESCRIPTION
Raises unit coverage on the lowest-covered non-generated modules from the
nightly coverage job — [run 33670880090](https://github.com/teng-lin/notebooklm-py/actions/runs/33670880090/job/100383961823),
`release/v0.8.2` @ `5c8bac5d`.

**Stacked on `release/v0.8.2`** (#2318). GitHub will retarget this to `main`
when that merges; no rebase needed unless it conflicts.

## Result

Reproducing the nightly's two-pass command locally (xdist pass + serial
Playwright `--cov-append`):

| | baseline (CI, same commit) | this branch |
|---|---|---|
| total coverage | 93.41% | **94.15%** |
| uncovered (statements + partial branches) | 3635 | **3239** (−396) |

Only two files land above their baseline uncovered count — `_auth/recovery.py`
(+4) and `_artifact/downloads.py` (+1), neither touched here; that is local-vs-CI
environment noise, not a regression.

## Per-module

| module | before | after |
|---|---|---|
| `_artifact/__init__.py` | 51% | 100% |
| `cli/_cookie_import.py` | 62% | 100% |
| `_web/transport/middleware/semaphore.py` | 71% | 100% |
| `_version_info.py` | 72% | 88% |
| `_source/__init__.py` | 76% | 100% |
| `_web/artifact/generation.py` | 76% | 99% |
| `_android/artifact_outputs.py` | 77% | 96% |
| `_android/codecs/documents.py` | 81% | 100% |
| `mcp/tools/_content_sanity.py` | 81% | 100% |
| `_android/labels.py` | 82% | 100% |
| `_android/collections.py` | 82% | 100% |
| `_android/codecs/notes.py` | 83% | 100% |
| `_app/download_specs.py` | 84% | 100% |
| `_source/markdown.py` | 84% | 100% |
| `cli/services/polling.py` | 84% | 100% |
| `_android/codecs/chat.py` | 85% | 100% |
| `_android/upload.py` | 85% | 89% |

The new cases target rejection and failure paths, not line count: range-admission
and structural-depth guards in the TailwindDoc codec, `generate_video`'s
option-compatibility rules, the organization adapters' post-write read-back and
`NOT_FOUND`-vs-other error split, `write_text_atomic`'s cancellation and
partial-file handling, the Drive metadata gate, and every registry invariant in
`_app/download_specs.py`.

## Things worth a reviewer's attention

1. **Deleted three dead helpers** in `cli/_cookie_import.py` —
   `_coerce_cookie_json_to_storage_state`, `_normalize_imported_cookie`,
   `_nonempty_cookie_names`. `23f28f2b` ("refactor(auth): add login cookie app
   boundary") moved the logic behind `_app/login_cookie` and left these
   unreferenced; a repo-wide search finds no caller, and `_nonempty_cookie_names`
   still lives in `_app/login_cookie.py` where it *is* called. Testing dead code
   seemed worse than removing it. This required **re-pinning the `cookie_import`
   semantic hash** in `tests/unit/app/test_app_login_cookie.py` — the live logic
   is unchanged.

2. **`_web/artifact/generation.py` stops at 99%**: lines 433-434 (`retry_failed`'s
   `if not status.task_id`) are unreachable — `_parse_generation_result` raises
   for every falsy id, so the guard can never be entered. Left as-is rather than
   contriving a test or deleting defensive code; happy to remove it if preferred.

3. **`_source._MODULE_EXPORTS["batch"]` is shadowed.** It names
   `_web.sources.batch`, but the real `_source/batch.py` submodule wins normal
   attribute lookup once anything imports it — and production always does
   (`_sources.py`, `_android/sources.py`, `_web/sources/batch.py` all import
   `SourceUrlBatchItem` from it). So `notebooklm._source.batch` resolves to the
   neutral module, import-order-dependently. Characterized in a test rather than
   changed here; flagging it as a real discrepancy.

4. **`SemaphoreMiddleware` had no direct tests.** Its docstring says it is
   retained "for direct middleware compatibility tests"; there were none. Added
   them, including the one-slot-per-logical-RPC contract (a nested retry does not
   release the slot).

## Verification

```
uv run pytest -n auto --dist loadgroup \
  -m "not repo_lint and not requires_playwright and not requires_chromium"   # 17182 passed
uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0
                                                                             # 84 passed
uv run pytest -m repo_lint                                                   # 1948 passed
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports   # clean
uv run ruff check / format                                                   # clean
```

No production behaviour changes beyond the dead-code deletion in (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af5NMrwQKctBjH1Nkm32TH
