### PR TITLE
test: cover the lifecycle drain path, Drive streaming, and artifact admission

### DIFF
--- a/tests/unit/android/test_artifacts.py
+++ b/tests/unit/android/test_artifacts.py
@@ -2788,3 +2788,79 @@ def test_artifact_source_uses_the_imported_exact_package_source_id() -> None:
         ),
     )
     assert request.artifact.sources[0].source_id.id == "source-1"
+
+
+# ===========================================================================
+# Input admission before any RPC is dispatched
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_audio_generation_requires_at_least_one_source() -> None:
+    session, _nb, _mm, _assets, api = _graph()
+
+    with pytest.raises(ValidationError, match="at least one source id"):
+        await api.generate_audio("notebook-1", source_ids=[])
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_audio_instructions_must_be_text() -> None:
+    session, _nb, _mm, _assets, api = _graph()
+
+    with pytest.raises(ValidationError, match="instructions must be a string or None"):
+        await api.generate_audio("notebook-1", source_ids=["s1"], instructions=7)
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "label"),
+    [
+        pytest.param("generate_video", "Video", id="video"),
+        pytest.param("generate_report", "Report", id="report"),
+    ],
+)
+async def test_a_supported_family_requires_at_least_one_source(method: str, label: str) -> None:
+    """An explicitly empty list is a caller error; ``None`` means "all sources"."""
+    session, _nb, _mm, _assets, api = _graph()
+
+    with pytest.raises(ValidationError, match=f"{label} generation requires at least one"):
+        await getattr(api, method)("notebook-1", source_ids=[])
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "output_format",
+    [pytest.param("docx", id="unsupported"), pytest.param("PDF", id="wrong-case")],
+)
+async def test_a_slide_deck_download_rejects_an_unknown_format(output_format: str) -> None:
+    session, _nb, _mm, _assets, api = _graph()
+
+    with pytest.raises(ValidationError, match="Must be 'pdf' or 'pptx'"):
+        await api.download_slide_deck("notebook-1", "deck.out", "slides", output_format)
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param("download_quiz", id="quiz"),
+        pytest.param("download_flashcards", id="flashcards"),
+    ],
+)
+async def test_an_interactive_app_download_rejects_an_unknown_output_format(
+    method: str,
+) -> None:
+    session, _nb, _mm, _assets, api = _graph()
+
+    with pytest.raises(ValidationError, match="Use one of: json, markdown, html"):
+        await getattr(api, method)("notebook-1", "out.txt", "app-1", "pdf")
+
+    assert session.calls == []

--- a/tests/unit/test_client_lifecycle_waves.py
+++ b/tests/unit/test_client_lifecycle_waves.py
@@ -29,6 +29,7 @@ class _Supervisor:
     events: list[str] = field(default_factory=list)
     wait_gate: asyncio.Event | None = None
     stop_error: BaseException | None = None
+    stop_errors: list[BaseException] = field(default_factory=list)
     wait_error: BaseException | None = None
     hook_errors: list[BaseException] = field(default_factory=list)
     start_error: BaseException | None = None
@@ -51,6 +52,10 @@ class _Supervisor:
 
     async def stop_accepting(self, epoch: int) -> None:
         self.events.append(f"drain:{epoch}")
+        # ``stop_errors`` fails a bounded number of calls; ``close()`` also
+        # calls this, so a persistent ``stop_error`` would break teardown too.
+        if self.stop_errors:
+            raise self.stop_errors.pop(0)
         if self.stop_error is not None:
             raise self.stop_error
 
@@ -1227,3 +1232,150 @@ def test_same_new_loop_waiter_can_join_cross_loop_reopen(waiter_action: str) -> 
     asyncio.run(second_generation())
 
     assert not lifecycle.is_open()
+
+
+# ===========================================================================
+# drain(): admission fencing without closing resources
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_draining_a_closed_lifecycle_is_a_no_op() -> None:
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    lifecycle = _lifecycle(supervisor, _Transport("t", events))
+
+    await lifecycle.drain()
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_a_negative_timeout() -> None:
+    events: list[str] = []
+    lifecycle = _lifecycle(_Supervisor(events=events), _Transport("t", events))
+
+    with pytest.raises(ValueError, match="timeout must be >= 0 or None"):
+        await lifecycle.drain(timeout=-1.0)
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_drain_stops_admission_and_waits_for_idle() -> None:
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    lifecycle = _lifecycle(supervisor, _Transport("t", events))
+    await lifecycle.open()
+    events.clear()
+
+    await lifecycle.drain(timeout=5.0)
+
+    assert events == ["drain:1", "idle:1:5.0"]
+    # Resources stay open: drain fences admission only, it does not close.
+    assert lifecycle._state is _ResourceState.OPEN
+    assert not any(event.startswith("close:") for event in events)
+
+
+@pytest.mark.asyncio
+async def test_a_drain_racing_a_close_joins_that_close_instead_of_failing() -> None:
+    """``stop_accepting`` raises once ``close()`` has claimed the epoch."""
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    close_gate = asyncio.Event()
+    transport = _Transport("t", events, close_gate=close_gate)
+    lifecycle = _lifecycle(supervisor, transport)
+    await lifecycle.open()
+
+    close_task = asyncio.create_task(lifecycle.close())
+    await _wait_for_event(events, "close:t")
+    # The epoch now belongs to the close wave, so a drain's ``stop_accepting``
+    # is the call that must be suppressed — not a real fault.
+    supervisor.stop_errors.append(RuntimeError("generation is not current"))
+
+    drain_task = asyncio.create_task(lifecycle.drain())
+    close_gate.set()
+    await asyncio.gather(drain_task, close_task)
+
+    assert lifecycle._state is _ResourceState.CLOSED
+
+
+@pytest.mark.asyncio
+async def test_an_unrelated_supervisor_failure_during_drain_propagates() -> None:
+    """Only the close race is suppressed — a real fault must stay loud."""
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    supervisor.stop_errors.append(RuntimeError("supervisor is broken"))
+    lifecycle = _lifecycle(supervisor, _Transport("t", events))
+    await lifecycle.open()
+
+    with pytest.raises(RuntimeError, match="supervisor is broken"):
+        await lifecycle.drain()
+
+    await lifecycle.close()
+
+
+@pytest.mark.asyncio
+async def test_a_drain_that_times_out_waiting_for_idle_propagates() -> None:
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    supervisor.wait_error = TimeoutError("still busy")
+    lifecycle = _lifecycle(supervisor, _Transport("t", events))
+    await lifecycle.open()
+
+    with pytest.raises(TimeoutError):
+        await lifecycle.drain(timeout=0.0)
+
+    supervisor.wait_error = None
+    await lifecycle.close()
+
+
+# ===========================================================================
+# open(): state guards
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_reopening_an_open_lifecycle_is_a_no_op() -> None:
+    events: list[str] = []
+    lifecycle = _lifecycle(_Supervisor(events=events), _Transport("t", events))
+    await lifecycle.open()
+    events.clear()
+
+    await lifecycle.open()
+
+    assert events == []
+    await lifecycle.close()
+
+
+@pytest.mark.asyncio
+async def test_opening_while_closing_is_refused() -> None:
+    events: list[str] = []
+    close_gate = asyncio.Event()
+    transport = _Transport("t", events, close_gate=close_gate)
+    lifecycle = _lifecycle(_Supervisor(events=events), transport)
+    await lifecycle.open()
+
+    close_task = asyncio.create_task(lifecycle.close())
+    await _wait_for_event(events, "close:t")
+
+    with pytest.raises(RuntimeError, match="closing; wait for close"):
+        await lifecycle.open()
+
+    close_gate.set()
+    await close_task
+
+
+@pytest.mark.asyncio
+async def test_an_admission_rollback_failure_does_not_mask_the_open_failure() -> None:
+    """A failed open rolls back; a rollback fault must not replace the cause."""
+    events: list[str] = []
+    supervisor = _Supervisor(events=events)
+    supervisor.mark_error = RuntimeError("rollback refused")
+    transport = _Transport("t", events, open_error=RuntimeError("transport open failed"))
+    lifecycle = _lifecycle(supervisor, transport)
+
+    with pytest.raises(RuntimeError, match="transport open failed"):
+        await lifecycle.open()
+
+    assert lifecycle._state is _ResourceState.CLOSED

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -724,13 +724,18 @@ async def test_a_writer_thread_failure_is_reraised_on_the_event_loop(
     A directory at the destination makes ``open(..., "wb")`` fail
     deterministically inside the writer thread. Without the one-slot exception
     box the caller would see a silent truncated download instead.
+
+    The assertion is on ``OSError``, not a specific subclass: POSIX raises
+    ``IsADirectoryError`` and Windows raises ``PermissionError`` for the same
+    call. Which errno the platform picks is not the contract — that the
+    writer's failure reaches the caller at all is.
     """
     fetcher = _fetcher(temp_dir=tmp_path)
     destination = tmp_path / "occupied-by-a-directory"
     destination.mkdir()
     response = _BodyOnly(b"x" * 64, chunk=8)
 
-    with pytest.raises(IsADirectoryError):
+    with pytest.raises(OSError):
         await fetcher._drain_to_temp(response, destination, "paper.pdf")
 
 
@@ -744,10 +749,12 @@ async def test_the_producer_stops_feeding_a_failed_writer(tmp_path: Path) -> Non
     # forever if it did not observe ``writer_failed``.
     response = _BodyOnly(b"y" * 8192, chunk=16)
 
-    with pytest.raises(IsADirectoryError):
+    with pytest.raises(OSError):
         await asyncio.wait_for(
             fetcher._drain_to_temp(response, destination, "paper.pdf"), timeout=10
         )
+    # Not a ValidationError from the cap or the empty-body guard — the writer's
+    # own failure is what surfaced.
 
     assert response.chunks_yielded < 8192 // 16
 

--- a/tests/unit/test_drive_import.py
+++ b/tests/unit/test_drive_import.py
@@ -30,8 +30,10 @@ from notebooklm._web.sources.drive_import import (
     DriveFetcher,
     DriveImportService,
     DriveRef,
+    _default_streaming_client,
     _filename_from_disposition,
     _find_confirm_params,
+    _read_capped_text,
     extract_drive_file_id,
     parse_drive_ref,
 )
@@ -574,3 +576,217 @@ class TestDriveImportService:
         with pytest.raises(ValidationError):
             await service.add_drive_file("nb_1", "not-a-valid-id")
         assert fetched is False
+
+
+# ---------------------------------------------------------------------------
+# _filename_from_disposition — RFC 5987 precedence and misses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("disposition", "expected"),
+    [
+        pytest.param('attachment; filename="paper.pdf"', "paper.pdf", id="quoted"),
+        pytest.param("attachment; filename=paper.pdf", "paper.pdf", id="unquoted"),
+        pytest.param("ATTACHMENT; FILENAME=paper.pdf", "paper.pdf", id="case-insensitive"),
+        pytest.param(
+            "attachment; filename=\"ascii.pdf\"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf",
+            "résumé.pdf",
+            id="rfc5987-wins-over-plain",
+        ),
+        pytest.param(
+            "attachment; filename*=UTF-8'en'file%20name.pdf",
+            "file name.pdf",
+            id="rfc5987-with-language-tag",
+        ),
+        pytest.param("", "", id="empty-header"),
+        pytest.param("attachment", "", id="no-filename-parameter"),
+        pytest.param("inline", "", id="inline-without-filename"),
+    ],
+)
+def test_filename_from_disposition(disposition: str, expected: str) -> None:
+    assert _filename_from_disposition(disposition) == expected
+
+
+# ---------------------------------------------------------------------------
+# _read_capped_text — never buffer more than the sniff cap
+# ---------------------------------------------------------------------------
+
+
+class _BodyOnly:
+    """Minimal response exposing only the streamed-body surface."""
+
+    def __init__(self, body: bytes, chunk: int) -> None:
+        self._body = body
+        self._chunk = chunk
+        self.chunks_yielded = 0
+
+    async def aiter_bytes(self, chunk_size: int = 65536) -> Any:
+        del chunk_size
+        for start in range(0, len(self._body), self._chunk):
+            self.chunks_yielded += 1
+            yield self._body[start : start + self._chunk]
+
+
+@pytest.mark.asyncio
+async def test_a_short_body_is_read_whole() -> None:
+    response = _BodyOnly(b"<html>hi</html>", chunk=4)
+
+    assert await _read_capped_text(response, 1024) == "<html>hi</html>"
+
+
+@pytest.mark.asyncio
+async def test_reading_stops_at_the_cap_without_pulling_a_whole_extra_chunk() -> None:
+    """A body far larger than the cap must not drag in another 64 KiB."""
+    response = _BodyOnly(b"x" * 4096, chunk=1000)
+
+    text = await _read_capped_text(response, 1500)
+
+    assert len(text) == 1500
+    # 1000 + 1000 sliced to 1500 — the third chunk is never requested.
+    assert response.chunks_yielded == 2
+
+
+@pytest.mark.asyncio
+async def test_a_body_exactly_at_the_cap_stops_without_another_read() -> None:
+    response = _BodyOnly(b"y" * 2000, chunk=1000)
+
+    text = await _read_capped_text(response, 2000)
+
+    assert len(text) == 2000
+    assert response.chunks_yielded == 2
+
+
+@pytest.mark.asyncio
+async def test_undecodable_bytes_degrade_rather_than_raise() -> None:
+    """The sniff only needs to classify; a decode error must not fail the fetch."""
+    response = _BodyOnly(b"\xff\xfe<html>", chunk=16)
+
+    assert "<html>" in await _read_capped_text(response, 1024)
+
+
+# ---------------------------------------------------------------------------
+# _reject_oversize_header — the pre-body size gate
+# ---------------------------------------------------------------------------
+
+
+def _header_only(headers: dict[str, str]) -> Any:
+    return httpx.Response(200, headers=headers)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        pytest.param({}, id="no-content-length"),
+        pytest.param({"content-length": "not-a-number"}, id="non-numeric"),
+        pytest.param({"content-length": "1024"}, id="under-cap"),
+    ],
+)
+def test_an_unusable_or_small_content_length_passes_the_size_gate(
+    headers: dict[str, str],
+) -> None:
+    """An unreadable header is not treated as over-cap; the stream cap still applies."""
+    fetcher = _fetcher(max_bytes=2048)
+
+    fetcher._reject_oversize_header(_header_only(headers), _FILE_ID)
+
+
+def test_a_declared_size_over_the_cap_is_refused_before_the_body() -> None:
+    fetcher = _fetcher(max_bytes=1024)
+
+    with pytest.raises(ValidationError, match="over the"):
+        fetcher._reject_oversize_header(_header_only({"content-length": "2048"}), _FILE_ID)
+
+
+@pytest.mark.asyncio
+async def test_a_non_html_client_error_is_a_hard_caller_error(tmp_path: Path) -> None:
+    """A 403/404 that is not the HTML interstitial cannot be retried into success."""
+    response = _FakeResponse(
+        status_code=403,
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    with pytest.raises(ValidationError, match="confirm the"):
+        await _fetcher(response, temp_dir=tmp_path)(DriveRef(_FILE_ID))
+
+
+# ---------------------------------------------------------------------------
+# _drain_to_temp — the writer thread's failure surfaces to the caller
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_writer_thread_failure_is_reraised_on_the_event_loop(
+    tmp_path: Path,
+) -> None:
+    """The write happens off-loop, so its exception has to be carried back.
+
+    A directory at the destination makes ``open(..., "wb")`` fail
+    deterministically inside the writer thread. Without the one-slot exception
+    box the caller would see a silent truncated download instead.
+    """
+    fetcher = _fetcher(temp_dir=tmp_path)
+    destination = tmp_path / "occupied-by-a-directory"
+    destination.mkdir()
+    response = _BodyOnly(b"x" * 64, chunk=8)
+
+    with pytest.raises(IsADirectoryError):
+        await fetcher._drain_to_temp(response, destination, "paper.pdf")
+
+
+@pytest.mark.asyncio
+async def test_the_producer_stops_feeding_a_failed_writer(tmp_path: Path) -> None:
+    """It must not keep draining the response into a queue nobody reads."""
+    fetcher = _fetcher(temp_dir=tmp_path)
+    destination = tmp_path / "occupied"
+    destination.mkdir()
+    # Far more chunks than the writer queue holds, so the producer would block
+    # forever if it did not observe ``writer_failed``.
+    response = _BodyOnly(b"y" * 8192, chunk=16)
+
+    with pytest.raises(IsADirectoryError):
+        await asyncio.wait_for(
+            fetcher._drain_to_temp(response, destination, "paper.pdf"), timeout=10
+        )
+
+    assert response.chunks_yielded < 8192 // 16
+
+
+@pytest.mark.asyncio
+async def test_an_empty_body_is_refused_rather_than_written_as_a_zero_byte_file(
+    tmp_path: Path,
+) -> None:
+    fetcher = _fetcher(temp_dir=tmp_path)
+    destination = tmp_path / "out.bin"
+
+    with pytest.raises(ValidationError, match="0 bytes"):
+        await fetcher._drain_to_temp(_BodyOnly(b"", chunk=8), destination, "paper.pdf")
+
+
+@pytest.mark.asyncio
+async def test_a_body_over_the_cap_aborts_mid_stream(tmp_path: Path) -> None:
+    """The cap is enforced producer-side, before the bytes reach disk."""
+    fetcher = _fetcher(max_bytes=64, temp_dir=tmp_path)
+    destination = tmp_path / "out.bin"
+    response = _BodyOnly(b"z" * 4096, chunk=32)
+
+    with pytest.raises(ValidationError, match="cap"):
+        await fetcher._drain_to_temp(response, destination, "paper.pdf")
+
+    assert response.chunks_yielded < 4096 // 32
+
+
+@pytest.mark.asyncio
+async def test_the_default_streaming_client_revalidates_every_redirect_hop() -> None:
+    """Redirects ARE followed — the #1521 protection is the per-hop event hook.
+
+    Auto-follow without that hook is the SSRF shape the hook exists to close,
+    so the two must be asserted together rather than assuming "no redirects".
+    """
+    client = _default_streaming_client(httpx.Cookies(), httpx.Timeout(30.0))
+
+    try:
+        assert client.follow_redirects is True
+        assert client.event_hooks["response"], "no redirect-revalidation hook installed"
+    finally:
+        await client.aclose()


### PR DESCRIPTION
The last three modules from the non-`_auth` list. Branched from `main`; disjoint from #2332 and #2334, so all three can merge in any order.

## Result

| module | uncovered | before | after |
|---|---|---|---|
| `_web/sources/drive_import.py` | 35 → **13** | 90.8% | **96.6%** |
| `_android/artifacts.py` | 40 → **33** | 91.9% | **93.3%** |
| `_runtime/lifecycle.py` | 34 → **28** | 93.7% | **94.8%** |

Total on this branch: **94.41%**, uncovered 3099.

## What these cover

- **`drive_import.py`** — `_filename_from_disposition` (RFC 5987 precedence over a plain `filename=`, the optional language tag, and the misses); `_read_capped_text`'s cap slicing, asserted by *counting chunks requested* so "a body far larger than the cap must not drag in another 64 KiB" is actually verified rather than assumed; the pre-body `content-length` gate; the non-HTML 4xx hard error; and `_drain_to_temp`'s writer thread — its failure is carried back to the event loop through the one-slot exception box (without it the caller sees a silently truncated download), and the producer stops feeding a failed writer instead of blocking forever on a queue nobody drains.
- **`lifecycle.py`** — `drain`'s admission fencing (no-op when closed, negative-timeout rejection, resources left open), the close-race suppression that must not swallow an unrelated supervisor fault, and `open`'s state guards including that an admission-rollback failure does not mask the original open failure.
- **`_android/artifacts.py`** — the input admission that runs before any RPC is dispatched: audio needs a source and text instructions, an explicitly empty `source_ids` is a caller error for each supported family (`None` still means "all sources"), and the slide-deck / interactive-app downloads reject unknown output formats. Each asserts nothing reached the wire.

## One test-fake change

The lifecycle fake gains a one-shot `stop_errors` queue. `close()` also calls `stop_accepting`, so a persistent `stop_error` breaks teardown — which is why the drain-vs-close race could not be expressed before.

## Where the remaining lines are

Deliberately stopped rather than padded:

- `_android/artifacts.py`'s remaining 33 are download-time error paths that need the asset-transfer graph wired per case — real work, not a quick win.
- `lifecycle.py`'s remaining 28 are cancellation interleavings inside the close wave, several of which need two waves racing at a specific await point.
- `drive_import.py`'s remaining 13 are the queue-saturation arms of `_drain_to_temp`'s error handler, which need a writer slow enough to fill an 8-slot queue while the producer is already unwinding.

Also worth repeating from #2332: `_sources.py` (19 uncovered) is entirely `@abstractmethod` bodies and is not worth testing — if you want that number moved, the lever is a coverage `exclude_lines` policy for `raise NotImplementedError`.

## Verification

```
uv run pytest -n auto --dist loadgroup \
  -m "not repo_lint and not requires_playwright and not requires_chromium"   # 17383 passed
uv run pytest tests/unit -m "(requires_playwright or requires_chromium) and not reality" -n 0
                                                                             # 84 passed
uv run pytest -m repo_lint                                                   # 1950 passed
uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports   # clean
uv run ruff check / format                                                   # clean
```

Tests only — no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Af5NMrwQKctBjH1Nkm32TH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for input validation across generation, slide downloads, quizzes, and flashcards.
  * Added lifecycle tests for shutdown, reopening, admission control, timeouts, and failure recovery.
  * Added Drive import coverage for filename handling, response-size limits, streaming failures, back-pressure, client errors, and redirects.
  * These tests help ensure invalid requests fail safely and lifecycle or import issues are handled predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->