### PR TITLE
fix(mcp): open the client lazily so the handshake can't time out (#2330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
+  `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
+  ladder when those fail — *before* answering the MCP `initialize` handshake.
+  That auth work's budget (a 15 s `RotateCookies` poke plus a 30 s CSRF fetch,
+  more on the recovery rungs) exceeds the 30 s deadline hosts give the handshake,
+  so a slow or rate-limited Google surfaced to the host as a dead server
+  (`MCP server notebooklm connection timed out after 30000ms`) rather than an
+  auth error, and every retry spawned a fresh process that redid the same work.
+  The client is now opened lazily behind a `ClientProvider` that the lifespan
+  warms in the background: the handshake answers immediately, the first tool call
+  awaits the open, an auth failure arrives as a normal categorized tool error,
+  and a failed open is retried by the next call — so a mid-session
+  `notebooklm login` recovers a running server without a restart ([#2330]).
+
 ### Changed
 
 - Pull requests run a reduced 7-cell compatibility matrix again (Python
@@ -146,6 +162,7 @@ change without notice.
 [#2307]: https://github.com/teng-lin/notebooklm-py/pull/2307
 [#2308]: https://github.com/teng-lin/notebooklm-py/pull/2308
 [#2313]: https://github.com/teng-lin/notebooklm-py/issues/2313
+[#2330]: https://github.com/teng-lin/notebooklm-py/issues/2330
 
 ## [0.8.1] - 2026-08-14
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -831,7 +831,16 @@ The MCP server is a second thin adapter beside `cli/`, opt-in behind the `mcp`
 extra and **experimental** (preview). `create_server()` builds a FastMCP server
 that exposes the `_app/` cores as MCP tools driving a single long-lived
 `NotebookLMClient`; run it with the `notebooklm-mcp` console script (stdio or
-loopback HTTP). It imports no `click` / `rich` / `cli` — like the CLI, it is built
+loopback HTTP). That client is opened **lazily**, behind a
+[`ClientProvider`](../src/notebooklm/mcp/_clientprovider.py): the lifespan starts
+the open in the background and yields immediately, so the MCP `initialize`
+handshake never waits on Google's auth round-trip — whose budget (a 15 s
+`RotateCookies` poke plus a 30 s CSRF fetch, more when the cold-recovery ladder
+runs) can exceed the 30 s deadline clients give the handshake, which surfaced as
+an opaque `CONNECT_TIMEOUT` (#2330). The first tool call awaits the open instead,
+where an auth failure is reported as a normal categorized tool error and the
+next call retries it — so a mid-session `notebooklm login` recovers the server
+without a restart. It imports no `click` / `rich` / `cli` — like the CLI, it is built
 on the `_app/` cores only (enforced by `tests/_guardrails/test_mcp_boundary.py`).
 Failures surface as `CODE: message` strings projected from `_app.errors.classify`,
 and mutating tools are confirmation-gated (they return a `needs_confirmation`
@@ -1685,7 +1694,7 @@ src/notebooklm/
 ├── mcp/                         # MCP server (opt-in `mcp` extra) — transport-neutral adapter over _app/, sibling to cli/
 │   ├── __init__.py              # Re-exports create_server / SERVER_NAME / SERVER_INSTRUCTIONS
 │   ├── __main__.py              # `notebooklm-mcp` entrypoint: argparse (--profile/--transport/--host/--port/--log-level), stderr logging, loopback HTTP bind guard + fail-closed auth guard (non-loopback bind requires a bearer token AND/OR self-hosted OAuth); composes the auth provider (build_auth) and passes it to create_server on the http path
-│   ├── server.py                # create_server(profile, client_factory, auth): FastMCP server; lifespan binds one NotebookLMClient; register_all tool-registration seam; auth passed explicitly (never reads the token env)
+│   ├── server.py                # create_server(profile, client_factory, auth): FastMCP server; lifespan binds one NotebookLMClient behind a ClientProvider and warms it in the background (never gating the handshake, #2330); register_all tool-registration seam; auth passed explicitly (never reads the token env)
 │   ├── _auth.py                 # Remote-transport bearer auth: McpBearerAuthProvider(TokenVerifier) with constant-time hmac.compare_digest over NOTEBOOKLM_MCP_TOKEN (env-only, never logged/repr'd); build_auth_provider/get_configured_token; build_auth(token, oauth) composes bearer | OAuth | MultiAuth | None (IdP-agnostic) — mirrors server/_auth.py, NOT fastmcp StaticTokenVerifier
 │   ├── _oauth.py                # Optional self-hosted OAuth 2.1 AS for claude.ai (OAuth-only connector UI): SelfHostedOAuthProvider(InMemoryOAuthProvider) + a password-gated /login (override authorize()→stash SDK-validated (client,params) under a single-use sid→/login→InMemoryOAuthProvider.authorize); scrypt password digest + per-IP throttle, capped DCR + evict-oldest pending stash, atomic 0600 persistence of clients+tokens; get_oauth_config/build_oauth_provider (env NOTEBOOKLM_MCP_OAUTH_PASSWORD + _BASE_URL). Composed with the bearer via MultiAuth
 │   ├── _host_guard.py           # LoopbackHostGuardMiddleware: ASGI guard that rejects HTTP requests with a non-loopback Host header (403; DNS-rebinding guard, #1869) on the loopback-bound HTTP transport via _serving.host_header_is_loopback; skipped when allow_external (REST-parity bearer/OAuth auth is mandatory there) — mirrors server/_auth
@@ -1694,7 +1703,8 @@ src/notebooklm/
 │   ├── _fileroutes.py           # register_file_routes(mcp, config): the /files/{dl,ul} custom routes mounted on the FastMCP http app (ADR-0024). GET /files/dl streams the artifact (download core → FileResponse, meaningful filename, inside-tempdir assert, BackgroundTask cleanup); GET /files/ul = minimal upload page (file picker + raw-body fetch POST); POST|PUT /files/ul streams request.stream() into a 0600 temp under a running byte cap (real DoS guard) + Content-Length early 413 → neutral source_add core. Signed token is the sole auth (custom routes bypass the bearer gate); HTML pages set no-referrer/no-store/DENY; local _safe_upload_name (no server/ import)
 │   ├── _uploadwidget.py         # register_upload_widget(mcp, config): OPT-IN in-app MCP-App upload widget (ADR-0027, NOTEBOOKLM_MCP_UPLOAD_WIDGET=1 → also auto-enables stateless HTTP). ONE ui:// resource (file-picker HTML, profile=mcp-app mime) + source_add_widget tool; both ui/resourceUri (claude.ai) and openai/outputTemplate (ChatGPT) point at it. Emits the render gates via FastMCP meta=/app=: _meta.ui.domain = sha256("<public-url>/mcp")[:32] + ".claudemcpcontent.com", flat ui/resourceUri, ui.csp; the widget POSTs bytes to /files/ul (reuses ADR-0024). Off the default surface unless enabled
 │   ├── _chattasks.py            # Detached chat asks for chat_start/chat_status (ADR-0024-shaped in-process state): ChatTaskRegistry (bounded + TTL-swept; idempotency-keyed via compute_chat_task_key; asyncio.create_task detachment so the remote transport's ~60s watchdog cancelling the start call cannot kill the generation; lifespan aclose) + ChatTaskEntry/ChatTaskCapacityError
-│   ├── _context.py              # AppState dataclass (client + optional file_transfer + cancelled_research + chat_tasks) + get_client(ctx) / get_file_transfer(ctx) / get_cancelled_research(ctx) / get_chat_tasks(ctx) (lifespan-bound) + get_client_from_app(request) (the guarded private-attr accessor for the bare-Request custom routes)
+│   ├── _clientprovider.py       # ClientProvider: lazy, single-flight ownership of the process-wide NotebookLMClient (#2330). The lifespan start()s the open in the BACKGROUND and yields at once, so MCP initialize is never gated on the auth round-trip (15s RotateCookies poke + 30s CSRF fetch + cold-recovery ladder > the client's 30s handshake deadline → CONNECT_TIMEOUT); get() joins the in-flight open under asyncio.shield (a cancelled waiter never aborts it), a failed open is retried by the next call (mid-session re-login recovers), aclose() cancels/closes
+│   ├── _context.py              # AppState dataclass (client_provider + optional file_transfer + cancelled_research + chat_tasks) + async get_client(ctx) (awaits the lazy open) / get_file_transfer(ctx) / get_cancelled_research(ctx) / get_chat_tasks(ctx) (lifespan-bound) + async get_client_from_app(request) (the guarded private-attr accessor for the bare-Request custom routes)
 │   ├── _errors.py               # Structured tool-error projection (CATEGORY_TABLE/ERROR_CODES/mcp_errors/to_tool_error/tool_error_payload) over _app.errors.classify
 │   ├── _resolve.py              # resolve_notebook/resolve_source/resolve_note/resolve_artifact — name + partial-id resolution over _app.resolve plus exact-title matching
 │   ├── _confirm.py              # needs_confirmation() both-mode envelope + READ_ONLY/DESTRUCTIVE ToolAnnotations

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -614,9 +614,9 @@ gate the destructive ones.
 ## Troubleshooting
 
 - **`AUTH` errors / "not authenticated".** Run `notebooklm login` (or `notebooklm -p <profile> login`)
-  in a terminal. If the server never managed to authenticate (it opens its client lazily, on first use),
-  no restart is needed — the next tool call retries the open and picks up the refreshed credentials.
-  Check with the `server_info` tool, which reports auth health.
+  in a terminal. If the server never managed to authenticate, no restart is needed: it starts opening
+  its client in the background at startup and retries a failed open on the next tool call, so it picks
+  up the refreshed credentials. Check with the `server_info` tool, which reports auth health.
 - **`uvx` / `uv` not found.** Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux)
   or `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). The desktop launcher also
   searches common install dirs beyond `PATH`.

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -614,7 +614,9 @@ gate the destructive ones.
 ## Troubleshooting
 
 - **`AUTH` errors / "not authenticated".** Run `notebooklm login` (or `notebooklm -p <profile> login`)
-  in a terminal, then restart the server. Check with the `server_info` tool, which reports auth health.
+  in a terminal. If the server never managed to authenticate (it opens its client lazily, on first use),
+  no restart is needed — the next tool call retries the open and picks up the refreshed credentials.
+  Check with the `server_info` tool, which reports auth health.
 - **`uvx` / `uv` not found.** Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh` (macOS/Linux)
   or `powershell -c "irm https://astral.sh/uv/install.ps1 | iex"` (Windows). The desktop launcher also
   searches common install dirs beyond `PATH`.
@@ -630,6 +632,11 @@ gate the destructive ones.
   `NOTEBOOKLM_PROFILE`. See [configuration.md](configuration.md#multiple-accounts).
 - **`RATE_LIMITED`.** NotebookLM enforces per-account quotas; the error is `retriable=true` — back off
   and retry.
+- **`CONNECT_TIMEOUT` / "connection timed out after 30000ms" on connect.** Fixed: the server used to
+  finish Google's auth round-trip before answering the MCP handshake, so slow or rate-limited auth
+  looked like a dead server. The client is now opened lazily in the background — the handshake answers
+  immediately and auth problems arrive as `AUTH` tool errors instead. Upgrade the server if you still
+  see it. See [troubleshooting.md](troubleshooting.md#mcp-server-connect_timeout-on-connect-connection-timed-out-after-30000ms).
 
 ## See also
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -953,6 +953,28 @@ into `source_add(bytes_base64=…)` (and `studio_get_prompt` into
 `source_add` with the new `bytes_base64` argument reached the upgraded server and
 worked without a reconnect.
 
+### MCP server `CONNECT_TIMEOUT` on connect ("connection timed out after 30000ms")
+
+**Cause (fixed in the version that shipped #2330):** the server used to open its
+`NotebookLMClient` — cookie rotation plus the CSRF fetch, and the cold-recovery
+ladder when those fail — *before* answering the MCP `initialize` handshake. That
+auth work has a larger budget (a 15 s `RotateCookies` poke plus a 30 s CSRF
+fetch, more on the recovery rungs) than the 30 s deadline hosts give the
+handshake, so a slow or rate-limited Google looked to the host like a dead
+server: `CONNECT_TIMEOUT`, with no way to tell "still working" from "stuck".
+Each retry spawned a fresh process that redid the same work, which is why it
+took several attempts (and, once cookies were warm, eventually succeeded).
+
+The client is now opened **lazily and in the background**: the handshake answers
+immediately, and the first tool call awaits the auth round-trip instead. An auth
+problem now arrives as a normal tool error (`AUTH: …`) naming the real cause, and
+the next call retries the open — so re-running `notebooklm login` recovers a
+running server without restarting it.
+
+**If you still see `CONNECT_TIMEOUT`:** you are on an older server. Upgrade, and
+check the host's MCP logs (the server logs to stderr) for the real error. It is
+not an auth problem in the client — the handshake never reaches auth.
+
 ## Getting Help
 
 1. Check this troubleshooting guide

--- a/src/notebooklm/mcp/_clientprovider.py
+++ b/src/notebooklm/mcp/_clientprovider.py
@@ -171,7 +171,7 @@ class ClientProvider:
         exc_type: type[BaseException] | None = None,
         exc: BaseException | None = None,
         tb: TracebackType | None = None,
-    ) -> None:
+    ) -> bool | None:
         """Close the client if it was opened, cancelling any in-flight open.
 
         Idempotent. After this the provider refuses to hand out a client.
@@ -181,7 +181,8 @@ class ClientProvider:
         ``NotebookLMClient.__aexit__`` arbitrates on it: when the lifespan body
         raised, a failure to close is demoted to a WARNING so it cannot mask the
         original cause. Passing ``(None, None, None)`` unconditionally would claim
-        the body succeeded and let a close error bury a real lifespan failure.
+        the body succeeded and let a close error bury a real lifespan failure. The
+        context manager's suppression result is returned to the lifespan unchanged.
         """
         self._closed = True
         # Cancel while the task is still registered so the done-callback clears
@@ -195,4 +196,5 @@ class ClientProvider:
         cm, self._cm = self._cm, None
         self._client = None
         if cm is not None:
-            await cm.__aexit__(exc_type, exc, tb)
+            return await cm.__aexit__(exc_type, exc, tb)
+        return None

--- a/src/notebooklm/mcp/_clientprovider.py
+++ b/src/notebooklm/mcp/_clientprovider.py
@@ -40,6 +40,8 @@ from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING
 
+from .._redact import redact
+
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
 
@@ -132,7 +134,15 @@ class ClientProvider:
             # Warm-up has no awaiter, so log here to both retrieve the exception
             # (no "never retrieved" warning) and leave a breadcrumb on stderr. A
             # tool call that joined this task still receives the real exception.
-            logger.warning("NotebookLM client open failed (will retry on next use): %s", error)
+            #
+            # Scrubbed at the SOURCE, not left to the logging pipeline: an open
+            # failure is an auth error more often than not, so its text can carry
+            # cookie values or the on-disk storage path — and ``mcp.__main__``
+            # configures stderr with a bare ``logging.basicConfig``, whose root
+            # handler carries no ``RedactingFilter``.
+            logger.warning(
+                "NotebookLM client open failed (will retry on next use): %s", redact(error)
+            )
 
     async def _open(self) -> NotebookLMClient:
         cm = self._factory()

--- a/src/notebooklm/mcp/_clientprovider.py
+++ b/src/notebooklm/mcp/_clientprovider.py
@@ -38,6 +38,7 @@ import contextlib
 import logging
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
+from types import TracebackType
 from typing import TYPE_CHECKING
 
 from .._redact import redact
@@ -122,15 +123,24 @@ class ClientProvider:
         return task
 
     def _on_open_done(self, task: asyncio.Task[NotebookLMClient]) -> None:
-        """Clear the slot after a failed/cancelled open so the next call retries."""
-        if self._open_task is not task:
-            return
+        """Clear the slot after a failed/cancelled open so the next call retries.
+
+        The failure is retrieved FIRST and the identity check only guards the slot
+        mutation. A callback runs a tick after its task settles, by which time a
+        retry (or ``aclose``) may already own the slot — and returning early there
+        would leave the exception unretrieved, so asyncio would later log it through
+        its default handler with the raw ``repr``, routing around the ``redact``
+        below. The identity check still has to exist: without it this callback would
+        clear a *newer* task's slot and strand its waiters.
+        """
         if task.cancelled():
-            self._open_task = None
+            if self._open_task is task:
+                self._open_task = None
             return
         error = task.exception()
         if error is not None:
-            self._open_task = None
+            if self._open_task is task:
+                self._open_task = None
             # Warm-up has no awaiter, so log here to both retrieve the exception
             # (no "never retrieved" warning) and leave a breadcrumb on stderr. A
             # tool call that joined this task still receives the real exception.
@@ -156,10 +166,22 @@ class ClientProvider:
         self._client = client
         return client
 
-    async def aclose(self) -> None:
+    async def aclose(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc: BaseException | None = None,
+        tb: TracebackType | None = None,
+    ) -> None:
         """Close the client if it was opened, cancelling any in-flight open.
 
         Idempotent. After this the provider refuses to hand out a client.
+
+        The exception triple is forwarded verbatim to the factory context manager,
+        exactly as the ``async with factory()`` this replaced used to do.
+        ``NotebookLMClient.__aexit__`` arbitrates on it: when the lifespan body
+        raised, a failure to close is demoted to a WARNING so it cannot mask the
+        original cause. Passing ``(None, None, None)`` unconditionally would claim
+        the body succeeded and let a close error bury a real lifespan failure.
         """
         self._closed = True
         # Cancel while the task is still registered so the done-callback clears
@@ -173,4 +195,4 @@ class ClientProvider:
         cm, self._cm = self._cm, None
         self._client = None
         if cm is not None:
-            await cm.__aexit__(None, None, None)
+            await cm.__aexit__(exc_type, exc, tb)

--- a/src/notebooklm/mcp/_clientprovider.py
+++ b/src/notebooklm/mcp/_clientprovider.py
@@ -1,0 +1,166 @@
+"""Lazy, single-flight ownership of the process-wide NotebookLM client.
+
+Issue #2330: the FastMCP lifespan used to *open* the client before yielding, so
+the MCP ``initialize`` handshake could not be answered until Google's auth
+round-trip finished. That handshake is on a client-side deadline (Claude Code
+gives it 30 s), while the open path's own budget is larger — a 15 s
+``RotateCookies`` poke plus a 30 s CSRF fetch on the happy rung, and more when
+the cold-recovery ladder (refresh command / headless re-auth / master-token
+re-mint) runs. A slow or rate-limited Google therefore surfaced to the user as
+an opaque ``CONNECT_TIMEOUT``, and each retry spawned a fresh process that
+redid the same work.
+
+This provider decouples the two. The lifespan constructs one and *warms* it in
+the background, then yields immediately, so ``initialize`` answers at once. The
+open is awaited at the first tool call instead, where a failure is reported as a
+real, categorized tool error rather than a dead transport.
+
+Contract:
+
+* **One client per process, one open at a time.** Concurrent callers join a
+  single in-flight open (``asyncio.Task``) rather than racing their own.
+* **A caller's cancellation never aborts the shared open.** Waiters
+  :func:`asyncio.shield` the task, so a client-side timeout on one tool call
+  leaves the warm-up running for everyone else.
+* **Failures are retried, not cached.** A failed open clears the slot so the
+  next tool call tries again — that is how a mid-session ``notebooklm login``
+  recovers a server that started with expired cookies, without a restart.
+* **Loop affinity (ADR-0004).** The provider is created and awaited entirely on
+  the server's event loop, so the client stays bound to the loop that opened it.
+
+This module imports NO ``click`` / ``rich`` / ``cli``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..client import NotebookLMClient
+
+__all__ = ["ClientProvider"]
+
+logger = logging.getLogger(__name__)
+
+#: A factory returns an async-context-manager that yields the client. Matches
+#: ``notebooklm.mcp.server.ClientFactory``; duplicated as a local alias so this
+#: module does not import ``server`` (which imports this one).
+ClientFactory = Callable[[], AbstractAsyncContextManager["NotebookLMClient"]]
+
+
+class ClientProvider:
+    """Own the lazily-opened, process-wide client behind a single-flight open."""
+
+    def __init__(self, factory: ClientFactory) -> None:
+        self._factory = factory
+        self._cm: AbstractAsyncContextManager[NotebookLMClient] | None = None
+        self._client: NotebookLMClient | None = None
+        self._open_task: asyncio.Task[NotebookLMClient] | None = None
+        self._closed = False
+
+    @classmethod
+    def of(cls, client: NotebookLMClient) -> ClientProvider:
+        """Return a provider already holding ``client`` (test seam).
+
+        The provider does not own ``client``: :meth:`aclose` leaves it open,
+        because whoever built it keeps the close responsibility.
+        """
+
+        def _factory() -> AbstractAsyncContextManager[NotebookLMClient]:  # pragma: no cover
+            raise AssertionError("ClientProvider.of() never opens a client")
+
+        provider = cls(_factory)
+        provider._client = client
+        return provider
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the client is already open (no round-trip needed to use it)."""
+        return self._client is not None
+
+    def start(self) -> None:
+        """Kick off the background warm-up open, if one is not already running.
+
+        Fire-and-forget: the caller does not await it, so the handshake is not
+        gated on Google. A warm-up failure is logged (and the slot cleared) so
+        the first real tool call retries and reports the error to the agent.
+        """
+        if self._client is not None or self._closed:
+            return
+        self._ensure_open_task()
+
+    async def get(self) -> NotebookLMClient:
+        """Return the open client, opening it (or joining an in-flight open) first.
+
+        Raises:
+            RuntimeError: the provider has been closed (server shutting down).
+            Exception: whatever the open path raised — an auth/network failure is
+                surfaced to the tool caller, which projects it onto an MCP error.
+        """
+        client = self._client
+        if client is not None:
+            return client
+        if self._closed:
+            raise RuntimeError("The MCP server is shutting down; its NotebookLM client is closed.")
+        # shield: a caller that gets cancelled (client-side timeout, disconnect)
+        # must not cancel the open that every other waiter is also joined to.
+        return await asyncio.shield(self._ensure_open_task())
+
+    def _ensure_open_task(self) -> asyncio.Task[NotebookLMClient]:
+        task = self._open_task
+        if task is None or task.done():
+            task = asyncio.ensure_future(self._open())
+            self._open_task = task
+            task.add_done_callback(self._on_open_done)
+        return task
+
+    def _on_open_done(self, task: asyncio.Task[NotebookLMClient]) -> None:
+        """Clear the slot after a failed/cancelled open so the next call retries."""
+        if self._open_task is not task:
+            return
+        if task.cancelled():
+            self._open_task = None
+            return
+        error = task.exception()
+        if error is not None:
+            self._open_task = None
+            # Warm-up has no awaiter, so log here to both retrieve the exception
+            # (no "never retrieved" warning) and leave a breadcrumb on stderr. A
+            # tool call that joined this task still receives the real exception.
+            logger.warning("NotebookLM client open failed (will retry on next use): %s", error)
+
+    async def _open(self) -> NotebookLMClient:
+        cm = self._factory()
+        client = await cm.__aenter__()
+        if self._closed:
+            # Shut down while we were opening — hand nothing out; close what we
+            # just opened rather than leaking its connection pool.
+            await cm.__aexit__(None, None, None)
+            raise RuntimeError("The MCP server is shutting down; its NotebookLM client is closed.")
+        self._cm = cm
+        self._client = client
+        return client
+
+    async def aclose(self) -> None:
+        """Close the client if it was opened, cancelling any in-flight open.
+
+        Idempotent. After this the provider refuses to hand out a client.
+        """
+        self._closed = True
+        # Cancel while the task is still registered so the done-callback clears
+        # the slot through its normal path; the reset below is belt-and-braces.
+        task = self._open_task
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
+        self._open_task = None
+        cm, self._cm = self._cm, None
+        self._client = None
+        if cm is not None:
+            await cm.__aexit__(None, None, None)

--- a/src/notebooklm/mcp/_context.py
+++ b/src/notebooklm/mcp/_context.py
@@ -2,9 +2,13 @@
 
 The server binds exactly one :class:`~notebooklm.client.NotebookLMClient` for the
 process lifetime via the FastMCP lifespan (one client, bound to the server's
-event loop, satisfying the ADR-0004 loop-affinity contract). Tools reach it
-through the request context. Keeping this in one place means the tool modules
-never touch FastMCP internals directly.
+event loop, satisfying the ADR-0004 loop-affinity contract). It is opened
+**lazily** behind a :class:`~notebooklm.mcp._clientprovider.ClientProvider` so
+the MCP handshake is not gated on Google's auth round-trip (#2330) — which makes
+:func:`get_client` a coroutine: the first tool call to reach it awaits the open
+(or joins the lifespan's background warm-up) and any auth failure surfaces there
+as a categorized tool error. Tools reach it through the request context. Keeping
+this in one place means the tool modules never touch FastMCP internals directly.
 
 This module imports NO ``click`` / ``rich`` / ``cli``.
 """
@@ -18,6 +22,7 @@ from typing import TYPE_CHECKING, cast
 from fastmcp import Context
 
 from ._chattasks import ChatTaskRegistry
+from ._clientprovider import ClientProvider
 
 if TYPE_CHECKING:
     from starlette.requests import Request
@@ -97,9 +102,12 @@ class AppState:
     :class:`~notebooklm.mcp._chattasks.ChatTaskRegistry`. Same process-scoped
     in-memory contract; the lifespan cancels its running tasks (``aclose``)
     before the client closes.
+
+    ``client_provider`` owns the lazily-opened client (#2330); read it through
+    :func:`get_client`, never by touching the provider from a tool.
     """
 
-    client: NotebookLMClient
+    client_provider: ClientProvider
     file_transfer: FileTransferConfig | None = None
     cancelled_research: CancelledResearchTracker = field(default_factory=CancelledResearchTracker)
     chat_tasks: ChatTaskRegistry = field(default_factory=ChatTaskRegistry)
@@ -118,14 +126,22 @@ def _app_state(ctx: Context) -> AppState:
     return cast("AppState", request_context.lifespan_context)
 
 
-def get_client(ctx: Context) -> NotebookLMClient:
-    """Return the lifespan-bound client for the current tool call.
+async def get_client(ctx: Context) -> NotebookLMClient:
+    """Return the lifespan-bound client for the current tool call, opening it first.
+
+    A coroutine because the client is opened lazily (#2330): the first caller
+    awaits the auth round-trip (or joins the lifespan's background warm-up)
+    instead of the MCP handshake blocking on it. A failed open is re-tried by the
+    next call rather than poisoning the server for its lifetime.
 
     Raises:
         RuntimeError: If called outside an active MCP request context (the
-            lifespan binding is always present during a real tool invocation).
+            lifespan binding is always present during a real tool invocation),
+            or if the server is shutting down.
+        Exception: Whatever the open path raised (auth, network) — tool bodies run
+            inside ``mcp_errors``, which projects it onto a structured MCP error.
     """
-    return _app_state(ctx).client
+    return await _app_state(ctx).client_provider.get()
 
 
 def get_cancelled_research(ctx: Context) -> CancelledResearchTracker:
@@ -163,7 +179,7 @@ def get_file_transfer(ctx: Context) -> FileTransferConfig | None:
     return _app_state(ctx).file_transfer
 
 
-def get_client_from_app(request: Request) -> NotebookLMClient:
+async def get_client_from_app(request: Request) -> NotebookLMClient:
     """Return the lifespan-bound client from a bare Starlette ``Request``.
 
     The ``/files/*`` custom routes receive a Starlette :class:`Request`, not an
@@ -174,12 +190,16 @@ def get_client_from_app(request: Request) -> NotebookLMClient:
     regression test pins this access path so a FastMCP upgrade that changes either
     fails loudly.
 
+    Awaits the lazy open exactly like :func:`get_client` does, so a ``/files/*``
+    request that lands before the background warm-up finished still gets a live
+    client instead of a 500.
+
     Raises:
-        RuntimeError: the lifespan has not bound the client yet (the route then
-            returns 500 rather than crashing).
+        RuntimeError: the lifespan has not bound the provider yet (the route then
+            returns 500 rather than crashing), or the server is shutting down.
     """
     server = request.app.state.fastmcp_server
     if not getattr(server, "_lifespan_result_set", False):
         raise RuntimeError("MCP lifespan client is not bound")
     state = cast("AppState", server._lifespan_result)
-    return state.client
+    return await state.client_provider.get()

--- a/src/notebooklm/mcp/_fileroutes.py
+++ b/src/notebooklm/mcp/_fileroutes.py
@@ -300,8 +300,12 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
         if spec is None:  # pragma: no cover - tokens are minted only for known types
             return PlainTextResponse("Unknown artifact type.", status_code=400)
         try:
-            client = get_client_from_app(request)
-        except RuntimeError:
+            client = await get_client_from_app(request)
+        except Exception:  # noqa: BLE001 - not-bound, shutting down, or a failed lazy open
+            # The client is opened lazily (#2330), so this now also covers an
+            # auth/network failure on the open. Never echo the cause: an auth error
+            # can carry the on-disk storage path, and this route is reachable by
+            # anyone holding the signed link.
             return PlainTextResponse("Server is not ready.", status_code=500)
 
         # ``aid`` rides inside the HMAC-signed token, so a non-string value should be
@@ -521,9 +525,12 @@ def register_file_routes(mcp: FastMCP, config: FileTransferConfig) -> None:
             except ValueError:
                 pass
         try:
-            client = get_client_from_app(request)
-        except RuntimeError:
-            return PlainTextResponse("Server is not ready.", status_code=500)
+            client = await get_client_from_app(request)
+        except Exception:  # noqa: BLE001 - not-bound, shutting down, or a failed lazy open
+            # Same widening as the download route (#2330), and it carries the CORS
+            # header like every other /files/ul error response — a bare 500 would be
+            # invisible to the in-app widget's fetch.
+            return PlainTextResponse("Server is not ready.", status_code=500, headers=_CORS_ORIGIN)
 
         # Atomically claim the single-use jti BEFORE any concurrency slot / spool: a
         # sequential replay (jti already consumed) or a concurrent duplicate (jti

--- a/src/notebooklm/mcp/_uploadwidget.py
+++ b/src/notebooklm/mcp/_uploadwidget.py
@@ -231,7 +231,7 @@ def register_upload_widget(mcp: FastMCP, config: FileTransferConfig | None) -> N
             cfg = get_file_transfer(ctx)
             if cfg is None:
                 return {"error": "file transfer not configured"}
-            nb_id = await resolve_notebook(get_client(ctx), notebook)
+            nb_id = await resolve_notebook(await get_client(ctx), notebook)
             # A POOL of independent single-use tokens — one per file the user may pick (each
             # cfg.upload_url() mints a fresh jti). The widget uploads file[i] to upload_urls[i], so
             # multi-file needs NO change to the /files/ul route or ADR-0024's single-use invariant;

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -21,7 +21,6 @@ Design highlights:
 from __future__ import annotations
 
 import asyncio
-import sys
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from types import TracebackType
@@ -111,15 +110,16 @@ async def _shutdown(
     exc_type: type[BaseException] | None,
     exc: BaseException | None,
     tb: TracebackType | None,
-) -> None:
+) -> bool | None:
     """Tear the lifespan down, forwarding the body's exception (if any) to the client.
 
     Detached chat asks are cancelled BEFORE the provider closes the client, so no
     server-owned task ever touches a closing client (see ``ChatTaskRegistry.aclose``).
+    The client context manager's suppression result is returned to the lifespan.
     """
     await state.chat_tasks.aclose()
     state.chat_tasks.set_bound_loop(None)
-    await provider.aclose(exc_type, exc, tb)
+    return await provider.aclose(exc_type, exc, tb)
 
 
 def create_server(
@@ -195,14 +195,16 @@ def create_server(
             provider.start()
             try:
                 yield state
-            finally:
-                # ``sys.exc_info()`` carries the in-flight exception while a
-                # ``finally`` unwinds (and is ``(None, None, None)`` on the clean
-                # path), so the triple reaches the client context manager exactly as
-                # the `async with factory()` this replaced delivered it —
-                # NotebookLMClient arbitrates on it, demoting a close failure to a
-                # WARNING rather than letting it mask the real cause.
-                await _shutdown(state, provider, *sys.exc_info())
+            except BaseException as exc:
+                # Forward the exact exception triple, then honor the client context
+                # manager's suppression result just as ``async with factory()`` did.
+                # NotebookLMClient normally returns false, but injected/embedded
+                # factories may deliberately suppress a lifespan exception.
+                suppressed = await _shutdown(state, provider, type(exc), exc, exc.__traceback__)
+                if not suppressed:
+                    raise
+            else:
+                await _shutdown(state, provider, None, None, None)
         finally:
             set_active_profile(previous_profile)
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -21,8 +21,10 @@ Design highlights:
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections.abc import AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from types import TracebackType
 from typing import Literal, cast
 
 from fastmcp import FastMCP
@@ -103,6 +105,23 @@ def register_all(mcp: FastMCP) -> None:
     register_file_tools(mcp)
 
 
+async def _shutdown(
+    state: AppState,
+    provider: ClientProvider,
+    exc_type: type[BaseException] | None,
+    exc: BaseException | None,
+    tb: TracebackType | None,
+) -> None:
+    """Tear the lifespan down, forwarding the body's exception (if any) to the client.
+
+    Detached chat asks are cancelled BEFORE the provider closes the client, so no
+    server-owned task ever touches a closing client (see ``ChatTaskRegistry.aclose``).
+    """
+    await state.chat_tasks.aclose()
+    state.chat_tasks.set_bound_loop(None)
+    await provider.aclose(exc_type, exc, tb)
+
+
 def create_server(
     *,
     profile: str | None = None,
@@ -177,12 +196,13 @@ def create_server(
             try:
                 yield state
             finally:
-                # Cancel any detached chat asks BEFORE the provider closes the
-                # client, so no server-owned task ever touches a closing client
-                # (see ChatTaskRegistry.aclose).
-                await state.chat_tasks.aclose()
-                state.chat_tasks.set_bound_loop(None)
-                await provider.aclose()
+                # ``sys.exc_info()`` carries the in-flight exception while a
+                # ``finally`` unwinds (and is ``(None, None, None)`` on the clean
+                # path), so the triple reaches the client context manager exactly as
+                # the `async with factory()` this replaced delivered it —
+                # NotebookLMClient arbitrates on it, demoting a close failure to a
+                # WARNING rather than letting it mask the real cause.
+                await _shutdown(state, provider, *sys.exc_info())
         finally:
             set_active_profile(previous_profile)
 

--- a/src/notebooklm/mcp/server.py
+++ b/src/notebooklm/mcp/server.py
@@ -2,11 +2,14 @@
 
 Design highlights:
 
-- **One client per process, bound at lifespan.** The FastMCP lifespan opens a
-  single :class:`~notebooklm.client.NotebookLMClient` via
-  ``from_storage(profile=..., keepalive=600.0)`` inside the server loop
-  (satisfies the ADR-0004 loop-affinity contract) and keeps it for the process
-  lifetime. Its keepalive task gives long sessions cookie rotation for free.
+- **One client per process, opened lazily.** The FastMCP lifespan binds a
+  :class:`~notebooklm.mcp._clientprovider.ClientProvider` over
+  ``from_storage(profile=..., keepalive=600.0)``, starts the open in the
+  background, and yields *immediately* — the MCP ``initialize`` handshake is
+  never gated on Google's auth round-trip (#2330). The open runs on the server
+  loop, so the client still satisfies the ADR-0004 loop-affinity contract, and
+  is kept for the process lifetime; its keepalive task gives long sessions
+  cookie rotation for free.
 - **Transport-neutral.** Tools are thin adapters over the ``_app/`` cores; this
   package imports NO ``click`` / ``rich`` / ``cli`` (enforced by
   ``tests/_guardrails/test_mcp_boundary.py``).
@@ -28,6 +31,7 @@ from fastmcp.server.auth import AuthProvider
 from .._runtime.config import DEFAULT_SERVER_KEEPALIVE_INTERVAL
 from ..client import NotebookLMClient
 from ..paths import get_active_profile, resolve_profile, set_active_profile
+from ._clientprovider import ClientProvider
 from ._context import AppState
 from ._filelink import FileTransferConfig
 
@@ -162,18 +166,23 @@ def create_server(
         previous_profile = get_active_profile()
         set_active_profile(resolve_profile(profile))
         try:
-            async with factory() as client:
-                state = AppState(client=client, file_transfer=file_transfer)
-                state.chat_tasks.set_bound_loop(asyncio.get_running_loop())
-                state.chat_tasks.reset_after_open()
-                try:
-                    yield state
-                finally:
-                    # Cancel any detached chat asks BEFORE the factory context
-                    # closes the client, so no server-owned task ever touches a
-                    # closing client (see ChatTaskRegistry.aclose).
-                    await state.chat_tasks.aclose()
-                    state.chat_tasks.set_bound_loop(None)
+            provider = ClientProvider(factory)
+            state = AppState(client_provider=provider, file_transfer=file_transfer)
+            state.chat_tasks.set_bound_loop(asyncio.get_running_loop())
+            state.chat_tasks.reset_after_open()
+            # Warm the client on the server loop WITHOUT awaiting it: the auth
+            # round-trip can outlast the client's handshake deadline, and gating
+            # ``initialize`` on it is what surfaced as CONNECT_TIMEOUT (#2330).
+            provider.start()
+            try:
+                yield state
+            finally:
+                # Cancel any detached chat asks BEFORE the provider closes the
+                # client, so no server-owned task ever touches a closing client
+                # (see ChatTaskRegistry.aclose).
+                await state.chat_tasks.aclose()
+                state.chat_tasks.set_bound_loop(None)
+                await provider.aclose()
         finally:
             set_active_profile(previous_profile)
 

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -181,7 +181,6 @@ def register(mcp: Any) -> None:
         result never contains a ``suggested_prompts`` key.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # A whitespace-only question counts as "no question" (recall path), so
             # a blank string can't slip past the guard into client.chat.ask.
             question = question.strip()
@@ -192,6 +191,7 @@ def register(mcp: Any) -> None:
                     "Provide a question to ask, history>0 to recall prior turns, "
                     "or suggest_followups=true for suggested questions."
                 )
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Resolve source refs ONCE up front so both the ask path and the
             # suggest path share the same ids. Tolerate ``source_ids`` sent as a
@@ -337,10 +337,10 @@ def register(mcp: Any) -> None:
         then ``chat_status`` reports ``unknown``.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             question = question.strip()
             if not question:
                 raise ValidationError("chat_start needs a non-empty question.")
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Same source-scoping contract as chat_ask: tolerant input shapes,
             # resolved ONCE up front; omitted/empty stays None (=> all sources).
@@ -574,7 +574,6 @@ def register(mcp: Any) -> None:
           is rejected, as it would reset every setting to its default.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # A partial custom config now merges (read-modify-write in
             # execute_configure), so goal/response_length are NO LONGER required
             # together — the omitted field is preserved. The one call still worth
@@ -596,6 +595,7 @@ def register(mcp: Any) -> None:
             # mutual-exclusion (chat_mode cannot be combined with goal/response_length)
             # is enforced transport-neutrally in ``execute_configure`` so the CLI and
             # this tool share one rule.
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await core.execute_configure(
                 client,

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -180,8 +180,8 @@ def register(mcp: Any) -> None:
         suggested questions without asking anything. When omitted/``False`` the
         result never contains a ``suggested_prompts`` key.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # A whitespace-only question counts as "no question" (recall path), so
             # a blank string can't slip past the guard into client.chat.ask.
             question = question.strip()
@@ -573,8 +573,8 @@ def register(mcp: Any) -> None:
           omitted field is preserved. Only a bare call (no preset, neither field)
           is rejected, as it would reset every setting to its default.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # A partial custom config now merges (read-modify-write in
             # execute_configure), so goal/response_length are NO LONGER required
             # together — the omitted field is preserved. The one call still worth
@@ -633,8 +633,8 @@ def register(mcp: Any) -> None:
         suggestions inline with a question (ask + follow-ups in one call); this tool
         is the standalone selector across every surface.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Tolerate source_ids as a JSON-array string / comma string / scalar,
             # then resolve each ref (id/prefix/title). Omitted/empty stays None

--- a/src/notebooklm/mcp/tools/chat.py
+++ b/src/notebooklm/mcp/tools/chat.py
@@ -180,7 +180,7 @@ def register(mcp: Any) -> None:
         suggested questions without asking anything. When omitted/``False`` the
         result never contains a ``suggested_prompts`` key.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # A whitespace-only question counts as "no question" (recall path), so
             # a blank string can't slip past the guard into client.chat.ask.
@@ -337,7 +337,7 @@ def register(mcp: Any) -> None:
         then ``chat_status`` reports ``unknown``.
         """
         with mcp_errors():
-            client = get_client(ctx)
+            client = await get_client(ctx)
             question = question.strip()
             if not question:
                 raise ValidationError("chat_start needs a non-empty question.")
@@ -433,7 +433,7 @@ def register(mcp: Any) -> None:
                     raise ValidationError(
                         "chat_status accepts either notebook or task_id, not both."
                     )
-                client = get_client(ctx)
+                client = await get_client(ctx)
                 nb_id = await resolve_notebook(client, notebook)
                 resolved_id = conversation_id or await client.chat.get_conversation_id(nb_id)
                 if resolved_id is None:
@@ -498,7 +498,7 @@ def register(mcp: Any) -> None:
         An unknown task ID or one belonging to another notebook is rejected.
         """
         with mcp_errors():
-            client = get_client(ctx)
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             registry = get_chat_tasks(ctx)
             entry = registry.status(task_id) if task_id is not None else None
@@ -573,7 +573,7 @@ def register(mcp: Any) -> None:
           omitted field is preserved. Only a bare call (no preset, neither field)
           is rejected, as it would reset every setting to its default.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # A partial custom config now merges (read-modify-write in
             # execute_configure), so goal/response_length are NO LONGER required
@@ -633,7 +633,7 @@ def register(mcp: Any) -> None:
         suggestions inline with a question (ask + follow-ups in one call); this tool
         is the standalone selector across every surface.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             # Tolerate source_ids as a JSON-array string / comma string / scalar,

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -30,7 +30,7 @@ from ...exceptions import NotebookLMError
 from ...paths import get_storage_path, resolve_profile
 from .._confirm import READ_ONLY
 from .._context import get_chat_tasks, get_client
-from .._errors import mcp_errors, redact
+from .._errors import mcp_errors, redact, tool_error_payload
 from ..server import SERVER_NAME
 
 
@@ -72,9 +72,18 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
     """
     try:
         client = await get_client(ctx)
-    except Exception as exc:  # noqa: BLE001 - degrade, never sink the whole response
-        # No client → no identity to report; the reason carries the (scrubbed) cause.
+    except NotebookLMError as exc:
+        # Expected library failures retain their useful, scrubbed diagnostic.
         return {"email": None, "authuser": None, "available": False, "reason": redact(exc)}
+    except Exception as exc:  # noqa: BLE001 - degrade, never sink the whole response
+        # Unexpected exception text can contain arbitrary secrets/host details that
+        # a denylist cannot reliably scrub. Reuse the MCP boundary's fixed message.
+        return {
+            "email": None,
+            "authuser": None,
+            "available": False,
+            "reason": tool_error_payload(exc)["message"],
+        }
     # Identity from a single source (the client). Never raises. ``live_fallback`` is
     # gated on ``authenticated`` — suppress the live WIZ probe when the session is
     # already known stale (it would just fail), so the unauth path stays network-free.

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -62,8 +62,19 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
     can still hit an expired session. Rather than sink the whole ``server_info``
     response, that degrades to ``available: False`` with a short (scrubbed) reason
     (identity still included) — keeping the diagnostic useful.
+
+    Acquiring the client can itself fail now that it is opened lazily (#2330), and
+    that degrades the same way rather than propagating. ``server_info`` is the tool
+    an agent reaches for when something is *already* wrong, so a broken session must
+    not sink the version + local-auth diagnostics — which need no client at all and
+    are the very fields that say what broke. An exception escaping to
+    ``server_info``'s own ``mcp_errors()`` would discard exactly those.
     """
-    client = await get_client(ctx)
+    try:
+        client = await get_client(ctx)
+    except Exception as exc:  # noqa: BLE001 - degrade, never sink the whole response
+        # No client → no identity to report; the reason carries the (scrubbed) cause.
+        return {"email": None, "authuser": None, "available": False, "reason": redact(exc)}
     # Identity from a single source (the client). Never raises. ``live_fallback`` is
     # gated on ``authenticated`` — suppress the live WIZ probe when the session is
     # already known stale (it would just fail), so the unauth path stays network-free.

--- a/src/notebooklm/mcp/tools/meta.py
+++ b/src/notebooklm/mcp/tools/meta.py
@@ -63,7 +63,7 @@ async def _account_block(ctx: Context, *, authenticated: bool) -> dict[str, Any]
     response, that degrades to ``available: False`` with a short (scrubbed) reason
     (identity still included) — keeping the diagnostic useful.
     """
-    client = get_client(ctx)
+    client = await get_client(ctx)
     # Identity from a single source (the client). Never raises. ``live_fallback`` is
     # gated on ``authenticated`` — suppress the live WIZ probe when the session is
     # already known stale (it would just fail), so the unauth path stays network-free.

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -46,7 +46,7 @@ def register(mcp: Any) -> None:
         0), plus ``total`` / ``offset`` / ``has_more``. Page forward by re-calling
         with ``offset += limit`` while ``has_more`` is true.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             notebooks = await client.notebooks.list()
             page, meta = paginate([_notebook_view(nb) for nb in notebooks], limit, offset)
@@ -55,7 +55,7 @@ def register(mcp: Any) -> None:
     @mcp.tool
     async def notebook_create(ctx: Context, title: str) -> dict[str, Any]:
         """Create a new notebook with the given title."""
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             result = await core.execute_notebook_create(client, title)
             # Flatten the created notebook to a top-level shape consistent with
@@ -85,7 +85,7 @@ def register(mcp: Any) -> None:
         (details + source list) and surface it under a ``metadata`` key; the
         default output (``include_metadata`` omitted) is unchanged.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if include_metadata:
@@ -138,7 +138,7 @@ def register(mcp: Any) -> None:
     @mcp.tool
     async def notebook_rename(ctx: Context, notebook: str, new_title: str) -> dict[str, Any]:
         """Rename a notebook. Accepts a notebook name or ID."""
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             result = await core.execute_notebook_rename(
@@ -154,7 +154,7 @@ def register(mcp: Any) -> None:
         NOT delete — it returns a ``needs_confirmation`` preview of the resolved
         notebook. Call again with ``confirm=True`` to perform the delete.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:

--- a/src/notebooklm/mcp/tools/notebooks.py
+++ b/src/notebooklm/mcp/tools/notebooks.py
@@ -46,8 +46,8 @@ def register(mcp: Any) -> None:
         0), plus ``total`` / ``offset`` / ``has_more``. Page forward by re-calling
         with ``offset += limit`` while ``has_more`` is true.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             notebooks = await client.notebooks.list()
             page, meta = paginate([_notebook_view(nb) for nb in notebooks], limit, offset)
             return {"notebooks": page, **meta}
@@ -55,8 +55,8 @@ def register(mcp: Any) -> None:
     @mcp.tool
     async def notebook_create(ctx: Context, title: str) -> dict[str, Any]:
         """Create a new notebook with the given title."""
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             result = await core.execute_notebook_create(client, title)
             # Flatten the created notebook to a top-level shape consistent with
             # the sibling create tool (``note_create``) and ``notebook_delete``,
@@ -85,8 +85,8 @@ def register(mcp: Any) -> None:
         (details + source list) and surface it under a ``metadata`` key; the
         default output (``include_metadata`` omitted) is unchanged.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if include_metadata:
                 # Two independent reads (description + metadata) → run concurrently
@@ -138,8 +138,8 @@ def register(mcp: Any) -> None:
     @mcp.tool
     async def notebook_rename(ctx: Context, notebook: str, new_title: str) -> dict[str, Any]:
         """Rename a notebook. Accepts a notebook name or ID."""
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await core.execute_notebook_rename(
                 client, nb_id, new_title, resolve_notebook_id=passthrough_notebook_id
@@ -154,8 +154,8 @@ def register(mcp: Any) -> None:
         NOT delete — it returns a ``needs_confirmation`` preview of the resolved
         notebook. Call again with ``confirm=True`` to perform the delete.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:
                 title = title_for_id(await client.notebooks.list(), nb_id)

--- a/src/notebooklm/mcp/tools/notes.py
+++ b/src/notebooklm/mcp/tools/notes.py
@@ -51,7 +51,7 @@ def register(mcp: Any) -> None:
           replaces the body). A ref that doesn't resolve is a not-found error, NEVER
           a stray create. Returns ``status="updated"``.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if note is None:

--- a/src/notebooklm/mcp/tools/notes.py
+++ b/src/notebooklm/mcp/tools/notes.py
@@ -51,8 +51,8 @@ def register(mcp: Any) -> None:
           replaces the body). A ref that doesn't resolve is a not-found error, NEVER
           a stray create. Returns ``status="updated"``.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if note is None:
                 if not title or not content:

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -127,11 +127,11 @@ def register(mcp: Any) -> None:
         (default) or ``deep`` (deep is web-only).
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # ``deep`` mode is web-only — reject the invalid combination at the tool
             # boundary (the independent Literals can't express this cross-field rule).
             if source == "drive" and mode == "deep":
                 raise ValidationError("mode 'deep' is web-only; use source 'web' for deep research")
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await client.research.start(nb_id, query, source, mode)
             # ``poll_task_id`` is the one id status/import/cancel drive off, chosen
@@ -194,7 +194,6 @@ def register(mcp: Any) -> None:
         ``not_found``. ``task_id`` is a deprecated alias (removed in v0.9.0).
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Fold the deprecated ``task_id`` pin into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_status", "task_id", poll_task_id, task_id
@@ -218,6 +217,7 @@ def register(mcp: Any) -> None:
             # backend as a spurious mismatch.
             poll_task_id = poll_task_id.strip() if poll_task_id is not None else None
 
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await research_core.poll_and_classify(client, nb_id, poll_task_id)
 
@@ -349,7 +349,6 @@ def register(mcp: Any) -> None:
         ``research_status`` afterward to confirm.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Fold the deprecated ``run_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_cancel", "run_id", poll_task_id, run_id
@@ -360,6 +359,7 @@ def register(mcp: Any) -> None:
             if not poll_task_id or not poll_task_id.strip():
                 raise ValidationError("poll_task_id is required to cancel a research run")
             poll_task_id = poll_task_id.strip()
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Preflight (``poll_task_id`` as the discriminator → typed NOT_FOUND
             # sentinel, never raises). Only an already-TERMINAL run
@@ -430,7 +430,6 @@ def register(mcp: Any) -> None:
         ``max_sources`` caps the count.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Fold the deprecated ``task_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_import", "task_id", poll_task_id, task_id
@@ -445,6 +444,7 @@ def register(mcp: Any) -> None:
             if max_sources is not None and max_sources < 1:
                 raise ValidationError("max_sources must be >= 1 (omit it to import all)")
             poll_task_id = poll_task_id.strip()
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Poll FOR THE REQUESTED task (via the shared importable-state guard,
             # which forwards ``poll_task_id`` to ``poll`` as the discriminator) so

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -126,8 +126,8 @@ def register(mcp: Any) -> None:
         ``source`` is ``web`` (default) or ``drive``. ``mode`` is ``fast``
         (default) or ``deep`` (deep is web-only).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # ``deep`` mode is web-only — reject the invalid combination at the tool
             # boundary (the independent Literals can't express this cross-field rule).
             if source == "drive" and mode == "deep":
@@ -193,8 +193,8 @@ def register(mcp: Any) -> None:
         for a single task (ambiguous with two+). An unmatched pin reports
         ``not_found``. ``task_id`` is a deprecated alias (removed in v0.9.0).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Fold the deprecated ``task_id`` pin into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_status", "task_id", poll_task_id, task_id
@@ -348,8 +348,8 @@ def register(mcp: Any) -> None:
         ``no_research`` (replication lag) is cancelled too. Fire-and-forget; poll
         ``research_status`` afterward to confirm.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Fold the deprecated ``run_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_cancel", "run_id", poll_task_id, run_id
@@ -429,8 +429,8 @@ def register(mcp: Any) -> None:
         ``cited_only`` imports only report-cited sources (all, if none resolve).
         ``max_sources`` caps the count.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Fold the deprecated ``task_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
                 "research_import", "task_id", poll_task_id, task_id

--- a/src/notebooklm/mcp/tools/research.py
+++ b/src/notebooklm/mcp/tools/research.py
@@ -126,7 +126,7 @@ def register(mcp: Any) -> None:
         ``source`` is ``web`` (default) or ``drive``. ``mode`` is ``fast``
         (default) or ``deep`` (deep is web-only).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # ``deep`` mode is web-only — reject the invalid combination at the tool
             # boundary (the independent Literals can't express this cross-field rule).
@@ -193,7 +193,7 @@ def register(mcp: Any) -> None:
         for a single task (ambiguous with two+). An unmatched pin reports
         ``not_found``. ``task_id`` is a deprecated alias (removed in v0.9.0).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Fold the deprecated ``task_id`` pin into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
@@ -348,7 +348,7 @@ def register(mcp: Any) -> None:
         ``no_research`` (replication lag) is cancelled too. Fire-and-forget; poll
         ``research_status`` afterward to confirm.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Fold the deprecated ``run_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(
@@ -429,7 +429,7 @@ def register(mcp: Any) -> None:
         ``cited_only`` imports only report-cited sources (all, if none resolve).
         ``max_sources`` caps the count.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Fold the deprecated ``task_id`` alias into ``poll_task_id`` (#1789).
             poll_task_id, deprecation = _resolve_poll_task_id(

--- a/src/notebooklm/mcp/tools/sharing.py
+++ b/src/notebooklm/mcp/tools/sharing.py
@@ -70,8 +70,8 @@ def register(mcp: Any) -> None:
         not report it (it would always read ``"full"``). Set it via
         ``share_set_access``, which echoes the value it just set.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             status = await client.sharing.get_status(nb_id)
             return _status_payload(status)
@@ -96,8 +96,8 @@ def register(mcp: Any) -> None:
         set here (the read API can't report it); with both fields it is applied
         before ``public`` so a partial failure fails closed.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if public is True and not confirm:
                 # Gate only a genuine widening (restricted → anyone-with-link). Read
@@ -161,8 +161,8 @@ def register(mcp: Any) -> None:
         ``notify`` (default ``False``) emails the user on grant/re-grade; ``message``
         is an optional welcome note. Returns the updated status (or a preview).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:
                 return needs_confirmation(
@@ -194,8 +194,8 @@ def register(mcp: Any) -> None:
         it returns a ``needs_confirmation`` preview. Call with ``confirm=True`` to
         actually remove the user.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:
                 return needs_confirmation(

--- a/src/notebooklm/mcp/tools/sharing.py
+++ b/src/notebooklm/mcp/tools/sharing.py
@@ -70,7 +70,7 @@ def register(mcp: Any) -> None:
         not report it (it would always read ``"full"``). Set it via
         ``share_set_access``, which echoes the value it just set.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             status = await client.sharing.get_status(nb_id)
@@ -96,7 +96,7 @@ def register(mcp: Any) -> None:
         set here (the read API can't report it); with both fields it is applied
         before ``public`` so a partial failure fails closed.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if public is True and not confirm:
@@ -161,7 +161,7 @@ def register(mcp: Any) -> None:
         ``notify`` (default ``False``) emails the user on grant/re-grade; ``message``
         is an optional welcome note. Returns the updated status (or a preview).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:
@@ -194,7 +194,7 @@ def register(mcp: Any) -> None:
         it returns a ``needs_confirmation`` preview. Call with ``confirm=True`` to
         actually remove the user.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             if not confirm:

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -251,8 +251,8 @@ def register(mcp: Any) -> None:
         a broken import's ghost row). Pass ``label`` (name or ID) to restrict to that
         label's members; composes with ``status``.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             sources = await listing_core.fetch_sources(
                 client, nb_id, label_filter=label, label_resolver=labels_core.resolve_label_id
@@ -296,8 +296,8 @@ def register(mcp: Any) -> None:
         ``detail="full"`` (ignored for ``summary``). Prefer ``chat_ask`` for
         querying large sources rather than pulling the whole body.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Validate windowing args unconditionally — a bad value must error even
             # in ``summary`` mode (where they are ignored), never silently pass.
             # (``execute_source_read`` re-validates for the full path; this keeps the
@@ -367,8 +367,8 @@ def register(mcp: Any) -> None:
         ctx: Context, notebook: str, source: str, new_title: str
     ) -> dict[str, Any]:
         """Rename a source. Accepts a notebook/source name or ID."""
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
             result = await mut_core.execute_source_rename(
@@ -390,8 +390,8 @@ def register(mcp: Any) -> None:
         ``needs_confirmation`` preview of the resolved source without deleting;
         call again with ``confirm=True`` to perform the delete.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
             if not confirm:
@@ -440,8 +440,8 @@ def register(mcp: Any) -> None:
         an input error, distinct from a resolved source the backend reports missing /
         failed / slow (which lands in a bucket).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Non-finite + range guards (shared with the REST route so the two
             # can't drift); fail-fast before any I/O.
             wait_core.validate_wait_bounds(timeout, interval)
@@ -579,8 +579,8 @@ def register(mcp: Any) -> None:
         single-mode named inputs (incl. ``bytes_base64``/``filename``/``wait``) are not
         valid with ``urls``; ``allow_internal`` applies to every entry.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Mode selection (fail-closed) BEFORE any notebook I/O, so a malformed
             # call never reaches notebooks.list. Exactly one of source_type / urls.
             if urls is not None and source_type is not None:

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -297,7 +297,6 @@ def register(mcp: Any) -> None:
         querying large sources rather than pulling the whole body.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Validate windowing args unconditionally — a bad value must error even
             # in ``summary`` mode (where they are ignored), never silently pass.
             # (``execute_source_read`` re-validates for the full path; this keeps the
@@ -306,6 +305,7 @@ def register(mcp: Any) -> None:
                 raise ValidationError(f"max_chars must be >= 0; got {max_chars}")
             if offset < 0:
                 raise ValidationError(f"offset must be >= 0; got {offset}")
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
 
@@ -441,7 +441,6 @@ def register(mcp: Any) -> None:
         failed / slow (which lands in a bucket).
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Non-finite + range guards (shared with the REST route so the two
             # can't drift); fail-fast before any I/O.
             wait_core.validate_wait_bounds(timeout, interval)
@@ -466,6 +465,7 @@ def register(mcp: Any) -> None:
                     f"got {len(coerced)}. Wait on a smaller subset."
                 )
 
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
 
             if coerced is not None:
@@ -580,7 +580,6 @@ def register(mcp: Any) -> None:
         valid with ``urls``; ``allow_internal`` applies to every entry.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Mode selection (fail-closed) BEFORE any notebook I/O, so a malformed
             # call never reaches notebooks.list. Exactly one of source_type / urls.
             if urls is not None and source_type is not None:
@@ -589,6 +588,7 @@ def register(mcp: Any) -> None:
                 )
             if urls is None and source_type is None:
                 raise ValidationError("provide 'source_type' (single add) or 'urls' (batch)")
+            client = await get_client(ctx)
             if urls is not None:
                 # Batch mode: reject single-mode scalars, then resolve + dispatch.
                 if wait:

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -251,7 +251,7 @@ def register(mcp: Any) -> None:
         a broken import's ghost row). Pass ``label`` (name or ID) to restrict to that
         label's members; composes with ``status``.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             sources = await listing_core.fetch_sources(
@@ -296,7 +296,7 @@ def register(mcp: Any) -> None:
         ``detail="full"`` (ignored for ``summary``). Prefer ``chat_ask`` for
         querying large sources rather than pulling the whole body.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Validate windowing args unconditionally — a bad value must error even
             # in ``summary`` mode (where they are ignored), never silently pass.
@@ -367,7 +367,7 @@ def register(mcp: Any) -> None:
         ctx: Context, notebook: str, source: str, new_title: str
     ) -> dict[str, Any]:
         """Rename a source. Accepts a notebook/source name or ID."""
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
@@ -390,7 +390,7 @@ def register(mcp: Any) -> None:
         ``needs_confirmation`` preview of the resolved source without deleting;
         call again with ``confirm=True`` to perform the delete.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             src_id = await resolve_source(client, nb_id, source)
@@ -440,7 +440,7 @@ def register(mcp: Any) -> None:
         an input error, distinct from a resolved source the backend reports missing /
         failed / slow (which lands in a bucket).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Non-finite + range guards (shared with the REST route so the two
             # can't drift); fail-fast before any I/O.
@@ -579,7 +579,7 @@ def register(mcp: Any) -> None:
         single-mode named inputs (incl. ``bytes_base64``/``filename``/``wait``) are not
         valid with ``urls``; ``allow_internal`` applies to every entry.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Mode selection (fail-closed) BEFORE any notebook I/O, so a malformed
             # call never reaches notebooks.list. Exactly one of source_type / urls.

--- a/src/notebooklm/mcp/tools/sources.py
+++ b/src/notebooklm/mcp/tools/sources.py
@@ -20,7 +20,7 @@ This module imports NO ``click`` / ``rich`` / ``cli``.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from fastmcp import Context
 from fastmcp.server.dependencies import get_http_request
@@ -588,9 +588,10 @@ def register(mcp: Any) -> None:
                 )
             if urls is None and source_type is None:
                 raise ValidationError("provide 'source_type' (single add) or 'urls' (batch)")
-            client = await get_client(ctx)
             if urls is not None:
-                # Batch mode: reject single-mode scalars, then resolve + dispatch.
+                # Batch mode: reject every client-independent input error before
+                # joining the lazy open. A malformed call must return VALIDATION
+                # immediately even when authentication is slow or broken.
                 if wait:
                     raise ValidationError(
                         "'wait' is single-mode only; batch 'urls' adds are async — "
@@ -615,6 +616,7 @@ def register(mcp: Any) -> None:
                         f"urls must contain at most {MAX_BATCH_URLS} entries; got {len(urls)}. "
                         "Split into multiple source_add calls."
                     )
+                client = await get_client(ctx)
                 nb_id = await resolve_notebook(client, notebook)
                 return await _add_url_batch(client, nb_id, urls, allow_internal=allow_internal)
 
@@ -625,10 +627,9 @@ def register(mcp: Any) -> None:
             if source_type is None:  # pragma: no cover - unreachable given the mode guards
                 raise ValidationError("internal error: source_type unexpectedly None")
 
-            # The drive-mime and content-scalar-exclusivity checks below run BEFORE
-            # resolve_notebook, so these malformed calls never pay a notebook
-            # round-trip. (Content *presence* + the YouTube-host guard still run
-            # later, during dispatch — that ordering is unchanged by #1696.)
+            # The drive-mime, content-scalar-exclusivity, content-presence, and
+            # YouTube-host checks below run BEFORE the lazy open and
+            # resolve_notebook, so malformed calls pay no auth/network round-trip.
             #
             # ``mime_type`` deliberately stays a free-text ``str`` (NOT a ``Literal``):
             # it is DUAL-USE — for ``source_type="file"`` it carries an arbitrary,
@@ -663,6 +664,36 @@ def register(mcp: Any) -> None:
             # payload never pays a notebook round-trip (see _decode_upload_b64).
             raw = _decode_upload_b64(bytes_base64) if bytes_base64 is not None else None
 
+            # Finish the source-type-specific local validation before awaiting the
+            # lazy client. Otherwise expired credentials can mask an immediately
+            # actionable VALIDATION error as AUTH/NETWORK.
+            file_transfer = None
+            content = None
+            if raw is None and source_type == "file":
+                file_transfer = get_file_transfer(ctx)
+                if file_transfer is not None:
+                    # Remote connector: the upload is a separate request, so there
+                    # is no source for this call to wait on yet.
+                    if wait:
+                        raise ValidationError(
+                            "source_add cannot wait on a remote file signed-URL upload (the "
+                            "upload is a separate step); add without wait, then source_wait, "
+                            "or pass bytes_base64 for a tiny file"
+                        )
+                elif _is_http_transport():
+                    raise ValidationError(
+                        "remote file transfer is not configured; set "
+                        "NOTEBOOKLM_MCP_PUBLIC_URL on the server to enable it"
+                    )
+                else:
+                    content = _select_content(source_type, url=url, text=text, path=path)
+            elif source_type == "drive":
+                if not document_id:
+                    raise ValidationError("source_type 'drive' requires 'document_id'")
+            elif raw is None:
+                content = _select_content(source_type, url=url, text=text, path=path)
+
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
 
             # In-channel bytes file-add (any transport): decode + spool + add, then
@@ -684,35 +715,20 @@ def register(mcp: Any) -> None:
                     src, to_jsonable(add_core.SourceAddResult(source=src)), notebook_id=nb_id
                 )
 
-            if source_type == "file":
-                cfg = get_file_transfer(ctx)
-                if cfg is not None:
-                    # Remote connector: broker a signed upload URL (the server path
-                    # is unreachable). A supplied `path` is accepted, not opened —
-                    # its basename seeds the default title. There is no source yet to
-                    # wait on — a caller wanting add+wait must use bytes_base64.
-                    if wait:
-                        raise ValidationError(
-                            "source_add cannot wait on a remote file signed-URL upload (the "
-                            "upload is a separate step); add without wait, then source_wait, "
-                            "or pass bytes_base64 for a tiny file"
-                        )
-                    return _broker_upload(cfg, nb_id, title=title, mime_type=mime_type, path=path)
-                if _is_http_transport():
-                    raise ValidationError(
-                        "remote file transfer is not configured; set "
-                        "NOTEBOOKLM_MCP_PUBLIC_URL on the server to enable it"
-                    )
-                # stdio: fall through to the existing local-path behavior below.
+            if file_transfer is not None:
+                # Remote connector: broker a signed upload URL (the server path
+                # is unreachable). A supplied `path` is accepted, not opened —
+                # its basename seeds the default title.
+                return _broker_upload(
+                    file_transfer, nb_id, title=title, mime_type=mime_type, path=path
+                )
 
             if source_type == "drive":
-                if not document_id:
-                    raise ValidationError("source_type 'drive' requires 'document_id'")
                 drive_result = await mut_core.execute_source_add_drive(
                     client,
                     mut_core.SourceAddDrivePlan(
                         notebook_id=nb_id,
-                        file_id=document_id,
+                        file_id=cast("str", document_id),
                         # Non-None + a valid choice, guaranteed by _validate_drive_mime above.
                         mime_type=mime_type,  # type: ignore[arg-type]
                         title=title or "",
@@ -735,7 +751,8 @@ def register(mcp: Any) -> None:
                     requested_title=title,
                 )
 
-            content = _select_content(source_type, url=url, text=text, path=path)
+            if content is None:  # pragma: no cover - raw/drive/remote branches returned above
+                raise ValidationError("internal error: source content unexpectedly missing")
             src = await _add_one(
                 client,
                 nb_id,

--- a/src/notebooklm/mcp/tools/sources_drive.py
+++ b/src/notebooklm/mcp/tools/sources_drive.py
@@ -54,7 +54,7 @@ def register(mcp: Any) -> None:
         step. Processed ASYNCHRONOUSLY; pass ``wait=true`` to block until READY (else
         confirm via ``source_wait`` / ``source_list(status="error")``).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             result = await mut_core.execute_source_add_drive_file(

--- a/src/notebooklm/mcp/tools/sources_drive.py
+++ b/src/notebooklm/mcp/tools/sources_drive.py
@@ -54,8 +54,8 @@ def register(mcp: Any) -> None:
         step. Processed ASYNCHRONOUSLY; pass ``wait=true`` to block until READY (else
         confirm via ``source_wait`` / ``source_list(status="error")``).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await mut_core.execute_source_add_drive_file(
                 client,

--- a/src/notebooklm/mcp/tools/sources_playbooks.py
+++ b/src/notebooklm/mcp/tools/sources_playbooks.py
@@ -47,8 +47,8 @@ def register(mcp: Any) -> None:
         be added), plus ``cover_url`` / ``store_url``. Empty for an account with no
         Play Books library. Web backend only.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             books = await fetch_play_books(client)
             page, meta = paginate([play_book_summary(b) for b in books], limit, offset)
             return {"play_books": page, **meta}
@@ -67,8 +67,8 @@ def register(mcp: Any) -> None:
         name or ID. Reads back as an ``expert_intelligence`` source. Processed
         asynchronously; pass ``wait=true`` to block until READY. Web backend only.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             result = await execute_source_add_play_book(
                 client,

--- a/src/notebooklm/mcp/tools/sources_playbooks.py
+++ b/src/notebooklm/mcp/tools/sources_playbooks.py
@@ -47,7 +47,7 @@ def register(mcp: Any) -> None:
         be added), plus ``cover_url`` / ``store_url``. Empty for an account with no
         Play Books library. Web backend only.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             books = await fetch_play_books(client)
             page, meta = paginate([play_book_summary(b) for b in books], limit, offset)
@@ -67,7 +67,7 @@ def register(mcp: Any) -> None:
         name or ID. Reads back as an ``expert_intelligence`` source. Processed
         asynchronously; pass ``wait=true`` to block until READY. Web backend only.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             result = await execute_source_add_play_book(

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -250,8 +250,8 @@ def register(mcp: Any) -> None:
           no match is NOT_FOUND. ``limit`` / ``offset`` / ``detail`` are ignored with
           ``item``; ``kind`` scopes resolution.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Validate pagination bounds unconditionally (inside ``mcp_errors`` so
             # the VALIDATION wire-contract applies) — ``studio_list(item=x,
             # limit=0)`` errors even though they're ignored on the single-fetch path.
@@ -418,8 +418,8 @@ def register(mcp: Any) -> None:
         (including ``mind-map``). ``language`` (optional) is a language code,
         e.g. ``en``/``ja``/``zh_Hans``.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             # Tolerate ``source_ids`` sent as a JSON-array string / comma string /
             # scalar (some MCP clients + LLM tool-callers do); normalize to a
             # ``list[str]`` up front. ``None`` stays ``None`` (=> all sources, the
@@ -527,8 +527,8 @@ def register(mcp: Any) -> None:
         ``url`` / ``error`` / ``is_complete`` / ``media_ready``; poll until done. A
         pending ``url`` is provisional — trust it only if ``media_ready``.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             status = await artifact_core.poll_artifact(client, nb_id, task_id)
             view = artifact_core.status_view(status)
@@ -565,8 +565,8 @@ def register(mcp: Any) -> None:
         connector an explicit ``artifact_id`` (and ``output_format``) is validated up
         front — an unknown/ambiguous id fails immediately, not as a 400 when opened.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Title of the resolved target, when known cheaply (the ref path and the
             # explicit-id pre-validation both already list, so they capture it) —
@@ -773,8 +773,8 @@ def register(mcp: Any) -> None:
         Returns ``item_id`` / ``type`` plus the applied ``new_title`` and
         ``is_mind_map``.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             item = item.strip()
             nb_id = await resolve_notebook(client, notebook)
             try:
@@ -830,8 +830,8 @@ def register(mcp: Any) -> None:
         ``status``; poll ``studio_status(notebook, task_id)`` until complete. A
         synchronous refusal (rate limit / quota / not-retryable) surfaces as an error.
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             art_id = await resolve_artifact(client, nb_id, artifact)
             try:
@@ -913,8 +913,8 @@ def register(mcp: Any) -> None:
         full id is idempotent (no error) — it routes down the artifact path (a
         present note would have been found in the list).
         """
-        client = await get_client(ctx)
         with mcp_errors():
+            client = await get_client(ctx)
             item = item.strip()
             nb_id = await resolve_notebook(client, notebook)
             try:

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -251,7 +251,6 @@ def register(mcp: Any) -> None:
           ``item``; ``kind`` scopes resolution.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Validate pagination bounds unconditionally (inside ``mcp_errors`` so
             # the VALIDATION wire-contract applies) — ``studio_list(item=x,
             # limit=0)`` errors even though they're ignored on the single-fetch path.
@@ -262,6 +261,7 @@ def register(mcp: Any) -> None:
             # ``kind`` is a ``Literal`` — FastMCP/Pydantic rejects an unknown value at
             # the schema boundary, so no runtime membership check is needed (same as
             # ``studio_generate``'s ``artifact_type``).
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             if item is not None:
                 # Single fetch by ref over the merged list; the resolved item's full
@@ -419,7 +419,6 @@ def register(mcp: Any) -> None:
         e.g. ``en``/``ja``/``zh_Hans``.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             # Tolerate ``source_ids`` sent as a JSON-array string / comma string /
             # scalar (some MCP clients + LLM tool-callers do); normalize to a
             # ``list[str]`` up front. ``None`` stays ``None`` (=> all sources, the
@@ -478,6 +477,7 @@ def register(mcp: Any) -> None:
                     )
                 overrides[key] = value
 
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             # Resolve each source ref the same way every other source-accepting tool
             # does (full-UUID fast-path, 12-char prefix, exact title) instead of
@@ -774,8 +774,8 @@ def register(mcp: Any) -> None:
         ``is_mind_map``.
         """
         with mcp_errors():
-            client = await get_client(ctx)
             item = item.strip()
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             try:
                 resolved = await resolve_studio_item(client, nb_id, item)
@@ -914,8 +914,8 @@ def register(mcp: Any) -> None:
         present note would have been found in the list).
         """
         with mcp_errors():
-            client = await get_client(ctx)
             item = item.strip()
+            client = await get_client(ctx)
             nb_id = await resolve_notebook(client, notebook)
             try:
                 resolved = await resolve_studio_item(client, nb_id, item)

--- a/src/notebooklm/mcp/tools/studio.py
+++ b/src/notebooklm/mcp/tools/studio.py
@@ -250,7 +250,7 @@ def register(mcp: Any) -> None:
           no match is NOT_FOUND. ``limit`` / ``offset`` / ``detail`` are ignored with
           ``item``; ``kind`` scopes resolution.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Validate pagination bounds unconditionally (inside ``mcp_errors`` so
             # the VALIDATION wire-contract applies) — ``studio_list(item=x,
@@ -418,7 +418,7 @@ def register(mcp: Any) -> None:
         (including ``mind-map``). ``language`` (optional) is a language code,
         e.g. ``en``/``ja``/``zh_Hans``.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             # Tolerate ``source_ids`` sent as a JSON-array string / comma string /
             # scalar (some MCP clients + LLM tool-callers do); normalize to a
@@ -527,7 +527,7 @@ def register(mcp: Any) -> None:
         ``url`` / ``error`` / ``is_complete`` / ``media_ready``; poll until done. A
         pending ``url`` is provisional — trust it only if ``media_ready``.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             status = await artifact_core.poll_artifact(client, nb_id, task_id)
@@ -565,7 +565,7 @@ def register(mcp: Any) -> None:
         connector an explicit ``artifact_id`` (and ``output_format``) is validated up
         front — an unknown/ambiguous id fails immediately, not as a 400 when opened.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             # Title of the resolved target, when known cheaply (the ref path and the
@@ -773,7 +773,7 @@ def register(mcp: Any) -> None:
         Returns ``item_id`` / ``type`` plus the applied ``new_title`` and
         ``is_mind_map``.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             item = item.strip()
             nb_id = await resolve_notebook(client, notebook)
@@ -830,7 +830,7 @@ def register(mcp: Any) -> None:
         ``status``; poll ``studio_status(notebook, task_id)`` until complete. A
         synchronous refusal (rate limit / quota / not-retryable) surfaces as an error.
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             nb_id = await resolve_notebook(client, notebook)
             art_id = await resolve_artifact(client, nb_id, artifact)
@@ -913,7 +913,7 @@ def register(mcp: Any) -> None:
         full id is idempotent (no error) — it routes down the artifact path (a
         present note would have been found in the list).
         """
-        client = get_client(ctx)
+        client = await get_client(ctx)
         with mcp_errors():
             item = item.strip()
             nb_id = await resolve_notebook(client, notebook)

--- a/tests/_guardrails/test_mcp_lazy_client_error_boundary.py
+++ b/tests/_guardrails/test_mcp_lazy_client_error_boundary.py
@@ -1,0 +1,229 @@
+"""Meta-lint: the lazy client open must resolve *inside* the MCP error boundary.
+
+The MCP client is opened lazily (#2330), so ``await get_client(ctx)`` can now
+raise a real auth/network error — where the old synchronous accessor could only
+raise ``RuntimeError`` for a missing lifespan. A call left *above* the
+``with mcp_errors():`` block therefore escapes as a raw exception and FastMCP
+reports it as an opaque internal error, losing the structured
+``{code, message, retriable, hint}`` contract every tool advertises — which is
+precisely the opacity #2330 set out to remove. The original fix shipped 33 such
+call sites; this gate is why they cannot come back.
+
+Two rules, over every module under ``mcp/``:
+
+* ``get_client`` — the call must be lexically inside a ``with mcp_errors():``
+  in the *same* function (a nested ``def`` resets the scope: its body runs after
+  the enclosing ``with`` has exited).
+* ``get_client_from_app`` — the ``/files/*`` routes have no ``mcp_errors``; the
+  call must instead sit in a ``try`` whose handler catches ``Exception`` (a
+  narrower ``except RuntimeError`` is what this rule exists to catch).
+
+Both rules resolve the *binding* names actually imported in each module, so an
+``import ... as`` alias or an attribute spelling (``_context.get_client(ctx)``)
+is covered rather than silently passing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MCP_DIR = REPO_ROOT / "src" / "notebooklm" / "mcp"
+
+_CLIENT_ACCESSOR = "get_client"
+_APP_ACCESSOR = "get_client_from_app"
+_BOUNDARY = "mcp_errors"
+
+#: Functions whose caller supplies the boundary. Each entry must name a *helper*
+#: (not an ``@mcp.tool``) whose every call site is itself inside ``mcp_errors``.
+#: Shrink-only: removing an entry is fine, adding one needs the same proof.
+_WRAPPED_BY_CALLER = {
+    # meta.py::server_info calls this from inside its own ``with mcp_errors():``.
+    ("tools/meta.py", "_account_block"),
+}
+
+
+def _bound_names(tree: ast.AST, target: str) -> set[str]:
+    """Local names ``target`` is reachable through: direct, aliased, or module-qualified."""
+    names = {target}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == target and alias.asname:
+                    names.add(alias.asname)
+    return names
+
+
+def _is_call_to(node: ast.AST, names: set[str]) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in names
+    if isinstance(func, ast.Attribute):  # e.g. ``_context.get_client(ctx)``
+        return func.attr in names
+    return False
+
+
+def _guarded_by_except_exception(node: ast.Try) -> bool:
+    for handler in node.handlers:
+        if handler.type is None:  # bare ``except:``
+            return True
+        candidates = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+        for exc in candidates:
+            if isinstance(exc, ast.Name) and exc.id in {"Exception", "BaseException"}:
+                return True
+    return False
+
+
+def _violations(source: str, rel: str) -> list[str]:
+    """Report accessor calls that sit outside their required guard."""
+    tree = ast.parse(source)
+    client_names = _bound_names(tree, _CLIENT_ACCESSOR)
+    app_names = _bound_names(tree, _APP_ACCESSOR)
+    boundary_names = _bound_names(tree, _BOUNDARY)
+    found: list[str] = []
+
+    def walk(node: ast.AST, *, in_boundary: bool, in_try: bool, func: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            child_boundary, child_try, child_func = in_boundary, in_try, func
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                # A nested body runs after the enclosing ``with`` / ``try`` exits.
+                child_boundary, child_try, child_func = False, False, child.name
+            elif isinstance(child, (ast.With, ast.AsyncWith)):
+                if any(_is_call_to(item.context_expr, boundary_names) for item in child.items):
+                    child_boundary = True
+            elif isinstance(child, ast.Try):
+                child_try = _guarded_by_except_exception(child)
+            elif _is_call_to(child, client_names) and not in_boundary:
+                if (rel, func) not in _WRAPPED_BY_CALLER:
+                    found.append(f"{rel}:{child.lineno} {func}() — outside `with mcp_errors():`")
+            elif _is_call_to(child, app_names) and not in_try:
+                found.append(f"{rel}:{child.lineno} {func}() — outside `except Exception`")
+            walk(child, in_boundary=child_boundary, in_try=child_try, func=child_func)
+
+    walk(tree, in_boundary=False, in_try=False, func="<module>")
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# The real gate
+# --------------------------------------------------------------------------- #
+def test_every_lazy_client_call_sits_inside_its_guard() -> None:
+    found: list[str] = []
+    for path in sorted(MCP_DIR.rglob("*.py")):
+        found += _violations(path.read_text(encoding="utf-8"), str(path.relative_to(MCP_DIR)))
+    assert not found, "lazy client open escaping its error boundary (#2330):\n" + "\n".join(found)
+
+
+def test_the_gate_actually_covers_the_call_sites() -> None:
+    """Non-vacuity: the scan must FIND the accessor, not pass on an empty sweep."""
+    total = sum(
+        path.read_text(encoding="utf-8").count(f"await {_CLIENT_ACCESSOR}(")
+        for path in MCP_DIR.rglob("*.py")
+    )
+    assert total >= 30, f"expected the tool surface to still call the accessor, saw {total}"
+
+
+def test_allowlist_entries_all_exist() -> None:
+    """Shrink-only guard: a stale allowlist entry must not silently excuse nothing."""
+    for rel, func in _WRAPPED_BY_CALLER:
+        source = (MCP_DIR / rel).read_text(encoding="utf-8")
+        assert f"def {func}(" in source, f"allowlist names a missing function: {rel}::{func}"
+
+
+# --------------------------------------------------------------------------- #
+# Injection self-checks — prove the detector bites, in every spelling
+# --------------------------------------------------------------------------- #
+_OUTSIDE = """
+from ._context import get_client
+from ._errors import mcp_errors
+
+async def tool(ctx):
+    client = await get_client(ctx)
+    with mcp_errors():
+        return await client.notebooks.list()
+"""
+
+_INSIDE = """
+from ._context import get_client
+from ._errors import mcp_errors
+
+async def tool(ctx):
+    with mcp_errors():
+        client = await get_client(ctx)
+        return await client.notebooks.list()
+"""
+
+_ALIASED = """
+from ._context import get_client as fetch_client
+from ._errors import mcp_errors
+
+async def tool(ctx):
+    client = await fetch_client(ctx)
+    with mcp_errors():
+        return client
+"""
+
+_ATTRIBUTE = """
+from . import _context
+from ._errors import mcp_errors
+
+async def tool(ctx):
+    client = await _context.get_client(ctx)
+    with mcp_errors():
+        return client
+"""
+
+_NESTED_DEF = """
+from ._context import get_client
+from ._errors import mcp_errors
+
+def register(mcp):
+    with mcp_errors():
+        async def tool(ctx):
+            return await get_client(ctx)
+"""
+
+_ROUTE_NARROW = """
+from ._context import get_client_from_app
+
+async def route(request):
+    try:
+        client = await get_client_from_app(request)
+    except RuntimeError:
+        return None
+    return client
+"""
+
+_ROUTE_WIDE = """
+from ._context import get_client_from_app
+
+async def route(request):
+    try:
+        client = await get_client_from_app(request)
+    except Exception:
+        return None
+    return client
+"""
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        pytest.param(_OUTSIDE, True, id="call-above-the-boundary-is-caught"),
+        pytest.param(_INSIDE, False, id="call-inside-the-boundary-is-clean"),
+        pytest.param(_ALIASED, True, id="aliased-import-cannot-bypass"),
+        pytest.param(_ATTRIBUTE, True, id="attribute-spelling-cannot-bypass"),
+        pytest.param(_NESTED_DEF, True, id="enclosing-with-does-not-cover-a-nested-def"),
+        pytest.param(_ROUTE_NARROW, True, id="except-RuntimeError-is-too-narrow"),
+        pytest.param(_ROUTE_WIDE, False, id="except-Exception-is-accepted"),
+    ],
+)
+def test_detector_self_checks(source: str, expected: bool) -> None:
+    assert bool(_violations(source, "synthetic.py")) is expected

--- a/tests/_guardrails/test_mcp_lazy_client_error_boundary.py
+++ b/tests/_guardrails/test_mcp_lazy_client_error_boundary.py
@@ -90,6 +90,19 @@ def _violations(source: str, rel: str) -> list[str]:
     found: list[str] = []
 
     def walk(node: ast.AST, *, in_boundary: bool, in_try: bool, func: str) -> None:
+        if isinstance(node, ast.Try):
+            # ONLY ``Try.body`` is covered by the handlers. ``orelse`` runs after the
+            # body succeeded and ``finalbody`` during unwinding — an exception from
+            # either escapes this ``except`` entirely, so protection must not leak
+            # into them (nor into ``handlers``, where a raise also escapes).
+            guarded = in_try or _guarded_by_except_exception(node)
+            for stmt in node.body:
+                walk(stmt, in_boundary=in_boundary, in_try=guarded, func=func)
+            for branch in (node.handlers, node.orelse, node.finalbody):
+                for stmt in branch:
+                    walk(stmt, in_boundary=in_boundary, in_try=in_try, func=func)
+            return
+
         for child in ast.iter_child_nodes(node):
             child_boundary, child_try, child_func = in_boundary, in_try, func
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -98,8 +111,6 @@ def _violations(source: str, rel: str) -> list[str]:
             elif isinstance(child, (ast.With, ast.AsyncWith)):
                 if any(_is_call_to(item.context_expr, boundary_names) for item in child.items):
                     child_boundary = True
-            elif isinstance(child, ast.Try):
-                child_try = _guarded_by_except_exception(child)
             elif _is_call_to(child, client_names) and not in_boundary:
                 if (rel, func) not in _WRAPPED_BY_CALLER:
                     found.append(f"{rel}:{child.lineno} {func}() — outside `with mcp_errors():`")
@@ -213,6 +224,54 @@ async def route(request):
 """
 
 
+_ROUTE_ELSE = """
+from ._context import get_client_from_app
+
+async def route(request):
+    try:
+        pass
+    except Exception:
+        return None
+    else:
+        return await get_client_from_app(request)
+"""
+
+_ROUTE_FINALLY = """
+from ._context import get_client_from_app
+
+async def route(request):
+    try:
+        pass
+    except Exception:
+        return None
+    finally:
+        await get_client_from_app(request)
+"""
+
+_ROUTE_HANDLER = """
+from ._context import get_client_from_app
+
+async def route(request):
+    try:
+        pass
+    except Exception:
+        return await get_client_from_app(request)
+"""
+
+_TOOL_TRY_DOES_NOT_SUBSTITUTE = """
+from ._context import get_client
+from ._errors import mcp_errors
+
+async def tool(ctx):
+    try:
+        client = await get_client(ctx)
+    except Exception:
+        raise
+    with mcp_errors():
+        return client
+"""
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
@@ -223,6 +282,14 @@ async def route(request):
         pytest.param(_NESTED_DEF, True, id="enclosing-with-does-not-cover-a-nested-def"),
         pytest.param(_ROUTE_NARROW, True, id="except-RuntimeError-is-too-narrow"),
         pytest.param(_ROUTE_WIDE, False, id="except-Exception-is-accepted"),
+        pytest.param(_ROUTE_ELSE, True, id="try-else-is-not-covered-by-the-handler"),
+        pytest.param(_ROUTE_FINALLY, True, id="try-finally-is-not-covered-by-the-handler"),
+        pytest.param(_ROUTE_HANDLER, True, id="the-handler-suite-is-not-covered-by-itself"),
+        pytest.param(
+            _TOOL_TRY_DOES_NOT_SUBSTITUTE,
+            True,
+            id="a-try-block-is-not-a-substitute-for-mcp_errors",
+        ),
     ],
 )
 def test_detector_self_checks(source: str, expected: bool) -> None:

--- a/tests/unit/mcp/test_clientprovider.py
+++ b/tests/unit/mcp/test_clientprovider.py
@@ -1,0 +1,265 @@
+"""Lazy client open + the #2330 handshake regression.
+
+Before #2330 the FastMCP lifespan *awaited* the client open, so the MCP
+``initialize`` handshake could not be answered until Google's auth round-trip
+finished. That round-trip's own budget (a 15 s ``RotateCookies`` poke plus a
+30 s CSRF fetch on the happy rung, more on the cold-recovery ladder) exceeds the
+30 s deadline Claude Code gives the handshake, so a slow or rate-limited Google
+surfaced as an opaque ``CONNECT_TIMEOUT`` instead of a real error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp import Client  # noqa: E402 - after importorskip guard
+
+from notebooklm.client import NotebookLMClient  # noqa: E402
+from notebooklm.mcp._clientprovider import ClientProvider  # noqa: E402
+from notebooklm.mcp.server import create_server  # noqa: E402
+
+
+class _SlowFactory:
+    """Client factory whose open blocks until released (stands in for slow auth)."""
+
+    def __init__(self, client: NotebookLMClient | None = None) -> None:
+        self.client = client if client is not None else cast("NotebookLMClient", MagicMock())
+        self.gate = asyncio.Event()
+        self.opens = 0
+        self.closes = 0
+        self.error: Exception | None = None
+        self.entered = asyncio.Event()
+
+    def __call__(self) -> contextlib.AbstractAsyncContextManager[NotebookLMClient]:
+        return self._cm()
+
+    @contextlib.asynccontextmanager
+    async def _cm(self) -> AsyncIterator[NotebookLMClient]:
+        self.opens += 1
+        self.entered.set()
+        await self.gate.wait()
+        if self.error is not None:
+            raise self.error
+        try:
+            yield self.client
+        finally:
+            self.closes += 1
+
+
+async def test_handshake_is_not_gated_on_the_client_open() -> None:
+    """#2330: initialize + tool discovery complete while the open is still blocked."""
+    factory = _SlowFactory()
+    server = create_server(client_factory=factory)
+
+    async with Client(server) as client:  # performs initialize
+        # The open has been *started* (warm-up) but has not completed.
+        await asyncio.wait_for(factory.entered.wait(), timeout=5)
+        tools = await asyncio.wait_for(client.list_tools(), timeout=5)
+        assert tools, "tool discovery must not wait on the client open"
+        factory.gate.set()
+
+    assert factory.opens == 1
+
+
+async def test_lifespan_warms_the_client_in_the_background() -> None:
+    """The lifespan starts the open itself, so the first tool call is usually warm."""
+    factory = _SlowFactory()
+    factory.gate.set()
+    server = create_server(client_factory=factory)
+
+    async with Client(server):
+        # Nothing was called yet, but the warm-up already opened the client.
+        for _ in range(50):
+            if factory.opens:
+                break
+            await asyncio.sleep(0.01)
+        assert factory.opens == 1
+
+
+async def test_lifespan_closes_the_client_it_opened() -> None:
+    factory = _SlowFactory()
+    factory.gate.set()
+    server = create_server(client_factory=factory)
+
+    async with Client(server):
+        pass
+
+    assert factory.closes == 1
+
+
+async def test_lifespan_shutdown_while_the_open_is_still_in_flight() -> None:
+    """A server torn down mid-open cancels the warm-up instead of hanging."""
+    factory = _SlowFactory()
+    server = create_server(client_factory=factory)
+
+    async with Client(server):
+        await asyncio.wait_for(factory.entered.wait(), timeout=5)
+    # Never released; shutdown must not wait on it.
+    assert factory.opens == 1
+
+
+async def test_get_opens_once_for_concurrent_callers() -> None:
+    """Concurrent tool calls join a single in-flight open, not one open each."""
+    factory = _SlowFactory()
+    provider = ClientProvider(factory)
+
+    waiters = [asyncio.create_task(provider.get()) for _ in range(5)]
+    await asyncio.wait_for(factory.entered.wait(), timeout=5)
+    factory.gate.set()
+
+    assert await asyncio.gather(*waiters) == [factory.client] * 5
+    assert factory.opens == 1
+    await provider.aclose()
+
+
+async def test_a_cancelled_waiter_does_not_abort_the_shared_open() -> None:
+    """One caller's timeout must not cancel the open every other caller joined."""
+    factory = _SlowFactory()
+    provider = ClientProvider(factory)
+
+    doomed = asyncio.create_task(provider.get())
+    survivor = asyncio.create_task(provider.get())
+    await asyncio.wait_for(factory.entered.wait(), timeout=5)
+
+    doomed.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await doomed
+    factory.gate.set()
+
+    assert await asyncio.wait_for(survivor, timeout=5) is factory.client
+    assert factory.opens == 1
+    await provider.aclose()
+
+
+async def test_a_failed_open_is_retried_by_the_next_call() -> None:
+    """A failed open is not cached: a mid-session re-login recovers the server."""
+    factory = _SlowFactory()
+    factory.error = RuntimeError("expired cookies")
+    factory.gate.set()
+    provider = ClientProvider(factory)
+
+    with pytest.raises(RuntimeError, match="expired cookies"):
+        await provider.get()
+    assert not provider.is_open
+
+    factory.error = None
+    assert await provider.get() is factory.client
+    assert factory.opens == 2
+    await provider.aclose()
+
+
+async def test_a_failed_warm_up_is_logged_and_retried(caplog: pytest.LogCaptureFixture) -> None:
+    """The unawaited warm-up retrieves its own exception and leaves a breadcrumb."""
+    factory = _SlowFactory()
+    factory.error = RuntimeError("expired cookies")
+    factory.gate.set()
+    provider = ClientProvider(factory)
+
+    with caplog.at_level("WARNING", logger="notebooklm.mcp._clientprovider"):
+        provider.start()
+        for _ in range(100):
+            if "expired cookies" in caplog.text:
+                break
+            await asyncio.sleep(0.01)
+
+    assert "expired cookies" in caplog.text
+    factory.error = None
+    assert await provider.get() is factory.client
+    await provider.aclose()
+
+
+async def test_start_is_a_no_op_once_open_or_closed() -> None:
+    factory = _SlowFactory()
+    factory.gate.set()
+    provider = ClientProvider(factory)
+
+    await provider.get()
+    provider.start()
+    assert factory.opens == 1
+
+    await provider.aclose()
+    provider.start()
+    assert factory.opens == 1
+
+
+async def test_get_after_close_refuses_instead_of_reopening() -> None:
+    factory = _SlowFactory()
+    factory.gate.set()
+    provider = ClientProvider(factory)
+    await provider.get()
+    await provider.aclose()
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await provider.get()
+    assert factory.opens == 1
+
+
+async def test_close_racing_an_in_flight_open_does_not_leak_the_client() -> None:
+    """An open that lands after aclose() closes what it opened and hands out nothing."""
+    factory = _SlowFactory()
+    provider = ClientProvider(factory)
+
+    pending = asyncio.create_task(provider.get())
+    await asyncio.wait_for(factory.entered.wait(), timeout=5)
+    # Reaching into ``_closed`` is deliberate: this pins the narrow window where
+    # ``aclose`` flipped the flag but the open had already passed its last await
+    # point, so the task's cancel arrives too late. ``aclose()`` itself cancels
+    # the in-flight open (covered above); only the flag reproduces THIS race.
+    provider._closed = True
+    factory.gate.set()
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await asyncio.wait_for(pending, timeout=5)
+    assert factory.closes == 1
+    assert not provider.is_open
+
+
+async def test_aclose_is_idempotent() -> None:
+    factory = _SlowFactory()
+    factory.gate.set()
+    provider = ClientProvider(factory)
+    await provider.get()
+
+    await provider.aclose()
+    await provider.aclose()
+    assert factory.closes == 1
+
+
+async def test_of_holds_a_client_it_does_not_own() -> None:
+    """The test seam hands back the client without ever opening or closing one."""
+    sentinel = cast("NotebookLMClient", MagicMock())
+    provider = ClientProvider.of(sentinel)
+
+    assert provider.is_open
+    assert await provider.get() is sentinel
+    await provider.aclose()  # does not close a client it never opened
+
+
+async def test_a_stale_done_callback_does_not_clobber_a_newer_open() -> None:
+    """A failed open's callback fires a tick later — by then a retry may already
+    own the slot, and clearing it would strand that retry's waiters."""
+    factory = _SlowFactory()
+    provider = ClientProvider(factory)
+
+    live = provider._ensure_open_task()
+
+    async def _boom() -> NotebookLMClient:
+        raise RuntimeError("an earlier, already-replaced open")
+
+    stale = asyncio.ensure_future(_boom())
+    with contextlib.suppress(RuntimeError):
+        await stale
+    provider._on_open_done(stale)
+
+    assert provider._open_task is live
+    factory.gate.set()
+    assert await asyncio.wait_for(live, timeout=5) is factory.client
+    await provider.aclose()

--- a/tests/unit/mcp/test_clientprovider.py
+++ b/tests/unit/mcp/test_clientprovider.py
@@ -263,3 +263,49 @@ async def test_a_stale_done_callback_does_not_clobber_a_newer_open() -> None:
     factory.gate.set()
     assert await asyncio.wait_for(live, timeout=5) is factory.client
     await provider.aclose()
+
+
+async def test_a_failed_open_reaches_the_agent_as_a_categorized_auth_error() -> None:
+    """The whole point of #2330: an auth failure must arrive as a real, actionable
+    tool error, not an opaque transport timeout — and not a generic UNEXPECTED,
+    which is what happens if the lazy open resolves outside ``mcp_errors()``."""
+    from fastmcp.exceptions import ToolError
+
+    from notebooklm.exceptions import AuthError
+
+    factory = _SlowFactory()
+    factory.error = AuthError("session expired: cookie SID=AAAA1111secret")
+    factory.gate.set()
+
+    async with Client(create_server(client_factory=factory)) as client:
+        with pytest.raises(ToolError) as excinfo:
+            await client.call_tool("notebook_list", {})
+
+    message = str(excinfo.value)
+    assert message.startswith("AUTH:"), message
+    assert "retriable" in message
+    assert "AAAA1111secret" not in message  # scrubbed on the way out
+
+
+async def test_the_warm_up_log_is_scrubbed_at_the_source(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``mcp.__main__`` configures stderr with a bare ``logging.basicConfig``, whose
+    root handler carries no ``RedactingFilter`` — so this line scrubs itself."""
+    from notebooklm.exceptions import AuthError
+
+    factory = _SlowFactory()
+    factory.error = AuthError("session expired: cookie SID=AAAA1111secret")
+    factory.gate.set()
+    provider = ClientProvider(factory)
+
+    with caplog.at_level("WARNING", logger="notebooklm.mcp._clientprovider"):
+        provider.start()
+        for _ in range(100):
+            if "client open failed" in caplog.text:
+                break
+            await asyncio.sleep(0.01)
+
+    assert "client open failed" in caplog.text
+    assert "AAAA1111secret" not in caplog.text
+    await provider.aclose()

--- a/tests/unit/mcp/test_clientprovider.py
+++ b/tests/unit/mcp/test_clientprovider.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator
+from types import TracebackType
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -322,13 +323,18 @@ async def test_a_stale_failure_is_retrieved_even_when_the_slot_moved_on() -> Non
     provider = ClientProvider(factory)
 
     stale = provider._ensure_open_task()
-    with contextlib.suppress(RuntimeError):
-        await stale
+    # Keep the exception genuinely unretrieved until the callback under test runs.
+    # Awaiting the task directly (even under suppress) would consume it and make
+    # this regression pass before _on_open_done did any work.
+    assert stale.remove_done_callback(provider._on_open_done) == 1
+    done, pending = await asyncio.wait({stale})
+    assert done == {stale}
+    assert not pending
+    assert getattr(stale, "_log_traceback", False)
     # Simulate the race the callback guards: something else claimed the slot.
     provider._open_task = None
     provider._on_open_done(stale)
 
-    assert stale.exception() is not None
     # The real assertion: the exception was consumed, so asyncio will not later
     # report it as "never retrieved" (which is what bypasses redaction).
     assert not getattr(stale, "_log_traceback", False)
@@ -407,6 +413,37 @@ async def test_shutdown_reports_a_clean_exit_as_clean() -> None:
 
     await _shutdown_clean(state, provider)
     assert seen == [None]
+
+
+async def test_lifespan_honors_client_context_manager_suppression() -> None:
+    """The lazy provider preserves the factory CM's normal suppression contract."""
+
+    class SuppressingManager:
+        def __init__(self) -> None:
+            self.client = cast("NotebookLMClient", MagicMock())
+            self.seen: list[tuple[type[BaseException] | None, BaseException | None]] = []
+
+        async def __aenter__(self) -> NotebookLMClient:
+            return self.client
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> bool:
+            self.seen.append((exc_type, exc))
+            return True
+
+    manager = SuppressingManager()
+    server = create_server(client_factory=lambda: manager)
+    lifespan = server._lifespan(server)
+    state = await lifespan.__aenter__()
+    await state.client_provider.get()  # ensure the background open has landed
+
+    boom = RuntimeError("lifespan body failed")
+    assert await lifespan.__aexit__(type(boom), boom, boom.__traceback__) is True
+    assert manager.seen == [(RuntimeError, boom)]
 
 
 async def _shutdown_clean(state: AppState, provider: ClientProvider) -> None:

--- a/tests/unit/mcp/test_clientprovider.py
+++ b/tests/unit/mcp/test_clientprovider.py
@@ -24,6 +24,7 @@ from fastmcp import Client  # noqa: E402 - after importorskip guard
 
 from notebooklm.client import NotebookLMClient  # noqa: E402
 from notebooklm.mcp._clientprovider import ClientProvider  # noqa: E402
+from notebooklm.mcp._context import AppState  # noqa: E402
 from notebooklm.mcp.server import create_server  # noqa: E402
 
 
@@ -309,3 +310,106 @@ async def test_the_warm_up_log_is_scrubbed_at_the_source(
     assert "client open failed" in caplog.text
     assert "AAAA1111secret" not in caplog.text
     await provider.aclose()
+
+
+async def test_a_stale_failure_is_retrieved_even_when_the_slot_moved_on() -> None:
+    """A done-callback runs a tick late — by then a retry may own the slot. The
+    failure must still be retrieved, or asyncio logs it through its own handler
+    with the raw ``repr``, routing around ``redact`` (#2330 review)."""
+    factory = _SlowFactory()
+    factory.error = RuntimeError("expired cookies")
+    factory.gate.set()
+    provider = ClientProvider(factory)
+
+    stale = provider._ensure_open_task()
+    with contextlib.suppress(RuntimeError):
+        await stale
+    # Simulate the race the callback guards: something else claimed the slot.
+    provider._open_task = None
+    provider._on_open_done(stale)
+
+    assert stale.exception() is not None
+    # The real assertion: the exception was consumed, so asyncio will not later
+    # report it as "never retrieved" (which is what bypasses redaction).
+    assert not getattr(stale, "_log_traceback", False)
+    await provider.aclose()
+
+
+async def test_aclose_forwards_the_lifespan_exception_to_the_client() -> None:
+    """``NotebookLMClient.__aexit__`` demotes a close failure to a WARNING only when
+    the body raised. Passing (None, None, None) would claim success and let a close
+    error bury the real cause, which the `async with factory()` this replaced never
+    did (#2330 review)."""
+    seen: list[tuple[object, object]] = []
+
+    @contextlib.asynccontextmanager
+    async def factory():
+        try:
+            yield MagicMock()
+        except BaseException as exc:  # what `async with` hands the CM
+            seen.append((type(exc), exc))
+            raise
+
+    provider = ClientProvider(factory)
+    await provider.get()
+
+    boom = ValueError("lifespan blew up")
+    await provider.aclose(type(boom), boom, boom.__traceback__)
+
+    assert seen == [(ValueError, boom)]
+
+
+async def test_shutdown_forwards_the_in_flight_exception() -> None:
+    """The lifespan reads ``sys.exc_info()`` in its ``finally`` and hands the triple
+    to ``_shutdown``; this pins that it reaches the client context manager."""
+    from notebooklm.mcp.server import _shutdown
+
+    seen: list[BaseException] = []
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[NotebookLMClient]:
+        try:
+            yield cast("NotebookLMClient", MagicMock())
+        except BaseException as exc:
+            seen.append(exc)
+            raise
+
+    provider = ClientProvider(factory)
+    await provider.get()
+    state = AppState(client_provider=provider)
+
+    boom = RuntimeError("host went away")
+    # ``_shutdown`` does not re-raise: contextlib's ``__aexit__`` returns False when
+    # the generator re-raises the exception it was handed, leaving propagation to the
+    # ``finally`` that is already unwinding. What matters is that the client SAW it.
+    await _shutdown(state, provider, type(boom), boom, boom.__traceback__)
+
+    assert seen == [boom]
+
+
+async def test_shutdown_reports_a_clean_exit_as_clean() -> None:
+    """The same path on the happy exit must NOT claim the body raised."""
+    seen: list[BaseException | None] = []
+
+    @contextlib.asynccontextmanager
+    async def factory() -> AsyncIterator[NotebookLMClient]:
+        try:
+            yield cast("NotebookLMClient", MagicMock())
+        except BaseException as exc:  # pragma: no cover - clean path takes the else
+            seen.append(exc)
+            raise
+        else:
+            seen.append(None)
+
+    provider = ClientProvider(factory)
+    await provider.get()
+    state = AppState(client_provider=provider)
+
+    await _shutdown_clean(state, provider)
+    assert seen == [None]
+
+
+async def _shutdown_clean(state: AppState, provider: ClientProvider) -> None:
+    from notebooklm.mcp.server import _shutdown
+
+    await _shutdown(state, provider, None, None, None)

--- a/tests/unit/mcp/test_fileroutes.py
+++ b/tests/unit/mcp/test_fileroutes.py
@@ -1024,6 +1024,43 @@ def test_lifespan_not_set_returns_500(mock_client, config) -> None:
     assert resp.status_code == 500
 
 
+def _failing_open_app(config: FileTransferConfig):
+    """A server whose lazy client open always fails (#2330), e.g. expired cookies."""
+
+    from notebooklm.exceptions import AuthError
+
+    @contextlib.asynccontextmanager
+    async def factory():
+        raise AuthError("session expired: cookie SID=AAAA1111secret")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    server = create_server(client_factory=factory, file_transfer=config)  # type: ignore[arg-type]
+    return server.http_app()
+
+
+def test_download_route_returns_500_when_the_lazy_open_fails(config) -> None:
+    # The client is opened lazily (#2330), so the accessor can now raise an
+    # auth/network error, not just RuntimeError. It must still be a clean 500 that
+    # echoes nothing of the cause (the route is reachable by anyone with the link).
+    url = config.download_url({"op": "dl", "nb": NB, "atype": "audio"})
+    with starlette_testclient.TestClient(_failing_open_app(config)) as client:
+        resp = client.get(_path(url))
+    assert resp.status_code == 500
+    assert "AAAA1111secret" not in resp.text
+    assert "session expired" not in resp.text
+
+
+def test_upload_route_500_on_failed_lazy_open_still_carries_cors(config) -> None:
+    # Same widening on the upload route — and the CORS header must ride along, or
+    # the in-app widget's cross-origin fetch cannot even read the failure.
+    url = config.upload_url({"op": "ul", "nb": NB})
+    with starlette_testclient.TestClient(_failing_open_app(config)) as client:
+        resp = client.post(_path(url), content=b"hello")
+    assert resp.status_code == 500
+    assert resp.headers["Access-Control-Allow-Origin"] == "*"
+    assert "AAAA1111secret" not in resp.text
+
+
 # --------------------------------------------------------------------------- #
 # Upstream-error classification + redaction (#1682)
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -395,4 +395,24 @@ async def test_server_info_survives_a_failed_lazy_client_open(tmp_path, monkeypa
     assert account["available"] is False
     assert account["email"] is None
     assert account["authuser"] is None
+    assert "session expired" in account["reason"]
     assert "AAAA1111secret" not in account["reason"]
+
+
+async def test_server_info_hides_unexpected_lazy_client_open_details(tmp_path, monkeypatch) -> None:
+    """Unexpected open failures degrade without echoing arbitrary exception text."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+
+    @contextlib.asynccontextmanager
+    async def failing_factory():
+        raise RuntimeError("internal host tenant_secret=not-a-known-token-shape")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    async with Client(create_server(client_factory=failing_factory)) as client:
+        result = await client.call_tool("server_info", {"include_account": True})
+
+    account = result.structured_content["account"]
+    assert account["available"] is False
+    assert account["reason"] == "An unexpected internal error occurred."
+    assert "tenant_secret" not in account["reason"]

--- a/tests/unit/mcp/test_meta.py
+++ b/tests/unit/mcp/test_meta.py
@@ -361,3 +361,38 @@ async def test_server_info_include_account_degraded_reason_is_scrubbed(
     # The OS username segment is masked; the rest of the message survives.
     assert "secretuser" not in reason
     assert "/home/***/" in reason
+
+
+async def test_server_info_survives_a_failed_lazy_client_open(tmp_path, monkeypatch) -> None:
+    """A failed lazy open (#2330) must degrade the ``account`` block, not sink the call.
+
+    ``server_info`` is the tool an agent reaches for when something is already wrong,
+    so the version + local-auth diagnostics — which need no client — must still come
+    back. Letting the open failure reach ``server_info``'s ``mcp_errors()`` would turn
+    the whole call into an AUTH error and discard exactly the fields that say what broke.
+    """
+    import contextlib
+
+    from notebooklm.exceptions import AuthError
+
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    _write_authed_storage()
+
+    @contextlib.asynccontextmanager
+    async def failing_factory():
+        raise AuthError("session expired: cookie SID=AAAA1111secret")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    async with Client(create_server(client_factory=failing_factory)) as client:
+        result = await client.call_tool("server_info", {"include_account": True})
+
+    payload = result.structured_content
+    # The client-free diagnostics survived.
+    assert payload["version"]
+    assert payload["auth"]["profile"]
+    # The account block degraded rather than sinking the response.
+    account = payload["account"]
+    assert account["available"] is False
+    assert account["email"] is None
+    assert account["authuser"] is None
+    assert "AAAA1111secret" not in account["reason"]

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -17,6 +17,7 @@ from fastmcp import Client, FastMCP  # noqa: E402 - after importorskip guard
 from notebooklm.client import NotebookLMClient  # noqa: E402 - after importorskip guard
 from notebooklm.mcp import __main__ as entry  # noqa: E402 - after importorskip guard
 from notebooklm.mcp._chattasks import ChatTaskRegistry  # noqa: E402 - after importorskip guard
+from notebooklm.mcp._clientprovider import ClientProvider  # noqa: E402 - after importorskip
 from notebooklm.mcp._context import (  # noqa: E402 - after importorskip guard
     AppState,
     CancelledResearchTracker,
@@ -145,20 +146,20 @@ async def test_backend_does_not_reparameterize_injected_factory(
     assert calls == 1
 
 
-def test_get_client_reads_appstate() -> None:
+async def test_get_client_reads_appstate() -> None:
     """get_client unwraps the AppState bound in the request lifespan context."""
     sentinel = MagicMock()
-    state = AppState(client=sentinel)
+    state = AppState(client_provider=ClientProvider.of(sentinel))
 
     ctx = MagicMock()
     ctx.request_context.lifespan_context = state
-    assert get_client(ctx) is sentinel
+    assert await get_client(ctx) is sentinel
 
 
 def test_get_cancelled_research_returns_live_appstate_tracker() -> None:
     """get_cancelled_research returns the live tracker on the bound AppState so
     research_cancel/research_status share cancel intent (issue #1922, F9)."""
-    state = AppState(client=MagicMock())
+    state = AppState(client_provider=ClientProvider.of(MagicMock()))
     ctx = MagicMock()
     ctx.request_context.lifespan_context = state
 

--- a/tests/unit/mcp/test_sources.py
+++ b/tests/unit/mcp/test_sources.py
@@ -1720,6 +1720,47 @@ async def test_source_add_missing_input_is_validation_error(mcp_call, mock_clien
     assert "VALIDATION" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    ("args", "detail"),
+    [
+        ({"urls": []}, "at least one URL"),
+        ({"urls": ["https://example.com"], "wait": True}, "single-mode only"),
+        (
+            {"source_type": "drive", "document_id": "drive-1", "mime_type": "bogus"},
+            "Invalid mime_type",
+        ),
+        ({"source_type": "drive", "mime_type": "google-doc"}, "document_id"),
+        (
+            {"source_type": "url", "url": "https://example.com", "wait": True, "timeout": -1},
+            "timeout",
+        ),
+        ({"source_type": "file", "bytes_base64": "%%%"}, "not valid base64"),
+    ],
+)
+async def test_source_add_local_validation_precedes_lazy_open_failure(args, detail) -> None:
+    """Malformed input stays VALIDATION even when the lazy client cannot authenticate."""
+    import contextlib
+
+    from fastmcp import Client
+
+    from notebooklm.exceptions import AuthError
+    from notebooklm.mcp.server import create_server
+
+    @contextlib.asynccontextmanager
+    async def failing_factory():
+        raise AuthError("expired credentials that must not mask validation")
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    async with Client(create_server(client_factory=failing_factory)) as client:
+        with pytest.raises(ToolError) as excinfo:
+            await client.call_tool("source_add", {"notebook": NB_ID, **args})
+
+    message = str(excinfo.value)
+    assert message.startswith("VALIDATION:"), message
+    assert detail in message
+    assert "expired credentials" not in message
+
+
 async def test_source_add_drive_bad_mime_is_validation_error(mcp_call, mock_client) -> None:
     """A bogus drive mime_type projects as VALIDATION (not UNEXPECTED)."""
     mock_client.sources.add_drive = AsyncMock(return_value=FakeSource(id=SRC_ID))

--- a/tests/unit/mcp/test_uploadwidget.py
+++ b/tests/unit/mcp/test_uploadwidget.py
@@ -19,6 +19,7 @@ import pytest
 pytest.importorskip("fastmcp")
 
 from notebooklm.mcp import _uploadwidget  # noqa: E402
+from notebooklm.mcp._clientprovider import ClientProvider  # noqa: E402
 from notebooklm.mcp._filelink import (  # noqa: E402
     UPLOAD_TTL,
     WIDGET_UPLOAD_TTL,
@@ -159,7 +160,9 @@ async def test_widget_tool_returns_single_use_token_pool(monkeypatch) -> None:
     monkeypatch.setattr(_uploadwidget, "resolve_notebook", AsyncMock(return_value="nb-123"))
     ctx = SimpleNamespace(
         request_context=SimpleNamespace(
-            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
+            lifespan_context=SimpleNamespace(
+                client_provider=ClientProvider.of(MagicMock()), file_transfer=cfg
+            )
         )
     )
 
@@ -184,7 +187,9 @@ async def test_widget_tool_returns_auto_confirm_contract(monkeypatch) -> None:
     monkeypatch.setattr(_uploadwidget, "resolve_notebook", AsyncMock(return_value="nb-123"))
     ctx = SimpleNamespace(
         request_context=SimpleNamespace(
-            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
+            lifespan_context=SimpleNamespace(
+                client_provider=ClientProvider.of(MagicMock()), file_transfer=cfg
+            )
         )
     )
 
@@ -210,7 +215,9 @@ async def test_widget_pool_tokens_carry_the_longer_widget_ttl(monkeypatch) -> No
     monkeypatch.setattr(_uploadwidget, "resolve_notebook", AsyncMock(return_value="nb-123"))
     ctx = SimpleNamespace(
         request_context=SimpleNamespace(
-            lifespan_context=SimpleNamespace(client=MagicMock(), file_transfer=cfg)
+            lifespan_context=SimpleNamespace(
+                client_provider=ClientProvider.of(MagicMock()), file_transfer=cfg
+            )
         )
     )
 


### PR DESCRIPTION
Fixes #2330.

## Root cause

The FastMCP lifespan **awaited** the `NotebookLMClient` open before yielding, so
the MCP `initialize` handshake could not be answered until Google's auth
round-trip finished:

`server.py` lifespan → `NotebookLMClient.from_storage(...).__aenter__()` →
`_load_stored_auth` → `_ProductionTokenAcquirer.acquire` →
`_fetch_tokens_with_jar`.

That auth path's own budget is larger than the deadline the host gives the
handshake (Claude Code: 30 s):

| step | timeout | where |
| --- | --- | --- |
| `RotateCookies` poke to `accounts.google.com` | 15 s | `_auth/mint_service.py:29` |
| CSRF/session `GET` on the app host | 30 s | `_auth/refresh.py:986` |
| cold-recovery ladder (refresh cmd → headless re-auth → master-token re-mint) | more | `_auth/refresh.py:_cold_fallbacks` |

So **45 s minimum worst case on the happy rung alone**. A slow or rate-limited
Google therefore reached the host as an opaque `CONNECT_TIMEOUT` rather than an
auth error — and because the host kills the process and retries, every attempt
spawned a fresh process that redid the same work, which is why it took several
retries and then "fixed itself" once cookies were warm.

## Reproduction

Measured against the **real stdio transport** (a subprocess driven over pipes),
with a client factory standing in for the slow auth hop:

```
before: initialize response after 9.18s (open delay 8s)
after:  initialize response after 1.21s (open delay 8s)   # 1.2s = process start
```

Pinned as a regression test in
`tests/unit/mcp/test_clientprovider.py::test_handshake_is_not_gated_on_the_client_open`.

## Fix

New `mcp/_clientprovider.py` — `ClientProvider`, lazy single-flight ownership of
the process-wide client. The lifespan constructs one, `start()`s the open in the
**background**, and yields immediately; the first tool call awaits the open
instead. Concretely:

- **The handshake never waits on Google.** `initialize` and `tools/list` answer
  at once, so a slow auth hop can no longer look like a dead server.
- **Auth failures become real errors.** They surface at the first tool call as a
  normal categorized `AUTH: …` tool error naming the cause, instead of a
  transport timeout the agent can't interpret. That is also the answer to the
  issue's second question ("distinguish retrying from dead").
- **A failed open is retried, not cached** — so a mid-session `notebooklm login`
  recovers a running server without a restart.
- **One open at a time**, and a cancelled waiter never aborts the shared open
  (`asyncio.shield`), so one tool call's client-side timeout doesn't strand the
  others.
- **Loop affinity (ADR-0004) is preserved**: the open still runs on the server
  loop, just not inside the handshake.

`get_client(ctx)` and `get_client_from_app(request)` are now coroutines; the 40
call sites `await` them. The two `/files/*` routes widen their
`except RuntimeError` to `except Exception`, since the accessor can now raise an
auth/network error — the upload route's 500 also gains the CORS header every
other `/files/ul` error already carries, or the in-app widget's fetch could not
read the failure.

## Not changed

The REST server (`server/app.py`) opens its client in the ASGI lifespan the same
way. It has no handshake deadline, so it does not have this bug; leaving it
alone keeps the blast radius on the reported path.

## Verification

- Full non-e2e suite: **19,241 passed** (`pytest tests/unit tests/_guardrails tests/integration tests/server -n auto --dist loadgroup`).
- `mypy src/notebooklm --ignore-missing-imports` clean; ruff format + check clean.
- New module at **100 %** coverage (14 tests: handshake regression, background
  warm-up, single-flight, shielded cancellation, retry-after-failure, shutdown
  races, idempotent close), plus 2 `/files/*` route tests.
- Docs: `architecture.md` (tree + MCP section), `mcp-guide.md`,
  `troubleshooting.md`, `CHANGELOG.md`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3uJGWpaEZ6C2joyXoBwSH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - MCP connections now complete promptly without waiting for authentication.
  - Authentication occurs when the first tool is used, with failures reported as clear, safer tool errors.
  - Authentication failures can be recovered by logging in again; subsequent tool calls retry automatically without restarting the server.
  - Upload and download errors now return safer, browser-readable responses.

- **Documentation**
  - Added troubleshooting guidance for connection timeouts and authentication recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->