### PR TITLE
fix(ci): match public E2E template title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Nightly E2E and RPC health template validation.** The disposable-copy contract now matches
   the immutable public template title, allowing provisioning to proceed in the scheduled Web and
-  Android lanes.
+  Android lanes. The lifecycle manager also uses the public notebook as its default when no
+  template override is configured.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Nightly E2E and RPC health template validation.** The disposable-copy contract now matches
-  the configured canonical template title, allowing provisioning to proceed in the scheduled Web
-  and Android lanes.
+  the immutable public template title, allowing provisioning to proceed in the scheduled Web and
+  Android lanes.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/docs/development.md
+++ b/docs/development.md
@@ -814,8 +814,9 @@ Studio artifacts. Its checked-in shape is `tests/fixtures/e2e_template_contract.
 chat history are deliberately absent from that contract. Provisioning creates and validates those
 on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.
-The configured template's immutable title is `Make Your Writing Clear and Persuasive`; replacing
-the template requires updating the title contract and template-ID secret together.
+The configured template is the public notebook titled
+`Make Your Writing More Powerful and Persuasive`. Its title cannot be changed; replacing the
+template requires updating the title contract and template-ID secret together.
 
 To qualify a template locally, use a dedicated profile and keep the template ID in the documented
 environment variable so it never appears on the command line:

--- a/docs/development.md
+++ b/docs/development.md
@@ -818,24 +818,23 @@ The configured template is the public notebook titled
 `Make Your Writing More Powerful and Persuasive`. Its title cannot be changed; replacing the
 template requires updating the title contract and template-ID secret together.
 
-To qualify a template locally, use a dedicated profile and keep the template ID in the documented
-environment variable so it never appears on the command line:
+The lifecycle manager defaults to the public template
+`a109ad5c-834d-4f3d-82a0-fe41aa72318e` when the environment variable is unset. Set
+`NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID` only to qualify a replacement template. To qualify the
+default locally, use a dedicated profile:
 
 ```bash
 export NOTEBOOKLM_PROFILE=agent-e2e-slot-A-web
-export NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID='<template-id>'
 export GITHUB_RUN_ID=1 GITHUB_RUN_ATTEMPT=1
 export GITHUB_REPOSITORY=teng-lin/notebooklm-py
 export RUNNER_TEMP="$(mktemp -d)"
 
 uv run python scripts/manage_ci_e2e_notebooks.py validate \
   --backend web \
-  --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
   --contract tests/fixtures/e2e_template_contract.json
 
 uv run python scripts/manage_ci_e2e_notebooks.py provision \
   --backend web \
-  --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
   --contract tests/fixtures/e2e_template_contract.json \
   --mode full --lane nightly-web-ubuntu --account-slot A \
   --manifest "$RUNNER_TEMP/notebooklm-e2e.json" \
@@ -844,7 +843,6 @@ uv run python scripts/manage_ci_e2e_notebooks.py provision \
 # Run pytest only after exporting the generated github-env entries.
 uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
   --backend web \
-  --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
   --manifest "$RUNNER_TEMP/notebooklm-e2e.json"
 ```
 
@@ -1546,18 +1544,17 @@ directory. Never use the template ID as a pytest fixture binding:
 ```bash
 export NOTEBOOKLM_PROFILE=agent-e2e-local
 export RUNNER_TEMP="$(mktemp -d)"
-export NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID=<template-id>
 export GITHUB_RUN_ID=1 GITHUB_RUN_ATTEMPT=1
 export GITHUB_REPOSITORY=teng-lin/notebooklm-py
 uv run python scripts/manage_ci_e2e_notebooks.py provision \
-  --backend web --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
+  --backend web \
   --contract tests/fixtures/e2e_template_contract.json --mode full \
   --lane verify-package --account-slot A \
   --manifest "$RUNNER_TEMP/notebooklm-e2e.json" --github-env "$RUNNER_TEMP/e2e.env"
 set -a; source "$RUNNER_TEMP/e2e.env"; set +a
 NOTEBOOKLM_E2E_GENERATION_JOURNAL_MODE=off uv run pytest tests/e2e -m "not variants"
 uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
-  --backend web --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
+  --backend web \
   --manifest "$RUNNER_TEMP/notebooklm-e2e.json"
 ```
 
@@ -1567,7 +1564,7 @@ environment/profile-cache/auto-create behavior described above.
 #### Account pool setup
 
 The `protected-readonly` Environment contains one independent opaque token per
-enabled slot and one template handle:
+enabled slot. It may also contain a template handle to override the checked-in public default:
 
 ```text
 NOTEBOOKLM_MASTER_TOKEN_JSON_A
@@ -1577,7 +1574,8 @@ NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID
 ```
 
 Bootstrap each authorized account in a separate local profile and upload its
-token without printing it. Upload the template ID through stdin as well:
+token without printing it. To override the public template, upload the replacement ID through
+stdin as well:
 
 ```bash
 NOTEBOOKLM_PROFILE=ci-bootstrap-a notebooklm login --master-token --account <account-a>

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Provision, validate, reconcile, and delete disposable CI E2E notebooks.
 
-Notebook IDs are sensitive resource handles.  This command writes them only to
-the local manifest and ``GITHUB_ENV``; human-facing diagnostics contain roles,
-counts, and categorized errors but never IDs, titles, or response bodies.
+Disposable notebook IDs are sensitive resource handles.  This command writes
+them only to the local manifest and ``GITHUB_ENV``; human-facing diagnostics
+contain roles, counts, and categorized errors but never IDs, titles, or
+response bodies.  The default template ID is an approved public resource.
 """
 
 from __future__ import annotations
@@ -57,6 +58,7 @@ from notebooklm import (
 from notebooklm._logging import scrub_secrets
 
 TEMPLATE_ID_ENV = "NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID"
+DEFAULT_TEMPLATE_ID = "a109ad5c-834d-4f3d-82a0-fe41aa72318e"
 DEFAULT_TEMPLATE_CONTRACT = (
     Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "e2e_template_contract.json"
 )
@@ -1228,9 +1230,9 @@ class NotebookLifecycleManager:
 def _template_id_from_env(name: str) -> str:
     if name != TEMPLATE_ID_ENV:
         raise ManifestError("template ID environment name is not allowlisted")
-    value = os.environ.get(name, "")
+    value = os.environ.get(name) or DEFAULT_TEMPLATE_ID
     if not is_valid_notebook_id(value):
-        raise ManifestError("template notebook ID environment value is missing or malformed")
+        raise ManifestError("template notebook ID environment value is malformed")
     return value
 
 
@@ -1264,7 +1266,7 @@ def build_parser() -> argparse.ArgumentParser:
     def common(name: str, *, manifest: bool = True) -> argparse.ArgumentParser:
         child = subparsers.add_parser(name)
         child.add_argument("--backend", choices=BACKENDS, required=True)
-        child.add_argument("--template-id-env", required=True)
+        child.add_argument("--template-id-env", default=TEMPLATE_ID_ENV)
         if manifest:
             child.add_argument("--manifest", type=Path, required=True)
         return child

--- a/tests/fixtures/e2e_template_contract.json
+++ b/tests/fixtures/e2e_template_contract.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "title_regex": "^Make Your Writing Clear and Persuasive$",
+  "title_regex": "^Make Your Writing More Powerful and Persuasive$",
   "reserved_title_prefix": "notebooklm-py-ci/",
   "sources": {
     "minimum_ready": 3,

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -32,6 +32,7 @@ from _ci_e2e_notebooks import (  # noqa: E402
     validate_manifest,
 )
 from manage_ci_e2e_notebooks import (  # noqa: E402
+    DEFAULT_TEMPLATE_ID,
     TEMPLATE_ID_ENV,
     CleanupError,
     ContractError,
@@ -1792,6 +1793,37 @@ def test_environment_block_contains_no_activation_for_partial_preparation(tmp_pa
     path.write_text("PREEXISTING=1\n")
     assert "NOTEBOOKLM_E2E_MANAGED_COPIES" not in path.read_text()
     assert os.fspath(path)
+
+
+def test_template_id_uses_public_default_when_environment_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(TEMPLATE_ID_ENV, raising=False)
+
+    assert lifecycle._template_id_from_env(TEMPLATE_ID_ENV) == DEFAULT_TEMPLATE_ID
+
+
+def test_template_id_environment_overrides_public_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(TEMPLATE_ID_ENV, TEMPLATE_ID)
+
+    assert lifecycle._template_id_from_env(TEMPLATE_ID_ENV) == TEMPLATE_ID
+
+
+def test_template_id_environment_rejects_malformed_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(TEMPLATE_ID_ENV, "not a notebook id")
+
+    with pytest.raises(ManifestError, match="malformed"):
+        lifecycle._template_id_from_env(TEMPLATE_ID_ENV)
+
+
+def test_cli_defaults_to_public_template_environment_name() -> None:
+    args = lifecycle.build_parser().parse_args(["validate", "--backend", "web"])
+
+    assert args.template_id_env == TEMPLATE_ID_ENV
 
 
 def test_cli_cleanup_absent_manifest_never_opens_auth(

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -58,7 +58,7 @@ from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 im
 )
 
 TEMPLATE_ID = "template-id"
-TEMPLATE_TITLE = "Make Your Writing Clear and Persuasive"
+TEMPLATE_TITLE = "Make Your Writing More Powerful and Persuasive"
 FINGERPRINT = "a" * 64
 
 
@@ -1463,7 +1463,7 @@ async def test_template_validation_rejects_noncanonical_title(
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
     manager, client, _store, _clock = _manager(tmp_path, contracts)
-    client.notebooks.items[TEMPLATE_ID].title = "notebooklm-py E2E template v1"
+    client.notebooks.items[TEMPLATE_ID].title = "Make Your Writing Clear and Persuasive"
 
     with pytest.raises(ContractError, match="title version does not match"):
         await manager.validate_template()


### PR DESCRIPTION
## Summary

- match the disposable-copy title contract to the immutable public notebook title
- default the lifecycle manager to public notebook `a109ad5c-834d-4f3d-82a0-fe41aa72318e` when no override is configured
- keep `NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID` as an optional validated override for replacement-template qualification
- document that the public template cannot be renamed
- keep regression coverage for the incorrect title assumed in #2351

No GitHub secret or external notebook change is required.

## Failure analysis

RPC Health Check run https://github.com/teng-lin/notebooklm-py/actions/runs/33904997704/job/101127832023 reached the configured notebook successfully but failed before source validation because #2351 expected `Make Your Writing Clear and Persuasive`. The immutable public title is `Make Your Writing More Powerful and Persuasive`.

## Validation

- `uv run pytest -q tests/unit/test_manage_ci_e2e_notebooks.py tests/unit/test_ci_account_pool_workflows.py tests/unit/test_ci_test_matrix.py tests/unit/test_check_workflow_secret_gates.py` — 207 passed
- `uv run ruff check scripts/manage_ci_e2e_notebooks.py tests/unit/test_manage_ci_e2e_notebooks.py`
- `uv run ruff format --check scripts/manage_ci_e2e_notebooks.py tests/unit/test_manage_ci_e2e_notebooks.py`
- `uv run pre-commit run --files CHANGELOG.md docs/development.md scripts/manage_ci_e2e_notebooks.py tests/fixtures/e2e_template_contract.json tests/unit/test_manage_ci_e2e_notebooks.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated end-to-end validation to recognize the current public template title.
  - Improved template selection so validation uses the approved public template by default and rejects malformed overrides.

- **Documentation**
  - Clarified that custom replacement templates require an explicit template ID.
  - Simplified setup, validation, provisioning, and cleanup examples by removing unnecessary template configuration for the standard public template.
  - Updated lifecycle guidance to reflect the default public notebook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->