### PR TITLE
test: cover Android sharing/notes outcome discipline, OAuth migration, and row shape guards

### DIFF
--- a/tests/unit/android/test_notes_sharing.py
+++ b/tests/unit/android/test_notes_sharing.py
@@ -1393,3 +1393,374 @@ async def test_sharing_status_five_maps_to_notebook_not_found() -> None:
         await _sharing(mutation_session)[0].set_public("missing-project", True)
     assert mutation_session.calls[0][2]["replay_safe"] is False
     assert mutation_session.calls[0][2]["expected_epoch"] == 7
+
+
+# ===========================================================================
+# Sharing: NOT_FOUND mapping and unconfirmed read-back
+#
+# Every sharing mutation maps a NOT_FOUND onto NotebookNotFoundError and lets
+# any other RPC error through untouched. When the write lands but the follow-up
+# status read fails, the result must be marked unconfirmed: the mutation may
+# already have taken effect (and, for set_users, already sent an invite email),
+# so a caller must not treat it as safely retryable.
+# ===========================================================================
+
+
+def _not_found() -> RPCError:
+    return RPCError("no such project", method_id="m", rpc_code=5)
+
+
+def _denied() -> RPCError:
+    return RPCError("permission denied", method_id="m", rpc_code=7)
+
+
+@pytest.mark.asyncio
+async def test_set_public_maps_not_found_to_the_typed_notebook_error() -> None:
+    session = SequencedSession({SHARE_PROJECT_METHOD: [_not_found()]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NotebookNotFoundError) as caught:
+        await api.set_public("nb-missing", True)
+
+    assert caught.value.__cause__ is not None
+
+
+@pytest.mark.asyncio
+async def test_set_public_lets_other_rpc_errors_through_unchanged() -> None:
+    denied = _denied()
+    session = SequencedSession({SHARE_PROJECT_METHOD: [denied]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(RPCError) as caught:
+        await api.set_public("nb-1", True)
+
+    assert caught.value is denied
+
+
+@pytest.mark.asyncio
+async def test_a_landed_set_public_with_a_failed_read_back_is_unconfirmed() -> None:
+    session = SequencedSession(
+        {
+            SHARE_PROJECT_METHOD: [exact_sharing_pb2.ShareProjectResponse()],
+            GET_PROJECT_DETAILS_METHOD: [NetworkError("status read lost")],
+        }
+    )
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NetworkError) as caught:
+        await api.set_public("nb-1", True)
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+@pytest.mark.asyncio
+async def test_set_view_level_maps_not_found_to_the_typed_notebook_error() -> None:
+    session = SequencedSession({MUTATE_PROJECT_METHOD: [_not_found()]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NotebookNotFoundError):
+        await api.set_view_level("nb-missing", ShareViewLevel.FULL_NOTEBOOK)
+
+
+@pytest.mark.asyncio
+async def test_set_view_level_lets_other_rpc_errors_through_unchanged() -> None:
+    denied = _denied()
+    session = SequencedSession({MUTATE_PROJECT_METHOD: [denied]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(RPCError) as caught:
+        await api.set_view_level("nb-1", ShareViewLevel.FULL_NOTEBOOK)
+
+    assert caught.value is denied
+
+
+@pytest.mark.asyncio
+async def test_a_landed_view_level_change_with_a_failed_read_back_is_unconfirmed() -> None:
+    session = SequencedSession(
+        {
+            MUTATE_PROJECT_METHOD: [read_pb2.Project(id="nb-1")],
+            GET_PROJECT_DETAILS_METHOD: [ServerError("status read failed")],
+        }
+    )
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(ServerError) as caught:
+        await api.set_view_level("nb-1", ShareViewLevel.FULL_NOTEBOOK)
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+@pytest.mark.asyncio
+async def test_a_successful_view_level_change_reports_the_requested_level() -> None:
+    fake = FakeNotesSharingServer()
+    api, _compat = _sharing(fake)
+
+    status = await api.set_view_level("nb-1", ShareViewLevel.FULL_NOTEBOOK)
+
+    assert status.view_level is ShareViewLevel.FULL_NOTEBOOK
+    assert fake.view_level == ShareViewLevel.FULL_NOTEBOOK.value
+
+
+@pytest.mark.asyncio
+async def test_set_users_maps_not_found_to_the_typed_notebook_error() -> None:
+    session = SequencedSession({SHARE_PROJECT_METHOD: [_not_found()]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NotebookNotFoundError):
+        await api.set_users("nb-missing", [("a@example.test", SharePermission.VIEWER)])
+
+
+@pytest.mark.asyncio
+async def test_set_users_lets_other_rpc_errors_through_unchanged() -> None:
+    denied = _denied()
+    session = SequencedSession({SHARE_PROJECT_METHOD: [denied]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(RPCError) as caught:
+        await api.set_users("nb-1", [("a@example.test", SharePermission.VIEWER)])
+
+    assert caught.value is denied
+
+
+@pytest.mark.asyncio
+async def test_a_landed_grant_with_a_failed_read_back_is_unconfirmed() -> None:
+    """An invite email may already have been sent — never look safe to retry."""
+    session = SequencedSession(
+        {
+            SHARE_PROJECT_METHOD: [exact_sharing_pb2.ShareProjectResponse()],
+            GET_PROJECT_DETAILS_METHOD: [NetworkError("status read lost")],
+        }
+    )
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NetworkError) as caught:
+        await api.set_users("nb-1", [("a@example.test", SharePermission.VIEWER)])
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+@pytest.mark.asyncio
+async def test_remove_user_maps_not_found_to_the_typed_notebook_error() -> None:
+    session = SequencedSession({SHARE_PROJECT_METHOD: [_not_found()]})
+    api = AndroidSharingAPI(_session(session))
+
+    with pytest.raises(NotebookNotFoundError):
+        await api.remove_user("nb-missing", "a@example.test")
+
+
+# ===========================================================================
+# Notes: confirmation policy
+#
+# Every mutation distinguishes three outcomes: confirmed, refused, and
+# *unconfirmed*. The last is load-bearing — a caller that retries an
+# unconfirmed create duplicates the note, so a create whose row cannot be
+# decoded or validated must never be reported as either success or failure.
+# ===========================================================================
+
+
+def test_a_notes_api_needs_at_least_one_deletion_poll_attempt() -> None:
+    session = SequencedSession({})
+
+    with pytest.raises(ValueError, match="at least one attempt"):
+        AndroidNotesAPI(_session(session), deletion_poll_delays=())
+
+
+@pytest.mark.asyncio
+async def test_a_create_whose_row_cannot_be_decoded_is_unconfirmed() -> None:
+    """The envelope proves dispatch; an unusable row cannot say which row landed."""
+    session = SequencedSession(
+        {CREATE_NOTE_METHOD: [notes_pb2.CreateNoteResponse(note=notes_pb2.ProjectNote(id=""))]}
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(DecodingError) as caught:
+        await api.create("nb-1", title="T", content="B")
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+@pytest.mark.asyncio
+async def test_a_create_whose_read_back_is_unavailable_returns_the_validated_response() -> None:
+    """A failed *optional* verification must not make a confirmed create ambiguous."""
+    created = notes_pb2.ProjectNote(id="note-created", name="T", content="B")
+    session = SequencedSession(
+        {
+            CREATE_NOTE_METHOD: [notes_pb2.CreateNoteResponse(note=created)],
+            GET_NOTES_METHOD: [NetworkError("verification read lost")],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    note = await api.create("nb-1", title="T", content="B")
+
+    assert note.id == "note-created"
+
+
+@pytest.mark.asyncio
+async def test_a_create_whose_row_is_not_yet_visible_returns_the_validated_response() -> None:
+    created = notes_pb2.ProjectNote(id="note-created", name="T", content="B")
+    session = SequencedSession(
+        {
+            CREATE_NOTE_METHOD: [notes_pb2.CreateNoteResponse(note=created)],
+            GET_NOTES_METHOD: [notes_pb2.GetNotesResponse(notes=[])],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    note = await api.create("nb-1", title="T", content="B")
+
+    assert note.id == "note-created"
+
+
+@pytest.mark.asyncio
+async def test_a_create_whose_read_back_disagrees_is_unconfirmed() -> None:
+    """The row landed but carries different content — neither success nor failure."""
+    created = notes_pb2.ProjectNote(id="note-created", name="T", content="B")
+    divergent = notes_pb2.ProjectNote(id="note-created", name="OTHER", content="OTHER")
+    session = SequencedSession(
+        {
+            CREATE_NOTE_METHOD: [notes_pb2.CreateNoteResponse(note=created)],
+            GET_NOTES_METHOD: [
+                notes_pb2.GetNotesResponse(notes=[notes_pb2.NoteOrStatus(note=divergent)])
+            ],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(DecodingError) as caught:
+        await api.create("nb-1", title="T", content="B")
+
+    assert getattr(caught.value, "unconfirmed", False) is True
+
+
+@pytest.mark.asyncio
+async def test_updating_an_absent_note_reports_it_as_not_found() -> None:
+    session = SequencedSession({GET_NOTES_METHOD: [notes_pb2.GetNotesResponse(notes=[])]})
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(NoteNotFoundError):
+        await api.update("nb-1", "note-absent", title="T", content="B")
+
+
+def _note_row(note_id: str = "note-1", *, title: str = "T", content: str = "B") -> Any:
+    return notes_pb2.GetNotesResponse(
+        notes=[
+            notes_pb2.NoteOrStatus(
+                note=notes_pb2.ProjectNote(
+                    id=note_id,
+                    name=title,
+                    content=content,
+                    metadata=notes_pb2.NoteMetadata(type=notes_pb2.USER_WRITTEN),
+                )
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_reading_an_absent_note_reports_it_as_not_found() -> None:
+    session = SequencedSession({GET_NOTES_METHOD: [notes_pb2.GetNotesResponse(notes=[])]})
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(NoteNotFoundError):
+        await api.get("nb-1", "note-absent")
+
+
+@pytest.mark.asyncio
+async def test_an_update_that_returns_a_different_note_identity_is_drift() -> None:
+    """Silently accepting it would report another note's row as this one's."""
+    session = SequencedSession(
+        {
+            GET_NOTES_METHOD: [_note_row()],
+            MUTATE_NOTE_METHOD: [
+                notes_pb2.MutateNoteResponse(
+                    note=notes_pb2.ProjectNote(id="other-note", name="T", content="B")
+                )
+            ],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(DecodingError, match="changed note identity"):
+        await api.update("nb-1", "note-1", title="T", content="B")
+
+
+@pytest.mark.asyncio
+async def test_an_update_whose_row_vanishes_before_read_back_reports_not_found() -> None:
+    session = SequencedSession(
+        {
+            GET_NOTES_METHOD: [_note_row(), notes_pb2.GetNotesResponse(notes=[])],
+            MUTATE_NOTE_METHOD: [
+                notes_pb2.MutateNoteResponse(
+                    note=notes_pb2.ProjectNote(id="note-1", name="T", content="B")
+                )
+            ],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(NoteNotFoundError):
+        await api.update("nb-1", "note-1", title="T", content="B")
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_already_absent_note_issues_no_write() -> None:
+    """Delete is idempotent — the preflight short-circuits it."""
+    session = SequencedSession({GET_NOTES_METHOD: [notes_pb2.GetNotesResponse(notes=[])]})
+    api = AndroidNotesAPI(_session(session))
+
+    await api.delete("nb-1", "note-absent")
+
+    assert [method for method, _req, _kw in session.calls] == [GET_NOTES_METHOD]
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_delete_reported_as_not_found_is_the_idempotent_outcome() -> None:
+    """The preflight proved it existed, so a status-5 means someone else won."""
+    session = SequencedSession(
+        {
+            GET_NOTES_METHOD: [_note_row()],
+            DELETE_NOTES_METHOD: [RPCError("gone", method_id="m", rpc_code=5)],
+        }
+    )
+    api = AndroidNotesAPI(_session(session))
+
+    await api.delete("nb-1", "note-1")
+
+
+@pytest.mark.asyncio
+async def test_a_delete_refused_for_another_reason_propagates() -> None:
+    denied = RPCError("permission denied", method_id="m", rpc_code=7)
+    session = SequencedSession({GET_NOTES_METHOD: [_note_row()], DELETE_NOTES_METHOD: [denied]})
+    api = AndroidNotesAPI(_session(session))
+
+    with pytest.raises(RPCError) as caught:
+        await api.delete("nb-1", "note-1")
+
+    assert caught.value is denied
+
+
+@pytest.mark.asyncio
+async def test_a_delete_polls_until_absence_becomes_visible() -> None:
+    """The row stays readable for one poll, then disappears."""
+    slept: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        slept.append(delay)
+
+    session = SequencedSession(
+        {
+            GET_NOTES_METHOD: [
+                _note_row(),
+                _note_row(),
+                notes_pb2.GetNotesResponse(notes=[]),
+            ],
+            DELETE_NOTES_METHOD: [notes_pb2.DeleteNotesResponse()],
+        }
+    )
+    api = AndroidNotesAPI(_session(session), sleep=_sleep, deletion_poll_delays=(0.0, 0.05))
+
+    await api.delete("nb-1", "note-1")
+
+    # The first attempt has a zero delay and must not sleep at all.
+    assert slept == [0.05]

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -8,10 +8,12 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from notebooklm.cli.profile_cmd import _PROFILE_NAME_RE, email_to_profile_name
+from notebooklm.cli.services.login.exceptions import LoginConfigurationError
 from notebooklm.notebooklm_cli import cli
 from notebooklm.paths import _reset_config_cache, set_active_profile
 
@@ -542,3 +544,108 @@ class TestProfileJsonOutput:
         payload = json.loads(result.output)
         assert payload["error"] is True
         assert payload["code"] == "VALIDATION_ERROR"
+
+
+class TestProfileNameTranslation:
+    """``_validate_profile_name_or_click`` owns the service->Click translation.
+
+    ADR-0015 Pattern B: the login service raises ``LoginConfigurationError``
+    and this command layer converts it, appending the hint when there is one.
+    """
+
+    def test_a_valid_name_passes_through(self):
+        assert profile_module._validate_profile_name_or_click("work") == "work"
+
+    def test_a_hintless_service_error_becomes_the_bare_message(self):
+        error = LoginConfigurationError("Profile name is empty.")
+        with (
+            patch.object(profile_module, "_validate_profile_name", side_effect=error),
+            pytest.raises(click.ClickException) as caught,
+        ):
+            profile_module._validate_profile_name_or_click("")
+
+        assert str(caught.value) == "Profile name is empty."
+        assert caught.value.__cause__ is None
+
+    def test_a_hinted_service_error_appends_its_hint(self):
+        error = LoginConfigurationError("Bad name.", hint="Use letters and digits.")
+        with (
+            patch.object(profile_module, "_validate_profile_name", side_effect=error),
+            pytest.raises(click.ClickException) as caught,
+        ):
+            profile_module._validate_profile_name_or_click("!!")
+
+        assert str(caught.value) == "Bad name. Use letters and digits."
+
+
+class TestReadConfigErrorPolicy:
+    """``_read_config`` tolerates a corrupt config only when asked to."""
+
+    def test_a_missing_config_reads_as_empty(self, tmp_path):
+        assert profile_module._read_config(tmp_path / "absent.json") == {}
+
+    def test_a_corrupt_config_is_suppressed_by_default(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        assert profile_module._read_config(path) == {}
+
+    def test_a_corrupt_config_propagates_when_errors_are_not_suppressed(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            profile_module._read_config(path, suppress_errors=False)
+
+    def test_a_non_object_payload_reads_as_empty(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text("[1, 2]", encoding="utf-8")
+
+        assert profile_module._read_config(path) == {}
+
+
+class TestProfilePathValidationIsTranslated:
+    """A traversal-shaped profile name surfaces as a friendly Click error.
+
+    ``get_profile_dir`` raises ``ValueError`` when the resolved name would
+    escape the profiles directory. Each command must translate that rather
+    than letting it escape as a traceback.
+    """
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            pytest.param(["profile", "create", "work"], id="create"),
+            pytest.param(["profile", "switch", "work"], id="switch"),
+            pytest.param(["profile", "delete", "work", "--yes"], id="delete"),
+            pytest.param(["profile", "rename", "work", "other"], id="rename"),
+        ],
+    )
+    def test_a_path_traversal_name_is_reported_not_raised(self, runner, tmp_path, argv):
+        with patch.object(
+            profile_module,
+            "get_profile_dir",
+            side_effect=ValueError("Profile name escapes the profiles directory"),
+        ):
+            result = runner.invoke(cli, argv, env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 1, result.output
+        assert "escapes the profiles directory" in result.output
+        assert "Traceback" not in result.output
+
+
+class TestRenameDestinationGuard:
+    def test_renaming_onto_an_existing_profile_is_refused(self, runner, tmp_path):
+        profiles = tmp_path / "profiles"
+        (profiles / "work").mkdir(parents=True)
+        (profiles / "taken").mkdir(parents=True)
+
+        result = runner.invoke(
+            cli, ["profile", "rename", "work", "taken"], env=notebooklm_env(tmp_path)
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "already exists" in result.output
+        # Neither directory is touched by the refusal.
+        assert (profiles / "work").exists()
+        assert (profiles / "taken").exists()

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -13,7 +13,6 @@ import pytest
 from click.testing import CliRunner
 
 from notebooklm.cli.profile_cmd import _PROFILE_NAME_RE, email_to_profile_name
-from notebooklm.cli.services.login.exceptions import LoginConfigurationError
 from notebooklm.notebooklm_cli import cli
 from notebooklm.paths import _reset_config_cache, set_active_profile
 
@@ -556,26 +555,32 @@ class TestProfileNameTranslation:
     def test_a_valid_name_passes_through(self):
         assert profile_module._validate_profile_name_or_click("work") == "work"
 
-    def test_a_hintless_service_error_becomes_the_bare_message(self):
-        error = LoginConfigurationError("Profile name is empty.")
-        with (
-            patch.object(profile_module, "_validate_profile_name", side_effect=error),
-            pytest.raises(click.ClickException) as caught,
-        ):
-            profile_module._validate_profile_name_or_click("")
+    @pytest.mark.parametrize(
+        "name",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("   ", id="whitespace-only"),
+            pytest.param("!!bad", id="illegal-characters"),
+            pytest.param("../escape", id="path-traversal-shaped"),
+            pytest.param("-leading-hyphen", id="illegal-leading-character"),
+        ],
+    )
+    def test_an_invalid_name_is_reported_with_the_service_hint(self, name):
+        """Driven through the real validator rather than a patched one.
 
-        assert str(caught.value) == "Profile name is empty."
+        ``_validate_profile_name`` always attaches a hint, so the hintless
+        branch of the translation is unreachable without substituting the
+        validator — which the ADR-0007 monkeypatch guardrail forbids, and
+        which would only assert that a stub was called.
+        """
+        with pytest.raises(click.ClickException) as caught:
+            profile_module._validate_profile_name_or_click(name)
+
+        message = str(caught.value)
+        assert "Invalid profile name" in message
+        assert "alphanumeric characters, hyphens, and underscores" in message
+        # The service exception is not chained into the user-facing error.
         assert caught.value.__cause__ is None
-
-    def test_a_hinted_service_error_appends_its_hint(self):
-        error = LoginConfigurationError("Bad name.", hint="Use letters and digits.")
-        with (
-            patch.object(profile_module, "_validate_profile_name", side_effect=error),
-            pytest.raises(click.ClickException) as caught,
-        ):
-            profile_module._validate_profile_name_or_click("!!")
-
-        assert str(caught.value) == "Bad name. Use letters and digits."
 
 
 class TestReadConfigErrorPolicy:

--- a/tests/unit/mcp/test_selfhosted_oauth.py
+++ b/tests/unit/mcp/test_selfhosted_oauth.py
@@ -854,3 +854,93 @@ def test_build_oauth_provider_wires_state_without_warning(
         provider = build_oauth_provider(cfg)
     assert isinstance(provider, SelfHostedOAuthProvider)
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_migrate_legacy_state_leaves_an_unreadable_legacy_for_the_next_startup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """A transient read error must not retire the file — the tokens are still in it."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {}}), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    def _unreadable(self: Path) -> bytes:
+        raise OSError("temporarily unreadable")
+
+    monkeypatch.setattr(Path, "read_bytes", _unreadable)
+
+    with caplog.at_level(logging.WARNING):
+        _migrate_legacy_state(new, legacy)
+
+    assert legacy.exists(), "the only copy of the tokens must survive"
+    assert not legacy.with_name("oauth_state.json.migrated").exists()
+    assert not new.exists()
+    assert "will retry" in caplog.text
+
+
+def test_migrate_legacy_state_retires_a_non_object_payload_without_writing_it(
+    tmp_path: Path, caplog
+) -> None:
+    """Valid JSON that is not an object is unusable state, not a partial migration."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    with caplog.at_level(logging.WARNING):
+        _migrate_legacy_state(new, legacy)
+
+    assert not new.exists()
+    assert not legacy.exists()
+    assert legacy.with_name("oauth_state.json.migrated").exists()
+    assert "unusable" in caplog.text
+
+
+def test_migrate_legacy_state_retires_a_reappeared_legacy_beside_a_marker(
+    tmp_path: Path,
+) -> None:
+    """A restored backup must never resurrect revoked tokens."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {"resurrected": {}}}), encoding="utf-8")
+    marker = legacy.with_name("oauth_state.json.migrated")
+    marker.write_text("{}", encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    _migrate_legacy_state(new, legacy)
+
+    assert not new.exists(), "a reappeared legacy file is never imported"
+    assert not legacy.exists()
+    assert marker.exists()
+
+
+def test_migrate_legacy_state_is_a_no_op_when_the_override_points_at_the_legacy_file(
+    tmp_path: Path,
+) -> None:
+    """Retiring it would delete the very file the provider is about to load."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {}}), encoding="utf-8")
+
+    _migrate_legacy_state(legacy, legacy)
+
+    assert legacy.exists()
+    assert not legacy.with_name("oauth_state.json.migrated").exists()
+
+
+def test_migrate_legacy_state_skips_when_the_legacy_cannot_be_retired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """The marker rename commits before the write; a failure there aborts cleanly."""
+    legacy = tmp_path / "oauth_state.json"
+    legacy.write_text(json.dumps({"clients": {}}), encoding="utf-8")
+    new = tmp_path / "oauth" / "host.abcd.json"
+
+    def _failing_replace(src: object, dst: object) -> None:
+        raise OSError("rename refused")
+
+    monkeypatch.setattr(os, "replace", _failing_replace)
+
+    with caplog.at_level(logging.WARNING):
+        _migrate_legacy_state(new, legacy)
+
+    assert legacy.exists()
+    assert not new.exists()
+    assert "retiring" in caplog.text

--- a/tests/unit/test_artifact_row_shape_guards.py
+++ b/tests/unit/test_artifact_row_shape_guards.py
@@ -1,0 +1,282 @@
+"""Shape rejections in the positional ``ArtifactRow`` decoder.
+
+Every property here reads a fixed index out of a backend-controlled list. The
+documented contract is that a short or malformed row degrades to an empty /
+``None`` result rather than raising, so a server-side reshape surfaces as
+missing data instead of an ``IndexError`` in the caller's face. These pin the
+degrade paths; the happy paths are covered by the golden-row suites.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from notebooklm._types.artifact_content import ArtifactMediaType
+from notebooklm._web.rows.artifacts import ArtifactRow, ReportSuggestionRow
+from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.rpc.types import ArtifactTypeCode
+
+URL = "https://lh3.googleusercontent.com/asset"
+
+
+def _row(**slots: Any) -> ArtifactRow:
+    """Build a row with ``slots`` placed at their positional indices."""
+    size = max(slots) + 1 if slots else 5
+    raw: list[Any] = [None] * max(size, 5)
+    raw[0] = "art-1"
+    raw[1] = "Title"
+    raw[2] = ArtifactTypeCode.AUDIO.value
+    raw[4] = 3
+    for index, value in slots.items():
+        raw[index] = value
+    return ArtifactRow(raw)
+
+
+def _audio(media_list: Any) -> ArtifactRow:
+    metadata: list[Any] = [None] * (ArtifactRow._AUDIO_MEDIA_LIST_POS + 1)
+    metadata[ArtifactRow._AUDIO_MEDIA_LIST_POS] = media_list
+    return _row(**{str(ArtifactRow._AUDIO_METADATA_POS): metadata})
+
+
+def _audio_row(media_list: Any) -> ArtifactRow:
+    metadata: list[Any] = [None] * (ArtifactRow._AUDIO_MEDIA_LIST_POS + 1)
+    metadata[ArtifactRow._AUDIO_MEDIA_LIST_POS] = media_list
+    raw: list[Any] = [None] * (ArtifactRow._AUDIO_METADATA_POS + 1)
+    raw[0], raw[1], raw[2], raw[4] = "art-1", "Title", ArtifactTypeCode.AUDIO.value, 3
+    raw[ArtifactRow._AUDIO_METADATA_POS] = metadata
+    return ArtifactRow(raw)
+
+
+# ---------------------------------------------------------------------------
+# source_ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sources", "expected"),
+    [
+        pytest.param(None, (), id="absent"),
+        pytest.param([], (), id="empty"),
+        pytest.param([["s1"], ["s2"]], ("s1", "s2"), id="flat"),
+        pytest.param([[["s1"]]], ("s1",), id="nested-one-level"),
+        pytest.param(["not-a-list", ["s1"]], ("s1",), id="non-list-entry-skipped"),
+        pytest.param([[], ["s1"]], ("s1",), id="empty-entry-skipped"),
+        pytest.param([[7], ["s1"]], ("s1",), id="non-string-id-skipped"),
+        pytest.param([[[]], ["s1"]], ("s1",), id="empty-nested-id-skipped"),
+    ],
+)
+def test_source_ids_skips_entries_it_cannot_read(sources: Any, expected: tuple) -> None:
+    row = ArtifactRow(["art-1", "Title", 1, sources, 3])
+
+    assert row.source_ids == expected
+
+
+# ---------------------------------------------------------------------------
+# audio_url / _media_entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "media_list",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param("not-a-list", id="not-a-list"),
+        pytest.param([], id="empty"),
+        pytest.param(["not-a-list"], id="non-list-entry"),
+        pytest.param([[]], id="empty-entry"),
+        pytest.param([["ftp://elsewhere/x"]], id="untrusted-url"),
+    ],
+)
+def test_audio_url_is_absent_for_an_unusable_media_list(media_list: Any) -> None:
+    assert _audio_row(media_list).audio_url is None
+
+
+def test_audio_url_prefers_the_mp4_entry_over_the_first_usable_one() -> None:
+    row = _audio_row([[URL + "/fallback", 1, "audio/other"], [URL + "/mp4", 1, "audio/mp4"]])
+
+    assert row.audio_url == URL + "/mp4"
+
+
+def test_audio_url_falls_back_to_the_first_usable_entry() -> None:
+    row = _audio_row(["skipped", [], [URL + "/first", 1, "audio/other"]])
+
+    assert row.audio_url == URL + "/first"
+
+
+@pytest.mark.parametrize(
+    "media_list",
+    [
+        pytest.param("not-a-list", id="not-a-list"),
+        pytest.param(["not-a-list"], id="non-list-entry"),
+        pytest.param([[]], id="empty-entry"),
+        pytest.param([["ftp://elsewhere/x"]], id="non-http-scheme"),
+    ],
+)
+def test_media_entries_drops_everything_it_cannot_admit(media_list: Any) -> None:
+    assert _audio_row(media_list).media_urls == ()
+
+
+def test_media_entries_keeps_the_type_code_even_for_an_unknown_kind() -> None:
+    row = _audio_row([[URL, 999, "audio/mp4"]])
+
+    (entry,) = row.media_urls
+    assert entry.url == URL
+    assert entry.type_code == 999
+    assert entry.kind is ArtifactMediaType.UNKNOWN
+
+
+def test_media_entries_ignores_a_boolean_type_code() -> None:
+    """``bool`` is an ``int`` subclass — admitting it would fabricate kind 1."""
+    row = _audio_row([[URL, True, "audio/mp4"]])
+
+    (entry,) = row.media_urls
+    assert entry.type_code is None
+
+
+# ---------------------------------------------------------------------------
+# _image_fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(None, (None, None, None), id="not-a-list"),
+        pytest.param([], (None, None, None), id="empty"),
+        pytest.param([URL], (URL, None, None), id="url-only"),
+        pytest.param([URL, 800, 600], (URL, 800, 600), id="full"),
+        pytest.param(["ftp://elsewhere/x", 800, 600], (None, 800, 600), id="non-http-scheme"),
+        pytest.param([7, 800, 600], (None, 800, 600), id="non-string-url"),
+        pytest.param([URL, "800", "600"], (URL, None, None), id="stringly-typed-size"),
+        pytest.param([URL, True, False], (URL, None, None), id="boolean-size"),
+    ],
+)
+def test_image_fields_admits_each_slot_independently(value: Any, expected: tuple) -> None:
+    assert ArtifactRow._image_fields(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# infographics / slides
+# ---------------------------------------------------------------------------
+
+
+def _infographic_row(items: Any) -> ArtifactRow:
+    block: list[Any] = [None] * (ArtifactRow._INFOGRAPHIC_ITEMS_POS + 1)
+    block[ArtifactRow._INFOGRAPHIC_ITEMS_POS] = items
+    raw: list[Any] = [None] * (ArtifactRow._INFOGRAPHIC_METADATA_POS + 1)
+    raw[0], raw[1], raw[2], raw[4] = "art-1", "Title", ArtifactTypeCode.INFOGRAPHIC.value, 3
+    raw[ArtifactRow._INFOGRAPHIC_METADATA_POS] = block
+    return ArtifactRow(raw)
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        pytest.param("not-a-list", id="items-not-a-list"),
+        pytest.param(["not-a-list"], id="non-list-item"),
+    ],
+)
+def test_infographics_drops_unreadable_items(items: Any) -> None:
+    assert _infographic_row(items).infographics == ()
+
+
+def test_infographics_are_absent_when_the_block_is_short() -> None:
+    raw: list[Any] = [None] * (ArtifactRow._INFOGRAPHIC_METADATA_POS + 1)
+    raw[0], raw[1], raw[2], raw[4] = "art-1", "Title", ArtifactTypeCode.INFOGRAPHIC.value, 3
+    raw[ArtifactRow._INFOGRAPHIC_METADATA_POS] = ["only-one"]
+
+    assert ArtifactRow(raw).infographics == ()
+
+
+def _slide_row(items: Any) -> ArtifactRow:
+    block: list[Any] = [None] * (ArtifactRow._SLIDE_ITEMS_POS + 1)
+    block[ArtifactRow._SLIDE_ITEMS_POS] = items
+    raw: list[Any] = [None] * (ArtifactRow._SLIDE_DECK_METADATA_POS + 1)
+    raw[0], raw[1], raw[2], raw[4] = "art-1", "Title", ArtifactTypeCode.SLIDE_DECK.value, 3
+    raw[ArtifactRow._SLIDE_DECK_METADATA_POS] = block
+    return ArtifactRow(raw)
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        pytest.param("not-a-list", id="items-not-a-list"),
+        pytest.param(["not-a-list"], id="non-list-item"),
+    ],
+)
+def test_slides_drop_unreadable_items(items: Any) -> None:
+    assert _slide_row(items).slides == ()
+
+
+# ---------------------------------------------------------------------------
+# report_markdown / report_kind
+# ---------------------------------------------------------------------------
+
+
+def _report_row(payload: Any) -> ArtifactRow:
+    raw: list[Any] = [None] * (ArtifactRow._REPORT_MARKDOWN_POS + 1)
+    raw[0], raw[1], raw[2], raw[4] = "art-1", "Title", ArtifactTypeCode.REPORT.value, 3
+    raw[ArtifactRow._REPORT_MARKDOWN_POS] = payload
+    return ArtifactRow(raw)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param([None], id="null-content"),
+        pytest.param([[7]], id="non-string-content"),
+    ],
+)
+def test_report_markdown_is_absent_for_an_unusable_payload(payload: Any) -> None:
+    assert _report_row(payload).report_markdown is None
+
+
+def test_an_empty_report_wrapper_is_reported_as_drift() -> None:
+    """A present-but-empty wrapper is a reshape, not "no report"."""
+    row = _report_row([])
+
+    with pytest.raises(UnknownRPCMethodError):
+        _ = row.report_markdown
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param(["content"], id="no-options-block"),
+        pytest.param(["content", "not-a-list"], id="options-not-a-list"),
+        pytest.param(["content", []], id="options-empty"),
+    ],
+)
+def test_report_kind_is_absent_for_an_unusable_options_block(payload: Any) -> None:
+    assert _report_row(payload).report_kind is None
+
+
+# ---------------------------------------------------------------------------
+# ReportSuggestionRow._str_at bounds guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(
+            ["Title", "Desc", None, None, "Prompt"],
+            ("Title", "Desc", "Prompt"),
+            id="present",
+        ),
+        pytest.param(["Title"], ("Title", "", ""), id="short-row"),
+        pytest.param([7, 8, 9, 10, 11], ("", "", ""), id="non-string-slots"),
+        pytest.param("not-a-list", ("", "", ""), id="row-not-a-list"),
+        pytest.param([], ("", "", ""), id="empty-row"),
+    ],
+)
+def test_a_short_or_malformed_suggestion_row_degrades_to_empty_strings(
+    raw: Any, expected: tuple[str, str, str]
+) -> None:
+    row = ReportSuggestionRow(raw)
+
+    assert (row.title, row.description, row.prompt) == expected


### PR DESCRIPTION
Fourth coverage tranche over the non-`_auth` modules. Branched from `main`; disjoint from #2332.

## Result

| | before | after |
|---|---|---|
| total coverage | 94.16% | **94.30%** |
| uncovered (statements + partial branches) | 3235 | **3157** (−78) |

| module | before | after |
|---|---|---|
| `_android/sharing.py` | 87.6% | **100%** |
| `_android/notes.py` | 87.8% | **97.3%** |
| `cli/profile_cmd.py` | 90.9% | **96.1%** |
| `_web/rows/artifacts.py` | 94.7% | **98.1%** |
| `mcp/_oauth.py` | 93.3% | **95.1%** |

## What these cover

The theme is **three-way outcome discipline** — confirmed / refused / *unconfirmed* — plus the shape-rejection contract of the positional row decoder.

- **`_android/sharing.py`** — every mutation maps `NOT_FOUND` onto `NotebookNotFoundError` and lets other RPC errors through untouched; when the write lands but the follow-up status read fails, the result is marked unconfirmed. That matters most for `set_users`, where an invite email may already have been sent, so the call must never look safely retryable.
- **`_android/notes.py`** — the same discipline for notes: a create whose row cannot be decoded, or whose read-back disagrees, is unconfirmed (retrying it would duplicate the note), while a create whose *optional* verification read is merely unavailable returns the validated response rather than becoming ambiguous. Plus update identity-drift, and delete's idempotent paths (already-absent issues no write, concurrent status-5 is the idempotent outcome, the absence poll skips its zero-delay first attempt).
- **`mcp/_oauth.py`** — each give-up path of the legacy state migration has a different safety obligation and none were exercised: a transient read error leaves the file (it is the only copy of the tokens), a non-object payload is retired without being written as state, a legacy file reappearing beside a `.migrated` marker is retired without import so a restored backup cannot resurrect revoked tokens, and an override pointing live state at the legacy file is a no-op rather than deleting what the provider is about to load.
- **`_web/rows/artifacts.py`** — the documented degrade contract: a short or malformed row yields empty/`None` rather than an `IndexError` in the caller's face.
- **`cli/profile_cmd.py`** — the path-traversal `ValueError` that create/switch/delete/rename must each report as a friendly error, `_read_config`'s suppress-vs-propagate policy, and the rename-onto-existing refusal.

## Two behaviours worth knowing

Both surprised me while writing the tests, and neither is obvious from the call sites, so they are pinned explicitly:

1. **`_is_valid_artifact_url` checks the URL *scheme* only, not the host.** An arbitrary https host is admitted at the row level; the host allowlist lives further down the download path.
2. **A present-but-empty report wrapper raises `UnknownRPCMethodError` (drift)** rather than reading as "no report" — that is what distinguishes a reshape from an absent field.

## One guardrail interaction

My first version of the profile tests used `patch.object(profile_module, "_validate_profile_name")`, which trips `test_no_private_attr_patch_object_outside_allowlist` (ADR-0007). Since that baseline only drains, the fix was to stop patching: the tests now drive the real validator with genuinely invalid names, which also asserts the message a user actually sees. The hintless branch of the translation is consequently untested — `_validate_profile_name` always attaches a hint, so reaching it would require substituting the validator, which the guardrail forbids and which would only prove a stub was called.

## Verification

```
uv run pytest -n auto --dist loadgroup \
  -m "not repo_lint and not requires_playwright and not requires_chromium"   # 17281 passed
uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0
                                                                             # 84 passed
uv run pytest -m repo_lint                                                   # 1950 passed
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports   # clean
uv run ruff check / format                                                   # clean
```

Tests only — no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af5NMrwQKctBjH1Nkm32TH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for user-facing error handling in note sharing, profile management, and OAuth migration scenarios.
  * Verified safer handling of invalid profile names, duplicate profile renames, missing configuration, and interrupted migrations.
  * Confirmed graceful degradation when backend responses are missing, malformed, unavailable, or inconsistent.

* **Tests**
  * Added comprehensive coverage for note and sharing operation outcomes, artifact decoding, and bounded deletion polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->