### PR TITLE
fix(ci): permit two-copy qualification manifests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -538,11 +538,17 @@ jobs:
         if any(manifest.get(key) != value for key, value in expected.items()):
             raise RuntimeError("manifest summary metadata mismatch")
         copies = manifest.get("copies")
-        roles = {
-            "full": ("reference", "generation", "multi-source"),
-            "readonly": ("reference",),
+        allowed_roles = {
+            "full": {
+                ("reference", "generation"),
+                ("reference", "generation", "multi-source"),
+            },
+            "readonly": {("reference",)},
         }[expected["mode"]]
-        if not isinstance(copies, list) or len(copies) != len(roles):
+        if not isinstance(copies, list):
+            raise RuntimeError("manifest summary role count mismatch")
+        roles = tuple(row.get("role") for row in copies if isinstance(row, dict))
+        if roles not in allowed_roles or len(roles) != len(copies):
             raise RuntimeError("manifest summary role count mismatch")
         rows = {row.get("role"): row for row in copies if isinstance(row, dict)}
         if set(rows) != set(roles):

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -250,10 +250,15 @@ jobs:
         if any(manifest.get(key) != value for key, value in expected.items()):
             raise RuntimeError("manifest summary metadata mismatch")
         copies = manifest.get("copies")
-        if not isinstance(copies, list) or len(copies) != 3:
+        if not isinstance(copies, list):
+            raise RuntimeError("manifest summary role count mismatch")
+        roles = tuple(row.get("role") for row in copies if isinstance(row, dict))
+        if roles not in {
+            ("reference", "generation"),
+            ("reference", "generation", "multi-source"),
+        } or len(roles) != len(copies):
             raise RuntimeError("manifest summary role count mismatch")
         rows = {row.get("role"): row for row in copies if isinstance(row, dict)}
-        roles = ("reference", "generation", "multi-source")
         if set(rows) != set(roles):
             raise RuntimeError("manifest summary roles mismatch")
         if any(row.get("status") not in {"confirmed", "reconciled"} for row in rows.values()):
@@ -268,7 +273,7 @@ jobs:
             "### Prepared package roles",
             f"- Lane/backend/slot: verify-package / web / {expected['account_slot']}",
             f"- Template contract: version=1 fingerprint={fingerprint}",
-            f"- Copy outcomes: total=3 confirmed={outcomes['confirmed']} reconciled={outcomes['reconciled']}",
+            f"- Copy outcomes: total={len(roles)} confirmed={outcomes['confirmed']} reconciled={outcomes['reconciled']}",
             "- Reference checks: seeded_notes=1 history=passed",
             "- Clean-role residuals: generation=0 multi-source=0",
         ]

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -506,7 +506,9 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
     nightly = _load("nightly.yml")["jobs"]["e2e"]
     nightly_provision = str(_step(nightly, "provision")["run"])
     assert "Template contract: version=1 fingerprint=" in nightly_provision
-    assert '"readonly": ("reference",)' in nightly_provision
+    assert '"readonly": {("reference",)}' in nightly_provision
+    assert '("reference", "generation")' in nightly_provision
+    assert '("reference", "generation", "multi-source")' in nightly_provision
     assert "Copy outcomes: total={len(roles)}" in nightly_provision
     assert "Clean-role residuals: generation=0 multi-source=0" in nightly_provision
     assert 'row["notebook_id"]' not in nightly_provision
@@ -520,7 +522,9 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
 
     package = _load("verify-package.yml")["jobs"]["verify"]
     package_provision = str(_step(package, "provision")["run"])
-    assert "Copy outcomes: total=3" in package_provision
+    assert '("reference", "generation")' in package_provision
+    assert '("reference", "generation", "multi-source")' in package_provision
+    assert "Copy outcomes: total={len(roles)}" in package_provision
     assert "Clean-role residuals: generation=0 multi-source=0" in package_provision
     assert 'row["notebook_id"]' not in package_provision
 


### PR DESCRIPTION
## Summary

- allow trusted Nightly qualification summaries to validate both legacy three-copy and new two-copy full manifests
- apply the same compatibility guard to Verify Package
- keep exact ordered roles, confirmed/reconciled outcomes, and prepared-state validation intact

This is the bootstrap needed for #2354 to consolidate generation and multi-source onto one mutable copy while the trusted workflow still runs from main.

## Tests

- `uv run pytest -q tests/unit/test_ci_account_pool_workflows.py`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest validation to correctly support both two-copy and three-copy full-mode configurations.
  * Preserved strict validation for readonly mode, which requires a reference copy.
  * Updated package verification summaries to report the actual number of manifest copies.

* **Tests**
  * Updated workflow checks to cover supported role combinations and dynamic copy counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->