### PR TITLE
fix(sources): resolve _source._MODULE_EXPORTS["batch"] to neutral submodule (#2322)

### DIFF
--- a/src/notebooklm/_source/__init__.py
+++ b/src/notebooklm/_source/__init__.py
@@ -1,6 +1,6 @@
 """Transport-neutral source services and lazy compatibility exports.
 
-Polling and Markdown rendering remain neutral. Historical package-level names
+Polling, batch types, and Markdown rendering remain neutral. Historical package-level names
 for concrete services resolve lazily to their web owners so importing
 ``notebooklm._source`` itself never pulls in the web backend.
 """
@@ -14,7 +14,7 @@ _MODULE_EXPORTS = {
     "markdown": "notebooklm._source.markdown",
     "polling": "notebooklm._source.polling",
     "add": "notebooklm._web.sources.add",
-    "batch": "notebooklm._web.sources.batch",
+    "batch": "notebooklm._source.batch",
     "content": "notebooklm._web.sources.content",
     "drive_import": "notebooklm._web.sources.drive_import",
     "listing": "notebooklm._web.sources.listing",

--- a/tests/unit/test_lazy_package_exports.py
+++ b/tests/unit/test_lazy_package_exports.py
@@ -69,17 +69,7 @@ def test_artifact_all_is_fully_resolvable() -> None:
         assert getattr(_artifact, name) is not None
 
 
-#: ``notebooklm._source.batch`` is a real neutral submodule, so once anything
-#: imports it (production does, for ``SourceUrlBatchItem``) normal attribute
-#: lookup finds it and ``__getattr__`` is never consulted for that name. Its
-#: ``_MODULE_EXPORTS`` entry pointing at the web module is therefore shadowed;
-#: covered separately below rather than asserted as a lazy alias.
-_SOURCE_SHADOWED_BY_A_REAL_SUBMODULE = frozenset({"batch"})
-
-
-@pytest.mark.parametrize(
-    "name", sorted(set(_source._MODULE_EXPORTS) - _SOURCE_SHADOWED_BY_A_REAL_SUBMODULE)
-)
+@pytest.mark.parametrize("name", sorted(_source._MODULE_EXPORTS))
 def test_source_module_exports_resolve_to_the_named_module(name: str) -> None:
     value = getattr(_source, name)
 
@@ -87,16 +77,34 @@ def test_source_module_exports_resolve_to_the_named_module(name: str) -> None:
     assert _source.__dict__[name] is value
 
 
-def test_a_real_submodule_shadows_its_lazy_alias() -> None:
-    """``_source.batch`` is the neutral module, not the web one the map names.
+def test_source_batch_resolves_to_the_neutral_submodule() -> None:
+    """``_source.batch`` must always resolve to the neutral submodule.
 
-    Characterization, not endorsement: the answer depends on whether anything
-    has imported ``notebooklm._source.batch`` yet, and production always has.
+    The declared ``_MODULE_EXPORTS['batch']`` matches the real neutral
+    submodule rather than pointing at ``_web.sources.batch``.
     """
     import notebooklm._source.batch as neutral_batch
 
     assert _source.batch is neutral_batch
-    assert _source._MODULE_EXPORTS["batch"] == "notebooklm._web.sources.batch"
+    assert _source._MODULE_EXPORTS["batch"] == "notebooklm._source.batch"
+
+
+def test_accessing_source_batch_adds_no_additional_web_modules() -> None:
+    """Accessing ``_source.batch`` must not import additional web backend modules."""
+    probe = (
+        "import sys, json; import notebooklm; "
+        "before = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
+        "import notebooklm._source; "
+        "_ = notebooklm._source.batch; "
+        "after = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
+        "print(json.dumps(sorted(after - before)))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert json.loads(result.stdout) == []
 
 
 @pytest.mark.parametrize("name", sorted(_source._SYMBOL_EXPORTS))

--- a/tests/unit/test_lazy_package_exports.py
+++ b/tests/unit/test_lazy_package_exports.py
@@ -93,8 +93,8 @@ def test_accessing_source_batch_adds_no_additional_web_modules() -> None:
     """Accessing ``_source.batch`` must not import additional web backend modules."""
     probe = (
         "import sys, json; import notebooklm; "
-        "before = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
         "import notebooklm._source; "
+        "before = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
         "_ = notebooklm._source.batch; "
         "after = {n for n in sys.modules if n.startswith('notebooklm._web')}; "
         "print(json.dumps(sorted(after - before)))"


### PR DESCRIPTION
## Summary

Resolves #2322.

In `src/notebooklm/_source/__init__.py`, `_MODULE_EXPORTS["batch"]` previously pointed to `"notebooklm._web.sources.batch"`. Because `src/notebooklm/_source/batch.py` is a real submodule that is imported during standard client usage (for `SourceUrlBatchItem`), Python binds the neutral submodule onto `_source`. This resulted in an import-order-dependent discrepancy: `_source.batch` resolved to the neutral submodule after any import of it, while `_MODULE_EXPORTS` declared the web module.

### Changes
- Updated `_source._MODULE_EXPORTS["batch"]` to `"notebooklm._source.batch"` (matching neutral siblings `"markdown"` and `"polling"`).
- Updated docstring of `src/notebooklm/_source/__init__.py` to reflect neutral batch types.
- Updated `tests/unit/test_lazy_package_exports.py`:
  - Removed `_SOURCE_SHADOWED_BY_A_REAL_SUBMODULE` so `test_source_module_exports_resolve_to_the_named_module` validates all module exports including `batch`.
  - Replaced `test_a_real_submodule_shadows_its_lazy_alias` with `test_source_batch_resolves_to_the_neutral_submodule`.
  - Added `test_accessing_source_batch_adds_no_additional_web_modules` asserting zero additional web modules are pulled in when accessing `_source.batch`.

### Local verification
```bash
uv run ruff check src/notebooklm/_source tests/unit/test_lazy_package_exports.py
uv run ruff format --check src/notebooklm/_source tests/unit/test_lazy_package_exports.py
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports
uv run pytest tests/unit/test_lazy_package_exports.py
uv run pytest tests/unit/ -n auto --dist loadgroup
uv run pytest tests/_guardrails/
uv run pre-commit run --all-files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Batch functionality is now resolved through a transport-neutral module, supporting consistent behavior across supported backends.
  * Accessing batch functionality no longer loads unnecessary web-specific components, improving module loading efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->