### PR TITLE
test: cover the Android transport, bearer provider, and module entry point

### DIFF
--- a/tests/unit/android/test_asset_url_policy.py
+++ b/tests/unit/android/test_asset_url_policy.py
@@ -1,0 +1,445 @@
+"""Host and URL admission policy for Android asset downloads.
+
+Every one of these helpers sits in front of an outbound request carrying a
+bearer token, so a permissive branch here is an SSRF/credential-leak shape, not
+a cosmetic gap. The adapter suites exercise the happy path; these pin the
+rejections exhaustively.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from notebooklm._android.assets import (
+    _MAX_APPLICATION_REDIRECT_BYTES,
+    _append_initial_alr,
+    _bearer_for,
+    _bounded_text,
+    _close_clients_and_settle_tasks,
+    _declared_content_length,
+    _default_client_factory,
+    _fsync_directory,
+    _is_android_download_host,
+    _safe_approved_host,
+    _single_location,
+    _validated_host,
+)
+from notebooklm._android.auth import BearerCredential
+
+BEARER = "ya29.asset-secret"
+APPROVED = "lh3.googleusercontent.com"
+
+
+# ---------------------------------------------------------------------------
+# _is_android_download_host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        pytest.param(APPROVED, id="primary-bearer-host"),
+        pytest.param("contribution.usercontent.google.com", id="contribution-host"),
+        pytest.param("r1---sn-abc.googlevideo.com", id="googlevideo-subdomain"),
+        pytest.param("usercontent.google.com", id="usercontent-subdomain-of-google"),
+    ],
+)
+def test_approved_download_hosts_are_admitted(host: str) -> None:
+    assert _is_android_download_host(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("evil.com", id="unrelated"),
+        pytest.param("googlevideo.com", id="bare-suffix-is-not-a-subdomain"),
+        pytest.param("notgooglevideo.com", id="suffix-without-the-dot"),
+        pytest.param("evil.com.googlevideo.com.attacker.net", id="suffix-in-the-middle"),
+        pytest.param("x" * 254, id="over-253-characters"),
+        pytest.param("lh3.googleusercontent.com:443", id="port-in-the-host"),
+        pytest.param("LH3.GOOGLEUSERCONTENT.COM", id="uppercase-is-not-normalised-here"),
+        pytest.param("evil%2egooglevideo.com", id="percent-encoded-dot"),
+        pytest.param("evil\\.googlevideo.com", id="backslash"),
+        pytest.param("a..googlevideo.com", id="empty-label"),
+        pytest.param("-a.googlevideo.com", id="label-starts-with-hyphen"),
+        pytest.param("a-.googlevideo.com", id="label-ends-with-hyphen"),
+        pytest.param(("x" * 64) + ".googlevideo.com", id="label-over-63-characters"),
+    ],
+)
+def test_unapproved_download_hosts_are_rejected(host: str) -> None:
+    assert _is_android_download_host(host) is False
+
+
+# ---------------------------------------------------------------------------
+# _safe_approved_host
+# ---------------------------------------------------------------------------
+
+
+def test_a_safe_host_is_reported_for_an_approved_url() -> None:
+    assert _safe_approved_host(f"https://{APPROVED}/asset") == APPROVED
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://evil.com/asset", id="unapproved-host"),
+        pytest.param("https://[oops/asset", id="unparseable"),
+        pytest.param("not a url", id="not-a-url"),
+    ],
+)
+def test_an_unapproved_or_unparseable_url_reports_a_placeholder(url: str) -> None:
+    """The rejected URL is never echoed back into a log line."""
+    assert _safe_approved_host(url) == "<rejected>"
+
+
+# ---------------------------------------------------------------------------
+# _validated_host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(f"https://{APPROVED}/asset", id="plain"),
+        pytest.param(f"https://{APPROVED}:443/asset", id="explicit-default-port"),
+        pytest.param(f"https://{APPROVED}/asset?alr=yes", id="with-query"),
+    ],
+)
+def test_a_well_formed_approved_url_yields_its_host(url: str) -> None:
+    assert _validated_host(url) == APPROVED
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(f"http://{APPROVED}/asset", id="not-https"),
+        pytest.param(f"https://{APPROVED}:8443/asset", id="non-default-port"),
+        pytest.param(f"https://user:pass@{APPROVED}/asset", id="embedded-credentials"),
+        pytest.param(f"https://user@{APPROVED}/asset", id="embedded-username"),
+        pytest.param(f"https://{APPROVED}/asset#fragment", id="fragment"),
+        pytest.param("https://evil.com/asset", id="unapproved-host"),
+        pytest.param("https:///asset", id="no-host"),
+        pytest.param(f"https://{APPROVED}/a\x01b", id="control-character"),
+        pytest.param(f"https://{APPROVED}/a\x7fb", id="delete-character"),
+        pytest.param("https://[oops/asset", id="unparseable"),
+        pytest.param(f"https://{APPROVED}:notaport/asset", id="invalid-port"),
+    ],
+)
+def test_a_url_failing_any_admission_rule_is_rejected(url: str) -> None:
+    assert _validated_host(url) is None
+
+
+# ---------------------------------------------------------------------------
+# _append_initial_alr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param("https://h/a", "https://h/a?alr=yes", id="no-query"),
+        pytest.param("https://h/a?x=1", "https://h/a?x=1&alr=yes", id="existing-query"),
+        pytest.param("https://h/a?alr=yes", "https://h/a?alr=yes", id="already-set"),
+    ],
+)
+def test_the_alr_parameter_is_added_once(url: str, expected: str) -> None:
+    assert _append_initial_alr(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://h/a?alr=no", id="explicitly-disabled"),
+        pytest.param("https://h/a?alr=", id="blank-value"),
+        pytest.param("https://h/a?alr=yes&alr=yes", id="repeated-parameter"),
+        pytest.param("https://h/a?alr=yes&alr=no", id="conflicting-values"),
+    ],
+)
+def test_a_url_declaring_its_own_alr_is_not_rewritten(url: str) -> None:
+    """Silently overriding the caller's redirect mode would change the hop."""
+    assert _append_initial_alr(url) is None
+
+
+def test_an_unparseable_url_yields_no_alr_variant() -> None:
+    assert _append_initial_alr("https://[oops/a") is None
+
+
+# ---------------------------------------------------------------------------
+# _bearer_for
+# ---------------------------------------------------------------------------
+
+
+def test_the_bearer_is_attached_only_for_hosts_that_require_it() -> None:
+    credential = BearerCredential(token=BEARER, generation=1)
+
+    assert _bearer_for(APPROVED, credential) == {"Authorization": f"Bearer {BEARER}"}
+    assert _bearer_for("contribution.usercontent.google.com", credential) == {
+        "Authorization": f"Bearer {BEARER}"
+    }
+
+
+@pytest.mark.parametrize(
+    ("host", "credential"),
+    [
+        pytest.param("r1.googlevideo.com", BearerCredential(BEARER, 1), id="media-cdn-host"),
+        pytest.param("evil.com", BearerCredential(BEARER, 1), id="unapproved-host"),
+        pytest.param(APPROVED, None, id="no-credential"),
+    ],
+)
+def test_the_bearer_is_withheld_from_every_other_hop(
+    host: str, credential: BearerCredential | None
+) -> None:
+    assert _bearer_for(host, credential) == {}
+
+
+# ---------------------------------------------------------------------------
+# Response helpers
+# ---------------------------------------------------------------------------
+
+
+class _Headers:
+    def __init__(self, values: dict[str, list[str]] | None = None) -> None:
+        self._values = values or {}
+
+    def get_list(self, name: str) -> list[str]:
+        return self._values.get(name, [])
+
+    def get(self, name: str, default: object = None) -> object:
+        values = self._values.get(name)
+        return values[0] if values else default
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        pytest.param({"location": ["https://h/next"]}, "https://h/next", id="single"),
+        pytest.param({}, None, id="absent"),
+        pytest.param({"location": ["https://h/a", "https://h/b"]}, None, id="ambiguous"),
+    ],
+)
+def test_only_an_unambiguous_redirect_location_is_followed(
+    values: dict[str, list[str]], expected: str | None
+) -> None:
+    assert _single_location(_Headers(values)) == expected
+
+
+def test_headers_without_a_get_list_accessor_fall_back_to_a_plain_get() -> None:
+    """Not every transport's header mapping exposes ``get_list``."""
+
+    class _PlainHeaders:
+        def __init__(self, value: str | None) -> None:
+            self._value = value
+
+        def get(self, name: str, default: object = None) -> object:
+            return self._value if name == "location" else default
+
+    assert _single_location(_PlainHeaders("https://h/next")) == "https://h/next"
+    assert _single_location(_PlainHeaders(None)) is None
+
+
+def test_an_empty_location_header_is_not_a_redirect() -> None:
+    assert _single_location(_Headers({"location": [""]})) is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("1024", 1024, id="numeric"),
+        pytest.param("0", 0, id="zero"),
+        pytest.param(None, None, id="absent"),
+        # ``-1`` is the module's "declared but unusable" sentinel, distinct from
+        # ``None`` ("not declared") — collapsing the two would let a malformed
+        # header read as an absent one.
+        pytest.param("not-a-number", -1, id="non-numeric"),
+        pytest.param("-1", -1, id="negative"),
+        pytest.param("12 34", -1, id="malformed"),
+    ],
+)
+def test_a_declared_content_length_is_admitted_only_when_usable(
+    raw: str | None, expected: int | None
+) -> None:
+    values = {} if raw is None else {"content-length": [raw]}
+
+    assert _declared_content_length(_Headers(values)) == expected
+
+
+class _Response:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+@pytest.mark.asyncio
+async def test_a_small_redirect_body_is_read_whole() -> None:
+    assert await _bounded_text(_Response([b"ab", b"cd"])) == b"abcd"
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_redirect_body_is_abandoned() -> None:
+    """A hop that streams a large body is not a redirect page — stop reading."""
+    oversized = b"x" * (_MAX_APPLICATION_REDIRECT_BYTES + 1)
+
+    assert await _bounded_text(_Response([oversized])) is None
+
+
+# ---------------------------------------------------------------------------
+# _fsync_directory
+# ---------------------------------------------------------------------------
+
+
+def test_fsync_directory_makes_a_real_directory_durable(tmp_path: Path) -> None:
+    _fsync_directory(tmp_path)
+
+
+def test_fsync_directory_ignores_a_path_it_cannot_open(tmp_path: Path) -> None:
+    """A platform without directory fsync must not fail the download."""
+    _fsync_directory(tmp_path / "does-not-exist")
+
+
+def test_fsync_directory_ignores_an_unsyncable_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    closed: list[int] = []
+    real_close = os.close
+
+    def _failing_fsync(_fd: int) -> None:
+        raise OSError("fsync unsupported on this filesystem")
+
+    def _tracking_close(fd: int) -> None:
+        closed.append(fd)
+        real_close(fd)
+
+    monkeypatch.setattr(os, "fsync", _failing_fsync)
+    monkeypatch.setattr(os, "close", _tracking_close)
+
+    _fsync_directory(tmp_path)
+
+    # The descriptor is still released on the failure path.
+    assert len(closed) == 1
+
+
+# ---------------------------------------------------------------------------
+# _close_clients_and_settle_tasks
+# ---------------------------------------------------------------------------
+
+
+class _Client:
+    """Transport client whose ``aclose`` can be scripted to fail."""
+
+    def __init__(self, error: BaseException | None = None) -> None:
+        self.error = error
+        self.closed = 0
+
+    async def aclose(self) -> None:
+        self.closed += 1
+        if self.error is not None:
+            raise self.error
+
+
+async def _settled(result: object = None, error: BaseException | None = None):
+    if error is not None:
+        raise error
+    return result
+
+
+@pytest.mark.asyncio
+async def test_closing_settles_every_client_and_task() -> None:
+    clients = (_Client(), _Client())
+    tasks = tuple(asyncio.ensure_future(_settled()) for _ in range(2))
+
+    outcome = await _close_clients_and_settle_tasks(clients, tasks)
+
+    assert [client.closed for client in clients] == [1, 1]
+    assert outcome.process_exit is None
+    assert outcome.close_failed is False
+
+
+@pytest.mark.asyncio
+async def test_a_failing_client_close_is_reported_without_stopping_the_sweep() -> None:
+    """Every remaining client must still be closed."""
+    failing = _Client(OSError("socket already gone"))
+    healthy = _Client()
+
+    outcome = await _close_clients_and_settle_tasks((failing, healthy), ())
+
+    assert healthy.closed == 1
+    assert outcome.close_failed is True
+    assert outcome.process_exit is None
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_transfer_task_is_absorbed() -> None:
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.ensure_future(_never())
+    task.cancel()
+
+    outcome = await _close_clients_and_settle_tasks((), (task,))
+
+    assert outcome.close_failed is False
+    assert outcome.process_exit is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_transfer_task_belongs_to_its_own_caller() -> None:
+    """Its failure was already published; the close sweep must not re-raise it."""
+    task = asyncio.ensure_future(_settled(error=OSError("transfer failed")))
+    await asyncio.gather(task, return_exceptions=True)
+
+    outcome = await _close_clients_and_settle_tasks((), (task,))
+
+    assert outcome.close_failed is False
+    assert outcome.process_exit is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [KeyboardInterrupt(), SystemExit()], ids=["keyboard-interrupt", "system-exit"]
+)
+async def test_an_interpreter_exit_while_closing_a_client_is_retained(
+    error: BaseException,
+) -> None:
+    """It is reported back rather than swallowed as an ordinary close failure."""
+    later = _Client()
+
+    outcome = await _close_clients_and_settle_tasks((_Client(error), later), ())
+
+    assert type(outcome.process_exit) is type(error)
+    assert later.closed == 1, "the sweep still finishes"
+
+
+@pytest.mark.asyncio
+async def test_only_the_first_interpreter_exit_is_retained() -> None:
+    first = KeyboardInterrupt()
+    second = SystemExit()
+
+    outcome = await _close_clients_and_settle_tasks((_Client(first), _Client(second)), ())
+
+    assert outcome.process_exit is first
+
+
+# NOTE: the sibling ``except (KeyboardInterrupt, SystemExit)`` in the task loop
+# has no test. CPython's ``Task.__step`` re-raises those two into the event loop
+# as soon as the coroutine raises them, so an awaiter never observes them from a
+# real task and the branch cannot be exercised without faking ``Task`` itself.
+
+
+def test_the_default_client_factory_builds_a_non_redirecting_transport() -> None:
+    """Redirects are followed manually so every hop is host-checked."""
+    client = _default_client_factory()
+
+    try:
+        assert client.follow_redirects is False
+    finally:
+        closer = getattr(client, "close", None)
+        if callable(closer):
+            closer()

--- a/tests/unit/android/test_asset_url_policy.py
+++ b/tests/unit/android/test_asset_url_policy.py
@@ -304,11 +304,25 @@ def test_fsync_directory_ignores_a_path_it_cannot_open(tmp_path: Path) -> None:
     _fsync_directory(tmp_path / "does-not-exist")
 
 
-def test_fsync_directory_ignores_an_unsyncable_descriptor(
+def test_fsync_directory_releases_the_descriptor_when_fsync_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A filesystem that refuses directory fsync must not leak the descriptor.
+
+    ``os.open`` is stubbed to hand back a real descriptor because Windows
+    cannot open a directory as a file at all — there the production code takes
+    its early-return branch, and this release path would never run.
+    """
+    probe = tmp_path / "probe"
+    probe.write_bytes(b"")
+    opened: list[int] = []
     closed: list[int] = []
-    real_close = os.close
+    real_open, real_close = os.open, os.close
+
+    def _open_a_real_file(_path: object, _flags: int) -> int:
+        descriptor = real_open(probe, os.O_RDONLY)
+        opened.append(descriptor)
+        return descriptor
 
     def _failing_fsync(_fd: int) -> None:
         raise OSError("fsync unsupported on this filesystem")
@@ -317,13 +331,13 @@ def test_fsync_directory_ignores_an_unsyncable_descriptor(
         closed.append(fd)
         real_close(fd)
 
+    monkeypatch.setattr(os, "open", _open_a_real_file)
     monkeypatch.setattr(os, "fsync", _failing_fsync)
     monkeypatch.setattr(os, "close", _tracking_close)
 
     _fsync_directory(tmp_path)
 
-    # The descriptor is still released on the failure path.
-    assert len(closed) == 1
+    assert closed == opened != []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/android/test_auth_lifecycle.py
+++ b/tests/unit/android/test_auth_lifecycle.py
@@ -1,0 +1,578 @@
+"""Lifecycle, loop-binding, and failure branches of the Android bearer provider.
+
+``tests/unit/android/test_auth.py`` covers the single-flight mint wave and the
+happy caching path. These cases target what surrounds it: the loop-binding
+assertions, ``reset_after_open``'s task disposal, the sanitized failure
+classification in ``_mint_once``, and the expiry-deadline arithmetic. Every one
+of these guards a credential path, so an unexercised branch here is the kind
+that fails open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from notebooklm._android.auth import (
+    BearerCredential,
+    BearerProvider,
+    _make_bearer_provider,
+    _NoMasterTokenProfile,
+)
+from notebooklm._auth.master_token_types import MasterToken
+from notebooklm._auth.mint_service import MintedOAuthToken, OAuthMintError
+from notebooklm._auth.profile_store import ProfileStore
+from notebooklm.exceptions import AuthError, ConfigurationError, MissingDependencyError
+
+MASTER_SECRET = "aas_et/never-render-this-master"
+BEARER_SECRET = "ya29.never-render-this-bearer"
+
+
+def _record() -> MasterToken:
+    return MasterToken(email="person@example.com", android_id="1234", secret=MASTER_SECRET)
+
+
+@dataclass
+class _Profile:
+    """Profile reader whose ``read_master_token`` can be scripted to fail."""
+
+    record: MasterToken | None = None
+    error: BaseException | None = None
+
+    def read_master_token(self) -> MasterToken | None:
+        if self.error is not None:
+            raise self.error
+        return self.record
+
+
+class _Minter:
+    def __init__(self, result: object = None) -> None:
+        self.result = result
+        self.calls = 0
+
+    async def mint_oauth(self, master_token, spec):  # noqa: ANN001, ANN202
+        self.calls += 1
+        if isinstance(self.result, BaseException):
+            raise self.result
+        return self.result
+
+
+class _BlockingMinter:
+    """Holds the mint open so a close can be raced against an in-flight wave."""
+
+    def __init__(self, result: object) -> None:
+        self.result = result
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def mint_oauth(self, master_token, spec):  # noqa: ANN001, ANN202
+        self.started.set()
+        await self.release.wait()
+        return self.result
+
+
+def _provider(
+    *,
+    profile: object | None = None,
+    minter: object | None = None,
+    wall_clock=lambda: 1_000.0,  # noqa: ANN001
+    monotonic=lambda: 500.0,  # noqa: ANN001
+) -> BearerProvider:
+    return BearerProvider(
+        profile if profile is not None else _Profile(record=_record()),
+        minter if minter is not None else _Minter(),
+        wall_clock=wall_clock,
+        monotonic=monotonic,
+    )
+
+
+async def _activate(provider: BearerProvider, epoch: int = 1) -> None:
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+    await provider.activate(epoch)
+
+
+# ---------------------------------------------------------------------------
+# Credential value + profile reader
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_credential_repr_never_renders_the_token() -> None:
+    rendered = repr(BearerCredential(token=BEARER_SECRET, generation=3))
+
+    assert BEARER_SECRET not in rendered
+    assert rendered == "BearerCredential(token=<redacted>, generation=3)"
+
+
+def test_the_profile_less_reader_reports_no_master_token() -> None:
+    """Direct clients with no profile path get ``None``, not an I/O attempt."""
+    assert _NoMasterTokenProfile().read_master_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Loop binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bound_loop_reports_the_lifecycle_assigned_loop() -> None:
+    provider = _provider()
+    loop = asyncio.get_running_loop()
+
+    assert provider.bound_loop is None
+    provider.set_bound_loop(loop)
+    assert provider.bound_loop is loop
+
+
+@pytest.mark.asyncio
+async def test_operations_refuse_to_run_before_the_lifecycle_binds_a_loop() -> None:
+    provider = _provider()
+
+    with pytest.raises(RuntimeError, match="not bound by the client lifecycle"):
+        await provider.get(1)
+
+
+@pytest.mark.asyncio
+async def test_reset_after_open_cancels_a_retained_mint_task() -> None:
+    """A rebind must not leave the previous loop's mint task running."""
+    provider = _provider()
+    provider.set_bound_loop(asyncio.get_running_loop())
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    provider._mint_task = task
+
+    provider.reset_after_open()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert task.cancelled()
+    assert provider._mint_task is None
+    assert provider._mint_waiters == 0
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_mint_task_result_is_consumed_without_raising() -> None:
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    BearerProvider._consume_task_result(task)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_mint_task_result_is_consumed_without_raising() -> None:
+    """Otherwise the discarded task logs 'exception was never retrieved'."""
+
+    async def _boom() -> None:
+        raise OAuthMintError("mint failed")
+
+    task = asyncio.create_task(_boom())
+    await asyncio.gather(task, return_exceptions=True)
+
+    BearerProvider._consume_task_result(task)
+
+
+# ---------------------------------------------------------------------------
+# activate(): profile read failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_a_profile_without_a_master_token() -> None:
+    provider = _provider(profile=_Profile(record=None))
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+
+    with pytest.raises(ConfigurationError) as caught:
+        await provider.activate(1)
+
+    assert MASTER_SECRET not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_profile_read_is_treated_as_no_token() -> None:
+    """An unreadable profile must not leak its OSError into the auth path."""
+    provider = _provider(profile=_Profile(error=OSError("/profile unreadable")))
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+
+    with pytest.raises(ConfigurationError) as caught:
+        await provider.activate(1)
+
+    assert "unreadable" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [KeyboardInterrupt(), SystemExit()], ids=["keyboard-interrupt", "system-exit"]
+)
+async def test_interpreter_exits_during_the_profile_read_propagate(
+    error: BaseException,
+) -> None:
+    """These are not 'no token available' — they must not be reclassified."""
+    provider = _provider(profile=_Profile(error=error))
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+
+    with pytest.raises(type(error)):
+        await provider.activate(1)
+
+
+@pytest.mark.asyncio
+async def test_a_non_master_token_record_is_rejected() -> None:
+    """``type(record) is not MasterToken`` — a subclass is not admitted either."""
+
+    class _Subclass(MasterToken):
+        pass
+
+    provider = _provider(
+        profile=_Profile(
+            record=_Subclass(email="p@example.com", android_id="1", secret=MASTER_SECRET)
+        )
+    )
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+
+    with pytest.raises(ConfigurationError):
+        await provider.activate(1)
+
+
+# ---------------------------------------------------------------------------
+# _mint_once(): failure classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raised", "expected"),
+    [
+        pytest.param(OAuthMintError("upstream said no"), AuthError, id="mint-error"),
+        pytest.param(MissingDependencyError("gpsoauth"), MissingDependencyError, id="missing-dep"),
+        pytest.param(ValueError("unexpected internal state"), AuthError, id="unexpected-error"),
+    ],
+)
+async def test_mint_failures_are_classified_without_echoing_the_cause(
+    raised: BaseException, expected: type[BaseException]
+) -> None:
+    provider = _provider(minter=_Minter(raised))
+    await _activate(provider)
+
+    with pytest.raises(expected) as caught:
+        await provider.get(1)
+
+    assert "upstream said no" not in str(caught.value)
+    assert "unexpected internal state" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [KeyboardInterrupt(), SystemExit()], ids=["keyboard-interrupt", "system-exit"]
+)
+async def test_interpreter_exits_during_mint_propagate(error: BaseException) -> None:
+    """Driven through ``_mint_once`` directly rather than ``get``.
+
+    ``get`` runs the mint in an ``asyncio.Task``; a ``KeyboardInterrupt``
+    escaping a task reaches the event loop and tears down the whole pytest
+    session instead of being caught by ``pytest.raises``. Awaiting the
+    coroutine in this frame exercises the same guard safely.
+    """
+    provider = _provider(minter=_Minter(error))
+    await _activate(provider)
+
+    with pytest.raises(type(error)):
+        await provider._mint_once(provider._provider_epoch)
+
+    # The record is dropped on the way out rather than retained past the raise.
+    assert provider._cached is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "minted",
+    [
+        pytest.param(None, id="nothing-returned"),
+        pytest.param(MintedOAuthToken(token="", expires_at=None), id="empty-token"),
+        pytest.param(object(), id="wrong-type"),
+    ],
+)
+async def test_an_unusable_mint_result_is_an_auth_error(minted: object) -> None:
+    provider = _provider(minter=_Minter(minted))
+    await _activate(provider)
+
+    with pytest.raises(AuthError):
+        await provider.get(1)
+
+
+@pytest.mark.asyncio
+async def test_minting_after_deactivation_reports_the_inactive_generation() -> None:
+    provider = _provider()
+    await _activate(provider)
+    provider._master_token = None
+
+    with pytest.raises(RuntimeError, match="not active for this client generation"):
+        await provider.get(1)
+
+
+# ---------------------------------------------------------------------------
+# Expiry deadline arithmetic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expires_at", "expected"),
+    [
+        pytest.param(None, None, id="no-expiry"),
+        pytest.param("1200", None, id="non-integer-expiry"),
+        pytest.param(1_000, None, id="already-expired"),
+        pytest.param(900, None, id="expired-in-the-past"),
+        # 600s remaining, margin = min(60, 10%) = 60 -> 500 + 600 - 60
+        pytest.param(1_600, 1_040.0, id="margin-capped-at-60s"),
+        # 100s remaining, margin = min(60, 10) = 10 -> 500 + 100 - 10
+        pytest.param(1_100, 590.0, id="margin-is-ten-percent"),
+    ],
+)
+async def test_expiry_deadline_leaves_a_refresh_margin(
+    expires_at: object, expected: float | None
+) -> None:
+    provider = _provider()
+
+    assert provider._expiry_deadline(expires_at) == expected
+
+
+@pytest.mark.asyncio
+async def test_a_token_expiring_entirely_within_the_margin_is_not_cached() -> None:
+    """Caching it would hand callers a bearer that dies mid-request."""
+    provider = _provider(
+        minter=_Minter(MintedOAuthToken(token=BEARER_SECRET, expires_at=1_000)),
+    )
+    await _activate(provider)
+
+    first = await provider.get(1)
+    second = await provider.get(1)
+
+    assert provider._cached is None
+    assert second.generation == first.generation + 1
+
+
+# ---------------------------------------------------------------------------
+# invalidate()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_ignores_a_stale_generation() -> None:
+    """A 401 from an already-replaced bearer must not clear the fresh one."""
+    provider = _provider(
+        minter=_Minter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000)),
+    )
+    await _activate(provider)
+    credential = await provider.get(1)
+
+    provider.invalidate(credential.generation - 1)
+    assert provider._cached is credential
+
+    provider.invalidate(credential.generation)
+    assert provider._cached is None
+
+
+@pytest.mark.asyncio
+async def test_consuming_a_still_pending_task_result_does_not_raise() -> None:
+    """``reset_after_open`` attaches this callback before the task settles."""
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    try:
+        BearerProvider._consume_task_result(task)
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_profile_read_propagates_rather_than_clearing_the_token() -> None:
+    """A cancelled ``activate`` is not 'this profile has no token'."""
+    provider = _provider(profile=_Profile(error=asyncio.CancelledError()))
+    provider.set_bound_loop(asyncio.get_running_loop())
+    provider.reset_after_open()
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.activate(1)
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_mint_propagates_and_retains_nothing() -> None:
+    provider = _provider(minter=_Minter(asyncio.CancelledError()))
+    await _activate(provider)
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider._mint_once(provider._provider_epoch)
+
+    assert provider._cached is None
+
+
+@pytest.mark.asyncio
+async def test_minting_for_a_superseded_provider_epoch_is_refused() -> None:
+    provider = _provider()
+    await _activate(provider)
+
+    with pytest.raises(RuntimeError, match="not active for this client generation"):
+        await provider._mint_once(provider._provider_epoch + 1)
+
+
+@pytest.mark.asyncio
+async def test_a_bearer_minted_across_a_close_is_never_published() -> None:
+    """The mint itself refuses once the provider generation has moved on."""
+    minter = _BlockingMinter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000))
+    provider = _provider(minter=minter)
+    await _activate(provider)
+
+    pending = asyncio.create_task(provider.get(1))
+    await minter.started.wait()
+    provider._provider_epoch += 1
+    minter.release.set()
+
+    with pytest.raises(RuntimeError, match="not active for this client generation"):
+        await pending
+    assert provider._cached is None
+
+
+@pytest.mark.asyncio
+async def test_a_successful_mint_is_dropped_if_the_session_ended_while_waiting() -> None:
+    """Covers the waiter's post-lock re-check, distinct from the mint's own.
+
+    The mint completes cleanly under an unchanged provider generation; the
+    session is deactivated while the waiter is blocked re-acquiring the lock,
+    so the credential must be discarded rather than published or cached.
+    """
+    minter = _BlockingMinter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000))
+    provider = _provider(minter=minter)
+    await _activate(provider)
+
+    pending = asyncio.create_task(provider.get(1))
+    await minter.started.wait()
+    # Hold the lock so the waiter parks on ``lock.acquire()`` after its mint.
+    lock = provider._get_lock()
+    await lock.acquire()
+    minter.release.set()
+    await asyncio.sleep(0)
+    provider._active_session_epoch = 999
+    lock.release()
+
+    with pytest.raises(RuntimeError, match="not active for this client generation"):
+        await pending
+    assert provider._cached is None
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_waiter_blocked_on_the_lock_releases_its_slot() -> None:
+    """Otherwise the waiter count never drops and the task is retained forever."""
+    minter = _BlockingMinter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000))
+    provider = _provider(minter=minter)
+    await _activate(provider)
+
+    pending = asyncio.create_task(provider.get(1))
+    await minter.started.wait()
+    lock = provider._get_lock()
+    await lock.acquire()
+    mint_task = provider._mint_task
+    assert mint_task is not None
+    minter.release.set()
+    # Let the mint settle, then let the waiter resume and park on ``acquire``.
+    await asyncio.wait_for(asyncio.shield(mint_task), timeout=5)
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert not pending.done(), "waiter should be blocked re-acquiring the lock"
+
+    pending.cancel()
+    await asyncio.gather(pending, return_exceptions=True)
+    lock.release()
+
+    assert provider._mint_waiters == 0
+
+
+@pytest.mark.asyncio
+async def test_a_mint_finishing_after_its_last_waiter_left_is_not_retained() -> None:
+    """``_mint_done`` clears the task when the wave has already drained."""
+    minter = _BlockingMinter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000))
+    provider = _provider(minter=minter)
+    await _activate(provider)
+
+    pending = asyncio.create_task(provider.get(1))
+    await minter.started.wait()
+    pending.cancel()
+    await asyncio.gather(pending, return_exceptions=True)
+    assert provider._mint_waiters == 0
+
+    minter.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert provider._mint_task is None
+
+
+@pytest.mark.asyncio
+async def test_a_settled_mint_task_is_released_when_no_waiter_remains() -> None:
+    provider = _provider(
+        minter=_Minter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000)),
+    )
+    await _activate(provider)
+
+    await provider.get(1)
+
+    assert provider._mint_task is None
+    assert provider._mint_waiters == 0
+
+
+@pytest.mark.asyncio
+async def test_prepare_close_fences_credentials_and_drains_the_mint_task() -> None:
+    minter = _BlockingMinter(MintedOAuthToken(token=BEARER_SECRET, expires_at=2_000))
+    provider = _provider(minter=minter)
+    await _activate(provider)
+    pending = asyncio.create_task(provider.get(1))
+    await minter.started.wait()
+
+    await provider.prepare_close()
+
+    assert provider._mint_task is None
+    assert provider._mint_waiters == 0
+    assert provider._master_token is None
+    assert provider._cached is None
+    assert provider._active_session_epoch is None
+    pending.cancel()
+    await asyncio.gather(pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_prepare_close_requires_a_bound_loop() -> None:
+    provider = _provider()
+
+    with pytest.raises(RuntimeError, match="not bound by the client lifecycle"):
+        await provider.prepare_close()
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+
+def test_a_provider_without_a_storage_path_reads_no_profile() -> None:
+    provider = _make_bearer_provider(None)
+
+    assert isinstance(provider._profile_store, _NoMasterTokenProfile)
+    assert provider._profile_store.read_master_token() is None
+
+
+def test_a_provider_with_a_storage_path_uses_the_profile_store(tmp_path) -> None:
+    provider = _make_bearer_provider(tmp_path)
+
+    assert isinstance(provider._profile_store, ProfileStore)

--- a/tests/unit/android/test_auth_lifecycle.py
+++ b/tests/unit/android/test_auth_lifecycle.py
@@ -271,26 +271,43 @@ async def test_mint_failures_are_classified_without_echoing_the_cause(
     assert "unexpected internal state" not in str(caught.value)
 
 
+def _mint_frame_locals(error: BaseException) -> dict:
+    """Return ``_mint_once``'s frame locals from an escaping exception."""
+    tb = error.__traceback__
+    while tb is not None:
+        if tb.tb_frame.f_code.co_name == "_mint_once":
+            return tb.tb_frame.f_locals
+        tb = tb.tb_next
+    raise AssertionError("_mint_once frame not found on the traceback")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "error", [KeyboardInterrupt(), SystemExit()], ids=["keyboard-interrupt", "system-exit"]
 )
-async def test_interpreter_exits_during_mint_propagate(error: BaseException) -> None:
-    """Driven through ``_mint_once`` directly rather than ``get``.
+async def test_interpreter_exits_during_mint_drop_the_master_token(
+    error: BaseException,
+) -> None:
+    """The exit propagates, and the master token is not left on the traceback.
 
-    ``get`` runs the mint in an ``asyncio.Task``; a ``KeyboardInterrupt``
-    escaping a task reaches the event loop and tears down the whole pytest
-    session instead of being caught by ``pytest.raises``. Awaiting the
-    coroutine in this frame exercises the same guard safely.
+    Driven through ``_mint_once`` directly rather than ``get``: a
+    ``KeyboardInterrupt`` escaping an ``asyncio.Task`` reaches the event loop
+    and tears down the whole pytest session instead of being caught by
+    ``pytest.raises``.
+
+    The assertion inspects ``_mint_once``'s surviving frame locals, because
+    that is what the handler's ``record = None`` exists to clear: an escaping
+    exception keeps its frames alive, so the master token would otherwise stay
+    reachable through the traceback.
     """
     provider = _provider(minter=_Minter(error))
     await _activate(provider)
 
-    with pytest.raises(type(error)):
+    with pytest.raises(type(error)) as caught:
         await provider._mint_once(provider._provider_epoch)
 
-    # The record is dropped on the way out rather than retained past the raise.
-    assert provider._cached is None
+    assert _mint_frame_locals(caught.value).get("record") is None
+    assert MASTER_SECRET not in repr(_mint_frame_locals(caught.value))
 
 
 @pytest.mark.asyncio
@@ -414,10 +431,10 @@ async def test_a_cancelled_mint_propagates_and_retains_nothing() -> None:
     provider = _provider(minter=_Minter(asyncio.CancelledError()))
     await _activate(provider)
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.CancelledError) as caught:
         await provider._mint_once(provider._provider_epoch)
 
-    assert provider._cached is None
+    assert _mint_frame_locals(caught.value).get("record") is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/android/test_codec_lazy_exports.py
+++ b/tests/unit/android/test_codec_lazy_exports.py
@@ -1,0 +1,96 @@
+"""Lazy package-level codec aliases in ``notebooklm._android.codecs``.
+
+The package initializer resolves the older private aliases through
+``__getattr__`` so importing one adapter does not fan out into every generated
+protobuf module. Concrete adapters import their codec submodules directly, so
+nothing in the runtime exercises this path — these cases do.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+
+import pytest
+
+from notebooklm._android import codecs
+
+_NOTEBOOK_ALIASES = ("decode_project", "map_get_project_error", "message_to_known_dict")
+_SOURCE_ALIASES = ("decode_source", "decode_sources")
+
+
+@pytest.mark.parametrize("name", _NOTEBOOK_ALIASES)
+def test_notebook_aliases_resolve_to_the_notebooks_codec(name: str) -> None:
+    from notebooklm._android.codecs import notebooks
+
+    assert getattr(codecs, name) is getattr(notebooks, name)
+
+
+@pytest.mark.parametrize("name", _SOURCE_ALIASES)
+def test_source_aliases_resolve_to_the_sources_codec(name: str) -> None:
+    from notebooklm._android.codecs import sources
+
+    assert getattr(codecs, name) is getattr(sources, name)
+
+
+def test_an_unknown_alias_raises_attribute_error() -> None:
+    missing = "decode_nothing"
+
+    with pytest.raises(AttributeError, match=missing):
+        getattr(codecs, missing)
+
+
+def test_every_advertised_alias_resolves() -> None:
+    """``__all__`` and the two resolver sets must not drift apart."""
+    assert set(codecs.__all__) == set(_NOTEBOOK_ALIASES) | set(_SOURCE_ALIASES)
+    for name in codecs.__all__:
+        assert callable(getattr(codecs, name))
+
+
+def test_importing_the_codec_package_pulls_in_no_generated_protobufs() -> None:
+    """The whole point of the lazy aliases — measured as an import delta.
+
+    Runs in a subprocess so the measurement cannot be perturbed by whatever
+    earlier tests in this worker already imported, and so it never has to evict
+    modules from this process (which would hand later tests a second copy of
+    those classes).
+    """
+    probe = (
+        "import sys, json; "
+        "import notebooklm._android.codecs; "
+        "print(json.dumps(sorted(n for n in sys.modules "
+        "if n.startswith('notebooklm._android.proto'))))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert json.loads(result.stdout) == []
+
+
+def test_resolving_an_alias_is_what_imports_the_submodule() -> None:
+    """Complements the test above: the fan-out happens on access, not import."""
+    probe = (
+        "import sys, json; "
+        "import notebooklm._android.codecs as c; "
+        "before = 'notebooklm._android.codecs.sources' in sys.modules; "
+        "c.decode_source; "
+        "after = 'notebooklm._android.codecs.sources' in sys.modules; "
+        "print(json.dumps([before, after]))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert json.loads(result.stdout) == [False, True]
+
+
+def test_resolution_survives_a_reimport_of_the_package() -> None:
+    """``__getattr__`` holds no cached state of its own."""
+    reloaded = importlib.reload(codecs)
+
+    assert reloaded.decode_source is not None

--- a/tests/unit/android/test_codec_lazy_exports.py
+++ b/tests/unit/android/test_codec_lazy_exports.py
@@ -91,6 +91,8 @@ def test_resolving_an_alias_is_what_imports_the_submodule() -> None:
 
 def test_resolution_survives_a_reimport_of_the_package() -> None:
     """``__getattr__`` holds no cached state of its own."""
+    from notebooklm._android.codecs import sources
+
     reloaded = importlib.reload(codecs)
 
-    assert reloaded.decode_source is not None
+    assert reloaded.decode_source is sources.decode_source

--- a/tests/unit/android/test_session.py
+++ b/tests/unit/android/test_session.py
@@ -15,10 +15,12 @@ from notebooklm._android.session import (
     ANDROID_GRPC_MAX_RECEIVE_MESSAGE_BYTES,
     ANDROID_GRPC_TARGET,
     AndroidSession,
+    _await_with_deadline,
     _default_grpc_loader,
     _default_protobuf_loader,
 )
 from notebooklm._client_metrics import ClientMetrics
+from notebooklm._deadline import RuntimeDeadline
 from notebooklm._runtime.call_supervisor import CallSupervisor
 from notebooklm._transport_drain import TransportDrainTracker
 from notebooklm.exceptions import (
@@ -767,3 +769,463 @@ def test_default_protobuf_loader_maps_generated_runtime_version_mismatch() -> No
         "google.protobuf.runtime_version",
         "notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1.notes_pb2",
     ]
+
+
+# ===========================================================================
+# Lifecycle, deadline, and epoch-fencing branches
+#
+# The cases above cover the wire path and its status mapping. These target the
+# surrounding transport contract: the unbounded-timeout path, the loop/epoch
+# assertions that fence a retired resource generation, ``prepare_metadata``'s
+# sanitization, and the queue-admission timeout that must surface as
+# DEADLINE_EXCEEDED rather than a bare ``TimeoutError``.
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# _await_with_deadline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_absent_deadline_awaits_without_a_timeout_wrapper() -> None:
+    """No deadline means no ``wait_for`` — the awaitable is returned directly."""
+
+    async def _work() -> str:
+        return "done"
+
+    assert await _await_with_deadline(_work(), None) == "done"
+
+
+# ---------------------------------------------------------------------------
+# Timeout resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timeout",
+    [
+        pytest.param(None, id="unset"),
+        pytest.param(float("inf"), id="infinite"),
+        pytest.param(float("nan"), id="nan"),
+    ],
+)
+async def test_a_non_finite_timeout_dispatches_without_a_deadline(timeout: float | None) -> None:
+    session, _bearer, channel, _grpc, _sup = await _open(timeout=timeout)
+
+    await session.unary(METHOD, _Message(b"request"), replay_safe=True, response_type=_Message)
+
+    # The wire call carries no timeout rather than a synthesized one.
+    assert channel.invocations[0][3] is None
+
+
+@pytest.mark.asyncio
+async def test_a_per_call_timeout_overrides_the_session_default() -> None:
+    session, _bearer, channel, _grpc, _sup = await _open(timeout=None)
+
+    await session.unary(
+        METHOD, _Message(b"request"), replay_safe=True, response_type=_Message, timeout=30.0
+    )
+
+    assert channel.invocations[0][3] is not None
+
+
+# ---------------------------------------------------------------------------
+# Loop and epoch fencing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_refuses_a_loop_the_lifecycle_did_not_bind() -> None:
+    session = AndroidSession(
+        _Bearer(),  # type: ignore[arg-type]
+        _supervisor(),
+        timeout=1.0,
+        grpc_loader=lambda: _Grpc(_Channel()),
+    )
+    session.set_bound_loop(asyncio.get_running_loop())
+
+    other_loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RuntimeError, match="not bound by the client lifecycle"):
+            await session.open(other_loop, 1)
+    finally:
+        other_loop.close()
+
+
+@pytest.mark.asyncio
+async def test_assert_epoch_accepts_the_active_generation() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+
+    session.assert_epoch(1)
+
+
+@pytest.mark.asyncio
+async def test_assert_epoch_rejects_a_retired_generation() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+
+    with pytest.raises(RuntimeError, match="retired resource generation"):
+        session.assert_epoch(2)
+
+
+@pytest.mark.asyncio
+async def test_assert_epoch_rejects_every_generation_once_closing() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+    await session.prepare_close()
+
+    with pytest.raises(RuntimeError, match="retired resource generation"):
+        session.assert_epoch(1)
+
+
+@pytest.mark.asyncio
+async def test_a_unary_call_naming_a_retired_generation_is_refused() -> None:
+    session, _bearer, channel, _grpc, _sup = await _open()
+
+    with pytest.raises(RuntimeError, match="retired resource generation"):
+        await session.unary(
+            METHOD,
+            _Message(b"request"),
+            replay_safe=True,
+            response_type=_Message,
+            expected_epoch=99,
+        )
+
+    assert channel.invocations == []
+
+
+@pytest.mark.asyncio
+async def test_active_epoch_tracks_open_and_close() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+
+    assert session.active_epoch == 1
+    await session.prepare_close()
+    assert session.active_epoch is None
+
+
+# ---------------------------------------------------------------------------
+# prepare_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_metadata_resolves_credential_derived_headers() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+
+    async def augment(bearer: str) -> tuple[tuple[str, bytes], ...]:
+        assert bearer == BEARER
+        return (("x-extra-bin", b"extra"),)
+
+    metadata = await session.prepare_metadata(augment, expected_epoch=1)
+
+    assert metadata == (("x-extra-bin", b"extra"),)
+
+
+@pytest.mark.asyncio
+async def test_prepare_metadata_refuses_a_retired_generation() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open()
+
+    async def augment(_bearer: str) -> tuple[tuple[str, bytes], ...]:
+        raise AssertionError("augmentor must not run for a retired generation")
+
+    with pytest.raises(RuntimeError, match="retired resource generation"):
+        await session.prepare_metadata(augment, expected_epoch=99)
+
+
+def _traceback_function_names(error: BaseException) -> list[str]:
+    names = []
+    tb = error.__traceback__
+    while tb is not None:
+        names.append(tb.tb_frame.f_code.co_name)
+        tb = tb.tb_next
+    return names
+
+
+@pytest.mark.asyncio
+async def test_prepare_metadata_detaches_the_frames_of_an_escaping_failure() -> None:
+    """The credential lives in the frames this path unwinds through.
+
+    ``sanitize_escaping_exception`` does not rewrite the message — it drops the
+    traceback and chain so those frames (and the bearer in their locals) are
+    not reachable from the exception a caller catches.
+    """
+    session, _bearer, _channel, _grpc, _sup = await _open()
+    inner = RuntimeError("upstream")
+
+    async def augment(_bearer: str) -> tuple[tuple[str, bytes], ...]:
+        try:
+            raise inner
+        except RuntimeError as error:
+            raise ValueError("augmentor blew up") from error
+
+    with pytest.raises(ValueError) as caught:
+        await session.prepare_metadata(augment, expected_epoch=1)
+
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+    # The re-raise in ``prepare_metadata`` attaches its own frame, but the
+    # credential-bearing frames it unwound through are gone.
+    frames = _traceback_function_names(caught.value)
+    assert "augment" not in frames
+    assert "_prepare_metadata_impl" not in frames
+
+
+# ---------------------------------------------------------------------------
+# Deadlines during an attempt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_deadline_reached_while_minting_reports_deadline_exceeded() -> None:
+    """The bearer wait is inside the deadline, so it maps to the gRPC status."""
+    bearer = _Bearer()
+    bearer.wait = asyncio.Event()
+    session, _bearer, _channel, _grpc, _sup = await _open(bearer=bearer, timeout=0.01)
+
+    with pytest.raises(RPCTimeoutError):
+        await session.unary(METHOD, _Message(b"request"), replay_safe=False, response_type=_Message)
+
+
+@pytest.mark.asyncio
+async def test_a_deadline_reached_inside_the_augmentor_reports_deadline_exceeded() -> None:
+    session, _bearer, _channel, _grpc, _sup = await _open(timeout=0.01)
+
+    async def augment(_bearer: str) -> tuple[tuple[str, bytes], ...]:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    with pytest.raises(RPCTimeoutError):
+        await session.unary(
+            METHOD,
+            _Message(b"request"),
+            replay_safe=False,
+            response_type=_Message,
+            metadata_augmentor=augment,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Queue admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_waiting_for_a_call_slot_past_the_deadline_is_a_timeout_not_an_error() -> None:
+    """A caller that never gets admitted must see DEADLINE_EXCEEDED."""
+    supervisor = _supervisor(limit=1)
+    blocker = asyncio.Event()
+    channel = _Channel()
+
+    async def _blocked() -> bytes:
+        await blocker.wait()
+        return b"response"
+
+    channel.unary_outcomes = [asyncio.ensure_future(_blocked()), b"response"]
+    session, _bearer, _channel, _grpc, _sup = await _open(
+        channel=channel, supervisor=supervisor, timeout=None
+    )
+
+    holder = asyncio.create_task(
+        session.unary(METHOD, _Message(b"a"), replay_safe=False, response_type=_Message)
+    )
+    await asyncio.sleep(0)
+
+    with pytest.raises(RPCTimeoutError):
+        await session.unary(
+            METHOD, _Message(b"b"), replay_safe=False, response_type=_Message, timeout=0.01
+        )
+
+    blocker.set()
+    await asyncio.gather(holder, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_a_deadline_is_started_from_the_injected_clock() -> None:
+    """``RuntimeDeadline`` must use the session's monotonic, not the global one."""
+    ticks = iter([100.0, 100.0, 101.0, 102.0, 103.0])
+    session, _bearer, _channel, _grpc, _sup = await _open(
+        timeout=5.0, monotonic=lambda: next(ticks, 103.0)
+    )
+
+    deadline = session._deadline(None)
+
+    assert isinstance(deadline, RuntimeDeadline)
+    assert deadline.timeout == 5.0
+
+
+@pytest.mark.asyncio
+async def test_a_stream_deadline_reached_while_minting_reports_deadline_exceeded() -> None:
+    bearer = _Bearer()
+    bearer.wait = asyncio.Event()
+    session, _bearer, _channel, _grpc, _sup = await _open(bearer=bearer, timeout=0.01)
+
+    stream = session.stream(METHOD, _Message(b"request"), response_type=_Message)
+    with pytest.raises(RPCTimeoutError):
+        async for _item in stream:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_a_stream_deadline_reached_mid_iteration_reports_deadline_exceeded() -> None:
+    """The per-frame await is inside the deadline, so a late frame times out.
+
+    The clock is advanced from the consumer between frames rather than by
+    sleeping, so the deadline expires deterministically.
+    """
+    channel = _Channel()
+    channel.stream_outcomes = [[_Message(b"one"), _Message(b"two")]]
+    clock = {"now": 0.0}
+    session, _bearer, _channel, _grpc, _sup = await _open(
+        channel=channel, timeout=1.0, monotonic=lambda: clock["now"]
+    )
+
+    received = []
+    stream = session.stream(METHOD, _Message(b"request"), response_type=_Message)
+    with pytest.raises(RPCTimeoutError):
+        async for item in stream:
+            received.append(item)
+            clock["now"] = 1_000.0
+
+    assert received == [_Message(b"one")]
+    # The abandoned call is cancelled rather than left running.
+    assert channel.stream_calls[0].cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_an_unmapped_stream_wire_error_logs_only_its_type(caplog) -> None:
+    """The wire error may embed the bearer; only the class name is recorded."""
+
+    class _Opaque(Exception):
+        def __str__(self) -> str:  # pragma: no cover - must never be logged
+            return f"opaque failure {BEARER}"
+
+    channel = _Channel()
+    channel.stream_outcomes = [[_Message(b"one"), _Opaque()]]
+    session, _bearer, _channel, _grpc, _sup = await _open(channel=channel)
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._android.session"):
+        stream = session.stream(METHOD, _Message(b"request"), response_type=_Message)
+        with pytest.raises(RPCError):
+            async for _item in stream:
+                pass
+
+    assert "_Opaque" in caplog.text
+    assert BEARER not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_stream_cancel_that_itself_fails_is_swallowed() -> None:
+    """Teardown must not replace the real failure with the cancel's error."""
+
+    class _UncancellableCall(_StreamCall):
+        def cancel(self) -> None:
+            raise RuntimeError("cancel is not supported by this transport")
+
+    channel = _Channel()
+
+    def unary_stream(method, *, request_serializer, response_deserializer):
+        def invoke(request, *, metadata, timeout):
+            return _UncancellableCall([_Message(b"one"), _RawRpcError(_Status.INTERNAL)])
+
+        return invoke
+
+    channel.unary_stream = unary_stream  # type: ignore[method-assign]
+    session, _bearer, _channel, _grpc, _sup = await _open(channel=channel)
+
+    stream = session.stream(METHOD, _Message(b"request"), response_type=_Message)
+    with pytest.raises(ServerError):
+        async for _item in stream:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_a_stream_waiting_for_a_call_slot_past_its_deadline_times_out() -> None:
+    supervisor = _supervisor(limit=1)
+    blocker = asyncio.Event()
+    channel = _Channel()
+
+    async def _blocked() -> bytes:
+        await blocker.wait()
+        return b"response"
+
+    channel.unary_outcomes = [asyncio.ensure_future(_blocked())]
+    channel.stream_outcomes = [[_Message(b"one")]]
+    session, _bearer, _channel, _grpc, _sup = await _open(
+        channel=channel, supervisor=supervisor, timeout=None
+    )
+
+    holder = asyncio.create_task(
+        session.unary(METHOD, _Message(b"a"), replay_safe=False, response_type=_Message)
+    )
+    await asyncio.sleep(0)
+
+    stream = session.stream(METHOD, _Message(b"b"), response_type=_Message, timeout=0.01)
+    with pytest.raises(RPCTimeoutError):
+        async for _item in stream:
+            pass
+
+    blocker.set()
+    await asyncio.gather(holder, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_closing_a_session_that_never_opened_a_channel_is_a_no_op() -> None:
+    """``close_resources`` runs on the teardown path even for an unused session."""
+    session, _bearer, channel, _grpc, _sup = await _open()
+
+    await session.close_resources()
+
+    assert channel.closed == 0
+    assert session._channel is None
+
+
+@pytest.mark.asyncio
+async def test_closing_is_idempotent_after_the_channel_is_released() -> None:
+    session, _bearer, channel, _grpc, _sup = await _open()
+    await session.unary(METHOD, _Message(b"request"), replay_safe=True, response_type=_Message)
+
+    await session.close_resources()
+    await session.close_resources()
+
+    assert channel.closed == 1
+    assert session._channel is None
+    assert session._callables == {}
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_teardown_tolerates_a_session_never_bound_to_a_loop() -> None:
+    """Both teardown hooks skip their loop assertion when nothing was bound."""
+    session = AndroidSession(
+        _Bearer(),  # type: ignore[arg-type]
+        _supervisor(),
+        timeout=1.0,
+        grpc_loader=lambda: _Grpc(_Channel()),
+    )
+
+    await session.prepare_close()
+    await session.close_resources()
+
+    assert session.active_epoch is None
+
+
+@pytest.mark.asyncio
+async def test_a_stream_call_without_a_cancel_hook_is_abandoned_cleanly() -> None:
+    """Not every transport exposes ``cancel`` — teardown must not require it."""
+
+    class _NoCancelCall(_StreamCall):
+        cancel = None  # type: ignore[assignment]
+
+    channel = _Channel()
+
+    def unary_stream(method, *, request_serializer, response_deserializer):
+        def invoke(request, *, metadata, timeout):
+            return _NoCancelCall([_Message(b"one"), _RawRpcError(_Status.INTERNAL)])
+
+        return invoke
+
+    channel.unary_stream = unary_stream  # type: ignore[method-assign]
+    session, _bearer, _channel, _grpc, _sup = await _open(channel=channel)
+
+    stream = session.stream(METHOD, _Message(b"request"), response_type=_Message)
+    with pytest.raises(ServerError):
+        async for _item in stream:
+            pass

--- a/tests/unit/android/test_session.py
+++ b/tests/unit/android/test_session.py
@@ -1039,17 +1039,31 @@ async def test_waiting_for_a_call_slot_past_the_deadline_is_a_timeout_not_an_err
 
 
 @pytest.mark.asyncio
-async def test_a_deadline_is_started_from_the_injected_clock() -> None:
-    """``RuntimeDeadline`` must use the session's monotonic, not the global one."""
-    ticks = iter([100.0, 100.0, 101.0, 102.0, 103.0])
+async def test_a_deadline_is_driven_by_the_injected_clock() -> None:
+    """``RuntimeDeadline`` must read the session's monotonic, not the global one.
+
+    Asserting ``deadline.timeout`` alone would pass either way; this drives the
+    injected clock forward and checks the budget it reports actually moves.
+    """
+    clock = {"now": 100.0}
     session, _bearer, _channel, _grpc, _sup = await _open(
-        timeout=5.0, monotonic=lambda: next(ticks, 103.0)
+        timeout=5.0, monotonic=lambda: clock["now"]
     )
 
     deadline = session._deadline(None)
 
     assert isinstance(deadline, RuntimeDeadline)
-    assert deadline.timeout == 5.0
+    assert deadline.monotonic is not time.monotonic
+    assert deadline.started_at == 100.0
+    assert deadline.remaining() == 5.0
+
+    clock["now"] = 102.0
+    assert deadline.elapsed() == 2.0
+    assert deadline.remaining() == 3.0
+
+    clock["now"] = 200.0
+    assert deadline.remaining() == 0.0
+    assert deadline.expired() is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_module_entry_point.py
+++ b/tests/unit/test_module_entry_point.py
@@ -1,0 +1,66 @@
+"""``python -m notebooklm`` — the packaged module entry point.
+
+``src/notebooklm/__main__.py`` is only reachable through ``python -m`` or
+``runpy``, so nothing in the suite exercised it: a rename of
+``notebooklm_cli.main`` would break the documented invocation with every test
+still green. These cases pin the wiring in-process (so coverage sees it) and
+end-to-end through a real interpreter.
+"""
+
+from __future__ import annotations
+
+import runpy
+import subprocess
+import sys
+
+import pytest
+
+import notebooklm.notebooklm_cli as cli_module
+
+
+def test_running_the_package_as_main_invokes_the_cli_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run_name="__main__"`` takes the guarded branch, not just the import."""
+    calls: list[tuple] = []
+    monkeypatch.setattr(cli_module, "main", lambda *a, **k: calls.append((a, k)))
+
+    runpy.run_module("notebooklm", run_name="__main__", alter_sys=True)
+
+    assert calls == [((), {})]
+
+
+def test_importing_the_module_does_not_invoke_the_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Imported under its real name, the ``__name__`` guard must hold."""
+    calls: list[tuple] = []
+    monkeypatch.setattr(cli_module, "main", lambda *a, **k: calls.append((a, k)))
+
+    runpy.run_module("notebooklm.__main__", run_name="notebooklm.__main__")
+
+    assert calls == []
+
+
+def test_python_dash_m_notebooklm_reports_the_cli_help() -> None:
+    """End-to-end through a real interpreter — no import-path shortcuts."""
+    result = subprocess.run(
+        [sys.executable, "-m", "notebooklm", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+
+
+def test_python_dash_m_notebooklm_propagates_a_nonzero_exit() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "notebooklm", "definitely-not-a-command"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode != 0


### PR DESCRIPTION
Second coverage tranche, continuing #2321/#2324 against the nightly job's per-file table. Branched from `main` (not a release branch, per the lesson from #2324).

## Result

| | before | after |
|---|---|---|
| total coverage | 94.16% | **94.35%** |
| uncovered (statements + partial branches) | 3235 | **3134** (−101) |

| module | before | after |
|---|---|---|
| `_android/auth.py` | 86% | **100%** |
| `_android/session.py` | 90% | **97%** |
| `_android/assets.py` | 90% | **94%** |
| `_android/codecs/__init__.py` | 35% | **100%** |
| `__main__.py` | 0% | **100%** |

No production changes — tests only.

## What these cover

The theme is credential-adjacent transport paths: the bearer provider's lifecycle, the gRPC session's epoch fencing, and the asset downloader's URL admission policy. Each is a place where a permissive or unexercised branch fails open rather than loud.

- **`_android/auth.py`** — the loop-binding assertions, `reset_after_open`'s task disposal, the profile-read failure classification (an unreadable profile must not leak its `OSError` into the auth path), `_mint_once`'s failure taxonomy, the expiry-margin arithmetic, and three lock/generation races: a mint landing after a close, a waiter cancelled while re-acquiring the lock, and a mint settling after its last waiter left.
- **`_android/session.py`** — timeout resolution (unset/infinite/NaN dispatch with no deadline at all), epoch and loop fencing, `prepare_metadata`'s frame detaching, deadlines reached while minting / inside the augmentor / mid-stream, queue-admission timeouts surfacing as DEADLINE_EXCEEDED, and stream teardown (unmapped wire errors logging only their type, a `cancel()` that itself raises, a call with no `cancel` hook, idempotent `close_resources`).
- **`_android/assets.py`** — the host allowlist's rejections (bare suffix that is not a subdomain, suffix appearing mid-host, percent-encoded and backslash dots, malformed labels), URL admission (scheme, non-default port, embedded credentials, fragments, control characters), `alr` handling, bearer scoping to the two hosts that require it, and the close sweep's failure absorption.
- **`__main__.py`** — nothing covered `python -m notebooklm` before. Renaming `notebooklm_cli.main` would have broken the documented invocation with the suite still green. Pinned both in-process (via `runpy`, so coverage sees the guarded branch) and end-to-end through a real interpreter.
- **`_android/codecs/__init__.py`** — every lazy alias, plus a subprocess import-delta proving the point of the indirection: importing the codec package pulls in no generated protobuf, and resolving an alias is what triggers the fan-out.

## Notes for review

1. **`log.py` was reported at 0% but is not a gap.** `tests/_guardrails/test_public_surface_manifest.py` covers it to 100%; the coverage job excludes `-m repo_lint`, so it reads as zero. Left alone rather than padded with a duplicate test. Worth knowing when reading that table — other entries may be the same artifact.

2. **Three branches are deliberately left uncovered, with comments.** The `(KeyboardInterrupt, SystemExit)` arms inside task loops cannot be exercised from a real `asyncio.Task`: CPython's `Task.__step` re-raises both into the event loop before any awaiter observes them, which tears down the pytest session rather than being catchable. Where the same guard was reachable by awaiting the coroutine directly (`_mint_once`), it is tested that way instead.

3. **Two tests correct my initial reading of the code, not the code.** `sanitize_escaping_exception` does not rewrite the message — it drops the traceback and chain so credential-bearing frames are unreachable, and the test asserts that. `_declared_content_length` returns `-1` for "declared but unusable", deliberately distinct from `None` for "not declared"; the test pins both.

4. **`_android/session.py` tests live in the existing `test_session.py`** rather than a sibling module, because `tests/unit/android/` has no `__init__.py` and the fakes there would otherwise have to be duplicated and could drift.

## Verification

```
uv run pytest -n auto --dist loadgroup \
  -m "not repo_lint and not requires_playwright and not requires_chromium"   # 17337 passed
uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0
                                                                             # 84 passed
uv run pytest -m repo_lint                                                   # 1950 passed
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports   # clean
uv run ruff check / format                                                   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af5NMrwQKctBjH1Nkm32TH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for Android asset downloads, authentication, session handling, URL validation, credential lifecycle, and cleanup behavior.
  - Added coverage for lazy codec loading and package-level alias behavior.
  - Added end-to-end checks for the `python -m notebooklm` command, including help output and invalid-command handling.
  - Improved validation of timeouts, cancellation, error handling, redirects, resource safety, and deadline calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->