### PR TITLE
test(guardrails): fix middleware context path to point to relocated directory

### DIFF
--- a/tests/_guardrails/test_backend_boundaries.py
+++ b/tests/_guardrails/test_backend_boundaries.py
@@ -386,11 +386,11 @@ def test_web_only_namespace_compatibility_modules_stay_thin_and_lazy(
 
 
 def test_relocated_package_shells_are_removed() -> None:
-    """Completed moves leave no Python package source at the old paths."""
+    """Completed moves leave no directory shells or Python package source at the old paths."""
     stale = [
-        str(path.relative_to(SRC_ROOT))
+        name
         for name in REMOVED_EMPTY_PACKAGE_SHELLS
-        for path in (SRC_ROOT / name).rglob("*.py")
+        if (SRC_ROOT / name).exists()
     ]
     assert stale == []
 

--- a/tests/_guardrails/test_backend_boundaries.py
+++ b/tests/_guardrails/test_backend_boundaries.py
@@ -387,11 +387,7 @@ def test_web_only_namespace_compatibility_modules_stay_thin_and_lazy(
 
 def test_relocated_package_shells_are_removed() -> None:
     """Completed moves leave no directory shells or Python package source at the old paths."""
-    stale = [
-        name
-        for name in REMOVED_EMPTY_PACKAGE_SHELLS
-        if (SRC_ROOT / name).exists()
-    ]
+    stale = [name for name in REMOVED_EMPTY_PACKAGE_SHELLS if (SRC_ROOT / name).exists()]
     assert stale == []
 
 

--- a/tests/_guardrails/test_backend_boundaries.py
+++ b/tests/_guardrails/test_backend_boundaries.py
@@ -386,8 +386,12 @@ def test_web_only_namespace_compatibility_modules_stay_thin_and_lazy(
 
 
 def test_relocated_package_shells_are_removed() -> None:
-    """Completed moves leave no directory shells or Python package source at the old paths."""
-    stale = [name for name in REMOVED_EMPTY_PACKAGE_SHELLS if (SRC_ROOT / name).exists()]
+    """Completed moves leave no Python package source at the old paths."""
+    stale = [
+        str(path.relative_to(SRC_ROOT))
+        for name in REMOVED_EMPTY_PACKAGE_SHELLS
+        for path in (SRC_ROOT / name).rglob("*.py")
+    ]
     assert stale == []
 
 

--- a/tests/_guardrails/test_middleware_context_contract.py
+++ b/tests/_guardrails/test_middleware_context_contract.py
@@ -29,7 +29,7 @@ ROOT = Path(__file__).resolve().parents[2]
 # are intentionally absent; after the transport/middleware extraction they
 # should not read or write request context directly.
 PRODUCTION_CONTEXT_FILES = [
-    *sorted((ROOT / "src/notebooklm/_middleware").glob("*.py")),
+    *sorted((ROOT / "src/notebooklm/_web/transport/middleware").glob("*.py")),
     ROOT / "src/notebooklm/_web/transport/runtime.py",
 ]
 


### PR DESCRIPTION
## Summary
- Fix `PRODUCTION_CONTEXT_FILES` in `tests/_guardrails/test_middleware_context_contract.py` to point to the relocated middleware path (`src/notebooklm/_web/transport/middleware`) rather than the retired `src/notebooklm/_middleware`, restoring context literal validation across the 12 active middleware files.

## Commands Run Locally
```bash
pytest tests/_guardrails/test_middleware_context_contract.py
ruff check tests/_guardrails/test_middleware_context_contract.py
```