### PR TITLE
fix(e2e): exclude quota shadows from artifact settlement

### DIFF
--- a/scripts/verify_ci_artifacts.py
+++ b/scripts/verify_ci_artifacts.py
@@ -571,11 +571,23 @@ async def verify_journal(
         }
     )
     quota_allowances = +quota_allowances
-    accepted_count = len(accepted_operations) + len(unjournaled_ids)
+    # A quota response can leave a matching placeholder in the public inventory,
+    # but the caller never received an accepted task ID for that row.  Keep those
+    # rows in the reconciliation candidate groups so they remain bounded by the
+    # journal, without promoting them into work that must settle.  An unmatched
+    # ``started`` operation is different: it represents a crash before the
+    # accepted ID could be appended and therefore still requires one terminal row
+    # of the matching target.  Grouping candidates by target is necessary because
+    # the public inventory cannot identify which same-family row belongs to which
+    # of those two operation shapes.
+    discovered_ids_by_target: dict[DiscoveredTarget, set[str]] = {}
+    for resource_id, target in unjournaled.items():
+        discovered_ids_by_target.setdefault(target, set()).add(resource_id)
+    accepted_count = len(accepted_operations) + sum(required_targets.values())
     if accepted_count == 0:
         raise EmptyArtifactsError("journal/inventory has no accepted producer operations")
     ever_visible_ids = set(by_id)
-    monitored_ids = (set(tracked) - authorized_deleted) | unjournaled_ids
+    monitored_ids = set(tracked) - authorized_deleted
     statuses: dict[str, str] = {}
     missing_counts: Counter[str] = Counter()
     while True:
@@ -603,10 +615,13 @@ async def verify_journal(
         if newly_visible:
             quota_allowances.subtract(newly_visible_targets)
             quota_allowances = +quota_allowances
-            new_ids = set(newly_visible)
-            unjournaled_ids.update(new_ids)
-            monitored_ids.update(new_ids)
-            accepted_count += len(new_ids)
+            for resource_id, artifact in newly_visible.items():
+                target = DiscoveredTarget(
+                    family=_family(artifact),
+                    id_kind=_public_id_kind(artifact),
+                )
+                discovered_ids_by_target.setdefault(target, set()).add(resource_id)
+                unjournaled_ids.add(resource_id)
         for resource_id, operation in tracked.items():
             artifact = current_by_id.get(resource_id)
             if artifact is None or resource_id in authorized_deleted:
@@ -640,12 +655,44 @@ async def verify_journal(
             if removed_ids & ever_visible_ids:
                 raise RemovedArtifactError("one or more accepted artifacts were delisted")
             raise RemovedArtifactError("one or more accepted artifacts were removed")
+
+        # Candidate IDs discovered without an ID-bearing journal event are
+        # indistinguishable within one family/backing target.  Require enough
+        # terminal candidates to cover only the unmatched ``started`` operations;
+        # any surplus is an authorized quota-shadow row.  Prefer failed outcomes
+        # when the assignment is ambiguous so quota reconciliation cannot hide a
+        # real failed producer operation.
+        for target, required in required_targets.items():
+            candidate_ids = discovered_ids_by_target.get(target, set())
+            candidate_statuses: list[str] = []
+            for resource_id in candidate_ids:
+                artifact = current_by_id.get(resource_id)
+                if artifact is None:
+                    missing_counts[resource_id] += 1
+                    status = (
+                        "removed" if missing_counts[resource_id] >= not_found_grace else "not_found"
+                    )
+                else:
+                    missing_counts[resource_id] = 0
+                    status = _snapshot_status(artifact)
+                candidate_statuses.append(status)
+            remaining = sum(status != "removed" for status in candidate_statuses)
+            if remaining < required:
+                raise RemovedArtifactError("one or more crash-reconciled artifacts were delisted")
+            candidate_failed = sum(status == "failed" for status in candidate_statuses)
+            candidate_completed = sum(status == "completed" for status in candidate_statuses)
+            terminal = min(required, candidate_failed + candidate_completed)
+            selected_failed = min(candidate_failed, terminal)
+            failed += selected_failed
+            completed += terminal - selected_failed
+            pending += required - terminal
+
         ever_visible_ids.update(current_ids)
         if pending == 0:
             never_visible = (set(tracked) - authorized_deleted) - ever_visible_ids
             if never_visible:
                 raise RemovedArtifactError("one or more accepted artifacts never became listable")
-            if not (monitored_ids & ever_visible_ids):
+            if not (monitored_ids & ever_visible_ids) and not required_targets:
                 raise EmptyArtifactsError("generation copy has no discovered persistent artifacts")
             denominator = completed + failed
             if denominator == 0:
@@ -660,7 +707,8 @@ async def verify_journal(
                 print("WARNING: missing artifact families: " + ", ".join(sorted(missing)))
             print(
                 f"Journal verification: accepted={accepted_count} "
-                f"completed={completed} failed={failed} pending=0 removed=0"
+                f"completed={completed} failed={failed} pending=0 removed=0 "
+                f"quota_committed={len(unjournaled_ids) - sum(required_targets.values())}"
             )
             print("Families: " + ", ".join(sorted(families)))
             return {
@@ -669,6 +717,7 @@ async def verify_journal(
                 "failed": failed,
                 "pending": 0,
                 "removed": 0,
+                "quota_committed": len(unjournaled_ids) - sum(required_targets.values()),
                 "families": sorted(families),
             }
         if clock() + poll_interval > deadline:

--- a/tests/unit/test_verify_ci_artifacts.py
+++ b/tests/unit/test_verify_ci_artifacts.py
@@ -633,16 +633,16 @@ async def test_unconfirmed_quota_may_match_one_committed_artifact(tmp_path) -> N
         ],
     )
     artifact = Artifact("committed-after-quota", "audio")
-    result = await verify.verify_journal(
-        Client([[artifact], [artifact]]),
-        notebook_id="generation-role",
-        journal_path=journal,
-        timeout=240,
-        minimum_discovery_window=0,
-        quiet_polls=1,
-        poll_interval=0,
-    )
-    assert result["accepted"] == 1
+    with pytest.raises(verify.EmptyArtifactsError, match="no accepted producer operations"):
+        await verify.verify_journal(
+            Client([[artifact], [artifact]]),
+            notebook_id="generation-role",
+            journal_path=journal,
+            timeout=240,
+            minimum_discovery_window=0,
+            quiet_polls=1,
+            poll_interval=0,
+        )
 
 
 @pytest.mark.asyncio
@@ -669,7 +669,7 @@ async def test_unconfirmed_quota_authorizes_matching_artifact_during_settlement(
     )
     tracked_pending = Artifact("tracked", "report", "pending")
     tracked_done = Artifact("tracked", "report")
-    late = Artifact("late-after-quota", "audio")
+    late = Artifact("late-after-quota", "audio", "pending")
     result = await verify.verify_journal(
         Client([[tracked_pending], [tracked_pending, late], [tracked_done, late]]),
         notebook_id="generation-role",
@@ -679,7 +679,8 @@ async def test_unconfirmed_quota_authorizes_matching_artifact_during_settlement(
         quiet_polls=1,
         poll_interval=0,
     )
-    assert result["accepted"] == 2
+    assert result["accepted"] == 1
+    assert result["quota_committed"] == 1
 
 
 @pytest.mark.asyncio
@@ -724,7 +725,7 @@ async def test_unconfirmed_quota_authorizes_at_most_one_matching_artifact(tmp_pa
             ),
         ],
     )
-    artifacts = [Artifact("first", "audio"), Artifact("second", "audio")]
+    artifacts = [Artifact("first", "audio"), Artifact("second", "audio", "pending")]
     with pytest.raises(verify.JournalError, match="no matching journal start"):
         await verify.verify_journal(
             Client([artifacts]),
@@ -753,7 +754,7 @@ async def test_started_and_unconfirmed_quota_reconcile_same_family_as_a_group(tm
             ),
         ],
     )
-    artifacts = [Artifact("first", "audio"), Artifact("second", "audio")]
+    artifacts = [Artifact("first", "audio"), Artifact("second", "audio", "pending")]
     result = await verify.verify_journal(
         Client([artifacts, artifacts]),
         notebook_id="generation-role",
@@ -763,7 +764,116 @@ async def test_started_and_unconfirmed_quota_reconcile_same_family_as_a_group(tm
         quiet_polls=1,
         poll_interval=0,
     )
-    assert result["accepted"] == 2
+    assert result["accepted"] == 1
+    assert result["quota_committed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_crash_reconciled_candidate_still_requires_settlement(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    operation_id = str(uuid.uuid4())
+    write_journal(journal, [row(operation_id, "started")])
+    pending = Artifact("crash-reconciled", "audio", "pending")
+    clock = Clock()
+
+    with pytest.raises(verify.SettlementTimeoutError):
+        await verify.verify_journal(
+            Client([[pending]] * 10),
+            notebook_id="generation-role",
+            journal_path=journal,
+            timeout=240,
+            clock=clock,
+            sleep=clock.sleep,
+            minimum_discovery_window=0,
+            quiet_polls=1,
+            poll_interval=30,
+        )
+
+
+@pytest.mark.asyncio
+async def test_quota_shadow_placeholders_do_not_block_accepted_settlement(tmp_path) -> None:
+    journal = tmp_path / "journal.jsonl"
+    rows = []
+    accepted = []
+    quota_shadows = []
+    for index, family in enumerate(("audio", "quiz", "flashcards", "infographic", "mind_map")):
+        operation_id = str(uuid.uuid4())
+        resource_id = f"accepted-{index}"
+        id_kind = "note_mind_map" if family == "mind_map" else "studio_task"
+        rows.extend(
+            [
+                row(operation_id, "started", family=family, id_kind=id_kind),
+                row(
+                    operation_id,
+                    "persisted" if family == "mind_map" else "accepted",
+                    resource_id=resource_id,
+                    family=family,
+                    id_kind=id_kind,
+                ),
+            ]
+        )
+        accepted.append(Artifact(resource_id, family))
+    for index, family in enumerate(
+        (
+            "audio",
+            "video",
+            "slide_deck",
+            "data_table",
+            "report",
+            "report",
+            "report",
+            "report",
+            "mind_map",
+        )
+    ):
+        operation_id = str(uuid.uuid4())
+        resource_id = f"quota-shadow-{index}"
+        rows.extend(
+            [
+                row(operation_id, "started", family=family),
+                row(
+                    operation_id,
+                    "quota_response_unconfirmed",
+                    family=family,
+                    reason="server_commit_unknown",
+                ),
+            ]
+        )
+        quota_shadows.append(
+            Artifact(resource_id, family, "pending", interactive=family == "mind_map")
+        )
+    write_journal(journal, rows)
+    inventory = accepted + quota_shadows
+
+    result = await verify.verify_journal(
+        Client([inventory, inventory]),
+        notebook_id="generation-role",
+        journal_path=journal,
+        timeout=240,
+        minimum_discovery_window=0,
+        quiet_polls=1,
+        poll_interval=0,
+    )
+
+    assert result == {
+        "accepted": 5,
+        "completed": 5,
+        "failed": 0,
+        "pending": 0,
+        "removed": 0,
+        "quota_committed": 9,
+        "families": [
+            "audio",
+            "data_table",
+            "flashcards",
+            "infographic",
+            "mind_map",
+            "quiz",
+            "report",
+            "slide_deck",
+            "video",
+        ],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- keep quota-response placeholder commits bounded by journal allowances without promoting them to accepted work
- require explicit accepted IDs and crash-before-journal candidates to settle, while reporting quota_committed separately
- cover the observed 5 completed plus 9 pending quota-shadow regression and mixed crash/quota reconciliation

## Root cause

The failing Web lane spent 44m51s in generation journal verification before reporting completed=5, failed=0, pending=9. Those nine pending rows were placeholder commits from CREATE_ARTIFACT calls that returned typed quota errors. The verifier authorized the rows correctly, but then treated them as accepted operations and waited for settlement.

The Android comparison confirms aggregation is not the bottleneck: Android has generation journal mode off and skips the Web-only verifier, while both aggregation steps themselves complete almost immediately.

- Failing Web job: https://github.com/teng-lin/notebooklm-py/actions/runs/33948873452/job/101259824514
- Android comparison: https://github.com/teng-lin/notebooklm-py/actions/runs/33948873452/job/101259824065

## Validation

- uv run pytest tests/unit/test_verify_ci_artifacts.py tests/unit/test_e2e_generation_journal.py tests/unit/test_e2e_conftest_options.py tests/unit/test_ci_pool_static_contracts.py tests/unit/test_ci_test_matrix.py -q — 139 passed
- uv run ruff check scripts/verify_ci_artifacts.py tests/unit/test_verify_ci_artifacts.py
- uv run ruff format --check scripts/verify_ci_artifacts.py tests/unit/test_verify_ci_artifacts.py
- uv run mypy src/notebooklm — no issues in 452 source files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of crash-reconciled operations and quota-shadow artifacts.
  * Prevented surplus artifacts from being counted as completed or failed operations.
  * Ensured pending artifacts still require settlement and correctly time out when unresolved.
  * Improved handling of quota placeholders across multiple artifact families.

* **Verification**
  * Verification results now report quota-committed artifacts separately from accepted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->