### PR TITLE
test: cover status projection, ref parsing, transport, and server request policy

### DIFF
--- a/src/notebooklm/_web/research.py
+++ b/src/notebooklm/_web/research.py
@@ -39,7 +39,6 @@ from ..exceptions import (
     NetworkError,
     RateLimitError,
     ResearchStartUnavailableError,
-    ResearchTimeoutError,
     RPCError,
     RPCTimeoutError,
     ServerError,
@@ -531,112 +530,6 @@ class WebResearchAPI(BaseResearchAPI):
             return ResearchTask.not_found(task_id)
 
         return ResearchTask.empty()
-
-    async def _web_wait_for_completion(
-        self,
-        notebook_id: str,
-        task_id: str | None = None,
-        *,
-        timeout: float = 1800,
-        initial_interval: float = _INITIAL_INTERVAL_UNSET,
-    ) -> ResearchTask:
-        """Poll until research reaches a terminal state or times out.
-
-        When the first poll returns a concrete ``task_id``, subsequent polls
-        pass it back through :meth:`poll` as the discriminator. This prevents a
-        later concurrent research task in the same notebook from substituting
-        its sources/report into this wait loop.
-
-        Args:
-            notebook_id: The notebook ID.
-            task_id: Optional research task discriminator. Pass the value
-                returned by :meth:`start` when available. When ``None`` and two
-                or more tasks are in flight on the first poll,
-                :class:`~notebooklm.exceptions.AmbiguousResearchTaskError` is
-                raised; a single in-flight task is selected and pinned silently.
-            timeout: Maximum seconds to wait.
-            initial_interval: Seconds between status checks (default: 5). This
-                is the canonical poll-interval keyword, matching
-                :meth:`SourcesAPI.wait_until_ready` and
-                :meth:`ArtifactsAPI.wait_for_completion`.
-
-        Returns:
-            The final :meth:`poll` result (a
-            :class:`~notebooklm._types.research.ResearchTask`) for
-            ``COMPLETED`` or ``FAILED`` statuses. ``NO_RESEARCH`` is returned
-            immediately only when no task id is known; for a known/pinned task
-            it can be a transient live-API state before the task appears in
-            ``POLL_RESEARCH``. Unlike :meth:`poll`, this method never returns
-            ``NOT_FOUND`` — a pinned task that is temporarily absent from a poll
-            is treated as a transient replication-lag condition and keeps
-            polling until it appears, reaches a terminal state, or times out.
-            Use attribute access (``result.status``).
-
-        Raises:
-            AmbiguousResearchTaskError: If ``task_id`` is ``None`` and two or
-                more tasks are in flight on the first poll (pass ``task_id``).
-            ResearchTimeoutError: If research does not reach a terminal status
-                before ``timeout`` elapses. Subclass of
-                :class:`WaitTimeoutError` and the built-in :class:`TimeoutError`,
-                so ``except TimeoutError`` continues to catch it.
-            ValueError: If ``timeout`` is negative or the poll interval is not
-                positive.
-            TypeError: If the resolved poll interval is not a number.
-        """
-        # Unset sentinel → default cadence. An *explicit* non-numeric value
-        # (``None``, ``"1"``) is a caller bug: fail fast with TypeError rather
-        # than silently coercing it back to the default.
-        if initial_interval is _INITIAL_INTERVAL_UNSET:
-            poll_interval = _DEFAULT_RESEARCH_POLL_INTERVAL
-        elif isinstance(initial_interval, bool) or not isinstance(initial_interval, (int, float)):
-            raise TypeError("poll interval must be a number")
-        else:
-            poll_interval = float(initial_interval)
-
-        if timeout < 0:
-            raise ValueError("timeout must be non-negative")
-        if poll_interval <= 0:
-            raise ValueError("poll interval must be positive")
-
-        loop = asyncio.get_running_loop()
-        start = loop.time()
-        pinned_task_id = task_id
-
-        while True:
-            parsed_tasks = self._select_polled_tasks(
-                await self._poll_task_models(notebook_id),
-                notebook_id=notebook_id,
-                task_id=pinned_task_id,
-                raise_on_ambiguous=pinned_task_id is None,
-            )
-            selected_task = next(iter(parsed_tasks), None)
-            if pinned_task_id is None and selected_task is not None:
-                pinned_task_id = selected_task.task_id
-
-            status_val: ResearchStatus = (
-                selected_task.status if selected_task is not None else ResearchStatus.NO_RESEARCH
-            )
-            if selected_task is not None and status_val in (
-                ResearchStatus.COMPLETED,
-                ResearchStatus.FAILED,
-            ):
-                return self._public_poll_result(selected_task, parsed_tasks)
-            if status_val == ResearchStatus.NO_RESEARCH and pinned_task_id is None:
-                return ResearchTask.empty()
-
-            elapsed = loop.time() - start
-            if elapsed >= timeout:
-                task_label = pinned_task_id or "unknown"
-                raise ResearchTimeoutError(
-                    notebook_id,
-                    task_label,
-                    timeout,
-                    last_status=status_val.value,
-                )
-
-            sleep_for = min(poll_interval, timeout - elapsed)
-            if sleep_for > 0:
-                await asyncio.sleep(sleep_for)
 
     def _wait_observed_status(self, result: ResearchTask) -> ResearchStatus:
         """Preserve Web wait's pre-neutralization pinned-absence status."""

--- a/tests/server/test_app_request_policy.py
+++ b/tests/server/test_app_request_policy.py
@@ -1,0 +1,173 @@
+"""Request-admission helpers in the REST server app.
+
+These decide how much body the server will read and how a bootstrap failure is
+projected to the client. They are pure functions in front of the middleware, so
+the rejections are cheap to pin and expensive to get wrong: a mis-parsed
+``Content-Length`` is an unbounded read, and a mis-projected startup error hides
+"your auth is stale" behind a generic 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi", reason="requires the optional [server] extra")
+
+from notebooklm.exceptions import AuthError, NotebookLMError, ValidationError  # noqa: E402
+from notebooklm.server.app import (  # noqa: E402
+    DEFAULT_JSON_BODY_BYTES,
+    _is_json_content_type,
+    _json_body_limit,
+    _media_type,
+    _normalize_client_startup_error,
+    _parse_content_length,
+)
+
+# ---------------------------------------------------------------------------
+# Content type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("application/json", "application/json", id="plain"),
+        pytest.param("application/json; charset=utf-8", "application/json", id="with-parameters"),
+        pytest.param("  APPLICATION/JSON  ", "application/json", id="normalised"),
+        pytest.param("", "", id="empty"),
+    ],
+)
+def test_the_media_type_drops_parameters_and_case(raw: str, expected: str) -> None:
+    assert _media_type(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "is_json"),
+    [
+        pytest.param("application/json", True, id="canonical"),
+        pytest.param("application/json; charset=utf-8", True, id="with-charset"),
+        pytest.param("APPLICATION/JSON", True, id="uppercase"),
+        pytest.param("application/merge-patch+json", True, id="structured-suffix"),
+        pytest.param("application/vnd.api+json", True, id="vendor-suffix"),
+        pytest.param("text/json", False, id="wrong-tree"),
+        pytest.param("application/jsonish", False, id="prefix-only"),
+        pytest.param("multipart/form-data", False, id="upload"),
+        pytest.param("", False, id="absent"),
+    ],
+)
+def test_json_content_types_are_recognised_by_suffix_not_substring(raw: str, is_json: bool) -> None:
+    assert _is_json_content_type(raw) is is_json
+
+
+# ---------------------------------------------------------------------------
+# Content-Length
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("0", 0, id="zero"),
+        pytest.param("1024", 1024, id="positive"),
+        pytest.param(" 1024 ", 1024, id="surrounding-whitespace"),
+        pytest.param("-1", None, id="negative"),
+        pytest.param("", None, id="empty"),
+        pytest.param("abc", None, id="non-numeric"),
+        pytest.param("1.5", None, id="fractional"),
+        pytest.param("0x10", None, id="hex"),
+    ],
+)
+def test_only_a_non_negative_integer_length_is_accepted(raw: str, expected: int | None) -> None:
+    """Anything else means the server cannot bound the read and must refuse."""
+    assert _parse_content_length(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Body limits
+# ---------------------------------------------------------------------------
+
+
+def test_a_mutating_json_route_falls_back_to_the_default_limit() -> None:
+    limit = _json_body_limit("POST", "/v1/notebooks/abc/unlisted", "application/json")
+
+    assert limit is not None
+    assert limit.max_bytes == DEFAULT_JSON_BODY_BYTES
+    assert limit.name == "JSON"
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "content_type"),
+    [
+        pytest.param("GET", "/v1/notebooks", "application/json", id="read-method"),
+        pytest.param("POST", "/healthz", "application/json", id="outside-v1"),
+        pytest.param("POST", "/v1/notebooks/abc/unlisted", "multipart/form-data", id="not-json"),
+        pytest.param(
+            "POST",
+            "/v1/notebooks/abc/artifacts/def/retry",
+            "application/json",
+            id="declared-no-body-route",
+        ),
+    ],
+)
+def test_routes_outside_the_json_mutation_shape_carry_no_limit(
+    method: str, path: str, content_type: str
+) -> None:
+    assert _json_body_limit(method, path, content_type) is None
+
+
+def test_the_method_is_matched_case_insensitively() -> None:
+    assert _json_body_limit("post", "/v1/notebooks/abc/unlisted", "application/json") is not None
+
+
+def test_an_explicit_route_limit_wins_over_the_content_type_gate() -> None:
+    """The declared table is consulted first, so its limit applies regardless."""
+    limit = _json_body_limit("POST", "/v1/notebooks", "multipart/form-data")
+
+    assert limit is not None
+    assert limit.name == "notebook create"
+    assert limit.max_bytes < DEFAULT_JSON_BODY_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Startup-error projection
+# ---------------------------------------------------------------------------
+
+
+def test_an_auth_error_is_reprojected_without_its_original_context() -> None:
+    normalized = _normalize_client_startup_error(AuthError("token expired"))
+
+    assert isinstance(normalized, AuthError)
+    assert str(normalized) == "token expired"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        pytest.param("Authentication expired", id="canonical-marker"),
+        pytest.param("AUTHENTICATION EXPIRED OR INVALID", id="uppercase"),
+        pytest.param("Please run 'notebooklm login' to continue", id="login-hint"),
+        pytest.param("authentication\n  expired", id="collapsed-whitespace"),
+    ],
+)
+def test_a_stale_auth_value_error_is_projected_onto_the_auth_category(message: str) -> None:
+    """The bootstrap path raises plain ``ValueError`` for a stale local profile."""
+    normalized = _normalize_client_startup_error(ValueError(message))
+
+    assert isinstance(normalized, AuthError)
+    assert str(normalized) == message
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(
+            ValueError("some unrelated configuration problem"), id="unrelated-value-error"
+        ),
+        pytest.param(ValidationError("bad input"), id="already-a-library-error"),
+        pytest.param(NotebookLMError("generic"), id="library-base-error"),
+        pytest.param(RuntimeError("authentication expired"), id="wrong-type-despite-marker"),
+        pytest.param(OSError("disk gone"), id="os-error"),
+    ],
+)
+def test_everything_else_is_left_for_the_generic_projector(exc: Exception) -> None:
+    assert _normalize_client_startup_error(exc) is None

--- a/tests/unit/android/test_grpc_status_projection.py
+++ b/tests/unit/android/test_grpc_status_projection.py
@@ -1,0 +1,131 @@
+"""Status extraction from gRPC-shaped errors.
+
+``grpc_status`` is the only thing standing between a dependency-controlled
+exception object and the public error text: it must read a *known* status name
+or number and nothing else. Every rejection below collapses to ``UNKNOWN``
+rather than letting an arbitrary value through.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notebooklm._android.errors import (
+    GrpcStatus,
+    grpc_status,
+    is_grpc_status,
+)
+from notebooklm.exceptions import AuthError, RPCError
+
+
+class _Code:
+    """Stands in for ``grpc.StatusCode``, whose members carry name and value."""
+
+    def __init__(self, name: Any = None, value: Any = None) -> None:
+        if name is not None:
+            self.name = name
+        if value is not None:
+            self.value = value
+
+
+class _Error(Exception):
+    def __init__(self, code: Any, *, raising: bool = False) -> None:
+        super().__init__("wire failure with secret ya29.token")
+        self._code = code
+        self._raising = raising
+
+    def code(self) -> Any:
+        if self._raising:
+            raise RuntimeError("code() blew up")
+        return self._code
+
+
+def test_a_known_status_name_is_admitted_with_its_canonical_code() -> None:
+    assert grpc_status(_Error(_Code(name="NOT_FOUND"))) == GrpcStatus("NOT_FOUND", 5)
+
+
+def test_the_name_wins_over_a_disagreeing_value() -> None:
+    """The canonical table decides the code, not the object's own number."""
+    status = grpc_status(_Error(_Code(name="UNAVAILABLE", value=999)))
+
+    assert status == GrpcStatus("UNAVAILABLE", 14)
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        pytest.param(_Code(value=(5, "not found")), GrpcStatus("NOT_FOUND", 5), id="tuple-value"),
+        pytest.param(_Code(value=16), GrpcStatus("UNAUTHENTICATED", 16), id="integer-value"),
+        pytest.param(_Code(value=0), GrpcStatus("OK", 0), id="zero-is-a-real-code"),
+    ],
+)
+def test_a_status_without_a_usable_name_falls_back_to_its_value(
+    code: Any, expected: GrpcStatus
+) -> None:
+    assert grpc_status(_Error(code)) == expected
+
+
+def test_a_bare_integer_code_is_mapped() -> None:
+    """Some transports return the raw number rather than an enum member."""
+    assert grpc_status(_Error(8)) == GrpcStatus("RESOURCE_EXHAUSTED", 8)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(Exception("no code attribute at all"), id="not-grpc-shaped"),
+        pytest.param(_Error(_Code(name="FUTURE_STATUS")), id="unknown-name"),
+        pytest.param(_Error(_Code(name=7)), id="non-string-name"),
+        pytest.param(_Error(_Code(value=999)), id="out-of-range-value"),
+        pytest.param(_Error(_Code(value=())), id="empty-tuple-value"),
+        pytest.param(_Error(_Code(value="5")), id="stringly-typed-value"),
+        pytest.param(_Error(_Code(value=True)), id="bool-is-not-an-int-code"),
+        pytest.param(_Error(_Code()), id="neither-name-nor-value"),
+        pytest.param(_Error(None), id="code-returns-none"),
+        pytest.param(_Error("5"), id="code-returns-a-string"),
+        pytest.param(_Error(None, raising=True), id="code-raises"),
+    ],
+)
+def test_anything_unrecognised_collapses_to_unknown(error: Exception) -> None:
+    status = grpc_status(error)
+
+    assert status == GrpcStatus("UNKNOWN", 2)
+
+
+def test_a_non_callable_code_attribute_is_not_invoked() -> None:
+    error = Exception("plain")
+    error.code = 5  # type: ignore[attr-defined]
+
+    assert grpc_status(error) == GrpcStatus("UNKNOWN", 2)
+
+
+def test_the_projection_never_carries_the_original_message() -> None:
+    """The wire error may embed a credential; only name and number survive."""
+    status = grpc_status(_Error(_Code(name="INTERNAL")))
+
+    assert "ya29" not in repr(status)
+
+
+# ---------------------------------------------------------------------------
+# is_grpc_status
+# ---------------------------------------------------------------------------
+
+
+def test_a_mapped_rpc_error_reports_its_code() -> None:
+    error = AuthError("denied", method_id="m", rpc_code=16)
+
+    assert is_grpc_status(error, 16) is True
+    assert is_grpc_status(error, 5) is False
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(ValueError("not an RPC error"), id="unrelated-exception"),
+        pytest.param(RPCError("no code", method_id="m"), id="rpc-error-without-a-code"),
+    ],
+)
+def test_a_non_matching_error_is_not_a_grpc_status(error: BaseException) -> None:
+    assert is_grpc_status(error, 16) is False

--- a/tests/unit/mcp/test_studio_ref_matching.py
+++ b/tests/unit/mcp/test_studio_ref_matching.py
@@ -1,0 +1,148 @@
+"""Cross-type studio ref matching.
+
+``_match_studio_ref`` decides which studio item a user-supplied string refers
+to, and ``studio_delete`` acts on the answer. The dangerous case is a note
+whose *title* happens to look like an id: a full UUID must never fall through
+to title matching, or a delete aimed at an absent id would remove a
+title-collision note instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="requires the optional [mcp] extra")
+
+from notebooklm._app.resolve import AmbiguousIdError  # noqa: E402
+from notebooklm.mcp.tools._studio_items import _match_studio_ref  # noqa: E402
+
+UUID_A = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+UUID_B = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"
+UUID_C = "cccccccc-3333-4333-8333-cccccccccccc"
+
+
+def _item(item_id: str, title: str | None, kind: str = "note") -> dict[str, Any]:
+    return {"id": item_id, "title": title, "type": kind}
+
+
+def test_a_full_uuid_matches_its_item() -> None:
+    items = [_item(UUID_A, "Notes"), _item(UUID_B, "Deck", "artifact")]
+
+    assert _match_studio_ref(items, UUID_A, None) == items[0]
+
+
+def test_a_full_uuid_matches_case_insensitively_and_returns_the_canonical_row() -> None:
+    items = [_item(UUID_A, "Notes")]
+
+    match = _match_studio_ref(items, UUID_A.upper(), None)
+
+    assert match is items[0]
+    assert match["id"] == UUID_A
+
+
+def test_an_absent_full_uuid_never_falls_through_to_a_title() -> None:
+    """A note titled like a UUID must not absorb a delete aimed at that id."""
+    items = [_item(UUID_A, UUID_B)]
+
+    assert _match_studio_ref(items, UUID_B, None) is None
+
+
+def test_a_unique_hex_prefix_resolves_to_the_canonical_id() -> None:
+    items = [_item(UUID_A, "Notes"), _item(UUID_B, "Deck")]
+
+    assert _match_studio_ref(items, "aaaaaaaa", None) == items[0]
+
+
+def test_an_ambiguous_hex_prefix_is_surfaced_rather_than_guessed() -> None:
+    items = [
+        _item("aaaaaaaa-1111-4111-8111-000000000001", "One"),
+        _item("aaaaaaaa-1111-4111-8111-000000000002", "Two"),
+    ]
+
+    with pytest.raises(AmbiguousIdError):
+        _match_studio_ref(items, "aaaaaaaa", None)
+
+
+def test_a_hex_prefix_that_matches_no_id_falls_through_to_the_title() -> None:
+    """An all-hex title stays reachable — only a *full* UUID is id-only."""
+    items = [_item(UUID_A, "beef")]
+
+    assert _match_studio_ref(items, "beef", None) == items[0]
+
+
+def test_an_exact_title_matches_case_insensitively() -> None:
+    items = [_item(UUID_A, "Weekly Report")]
+
+    assert _match_studio_ref(items, "weekly REPORT", None) == items[0]
+
+
+def test_an_untitled_item_is_not_matched_by_an_empty_ref() -> None:
+    items = [_item(UUID_A, None)]
+
+    assert _match_studio_ref(items, "anything", None) is None
+
+
+def test_a_miss_returns_none_for_the_caller_to_classify() -> None:
+    items = [_item(UUID_A, "Notes")]
+
+    assert _match_studio_ref(items, "absent", None) is None
+
+
+def test_an_ambiguous_title_names_its_candidates() -> None:
+    items = [_item(UUID_A, "Draft"), _item(UUID_B, "Draft")]
+
+    with pytest.raises(AmbiguousIdError) as caught:
+        _match_studio_ref(items, "Draft", None)
+
+    message = str(caught.value)
+    assert "matches 2 items" in message
+    assert UUID_A[:12] in message
+    assert "more specific title or the id" in message
+
+
+def test_an_ambiguous_title_listing_is_truncated() -> None:
+    items = [_item(f"{index:08d}-1111-4111-8111-aaaaaaaaaaaa", "Draft") for index in range(9)]
+
+    with pytest.raises(AmbiguousIdError) as caught:
+        _match_studio_ref(items, "Draft", None)
+
+    message = str(caught.value)
+    assert "matches 9 items" in message
+    assert "... and 4 more" in message
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_id"),
+    [
+        pytest.param("note", UUID_A, id="note-scope"),
+        pytest.param("artifact", UUID_B, id="artifact-scope"),
+    ],
+)
+def test_a_kind_scope_restricts_the_candidate_set(kind: str, expected_id: str) -> None:
+    items = [_item(UUID_A, "Same", "note"), _item(UUID_B, "Same", "artifact")]
+
+    match = _match_studio_ref(items, "Same", kind)
+
+    assert match is not None
+    assert match["id"] == expected_id
+
+
+def test_a_kind_scope_hides_an_item_of_another_type() -> None:
+    items = [_item(UUID_A, "Notes", "note")]
+
+    assert _match_studio_ref(items, UUID_A, "artifact") is None
+
+
+def test_a_kind_scope_resolves_what_would_otherwise_be_ambiguous() -> None:
+    items = [_item(UUID_A, "Draft", "note"), _item(UUID_B, "Draft", "artifact")]
+
+    match = _match_studio_ref(items, "Draft", "note")
+
+    assert match is not None
+    assert match["id"] == UUID_A
+
+
+def test_an_empty_item_list_matches_nothing() -> None:
+    assert _match_studio_ref([], UUID_C, None) is None

--- a/tests/unit/mcp/test_studio_ref_matching.py
+++ b/tests/unit/mcp/test_studio_ref_matching.py
@@ -23,12 +23,20 @@ UUID_B = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"
 UUID_C = "cccccccc-3333-4333-8333-cccccccccccc"
 
 
-def _item(item_id: str, title: str | None, kind: str = "note") -> dict[str, Any]:
+#: Studio items carry a note's literal ``"note"`` or an artifact's *hyphenated*
+#: kind (``hyphenated_type``), never a generic ``"artifact"`` — keeping that
+#: vocabulary here is what makes the scoping cases relate to real behaviour.
+NOTE = "note"
+SLIDE_DECK = "slide-deck"
+MIND_MAP = "mind-map"
+
+
+def _item(item_id: str, title: str | None, kind: str = NOTE) -> dict[str, Any]:
     return {"id": item_id, "title": title, "type": kind}
 
 
 def test_a_full_uuid_matches_its_item() -> None:
-    items = [_item(UUID_A, "Notes"), _item(UUID_B, "Deck", "artifact")]
+    items = [_item(UUID_A, "Notes"), _item(UUID_B, "Deck", SLIDE_DECK)]
 
     assert _match_studio_ref(items, UUID_A, None) == items[0]
 
@@ -116,12 +124,12 @@ def test_an_ambiguous_title_listing_is_truncated() -> None:
 @pytest.mark.parametrize(
     ("kind", "expected_id"),
     [
-        pytest.param("note", UUID_A, id="note-scope"),
-        pytest.param("artifact", UUID_B, id="artifact-scope"),
+        pytest.param(NOTE, UUID_A, id="note-scope"),
+        pytest.param(SLIDE_DECK, UUID_B, id="slide-deck-scope"),
     ],
 )
 def test_a_kind_scope_restricts_the_candidate_set(kind: str, expected_id: str) -> None:
-    items = [_item(UUID_A, "Same", "note"), _item(UUID_B, "Same", "artifact")]
+    items = [_item(UUID_A, "Same", NOTE), _item(UUID_B, "Same", SLIDE_DECK)]
 
     match = _match_studio_ref(items, "Same", kind)
 
@@ -130,15 +138,15 @@ def test_a_kind_scope_restricts_the_candidate_set(kind: str, expected_id: str) -
 
 
 def test_a_kind_scope_hides_an_item_of_another_type() -> None:
-    items = [_item(UUID_A, "Notes", "note")]
+    items = [_item(UUID_A, "Notes", NOTE)]
 
-    assert _match_studio_ref(items, UUID_A, "artifact") is None
+    assert _match_studio_ref(items, UUID_A, SLIDE_DECK) is None
 
 
 def test_a_kind_scope_resolves_what_would_otherwise_be_ambiguous() -> None:
-    items = [_item(UUID_A, "Draft", "note"), _item(UUID_B, "Draft", "artifact")]
+    items = [_item(UUID_A, "Draft", NOTE), _item(UUID_B, "Draft", MIND_MAP)]
 
-    match = _match_studio_ref(items, "Draft", "note")
+    match = _match_studio_ref(items, "Draft", NOTE)
 
     assert match is not None
     assert match["id"] == UUID_A

--- a/tests/unit/mcp/test_studio_ref_matching.py
+++ b/tests/unit/mcp/test_studio_ref_matching.py
@@ -15,7 +15,8 @@ import pytest
 
 pytest.importorskip("fastmcp", reason="requires the optional [mcp] extra")
 
-from notebooklm._app.resolve import AmbiguousIdError  # noqa: E402
+from notebooklm._app.resolve import AmbiguousIdError, validate_id  # noqa: E402
+from notebooklm.exceptions import ValidationError  # noqa: E402
 from notebooklm.mcp.tools._studio_items import _match_studio_ref  # noqa: E402
 
 UUID_A = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
@@ -86,10 +87,33 @@ def test_an_exact_title_matches_case_insensitively() -> None:
     assert _match_studio_ref(items, "weekly REPORT", None) == items[0]
 
 
-def test_an_untitled_item_is_not_matched_by_an_empty_ref() -> None:
+def test_an_untitled_item_is_not_matched_by_an_unrelated_ref() -> None:
     items = [_item(UUID_A, None)]
 
     assert _match_studio_ref(items, "anything", None) is None
+
+
+def test_the_matcher_itself_does_not_guard_an_empty_ref() -> None:
+    """Characterization, not endorsement.
+
+    A missing title normalises to ``""``, so an empty ref *does* match an
+    untitled item at this level. That is safe only because the empty ref is
+    rejected upstream — see the companion test below. Anything that calls
+    ``_match_studio_ref`` directly has to do that rejection itself.
+    """
+    items = [_item(UUID_A, None)]
+
+    assert _match_studio_ref(items, "", None) is items[0]
+
+
+@pytest.mark.parametrize(
+    "ref", [pytest.param("", id="empty"), pytest.param("   ", id="whitespace-only")]
+)
+def test_an_empty_ref_is_rejected_before_it_reaches_the_matcher(ref: str) -> None:
+    """``resolve_studio_item`` validates the ref first, so a blank one cannot
+    reach the title path and select an untitled note for deletion."""
+    with pytest.raises(ValidationError):
+        validate_id(ref, "item")
 
 
 def test_a_miss_returns_none_for_the_caller_to_classify() -> None:

--- a/tests/unit/test_call_supervisor.py
+++ b/tests/unit/test_call_supervisor.py
@@ -864,8 +864,9 @@ async def test_spawn_child_is_safe_with_eager_task_factory() -> None:
 # ---------------------------------------------------------------------------
 # Admission-generation state machine
 #
-# These guards keep a retired resource generation from admitting work. They are
-# raised, not returned, so an unexercised one fails open rather than loud.
+# These guards keep a retired resource generation from admitting work. They
+# raise rather than returning a sentinel, so an invalid transition fails closed
+# and loudly — and an unexercised guard is one nothing proves still fires.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_call_supervisor.py
+++ b/tests/unit/test_call_supervisor.py
@@ -859,3 +859,226 @@ async def test_spawn_child_is_safe_with_eager_task_factory() -> None:
         assert observed_parent_depth == [1]
     finally:
         loop.set_task_factory(previous)
+
+
+# ---------------------------------------------------------------------------
+# Admission-generation state machine
+#
+# These guards keep a retired resource generation from admitting work. They are
+# raised, not returned, so an unexercised one fails open rather than loud.
+# ---------------------------------------------------------------------------
+
+
+def test_a_concurrency_limit_below_one_is_rejected() -> None:
+    with pytest.raises(ValueError, match="max_concurrent_rpcs must be >= 1"):
+        CallSupervisor(
+            metrics=ClientMetrics(),
+            drain_tracker=TransportDrainTracker(),
+            max_concurrent_rpcs=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_bound_loop_is_reported_once_assigned() -> None:
+    supervisor = CallSupervisor(
+        metrics=ClientMetrics(),
+        drain_tracker=TransportDrainTracker(),
+        max_concurrent_rpcs=1,
+    )
+    loop = asyncio.get_running_loop()
+
+    assert supervisor.bound_loop is None
+    supervisor.set_bound_loop(loop)
+    assert supervisor.bound_loop is loop
+
+
+@pytest.mark.asyncio
+async def test_preparing_a_second_generation_while_one_is_current_is_refused() -> None:
+    supervisor = _supervisor()
+
+    with pytest.raises(RuntimeError, match="is still current"):
+        supervisor.prepare_generation(2)
+
+
+@pytest.mark.asyncio
+async def test_a_generation_epoch_must_move_forward() -> None:
+    """Reusing an epoch would let retired work rejoin admission."""
+    supervisor = _supervisor()
+    supervisor.mark_closed(1)
+
+    with pytest.raises(RuntimeError, match="not newer than prior epochs"):
+        supervisor.prepare_generation(1)
+
+
+@pytest.mark.asyncio
+async def test_a_generation_can_only_start_from_closed() -> None:
+    supervisor = _supervisor()
+
+    with pytest.raises(RuntimeError, match="cannot start from accepting"):
+        supervisor.start_accepting(1)
+
+
+@pytest.mark.asyncio
+async def test_operations_naming_a_non_current_generation_are_refused() -> None:
+    supervisor = _supervisor()
+
+    with pytest.raises(RuntimeError, match="generation 99 is not current"):
+        supervisor.start_accepting(99)
+
+
+@pytest.mark.asyncio
+async def test_closing_is_idempotent_but_cannot_reopen_a_closed_generation() -> None:
+    supervisor = _supervisor()
+
+    await supervisor.begin_closing(1)
+    # Repeating the transition is a no-op rather than an error.
+    await supervisor.begin_closing(1)
+
+    supervisor.mark_closed(1)
+    supervisor.prepare_generation(2)
+    with pytest.raises(RuntimeError, match="cannot close from closed"):
+        await supervisor.begin_closing(2)
+
+
+@pytest.mark.asyncio
+async def test_a_negative_idle_timeout_is_rejected() -> None:
+    supervisor = _supervisor()
+
+    with pytest.raises(ValueError, match="timeout must be >= 0 or None"):
+        await supervisor.wait_for_idle(1, -1.0)
+
+
+@pytest.mark.asyncio
+async def test_waiting_for_idle_on_an_already_idle_generation_returns_at_once() -> None:
+    supervisor = _supervisor()
+
+    await supervisor.wait_for_idle(1, None)
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_generation_is_named_in_the_error() -> None:
+    supervisor = _supervisor()
+
+    with pytest.raises(RuntimeError, match="generation 42 is unknown"):
+        supervisor._find_generation(42)
+
+
+@pytest.mark.asyncio
+async def test_task_depth_is_zero_outside_a_known_generation() -> None:
+    """Depth lookups happen on teardown paths where the generation may be gone."""
+    supervisor = _supervisor()
+    task = asyncio.current_task()
+
+    assert supervisor._task_depth(None, 1) == 0
+    assert supervisor._task_depth(task, 999) == 0
+    assert supervisor._task_depth(task, 1) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_other_generation_depth_without_a_task() -> None:
+    supervisor = _supervisor()
+
+    assert supervisor._has_other_generation_depth(None, 1) is False
+
+
+@pytest.mark.asyncio
+async def test_spawning_a_child_without_a_current_generation_is_refused() -> None:
+    """The factory must not be invoked once the generation is gone.
+
+    The message comes from ``assert_bound_loop``, which checks ``_current is
+    None`` first; ``spawn_child``'s own "requires a current generation" guard
+    is consequently unreachable and is left untested rather than contrived.
+    """
+    supervisor = _supervisor()
+    supervisor.mark_closed(1)
+    spawned: list[str] = []
+
+    def _factory():  # noqa: ANN202
+        spawned.append("factory")  # pragma: no cover - must never be reached
+        raise AssertionError("child must not start")
+
+    with pytest.raises(RuntimeError, match="Client not initialized"):
+        await supervisor.spawn_child("label", _factory)
+
+    assert spawned == []
+
+
+# ---------------------------------------------------------------------------
+# Drain hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_running_drain_hooks_without_any_registered_is_a_no_op() -> None:
+    supervisor = _supervisor()
+
+    await supervisor.run_drain_hooks()
+
+
+@pytest.mark.asyncio
+async def test_every_drain_hook_runs_even_when_one_fails(caplog) -> None:
+    """A feature's close hook must not be able to skip another feature's."""
+    supervisor = _supervisor()
+    ran: list[str] = []
+
+    async def _ok() -> None:
+        ran.append("ok")
+
+    async def _boom() -> None:
+        ran.append("boom")
+        raise RuntimeError("hook failed")
+
+    supervisor.register_drain_hook("boom", _boom)
+    supervisor.register_drain_hook("ok", _ok)
+
+    with caplog.at_level("WARNING"):
+        await supervisor.run_drain_hooks()
+
+    assert sorted(ran) == ["boom", "ok"]
+    assert "hook failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_registering_a_hook_under_an_existing_name_replaces_it() -> None:
+    supervisor = _supervisor()
+    ran: list[str] = []
+
+    async def _first() -> None:  # pragma: no cover - replaced before running
+        ran.append("first")
+
+    async def _second() -> None:
+        ran.append("second")
+
+    supervisor.register_drain_hook("only", _first)
+    supervisor.register_drain_hook("only", _second)
+
+    await supervisor.run_drain_hooks()
+
+    assert ran == ["second"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [KeyboardInterrupt(), SystemExit()], ids=["keyboard-interrupt", "system-exit"]
+)
+async def test_an_interpreter_exit_from_a_drain_hook_takes_precedence(
+    error: BaseException,
+) -> None:
+    """It is re-raised after the sweep rather than logged like an ordinary failure."""
+    supervisor = _supervisor()
+    ran: list[str] = []
+
+    async def _exiting() -> None:
+        raise error
+
+    async def _ordinary() -> None:
+        ran.append("ordinary")
+        raise RuntimeError("logged, not raised")
+
+    supervisor.register_drain_hook("exiting", _exiting)
+    supervisor.register_drain_hook("ordinary", _ordinary)
+
+    with pytest.raises(type(error)):
+        await supervisor.run_drain_hooks()
+
+    assert ran == ["ordinary"], "the sweep still completes"

--- a/tests/unit/test_curl_cffi_transport_poc.py
+++ b/tests/unit/test_curl_cffi_transport_poc.py
@@ -76,6 +76,42 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def do_DELETE(self):  # noqa: N802
+        if self.path == "/gone":
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/deleted")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        body = b"deleted " + self.path.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Set-Cookie", "DELCOOKIE=set; Path=/")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_PUT(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        data = self.rfile.read(length)
+        if self.path == "/boom":
+            self.send_response(500)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        body = b"put:" + data
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("X-Echo-Len", str(len(data)))
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
     def do_POST(self):  # noqa: N802
         length = int(self.headers.get("Content-Length", 0))
         data = self.rfile.read(length)
@@ -453,3 +489,245 @@ async def test_env_seam_selects_curl_cffi_factory(monkeypatch):
         assert isinstance(inst, CurlCffiAsyncClient)
     finally:
         await inst.aclose()
+
+
+# ---------------------------------------------------------------------------
+# DELETE — the Drive staging cleanup path
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_returns_an_httpx_response_and_syncs_cookies(server):
+    """Without this method the Drive cleanup in ``_android.drive_staging`` raises
+    ``AttributeError`` under ``NOTEBOOKLM_TRANSPORT=curl_cffi`` and, because the
+    cleanup is best-effort, silently leaves the staged file in the user's Drive."""
+    client = CurlCffiAsyncClient(cookies=httpx.Cookies())
+    try:
+        response = await client.delete(f"{server}/staged-file")
+
+        assert isinstance(response, httpx.Response)
+        assert response.status_code == 200
+        assert response.text == "deleted /staged-file"
+        # The response jar is synced back like every other verb.
+        assert client.cookies.get("DELCOOKIE") == "set"
+    finally:
+        await client.aclose()
+
+
+async def test_delete_forwards_request_headers(server):
+    client = CurlCffiAsyncClient()
+    try:
+        response = await client.delete(
+            f"{server}/staged-file", headers={"Authorization": "Bearer token"}
+        )
+
+        assert response.status_code == 200
+    finally:
+        await client.aclose()
+
+
+async def test_delete_surfaces_a_not_found_without_raising(server):
+    """Cleanup is best-effort; a 404 is a normal response, not a transport error."""
+    client = CurlCffiAsyncClient()
+    try:
+        response = await client.delete(f"{server}/gone")
+
+        assert response.status_code == 404
+    finally:
+        await client.aclose()
+
+
+async def test_delete_maps_a_transport_failure_to_httpx_request_error():
+    client = CurlCffiAsyncClient()
+    try:
+        with pytest.raises(httpx.RequestError):
+            # Port 1 is reserved and refuses connections.
+            await client.delete("http://127.0.0.1:1/staged-file")
+    finally:
+        await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# stream_upload — the resumable upload leg
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_upload_sends_a_file_from_disk_without_buffering(server, tmp_path):
+    payload = b"x" * 4096
+    source = tmp_path / "upload.bin"
+    source.write_bytes(payload)
+    client = CurlCffiAsyncClient()
+    try:
+        response = await client.stream_upload(
+            f"{server}/target",
+            source,
+            total_bytes=len(payload),
+            headers={"Content-Type": "application/octet-stream"},
+            method="PUT",
+        )
+
+        assert response.status_code == 200
+        assert response.headers["X-Echo-Len"] == str(len(payload))
+        assert response.text.startswith("put:")
+    finally:
+        await client.aclose()
+
+
+async def test_stream_upload_accepts_an_already_open_handle_and_leaves_it_open(server, tmp_path):
+    """``source`` as a file object is caller-owned — the adapter must not close it."""
+    payload = b"y" * 512
+    source = tmp_path / "upload.bin"
+    source.write_bytes(payload)
+    client = CurlCffiAsyncClient()
+    handle = source.open("rb")
+    try:
+        response = await client.stream_upload(
+            f"{server}/target",
+            handle,
+            total_bytes=len(payload),
+            headers={},
+            method="PUT",
+        )
+
+        assert response.status_code == 200
+        assert handle.closed is False
+    finally:
+        handle.close()
+        await client.aclose()
+
+
+async def test_stream_upload_reports_progress_per_chunk(server, tmp_path):
+    payload = b"z" * 8192
+    source = tmp_path / "upload.bin"
+    source.write_bytes(payload)
+    seen: list[int] = []
+
+    async def on_chunk(count: int) -> None:
+        seen.append(count)
+
+    client = CurlCffiAsyncClient()
+    try:
+        response = await client.stream_upload(
+            f"{server}/target",
+            source,
+            total_bytes=len(payload),
+            headers={},
+            method="PUT",
+            on_chunk=on_chunk,
+        )
+
+        assert response.status_code == 200
+        assert sum(seen) == len(payload)
+    finally:
+        await client.aclose()
+
+
+async def test_stream_upload_surfaces_a_server_error_as_a_response(server, tmp_path):
+    source = tmp_path / "upload.bin"
+    source.write_bytes(b"data")
+    client = CurlCffiAsyncClient()
+    try:
+        response = await client.stream_upload(
+            f"{server}/boom",
+            source,
+            total_bytes=4,
+            headers={},
+            method="PUT",
+        )
+
+        assert response.status_code == 500
+    finally:
+        await client.aclose()
+
+
+async def test_stream_upload_maps_a_transport_failure_to_httpx_request_error(tmp_path):
+    source = tmp_path / "upload.bin"
+    source.write_bytes(b"data")
+    client = CurlCffiAsyncClient()
+    try:
+        with pytest.raises(httpx.RequestError):
+            await client.stream_upload(
+                "http://127.0.0.1:1/target",
+                source,
+                total_bytes=4,
+                headers={},
+                method="PUT",
+            )
+    finally:
+        await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Client and stream lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_the_client_works_as_an_async_context_manager(server):
+    async with CurlCffiAsyncClient() as client:
+        response = await client.get(f"{server}/")
+
+    assert response.status_code == 200
+
+
+async def test_get_guarded_maps_a_transport_failure_to_httpx_request_error():
+    client = CurlCffiAsyncClient()
+    try:
+        with pytest.raises(httpx.RequestError):
+            # HTTPS: the scheme guard runs before the connection, and rejecting
+            # ``http://`` here would never reach the transport-failure branch.
+            await client.get_guarded(
+                "https://127.0.0.1:1/asset", is_trusted_host=lambda _host: True
+            )
+    finally:
+        await client.aclose()
+
+
+async def test_opening_a_stream_against_a_dead_peer_raises_and_closes_the_handle():
+    """``__aexit__`` is not auto-called when ``__aenter__`` raises."""
+    client = CurlCffiAsyncClient()
+    try:
+        with pytest.raises(httpx.RequestError):
+            async with client.stream("GET", "http://127.0.0.1:1/asset"):
+                pass  # pragma: no cover - the enter must raise
+    finally:
+        await client.aclose()
+
+
+async def test_aborting_a_streamed_response_twice_is_idempotent(server):
+    client = CurlCffiAsyncClient()
+    try:
+        async with client.stream("GET", f"{server}/") as response:
+            response.abort()
+            response.abort()
+    finally:
+        await client.aclose()
+
+
+async def test_closing_a_streamed_response_after_abort_settles_cleanly(server):
+    client = CurlCffiAsyncClient()
+    try:
+        async with client.stream("GET", f"{server}/") as response:
+            response.abort()
+            await response.aclose()
+    finally:
+        await client.aclose()
+
+
+async def test_stream_upload_sends_the_session_cookie_jar_for_that_url(server, tmp_path):
+    source = tmp_path / "upload.bin"
+    source.write_bytes(b"payload")
+    cookies = httpx.Cookies()
+    cookies.set("SESSION", "value", domain="127.0.0.1")
+    client = CurlCffiAsyncClient(cookies=cookies)
+    try:
+        response = await client.stream_upload(
+            f"{server}/target",
+            source,
+            total_bytes=7,
+            headers={},
+            method="PUT",
+            overall_timeout=30.0,
+        )
+
+        assert response.status_code == 200
+    finally:
+        await client.aclose()

--- a/tests/unit/test_curl_cffi_transport_poc.py
+++ b/tests/unit/test_curl_cffi_transport_poc.py
@@ -14,6 +14,7 @@ contract the transport kernel relies on, end-to-end, without Google auth:
 from __future__ import annotations
 
 import asyncio
+import socket
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -76,6 +77,17 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    @staticmethod
+    def _echo_safe(value: str) -> str:
+        """Strip CR/LF before reflecting a request value into a response.
+
+        Echoing a client-controlled value into a response header is HTTP
+        response splitting (flagged by CodeQL) even in a test server. The
+        assertions only need the value's content, so drop the control
+        characters and bound the length.
+        """
+        return "".join(ch for ch in value if ch not in "\r\n")[:200]
+
     def do_DELETE(self):  # noqa: N802
         if self.path == "/gone":
             self.send_response(404)
@@ -88,7 +100,8 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
-        body = (f"deleted {self.path} auth={self.headers.get('Authorization', '')}").encode()
+        auth = self._echo_safe(self.headers.get("Authorization", ""))
+        body = f"deleted {self.path} auth={auth}".encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")
         self.send_header("Set-Cookie", "DELCOOKIE=set; Path=/")
@@ -110,9 +123,14 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("X-Echo-Len", str(len(data)))
         # Echo what the client actually sent, so a test can prove the header
         # and cookie plumbing is real rather than merely non-fatal.
-        self.send_header("X-Echo-Content-Type", self.headers.get("Content-Type", ""))
-        self.send_header("X-Echo-Cookie", self.headers.get("Cookie", ""))
-        self.send_header("X-Echo-Upload-Command", self.headers.get("X-Goog-Upload-Command", ""))
+        self.send_header(
+            "X-Echo-Content-Type", self._echo_safe(self.headers.get("Content-Type", ""))
+        )
+        self.send_header("X-Echo-Cookie", self._echo_safe(self.headers.get("Cookie", "")))
+        self.send_header(
+            "X-Echo-Upload-Command",
+            self._echo_safe(self.headers.get("X-Goog-Upload-Command", "")),
+        )
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -140,6 +158,23 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+
+@pytest.fixture
+def refused_url():
+    """A loopback address guaranteed to refuse connections.
+
+    Port 1 is only *usually* free; a local service can bind it and turn a
+    transport-failure test into a false pass. A socket that is bound but never
+    listening refuses deterministically, and holding it open for the test keeps
+    the port reserved.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    try:
+        yield f"127.0.0.1:{sock.getsockname()[1]}"
+    finally:
+        sock.close()
 
 
 @pytest.fixture
@@ -544,12 +579,11 @@ async def test_delete_surfaces_a_not_found_without_raising(server):
         await client.aclose()
 
 
-async def test_delete_maps_a_transport_failure_to_httpx_request_error():
+async def test_delete_maps_a_transport_failure_to_httpx_request_error(refused_url):
     client = CurlCffiAsyncClient()
     try:
         with pytest.raises(httpx.RequestError):
-            # Port 1 is reserved and refuses connections.
-            await client.delete("http://127.0.0.1:1/staged-file")
+            await client.delete(f"http://{refused_url}/staged-file")
     finally:
         await client.aclose()
 
@@ -578,7 +612,9 @@ async def test_stream_upload_sends_a_file_from_disk_without_buffering(server, tm
 
         assert response.status_code == 200
         assert response.headers["X-Echo-Len"] == str(len(payload))
-        assert response.text.startswith("put:")
+        # The server echoes the body's leading bytes, so a corrupted or
+        # truncated read function is caught, not just a wrong length.
+        assert response.text == "put:" + payload[:8].decode()
         # Real resumable-upload callers depend on these reaching the server.
         assert response.headers["X-Echo-Content-Type"] == "application/octet-stream"
         assert response.headers["X-Echo-Upload-Command"] == "upload, finalize"
@@ -656,14 +692,14 @@ async def test_stream_upload_surfaces_a_server_error_as_a_response(server, tmp_p
         await client.aclose()
 
 
-async def test_stream_upload_maps_a_transport_failure_to_httpx_request_error(tmp_path):
+async def test_stream_upload_maps_a_transport_failure_to_httpx_request_error(tmp_path, refused_url):
     source = tmp_path / "upload.bin"
     source.write_bytes(b"data")
     client = CurlCffiAsyncClient()
     try:
         with pytest.raises(httpx.RequestError):
             await client.stream_upload(
-                "http://127.0.0.1:1/target",
+                f"http://{refused_url}/target",
                 source,
                 total_bytes=4,
                 headers={},
@@ -685,21 +721,21 @@ async def test_the_client_works_as_an_async_context_manager(server):
     assert response.status_code == 200
 
 
-async def test_get_guarded_maps_a_transport_failure_to_httpx_request_error():
+async def test_get_guarded_maps_a_transport_failure_to_httpx_request_error(refused_url):
     client = CurlCffiAsyncClient()
     try:
         with pytest.raises(httpx.RequestError):
             # HTTPS: the scheme guard runs before the connection, and rejecting
             # ``http://`` here would never reach the transport-failure branch.
             await client.get_guarded(
-                "https://127.0.0.1:1/asset", is_trusted_host=lambda _host: True
+                f"https://{refused_url}/asset", is_trusted_host=lambda _host: True
             )
     finally:
         await client.aclose()
 
 
 async def test_opening_a_stream_against_a_dead_peer_raises_and_closes_the_handle(
-    monkeypatch,
+    monkeypatch, refused_url
 ):
     """``__aexit__`` is not auto-called when ``__aenter__`` raises.
 
@@ -725,7 +761,7 @@ async def test_opening_a_stream_against_a_dead_peer_raises_and_closes_the_handle
     monkeypatch.setattr(client._curl, "stream", _instrumented_stream)
     try:
         with pytest.raises(httpx.RequestError):
-            async with client.stream("GET", "http://127.0.0.1:1/asset"):
+            async with client.stream("GET", f"http://{refused_url}/asset"):
                 pass  # pragma: no cover - the enter must raise
 
         assert exits, "the curl stream handle was never closed on the failure path"

--- a/tests/unit/test_curl_cffi_transport_poc.py
+++ b/tests/unit/test_curl_cffi_transport_poc.py
@@ -88,7 +88,7 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
-        body = b"deleted " + self.path.encode()
+        body = (f"deleted {self.path} auth={self.headers.get('Authorization', '')}").encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")
         self.send_header("Set-Cookie", "DELCOOKIE=set; Path=/")
@@ -104,10 +104,15 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.end_headers()
             return
-        body = b"put:" + data
+        body = b"put:" + data[:8]
         self.send_response(200)
         self.send_header("Content-Type", "text/plain")
         self.send_header("X-Echo-Len", str(len(data)))
+        # Echo what the client actually sent, so a test can prove the header
+        # and cookie plumbing is real rather than merely non-fatal.
+        self.send_header("X-Echo-Content-Type", self.headers.get("Content-Type", ""))
+        self.send_header("X-Echo-Cookie", self.headers.get("Cookie", ""))
+        self.send_header("X-Echo-Upload-Command", self.headers.get("X-Goog-Upload-Command", ""))
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -506,7 +511,7 @@ async def test_delete_returns_an_httpx_response_and_syncs_cookies(server):
 
         assert isinstance(response, httpx.Response)
         assert response.status_code == 200
-        assert response.text == "deleted /staged-file"
+        assert response.text.startswith("deleted /staged-file")
         # The response jar is synced back like every other verb.
         assert client.cookies.get("DELCOOKIE") == "set"
     finally:
@@ -514,6 +519,8 @@ async def test_delete_returns_an_httpx_response_and_syncs_cookies(server):
 
 
 async def test_delete_forwards_request_headers(server):
+    """Dropping ``headers`` would make the authenticated Drive cleanup 401 and
+    silently leave the staged file behind, so the server echoes what it saw."""
     client = CurlCffiAsyncClient()
     try:
         response = await client.delete(
@@ -521,6 +528,7 @@ async def test_delete_forwards_request_headers(server):
         )
 
         assert response.status_code == 200
+        assert "auth=Bearer token" in response.text
     finally:
         await client.aclose()
 
@@ -552,7 +560,7 @@ async def test_delete_maps_a_transport_failure_to_httpx_request_error():
 
 
 async def test_stream_upload_sends_a_file_from_disk_without_buffering(server, tmp_path):
-    payload = b"x" * 4096
+    payload = b"x" * (512 * 1024)
     source = tmp_path / "upload.bin"
     source.write_bytes(payload)
     client = CurlCffiAsyncClient()
@@ -561,13 +569,19 @@ async def test_stream_upload_sends_a_file_from_disk_without_buffering(server, tm
             f"{server}/target",
             source,
             total_bytes=len(payload),
-            headers={"Content-Type": "application/octet-stream"},
+            headers={
+                "Content-Type": "application/octet-stream",
+                "X-Goog-Upload-Command": "upload, finalize",
+            },
             method="PUT",
         )
 
         assert response.status_code == 200
         assert response.headers["X-Echo-Len"] == str(len(payload))
         assert response.text.startswith("put:")
+        # Real resumable-upload callers depend on these reaching the server.
+        assert response.headers["X-Echo-Content-Type"] == "application/octet-stream"
+        assert response.headers["X-Echo-Upload-Command"] == "upload, finalize"
     finally:
         await client.aclose()
 
@@ -596,7 +610,8 @@ async def test_stream_upload_accepts_an_already_open_handle_and_leaves_it_open(s
 
 
 async def test_stream_upload_reports_progress_per_chunk(server, tmp_path):
-    payload = b"z" * 8192
+    """Several positive callbacks, not one after buffering the whole file."""
+    payload = b"z" * (512 * 1024)
     source = tmp_path / "upload.bin"
     source.write_bytes(payload)
     seen: list[int] = []
@@ -617,6 +632,8 @@ async def test_stream_upload_reports_progress_per_chunk(server, tmp_path):
 
         assert response.status_code == 200
         assert sum(seen) == len(payload)
+        assert all(count > 0 for count in seen)
+        assert len(seen) > 1, f"body was delivered in one read: {seen}"
     finally:
         await client.aclose()
 
@@ -681,13 +698,37 @@ async def test_get_guarded_maps_a_transport_failure_to_httpx_request_error():
         await client.aclose()
 
 
-async def test_opening_a_stream_against_a_dead_peer_raises_and_closes_the_handle():
-    """``__aexit__`` is not auto-called when ``__aenter__`` raises."""
+async def test_opening_a_stream_against_a_dead_peer_raises_and_closes_the_handle(
+    monkeypatch,
+):
+    """``__aexit__`` is not auto-called when ``__aenter__`` raises.
+
+    The curl stream context is instrumented so this proves the explicit
+    failure-path cleanup ran, rather than relying on the later
+    ``client.aclose()`` to tidy the whole session.
+    """
     client = CurlCffiAsyncClient()
+    exits: list[object] = []
+    real_stream = client._curl.stream
+
+    def _instrumented_stream(method, url, **kwargs):
+        cm = real_stream(method, url, **kwargs)
+        real_aexit = cm.__aexit__
+
+        async def _tracking_aexit(*exc):
+            exits.append(exc[0])
+            return await real_aexit(*exc)
+
+        cm.__aexit__ = _tracking_aexit
+        return cm
+
+    monkeypatch.setattr(client._curl, "stream", _instrumented_stream)
     try:
         with pytest.raises(httpx.RequestError):
             async with client.stream("GET", "http://127.0.0.1:1/asset"):
                 pass  # pragma: no cover - the enter must raise
+
+        assert exits, "the curl stream handle was never closed on the failure path"
     finally:
         await client.aclose()
 
@@ -729,5 +770,7 @@ async def test_stream_upload_sends_the_session_cookie_jar_for_that_url(server, t
         )
 
         assert response.status_code == 200
+        # Without the CURLOPT_COOKIE setup this upload leg would be anonymous.
+        assert "SESSION=value" in response.headers["X-Echo-Cookie"]
     finally:
         await client.aclose()

--- a/tests/unit/test_research_import_with_verification.py
+++ b/tests/unit/test_research_import_with_verification.py
@@ -1638,6 +1638,8 @@ class TestImportProvenanceGuards:
         )
 
         research.import_sources.assert_awaited()
+        # ``assert_awaited`` alone would pass if a different task id were sent.
+        assert research.import_sources.await_args.args[1] == "task-1"
 
 
 class TestResearchPublicHelperDelegation:

--- a/tests/unit/test_research_import_with_verification.py
+++ b/tests/unit/test_research_import_with_verification.py
@@ -22,7 +22,12 @@ import pytest
 
 import notebooklm._research as _research_mod
 from notebooklm._web.research import ResearchAPI
-from notebooklm.exceptions import NetworkError, RPCError, RPCTimeoutError
+from notebooklm.exceptions import (
+    NetworkError,
+    ResearchTaskMismatchError,
+    RPCError,
+    RPCTimeoutError,
+)
 
 
 class _RecordingRpc:
@@ -1575,3 +1580,83 @@ class TestImportSourcesIdempotency:
             {"url": "https://x.example.com", "title": "X"}
         ]
         mock_sleep.assert_awaited_once_with(5)
+
+
+class TestImportProvenanceGuards:
+    """Input admission before any RPC is sent.
+
+    Provenance is a correctness boundary: sources discovered under one research
+    task must not be imported under another, because the server attributes the
+    import to the task id the caller passes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_empty_source_list_returns_without_touching_the_backend(self) -> None:
+        research, mock_rpc, mock_source_lister = _make_research()
+
+        result = await research._import_sources_with_verification("nb1", "task-1", [])
+
+        assert result == []
+        mock_rpc.rpc_call.assert_not_called()
+        mock_source_lister.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_source_from_another_research_task_is_refused(self) -> None:
+        research, mock_rpc, _lister = _make_research()
+        sources = [{"url": "https://a.example/x", "research_task_id": "task-OTHER"}]
+
+        with pytest.raises(ResearchTaskMismatchError) as caught:
+            await research._import_sources_with_verification("nb1", "task-1", sources)
+
+        assert caught.value.task_id == "task-1"
+        assert caught.value.source_research_task_id == "task-OTHER"
+        mock_rpc.rpc_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_batch_spanning_two_research_tasks_is_refused(self) -> None:
+        """Each source matches the caller's id individually is not enough."""
+        research, mock_rpc, _lister = _make_research()
+        sources = [
+            {"url": "https://a.example/x", "research_task_id": "task-1"},
+            {"url": "https://b.example/y", "research_task_id": "task-2"},
+        ]
+
+        with pytest.raises(ResearchTaskMismatchError):
+            await research._import_sources_with_verification("nb1", "task-1", sources)
+
+        mock_rpc.rpc_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sources_without_provenance_are_admitted(self) -> None:
+        """An unstamped source inherits the caller's task id rather than failing."""
+        research, _rpc, mock_source_lister = _make_research()
+        mock_source_lister.list = AsyncMock(return_value=[])
+        research.import_sources = AsyncMock(return_value=[])
+
+        await research._import_sources_with_verification(
+            "nb1", "task-1", [{"url": "https://a.example/x"}]
+        )
+
+        research.import_sources.assert_awaited()
+
+
+class TestResearchPublicHelperDelegation:
+    """The API surfaces the module-level helpers under stable names."""
+
+    def test_normalize_url_matches_the_public_helper(self) -> None:
+        from notebooklm import research as research_pub
+
+        raw = "HTTPS://Example.COM/a/../b?utm_source=x"
+
+        assert ResearchAPI._normalize_url(raw) == research_pub.normalize_url(raw)
+
+    def test_extract_report_urls_matches_the_public_helper(self) -> None:
+        from notebooklm import research as research_pub
+
+        report = "See https://a.example/one and https://b.example/two for detail."
+
+        assert ResearchAPI.extract_report_urls(report) == research_pub.extract_report_urls(report)
+        assert ResearchAPI.extract_report_urls(report) == {
+            "https://a.example/one",
+            "https://b.example/two",
+        }

--- a/tests/unit/test_source_drive_ref.py
+++ b/tests/unit/test_source_drive_ref.py
@@ -1,0 +1,124 @@
+"""Parsing of Google Drive references.
+
+``parse_drive_ref`` is an input boundary: it decides which strings become a
+Drive file id the client will later fetch. The host check is the interesting
+part — a share URL is only trusted on ``google.com`` and its subdomains, so a
+look-alike host must fall through to the rejection rather than yield an id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm._source.drive import DriveRef, _trusted_google_host, parse_drive_ref
+from notebooklm.exceptions import ValidationError
+
+FILE_ID = "1AbCdEfGhIjKlMnOpQrStUvWxYz01"
+KEY = "0-AbCdEf"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(FILE_ID, DriveRef(FILE_ID), id="raw-id"),
+        pytest.param(f"  {FILE_ID}  ", DriveRef(FILE_ID), id="surrounding-whitespace"),
+        pytest.param(
+            f"https://drive.google.com/file/d/{FILE_ID}/view",
+            DriveRef(FILE_ID),
+            id="file-share-url",
+        ),
+        pytest.param(
+            f"https://drive.google.com/d/{FILE_ID}",
+            DriveRef(FILE_ID),
+            id="short-d-path",
+        ),
+        pytest.param(
+            f"https://docs.google.com/document/d/{FILE_ID}/edit",
+            DriveRef(FILE_ID),
+            id="docs-subdomain",
+        ),
+        pytest.param(
+            f"https://drive.google.com/open?id={FILE_ID}",
+            DriveRef(FILE_ID),
+            id="query-id",
+        ),
+        pytest.param(
+            f"https://drive.google.com/open?id=short&id={FILE_ID}",
+            DriveRef(FILE_ID),
+            id="first-usable-query-id-wins",
+        ),
+        pytest.param(
+            f"https://drive.google.com/file/d/{FILE_ID}/view?resourcekey={KEY}",
+            DriveRef(FILE_ID, KEY),
+            id="link-shared-resource-key",
+        ),
+        pytest.param(
+            f"https://drive.google.com/open?id={FILE_ID}&resourcekey={KEY}",
+            DriveRef(FILE_ID, KEY),
+            id="query-id-with-resource-key",
+        ),
+        pytest.param(
+            f"https://drive.google.com/file/d/{FILE_ID}/view?resourcekey=&resourcekey={KEY}",
+            DriveRef(FILE_ID, KEY),
+            id="blank-resource-key-is-skipped",
+        ),
+        pytest.param(
+            f"https://GOOGLE.COM/file/d/{FILE_ID}/view",
+            DriveRef(FILE_ID),
+            id="uppercase-host",
+        ),
+        pytest.param(
+            f"https://drive.google.com./file/d/{FILE_ID}/view",
+            DriveRef(FILE_ID),
+            id="fully-qualified-trailing-dot",
+        ),
+    ],
+)
+def test_admitted_drive_references(value: str, expected: DriveRef) -> None:
+    assert parse_drive_ref(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param("short-id", id="too-short-to-be-an-id"),
+        pytest.param("has spaces in it and is long enough", id="illegal-characters"),
+        pytest.param(f"http://drive.google.com/file/d/{FILE_ID}/view", id="not-https"),
+        pytest.param(f"https://drive.google.com.evil.test/file/d/{FILE_ID}", id="suffix-attack"),
+        pytest.param(f"https://notgoogle.com/file/d/{FILE_ID}", id="unrelated-host"),
+        pytest.param(f"https://evil.test/?id={FILE_ID}", id="untrusted-host-with-query-id"),
+        pytest.param("https://drive.google.com/file/d/short/view", id="path-id-too-short"),
+        pytest.param("https://drive.google.com/open?id=short", id="query-id-too-short"),
+        pytest.param("https://drive.google.com/", id="no-id-anywhere"),
+    ],
+)
+def test_rejected_drive_references(value: str) -> None:
+    with pytest.raises(ValidationError) as caught:
+        parse_drive_ref(value)
+
+    assert "Drive" in str(caught.value)
+
+
+def test_a_null_reference_is_rejected_without_raising_a_type_error() -> None:
+    with pytest.raises(ValidationError, match="required"):
+        parse_drive_ref(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("host", "trusted"),
+    [
+        pytest.param("google.com", True, id="apex"),
+        pytest.param("drive.google.com", True, id="subdomain"),
+        pytest.param("GOOGLE.COM", True, id="uppercase"),
+        pytest.param("google.com.", True, id="trailing-dot"),
+        pytest.param(None, False, id="absent"),
+        pytest.param("", False, id="empty"),
+        pytest.param("notgoogle.com", False, id="suffix-without-the-dot"),
+        pytest.param("google.com.evil.test", False, id="apex-in-the-middle"),
+        pytest.param("evil.test", False, id="unrelated"),
+    ],
+)
+def test_the_trusted_host_rule(host: str | None, trusted: bool) -> None:
+    assert _trusted_google_host(host) is trusted


### PR DESCRIPTION
Third coverage tranche, over the **non-`_auth`** modules from the current per-file table. The `_auth/*` cluster is excluded — it's mid-refactor.

Branched from `main`, independent of #2327 (disjoint files), so the two can merge in either order.

## Result

| | before | after |
|---|---|---|
| total coverage | 94.16% | **94.45%** |
| uncovered (statements + partial branches) | 3235 | **3099** (−136) |

| module | before | after |
|---|---|---|
| `_android/errors.py` | 76.5% | **98.8%** |
| `_source/drive.py` | 79.2% | **100%** |
| `mcp/tools/_studio_items.py` | 83.8% | **98.5%** |
| `_web/research.py` | 84.8% | **97.5%** |
| `_curl_cffi_transport.py` | 87.6% | **94.8%** |
| `_runtime/call_supervisor.py` | 89.1% | **94.6%** |
| `server/app.py` | 91.5% | **96.6%** |

## What these cover

The theme is input-admission and status-projection boundaries — the places where a permissive branch silently widens what the client accepts.

- **`_android/errors.py`** — `grpc_status` is the only thing between a dependency-controlled exception object and public error text. Every rejection is pinned: unknown/future names, non-string names, out-of-range and stringly-typed values, an empty tuple value, a `code()` that raises, a non-callable `code`, and name-beats-value precedence. Plus: the projection never carries the original message.
- **`_source/drive.py`** — admitted reference forms, and the rejections that matter: the `drive.google.com.evil.test` suffix attack, and an untrusted host carrying a well-formed query id.
- **`mcp/tools/_studio_items.py`** — the rule that makes `studio_delete` safe: a full UUID never falls through to title matching, so a note *titled* like a UUID cannot absorb a delete aimed at that id. Plus prefix ambiguity, the hex-title fallthrough, and kind scoping.
- **`_curl_cffi_transport.py`** — `delete()` was **entirely untested**, and its own docstring says it exists because its absence silently left staged files in the user's Drive under `NOTEBOOKLM_TRANSPORT=curl_cffi`. Now covered end-to-end against the local test server, along with `stream_upload` (disk streaming, caller-owned handles, progress callbacks, transport failures).
- **`_runtime/call_supervisor.py`** — the admission-generation state machine: epochs must move forward, a prepared generation can't be replaced, transitions are refused from the wrong state, and drain hooks all run even when one fails (with interpreter-exit precedence).
- **`server/app.py`** — content-type recognition by structured suffix rather than substring, `Content-Length` parsing where anything but a non-negative integer must refuse the read, body-limit table precedence, and the stale-auth startup projection.
- **`_research.py`** — cross-task provenance refusal, asserted to happen before any RPC is dispatched.

## One deletion

**`WebResearchAPI._web_wait_for_completion` (106 lines) is removed.** It has no caller in `src/`, `tests/`, or docs. `d5df15e7` ("feat(android): close public API parity gaps", #2269) hoisted the wait loop into `BaseResearchAPI._wait_for_completion` and left this copy orphaned. The Web subclass still contributes its live `_wait_observed_status` override, and the existing `test_wait_for_completion_*` cases exercise the inherited path — including the ambiguous-first-poll raise. Two wait implementations that can drift is worse than one, so it's deleted rather than tested. That accounts for most of `_web/research.py`'s jump.

## Two things I deliberately did *not* do

1. **`_sources.py` (19 uncovered, 85.0%) is skipped.** All 19 lines are `raise NotImplementedError` bodies of `@abstractmethod`s on an ABC — structurally unreachable, since Python refuses to instantiate `SourcesAPI` and every backend overrides them. Testing them would be coverage theatre. If you want the number moved, the right lever is a coverage `exclude_lines` policy for `raise NotImplementedError`, which is a config decision rather than something to slip into a test PR.

2. **`log.py`-style false positives.** As flagged on #2327, some 0%/low entries in that table are measurement artifacts of the coverage job excluding `-m repo_lint`, not real gaps. Worth keeping in mind when reading the table.

## Verification

```
uv run pytest -n auto --dist loadgroup \
  -m "not repo_lint and not requires_playwright and not requires_chromium"   # 17335 passed
uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0
                                                                             # 84 passed
uv run pytest -m repo_lint                                                   # 1950 passed
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports   # clean
uv run ruff check / format                                                   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af5NMrwQKctBjH1Nkm32TH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for request admission, media types, content lengths, and startup error reporting.
  * Added validation tests for Android gRPC status handling, Studio reference matching, call supervision, generation lifecycles, and drain hooks.
  * Added tests for transport failures, streaming uploads, research source verification, and Google Drive reference validation.

* **Maintenance**
  * Removed unused research completion polling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->