### PR TITLE
fix(ci): match public template artifact inventory

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -539,7 +539,7 @@ jobs:
             raise RuntimeError("manifest summary metadata mismatch")
         copies = manifest.get("copies")
         roles = {
-            "full": ("reference", "generation", "multi-source"),
+            "full": ("reference", "generation"),
             "readonly": ("reference",),
         }[expected["mode"]]
         if not isinstance(copies, list) or len(copies) != len(roles):
@@ -563,7 +563,7 @@ jobs:
             "- Reference checks: seeded_notes=1 history=passed",
         ]
         if expected["mode"] == "full":
-            lines.append("- Clean-role residuals: generation=0 multi-source=0")
+            lines.append("- Clean workspace residuals: generation/multi-source=0")
         with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as stream:
             stream.write("\n".join(lines) + "\n")
         PY

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -250,10 +250,10 @@ jobs:
         if any(manifest.get(key) != value for key, value in expected.items()):
             raise RuntimeError("manifest summary metadata mismatch")
         copies = manifest.get("copies")
-        if not isinstance(copies, list) or len(copies) != 3:
+        if not isinstance(copies, list) or len(copies) != 2:
             raise RuntimeError("manifest summary role count mismatch")
         rows = {row.get("role"): row for row in copies if isinstance(row, dict)}
-        roles = ("reference", "generation", "multi-source")
+        roles = ("reference", "generation")
         if set(rows) != set(roles):
             raise RuntimeError("manifest summary roles mismatch")
         if any(row.get("status") not in {"confirmed", "reconciled"} for row in rows.values()):
@@ -268,9 +268,9 @@ jobs:
             "### Prepared package roles",
             f"- Lane/backend/slot: verify-package / web / {expected['account_slot']}",
             f"- Template contract: version=1 fingerprint={fingerprint}",
-            f"- Copy outcomes: total=3 confirmed={outcomes['confirmed']} reconciled={outcomes['reconciled']}",
+            f"- Copy outcomes: total=2 confirmed={outcomes['confirmed']} reconciled={outcomes['reconciled']}",
             "- Reference checks: seeded_notes=1 history=passed",
-            "- Clean-role residuals: generation=0 multi-source=0",
+            "- Clean workspace residuals: generation/multi-source=0",
         ]
         with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as stream:
             stream.write("\n".join(lines) + "\n")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for ready sources before removing inherited artifacts. The lifecycle manager also uses the
   public notebook as its default when no template override is configured. A close-time transport
   failure after a one-shot lifecycle command has completed is now reported as a warning instead of
-  reversing the command's successful result.
+  reversing the command's successful result. Read-only download checks now distinguish completed
+  artifact inventory from an actually downloadable asset, since public copies omit asset URLs.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Nightly E2E and RPC health template validation.** The disposable-copy contract now matches
-  the immutable public template title, allowing provisioning to proceed in the scheduled Web and
-  Android lanes. The lifecycle manager also uses the public notebook as its default when no
-  template override is configured.
+  the immutable public template title and its cross-backend copied artifact inventory, allowing
+  provisioning to proceed in the scheduled Web and Android lanes. Legacy quiz/flashcard rows that
+  Web cannot classify and absent optional artifact families no longer block provisioning; full E2E
+  still generates those families on disposable notebooks. The lifecycle manager also uses the
+  public notebook as its default when no template override is configured.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the immutable public template title and its cross-backend copied artifact inventory, allowing
   provisioning to proceed in the scheduled Web and Android lanes. Legacy quiz/flashcard rows that
   Web cannot classify and absent optional artifact families no longer block provisioning; full E2E
-  still generates those families on disposable notebooks. The lifecycle manager also uses the
+  still generates those families on disposable notebooks. Reference copies are polled for up to
+  ten minutes while inherited sources and artifacts finish processing; clean-role copies wait only
+  for ready sources before removing inherited artifacts. The lifecycle manager also uses the
   public notebook as its default when no template override is configured.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still generates those families on disposable notebooks. Reference copies are polled for up to
   ten minutes while inherited sources and artifacts finish processing; clean-role copies wait only
   for ready sources before removing inherited artifacts. The lifecycle manager also uses the
-  public notebook as its default when no template override is configured.
+  public notebook as its default when no template override is configured. A close-time transport
+  failure after a one-shot lifecycle command has completed is now reported as a warning instead of
+  reversing the command's successful result.
 - **MCP server: `CONNECT_TIMEOUT` on connect.** The FastMCP lifespan opened the
   `NotebookLMClient` — cookie rotation, the CSRF fetch, and the cold-recovery
   ladder when those fail — *before* answering the MCP `initialize` handshake.

--- a/docs/development.md
+++ b/docs/development.md
@@ -814,10 +814,12 @@ can identify consistently: ready sources plus completed audio, video, infographi
 artifacts. Legacy quiz and flashcard rows in this public notebook have no Web variant metadata;
 report, data-table, and interactive mind-map artifacts are absent. Those optional read-only checks
 skip when unavailable, while the full E2E lanes generate and exercise every family on disposable
-notebooks. Copying is asynchronous: provisioning polls the copied source and artifact states for up
-to ten minutes before treating a missing required family on the read-only reference copy as a
-contract failure. Generation, multi-source, and RPC copies wait only for ready sources because
-their inherited artifacts are immediately removed. The checked-in template shape is
+notebooks. Copying is asynchronous: provisioning dispatches every physical copy first, then polls
+each copied source and artifact state for up to ten minutes before preparation. Full lanes use a
+stable reference copy plus one clean mutable workspace shared by generation and multi-source
+tests; RPC health uses one clean fallback copy. Waiting for inherited artifacts before deletion is
+required because artifact propagation can lag behind the initial copy response. The checked-in
+template shape is
 `tests/fixtures/e2e_template_contract.json`. Notes and chat history are deliberately absent from
 that contract. Provisioning creates and validates those on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.
@@ -853,9 +855,10 @@ uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
   --manifest "$RUNNER_TEMP/notebooklm-e2e.json"
 ```
 
-Cleanup is mandatory even when validation or pytest fails. Managed full mode publishes three
-distinct role IDs (`reference`, `generation`, and `multi-source`); managed read-only mode publishes
-only `reference`. Both publish the activation flag last. With that flag present, pytest never
+Cleanup is mandatory even when validation or pytest fails. Managed full mode publishes two
+physical IDs: a distinct `reference` ID and one mutable ID bound to both `generation` and
+`multi-source`; managed read-only mode publishes only `reference`. Both publish the activation flag
+last. With that flag present, pytest never
 consults profile cache files, creates a role notebook, cleans copied children on first use, or
 deletes a workflow-owned copy during teardown. `temp_notebook` and other function-level CRUD
 fixtures retain their existing lifecycle.
@@ -1533,16 +1536,17 @@ baseline by hand, not something the canary fixes.
 
 Canonical CI never points pytest or full RPC health at the immutable template.
 Each authenticated lane selects one opaque account slot, materializes only that
-slot's master token, and creates role-specific copies. Full lanes prepare
-separate `reference`, `generation`, and `multi-source` copies; Web RPC health
-uses one `rpc` fallback copy. The Android RPC canary is the only lane that reads
-the template directly, and it performs no notebook mutation.
+slot's master token, and creates workload-isolated copies. Full lanes prepare a
+stable `reference` copy plus one mutable copy shared by `generation` and
+`multi-source`; Web RPC health uses one `rpc` fallback copy. The Android RPC
+canary is the only lane that reads the template directly, and it performs no
+notebook mutation.
 
 The contracts are checked in at `tests/fixtures/e2e_template_contract.json` and
 `tests/fixtures/e2e_prepared_role_contract.json`. Provisioning seeds the
 reference copy's note and persisted Q&A, removes inherited writable children
-from the other roles, and publishes the managed fixture bindings only after all
-roles pass. Cleanup runs under `always()` after verification, while the next
+from the mutable workspace, and publishes the managed fixture bindings only
+after both workspaces pass. Cleanup runs under `always()` after verification, while the next
 selected run also sweeps owned, reserved-prefix copies older than 24 hours.
 
 For a local managed-copy run, use an isolated profile and runner-style scratch

--- a/docs/development.md
+++ b/docs/development.md
@@ -814,9 +814,12 @@ can identify consistently: ready sources plus completed audio, video, infographi
 artifacts. Legacy quiz and flashcard rows in this public notebook have no Web variant metadata;
 report, data-table, and interactive mind-map artifacts are absent. Those optional read-only checks
 skip when unavailable, while the full E2E lanes generate and exercise every family on disposable
-notebooks. The checked-in template shape is `tests/fixtures/e2e_template_contract.json`. Notes and
-chat history are deliberately absent from that contract. Provisioning creates and validates those
-on the disposable `reference` copy using
+notebooks. Copying is asynchronous: provisioning polls the copied source and artifact states for up
+to ten minutes before treating a missing required family on the read-only reference copy as a
+contract failure. Generation, multi-source, and RPC copies wait only for ready sources because
+their inherited artifacts are immediately removed. The checked-in template shape is
+`tests/fixtures/e2e_template_contract.json`. Notes and chat history are deliberately absent from
+that contract. Provisioning creates and validates those on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.
 The configured template is the public notebook titled
 `Make Your Writing More Powerful and Persuasive`. Its title cannot be changed; replacing the

--- a/docs/development.md
+++ b/docs/development.md
@@ -809,8 +809,12 @@ variable at `NOTEBOOKLM_CI_ACCOUNT_SLOTS=A`. Release verification must dispatch 
 and `verify-package.yml` with `--ref main`; release and feature refs cannot reach their protected
 authenticated jobs.
 
-The canonical template describes only state the copy API promises to preserve: ready sources and
-Studio artifacts. Its checked-in shape is `tests/fixtures/e2e_template_contract.json`. Notes and
+The canonical template describes only state the copy API promises to preserve and both backends
+can identify consistently: ready sources plus completed audio, video, infographic, and slide-deck
+artifacts. Legacy quiz and flashcard rows in this public notebook have no Web variant metadata;
+report, data-table, and interactive mind-map artifacts are absent. Those optional read-only checks
+skip when unavailable, while the full E2E lanes generate and exercise every family on disposable
+notebooks. The checked-in template shape is `tests/fixtures/e2e_template_contract.json`. Notes and
 chat history are deliberately absent from that contract. Provisioning creates and validates those
 on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.

--- a/scripts/_ci_e2e_notebooks.py
+++ b/scripts/_ci_e2e_notebooks.py
@@ -42,7 +42,7 @@ LANE_BACKENDS: Mapping[str, str] = {
 }
 ROLES = ("reference", "generation", "multi-source", "rpc")
 MODE_ROLES: Mapping[str, tuple[str, ...]] = {
-    "full": ("reference", "generation", "multi-source"),
+    "full": ("reference", "generation"),
     "readonly": ("reference",),
     "rpc": ("rpc",),
 }
@@ -477,7 +477,7 @@ def github_env_lines(mode: str, copies: Sequence[Mapping[str, Any]]) -> list[str
         return [
             f"NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID={ids['reference']}",
             f"NOTEBOOKLM_GENERATION_NOTEBOOK_ID={ids['generation']}",
-            f"NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID={ids['multi-source']}",
+            f"NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID={ids['generation']}",
             "NOTEBOOKLM_E2E_MANAGED_MODE=full",
             "NOTEBOOKLM_E2E_REFERENCE_PREPARED=1",
             "NOTEBOOKLM_E2E_MANAGED_COPIES=1",

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -66,6 +66,8 @@ DEFAULT_PREPARED_CONTRACT = (
     Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "e2e_prepared_role_contract.json"
 )
 _COPIED_TEMPLATE_REQUIRED_FAMILIES = frozenset({"audio", "video", "infographic", "slide_deck"})
+_COPY_SETTLE_TIMEOUT_SECONDS = 600.0
+_COPY_SETTLE_POLL_SECONDS = 10.0
 
 T = TypeVar("T")
 
@@ -454,8 +456,20 @@ class NotebookLifecycleManager:
         if _turn_has_content(turns):
             raise ContractError("prepared clean role inherited conversation state")
 
-    async def validate_template(self, *, include_title: bool = True) -> dict[str, int]:
-        """Validate immutable copied state using public typed APIs only."""
+    async def validate_template(
+        self,
+        *,
+        include_title: bool = True,
+        tolerate_incomplete: bool = False,
+        require_artifacts: bool = True,
+    ) -> dict[str, int] | None:
+        """Validate immutable copied state using public typed APIs only.
+
+        A newly copied notebook exposes its sources and artifact rows before
+        their processing states settle. ``tolerate_incomplete`` turns only
+        those content deficiencies into ``None`` so the bounded copy poller
+        can retry them; identity and title violations still fail immediately.
+        """
 
         try:
             notebook = await self._read(lambda: self.client.notebooks.get(self.template_id))
@@ -476,6 +490,7 @@ class NotebookLifecycleManager:
         sources = await self._read(lambda: self.client.sources.list(self.template_id, strict=True))
         source_contract = self.template_contract["sources"]
         ready_sources = [source for source in sources if getattr(source, "is_ready", False)]
+        incomplete: list[str] = []
         if source_contract["require_text_addressable"] is True:
             non_text_kinds = {"image", "media", "unknown"}
             text_ready = [
@@ -484,39 +499,63 @@ class NotebookLifecycleManager:
                 if _kind_value(getattr(source, "kind", None)) not in non_text_kinds
             ]
             if len(text_ready) < source_contract["minimum_ready"]:
-                raise ContractError("template has too few text-addressable ready sources")
+                incomplete.append("template has too few text-addressable ready sources")
         distinct_titles = {
             str(getattr(source, "title", "")).strip().casefold()
             for source in ready_sources
             if str(getattr(source, "title", "")).strip()
         }
         if len(ready_sources) < source_contract["minimum_ready"]:
-            raise ContractError("template has too few ready sources")
+            incomplete.append("template has too few ready sources")
         if len(distinct_titles) < source_contract["minimum_distinct_titles"]:
-            raise ContractError("template source topics are not sufficiently distinct")
+            incomplete.append("template source topics are not sufficiently distinct")
 
-        artifacts = await self._read(lambda: self.client.artifacts.list(self.template_id))
-        completed = [artifact for artifact in artifacts if _artifact_completed(artifact)]
-        families = {_kind_value(getattr(artifact, "kind", None)) for artifact in completed}
-        required = set(self.template_contract["artifacts"]["required_completed_families"])
-        missing = sorted(required - families)
-        if missing:
-            raise ContractError("template is missing completed families: " + ",".join(missing))
-        if self.template_contract["artifacts"]["require_interactive_mind_map"] and not any(
-            getattr(artifact, "is_interactive_mind_map", False) for artifact in completed
-        ):
-            raise ContractError("template is missing a completed interactive mind map")
+        completed: list[Any] = []
+        families: set[str] = set()
+        if require_artifacts:
+            artifacts = await self._read(lambda: self.client.artifacts.list(self.template_id))
+            completed = [artifact for artifact in artifacts if _artifact_completed(artifact)]
+            families = {_kind_value(getattr(artifact, "kind", None)) for artifact in completed}
+            required = set(self.template_contract["artifacts"]["required_completed_families"])
+            missing = sorted(required - families)
+            if missing:
+                incomplete.append("template is missing completed families: " + ",".join(missing))
+            if self.template_contract["artifacts"]["require_interactive_mind_map"] and not any(
+                getattr(artifact, "is_interactive_mind_map", False) for artifact in completed
+            ):
+                incomplete.append("template is missing a completed interactive mind map")
+        if incomplete:
+            if tolerate_incomplete:
+                return None
+            raise ContractError(incomplete[0])
         return {
             "ready_sources": len(ready_sources),
             "completed_artifacts": len(completed),
             "artifact_families": len(families),
         }
 
-    async def _validate_copy_shape(self, notebook_id: str) -> dict[str, int]:
+    async def _validate_copy_shape(
+        self,
+        notebook_id: str,
+        *,
+        require_artifacts: bool = True,
+    ) -> dict[str, int]:
         original = self.template_id
         self.template_id = notebook_id
         try:
-            return await self.validate_template(include_title=False)
+            deadline = self.clock() + _COPY_SETTLE_TIMEOUT_SECONDS
+            while True:
+                counts = await self.validate_template(
+                    include_title=False,
+                    tolerate_incomplete=True,
+                    require_artifacts=require_artifacts,
+                )
+                if counts is not None:
+                    return counts
+                now = self.clock()
+                if now >= deadline:
+                    raise ContractError("copied template state did not settle within ten minutes")
+                await self.sleep(min(_COPY_SETTLE_POLL_SECONDS, deadline - now))
         finally:
             self.template_id = original
 
@@ -1020,7 +1059,10 @@ class NotebookLifecycleManager:
             notebook_id = str(row["notebook_id"])
             if mask is not None:
                 mask(notebook_id)
-            await self._validate_copy_shape(notebook_id)
+            await self._validate_copy_shape(
+                notebook_id,
+                require_artifacts=role == "reference",
+            )
             if role == "reference":
                 await self.prepare_reference(notebook_id)
             else:

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -313,9 +313,9 @@ def load_prepared_contract(path: Path) -> dict[str, Any]:
             or reference["require_conversation_id"] is not True
             or reference["require_nonempty_history_pair"] is not True
             or reference["conversation_turn_limit"] != 2
-            or tuple(clean["roles"]) != ("generation", "multi-source", "rpc")
+            or tuple(clean["roles"]) != ("generation", "rpc")
             or tuple(clean["disallowed"]) != ("artifacts", "notes", "mind_maps")
-            or tuple(clean["empty_chat_roles"]) != ("multi-source", "rpc")
+            or tuple(clean["empty_chat_roles"]) != ("generation", "rpc")
             or clean["minimum_ready_sources"] < 3
             or clean["poll_interval_seconds"] != 30
             or clean["quiet_period_seconds"] != 90
@@ -1079,14 +1079,21 @@ class NotebookLifecycleManager:
             template_fingerprint=template_fingerprint,
         )
         self._persist_manifest(manifest)
+        role_ids: dict[str, str] = {}
         for role in MODE_ROLES[mode]:
             row = await self.copy_one(manifest, role)
             notebook_id = str(row["notebook_id"])
+            role_ids[role] = notebook_id
             if mask is not None:
                 mask(notebook_id)
+
+        # CopyProject returns before its asynchronous source/artifact propagation
+        # completes. Dispatch every exactly-once copy first so that propagation
+        # overlaps while the roles remain durably tracked and immediately masked.
+        for role, notebook_id in role_ids.items():
             await self._validate_copy_shape(
                 notebook_id,
-                require_artifacts=role == "reference",
+                require_artifacts=True,
             )
             if role == "reference":
                 await self.prepare_reference(notebook_id)
@@ -1401,7 +1408,7 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("--contract", type=Path, default=DEFAULT_TEMPLATE_CONTRACT)
     validate.add_argument("--prepared-contract", type=Path, default=DEFAULT_PREPARED_CONTRACT)
     validate.add_argument("--manifest", type=Path)
-    validate.add_argument("--role", choices=("reference", "generation", "multi-source", "rpc"))
+    validate.add_argument("--role", choices=("reference", "generation", "rpc"))
 
     common("cleanup")
 

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -1086,7 +1086,7 @@ class NotebookLifecycleManager:
                 mask(notebook_id)
             await self._validate_copy_shape(
                 notebook_id,
-                require_artifacts=True,
+                require_artifacts=role == "reference",
             )
             if role == "reference":
                 await self.prepare_reference(notebook_id)

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -65,6 +65,7 @@ DEFAULT_TEMPLATE_CONTRACT = (
 DEFAULT_PREPARED_CONTRACT = (
     Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "e2e_prepared_role_contract.json"
 )
+_COPIED_TEMPLATE_REQUIRED_FAMILIES = frozenset({"audio", "video", "infographic", "slide_deck"})
 
 T = TypeVar("T")
 
@@ -233,18 +234,8 @@ def load_template_contract(path: Path) -> tuple[dict[str, Any], str]:
         re.compile(contract["title_regex"])
         source = contract["sources"]
         artifacts = contract["artifacts"]
+        artifact_families = artifacts["required_completed_families"]
         content_policy = contract["content_policy"]
-        required_families = {
-            "audio",
-            "video",
-            "report",
-            "quiz",
-            "flashcards",
-            "mind_map",
-            "infographic",
-            "slide_deck",
-            "data_table",
-        }
         if (
             set(contract)
             != {
@@ -255,6 +246,7 @@ def load_template_contract(path: Path) -> tuple[dict[str, Any], str]:
                 "artifacts",
                 "content_policy",
             }
+            or contract["version"] != 1
             or set(source)
             != {"minimum_ready", "minimum_distinct_titles", "require_text_addressable"}
             or set(artifacts) != {"required_completed_families", "require_interactive_mind_map"}
@@ -264,9 +256,11 @@ def load_template_contract(path: Path) -> tuple[dict[str, Any], str]:
             or not isinstance(source["minimum_distinct_titles"], int)
             or source["minimum_distinct_titles"] < 3
             or source["require_text_addressable"] is not True
-            or artifacts["require_interactive_mind_map"] is not True
-            or not isinstance(artifacts["required_completed_families"], list)
-            or not required_families.issubset(artifacts["required_completed_families"])
+            or not isinstance(artifacts["require_interactive_mind_map"], bool)
+            or not isinstance(artifact_families, list)
+            or any(not isinstance(family, str) for family in artifact_families)
+            or len(set(artifact_families)) != len(artifact_families)
+            or not _COPIED_TEMPLATE_REQUIRED_FAMILIES.issubset(artifact_families)
             or content_policy
             != {
                 "private_personal_licensed_or_unstable_web_content_allowed": False,
@@ -508,7 +502,9 @@ class NotebookLifecycleManager:
         missing = sorted(required - families)
         if missing:
             raise ContractError("template is missing completed families: " + ",".join(missing))
-        if not any(getattr(artifact, "is_interactive_mind_map", False) for artifact in completed):
+        if self.template_contract["artifacts"]["require_interactive_mind_map"] and not any(
+            getattr(artifact, "is_interactive_mind_map", False) for artifact in completed
+        ):
             raise ContractError("template is missing a completed interactive mind map")
         return {
             "ready_sources": len(ready_sources),

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -627,7 +627,7 @@ class NotebookLifecycleManager:
             )
 
     async def prepare_clean_role(self, notebook_id: str, role: str) -> dict[str, int]:
-        """Remove inherited children and prove a 90-second stable empty inventory."""
+        """Remove settled inherited children and prove a stable empty inventory."""
 
         clean = self.prepared_contract["clean_roles"]
         if role not in clean["roles"]:
@@ -1063,7 +1063,7 @@ class NotebookLifecycleManager:
                 mask(notebook_id)
             await self._validate_copy_shape(
                 notebook_id,
-                require_artifacts=role == "reference",
+                require_artifacts=True,
             )
             if role == "reference":
                 await self.prepare_reference(notebook_id)

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -69,7 +69,8 @@ DEFAULT_PREPARED_CONTRACT = (
 )
 _COPIED_TEMPLATE_REQUIRED_FAMILIES = frozenset({"audio", "video", "infographic", "slide_deck"})
 _COPY_SETTLE_TIMEOUT_SECONDS = 600.0
-_COPY_SETTLE_POLL_SECONDS = 10.0
+_COPY_SETTLE_POLL_SECONDS = 30.0
+_COPY_SETTLE_QUOTA_BACKOFF_SECONDS = 60.0
 
 T = TypeVar("T")
 
@@ -489,6 +490,19 @@ class NotebookLifecycleManager:
                 raise ContractError("template title violates the immutable title contract")
             if re.fullmatch(str(self.template_contract["title_regex"]), title) is None:
                 raise ContractError("template title version does not match the contract")
+        return await self._validate_template_content(
+            tolerate_incomplete=tolerate_incomplete,
+            require_artifacts=require_artifacts,
+        )
+
+    async def _validate_template_content(
+        self,
+        *,
+        tolerate_incomplete: bool,
+        require_artifacts: bool,
+    ) -> dict[str, int] | None:
+        """Validate sources and artifacts without repeating notebook identity reads."""
+
         sources = await self._read(lambda: self.client.sources.list(self.template_id, strict=True))
         source_contract = self.template_contract["sources"]
         ready_sources = [source for source in sources if getattr(source, "is_ready", False)]
@@ -546,12 +560,21 @@ class NotebookLifecycleManager:
         self.template_id = notebook_id
         try:
             deadline = self.clock() + _COPY_SETTLE_TIMEOUT_SECONDS
+            notebook = await self._read(lambda: self.client.notebooks.get(notebook_id))
+            if getattr(notebook, "id", None) != notebook_id:
+                raise ContractError("template lookup returned the wrong notebook")
             while True:
-                counts = await self.validate_template(
-                    include_title=False,
-                    tolerate_incomplete=True,
-                    require_artifacts=require_artifacts,
-                )
+                try:
+                    counts = await self._validate_template_content(
+                        tolerate_incomplete=True,
+                        require_artifacts=require_artifacts,
+                    )
+                except RateLimitError:
+                    now = self.clock()
+                    if now >= deadline:
+                        raise
+                    await self.sleep(min(_COPY_SETTLE_QUOTA_BACKOFF_SECONDS, deadline - now))
+                    continue
                 if counts is not None:
                     return counts
                 now = self.clock()

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -19,12 +19,14 @@ import secrets
 import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, TypeVar
 
+import httpx
 from _ci_e2e_notebooks import (
     ACCOUNT_SLOTS,
     BACKENDS,
@@ -1279,6 +1281,56 @@ def _runner_temp() -> Path | None:
     return Path(value) if value else None
 
 
+def _is_transient_close_error(exc: Exception) -> bool:
+    """Identify close-only auth and transport failures safe to demote in CI."""
+
+    if isinstance(exc, (AuthError, NetworkError, RateLimitError, ServerError)):
+        return True
+    if isinstance(exc, httpx.TransportError):
+        return True
+    return isinstance(exc, httpx.HTTPStatusError) and (
+        exc.response.status_code in {408, 425, 429} or exc.response.status_code >= 500
+    )
+
+
+@asynccontextmanager
+async def _ci_client(*, backend: str) -> Any:
+    """Keep a completed one-shot lifecycle command successful if close is transient."""
+
+    context = NotebookLMClient.from_storage(
+        backend=backend,
+        rate_limit_max_retries=0,
+        server_error_max_retries=0,
+    )
+    client = await context.__aenter__()
+    body_error: BaseException | None = None
+    try:
+        yield client
+    except BaseException as exc:
+        body_error = exc
+        raise
+    finally:
+        try:
+            await context.__aexit__(
+                type(body_error) if body_error is not None else None,
+                body_error,
+                body_error.__traceback__ if body_error is not None else None,
+            )
+        except Exception as exc:
+            if not _is_transient_close_error(exc):
+                raise
+            # These commands run in short-lived CI processes.  Their durable
+            # work is already complete here, so a late transport/auth-refresh
+            # failure during teardown must not reverse that outcome. Unknown
+            # close bugs, process exits, and task cancellation remain fatal.
+            outcome = "completed" if body_error is None else "failed"
+            print(
+                f"::warning::client close failed after lifecycle command {outcome} "
+                f"({_safe_exception_name(exc)})",
+                file=sys.stderr,
+            )
+
+
 def _metadata() -> tuple[str, str, str]:
     """Read trusted lifecycle identity only from the GitHub runner environment."""
 
@@ -1360,11 +1412,7 @@ async def _run(args: argparse.Namespace) -> int:
     manifest_path = getattr(args, "manifest", None)
     store_path = manifest_path or Path(os.devnull)
     store = AtomicJSONStore(store_path, runner_temp=_runner_temp())
-    async with NotebookLMClient.from_storage(
-        backend=args.backend,
-        rate_limit_max_retries=0,
-        server_error_max_retries=0,
-    ) as client:
+    async with _ci_client(backend=args.backend) as client:
         manager = NotebookLifecycleManager(
             client,
             template_id=template_id,

--- a/scripts/verify_ci_artifacts.py
+++ b/scripts/verify_ci_artifacts.py
@@ -40,6 +40,7 @@ EVENTS = {
     "completed",
     "discovered_accepted",
     "rate_limited_rejected",
+    "quota_response_unconfirmed",
     "quota_no_commit_observed",
     "delete_confirmed",
 }
@@ -219,6 +220,11 @@ def _matches_operation_target(operation: JournalOperation, artifact: Any) -> boo
     return _family(artifact) == expected_family and _public_id_kind(artifact) == operation.id_kind
 
 
+def _operation_target(operation: JournalOperation) -> DiscoveredTarget:
+    family = "report" if operation.family == "study_guide" else operation.family
+    return DiscoveredTarget(family=family, id_kind=operation.id_kind)
+
+
 def _has_untracked_operation_target(
     operation: JournalOperation,
     inventory: dict[str, Any],
@@ -245,6 +251,7 @@ def _validate_transition(
             "persisted",
             "discovered_accepted",
             "rate_limited_rejected",
+            "quota_response_unconfirmed",
             "quota_no_commit_observed",
         },
         "accepted": {"completed", "delete_confirmed"},
@@ -252,6 +259,7 @@ def _validate_transition(
         "completed": {"delete_confirmed"},
         "discovered_accepted": {"delete_confirmed"},
         "rate_limited_rejected": set(),
+        "quota_response_unconfirmed": set(),
         "quota_no_commit_observed": set(),
         "delete_confirmed": set(),
     }
@@ -274,6 +282,8 @@ def _validate_transition(
         raise JournalError("discovered acceptance has no started event")
     if event == "discovered_accepted" and operation.lifecycle != "test_owned":
         raise JournalError("discovered acceptance is not test-owned")
+    if event == "quota_response_unconfirmed" and operation.lifecycle != "settle":
+        raise JournalError("unconfirmed quota response does not use settle lifecycle")
     if event == "delete_confirmed" and not (
         previous & {"accepted", "persisted", "discovered_accepted", "completed"}
     ):
@@ -338,6 +348,7 @@ def parse_journal(path: Path, *, notebook_id: str) -> dict[str, JournalOperation
         expected_reasons = {
             "discovered_accepted": {"post_create_quota", "retry_preclean"},
             "rate_limited_rejected": {"typed_pre_acceptance"},
+            "quota_response_unconfirmed": {"server_commit_unknown"},
             "quota_no_commit_observed": {"post_create_reconciliation"},
             "delete_confirmed": {"test_teardown", "post_create_quota", "retry_preclean"},
         }
@@ -538,20 +549,28 @@ async def verify_journal(
     unmatched_started = [
         operation for operation in operations.values() if operation.event_names == {"started"}
     ]
-    unmatched_candidates = set(unjournaled_ids)
-    for operation in unmatched_started:
-        expected = "report" if operation.family == "study_guide" else operation.family
-        candidates = {
-            resource_id
-            for resource_id in unmatched_candidates
-            if unjournaled[resource_id].family == expected
-            and unjournaled[resource_id].id_kind == operation.id_kind
-        }
-        if len(candidates) != 1:
-            raise JournalError("unmatched started operation could not be uniquely reconciled")
-        unmatched_candidates.remove(candidates.pop())
-    if unmatched_candidates:
+    unconfirmed_quota = [
+        operation
+        for operation in operations.values()
+        if operation.event_names == {"started", "quota_response_unconfirmed"}
+    ]
+    discovered_targets = Counter(unjournaled.values())
+    required_targets = Counter(_operation_target(operation) for operation in unmatched_started)
+    quota_allowances = Counter(_operation_target(operation) for operation in unconfirmed_quota)
+    if any(discovered_targets[target] < count for target, count in required_targets.items()):
+        raise JournalError("unmatched started operation could not be uniquely reconciled")
+    if any(
+        count > required_targets[target] + quota_allowances[target]
+        for target, count in discovered_targets.items()
+    ):
         raise JournalError("inventory artifact has no matching journal start")
+    quota_allowances.subtract(
+        {
+            target: max(0, count - required_targets[target])
+            for target, count in discovered_targets.items()
+        }
+    )
+    quota_allowances = +quota_allowances
     accepted_count = len(accepted_operations) + len(unjournaled_ids)
     if accepted_count == 0:
         raise EmptyArtifactsError("journal/inventory has no accepted producer operations")
@@ -570,8 +589,24 @@ async def verify_journal(
             raise JournalError("test-owned operation has no verified deletion")
         if authorized_deleted & current_ids:
             raise JournalError("delete-confirmed resource is still present")
-        if current_ids - tracked_ids - unjournaled_ids:
+        newly_visible = {
+            resource_id: artifact
+            for resource_id, artifact in current_by_id.items()
+            if resource_id not in tracked_ids and resource_id not in unjournaled_ids
+        }
+        newly_visible_targets = Counter(
+            DiscoveredTarget(family=_family(artifact), id_kind=_public_id_kind(artifact))
+            for artifact in newly_visible.values()
+        )
+        if any(count > quota_allowances[target] for target, count in newly_visible_targets.items()):
             raise JournalError("inventory artifact has no matching journal start")
+        if newly_visible:
+            quota_allowances.subtract(newly_visible_targets)
+            quota_allowances = +quota_allowances
+            new_ids = set(newly_visible)
+            unjournaled_ids.update(new_ids)
+            monitored_ids.update(new_ids)
+            accepted_count += len(new_ids)
         for resource_id, operation in tracked.items():
             artifact = current_by_id.get(resource_id)
             if artifact is None or resource_id in authorized_deleted:

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -18,13 +18,14 @@ def completed_download_candidates(
     if family not in URL_BACKED_ARTIFACT_FAMILIES:
         raise ValueError(f"artifact family is not URL-backed: {family}")
     hydrate_android_slide = backend == "android" and family == "slide_deck"
-    return [
+    candidates = [
         artifact
         for artifact in artifacts
         if artifact.kind == family
         and artifact.is_completed
         and (hydrate_android_slide or bool(artifact.url))
     ]
+    return sorted(candidates, key=lambda artifact: bool(artifact.url), reverse=True)
 
 
 def studio_item_may_have_download_payload(item: dict[str, object], *, backend: str) -> bool:

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -4,6 +4,29 @@ from __future__ import annotations
 
 from notebooklm import Artifact
 
+URL_BACKED_ARTIFACT_FAMILIES = frozenset({"audio", "video", "infographic", "slide_deck"})
+URL_BACKED_STUDIO_TYPES = frozenset(
+    family.replace("_", "-") for family in URL_BACKED_ARTIFACT_FAMILIES
+)
+
+
+def completed_url_artifacts(artifacts: list[Artifact], family: str) -> list[Artifact]:
+    """Return completed artifacts whose listing exposes the required asset URL."""
+
+    if family not in URL_BACKED_ARTIFACT_FAMILIES:
+        raise ValueError(f"artifact family is not URL-backed: {family}")
+    return [
+        artifact
+        for artifact in artifacts
+        if artifact.kind == family and artifact.is_completed and bool(artifact.url)
+    ]
+
+
+def studio_item_has_download_payload(item: dict[str, object]) -> bool:
+    """Check the URL field for Studio types whose download requires one."""
+
+    return item.get("type") not in URL_BACKED_STUDIO_TYPES or bool(item.get("url"))
+
 
 def completed_interactive_mind_maps(artifacts: list[Artifact]) -> list[Artifact]:
     """Return only downloadable interactive mind-map artifacts."""

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -10,22 +10,31 @@ URL_BACKED_STUDIO_TYPES = frozenset(
 )
 
 
-def completed_url_artifacts(artifacts: list[Artifact], family: str) -> list[Artifact]:
-    """Return completed artifacts whose listing exposes the required asset URL."""
+def completed_download_candidates(
+    artifacts: list[Artifact], family: str, *, backend: str
+) -> list[Artifact]:
+    """Return completed artifacts whose backend can attempt payload resolution."""
 
     if family not in URL_BACKED_ARTIFACT_FAMILIES:
         raise ValueError(f"artifact family is not URL-backed: {family}")
+    hydrate_android_slide = backend == "android" and family == "slide_deck"
     return [
         artifact
         for artifact in artifacts
-        if artifact.kind == family and artifact.is_completed and bool(artifact.url)
+        if artifact.kind == family
+        and artifact.is_completed
+        and (hydrate_android_slide or bool(artifact.url))
     ]
 
 
-def studio_item_has_download_payload(item: dict[str, object]) -> bool:
-    """Check the URL field for Studio types whose download requires one."""
+def studio_item_may_have_download_payload(item: dict[str, object], *, backend: str) -> bool:
+    """Check whether the selected backend can attempt Studio payload resolution."""
 
-    return item.get("type") not in URL_BACKED_STUDIO_TYPES or bool(item.get("url"))
+    item_type = item.get("type")
+    hydrate_android_slide = backend == "android" and item_type == "slide-deck"
+    return (
+        item_type not in URL_BACKED_STUDIO_TYPES or hydrate_android_slide or bool(item.get("url"))
+    )
 
 
 def completed_interactive_mind_maps(artifacts: list[Artifact]) -> list[Artifact]:

--- a/tests/e2e/_generation_helpers.py
+++ b/tests/e2e/_generation_helpers.py
@@ -8,10 +8,10 @@ _TYPED_RATE_LIMIT_ATTR = "_notebooklm_typed_rate_limit"
 
 
 async def generate_note_mind_map(client: Any, notebook_id: str, operation: Any) -> Any:
-    """Close the manual note-map journal operation when typed quota rejects creation."""
+    """Record an uncertain note-map outcome when creation returns typed quota."""
     try:
         return await client.artifacts.generate_mind_map(notebook_id)
     except BaseException as exc:
         if bool(getattr(exc, _TYPED_RATE_LIMIT_ATTR, False)):
-            operation.rate_limited_rejected()
+            operation.quota_response_unconfirmed()
         raise

--- a/tests/e2e/_generation_journal.py
+++ b/tests/e2e/_generation_journal.py
@@ -43,6 +43,7 @@ EVENTS = frozenset(
         "completed",
         "discovered_accepted",
         "rate_limited_rejected",
+        "quota_response_unconfirmed",
         "quota_no_commit_observed",
         "delete_confirmed",
     }
@@ -238,6 +239,7 @@ class JournalOperation:
                 "persisted",
                 "discovered_accepted",
                 "rate_limited_rejected",
+                "quota_response_unconfirmed",
                 "quota_no_commit_observed",
             },
             "accepted": {"completed", "delete_confirmed"},
@@ -245,6 +247,7 @@ class JournalOperation:
             "completed": {"delete_confirmed"},
             "discovered_accepted": {"delete_confirmed"},
             "rate_limited_rejected": set(),
+            "quota_response_unconfirmed": set(),
             "quota_no_commit_observed": set(),
             "delete_confirmed": set(),
         }
@@ -268,6 +271,7 @@ class JournalOperation:
         allowed_reasons = {
             "discovered_accepted": {"post_create_quota", "retry_preclean"},
             "rate_limited_rejected": {"typed_pre_acceptance"},
+            "quota_response_unconfirmed": {"server_commit_unknown"},
             "quota_no_commit_observed": {"post_create_reconciliation"},
             "delete_confirmed": {"test_teardown", "post_create_quota", "retry_preclean"},
         }.get(event)
@@ -277,6 +281,8 @@ class JournalOperation:
             raise ValueError("journal event reason is not allowlisted")
         if event == "discovered_accepted" and self._envelope.lifecycle != "test_owned":
             raise ValueError("discovered acceptance must be test-owned")
+        if event == "quota_response_unconfirmed" and self._envelope.lifecycle != "settle":
+            raise ValueError("unconfirmed quota responses must settle")
         if event == "delete_confirmed":
             if self._envelope.lifecycle == "settle" and reason != "retry_preclean":
                 raise ValueError("settling resources may be deleted only during retry pre-clean")
@@ -326,6 +332,10 @@ class JournalOperation:
 
     def rate_limited_rejected(self) -> None:
         self._write("rate_limited_rejected", reason="typed_pre_acceptance")
+
+    def quota_response_unconfirmed(self) -> None:
+        """Record a quota response that may still have committed the mutation."""
+        self._write("quota_response_unconfirmed", reason="server_commit_unknown")
 
     def quota_no_commit_observed(self) -> None:
         self._write("quota_no_commit_observed", reason="post_create_reconciliation")
@@ -502,6 +512,9 @@ class DisabledOperation:
         pass
 
     def rate_limited_rejected(self) -> None:
+        pass
+
+    def quota_response_unconfirmed(self) -> None:
         pass
 
     def quota_no_commit_observed(self) -> None:

--- a/tests/e2e/_mcp_live_helpers.py
+++ b/tests/e2e/_mcp_live_helpers.py
@@ -21,7 +21,7 @@ from fastmcp import Client
 from notebooklm import NotebookLMClient
 from notebooklm.mcp.server import create_server
 
-from ._artifact_helpers import studio_item_has_download_payload
+from ._artifact_helpers import studio_item_may_have_download_payload
 
 #: Merged ``studio_list`` item ``type`` values (hyphenated, the shared Studio
 #: vocabulary) whose download is wired through ``studio_download``. An item's
@@ -40,7 +40,9 @@ DOWNLOADABLE_ARTIFACT_TYPES = {
 }
 
 
-def pick_downloadable_artifact(items: list[dict[str, Any]]) -> dict[str, Any] | None:
+def pick_downloadable_artifact(
+    items: list[dict[str, Any]], *, backend: str
+) -> dict[str, Any] | None:
     """Return the first ready, downloadable artifact among merged studio ``items``.
 
     Operates on the unified ``studio_list`` item shape: a hyphenated ``type``
@@ -55,7 +57,7 @@ def pick_downloadable_artifact(items: list[dict[str, Any]]) -> dict[str, Any] | 
             for it in items
             if it.get("type") in DOWNLOADABLE_ARTIFACT_TYPES
             and it.get("status_label") in (None, "ready", "completed")
-            and studio_item_has_download_payload(it)
+            and studio_item_may_have_download_payload(it, backend=backend)
         ),
         None,
     )

--- a/tests/e2e/_mcp_live_helpers.py
+++ b/tests/e2e/_mcp_live_helpers.py
@@ -21,6 +21,8 @@ from fastmcp import Client
 from notebooklm import NotebookLMClient
 from notebooklm.mcp.server import create_server
 
+from ._artifact_helpers import studio_item_has_download_payload
+
 #: Merged ``studio_list`` item ``type`` values (hyphenated, the shared Studio
 #: vocabulary) whose download is wired through ``studio_download``. An item's
 #: ``type`` doubles as the ``studio_download`` ``artifact_type`` key, so no
@@ -53,6 +55,7 @@ def pick_downloadable_artifact(items: list[dict[str, Any]]) -> dict[str, Any] | 
             for it in items
             if it.get("type") in DOWNLOADABLE_ARTIFACT_TYPES
             and it.get("status_label") in (None, "ready", "completed")
+            and studio_item_has_download_payload(it)
         ),
         None,
     )

--- a/tests/e2e/_mcp_live_helpers.py
+++ b/tests/e2e/_mcp_live_helpers.py
@@ -51,16 +51,24 @@ def pick_downloadable_artifact(
     as the terminal ``ready``/``completed`` states). Lets a test reuse whatever
     artifact a notebook already has and skip cleanly when none qualifies.
     """
-    return next(
+    candidates = [
+        item
+        for item in items
+        if item.get("type") in DOWNLOADABLE_ARTIFACT_TYPES
+        and item.get("status_label") in (None, "ready", "completed")
+        and studio_item_may_have_download_payload(item, backend=backend)
+    ]
+    confirmed = next(
         (
-            it
-            for it in items
-            if it.get("type") in DOWNLOADABLE_ARTIFACT_TYPES
-            and it.get("status_label") in (None, "ready", "completed")
-            and studio_item_may_have_download_payload(it, backend=backend)
+            item
+            for item in candidates
+            if not (
+                backend == "android" and item.get("type") == "slide-deck" and not item.get("url")
+            )
         ),
         None,
     )
+    return confirmed or (candidates[0] if candidates else None)
 
 
 @contextlib.asynccontextmanager

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -401,8 +401,15 @@ def _managed_bindings() -> dict[str, str] | None:
     missing = [name for name, value in bindings.items() if not value]
     if missing:
         raise ValueError(f"managed {mode} mode is missing role bindings: " + ", ".join(missing))
-    if len(set(bindings.values())) != len(bindings):
-        raise ValueError(f"managed {mode}-mode role bindings must be distinct")
+    if mode == "full":
+        reference = bindings["NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID"]
+        generation = bindings["NOTEBOOKLM_GENERATION_NOTEBOOK_ID"]
+        multi_source = bindings["NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID"]
+        if reference == generation or multi_source != generation:
+            raise ValueError(
+                "managed full-mode bindings require one distinct reference and one shared "
+                "generation/multi-source workspace"
+            )
     if os.environ.get(_MANAGED_REFERENCE_READY_ENV) != "1":
         raise ValueError("managed reference preparation marker is missing")
     return bindings

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -247,12 +247,12 @@ def _install_generation_journal(client: NotebookLMClient, journal) -> None:
                     result = await __original(*args, **kwargs)
                 except BaseException as exc:
                     if _typed_rate_limit_cause(exc) is not None:
-                        operation.rate_limited_rejected()
+                        operation.quota_response_unconfirmed()
                     raise
                 if result is not None and getattr(result, "task_id", None):
                     operation.accepted(result.task_id)
                 elif result is not None and bool(getattr(result, "is_rate_limited", False)):
-                    operation.rate_limited_rejected()
+                    operation.quota_response_unconfirmed()
                 return result
             finally:
                 journal_call_active.reset(journal_token)
@@ -446,7 +446,7 @@ def journal_generation_started(result, operation, artifact_type: str = "Artifact
     if result.task_id:
         operation.accepted(result.task_id)
     elif result.is_rate_limited:
-        operation.rate_limited_rejected()
+        operation.quota_response_unconfirmed()
         pytest.skip("Rate limited by API")
     assert_generation_started(result, artifact_type)
 
@@ -470,11 +470,10 @@ async def journal_studio_generation(
     try:
         result = await awaitable
     except BaseException as exc:
-        # Direct Studio generate methods only raise the typed quota skip before
-        # returning an accepted ID. Interactive generation, which has post-
-        # create reads, owns a stronger reconciliation fixture separately.
+        # A typed quota response can race with an asynchronous server-side
+        # commit, so the verifier must reconcile it against the quiet inventory.
         if _typed_rate_limit_cause(exc) is not None:
-            operation.rate_limited_rejected()
+            operation.quota_response_unconfirmed()
         raise
     journal_generation_started(result, operation)
     return result

--- a/tests/e2e/test_cli_live.py
+++ b/tests/e2e/test_cli_live.py
@@ -151,7 +151,7 @@ class TestCliLive:
             "--json",
         )
         if _is_typed_generation_rejection(proc):
-            operation.rate_limited_rejected()
+            operation.quota_response_unconfirmed()
             pytest.skip("generation rate-limited (typed CLI rejection)")
         assert proc.returncode == 0, "CLI generation failed before returning a typed task ID"
         payload = json.loads(proc.stdout)

--- a/tests/e2e/test_downloads.py
+++ b/tests/e2e/test_downloads.py
@@ -7,7 +7,7 @@ import pytest
 
 from notebooklm.exceptions import ArtifactNotReadyError
 
-from ._artifact_helpers import completed_interactive_mind_maps
+from ._artifact_helpers import completed_interactive_mind_maps, completed_url_artifacts
 from .conftest import _managed_bindings, requires_auth
 
 # Large artifact transfers can be hundreds of MiB and need several minutes on
@@ -19,6 +19,16 @@ pytestmark = pytest.mark.timeout(600)
 PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 PDF_MAGIC = b"%PDF"
 MP4_FTYP = b"ftyp"  # At offset 4
+
+
+async def downloadable_url_artifact_id(client, notebook_id: str, family: str) -> str:
+    """Select a completed URL-backed artifact, or skip an inventory-only copy."""
+
+    artifacts = await client.artifacts.list(notebook_id)
+    candidates = completed_url_artifacts(artifacts, family)
+    if not candidates:
+        pytest.skip(f"No completed downloadable {family} artifact available")
+    return candidates[0].id
 
 
 def is_png(path: str) -> bool:
@@ -54,8 +64,11 @@ class TestDownloadAudio:
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "audio.mp4")
+            artifact_id = await downloadable_url_artifact_id(client, read_only_notebook_id, "audio")
             try:
-                result = await client.artifacts.download_audio(read_only_notebook_id, output_path)
+                result = await client.artifacts.download_audio(
+                    read_only_notebook_id, output_path, artifact_id=artifact_id
+                )
                 assert result == output_path
                 assert os.path.exists(output_path)
                 assert os.path.getsize(output_path) > 0
@@ -72,8 +85,11 @@ class TestDownloadVideo:
         """Downloads existing video artifact - read-only."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "video.mp4")
+            artifact_id = await downloadable_url_artifact_id(client, read_only_notebook_id, "video")
             try:
-                result = await client.artifacts.download_video(read_only_notebook_id, output_path)
+                result = await client.artifacts.download_video(
+                    read_only_notebook_id, output_path, artifact_id=artifact_id
+                )
                 assert result == output_path
                 assert os.path.exists(output_path)
                 assert os.path.getsize(output_path) > 0
@@ -90,9 +106,12 @@ class TestDownloadInfographic:
         """Downloads existing infographic - read-only."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "infographic.png")
+            artifact_id = await downloadable_url_artifact_id(
+                client, read_only_notebook_id, "infographic"
+            )
             try:
                 result = await client.artifacts.download_infographic(
-                    read_only_notebook_id, output_path
+                    read_only_notebook_id, output_path, artifact_id=artifact_id
                 )
                 assert result == output_path
                 assert os.path.exists(output_path)
@@ -110,9 +129,12 @@ class TestDownloadSlideDeck:
         """Downloads existing slide deck as PDF - read-only."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "slides.pdf")
+            artifact_id = await downloadable_url_artifact_id(
+                client, read_only_notebook_id, "slide_deck"
+            )
             try:
                 result = await client.artifacts.download_slide_deck(
-                    read_only_notebook_id, output_path
+                    read_only_notebook_id, output_path, artifact_id=artifact_id
                 )
                 assert result == output_path
                 assert os.path.exists(output_path)

--- a/tests/e2e/test_downloads.py
+++ b/tests/e2e/test_downloads.py
@@ -8,7 +8,7 @@ import pytest
 from notebooklm.exceptions import ArtifactNotReadyError
 
 from ._artifact_helpers import completed_interactive_mind_maps
-from .conftest import _managed_bindings, requires_auth, skip_or_fail_missing_reference
+from .conftest import _managed_bindings, requires_auth
 
 # Large artifact transfers can be hundreds of MiB and need several minutes on
 # Windows runners. The HTTP client's 60-second read timeout still catches a
@@ -199,9 +199,7 @@ class TestDownloadMindMap:
             artifacts = await client.artifacts.list(read_only_notebook_id)
             interactive = completed_interactive_mind_maps(artifacts)
             if not interactive:
-                skip_or_fail_missing_reference(
-                    "copied reference has no completed Studio-backed interactive mind map"
-                )
+                pytest.skip("No completed Studio-backed interactive mind map available")
             artifact_id = interactive[0].id
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "mindmap.json")
@@ -219,7 +217,7 @@ class TestDownloadMindMap:
                     data = json.load(f)
                 assert "name" in data, "Mind map JSON should have 'name' field"
             except ArtifactNotReadyError:
-                skip_or_fail_missing_reference("No mind map artifact available")
+                pytest.skip("No mind map artifact available")
 
 
 @requires_auth

--- a/tests/e2e/test_downloads.py
+++ b/tests/e2e/test_downloads.py
@@ -5,9 +5,9 @@ import tempfile
 
 import pytest
 
-from notebooklm.exceptions import ArtifactNotReadyError
+from notebooklm.exceptions import ArtifactDownloadError, ArtifactNotReadyError
 
-from ._artifact_helpers import completed_interactive_mind_maps, completed_url_artifacts
+from ._artifact_helpers import completed_download_candidates, completed_interactive_mind_maps
 from .conftest import _managed_bindings, requires_auth
 
 # Large artifact transfers can be hundreds of MiB and need several minutes on
@@ -22,10 +22,14 @@ MP4_FTYP = b"ftyp"  # At offset 4
 
 
 async def downloadable_url_artifact_id(client, notebook_id: str, family: str) -> str:
-    """Select a completed URL-backed artifact, or skip an inventory-only copy."""
+    """Select a completed downloadable artifact, or skip an inventory-only copy."""
 
     artifacts = await client.artifacts.list(notebook_id)
-    candidates = completed_url_artifacts(artifacts, family)
+    candidates = completed_download_candidates(
+        artifacts,
+        family,
+        backend=client.backends["artifacts"],
+    )
     if not candidates:
         pytest.skip(f"No completed downloadable {family} artifact available")
     return candidates[0].id
@@ -74,6 +78,8 @@ class TestDownloadAudio:
                 assert os.path.getsize(output_path) > 0
                 assert is_mp4(output_path), "Downloaded audio is not a valid MP4 file"
             except ArtifactNotReadyError:
+                if _managed_bindings() is not None:
+                    raise
                 pytest.skip("No completed audio artifact available")
 
 
@@ -95,6 +101,8 @@ class TestDownloadVideo:
                 assert os.path.getsize(output_path) > 0
                 assert is_mp4(output_path), "Downloaded video is not a valid MP4 file"
             except ArtifactNotReadyError:
+                if _managed_bindings() is not None:
+                    raise
                 pytest.skip("No completed video artifact available")
 
 
@@ -118,6 +126,8 @@ class TestDownloadInfographic:
                 assert os.path.getsize(output_path) > 0
                 assert is_png(output_path), "Downloaded infographic is not a valid PNG file"
             except ArtifactNotReadyError:
+                if _managed_bindings() is not None:
+                    raise
                 pytest.skip("No completed infographic artifact available")
 
 
@@ -141,7 +151,16 @@ class TestDownloadSlideDeck:
                 assert os.path.getsize(output_path) > 0
                 assert is_pdf(output_path), "Downloaded slide deck is not a valid PDF file"
             except ArtifactNotReadyError:
+                if _managed_bindings() is not None:
+                    raise
                 pytest.skip("No completed slide deck artifact available")
+            except ArtifactDownloadError as error:
+                if (
+                    client.backends["artifacts"] == "android"
+                    and error.details == "PDF URL not available in artifact data"
+                ):
+                    pytest.skip("Android hydration confirmed an inventory-only slide deck")
+                raise
 
 
 @requires_auth
@@ -239,6 +258,8 @@ class TestDownloadMindMap:
                     data = json.load(f)
                 assert "name" in data, "Mind map JSON should have 'name' field"
             except ArtifactNotReadyError:
+                if _managed_bindings() is not None:
+                    raise
                 pytest.skip("No mind map artifact available")
 
 

--- a/tests/e2e/test_interactive_mind_map.py
+++ b/tests/e2e/test_interactive_mind_map.py
@@ -19,7 +19,6 @@ import pytest
 from notebooklm.types import MindMapKind
 
 from ._generation_helpers import _TYPED_RATE_LIMIT_ATTR
-from .conftest import _RATE_LIMIT_METHOD_ATTR
 
 # Live CREATE_ARTIFACT coverage — monitored by the nightly generation coverage
 # floor so a fully-throttled run (every generation skipped) reds the nightly
@@ -42,10 +41,11 @@ async def swept_interactive_mind_maps(client, generation_notebook_id):
 
     This teardown runs regardless of test outcome (pass / fail / skip) and
     deletes every interactive mind map left in the generation notebook, so no
-    post-create skip location can leak one. A create-time skip raises before
-    any artifact exists, so the sweep simply finds nothing. Best-effort: a
-    throttled sweep can't clean up, but the next session's pre-test
-    ``_cleanup_generation_notebook`` deletes all artifacts anyway.
+    ambiguous quota response can leak one. Even a typed quota response from
+    CREATE_ARTIFACT can race with a server-side commit, so every quota path is
+    reconciled instead of trusting the method label as proof of rejection.
+    Best-effort: a throttled sweep can't clean up, but the next session's
+    pre-test ``_cleanup_generation_notebook`` deletes all artifacts anyway.
 
     Enumerates via the *unfiltered* ``client.artifacts.list`` and matches
     ``is_interactive_mind_map`` OR ``is_unclassified_type4`` — mirroring
@@ -64,11 +64,10 @@ async def swept_interactive_mind_maps(client, generation_notebook_id):
         "baseline": baseline,
         "operation": None,
         "typed_quota": False,
-        "pre_accept_rejected": False,
     }
     yield state
     operation = state["operation"]
-    attempts = 5 if state["typed_quota"] and not state["pre_accept_rejected"] else 1
+    attempts = 5 if state["typed_quota"] else 1
     current = []
     for attempt in range(attempts):
         current = [
@@ -116,8 +115,6 @@ async def swept_interactive_mind_maps(client, generation_notebook_id):
             )
     if multiple:
         pytest.fail("interactive mind-map reconciliation found multiple new rows")
-    if state["pre_accept_rejected"] and created:
-        pytest.fail("pre-acceptance quota rejection unexpectedly created an artifact")
 
 
 @pytest.mark.e2e
@@ -151,15 +148,7 @@ async def test_interactive_mind_map_full_lifecycle(
         )
     except BaseException as exc:
         typed_quota = bool(getattr(exc, _TYPED_RATE_LIMIT_ATTR, False))
-        method_id = getattr(exc, _RATE_LIMIT_METHOD_ATTR, None)
-        pre_accept_rejected = typed_quota and (
-            method_id == "R7cb6c"
-            or (isinstance(method_id, str) and method_id.endswith("/CreateArtifact"))
-        )
-        swept_interactive_mind_maps["typed_quota"] = typed_quota and not pre_accept_rejected
-        swept_interactive_mind_maps["pre_accept_rejected"] = pre_accept_rejected
-        if pre_accept_rejected:
-            operation.rate_limited_rejected()
+        swept_interactive_mind_maps["typed_quota"] = typed_quota
         raise
     operation.accepted(mind_map.id)
     try:

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -469,6 +469,7 @@ class TestMcpArtifacts:
             {
                 "notebook": read_only_notebook_id,
                 "artifact_type": dl_type,
+                "artifact_id": candidate["id"],
                 "path": str(out_path),
             },
         )

--- a/tests/e2e/test_mcp.py
+++ b/tests/e2e/test_mcp.py
@@ -456,7 +456,9 @@ class TestMcpArtifacts:
         cleanly when none is present, so this never depends on cross-file ordering.
         """
         listing = await _call(client, "studio_list", {"notebook": read_only_notebook_id})
-        candidate = _pick_downloadable_artifact(listing["items"])
+        candidate = _pick_downloadable_artifact(
+            listing["items"], backend=client.backends["artifacts"]
+        )
         if candidate is None:
             pytest.skip("no existing downloadable artifact on the reference notebook")
 
@@ -474,6 +476,13 @@ class TestMcpArtifacts:
             },
         )
         assert isinstance(result, dict)
+        if (
+            client.backends["artifacts"] == "android"
+            and dl_type == "slide-deck"
+            and result.get("outcome") == "error"
+            and "PDF URL not available in artifact data" in str(result.get("error"))
+        ):
+            pytest.skip("Android hydration confirmed an inventory-only slide deck")
         # The stdio download core writes the file and reports its path; assert
         # bytes landed on disk.
         written = Path(result.get("output_path") or out_path)

--- a/tests/e2e/test_mcp_http.py
+++ b/tests/e2e/test_mcp_http.py
@@ -194,7 +194,9 @@ class TestMcpHttpFileRoutes:
                 listing = await mcp.call_tool("studio_list", {"notebook": read_only_notebook_id})
                 sc = listing.structured_content
                 assert sc is not None, "studio_list returned no structured content"
-                candidate = pick_downloadable_artifact(sc["items"])
+                candidate = pick_downloadable_artifact(
+                    sc["items"], backend=client.backends["artifacts"]
+                )
                 if candidate is None:
                     pytest.skip("no existing downloadable artifact on the reference notebook")
 
@@ -214,6 +216,13 @@ class TestMcpHttpFileRoutes:
 
             async with im.raw_client() as raw:
                 resp = await raw.get(download_path)
+            if (
+                client.backends["artifacts"] == "android"
+                and dl_type == "slide-deck"
+                and resp.status_code == 409
+                and resp.text == "No completed slide-deck artifact is available yet."
+            ):
+                pytest.skip("Android hydration confirmed an inventory-only slide deck")
             assert resp.status_code == 200, resp.text
             assert len(resp.content) > 0
             assert "content-disposition" in {k.lower() for k in resp.headers}

--- a/tests/e2e/test_mcp_http.py
+++ b/tests/e2e/test_mcp_http.py
@@ -202,7 +202,11 @@ class TestMcpHttpFileRoutes:
                 dl_type = candidate["type"]
                 result = await mcp.call_tool(
                     "studio_download",
-                    {"notebook": read_only_notebook_id, "artifact_type": dl_type},
+                    {
+                        "notebook": read_only_notebook_id,
+                        "artifact_type": dl_type,
+                        "artifact_id": candidate["id"],
+                    },
                 )
             structured = result.structured_content
             assert structured["status"] == "download_ready"

--- a/tests/fixtures/e2e_prepared_role_contract.json
+++ b/tests/fixtures/e2e_prepared_role_contract.json
@@ -10,10 +10,10 @@
     "conversation_turn_limit": 2
   },
   "clean_roles": {
-    "roles": ["generation", "multi-source", "rpc"],
+    "roles": ["generation", "rpc"],
     "minimum_ready_sources": 3,
     "disallowed": ["artifacts", "notes", "mind_maps"],
-    "empty_chat_roles": ["multi-source", "rpc"],
+    "empty_chat_roles": ["generation", "rpc"],
     "poll_interval_seconds": 30,
     "quiet_period_seconds": 90,
     "preparation_deadline_seconds": 300

--- a/tests/fixtures/e2e_template_contract.json
+++ b/tests/fixtures/e2e_template_contract.json
@@ -11,15 +11,10 @@
     "required_completed_families": [
       "audio",
       "video",
-      "report",
-      "quiz",
-      "flashcards",
-      "mind_map",
       "infographic",
-      "slide_deck",
-      "data_table"
+      "slide_deck"
     ],
-    "require_interactive_mind_map": true
+    "require_interactive_mind_map": false
   },
   "content_policy": {
     "private_personal_licensed_or_unstable_web_content_allowed": false,

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -508,7 +508,8 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
     assert "Template contract: version=1 fingerprint=" in nightly_provision
     assert '"readonly": ("reference",)' in nightly_provision
     assert "Copy outcomes: total={len(roles)}" in nightly_provision
-    assert "Clean-role residuals: generation=0 multi-source=0" in nightly_provision
+    assert '"full": ("reference", "generation")' in nightly_provision
+    assert "Clean workspace residuals: generation/multi-source=0" in nightly_provision
     assert 'row["notebook_id"]' not in nightly_provision
     assert "Coverage floor:" in str(_step(nightly, "coverage")["run"])
 
@@ -520,8 +521,8 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
 
     package = _load("verify-package.yml")["jobs"]["verify"]
     package_provision = str(_step(package, "provision")["run"])
-    assert "Copy outcomes: total=3" in package_provision
-    assert "Clean-role residuals: generation=0 multi-source=0" in package_provision
+    assert "Copy outcomes: total=2" in package_provision
+    assert "Clean workspace residuals: generation/multi-source=0" in package_provision
     assert 'row["notebook_id"]' not in package_provision
 
 

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -738,7 +738,7 @@ class TestGenerationRateLimitSkip:
         with pytest.raises(RuntimeError, match="429"):
             await client.artifacts.generate_audio("nb-1")
 
-    async def test_journal_closes_only_on_typed_quota_evidence(self):
+    async def test_journal_records_only_typed_quota_uncertainty(self):
         conftest = _load_e2e_conftest()
         recorded: list[str] = []
 
@@ -748,6 +748,9 @@ class TestGenerationRateLimitSkip:
 
             def rate_limited_rejected(self):
                 recorded.append("rate_limited_rejected")
+
+            def quota_response_unconfirmed(self):
+                recorded.append("quota_response_unconfirmed")
 
         class Journal:
             notebook_id = "generation-role"
@@ -781,7 +784,7 @@ class TestGenerationRateLimitSkip:
         conftest._install_generation_journal(client, Journal())
         with pytest.raises(RateLimitError):
             await artifacts.generate_audio("generation-role")
-        assert recorded == ["started", "rate_limited_rejected"]
+        assert recorded == ["started", "quota_response_unconfirmed"]
 
     async def test_journal_records_delegated_generation_only_once(self):
         conftest = _load_e2e_conftest()

--- a/tests/unit/test_e2e_generation_journal.py
+++ b/tests/unit/test_e2e_generation_journal.py
@@ -59,7 +59,7 @@ def test_required_journal_appends_versioned_transitions_without_printing_ids(
 
 
 @pytest.mark.asyncio
-async def test_note_mind_map_typed_quota_closes_manual_operation() -> None:
+async def test_note_mind_map_typed_quota_records_unconfirmed_outcome() -> None:
     from tests.e2e._generation_helpers import generate_note_mind_map
 
     events: list[str] = []
@@ -71,12 +71,14 @@ async def test_note_mind_map_typed_quota_closes_manual_operation() -> None:
             skipped._notebooklm_typed_rate_limit = True
             raise skipped
 
-    operation = SimpleNamespace(rate_limited_rejected=lambda: events.append("rejected"))
+    operation = SimpleNamespace(
+        quota_response_unconfirmed=lambda: events.append("quota_unconfirmed")
+    )
     with pytest.raises(pytest.skip.Exception, match="typed quota"):
         await generate_note_mind_map(
             SimpleNamespace(artifacts=Artifacts()), "generation-role", operation
         )
-    assert events == ["rejected"]
+    assert events == ["quota_unconfirmed"]
 
 
 def test_primary_and_retry_processes_append_without_truncation(tmp_path) -> None:
@@ -103,6 +105,22 @@ def test_primary_and_retry_processes_append_without_truncation(tmp_path) -> None
     assert len(rows) == 4
     assert {row["node_id"] for row in rows} == {"first", "retry"}
     assert {row["surface"] for row in rows} == {"cli", "mcp"}
+
+
+def test_quota_response_records_commit_uncertainty(tmp_path) -> None:
+    path = _journal_file(tmp_path)
+    journal = journal_from_environment(env=_required_env(tmp_path, path), node_id="quota")
+    operation = journal.operation(
+        notebook_id="generation-role",
+        family="audio",
+        surface="client",
+        id_kind="studio_task",
+        lifecycle="settle",
+    )
+    operation.quota_response_unconfirmed()
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert [row["event"] for row in rows] == ["started", "quota_response_unconfirmed"]
+    assert rows[-1]["reason"] == "server_commit_unknown"
 
 
 def test_retry_cleanup_resumes_prior_operation_uuid(tmp_path) -> None:

--- a/tests/unit/test_e2e_managed_fixtures.py
+++ b/tests/unit/test_e2e_managed_fixtures.py
@@ -10,6 +10,7 @@ from tests.e2e._artifact_helpers import (
     completed_interactive_mind_maps,
     studio_item_may_have_download_payload,
 )
+from tests.e2e._mcp_live_helpers import pick_downloadable_artifact
 
 MANAGED = {
     "NOTEBOOKLM_E2E_MANAGED_COPIES": "1",
@@ -133,14 +134,33 @@ def test_android_slide_deck_download_selectors_allow_backend_hydration() -> None
     inventory_only = SimpleNamespace(
         kind="slide_deck", is_completed=True, url=None, id="inventory-only"
     )
+    downloadable = SimpleNamespace(
+        kind="slide_deck", is_completed=True, url="https://asset.test", id="downloadable"
+    )
 
     assert completed_download_candidates([inventory_only], "slide_deck", backend="web") == []
-    assert completed_download_candidates([inventory_only], "slide_deck", backend="android") == [
-        inventory_only
+    assert completed_download_candidates(
+        [inventory_only, downloadable], "slide_deck", backend="android"
+    ) == [
+        downloadable,
+        inventory_only,
     ]
     item = {"type": "slide-deck", "status_label": "completed", "url": None}
     assert studio_item_may_have_download_payload(item, backend="web") is False
     assert studio_item_may_have_download_payload(item, backend="android") is True
+
+
+def test_android_mcp_selector_prefers_confirmed_payload_before_slide_hydration() -> None:
+    fallback = {"id": "fallback", "type": "slide-deck", "status_label": "completed"}
+    confirmed = {
+        "id": "confirmed",
+        "type": "audio",
+        "status_label": "completed",
+        "url": "https://asset.test",
+    }
+
+    assert pick_downloadable_artifact([fallback, confirmed], backend="android") is confirmed
+    assert pick_downloadable_artifact([fallback], backend="android") is fallback
 
 
 def test_unmanaged_configuration_preserves_legacy_path(monkeypatch) -> None:

--- a/tests/unit/test_e2e_managed_fixtures.py
+++ b/tests/unit/test_e2e_managed_fixtures.py
@@ -18,7 +18,7 @@ MANAGED = {
     "NOTEBOOKLM_E2E_REFERENCE_PREPARED": "1",
     "NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID": "reference-role",
     "NOTEBOOKLM_GENERATION_NOTEBOOK_ID": "generation-role",
-    "NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "multi-source-role",
+    "NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "generation-role",
 }
 
 
@@ -30,19 +30,20 @@ def install(monkeypatch, **overrides: str | None) -> None:
             monkeypatch.setenv(name, value)
 
 
-def test_managed_full_requires_activation_mode_preparation_and_distinct_roles(monkeypatch) -> None:
+def test_managed_full_requires_reference_and_shared_mutable_workspace(monkeypatch) -> None:
     install(monkeypatch)
     assert e2e._managed_bindings() == {
         "NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID": "reference-role",
         "NOTEBOOKLM_GENERATION_NOTEBOOK_ID": "generation-role",
-        "NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "multi-source-role",
+        "NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "generation-role",
     }
     for overrides in (
         {"NOTEBOOKLM_E2E_MANAGED_COPIES": "true"},
         {"NOTEBOOKLM_E2E_MANAGED_MODE": "rpc"},
         {"NOTEBOOKLM_E2E_REFERENCE_PREPARED": None},
         {"NOTEBOOKLM_GENERATION_NOTEBOOK_ID": None},
-        {"NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "generation-role"},
+        {"NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID": "multi-source-role"},
+        {"NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID": "generation-role"},
     ):
         install(monkeypatch, **overrides)
         with pytest.raises(ValueError):
@@ -65,7 +66,7 @@ async def test_managed_role_fixtures_do_not_touch_cache_create_cleanup_or_client
         await anext(generation)
 
     multi_source = e2e.multi_source_notebook_id.__wrapped__(ExplodingClient())
-    assert await anext(multi_source) == "multi-source-role"
+    assert await anext(multi_source) == "generation-role"
     with pytest.raises(StopAsyncIteration):
         await anext(multi_source)
 

--- a/tests/unit/test_e2e_managed_fixtures.py
+++ b/tests/unit/test_e2e_managed_fixtures.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 import pytest
 
 from tests.e2e import conftest as e2e
-from tests.e2e._artifact_helpers import completed_interactive_mind_maps
+from tests.e2e._artifact_helpers import (
+    completed_interactive_mind_maps,
+    completed_url_artifacts,
+    studio_item_has_download_payload,
+)
 
 MANAGED = {
     "NOTEBOOKLM_E2E_MANAGED_COPIES": "1",
@@ -89,6 +93,36 @@ def test_managed_mind_map_download_selects_only_completed_interactive_artifacts(
     assert completed_interactive_mind_maps([processing, completed, completed_other_kind]) == [
         completed
     ]
+
+
+def test_url_backed_download_selectors_reject_inventory_only_artifacts() -> None:
+    inventory_only = SimpleNamespace(kind="audio", is_completed=True, url=None, id="inventory-only")
+    processing = SimpleNamespace(kind="audio", is_completed=False, url="https://asset.test")
+    downloadable = SimpleNamespace(
+        kind="audio", is_completed=True, url="https://asset.test", id="downloadable"
+    )
+
+    assert completed_url_artifacts([inventory_only, processing, downloadable], "audio") == [
+        downloadable
+    ]
+    assert (
+        studio_item_has_download_payload(
+            {"type": "audio", "status_label": "completed", "url": None}
+        )
+        is False
+    )
+    assert (
+        studio_item_has_download_payload(
+            {"type": "audio", "status_label": "completed", "url": "https://asset.test"}
+        )
+        is True
+    )
+    assert (
+        studio_item_has_download_payload(
+            {"type": "report", "status_label": "completed", "url": None}
+        )
+        is True
+    )
 
 
 def test_unmanaged_configuration_preserves_legacy_path(monkeypatch) -> None:

--- a/tests/unit/test_e2e_managed_fixtures.py
+++ b/tests/unit/test_e2e_managed_fixtures.py
@@ -6,9 +6,9 @@ import pytest
 
 from tests.e2e import conftest as e2e
 from tests.e2e._artifact_helpers import (
+    completed_download_candidates,
     completed_interactive_mind_maps,
-    completed_url_artifacts,
-    studio_item_has_download_payload,
+    studio_item_may_have_download_payload,
 )
 
 MANAGED = {
@@ -102,27 +102,45 @@ def test_url_backed_download_selectors_reject_inventory_only_artifacts() -> None
         kind="audio", is_completed=True, url="https://asset.test", id="downloadable"
     )
 
-    assert completed_url_artifacts([inventory_only, processing, downloadable], "audio") == [
-        downloadable
-    ]
+    assert completed_download_candidates(
+        [inventory_only, processing, downloadable], "audio", backend="web"
+    ) == [downloadable]
+    assert completed_download_candidates(
+        [inventory_only, processing, downloadable], "audio", backend="android"
+    ) == [downloadable]
     assert (
-        studio_item_has_download_payload(
-            {"type": "audio", "status_label": "completed", "url": None}
+        studio_item_may_have_download_payload(
+            {"type": "audio", "status_label": "completed", "url": None}, backend="web"
         )
         is False
     )
     assert (
-        studio_item_has_download_payload(
-            {"type": "audio", "status_label": "completed", "url": "https://asset.test"}
+        studio_item_may_have_download_payload(
+            {"type": "audio", "status_label": "completed", "url": "https://asset.test"},
+            backend="android",
         )
         is True
     )
     assert (
-        studio_item_has_download_payload(
-            {"type": "report", "status_label": "completed", "url": None}
+        studio_item_may_have_download_payload(
+            {"type": "report", "status_label": "completed", "url": None}, backend="web"
         )
         is True
     )
+
+
+def test_android_slide_deck_download_selectors_allow_backend_hydration() -> None:
+    inventory_only = SimpleNamespace(
+        kind="slide_deck", is_completed=True, url=None, id="inventory-only"
+    )
+
+    assert completed_download_candidates([inventory_only], "slide_deck", backend="web") == []
+    assert completed_download_candidates([inventory_only], "slide_deck", backend="android") == [
+        inventory_only
+    ]
+    item = {"type": "slide-deck", "status_label": "completed", "url": None}
+    assert studio_item_may_have_download_payload(item, backend="web") is False
+    assert studio_item_may_have_download_payload(item, backend="android") is True
 
 
 def test_unmanaged_configuration_preserves_legacy_path(monkeypatch) -> None:

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -1489,6 +1489,61 @@ async def test_template_validation_enforces_interactive_mind_map_when_required(
 
 
 @pytest.mark.asyncio
+async def test_copy_shape_waits_for_processing_artifacts_to_settle(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copied = client.notebooks._commit(
+        "notebooklm-py-ci/100/2/rpc-health-web/rpc/00000000000000000000000000000001"
+    )
+    client.artifacts.list_script.append(
+        [artifact for artifact in _artifacts() if artifact.kind not in {"audio", "video"}]
+    )
+
+    counts = await manager._validate_copy_shape(copied.id)
+
+    assert counts["completed_artifacts"] == 9
+    assert clock.value == 10.0
+
+
+@pytest.mark.asyncio
+async def test_copy_shape_fails_closed_when_processing_never_settles(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copied = client.notebooks._commit(
+        "notebooklm-py-ci/100/2/rpc-health-web/rpc/00000000000000000000000000000001"
+    )
+    client.artifacts.by_notebook[copied.id] = [
+        artifact for artifact in _artifacts() if artifact.kind != "audio"
+    ]
+
+    with pytest.raises(ContractError, match="did not settle within ten minutes"):
+        await manager._validate_copy_shape(copied.id)
+
+    assert clock.value == 600.0
+
+
+@pytest.mark.asyncio
+async def test_clean_copy_shape_requires_sources_but_not_inherited_artifact_completion(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copied = client.notebooks._commit(
+        "notebooklm-py-ci/100/2/rpc-health-web/rpc/00000000000000000000000000000001"
+    )
+    client.artifacts.by_notebook[copied.id] = []
+
+    counts = await manager._validate_copy_shape(copied.id, require_artifacts=False)
+
+    assert counts == {"ready_sources": 3, "completed_artifacts": 0, "artifact_families": 0}
+    assert clock.value == 0.0
+
+
+@pytest.mark.asyncio
 async def test_template_validation_rejects_wrong_notebook_lookup(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -376,6 +376,16 @@ def contracts() -> tuple[dict[str, Any], dict[str, Any]]:
     return template, prepared
 
 
+def test_template_contract_matches_public_cross_backend_inventory(
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    artifact_contract = contracts[0]["artifacts"]
+    assert artifact_contract == {
+        "required_completed_families": ["audio", "video", "infographic", "slide_deck"],
+        "require_interactive_mind_map": False,
+    }
+
+
 def _manager(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
@@ -1445,6 +1455,37 @@ async def test_template_contract_failure_names_family_but_never_ids(
     assert "audio" in message
     assert TEMPLATE_ID not in message
     assert "artifact-" not in message
+
+
+@pytest.mark.asyncio
+async def test_template_validation_allows_optional_interactive_mind_map(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, _clock = _manager(tmp_path, contracts)
+    client.artifacts.by_notebook[TEMPLATE_ID] = [
+        artifact for artifact in _artifacts() if not artifact.is_interactive_mind_map
+    ]
+
+    counts = await manager.validate_template()
+
+    assert counts["completed_artifacts"] == 8
+
+
+@pytest.mark.asyncio
+async def test_template_validation_enforces_interactive_mind_map_when_required(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    strict_contracts = deepcopy(contracts)
+    strict_contracts[0]["artifacts"]["require_interactive_mind_map"] = True
+    manager, client, _store, _clock = _manager(tmp_path, strict_contracts)
+    client.artifacts.by_notebook[TEMPLATE_ID] = [
+        artifact for artifact in _artifacts() if not artifact.is_interactive_mind_map
+    ]
+
+    with pytest.raises(ContractError, match="interactive mind map"):
+        await manager.validate_template()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -658,7 +658,7 @@ def test_posix_store_rejects_runner_escape_before_creating_parent(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_full_provision_creates_three_roles_and_publishes_activation_last(
+async def test_full_provision_creates_two_workspaces_and_publishes_activation_last(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
@@ -669,14 +669,16 @@ async def test_full_provision_creates_three_roles_and_publishes_activation_last(
     assert [row["role"] for row in manifest["copies"]] == [
         "reference",
         "generation",
-        "multi-source",
     ]
-    assert len(client.notebooks.copy_calls) == 3
-    assert len({row["notebook_id"] for row in manifest["copies"]}) == 3
+    assert len(client.notebooks.copy_calls) == 2
+    assert len({row["notebook_id"] for row in manifest["copies"]}) == 2
     assert all(row["prepared"] for row in manifest["copies"])
-    assert clock.value == 180
+    assert clock.value == 90
     assert set(masked) == {row["notebook_id"] for row in manifest["copies"]}
     lines = (tmp_path / "github-env").read_text().splitlines()
+    generation = next(line for line in lines if line.startswith("NOTEBOOKLM_GENERATION"))
+    multi_source = next(line for line in lines if line.startswith("NOTEBOOKLM_MULTI_SOURCE"))
+    assert generation.split("=", 1)[1] == multi_source.split("=", 1)[1]
     assert lines[-1] == "NOTEBOOKLM_E2E_MANAGED_COPIES=1"
     assert lines[-2] == "NOTEBOOKLM_E2E_REFERENCE_PREPARED=1"
     assert "NOTEBOOKLM_E2E_MANAGED_MODE=full" in lines
@@ -722,7 +724,7 @@ async def test_readonly_provision_creates_only_a_managed_reference_copy(
     [("web", "nightly-web-ubuntu"), ("android", "nightly-android-macos")],
 )
 @pytest.mark.asyncio
-async def test_full_mode_uses_three_distinct_roles_on_designated_os_lanes(
+async def test_full_mode_uses_two_distinct_workspaces_on_designated_os_lanes(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
     backend: str,
@@ -740,8 +742,8 @@ async def test_full_mode_uses_three_distinct_roles_on_designated_os_lanes(
         github_env=tmp_path / "github-env",
     )
     assert manifest["backend"] == backend
-    assert len(client.notebooks.copy_calls) == 3
-    assert len({row["notebook_id"] for row in manifest["copies"]}) == 3
+    assert len(client.notebooks.copy_calls) == 2
+    assert len({row["notebook_id"] for row in manifest["copies"]}) == 2
 
 
 @pytest.mark.asyncio
@@ -776,9 +778,9 @@ async def test_partial_preparation_never_publishes_managed_activation(
         await _provision(manager, tmp_path, mask=masked.append)
     assert not (tmp_path / "github-env").exists()
     manifest = store.read(template_id=TEMPLATE_ID)
-    assert len(manifest["copies"]) == 1
-    assert manifest["copies"][0]["prepared"] is False
-    assert masked == [manifest["copies"][0]["notebook_id"]]
+    assert len(manifest["copies"]) == 2
+    assert all(row["prepared"] is False for row in manifest["copies"])
+    assert masked == [row["notebook_id"] for row in manifest["copies"]]
 
 
 @pytest.mark.asyncio
@@ -1144,7 +1146,7 @@ async def test_cleanup_processes_roles_in_reverse_order(
     manifest = await _provision(manager, tmp_path)
     expected = [str(row["notebook_id"]) for row in reversed(manifest["copies"])]
     result = await manager.cleanup()
-    assert result == {"deleted": 3, "already_missing": 0, "failed": 0}
+    assert result == {"deleted": 2, "already_missing": 0, "failed": 0}
     assert client.notebooks.delete_calls == expected
     assert all(row["status"] == "deleted" for row in manager.store.read()["copies"])
 
@@ -1570,7 +1572,7 @@ async def test_clean_copy_shape_requires_sources_but_not_inherited_artifact_comp
 
 
 @pytest.mark.asyncio
-async def test_provision_requires_artifacts_only_for_reference_role(
+async def test_provision_waits_for_artifacts_before_preparing_every_workspace(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
@@ -1588,7 +1590,37 @@ async def test_provision_requires_artifacts_only_for_reference_role(
 
     await _provision(manager, tmp_path, mode="full")
 
-    assert observed_require_artifacts == [True, False, False]
+    assert observed_require_artifacts == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_provision_dispatches_all_copies_before_settling_any_role(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, _client, _store, _clock = _manager(tmp_path, contracts)
+    events: list[str] = []
+    copy_one = manager.copy_one
+    validate_copy_shape = manager._validate_copy_shape
+
+    async def recording_copy_one(manifest: dict[str, Any], role: str) -> dict[str, Any]:
+        row = await copy_one(manifest, role)
+        events.append(f"copied:{role}")
+        return row
+
+    async def recording_validate_copy_shape(
+        notebook_id: str, *, require_artifacts: bool = True
+    ) -> dict[str, int]:
+        events.append(f"settling:{notebook_id}")
+        return await validate_copy_shape(notebook_id, require_artifacts=require_artifacts)
+
+    manager.copy_one = recording_copy_one  # type: ignore[method-assign]
+    manager._validate_copy_shape = recording_validate_copy_shape  # type: ignore[method-assign]
+
+    await _provision(manager, tmp_path, mode="full")
+
+    assert events[:2] == ["copied:reference", "copied:generation"]
+    assert events[2] == "settling:copy-1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -61,6 +62,12 @@ from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 im
 TEMPLATE_ID = "template-id"
 TEMPLATE_TITLE = "Make Your Writing More Powerful and Persuasive"
 FINGERPRINT = "a" * 64
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://notebooklm.google.com/")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("sensitive response", request=request, response=response)
 
 
 @dataclass
@@ -1920,6 +1927,99 @@ def test_cli_defaults_to_public_template_environment_name() -> None:
     args = lifecycle.build_parser().parse_args(["validate", "--backend", "web"])
 
     assert args.template_id_env == TEMPLATE_ID_ENV
+
+
+@pytest.mark.asyncio
+async def test_ci_client_demotes_close_failure_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class FailingCloseContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            raise _http_status_error(502)
+
+    monkeypatch.setattr(
+        lifecycle.NotebookLMClient,
+        "from_storage",
+        lambda **_kwargs: FailingCloseContext(),
+    )
+
+    async with lifecycle._ci_client(backend="web"):
+        pass
+
+    captured = capsys.readouterr()
+    assert "::warning::client close failed" in captured.err
+    assert "HTTPStatusError" in captured.err
+    assert "sensitive response" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_ci_client_preserves_body_failure_when_close_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingCloseContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            raise _http_status_error(502)
+
+    monkeypatch.setattr(
+        lifecycle.NotebookLMClient,
+        "from_storage",
+        lambda **_kwargs: FailingCloseContext(),
+    )
+
+    with pytest.raises(ValueError, match="body failed"):
+        async with lifecycle._ci_client(backend="web"):
+            raise ValueError("body failed")
+
+
+@pytest.mark.asyncio
+async def test_ci_client_does_not_suppress_unknown_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingCloseContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            raise RuntimeError("close invariant failed")
+
+    monkeypatch.setattr(
+        lifecycle.NotebookLMClient,
+        "from_storage",
+        lambda **_kwargs: FailingCloseContext(),
+    )
+
+    with pytest.raises(RuntimeError, match="close invariant failed"):
+        async with lifecycle._ci_client(backend="web"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_ci_client_does_not_suppress_close_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CancelledCloseContext:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        lifecycle.NotebookLMClient,
+        "from_storage",
+        lambda **_kwargs: CancelledCloseContext(),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async with lifecycle._ci_client(backend="web"):
+            pass
 
 
 def test_cli_cleanup_absent_manifest_never_opens_auth(

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -1511,7 +1511,26 @@ async def test_copy_shape_waits_for_processing_artifacts_to_settle(
     counts = await manager._validate_copy_shape(copied.id)
 
     assert counts["completed_artifacts"] == 9
-    assert clock.value == 10.0
+    assert client.notebooks.get_calls == [copied.id]
+    assert clock.value == 30.0
+
+
+@pytest.mark.asyncio
+async def test_copy_shape_backs_off_after_content_read_quota(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copied = client.notebooks._commit(
+        "notebooklm-py-ci/100/2/rpc-health-web/rpc/00000000000000000000000000000001"
+    )
+    client.artifacts.list_script.append(RateLimitError("quota", method_id="artifact-list"))
+
+    counts = await manager._validate_copy_shape(copied.id)
+
+    assert counts["completed_artifacts"] == 9
+    assert client.notebooks.get_calls == [copied.id]
+    assert clock.value == 60.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -1570,7 +1570,7 @@ async def test_clean_copy_shape_requires_sources_but_not_inherited_artifact_comp
 
 
 @pytest.mark.asyncio
-async def test_provision_waits_for_artifacts_before_preparing_every_clean_role(
+async def test_provision_requires_artifacts_only_for_reference_role(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
@@ -1588,7 +1588,7 @@ async def test_provision_waits_for_artifacts_before_preparing_every_clean_role(
 
     await _provision(manager, tmp_path, mode="full")
 
-    assert observed_require_artifacts == [True, True, True]
+    assert observed_require_artifacts == [True, False, False]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -1551,6 +1551,28 @@ async def test_clean_copy_shape_requires_sources_but_not_inherited_artifact_comp
 
 
 @pytest.mark.asyncio
+async def test_provision_waits_for_artifacts_before_preparing_every_clean_role(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, _client, _store, _clock = _manager(tmp_path, contracts)
+    observed_require_artifacts: list[bool] = []
+    validate_copy_shape = manager._validate_copy_shape
+
+    async def recording_validate_copy_shape(
+        notebook_id: str, *, require_artifacts: bool = True
+    ) -> dict[str, int]:
+        observed_require_artifacts.append(require_artifacts)
+        return await validate_copy_shape(notebook_id, require_artifacts=require_artifacts)
+
+    manager._validate_copy_shape = recording_validate_copy_shape  # type: ignore[method-assign]
+
+    await _provision(manager, tmp_path, mode="full")
+
+    assert observed_require_artifacts == [True, True, True]
+
+
+@pytest.mark.asyncio
 async def test_template_validation_rejects_wrong_notebook_lookup(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],

--- a/tests/unit/test_verify_ci_artifacts.py
+++ b/tests/unit/test_verify_ci_artifacts.py
@@ -587,6 +587,186 @@ async def test_unmatched_started_requires_matching_public_backing(tmp_path) -> N
 
 
 @pytest.mark.asyncio
+async def test_unconfirmed_quota_may_have_no_committed_artifact(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    quota_operation, accepted_operation = str(uuid.uuid4()), str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(quota_operation, "started", family="video"),
+            row(
+                quota_operation,
+                "quota_response_unconfirmed",
+                family="video",
+                reason="server_commit_unknown",
+            ),
+            row(accepted_operation, "started"),
+            row(accepted_operation, "accepted", resource_id="tracked"),
+        ],
+    )
+    tracked = Artifact("tracked", "audio")
+    result = await verify.verify_journal(
+        Client([[tracked], [tracked]]),
+        notebook_id="generation-role",
+        journal_path=journal,
+        timeout=240,
+        minimum_discovery_window=0,
+        quiet_polls=1,
+        poll_interval=0,
+    )
+    assert result["accepted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_quota_may_match_one_committed_artifact(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    operation_id = str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(operation_id, "started"),
+            row(
+                operation_id,
+                "quota_response_unconfirmed",
+                reason="server_commit_unknown",
+            ),
+        ],
+    )
+    artifact = Artifact("committed-after-quota", "audio")
+    result = await verify.verify_journal(
+        Client([[artifact], [artifact]]),
+        notebook_id="generation-role",
+        journal_path=journal,
+        timeout=240,
+        minimum_discovery_window=0,
+        quiet_polls=1,
+        poll_interval=0,
+    )
+    assert result["accepted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_quota_authorizes_matching_artifact_during_settlement(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    quota_operation, accepted_operation = str(uuid.uuid4()), str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(quota_operation, "started"),
+            row(
+                quota_operation,
+                "quota_response_unconfirmed",
+                reason="server_commit_unknown",
+            ),
+            row(accepted_operation, "started", family="report"),
+            row(
+                accepted_operation,
+                "accepted",
+                resource_id="tracked",
+                family="report",
+            ),
+        ],
+    )
+    tracked_pending = Artifact("tracked", "report", "pending")
+    tracked_done = Artifact("tracked", "report")
+    late = Artifact("late-after-quota", "audio")
+    result = await verify.verify_journal(
+        Client([[tracked_pending], [tracked_pending, late], [tracked_done, late]]),
+        notebook_id="generation-role",
+        journal_path=journal,
+        timeout=240,
+        minimum_discovery_window=0,
+        quiet_polls=1,
+        poll_interval=0,
+    )
+    assert result["accepted"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_quota_does_not_authorize_unrelated_inventory(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    operation_id = str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(operation_id, "started"),
+            row(
+                operation_id,
+                "quota_response_unconfirmed",
+                reason="server_commit_unknown",
+            ),
+        ],
+    )
+    with pytest.raises(verify.JournalError, match="no matching journal start"):
+        await verify.verify_journal(
+            Client([[Artifact("wrong-family", "video")]]),
+            notebook_id="generation-role",
+            journal_path=journal,
+            timeout=240,
+            minimum_discovery_window=0,
+            quiet_polls=1,
+            poll_interval=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_quota_authorizes_at_most_one_matching_artifact(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    operation_id = str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(operation_id, "started"),
+            row(
+                operation_id,
+                "quota_response_unconfirmed",
+                reason="server_commit_unknown",
+            ),
+        ],
+    )
+    artifacts = [Artifact("first", "audio"), Artifact("second", "audio")]
+    with pytest.raises(verify.JournalError, match="no matching journal start"):
+        await verify.verify_journal(
+            Client([artifacts]),
+            notebook_id="generation-role",
+            journal_path=journal,
+            timeout=240,
+            minimum_discovery_window=0,
+            quiet_polls=1,
+            poll_interval=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_started_and_unconfirmed_quota_reconcile_same_family_as_a_group(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    started_operation, quota_operation = str(uuid.uuid4()), str(uuid.uuid4())
+    write_journal(
+        journal,
+        [
+            row(started_operation, "started"),
+            row(quota_operation, "started"),
+            row(
+                quota_operation,
+                "quota_response_unconfirmed",
+                reason="server_commit_unknown",
+            ),
+        ],
+    )
+    artifacts = [Artifact("first", "audio"), Artifact("second", "audio")]
+    result = await verify.verify_journal(
+        Client([artifacts, artifacts]),
+        notebook_id="generation-role",
+        journal_path=journal,
+        timeout=240,
+        minimum_discovery_window=0,
+        quiet_polls=1,
+        poll_interval=0,
+    )
+    assert result["accepted"] == 2
+
+
+@pytest.mark.asyncio
 async def test_inventory_artifact_requires_a_matching_journal_start(tmp_path) -> None:
     journal = tmp_path / "journal.jsonl"
     operation_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary

- align the copied public-template contract with the artifact inventory visible through both Web and Android
- treat notebook copy as asynchronous by polling copied sources and artifacts to a stable state
- dispatch both physical copies before waiting, overlapping backend propagation without weakening validation
- provision exactly two workspaces: a stable read-only reference and one clean mutable workspace shared by generation and multi-source tests
- preserve terminal lifecycle outcomes, reconcile backend-specific artifact visibility, and make downloads prefer confirmed payloads
- record quota responses as uncertain until the final artifact inventory proves whether the server committed the request

## Diagnosis

The immutable public notebook `a109ad5c-834d-4f3d-82a0-fe41aa72318e` contains 16 ready sources and stable completed audio, video, infographic, and slide-deck artifacts. `CopyProject` returns before those sources and artifacts finish propagating, and neither the current Web bundle nor Android 1.55 exposes a copy-operation ID or copy-status RPC. Provisioning therefore has to infer completion from notebook state and artifact inventory.

Reference tests need their inherited artifacts and seeded conversation to remain stable. Generation and multi-source tests both require a clean mutable notebook with at least three ready sources, so they safely share the second copy in the sequential E2E suite. This removes a redundant third copy while preserving isolation where it matters.

## Validation

- `uv run pytest -q tests/unit/test_manage_ci_e2e_notebooks.py tests/unit/test_ci_account_pool_workflows.py tests/unit/test_e2e_managed_fixtures.py tests/unit/test_e2e_generation_journal.py tests/unit/test_e2e_conftest_options.py tests/unit/test_verify_ci_artifacts.py` (273 passed)
- `uv run pytest --collect-only -q tests/e2e` (221 collected)
- `uv run pre-commit run --all-files`
- live Web and Android inspection of the immutable template

Exact-head live qualification will run in order: RPC Check, short read-only E2E, full Web E2E, then full Android E2E. Any code change restarts the sequence from RPC Check.
