### PR TITLE
fix(ci): align live template title contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nightly E2E and RPC health template validation.** The disposable-copy contract now matches
+  the configured canonical template title, allowing provisioning to proceed in the scheduled Web
+  and Android lanes.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/docs/development.md
+++ b/docs/development.md
@@ -814,6 +814,8 @@ Studio artifacts. Its checked-in shape is `tests/fixtures/e2e_template_contract.
 chat history are deliberately absent from that contract. Provisioning creates and validates those
 on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.
+The configured template's immutable title is `Make Your Writing Clear and Persuasive`; replacing
+the template requires updating the title contract and template-ID secret together.
 
 To qualify a template locally, use a dedicated profile and keep the template ID in the documented
 environment variable so it never appears on the command line:

--- a/tests/fixtures/e2e_template_contract.json
+++ b/tests/fixtures/e2e_template_contract.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "title_regex": "^notebooklm-py E2E template v1(?:$|[ -].*)",
+  "title_regex": "^Make Your Writing Clear and Persuasive$",
   "reserved_title_prefix": "notebooklm-py-ci/",
   "sources": {
     "minimum_ready": 3,

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -58,7 +58,7 @@ from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 im
 )
 
 TEMPLATE_ID = "template-id"
-TEMPLATE_TITLE = "notebooklm-py E2E template v1"
+TEMPLATE_TITLE = "Make Your Writing Clear and Persuasive"
 FINGERPRINT = "a" * 64
 
 
@@ -1454,6 +1454,18 @@ async def test_template_validation_rejects_wrong_notebook_lookup(
     manager, client, _store, _clock = _manager(tmp_path, contracts)
     client.notebooks.items[TEMPLATE_ID].id = "different-notebook"
     with pytest.raises(ContractError, match="wrong notebook"):
+        await manager.validate_template()
+
+
+@pytest.mark.asyncio
+async def test_template_validation_rejects_noncanonical_title(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, _clock = _manager(tmp_path, contracts)
+    client.notebooks.items[TEMPLATE_ID].title = "notebooklm-py E2E template v1"
+
+    with pytest.raises(ContractError, match="title version does not match"):
         await manager.validate_template()
 
 


### PR DESCRIPTION
## Summary

- align the disposable E2E template contract with the configured canonical notebook title
- update lifecycle test fixtures and add regression coverage for noncanonical titles
- document the immutable title and replacement procedure

## Failure analysis

Both scheduled workflows failed before creating disposable copies because template validation expected the placeholder title `notebooklm-py E2E template v1`, while the configured canonical notebook reports `Make Your Writing Clear and Persuasive`.

- Nightly E2E failure: https://github.com/teng-lin/notebooklm-py/actions/runs/33842980611/job/100928937992
- RPC health failure: https://github.com/teng-lin/notebooklm-py/actions/runs/33847359548/job/100942185109

## Validation

- `uv run pytest -q tests/unit/test_manage_ci_e2e_notebooks.py tests/unit/test_ci_account_pool_workflows.py tests/unit/test_ci_test_matrix.py` — 136 passed
- `uv run ruff check tests/unit/test_manage_ci_e2e_notebooks.py`
- `uv run ruff format --check tests/unit/test_manage_ci_e2e_notebooks.py`
- `uv run pre-commit run --files CHANGELOG.md docs/development.md tests/fixtures/e2e_template_contract.json tests/unit/test_manage_ci_e2e_notebooks.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nightly Web and Android health checks so template validation recognizes the configured canonical template and provisioning can proceed successfully.
  * Added validation to reject noncanonical template titles, improving reliability of automated checks.

* **Documentation**
  * Clarified the canonical template title and the required updates when replacing the template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->