### PR TITLE
fix(rpc): catch RateLimitError in RPC health chat probes (#2323)

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -73,6 +73,7 @@ import json
 import os
 import re
 import sys
+import traceback
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
@@ -115,6 +116,7 @@ from notebooklm.exceptions import (
     ChatError,
     ChatResponseParseError,
     DecodingError,
+    RateLimitError,
     UnknownRPCMethodError,
 )
 from notebooklm.paths import get_storage_path
@@ -1059,7 +1061,7 @@ async def check_chat_query(
             found_ids=[],
             error=f"Parse error: {e}",
         )
-    except ChatError as e:
+    except (ChatError, RateLimitError) as e:
         # A recognized server-side ``"er"`` / rate-limit frame: the wire shape
         # is INTACT (the parser identified the frame), the server simply
         # declined this request. Treat as OK — the contract is healthy. The
@@ -1521,7 +1523,7 @@ async def probe_rebrand_chat(
             RebrandProbeStatus.ABSENT,
             "HTTP 200 but the body is not a streamed-chat response",
         )
-    except ChatError as e:
+    except (ChatError, RateLimitError) as e:
         return RebrandProbe(
             REBRAND_CHAT,
             RebrandProbeStatus.PRESENT,
@@ -2340,6 +2342,7 @@ TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
     "HTTP 429",
     "RESOURCE_EXHAUSTED",
     "API rate limit",
+    "Chat rate limit",
     "ReadTimeout",
 )
 
@@ -2656,16 +2659,23 @@ def main() -> int:
     print("=" * 60)
     print()
 
-    results, customization_status, rebrand_state, build_label = asyncio.run(
-        run_health_check(
-            full_mode=args.full,
-            base_url_source=source,
-            rebrand_state_path=args.rebrand_state_file,
-            rebrand_previous_state_path=args.rebrand_previous_state_file,
-            rebrand_run_id=args.rebrand_run_id,
+    try:
+        results, customization_status, rebrand_state, build_label = asyncio.run(
+            run_health_check(
+                full_mode=args.full,
+                base_url_source=source,
+                rebrand_state_path=args.rebrand_state_file,
+                rebrand_previous_state_path=args.rebrand_previous_state_file,
+                rebrand_run_id=args.rebrand_run_id,
+            )
         )
-    )
-    return print_summary(results, customization_status, rebrand_state, build_label)
+        return print_summary(results, customization_status, rebrand_state, build_label)
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"\nFATAL: RPC health check crashed: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -2673,8 +2673,8 @@ def main() -> int:
     except SystemExit:
         raise
     except Exception as e:
-        print(f"\nFATAL: RPC health check crashed: {e}", file=sys.stderr)
-        traceback.print_exc(file=sys.stderr)
+        print(f"\nFATAL: RPC health check crashed: {scrub_secrets(e)}", file=sys.stderr)
+        print(scrub_secrets(traceback.format_exc()), file=sys.stderr)
         return 2
 
 

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -361,6 +361,7 @@ def test_is_transient_error_classifies_readtimeout_as_transient() -> None:
     # point at client- or network-side problems worth surfacing. If this
     # policy ever changes, update this test deliberately — don't drop it.
     assert is_transient_error("ReadTimeout") is True
+    assert is_transient_error("Chat rate limit reached: terminal stream sequence 3") is True
     assert is_transient_error("ConnectTimeout") is False
     assert is_transient_error("WriteTimeout") is False
     assert is_transient_error("PoolTimeout") is False
@@ -703,6 +704,27 @@ async def test_chat_probe_ok_on_recognized_server_error_frame() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_probe_ok_on_rate_limit_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A terminal stream sequence without an RPC payload raises RateLimitError
+    # (server quota exhausted): the wire contract is intact, the server merely
+    # declined. -> OK (#2323).
+    from notebooklm.exceptions import RateLimitError
+
+    def _raise_rate_limit(_text: str) -> Any:
+        raise RateLimitError(
+            "Chat rate limit reached: the request ended before the server "
+            "returned an RPC payload (terminal stream sequence 3). Retry later."
+        )
+
+    monkeypatch.setattr(check_rpc_health, "parse_streaming_chat_response", _raise_rate_limit)
+    client = _ChatClient(text=")]}'\n")
+    result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
+    assert result.status is CheckStatus.OK
+    assert "Server declined (recognized frame)" in (result.error or "")
+    assert "rate limit reached" in (result.error or "")
+
+
+@pytest.mark.asyncio
 async def test_chat_probe_error_on_http_status() -> None:
     client = _ChatClient(status=500, text="boom")
     result = await check_rpc_health.check_chat_query(client, _chat_auth(), "nb_123")
@@ -748,6 +770,25 @@ def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch, tmp_p
     with pytest.raises(SystemExit) as excinfo:
         check_rpc_health.main()
     assert excinfo.value.code == 2
+
+
+def test_main_exits_two_on_unhandled_crash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An unhandled crash in main must return exit code 2 (infrastructure failure),
+    never exit 1 which the workflow interprets as an RPC mismatch (#2323).
+    """
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", "{}")
+    monkeypatch.setattr("sys.argv", ["check_rpc_health.py"])
+
+    async def _crashing_run(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("Unexpected pipeline crash")
+
+    monkeypatch.setattr(check_rpc_health, "run_health_check", _crashing_run)
+    exit_code = check_rpc_health.main()
+    assert exit_code == 2
+    err = capsys.readouterr().err
+    assert "FATAL: RPC health check crashed: Unexpected pipeline crash" in err
 
 
 async def _load_auth_raising(monkeypatch: pytest.MonkeyPatch, error: BaseException) -> None:
@@ -1352,6 +1393,25 @@ async def test_rebrand_chat_present_on_recognized_server_frame() -> None:
         client, _chat_auth(), "notebook.google.com", "nb_123"
     )
     assert probe.status is RebrandProbeStatus.PRESENT
+
+
+@pytest.mark.asyncio
+async def test_rebrand_chat_present_on_rate_limit_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rate-limit frame proves the endpoint is live — it just declined (#2323)."""
+    from notebooklm.exceptions import RateLimitError
+
+    def _raise_rate_limit(_text: str) -> Any:
+        raise RateLimitError("Chat rate limit reached")
+
+    monkeypatch.setattr(check_rpc_health, "parse_streaming_chat_response", _raise_rate_limit)
+    client = _ChatClient(text=")]}'\n")
+    probe = await check_rpc_health.probe_rebrand_chat(
+        client, _chat_auth(), "notebook.google.com", "nb_123"
+    )
+    assert probe.status is RebrandProbeStatus.PRESENT
+    assert "recognized server frame" in probe.detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -777,18 +777,22 @@ def test_main_exits_two_on_unhandled_crash(
 ) -> None:
     """An unhandled crash in main must return exit code 2 (infrastructure failure),
     never exit 1 which the workflow interprets as an RPC mismatch (#2323).
+    Secrets in the exception and formatted traceback must be scrubbed.
     """
     monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", "{}")
     monkeypatch.setattr("sys.argv", ["check_rpc_health.py"])
 
     async def _crashing_run(*_args: Any, **_kwargs: Any) -> Any:
-        raise RuntimeError("Unexpected pipeline crash")
+        # Include a secret token that should be redacted by scrub_secrets
+        raise RuntimeError("Crash with SID=secret_cookie_value_here")
 
     monkeypatch.setattr(check_rpc_health, "run_health_check", _crashing_run)
     exit_code = check_rpc_health.main()
     assert exit_code == 2
     err = capsys.readouterr().err
-    assert "FATAL: RPC health check crashed: Unexpected pipeline crash" in err
+    assert "FATAL: RPC health check crashed:" in err
+    assert "secret_cookie_value_here" not in err
+    assert "***" in err
 
 
 async def _load_auth_raising(monkeypatch: pytest.MonkeyPatch, error: BaseException) -> None:


### PR DESCRIPTION
## Summary

Fixes #2323.

- Catch `RateLimitError` alongside `ChatError` in `check_chat_query` and `probe_rebrand_chat` in `scripts/check_rpc_health.py`.
  - Quota exhaustion / chat rate limit streams terminate without an RPC payload and raise `RateLimitError`. Because `RateLimitError` subclasses `RPCError` instead of `ChatError`, it previously escaped unhandled and caused the process to crash with exit code `1`.
  - The workflow (`.github/workflows/rpc-health.yml`) maps exit code `1` to RPC method mismatches, filing false-positive "RPC ID Mismatch Detected" issues.
- Added `"Chat rate limit"` to `TRANSIENT_ERROR_MARKERS`.
- Wrapped `main()` execution in `scripts/check_rpc_health.py` to return exit code `2` (infrastructure / runner failure) on unexpected exception crashes, preventing crashes from being misclassified as RPC method mismatches.
- Added unit test coverage for `RateLimitError` in `check_chat_query`, `probe_rebrand_chat`, and unhandled crash exits in `test_check_rpc_health.py`.

## Verification

- `uv run pytest tests/unit/test_check_rpc_health.py` (182 passed)
- `uv run pytest -n auto --dist=worksteal` (17,565 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Health checks now correctly recognize chat rate-limit responses as valid server responses.
  - Rate-limit conditions are classified as temporary issues, improving health-check accuracy.
  - Unexpected health-check failures now return a consistent failure status and provide a clear fatal diagnostic.
  - Fatal error details and tracebacks are scrubbed before being displayed, helping prevent sensitive information from appearing in diagnostics.

- **Tests**
  - Added coverage for chat rate-limit handling, unexpected health-check crashes, and sensitive-data redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->