### PR TITLE
feat(ci): add pre-merge live qualification

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,7 @@ jobs:
       is_standard: ${{ steps.resolve.outputs.is_standard }}
       sha: ${{ steps.target.outputs.sha }}
       short_sha: ${{ steps.target.outputs.short_sha }}
+      trusted_sha: ${{ steps.resolve.outputs.trusted_sha }}
     steps:
     - name: Resolve trusted target
       id: resolve
@@ -57,6 +58,7 @@ jobs:
         EVENT_NAME: ${{ github.event_name }}
         GITHUB_ACTOR_VALUE: ${{ github.actor }}
         GITHUB_REF_VALUE: ${{ github.ref }}
+        GITHUB_SHA_VALUE: ${{ github.sha }}
         GITHUB_TRIGGERING_ACTOR_VALUE: ${{ github.triggering_actor }}
         GH_TOKEN: ${{ github.token }}
         QUALIFICATION_PR: ${{ inputs.qualification_pr }}
@@ -69,11 +71,17 @@ jobs:
           echo "::error::Dispatch the trusted nightly workflow on main"
           exit 1
         fi
+        if ! [[ "$GITHUB_SHA_VALUE" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::GitHub returned an invalid trusted workflow SHA"
+          exit 1
+        fi
+        echo "trusted_sha=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
 
         if [ -z "$QUALIFICATION_PR" ]; then
           echo "branch=main" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
-          echo "expected_sha=" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
           echo "is_standard=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
@@ -143,7 +151,7 @@ jobs:
         printf '### Live target\n\nTarget: `%s@%s`\n' \
           "$TARGET_LABEL" "$actual_sha" >> "$GITHUB_STEP_SUMMARY"
 
-  # The reviewed selector runs from the resolved SHA without any secret. Its
+  # The account selector runs from the trusted workflow SHA without any secret. Its
   # matrix contains aliases and allowlisted secret names, never secret values.
   plan-live-lanes:
     needs: resolve-target
@@ -156,7 +164,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        ref: ${{ needs.resolve-target.outputs.sha }}
+        ref: ${{ needs.resolve-target.outputs.trusted_sha }}
         fetch-depth: 1
         persist-credentials: false
     - name: Select live account slots
@@ -415,6 +423,13 @@ jobs:
         ref: ${{ needs.resolve-target.outputs.sha }}
         fetch-depth: 1
         persist-credentials: false
+    - name: Checkout trusted CI helpers
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.trusted_sha }}
+        path: trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}
+        fetch-depth: 1
+        persist-credentials: false
     - name: Configure runner-local paths
       run: |
         {
@@ -463,9 +478,11 @@ jobs:
       continue-on-error: true
       env:
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[matrix.master_token_secret_name] }}
-      run: >-
-        uv run python scripts/materialize_ci_auth.py
-        --account-slot "${{ matrix.account_slot }}" --profile "$NOTEBOOKLM_PROFILE"
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
+          "$trusted_root/scripts/materialize_ci_auth.py" \
+          --account-slot "${{ matrix.account_slot }}" --profile "$NOTEBOOKLM_PROFILE"
     - name: Sweep stale managed copies
       id: sweep
       if: steps.auth.outcome == 'success'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -454,6 +454,25 @@ jobs:
         cache: pip
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+    - name: Install trusted auth environment
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        uv sync --frozen --extra headless --no-dev
+    - name: Materialize selected account
+      id: auth
+      if: >-
+        needs.resolve-target.outputs.is_standard == 'true' &&
+        github.repository == 'teng-lin/notebooklm-py'
+      continue-on-error: true
+      env:
+        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[matrix.master_token_secret_name] }}
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        PYTHONPATH="$trusted_root/src" uv run --frozen --no-sync python \
+          scripts/materialize_ci_auth.py \
+          --account-slot "${{ matrix.account_slot }}" --profile "$NOTEBOOKLM_PROFILE"
     - name: Install dependencies
       run: >-
         uv sync --frozen --extra browser --extra dev --extra markdown
@@ -470,19 +489,6 @@ jobs:
         key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}-ws
     - name: Install Playwright browsers
       run: uv run playwright install chromium
-    - name: Materialize selected account
-      id: auth
-      if: >-
-        needs.resolve-target.outputs.is_standard == 'true' &&
-        github.repository == 'teng-lin/notebooklm-py'
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[matrix.master_token_secret_name] }}
-      run: |
-        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
-        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
-          "$trusted_root/scripts/materialize_ci_auth.py" \
-          --account-slot "${{ matrix.account_slot }}" --profile "$NOTEBOOKLM_PROFILE"
     - name: Sweep stale managed copies
       id: sweep
       if: steps.auth.outcome == 'success'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,17 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
+      qualification_pr:
+        description: 'Open same-repository PR to qualify (dispatch this workflow on main)'
+        required: false
+        type: string
+        default: ''
+      e2e_lane:
+        description: 'Live E2E lane(s) to run'
+        required: true
+        type: choice
+        default: all
+        options: [all, web, android, readonly]
       test_filter:
         description: 'Specific pytest node ID (empty runs the full E2E suite)'
         required: false
@@ -25,11 +36,14 @@ permissions:
   contents: read
 
 jobs:
-  # This no-secret job is the only place a mutable ref is resolved. Only main
-  # is trusted for the protected CI account pool.
+  # This no-secret job is the only place a mutable ref is resolved. The trusted
+  # workflow must run on main; an owner-authorized same-repo PR is pinned here.
   resolve-target:
     runs-on: ubuntu-latest
     if: github.repository == 'teng-lin/notebooklm-py'
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       branch: ${{ steps.resolve.outputs.branch }}
       is_standard: ${{ steps.resolve.outputs.is_standard }}
@@ -39,31 +53,95 @@ jobs:
     - name: Resolve trusted target
       id: resolve
       env:
+        CANONICAL_REPOSITORY: teng-lin/notebooklm-py
+        EVENT_NAME: ${{ github.event_name }}
+        GITHUB_ACTOR_VALUE: ${{ github.actor }}
         GITHUB_REF_VALUE: ${{ github.ref }}
+        GITHUB_TRIGGERING_ACTOR_VALUE: ${{ github.triggering_actor }}
+        GH_TOKEN: ${{ github.token }}
+        QUALIFICATION_PR: ${{ inputs.qualification_pr }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
       shell: bash
       run: |
         set -euo pipefail
-        echo "branch=main" >> "$GITHUB_OUTPUT"
-        if [ "$GITHUB_REF_VALUE" = refs/heads/main ]; then
-          echo "is_standard=true" >> "$GITHUB_OUTPUT"
-        else
+        if [ "$GITHUB_REF_VALUE" != refs/heads/main ]; then
           echo "is_standard=false" >> "$GITHUB_OUTPUT"
-          echo "::error::Authenticated nightly runs accept only refs/heads/main"
+          echo "::error::Dispatch the trusted nightly workflow on main"
           exit 1
         fi
+
+        if [ -z "$QUALIFICATION_PR" ]; then
+          echo "branch=main" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=" >> "$GITHUB_OUTPUT"
+          echo "is_standard=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [ "$EVENT_NAME" != workflow_dispatch ]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::PR qualification is available only through workflow_dispatch"
+          exit 1
+        fi
+        if [ "$GITHUB_ACTOR_VALUE" != teng-lin ] || \
+           [ "$GITHUB_TRIGGERING_ACTOR_VALUE" != teng-lin ]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::Only the repository owner may authorize live PR qualification"
+          exit 1
+        fi
+        if [ "$RUN_ATTEMPT" != 1 ]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::PR qualification cannot be rerun; dispatch a fresh run to pin its head"
+          exit 1
+        fi
+        if ! [[ "$QUALIFICATION_PR" =~ ^[1-9][0-9]*$ ]]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::qualification_pr must be a positive PR number"
+          exit 1
+        fi
+
+        pr_fields=$(gh api "repos/$CANONICAL_REPOSITORY/pulls/$QUALIFICATION_PR" \
+          --jq '[.state, .base.repo.full_name, .base.ref, .head.repo.full_name, .head.sha] | @tsv')
+        IFS=$'\t' read -r state base_repo base_ref head_repo head_sha <<< "$pr_fields"
+        if [ "$state" != open ] || [ "$base_repo" != "$CANONICAL_REPOSITORY" ] || \
+           [ "$base_ref" != main ] || [ "$head_repo" != "$CANONICAL_REPOSITORY" ]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::Qualification requires an open, same-repository PR targeting main"
+          exit 1
+        fi
+        if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "is_standard=false" >> "$GITHUB_OUTPUT"
+          echo "::error::GitHub returned an invalid PR head SHA"
+          exit 1
+        fi
+        echo "branch=pr-$QUALIFICATION_PR" >> "$GITHUB_OUTPUT"
+        echo "checkout_ref=$head_sha" >> "$GITHUB_OUTPUT"
+        echo "expected_sha=$head_sha" >> "$GITHUB_OUTPUT"
+        echo "is_standard=true" >> "$GITHUB_OUTPUT"
     - uses: actions/checkout@v7
       if: steps.resolve.outputs.is_standard == 'true'
       with:
-        ref: refs/heads/main
+        ref: ${{ steps.resolve.outputs.checkout_ref }}
         fetch-depth: 1
         persist-credentials: false
     - name: Resolve immutable commit
       id: target
       if: steps.resolve.outputs.is_standard == 'true'
       shell: bash
+      env:
+        EXPECTED_SHA: ${{ steps.resolve.outputs.expected_sha }}
+        TARGET_LABEL: ${{ steps.resolve.outputs.branch }}
       run: |
-        echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-        echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+        actual_sha=$(git rev-parse HEAD)
+        if [ -n "$EXPECTED_SHA" ] && [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+          echo "::error::Checked-out commit does not match the authorized PR head SHA"
+          exit 1
+        fi
+        echo "sha=$actual_sha" >> "$GITHUB_OUTPUT"
+        echo "short_sha=${actual_sha:0:12}" >> "$GITHUB_OUTPUT"
+        printf '### Live target\n\nTarget: `%s@%s`\n' \
+          "$TARGET_LABEL" "$actual_sha" >> "$GITHUB_STEP_SUMMARY"
 
   # The reviewed selector runs from the resolved SHA without any secret. Its
   # matrix contains aliases and allowlisted secret names, never secret values.
@@ -86,6 +164,7 @@ jobs:
       env:
         ENABLED_SLOTS: ${{ vars.NOTEBOOKLM_CI_ACCOUNT_SLOTS }}
         MANUAL_BASE: ${{ inputs.account_rotation_base || 'auto' }}
+        E2E_LANE: ${{ inputs.e2e_lane || 'all' }}
         TEST_FILTER: ${{ inputs.test_filter }}
       shell: bash
       run: |
@@ -121,17 +200,29 @@ jobs:
         web = read_outputs("web-slot.out")
         android = read_outputs("android-slot.out")
         readonly = read_outputs("readonly-slot.out")
-        include = [
-            {"os": "ubuntu-latest", "backend": "web", "lane": "nightly-web-ubuntu",
-             "mode": "full", "selection": "not variants",
-             "account_slot": web["account_slot"],
-             "master_token_secret_name": web["master_token_secret_name"]},
-            {"os": "macos-latest", "backend": "android",
-             "lane": "nightly-android-macos", "mode": "full",
-             "selection": "not variants", "account_slot": android["account_slot"],
-             "master_token_secret_name": android["master_token_secret_name"]},
-        ]
-        if not os.environ["TEST_FILTER"]:
+        selected_lane = os.environ["E2E_LANE"]
+        test_filter = os.environ["TEST_FILTER"]
+        if selected_lane not in {"all", "web", "android", "readonly"}:
+            raise SystemExit(f"unsupported e2e_lane: {selected_lane}")
+        if selected_lane == "readonly" and test_filter:
+            raise SystemExit("e2e_lane=readonly cannot be combined with test_filter")
+
+        include = []
+        if selected_lane in {"all", "web"}:
+            include.append(
+                {"os": "ubuntu-latest", "backend": "web",
+                 "lane": "nightly-web-ubuntu", "mode": "full",
+                 "selection": "not variants", "account_slot": web["account_slot"],
+                 "master_token_secret_name": web["master_token_secret_name"]}
+            )
+        if selected_lane in {"all", "android"}:
+            include.append(
+                {"os": "macos-latest", "backend": "android",
+                 "lane": "nightly-android-macos", "mode": "full",
+                 "selection": "not variants", "account_slot": android["account_slot"],
+                 "master_token_secret_name": android["master_token_secret_name"]}
+            )
+        if selected_lane in {"all", "readonly"} and not test_filter:
             include.append(
                 {"os": "windows-latest", "backend": "web",
                  "lane": "nightly-readonly-windows", "mode": "readonly",
@@ -144,14 +235,17 @@ jobs:
         with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
             stream.write(f"matrix={value}\n")
             stream.write(f"rotation_day={web['rotation_day']}\n")
+            stream.write(f"web_slot={web['account_slot']}\n")
+            stream.write(f"android_slot={android['account_slot']}\n")
             stream.write(f"readonly_slot={readonly['account_slot']}\n")
         PY
     - name: Summarize safe lane selection
       env:
         ENABLED_SLOTS: ${{ vars.NOTEBOOKLM_CI_ACCOUNT_SLOTS }}
-        WEB_SLOT: ${{ fromJSON(steps.plan.outputs.matrix).include[0].account_slot }}
-        ANDROID_SLOT: ${{ fromJSON(steps.plan.outputs.matrix).include[1].account_slot }}
+        WEB_SLOT: ${{ steps.plan.outputs.web_slot }}
+        ANDROID_SLOT: ${{ steps.plan.outputs.android_slot }}
         READONLY_SLOT: ${{ steps.plan.outputs.readonly_slot }}
+        E2E_LANE: ${{ inputs.e2e_lane || 'all' }}
         TEST_FILTER: ${{ inputs.test_filter }}
         SELECTION_MODE: ${{ (inputs.account_rotation_base == '' || inputs.account_rotation_base == 'auto') && 'automatic' || 'manual base' }}
         ROTATION_DAY: ${{ steps.plan.outputs.rotation_day }}
@@ -164,12 +258,18 @@ jobs:
           echo "Rotation day: $ROTATION_DAY; enabled slot count: $enabled_count"
           echo "| Lane | Runner | Backend | Suite | Slot | Selection |"
           echo "| --- | --- | --- | --- | --- | --- |"
-          echo "| nightly-web-ubuntu | Ubuntu | web | full | $WEB_SLOT | $SELECTION_MODE |"
-          echo "| nightly-android-macos | macOS | android | full | $ANDROID_SLOT | $SELECTION_MODE |"
-          if [ -n "$TEST_FILTER" ]; then
-            echo "| nightly-readonly-windows | Windows | web | omitted | $READONLY_SLOT | filtered dispatch |"
-          else
-            echo "| nightly-readonly-windows | Windows | web | readonly | $READONLY_SLOT | $SELECTION_MODE |"
+          if [ "$E2E_LANE" = all ] || [ "$E2E_LANE" = web ]; then
+            echo "| nightly-web-ubuntu | Ubuntu | web | full | $WEB_SLOT | $SELECTION_MODE |"
+          fi
+          if [ "$E2E_LANE" = all ] || [ "$E2E_LANE" = android ]; then
+            echo "| nightly-android-macos | macOS | android | full | $ANDROID_SLOT | $SELECTION_MODE |"
+          fi
+          if [ "$E2E_LANE" = all ] || [ "$E2E_LANE" = readonly ]; then
+            if [ -n "$TEST_FILTER" ]; then
+              echo "| nightly-readonly-windows | Windows | web | omitted | $READONLY_SLOT | filtered dispatch |"
+            else
+              echo "| nightly-readonly-windows | Windows | web | readonly | $READONLY_SLOT | $SELECTION_MODE |"
+            fi
           fi
         } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -247,6 +247,29 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
 
+    - name: Install trusted auth environment
+      shell: bash
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        uv sync --frozen --extra headless --no-dev
+
+    - name: Materialize selected account
+      id: auth
+      if: >-
+        needs.resolve-target.outputs.is_standard == 'true' &&
+        github.repository == 'teng-lin/notebooklm-py'
+      continue-on-error: true
+      env:
+        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.web_secret_name] }}
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        PYTHONPATH="$trusted_root/src" uv run --frozen --no-sync python \
+          scripts/materialize_ci_auth.py \
+          --account-slot "${{ needs.plan-live-lanes.outputs.web_account_slot }}" \
+          --profile "$NOTEBOOKLM_PROFILE"
+
     - name: Install dependencies
       # `uv sync --frozen` reproduces the lockfile-pinned dep tree. The RPC
       # health script (`scripts/check_rpc_health.py`) only needs the core
@@ -268,21 +291,6 @@ jobs:
           sleep $((attempt * 15))
           attempt=$((attempt + 1))
         done
-
-    - name: Materialize selected account
-      id: auth
-      if: >-
-        needs.resolve-target.outputs.is_standard == 'true' &&
-        github.repository == 'teng-lin/notebooklm-py'
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.web_secret_name] }}
-      run: |
-        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
-        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
-          "$trusted_root/scripts/materialize_ci_auth.py" \
-          --account-slot "${{ needs.plan-live-lanes.outputs.web_account_slot }}" \
-          --profile "$NOTEBOOKLM_PROFILE"
 
     - name: Sweep stale RPC copies
       id: sweep
@@ -1083,6 +1091,29 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
 
+    - name: Install trusted auth environment
+      shell: bash
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        uv sync --frozen --extra headless --no-dev
+
+    - name: Materialize selected account
+      id: auth
+      if: >-
+        needs.resolve-target.outputs.is_standard == 'true' &&
+        github.repository == 'teng-lin/notebooklm-py'
+      continue-on-error: true
+      env:
+        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.android_secret_name] }}
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        cd "$trusted_root"
+        PYTHONPATH="$trusted_root/src" uv run --frozen --no-sync python \
+          scripts/materialize_ci_auth.py \
+          --account-slot "${{ needs.plan-live-lanes.outputs.android_account_slot }}" \
+          --profile "$NOTEBOOKLM_PROFILE"
+
     - name: Install dependencies
       # The SAME extras line as the nightly Android E2E lane, so the canary
       # resolves the identical lockfile-pinned dependency tree that lane
@@ -1102,21 +1133,6 @@ jobs:
           sleep $((attempt * 15))
           attempt=$((attempt + 1))
         done
-
-    - name: Materialize selected account
-      id: auth
-      if: >-
-        needs.resolve-target.outputs.is_standard == 'true' &&
-        github.repository == 'teng-lin/notebooklm-py'
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.android_secret_name] }}
-      run: |
-        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
-        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
-          "$trusted_root/scripts/materialize_ci_auth.py" \
-          --account-slot "${{ needs.plan-live-lanes.outputs.android_account_slot }}" \
-          --profile "$NOTEBOOKLM_PROFILE"
 
     - name: Validate immutable template through Android
       id: template_validate

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -32,6 +32,7 @@ jobs:
       branch: ${{ steps.resolve.outputs.branch }}
       is_standard: ${{ steps.resolve.outputs.is_standard }}
       sha: ${{ steps.target.outputs.sha }}
+      trusted_sha: ${{ steps.resolve.outputs.trusted_sha }}
     steps:
       - name: Resolve trusted target
         id: resolve
@@ -40,6 +41,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           GITHUB_ACTOR_VALUE: ${{ github.actor }}
           GITHUB_REF_VALUE: ${{ github.ref }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
           GITHUB_TRIGGERING_ACTOR_VALUE: ${{ github.triggering_actor }}
           GH_TOKEN: ${{ github.token }}
           QUALIFICATION_PR: ${{ inputs.qualification_pr }}
@@ -51,11 +53,17 @@ jobs:
             echo "::error::Dispatch the trusted RPC health workflow on main"
             exit 1
           fi
+          if ! [[ "$GITHUB_SHA_VALUE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::GitHub returned an invalid trusted workflow SHA"
+            exit 1
+          fi
+          echo "trusted_sha=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
 
           if [ -z "$QUALIFICATION_PR" ]; then
             echo "branch=main" >> "$GITHUB_OUTPUT"
-            echo "checkout_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
-            echo "expected_sha=" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
+            echo "expected_sha=$GITHUB_SHA_VALUE" >> "$GITHUB_OUTPUT"
             echo "is_standard=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -137,7 +145,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        ref: ${{ needs.resolve-target.outputs.sha }}
+        ref: ${{ needs.resolve-target.outputs.trusted_sha }}
         fetch-depth: 1
         persist-credentials: false
     - name: Select health account slots
@@ -215,6 +223,14 @@ jobs:
         fetch-depth: 1
         persist-credentials: false
 
+    - name: Checkout trusted CI helpers
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.trusted_sha }}
+        path: trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}
+        fetch-depth: 1
+        persist-credentials: false
+
     - name: Configure runner-local paths
       run: |
         {
@@ -261,10 +277,12 @@ jobs:
       continue-on-error: true
       env:
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.web_secret_name] }}
-      run: >-
-        uv run python scripts/materialize_ci_auth.py
-        --account-slot "${{ needs.plan-live-lanes.outputs.web_account_slot }}"
-        --profile "$NOTEBOOKLM_PROFILE"
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
+          "$trusted_root/scripts/materialize_ci_auth.py" \
+          --account-slot "${{ needs.plan-live-lanes.outputs.web_account_slot }}" \
+          --profile "$NOTEBOOKLM_PROFILE"
 
     - name: Sweep stale RPC copies
       id: sweep
@@ -1045,6 +1063,14 @@ jobs:
         fetch-depth: 1
         persist-credentials: false
 
+    - name: Checkout trusted CI helpers
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.trusted_sha }}
+        path: trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}
+        fetch-depth: 1
+        persist-credentials: false
+
     - name: Configure runner-local paths
       run: echo "NOTEBOOKLM_HOME=$RUNNER_TEMP/notebooklm-home" >> "$GITHUB_ENV"
 
@@ -1085,10 +1111,12 @@ jobs:
       continue-on-error: true
       env:
         NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[needs.plan-live-lanes.outputs.android_secret_name] }}
-      run: >-
-        uv run python scripts/materialize_ci_auth.py
-        --account-slot "${{ needs.plan-live-lanes.outputs.android_account_slot }}"
-        --profile "$NOTEBOOKLM_PROFILE"
+      run: |
+        trusted_root="$GITHUB_WORKSPACE/trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}"
+        PYTHONPATH="$trusted_root/src" uv run --no-sync python \
+          "$trusted_root/scripts/materialize_ci_auth.py" \
+          --account-slot "${{ needs.plan-live-lanes.outputs.android_account_slot }}" \
+          --profile "$NOTEBOOKLM_PROFILE"
 
     - name: Validate immutable template through Android
       id: template_validate

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
+      qualification_pr:
+        description: 'Open same-repository PR to qualify (dispatch this workflow on main)'
+        required: false
+        type: string
+        default: ''
       account_rotation_base:
         description: 'Account-rotation base; lane offsets still apply'
         required: true
@@ -20,6 +25,9 @@ jobs:
   resolve-target:
     runs-on: ubuntu-latest
     if: github.repository == 'teng-lin/notebooklm-py'
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       branch: ${{ steps.resolve.outputs.branch }}
       is_standard: ${{ steps.resolve.outputs.is_standard }}
@@ -28,27 +36,92 @@ jobs:
       - name: Resolve trusted target
         id: resolve
         env:
+          CANONICAL_REPOSITORY: teng-lin/notebooklm-py
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_ACTOR_VALUE: ${{ github.actor }}
           GITHUB_REF_VALUE: ${{ github.ref }}
+          GITHUB_TRIGGERING_ACTOR_VALUE: ${{ github.triggering_actor }}
+          GH_TOKEN: ${{ github.token }}
+          QUALIFICATION_PR: ${{ inputs.qualification_pr }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          echo "branch=main" >> "$GITHUB_OUTPUT"
-          if [ "$GITHUB_REF_VALUE" = refs/heads/main ]; then
-            echo "is_standard=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ "$GITHUB_REF_VALUE" != refs/heads/main ]; then
             echo "is_standard=false" >> "$GITHUB_OUTPUT"
-            echo "::error::Authenticated RPC health accepts only refs/heads/main"
+            echo "::error::Dispatch the trusted RPC health workflow on main"
             exit 1
           fi
+
+          if [ -z "$QUALIFICATION_PR" ]; then
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=refs/heads/main" >> "$GITHUB_OUTPUT"
+            echo "expected_sha=" >> "$GITHUB_OUTPUT"
+            echo "is_standard=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" != workflow_dispatch ]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::PR qualification is available only through workflow_dispatch"
+            exit 1
+          fi
+          if [ "$GITHUB_ACTOR_VALUE" != teng-lin ] || \
+             [ "$GITHUB_TRIGGERING_ACTOR_VALUE" != teng-lin ]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Only the repository owner may authorize live PR qualification"
+            exit 1
+          fi
+          if [ "$RUN_ATTEMPT" != 1 ]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::PR qualification cannot be rerun; dispatch a fresh run to pin its head"
+            exit 1
+          fi
+          if ! [[ "$QUALIFICATION_PR" =~ ^[1-9][0-9]*$ ]]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::qualification_pr must be a positive PR number"
+            exit 1
+          fi
+
+          pr_fields=$(gh api "repos/$CANONICAL_REPOSITORY/pulls/$QUALIFICATION_PR" \
+            --jq '[.state, .base.repo.full_name, .base.ref, .head.repo.full_name, .head.sha] | @tsv')
+          IFS=$'\t' read -r state base_repo base_ref head_repo head_sha <<< "$pr_fields"
+          if [ "$state" != open ] || [ "$base_repo" != "$CANONICAL_REPOSITORY" ] || \
+             [ "$base_ref" != main ] || [ "$head_repo" != "$CANONICAL_REPOSITORY" ]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Qualification requires an open, same-repository PR targeting main"
+            exit 1
+          fi
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "is_standard=false" >> "$GITHUB_OUTPUT"
+            echo "::error::GitHub returned an invalid PR head SHA"
+            exit 1
+          fi
+          echo "branch=pr-$QUALIFICATION_PR" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "is_standard=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         if: steps.resolve.outputs.is_standard == 'true'
         with:
-          ref: refs/heads/main
+          ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 1
           persist-credentials: false
       - name: Resolve immutable commit
         id: target
         if: steps.resolve.outputs.is_standard == 'true'
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          EXPECTED_SHA: ${{ steps.resolve.outputs.expected_sha }}
+          TARGET_LABEL: ${{ steps.resolve.outputs.branch }}
+        run: |
+          set -euo pipefail
+          actual_sha=$(git rev-parse HEAD)
+          if [ -n "$EXPECTED_SHA" ] && [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::Checked-out commit does not match the authorized PR head SHA"
+            exit 1
+          fi
+          echo "sha=$actual_sha" >> "$GITHUB_OUTPUT"
+          printf '### Live target\n\nTarget: `%s@%s`\n' \
+            "$TARGET_LABEL" "$actual_sha" >> "$GITHUB_STEP_SUMMARY"
 
   plan-live-lanes:
     needs: resolve-target
@@ -957,10 +1030,10 @@ jobs:
       cancel-in-progress: false
     # Explicit: a red canary must surface as a red job, never be absorbed.
     continue-on-error: false
-    # Same unconditional environment binding as ``health-check`` (#1009);
-    # a feature-branch workflow_dispatch never reaches this job because of
-    # the ``is_standard`` gate above. See docs/development.md → "Workflow
-    # secret gates".
+    # Same unconditional environment binding as ``health-check`` (#1009).
+    # Direct feature-ref dispatches stay blocked; only an owner-authorized PR
+    # SHA resolved by the trusted main workflow can reach this job. See
+    # docs/development.md → "Workflow secret gates".
     environment: protected-readonly
     env:
       NOTEBOOKLM_PROFILE: ci-${{ needs.plan-live-lanes.outputs.android_account_slot }}-rpc-health-android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-merge live CI qualification.** The repository owner can dispatch RPC health or nightly
   E2E from the trusted `main` workflow against the immutable head SHA of an open, same-repository
   PR targeting `main`. Forks, non-owner dispatches, and direct feature-ref dispatches remain
-  blocked from protected credentials. Nightly dispatches can also select only the full Web,
-  Android, or read-only live lane.
+  blocked from protected credentials, while account selection and raw-token materialization remain
+  pinned to trusted `main` code. Nightly dispatches can also select only the full Web, Android, or
+  read-only live lane.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   E2E from the trusted `main` workflow against the immutable head SHA of an open, same-repository
   PR targeting `main`. Forks, non-owner dispatches, and direct feature-ref dispatches remain
   blocked from protected credentials, while account selection and raw-token materialization remain
-  pinned to trusted `main` code. Nightly dispatches can also select only the full Web, Android, or
-  read-only live lane.
+  pinned to trusted `main` code and a trusted lockfile-built environment before candidate
+  dependencies execute. Nightly dispatches can also select only the full Web, Android, or read-only
+  live lane.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pre-merge live CI qualification.** The repository owner can dispatch RPC health or nightly
+  E2E from the trusted `main` workflow against the immutable head SHA of an open, same-repository
+  PR targeting `main`. Forks, non-owner dispatches, and direct feature-ref dispatches remain
+  blocked from protected credentials. Nightly dispatches can also select only the full Web,
+  Android, or read-only live lane.
+
 ### Fixed
 
 - **Nightly E2E and RPC health template validation.** The disposable-copy contract now matches

--- a/docs/development.md
+++ b/docs/development.md
@@ -1467,8 +1467,8 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `test.yml` | Push/PR | Reduced 7-cell compatibility matrix (Ubuntu × Python 3.10–3.14, plus macOS/Windows on 3.12), linting, type checking |
-| `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Full compatibility/coverage plus managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E; the full Web lane settles its generation journal before cleanup |
-| `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on a disposable fallback copy plus the template-read-only [Android gRPC canary](#android-grpc-canary) |
+| `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Full compatibility/coverage plus managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E; an owner may qualify an open same-repository PR at its pinned head SHA |
+| `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on a disposable fallback copy plus the template-read-only [Android gRPC canary](#android-grpc-canary); an owner may qualify an open same-repository PR at its pinned head SHA |
 | `testpypi-publish.yml` | Manual dispatch | Publish to TestPyPI |
 | `verify-package.yml` | Manual dispatch on `main` | Verify TestPyPI or PyPI install plus managed-copy E2E; artifact inventory is advisory |
 | `publish.yml` | Tag push | Publish to PyPI |
@@ -1608,6 +1608,30 @@ generation notebook are no longer part of CI.
 An unfiltered nightly run includes all three live lanes. A manual dispatch with
 `test_filter` runs the requested node only on the two full lanes and omits the Windows
 read-only lane, because an arbitrary node ID is not guaranteed to carry the `readonly` marker.
+The `e2e_lane` input can instead select only `web`, `android`, or `readonly`; `web` means the
+full Web/Ubuntu lane, while `all` preserves the scheduled matrix.
+
+To qualify code before merge, dispatch the workflow definition on `main` and pass the open PR
+number. Do **not** select the feature branch in the Actions ref picker. The resolver permits this
+mode only for actor `teng-lin`, verifies that the PR is open, targets `main`, and has a head branch
+inside `teng-lin/notebooklm-py`, then pins and verifies the returned 40-character head SHA. Fork
+PRs are deliberately ineligible because the candidate code runs with the protected live account.
+PR qualification reruns are rejected; use a fresh dispatch so a moved PR head is authorized again:
+
+```bash
+# Run both RPC backends against the PR head.
+gh workflow run rpc-health.yml --ref main \
+  -f qualification_pr=2353 -f account_rotation_base=auto
+
+# If RPC passes, run only the full Web E2E lane against the same PR.
+gh workflow run nightly.yml --ref main \
+  -f qualification_pr=2353 -f e2e_lane=web \
+  -f account_rotation_base=auto -f run_compatibility=false
+```
+
+Before merging, compare the run summary's resolved SHA with
+`gh pr view 2353 --json headRefOid`. Pushes to the PR after dispatch are not included; dispatch
+again to qualify the new head.
 
 #### Operations runbooks
 
@@ -1639,14 +1663,15 @@ Every generic workflow secret is protected by an approved Environment or an
 allowlisted actor/ref gate. Pool credentials are stricter: every live job must
 simultaneously bind literal `environment: protected-readonly`, test
 `github.repository == 'teng-lin/notebooklm-py'`, and consume
-`needs.resolve-target.outputs.is_standard == 'true'`. The resolver accepts only
-`refs/heads/main`, publishes its immutable SHA, and every planner and
-secret-bearing checkout uses that SHA.
+`needs.resolve-target.outputs.is_standard == 'true'`. The resolver accepts a normal
+`refs/heads/main` run or an owner-authorized open same-repository PR requested from the trusted
+`main` workflow, publishes the immutable resolved SHA, and every planner and secret-bearing
+checkout uses that SHA.
 
 | Gate | Where | Mechanism |
 |------|-------|-----------|
 | `environment: protected-readonly` | Job-level | GitHub Environment hosting the canonical secret values. Bind it **unconditionally** (`environment: protected-readonly`) so every trigger — scheduled `cron` and `workflow_dispatch` alike — sees the same secret. **Note:** the earlier conditional form (`${{ github.event_name == 'workflow_dispatch' && 'protected-readonly' \|\| '' }}`) silently broke scheduled crons once the secrets stopped existing at repo level (issue #1009); the same env binding is now the single source of truth. If you want to block `workflow_dispatch` behind manual approval, add a **required reviewers** rule on the environment — but be aware scheduled runs will then queue at the same gate. |
-| `needs.resolve-target.outputs.is_standard == 'true'` plus canonical repository equality | Job-level `if:` | Pool jobs accept only a resolved `refs/heads/main`; releases, tags, and feature refs cannot reach the Environment job. |
+| `needs.resolve-target.outputs.is_standard == 'true'` plus canonical repository equality | Job-level `if:` | Pool jobs accept normal `main`, or the exact head SHA of an open same-repository PR explicitly authorized by the owner through a `main` workflow dispatch. Direct release, tag, feature-ref, fork, and non-owner dispatches cannot reach the Environment job. |
 | `github.event.sender.login == 'teng-lin'` | Job-level `if:` | Pin webhook-triggered workflows (e.g. `claude.yml`) to a specific maintainer actor. Any other actor's trigger never reaches the secret-bearing steps. |
 
 `scripts/check_workflow_secret_gates.py` (wired into the `test.yml` quality job)
@@ -1712,8 +1737,9 @@ their own.
 6. **Smoke-test the gate.** Dispatch one of the workflows above on `main` and
    verify the live job records a `protected-readonly` deployment. If required
    reviewers are configured, also confirm it pauses at "Waiting for review".
-   Dispatching a feature/tag ref must stop in `resolve-target` before any
-   Environment job is created. Do not enable the pool until both checks pass.
+   Dispatching a feature/tag ref directly must stop in `resolve-target` before any Environment job
+   is created. The only feature-code exception is a valid `qualification_pr` supplied while
+   dispatching the trusted workflow on `main`. Do not enable the pool until both checks pass.
 
 For automation-driven setup (e.g. infrastructure-as-code), the same configuration
 can be applied via the GitHub REST API:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1633,6 +1633,12 @@ Before merging, compare the run summary's resolved SHA with
 `gh pr view 2353 --json headRefOid`. Pushes to the PR after dispatch are not included; dispatch
 again to qualify the new head.
 
+The account planner and raw master-token consumer always execute from the immutable `main` SHA
+that supplied the workflow, not from the candidate checkout. This keeps slot-to-secret mapping and
+credential materialization outside PR control. Candidate code receives only the selected account's
+materialized profile, which is still a privileged credential: review the exact pinned diff before
+authorizing the dispatch.
+
 #### Operations runbooks
 
 - Disable a failing slot by removing it from `NOTEBOOKLM_CI_ACCOUNT_SLOTS`;

--- a/scripts/check_workflow_secret_gates.py
+++ b/scripts/check_workflow_secret_gates.py
@@ -171,8 +171,8 @@ _FLOW_STYLE_ENV_RE = re.compile(r"^\s*(?:-\s+)?(?:\{.*)?(?:env|['\"]env['\"])\s*
 # literal value so an inverted guard is rejected (C-CODEX-3 fix).
 #
 # Tokens:
-#   * ``needs.<job>.outputs.is_standard == 'true'`` — branch-class pin
-#     (live workflows' ``resolve-target`` job sets this only for exact main).
+#   * ``needs.<job>.outputs.is_standard == 'true'`` — trusted-target pin
+#     (live resolvers publish an immutable main or owner-authorized PR SHA).
 #   * ``github.event.sender.login == '<actor>'`` /
 #     ``github.actor == '<actor>'`` — actor pin (claude.yml's
 #     load-bearing security check).

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -87,7 +87,12 @@ def test_live_workflows_resolve_trusted_targets_before_planning_or_secrets() -> 
         assert "secrets." not in str(planner)
         assert "secrets[" not in str(planner)
         checkout = next(step for step in _steps(planner) if "checkout@" in str(step.get("uses")))
-        assert checkout["with"]["ref"] == "${{ needs.resolve-target.outputs.sha }}"
+        expected_ref = (
+            "${{ needs.resolve-target.outputs.sha }}"
+            if name == "verify-package.yml"
+            else "${{ needs.resolve-target.outputs.trusted_sha }}"
+        )
+        assert checkout["with"]["ref"] == expected_ref
 
 
 @pytest.mark.parametrize("name", LIVE_NAMES)
@@ -123,6 +128,7 @@ def test_trusted_target_shell_defaults_to_main_and_rejects_other_workflow_refs(
             "EVENT_NAME": event_name,
             "GITHUB_ACTOR_VALUE": "teng-lin",
             "GITHUB_REF_VALUE": ref,
+            "GITHUB_SHA_VALUE": "b" * 40,
             "GITHUB_OUTPUT": str(output),
             "QUALIFICATION_PR": "",
         },
@@ -159,6 +165,7 @@ def test_owner_can_pin_an_open_same_repo_main_pr_for_live_qualification(
             "EVENT_NAME": "workflow_dispatch",
             "GITHUB_ACTOR_VALUE": "teng-lin",
             "GITHUB_REF_VALUE": "refs/heads/main",
+            "GITHUB_SHA_VALUE": "b" * 40,
             "GITHUB_TRIGGERING_ACTOR_VALUE": "teng-lin",
             "GITHUB_OUTPUT": str(output),
             "GH_STUB_FIELDS": (
@@ -180,6 +187,7 @@ def test_owner_can_pin_an_open_same_repo_main_pr_for_live_qualification(
         "checkout_ref": sha,
         "expected_sha": sha,
         "is_standard": "true",
+        "trusted_sha": "b" * 40,
     }
 
 
@@ -250,6 +258,7 @@ def test_live_pr_qualification_rejects_untrusted_candidates(
             "EVENT_NAME": "workflow_dispatch",
             "GITHUB_ACTOR_VALUE": actor,
             "GITHUB_REF_VALUE": "refs/heads/main",
+            "GITHUB_SHA_VALUE": "b" * 40,
             "GITHUB_TRIGGERING_ACTOR_VALUE": triggering_actor,
             "GITHUB_OUTPUT": str(output),
             "GH_STUB_FIELDS": fields,
@@ -265,6 +274,42 @@ def test_live_pr_qualification_rejects_untrusted_candidates(
         if "=" in line
     )
     assert values["is_standard"] == "false"
+
+
+def test_pr_qualification_keeps_account_selection_and_raw_token_consumer_trusted() -> None:
+    workflows = (_load("nightly.yml"), _load("rpc-health.yml"))
+    for workflow in workflows:
+        planner = workflow["jobs"]["plan-live-lanes"]
+        planner_checkout = next(
+            step for step in _steps(planner) if "checkout@" in str(step.get("uses"))
+        )
+        assert planner_checkout["with"]["ref"] == (
+            "${{ needs.resolve-target.outputs.trusted_sha }}"
+        )
+
+    live_jobs = (
+        workflows[0]["jobs"]["e2e"],
+        workflows[1]["jobs"]["health-check"],
+        workflows[1]["jobs"]["android-grpc-health"],
+    )
+    for job in live_jobs:
+        trusted_checkout = next(
+            step for step in _steps(job) if step.get("name") == "Checkout trusted CI helpers"
+        )
+        assert trusted_checkout["with"] == {
+            "ref": "${{ needs.resolve-target.outputs.trusted_sha }}",
+            "path": "trusted-ci-${{ github.run_id }}-${{ github.run_attempt }}",
+            "fetch-depth": 1,
+            "persist-credentials": False,
+        }
+        auth = next(
+            step for step in _steps(job) if step.get("name") == "Materialize selected account"
+        )
+        auth_run = str(auth["run"])
+        assert 'PYTHONPATH="$trusted_root/src"' in auth_run
+        assert "uv run --no-sync python" in auth_run
+        assert '"$trusted_root/scripts/materialize_ci_auth.py"' in auth_run
+        assert "uv run python scripts/materialize_ci_auth.py" not in auth_run
 
 
 def test_secret_bearing_jobs_have_both_literal_gates_and_exact_sha_checkout() -> None:

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -54,7 +54,7 @@ def test_manifest_paths_use_a_store_owned_private_child_directory() -> None:
         assert "CI_E2E_MANIFEST=$RUNNER_TEMP/notebooklm-e2e/manifest.json" in str(configure["run"])
 
 
-def test_live_workflows_resolve_only_main_before_planning_or_secrets() -> None:
+def test_live_workflows_resolve_trusted_targets_before_planning_or_secrets() -> None:
     for name in LIVE_NAMES:
         workflow = _load(name)
         resolver = workflow["jobs"]["resolve-target"]
@@ -63,6 +63,24 @@ def test_live_workflows_resolve_only_main_before_planning_or_secrets() -> None:
         assert "release/" not in resolver_text
         assert "secrets." not in resolver_text
         assert "secrets[" not in resolver_text
+        if name != "verify-package.yml":
+            assert workflow["permissions"] == {"contents": "read"}
+            assert resolver["permissions"] == {
+                "contents": "read",
+                "pull-requests": "read",
+            }
+            assert "qualification_pr" in resolver_text
+            assert "github.actor" in resolver_text
+            assert "github.triggering_actor" in resolver_text
+            assert "github.run_attempt" in resolver_text
+            assert "same-repository PR targeting main" in resolver_text
+            resolver_checkout = next(
+                step for step in _steps(resolver) if "checkout@" in str(step.get("uses"))
+            )
+            assert resolver_checkout["with"]["ref"] == ("${{ steps.resolve.outputs.checkout_ref }}")
+            target = _step(resolver, "target")
+            assert target["env"]["EXPECTED_SHA"] == ("${{ steps.resolve.outputs.expected_sha }}")
+            assert 'actual_sha" != "$EXPECTED_SHA' in str(target["run"])
 
         planner_name = "plan-live-lanes" if name != "verify-package.yml" else "plan-account"
         planner = workflow["jobs"][planner_name]
@@ -83,7 +101,7 @@ def test_live_workflows_resolve_only_main_before_planning_or_secrets() -> None:
         ("workflow_dispatch", "refs/tags/v0.9.0", "false"),
     ],
 )
-def test_trusted_target_shell_accepts_only_exact_main(
+def test_trusted_target_shell_defaults_to_main_and_rejects_other_workflow_refs(
     name: str,
     event_name: str,
     ref: str,
@@ -94,7 +112,6 @@ def test_trusted_target_shell_accepts_only_exact_main(
     resolver = workflow["jobs"]["resolve-target"]
     step_id = "trust" if name == "verify-package.yml" else "resolve"
     command = str(_step(resolver, step_id)["run"])
-    assert "EVENT_NAME" not in command
     output = tmp_path / f"{name}-{event_name}-{expected}.out"
     completed = subprocess.run(
         ["bash", "-c", command],
@@ -104,8 +121,10 @@ def test_trusted_target_shell_accepts_only_exact_main(
         env={
             **os.environ,
             "EVENT_NAME": event_name,
+            "GITHUB_ACTOR_VALUE": "teng-lin",
             "GITHUB_REF_VALUE": ref,
             "GITHUB_OUTPUT": str(output),
+            "QUALIFICATION_PR": "",
         },
     )
     assert completed.returncode == (0 if expected == "true" else 1)
@@ -115,6 +134,137 @@ def test_trusted_target_shell_accepts_only_exact_main(
         if "=" in line
     )
     assert values["is_standard"] == expected
+
+
+@pytest.mark.parametrize("name", ("nightly.yml", "rpc-health.yml"))
+def test_owner_can_pin_an_open_same_repo_main_pr_for_live_qualification(
+    name: str,
+    tmp_path: Path,
+) -> None:
+    workflow = _load(name)
+    command = str(_step(workflow["jobs"]["resolve-target"], "resolve")["run"])
+    output = tmp_path / f"{name}-pr.out"
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$GH_STUB_FIELDS"\n', encoding="utf-8")
+    fake_gh.chmod(0o755)
+    sha = "a" * 40
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CANONICAL_REPOSITORY": "teng-lin/notebooklm-py",
+            "EVENT_NAME": "workflow_dispatch",
+            "GITHUB_ACTOR_VALUE": "teng-lin",
+            "GITHUB_REF_VALUE": "refs/heads/main",
+            "GITHUB_TRIGGERING_ACTOR_VALUE": "teng-lin",
+            "GITHUB_OUTPUT": str(output),
+            "GH_STUB_FIELDS": (
+                f"open\tteng-lin/notebooklm-py\tmain\tteng-lin/notebooklm-py\t{sha}"
+            ),
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "QUALIFICATION_PR": "2353",
+            "RUN_ATTEMPT": "1",
+        },
+    )
+    assert completed.returncode == 0, completed.stderr
+    values = dict(
+        line.split("=", 1)
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    assert values == {
+        "branch": "pr-2353",
+        "checkout_ref": sha,
+        "expected_sha": sha,
+        "is_standard": "true",
+    }
+
+
+@pytest.mark.parametrize("name", ("nightly.yml", "rpc-health.yml"))
+@pytest.mark.parametrize(
+    ("actor", "triggering_actor", "run_attempt", "fields"),
+    [
+        (
+            "another-maintainer",
+            "another-maintainer",
+            "1",
+            f"open\tteng-lin/notebooklm-py\tmain\tteng-lin/notebooklm-py\t{'a' * 40}",
+        ),
+        (
+            "teng-lin",
+            "another-maintainer",
+            "1",
+            f"open\tteng-lin/notebooklm-py\tmain\tteng-lin/notebooklm-py\t{'a' * 40}",
+        ),
+        (
+            "teng-lin",
+            "teng-lin",
+            "2",
+            f"open\tteng-lin/notebooklm-py\tmain\tteng-lin/notebooklm-py\t{'a' * 40}",
+        ),
+        (
+            "teng-lin",
+            "teng-lin",
+            "1",
+            f"open\tteng-lin/notebooklm-py\tmain\ta-contributor/notebooklm-py\t{'a' * 40}",
+        ),
+        (
+            "teng-lin",
+            "teng-lin",
+            "1",
+            f"closed\tteng-lin/notebooklm-py\tmain\tteng-lin/notebooklm-py\t{'a' * 40}",
+        ),
+        (
+            "teng-lin",
+            "teng-lin",
+            "1",
+            f"open\tteng-lin/notebooklm-py\tdevelop\tteng-lin/notebooklm-py\t{'a' * 40}",
+        ),
+    ],
+)
+def test_live_pr_qualification_rejects_untrusted_candidates(
+    name: str,
+    actor: str,
+    triggering_actor: str,
+    run_attempt: str,
+    fields: str,
+    tmp_path: Path,
+) -> None:
+    workflow = _load(name)
+    command = str(_step(workflow["jobs"]["resolve-target"], "resolve")["run"])
+    output = tmp_path / f"{name}-rejected-pr.out"
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$GH_STUB_FIELDS"\n', encoding="utf-8")
+    fake_gh.chmod(0o755)
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CANONICAL_REPOSITORY": "teng-lin/notebooklm-py",
+            "EVENT_NAME": "workflow_dispatch",
+            "GITHUB_ACTOR_VALUE": actor,
+            "GITHUB_REF_VALUE": "refs/heads/main",
+            "GITHUB_TRIGGERING_ACTOR_VALUE": triggering_actor,
+            "GITHUB_OUTPUT": str(output),
+            "GH_STUB_FIELDS": fields,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "QUALIFICATION_PR": "2353",
+            "RUN_ATTEMPT": run_attempt,
+        },
+    )
+    assert completed.returncode == 1
+    values = dict(
+        line.split("=", 1)
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    assert values["is_standard"] == "false"
 
 
 def test_secret_bearing_jobs_have_both_literal_gates_and_exact_sha_checkout() -> None:

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -305,11 +305,24 @@ def test_pr_qualification_keeps_account_selection_and_raw_token_consumer_trusted
         auth = next(
             step for step in _steps(job) if step.get("name") == "Materialize selected account"
         )
+        trusted_install = next(
+            step for step in _steps(job) if step.get("name") == "Install trusted auth environment"
+        )
+        trusted_install_run = str(trusted_install["run"])
+        assert 'cd "$trusted_root"' in trusted_install_run
+        assert "uv sync --frozen --extra headless --no-dev" in trusted_install_run
         auth_run = str(auth["run"])
         assert 'PYTHONPATH="$trusted_root/src"' in auth_run
-        assert "uv run --no-sync python" in auth_run
-        assert '"$trusted_root/scripts/materialize_ci_auth.py"' in auth_run
+        assert 'cd "$trusted_root"' in auth_run
+        assert "uv run --frozen --no-sync python" in auth_run
+        assert "scripts/materialize_ci_auth.py" in auth_run
         assert "uv run python scripts/materialize_ci_auth.py" not in auth_run
+        steps = _steps(job)
+        assert steps.index(trusted_install) < steps.index(auth)
+        candidate_install = next(
+            step for step in steps if step.get("name") == "Install dependencies"
+        )
+        assert steps.index(auth) < steps.index(candidate_install)
 
 
 def test_secret_bearing_jobs_have_both_literal_gates_and_exact_sha_checkout() -> None:

--- a/tests/unit/test_ci_test_matrix.py
+++ b/tests/unit/test_ci_test_matrix.py
@@ -345,7 +345,7 @@ def test_nightly_coverage_is_sha_pinned_secret_free_and_enforces_floors() -> Non
         if str(step.get("uses", "")).startswith("actions/checkout@")
     )
     assert resolve_checkout["with"] == {
-        "ref": "refs/heads/main",
+        "ref": "${{ steps.resolve.outputs.checkout_ref }}",
         "fetch-depth": 1,
         "persist-credentials": False,
     }
@@ -448,7 +448,15 @@ def test_nightly_e2e_maps_backends_and_suites_to_designated_runners() -> None:
     assert planner_run.count('"mode": "full"') == 2
     assert planner_run.count('"mode": "readonly"') == 1
     assert '"selection": "readonly and not variants"' in planner_run
-    assert 'if not os.environ["TEST_FILTER"]' in planner_run
+    assert 'selected_lane in {"all", "web"}' in planner_run
+    assert 'selected_lane in {"all", "android"}' in planner_run
+    assert 'selected_lane in {"all", "readonly"} and not test_filter' in planner_run
+
+    triggers = workflow.get("on", workflow.get(True))
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["qualification_pr"]["type"] == "string"
+    assert inputs["qualification_pr"]["default"] == ""
+    assert inputs["e2e_lane"]["options"] == ["all", "web", "android", "readonly"]
 
     install = str(_step(job, "Install dependencies")["run"])
     assert "uv sync --frozen" in install


### PR DESCRIPTION
## Summary

- add an owner-gated qualification_pr input to RPC Health Check and Nightly E2E
- resolve only open same-repository PRs targeting main, then pin and verify the immutable head SHA
- reject forks, non-owner triggers, direct feature-ref dispatches, and reruns
- add a nightly e2e_lane selector for Web-only, Android-only, or read-only qualification
- document the RPC-first, Web-E2E-second runbook

## Security boundary

The workflow definition and Environment deployment ref remain on main. Candidate code receives the selected protected live account only after teng-lin explicitly dispatches a fresh run for its PR number.

## Validation

- uv run pytest -m repo_lint -q --no-cov (2188 passed, 8 skipped, 1 xfailed)
- uv run pytest tests/unit/test_ci_account_pool_workflows.py tests/unit/test_ci_test_matrix.py -q --no-cov
- uv run python scripts/check_workflow_secret_gates.py
- uv run python scripts/check_workflow_permissions.py
- uv run python scripts/check_action_pinning.py
- uv run ruff check tests/unit/test_ci_account_pool_workflows.py scripts/check_workflow_secret_gates.py

## Bootstrap note

This PR cannot qualify itself with the new input because GitHub must first have the trusted workflow version on main. Once merged, later PRs can be qualified before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added owner-authorized live CI qualification for open, same-repository pull requests targeting `main`.
  - Nightly E2E runs can select Web, Android, read-only, or all lanes.
  - Live runs verify the selected pull request’s immutable commit before execution.

- **Bug Fixes**
  - Improved validation for unauthorized actors, forks, closed pull requests, non-`main` targets, and invalid workflow contexts.
  - CI account selection and credential materialization now use trusted, pinned workflow code and dependencies.

- **Documentation**
  - Updated changelog and development documentation with qualification procedures, lane options, and security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->