### PR TITLE
feat(cli): add live compute usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ notebooklm agent show claude         # Print bundled Claude Code skill template
 notebooklm language list             # List supported output languages
 notebooklm metadata --json           # Export notebook metadata and sources
 notebooklm usage                     # Show live compute usage and reset times
-notebooklm usage --json              # Export the full usage snapshot, including actions
+notebooklm usage --json              # Export the full usage snapshot, including categories
 notebooklm share status              # Inspect sharing state
 notebooklm source add-research "AI" --import-all  # web research + import found sources
 notebooklm skill status              # Check local agent skill installation

--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ notebooklm agent show codex          # Print bundled Codex instructions
 notebooklm agent show claude         # Print bundled Claude Code skill template
 notebooklm language list             # List supported output languages
 notebooklm metadata --json           # Export notebook metadata and sources
+notebooklm usage                     # Show live compute usage and reset times
+notebooklm usage --json              # Export the full usage snapshot, including actions
 notebooklm share status              # Inspect sharing state
 notebooklm source add-research "AI" --import-all  # web research + import found sources
 notebooklm skill status              # Check local agent skill installation

--- a/SKILL.md
+++ b/SKILL.md
@@ -132,6 +132,7 @@ Common operations:
 
 | Goal | Command |
 |---|---|
+| Check compute usage | `notebooklm usage --json`; `notebooklm usage --categories` for category availability and estimated costs |
 | List or create notebooks | `notebooklm list --json`; `notebooklm create "Title" --json` |
 | Add and wait for a source | `notebooklm source add <input> -n <nb> --json`; `notebooklm source wait <src> -n <nb>` |
 | Chat | `notebooklm ask "question" -n <nb> --json` |

--- a/docs/adr/0037-live-usage-and-quota-api.md
+++ b/docs/adr/0037-live-usage-and-quota-api.md
@@ -376,7 +376,7 @@ processes with `NOTEBOOKLM_PROFILE=YOUR_STANDARD_PROFILE` and
 performs no generation and consumes no metered usage.
 
 The top-level `notebooklm usage` command projects this API in the `SectionedGroup` Session section.
-It shows both windows, optionally expands action details with `--actions`, and emits the full
+It shows both windows, optionally expands usage categories with `--categories` (alias `--actions`), and emits the full
 snapshot with `--json`, including explicit ISO 8601 reset timestamps. The CLI contract baseline,
 documentation, and JSON timestamp assertions cover this projection. MCP and REST usage projections
 remain additive follow-ups.

--- a/docs/adr/0037-live-usage-and-quota-api.md
+++ b/docs/adr/0037-live-usage-and-quota-api.md
@@ -158,8 +158,8 @@ usage = await client.settings.get_usage()
 ```
 
 `SettingsAPI` already owns `get_account_limits()` and account RPCs. A new root namespace would add
-assembly, backend-manifest, fake, and lifecycle surface without a distinct state owner. A future
-CLI can still expose `notebooklm usage --json`.
+assembly, backend-manifest, fake, and lifecycle surface without a distinct state owner. The
+CLI exposes this API through `notebooklm usage --json`.
 
 ### Public model
 
@@ -375,8 +375,11 @@ processes with `NOTEBOOKLM_PROFILE=YOUR_STANDARD_PROFILE` and
 `NOTEBOOKLM_PROFILE=YOUR_PRO_PROFILE`; an operation never switches identity mid-run. Ordinary CI
 performs no generation and consumes no metered usage.
 
-CLI, MCP, and REST *usage projections* are additive follow-ups. If a top-level CLI command is added,
-it must be assigned to a `SectionedGroup` section and update CLI/docs/JSON datetime baselines.
+The top-level `notebooklm usage` command projects this API in the `SectionedGroup` Session section.
+It shows both windows, optionally expands action details with `--actions`, and emits the full
+snapshot with `--json`, including explicit ISO 8601 reset timestamps. The CLI contract baseline,
+documentation, and JSON timestamp assertions cover this projection. MCP and REST usage projections
+remain additive follow-ups.
 
 ## Consequences
 

--- a/docs/android/usage-quota-evidence.md
+++ b/docs/android/usage-quota-evidence.md
@@ -50,6 +50,21 @@ the response field identity. Live generation independently corroborates action 9
 action 10 as Quiz; current frontend behavior corroborates action 15 as Deep Research. The live
 first-party protobuf JSON response closes newer code 22 as `SUGGESTION_CHIPS`.
 
+### CLI display names
+
+Protocol enum names are not necessarily the names shown in the product. The recorded translator
+maps video format `3` to action `3`; `VideoFormat.CINEMATIC = 3` and the cinematic generation builder
+establish its CLI label as **Cinematic video**, despite the protocol name `BREAKDOWNS_VIDEO`.
+Other display labels expand abbreviations or match existing CLI features: `QNA` becomes **Chat
+Q&A**, `SUGGESTION_CHIPS` becomes **Suggested questions**, and `DOCUMENT_GUIDE` becomes **Source
+guide** (the source snippet/main-ideas response from `GenerateDocumentGuides`).
+
+`NOS` and `NOS_IMAGE_GENERATION` remain exact recovered protocol names. The adjacent Android
+`ClientCapability.NOTEBOOK_OS_AGENCY` and `SuggestionConfigId.SUGGESTION_CONFIG_NOS_APP` names suggest
+an internal Notebook OS connection, but do not establish the quota actions' public feature mapping.
+The CLI therefore retains `NOS` with an explicit uncertainty note. JSON `kind` preserves all exact
+enum names; these presentation labels do not rename protocol values.
+
 ## Android static and route recovery
 
 The official app contains an exact generated protobuf RPC binding with these properties:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1858,6 +1858,7 @@ src/notebooklm/
     ├── label_cmd.py             # label list/sources/generate/create/rename/emoji/add/remove/delete
     ├── collection_cmd.py        # collection list/notebooks/create/rename/add/remove/delete (account-level)
     ├── language_cmd.py          # Language configuration CLI commands
+    ├── usage_cmd.py             # Account compute usage windows and action details
     ├── master_token_login.py    # Command driver for `login --master-token[-refresh]` (ADR-0023)
     ├── mcp_cmd.py               # `mcp install <client>` command — thin Click adapter over `_app/mcp_install.py`; resolves the client config path (`--config-path` override) and applies the merge inside `notebooklm.io.atomic_update_json` (locked, crash-safe, merge-not-clobber)
     ├── notebook_cmd.py          # list, create, delete, rename

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,7 +1,7 @@
 # CLI Reference
 
 **Status:** Active
-**Last Updated:** 2026-09-02
+**Last Updated:** 2026-09-05
 
 Complete command reference for the `notebooklm` CLI—providing full programmatic access to all NotebookLM features, including capabilities not exposed in the web UI.
 
@@ -63,6 +63,9 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `status` | Show current context | `notebooklm status` |
 | `status --paths` | Show configuration paths | `notebooklm status --paths` |
 | `status --json` | Output status as JSON | `notebooklm status --json` |
+| `usage` | Show live account compute usage and reset times | `notebooklm usage` |
+| `usage --actions` | Include action availability and advertised costs | `notebooklm usage --actions` |
+| `usage --json` | Output the full usage snapshot as JSON | `notebooklm -p work usage --json` |
 | `clear` | Clear current context | `notebooklm clear` |
 | `auth check` | Diagnose authentication issues | `notebooklm auth check` |
 | `auth check --test` | Validate with network test | `notebooklm auth check --test` |
@@ -76,6 +79,44 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `doctor --fix` | Auto-fix detected issues | `notebooklm doctor --fix` |
 | `doctor --json` | Output diagnostics as JSON | `notebooklm doctor --json` |
 | `completion <shell>` | Print shell completion script (`bash`/`zsh`/`fish`) | `notebooklm completion zsh > ~/.zfunc/_notebooklm` |
+
+### Live Compute Usage (`notebooklm usage`)
+
+Shows the current account's five-hour and weekly compute usage percentages and the reset timestamps
+supplied by the server. It requires authentication but no active notebook. Global `--profile`,
+`--storage`, and `--backend web|android` options apply as usual.
+
+```bash
+notebooklm usage
+notebooklm usage --actions
+notebooklm -p work usage --json
+notebooklm --backend android usage --json
+```
+
+`--actions` adds a table of action codes, names, quota sufficiency, relative cost tiers, estimated
+cost percentages, and remaining deferred artifact generations. JSON always includes these details.
+Text percentages are rounded to two decimal places; JSON preserves the returned precision.
+
+The JSON object contains:
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `ready`, `disabled` (meter not enabled for the account), or `skipped` (temporarily unavailable) |
+| `enabled`, `available` | Account eligibility and whether a snapshot is ready |
+| `is_exhausted` | Whether the active window is exhausted; `null` when unavailable |
+| `active_window` | `weekly` when weekly usage is at least 100%, otherwise `five_hour`; `null` when unavailable |
+| `windows` | Rows with `kind` (`five_hour` or `weekly`), `used_percent`, `remaining_percent`, and `resets_at` (ISO 8601 UTC, e.g. `2026-09-05T18:30:00+00:00`) |
+| `actions` | Rows with `code`, `kind` (lowercase enum name, e.g. `audio_overview`), `has_sufficient_quota`, `cost_tier` (`low`, `medium`, `high`, `very_high`, or `null`), `remaining_deferred_artifact_generations`, and `estimated_cost_percent` |
+
+Unknown action codes remain in JSON with `kind: null`. Absent cost estimates, cost tiers, and
+deferred-generation counts are `null`, distinct from zero. Disabled and skipped meters return empty
+`windows` and `actions` arrays and exit `0`; transport, authentication, and decoding failures use the
+standard error envelope and exit nonzero. An exhausted snapshot also exits `0`: the command reports
+usage rather than enforcing it.
+
+This is the live compute meter, separate from [static published plan limits](quota-limits.md).
+Percentages may change after generation settles. Advertised action costs are estimates, not final
+charges or a credit balance; reset timestamps are reported directly without calculating a countdown.
 
 ### Profile Commands (`notebooklm profile <cmd>`)
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,7 +64,7 @@ See [Configuration](configuration.md) for full env-var precedence and CI/CD setu
 | `status --paths` | Show configuration paths | `notebooklm status --paths` |
 | `status --json` | Output status as JSON | `notebooklm status --json` |
 | `usage` | Show live account compute usage and reset times | `notebooklm usage` |
-| `usage --actions` | Include action availability and advertised costs | `notebooklm usage --actions` |
+| `usage --categories` | Include usage categories, availability, and estimated costs | `notebooklm usage --categories` |
 | `usage --json` | Output the full usage snapshot as JSON | `notebooklm -p work usage --json` |
 | `clear` | Clear current context | `notebooklm clear` |
 | `auth check` | Diagnose authentication issues | `notebooklm auth check` |
@@ -88,14 +88,29 @@ supplied by the server. It requires authentication but no active notebook. Globa
 
 ```bash
 notebooklm usage
-notebooklm usage --actions
+notebooklm usage --categories
 notebooklm -p work usage --json
 notebooklm --backend android usage --json
 ```
 
-`--actions` adds a table of action codes, names, quota sufficiency, relative cost tiers, estimated
-cost percentages, and remaining deferred artifact generations. JSON always includes these details.
+`--categories` (alias `--actions`) adds a table of category codes, names, quota sufficiency, relative
+cost tiers, estimated cost percentages, and remaining deferred artifact generations. JSON always
+includes these details.
 Text percentages are rounded to two decimal places; JSON preserves the returned precision.
+
+The category table uses readable feature names: for example, Cinematic video (code 3), Slide deck
+(6), Data table (8), Chat Q&A (18), Source guide (21), and Suggested questions (22). JSON retains the
+`actions` array and exact protocol enum names in `kind` for scripts. `NOS` (16) and
+`NOS_IMAGE_GENERATION` (19) are internal server names without a verified public feature mapping;
+the table marks that uncertainty instead of guessing a feature name. See the
+[protocol evidence](android/usage-quota-evidence.md).
+
+`Est. cost*` is the server's estimated percentage of budget. In the recorded Flashcards and Quiz
+generations it matched the initial reservation against the **five-hour** window; the weekly debit
+was a different percentage, and final usage settled lower. The response does not explicitly name
+the estimate's budget window, so the CLI describes the five-hour basis as observed behavior. The
+`Quota` column is the current account-level availability flag for that category, not a separate
+five-hour or weekly availability reading.
 
 The JSON object contains:
 

--- a/docs/quota-limits.md
+++ b/docs/quota-limits.md
@@ -12,7 +12,7 @@ implemented API. The historical investigation is in
 [#2283](https://github.com/teng-lin/notebooklm-py/issues/2283). This document remains **prose
 reference, not shipped code** (see [Why this lives in docs](#why-this-lives-in-docs-not-code)).
 
-Inspect the live meter with `notebooklm usage`, add `--actions` for action availability and advertised
+Inspect the live meter with `notebooklm usage`, add `--categories` for category availability and estimated
 costs, or use `notebooklm usage --json` for the full snapshot. See the
 [CLI usage reference](cli-reference.md#live-compute-usage-notebooklm-usage) for fields and unavailable
 states.

--- a/docs/quota-limits.md
+++ b/docs/quota-limits.md
@@ -12,6 +12,11 @@ implemented API. The historical investigation is in
 [#2283](https://github.com/teng-lin/notebooklm-py/issues/2283). This document remains **prose
 reference, not shipped code** (see [Why this lives in docs](#why-this-lives-in-docs-not-code)).
 
+Inspect the live meter with `notebooklm usage`, add `--actions` for action availability and advertised
+costs, or use `notebooklm usage --json` for the full snapshot. See the
+[CLI usage reference](cli-reference.md#live-compute-usage-notebooklm-usage) for fields and unavailable
+states.
+
 The rotating CI account pool proposed in
 [#2331](https://github.com/teng-lin/notebooklm-py/issues/2331) is load distribution across
 authorized, independently managed accounts—not quota telemetry and not an attempt to infer or

--- a/src/notebooklm/cli/__init__.py
+++ b/src/notebooklm/cli/__init__.py
@@ -24,6 +24,7 @@ break Python's package-attribute shadowing — see
   rename, summary, metadata)
 - ``chat_cmd``: Chat commands (ask, configure, history)
 - ``doctor_cmd``: Diagnostic and migration commands
+- ``usage_cmd``: Live compute usage command
 
 The click groups themselves are still exported here under their historical
 names (``source``, ``artifact``, …) so ``from notebooklm.cli import source``
@@ -90,6 +91,7 @@ from .session_cmd import register_session_commands
 from .share_cmd import share
 from .skill_cmd import skill
 from .source_cmd import source
+from .usage_cmd import usage
 
 __all__ = [
     # Command groups (subcommand style)
@@ -107,6 +109,7 @@ __all__ = [
     "language",
     "profile",
     "mcp",
+    "usage",
     # Language config
     "get_language",
     # Register functions (top-level command style)

--- a/src/notebooklm/cli/grouped.py
+++ b/src/notebooklm/cli/grouped.py
@@ -49,7 +49,7 @@ class SectionedGroup(click.Group):
     """Click group that displays commands organized in sections.
 
     Instead of a flat alphabetical list, commands are grouped by function:
-    - Session: login, use, status, clear, doctor, auth, completion
+    - Session: login, use, status, usage, clear, doctor, auth, completion
     - Notebooks: list, create, copy, delete, rename, summary, metadata
     - Chat: ask, suggest-prompts, suggest-next-steps, configure, history
     - Command Groups: source, artifact, note, label, collection, share, research,
@@ -61,7 +61,10 @@ class SectionedGroup(click.Group):
     # Regular commands - show help text
     command_sections = OrderedDict(
         [
-            ("Session", ["login", "use", "status", "clear", "doctor", "auth", "completion"]),
+            (
+                "Session",
+                ["login", "use", "status", "usage", "clear", "doctor", "auth", "completion"],
+            ),
             ("Notebooks", ["list", "create", "copy", "delete", "rename", "summary", "metadata"]),
             ("Chat", ["ask", "suggest-prompts", "suggest-next-steps", "configure", "history"]),
         ]

--- a/src/notebooklm/cli/usage_cmd.py
+++ b/src/notebooklm/cli/usage_cmd.py
@@ -7,13 +7,49 @@ from typing import TYPE_CHECKING, Any
 import click
 from rich.table import Table
 
-from ..types import UsageSummary, UsageSummaryStatus, UsageWindowKind
+from ..types import UsageAction, UsageActionKind, UsageSummary, UsageSummaryStatus, UsageWindowKind
 from .auth_runtime import run_client_workflow
 from .options import json_option
 from .rendering import cli_print, json_output_response
 
 if TYPE_CHECKING:
     from ..client import NotebookLMClient
+
+
+# Presentation labels are separate from the exact protocol enum names. In the
+# recorded Web translator, video format 3 maps to action 3 (Cinematic video).
+# See docs/android/usage-quota-evidence.md; NOS has no verified public mapping.
+_CATEGORY_LABELS = {
+    UsageActionKind.AUDIO_OVERVIEW: "Audio overview",
+    UsageActionKind.VIDEO_OVERVIEW: "Video overview",
+    UsageActionKind.BREAKDOWNS_VIDEO: "Cinematic video",
+    UsageActionKind.SHORTS_VIDEO: "Short video",
+    UsageActionKind.INFOGRAPHIC: "Infographic",
+    UsageActionKind.SLIDES: "Slide deck",
+    UsageActionKind.REPORTS: "Reports",
+    UsageActionKind.TABLES: "Data table",
+    UsageActionKind.FLASHCARDS: "Flashcards",
+    UsageActionKind.QUIZ: "Quiz",
+    UsageActionKind.MINDMAP: "Mind map",
+    UsageActionKind.CANVAS: "Canvas",
+    UsageActionKind.SLIDES_EDITING: "Slide editing",
+    UsageActionKind.FLASHCARD_EDITING: "Flashcard editing",
+    UsageActionKind.DEEP_RESEARCH: "Deep research",
+    UsageActionKind.NOS: "Unmapped category (NOS)",
+    UsageActionKind.FAST_RESEARCH: "Fast research",
+    UsageActionKind.QNA: "Chat Q&A",
+    UsageActionKind.NOS_IMAGE_GENERATION: "Image generation (NOS)",
+    UsageActionKind.GUIDED_VIEW: "Guided view",
+    UsageActionKind.DOCUMENT_GUIDE: "Source guide",
+    UsageActionKind.SUGGESTION_CHIPS: "Suggested questions",
+}
+
+
+def _category_label(action: UsageAction) -> str:
+    """Name known features while keeping unmapped category codes identifiable."""
+    if action.kind is None:
+        return f"Unknown category ({action.code})"
+    return _CATEGORY_LABELS[action.kind]
 
 
 def _usage_json(summary: UsageSummary) -> dict[str, Any]:
@@ -52,8 +88,8 @@ def _usage_json(summary: UsageSummary) -> dict[str, Any]:
     }
 
 
-def _render_usage(summary: UsageSummary, *, actions: bool) -> None:
-    """Display meter availability, reset windows, and optional action details."""
+def _render_usage(summary: UsageSummary, *, categories: bool) -> None:
+    """Display meter availability, reset windows, and optional category details."""
     if summary.status is UsageSummaryStatus.DISABLED:
         cli_print("Live compute metering is not enabled for this account (disabled).")
         return
@@ -78,24 +114,24 @@ def _render_usage(summary: UsageSummary, *, actions: bool) -> None:
     if summary.is_exhausted:
         cli_print("[yellow]The active compute usage window is exhausted.[/yellow]")
 
-    if not actions:
-        cli_print("[dim]Use --actions for action availability and advertised costs.[/dim]")
+    if not categories:
+        cli_print("[dim]Use --categories for availability and estimated costs by category.[/dim]")
         return
     if not summary.actions:
-        cli_print("No action usage details were supplied by the server.")
+        cli_print("No usage category details were supplied by the server.")
         return
 
-    table = Table(title="Action availability and advertised costs")
+    table = Table(title="Usage categories")
     table.add_column("Code", justify="right")
-    table.add_column("Action", style="cyan")
+    table.add_column("Category", style="cyan")
     table.add_column("Quota")
     table.add_column("Cost tier")
-    table.add_column("Est. cost", justify="right")
+    table.add_column("Est. cost*", justify="right")
     table.add_column("Deferred left", justify="right")
     for action in summary.actions:
         table.add_row(
             str(action.code),
-            action.kind.name.lower().replace("_", " ") if action.kind is not None else "Unknown",
+            _category_label(action),
             "Sufficient" if action.has_sufficient_quota else "Insufficient",
             action.cost_tier.name.lower().replace("_", " ")
             if action.cost_tier is not None
@@ -108,24 +144,42 @@ def _render_usage(summary: UsageSummary, *, actions: bool) -> None:
             else "Unknown",
         )
     cli_print(table)
+    cli_print(
+        "[dim]* Estimates matched the five-hour budget in recorded tests. The server does not "
+        "name the window; final usage may differ.[/dim]"
+    )
+    if any(
+        action.kind in (UsageActionKind.NOS, UsageActionKind.NOS_IMAGE_GENERATION)
+        for action in summary.actions
+    ):
+        cli_print(
+            "[dim]NOS is an internal server name; its public feature mapping is unverified.[/dim]"
+        )
 
 
 @click.command("usage")
-@click.option("--actions", is_flag=True, help="Include action availability and advertised costs.")
+@click.option(
+    "--categories",
+    "--actions",
+    "show_categories",
+    is_flag=True,
+    help="Include usage categories, availability, and estimated costs.",
+)
 @json_option
 @click.pass_context
-def usage(ctx: click.Context, actions: bool, json_output: bool) -> None:
+def usage(ctx: click.Context, show_categories: bool, json_output: bool) -> None:
     """Show live compute usage for the current account.
 
     Displays five-hour and weekly percentages and server-provided reset times.
 
     No active notebook is required. Supports both Web and Android backends.
-    JSON always includes action details; --actions adds them to text output.
+    JSON always includes category details in its actions array. Use --categories
+    (alias --actions) to add them to text output.
 
     \b
     Examples:
       notebooklm usage
-      notebooklm usage --actions
+      notebooklm usage --categories
       notebooklm -p work usage --json
       notebooklm --backend android usage --json
     """
@@ -137,4 +191,4 @@ def usage(ctx: click.Context, actions: bool, json_output: bool) -> None:
     if json_output:
         json_output_response(_usage_json(summary))
     else:
-        _render_usage(summary, actions=actions)
+        _render_usage(summary, categories=show_categories)

--- a/src/notebooklm/cli/usage_cmd.py
+++ b/src/notebooklm/cli/usage_cmd.py
@@ -1,0 +1,140 @@
+"""Account-scoped live compute usage CLI command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import click
+from rich.table import Table
+
+from ..types import UsageSummary, UsageSummaryStatus, UsageWindowKind
+from .auth_runtime import run_client_workflow
+from .options import json_option
+from .rendering import cli_print, json_output_response
+
+if TYPE_CHECKING:
+    from ..client import NotebookLMClient
+
+
+def _usage_json(summary: UsageSummary) -> dict[str, Any]:
+    """Project the snapshot with named enums and explicit ISO 8601 timestamps."""
+    active = summary.active_window
+    return {
+        "status": summary.status.value,
+        "enabled": summary.enabled,
+        "available": summary.available,
+        "is_exhausted": summary.is_exhausted,
+        "active_window": active.kind.name.lower() if active is not None else None,
+        "windows": [
+            {
+                "kind": window.kind.name.lower(),
+                "used_percent": window.used_percent,
+                "remaining_percent": window.remaining_percent,
+                "resets_at": window.resets_at.isoformat(),
+            }
+            for window in summary.windows
+        ],
+        "actions": [
+            {
+                "code": action.code,
+                "kind": action.kind.name.lower() if action.kind is not None else None,
+                "has_sufficient_quota": action.has_sufficient_quota,
+                "cost_tier": action.cost_tier.name.lower()
+                if action.cost_tier is not None
+                else None,
+                "remaining_deferred_artifact_generations": (
+                    action.remaining_deferred_artifact_generations
+                ),
+                "estimated_cost_percent": action.estimated_cost_percent,
+            }
+            for action in summary.actions
+        ],
+    }
+
+
+def _render_usage(summary: UsageSummary, *, actions: bool) -> None:
+    """Display meter availability, reset windows, and optional action details."""
+    if summary.status is UsageSummaryStatus.DISABLED:
+        cli_print("Live compute metering is not enabled for this account (disabled).")
+        return
+    if summary.status is UsageSummaryStatus.SKIPPED:
+        cli_print("Live compute usage is temporarily unavailable (skipped). Try again later.")
+        return
+
+    table = Table(title="Live compute usage")
+    table.add_column("Window", style="cyan")
+    table.add_column("Used", justify="right")
+    table.add_column("Remaining", justify="right")
+    table.add_column("Resets at (UTC)")
+    for window in summary.windows:
+        label = "Five-hour" if window.kind is UsageWindowKind.FIVE_HOUR else "Weekly"
+        table.add_row(
+            label,
+            f"{window.used_percent:.2f}%",
+            f"{window.remaining_percent:.2f}%",
+            window.resets_at.isoformat(),
+        )
+    cli_print(table)
+    if summary.is_exhausted:
+        cli_print("[yellow]The active compute usage window is exhausted.[/yellow]")
+
+    if not actions:
+        cli_print("[dim]Use --actions for action availability and advertised costs.[/dim]")
+        return
+    if not summary.actions:
+        cli_print("No action usage details were supplied by the server.")
+        return
+
+    table = Table(title="Action availability and advertised costs")
+    table.add_column("Code", justify="right")
+    table.add_column("Action", style="cyan")
+    table.add_column("Quota")
+    table.add_column("Cost tier")
+    table.add_column("Est. cost", justify="right")
+    table.add_column("Deferred left", justify="right")
+    for action in summary.actions:
+        table.add_row(
+            str(action.code),
+            action.kind.name.lower().replace("_", " ") if action.kind is not None else "Unknown",
+            "Sufficient" if action.has_sufficient_quota else "Insufficient",
+            action.cost_tier.name.lower().replace("_", " ")
+            if action.cost_tier is not None
+            else "Unknown",
+            f"{action.estimated_cost_percent:.2f}%"
+            if action.estimated_cost_percent is not None
+            else "Unknown",
+            str(action.remaining_deferred_artifact_generations)
+            if action.remaining_deferred_artifact_generations is not None
+            else "Unknown",
+        )
+    cli_print(table)
+
+
+@click.command("usage")
+@click.option("--actions", is_flag=True, help="Include action availability and advertised costs.")
+@json_option
+@click.pass_context
+def usage(ctx: click.Context, actions: bool, json_output: bool) -> None:
+    """Show live compute usage for the current account.
+
+    Displays five-hour and weekly percentages and server-provided reset times.
+
+    No active notebook is required. Supports both Web and Android backends.
+    JSON always includes action details; --actions adds them to text output.
+
+    \b
+    Examples:
+      notebooklm usage
+      notebooklm usage --actions
+      notebooklm -p work usage --json
+      notebooklm --backend android usage --json
+    """
+
+    async def body(client: NotebookLMClient) -> UsageSummary:
+        return await client.settings.get_usage()
+
+    summary = run_client_workflow(ctx, command_name="usage", json_output=json_output, body=body)
+    if json_output:
+        json_output_response(_usage_json(summary))
+    else:
+        _render_usage(summary, actions=actions)

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -115,6 +115,7 @@ from .cli import (
     share,
     skill,
     source,
+    usage,
 )
 from .cli.grouped import SectionedGroup
 
@@ -269,6 +270,7 @@ cli.add_command(research)
 cli.add_command(language)
 cli.add_command(profile)
 cli.add_command(mcp)
+cli.add_command(usage)
 
 
 # =============================================================================

--- a/tests/_baselines/cli_contract.py
+++ b/tests/_baselines/cli_contract.py
@@ -55,7 +55,7 @@ CLICK_GROUPS = (
 )
 
 TOP_LEVEL_SURFACES = {
-    "session": ("login", "auth", "use", "status", "clear"),
+    "session": ("login", "auth", "use", "status", "usage", "clear"),
     "notebook": ("list", "create", "copy", "delete", "rename", "metadata", "summary"),
     "chat": ("ask", "suggest-prompts", "configure", "history"),
 }

--- a/tests/fixtures/baselines/backend_static_coupling.json
+++ b/tests/fixtures/baselines/backend_static_coupling.json
@@ -7934,6 +7934,24 @@
     },
     {
       "kind": "from",
+      "lineno": 10,
+      "scope": null,
+      "scope_kind": "module",
+      "source": "notebooklm.cli.usage_cmd",
+      "target": "notebooklm.types",
+      "type_only": false
+    },
+    {
+      "kind": "from",
+      "lineno": 16,
+      "scope": null,
+      "scope_kind": "module",
+      "source": "notebooklm.cli.usage_cmd",
+      "target": "notebooklm.client",
+      "type_only": true
+    },
+    {
+      "kind": "from",
       "lineno": 36,
       "scope": null,
       "scope_kind": "module",
@@ -8978,7 +8996,7 @@
     },
     {
       "kind": "from",
-      "lineno": 119,
+      "lineno": 120,
       "scope": null,
       "scope_kind": "module",
       "source": "notebooklm.notebooklm_cli",
@@ -8987,7 +9005,7 @@
     },
     {
       "kind": "from",
-      "lineno": 217,
+      "lineno": 218,
       "scope": "cli",
       "scope_kind": "function",
       "source": "notebooklm.notebooklm_cli",
@@ -9729,15 +9747,15 @@
       "modules": 32
     },
     "cli": {
-      "lines": 21850,
-      "modules": 75
+      "lines": 21996,
+      "modules": 76
     },
     "mcp": {
       "lines": 10702,
       "modules": 37
     },
     "root": {
-      "lines": 22748,
+      "lines": 22750,
       "modules": 76
     },
     "rpc": {
@@ -9762,14 +9780,14 @@
     }
   },
   "summary": {
-    "authored_lines": 142853,
-    "authored_modules": 452,
+    "authored_lines": 143001,
+    "authored_modules": 453,
     "class_local_edges": 0,
-    "cross_subsystem_edges": 1068,
+    "cross_subsystem_edges": 1070,
     "dynamic_import_calls": 10,
     "function_local_edges": 72,
-    "module_level_edges": 996,
-    "type_only_edges": 118
+    "module_level_edges": 998,
+    "type_only_edges": 119
   },
   "version": 1
 }

--- a/tests/fixtures/baselines/backend_static_coupling.json
+++ b/tests/fixtures/baselines/backend_static_coupling.json
@@ -9747,7 +9747,7 @@
       "modules": 32
     },
     "cli": {
-      "lines": 21996,
+      "lines": 22050,
       "modules": 76
     },
     "mcp": {
@@ -9780,7 +9780,7 @@
     }
   },
   "summary": {
-    "authored_lines": 143001,
+    "authored_lines": 143055,
     "authored_modules": 453,
     "class_local_edges": 0,
     "cross_subsystem_edges": 1070,

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -12309,12 +12309,13 @@
           "default": false,
           "envvar": null,
           "has_custom_shell_complete": false,
-          "help": "Include action availability and advertised costs.",
+          "help": "Include usage categories, availability, and estimated costs.",
           "is_flag": true,
           "kind": "option",
           "multiple": false,
-          "name": "actions",
+          "name": "show_categories",
           "opts": [
+            "--categories",
             "--actions"
           ],
           "required": false,

--- a/tests/fixtures/cli_contract_baseline.json
+++ b/tests/fixtures/cli_contract_baseline.json
@@ -8597,6 +8597,7 @@
         "suggest-next-steps",
         "suggest-prompts",
         "summary",
+        "usage",
         "use"
       ],
       "params": [
@@ -12301,6 +12302,48 @@
       ],
       "short_help": "Get notebook summary with AI-generated..."
     },
+    "usage": {
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Include action availability and advertised costs.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "actions",
+          "opts": [
+            "--actions"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "has_custom_shell_complete": false,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Show live compute usage for the current..."
+    },
     "use": {
       "class": "Command",
       "params": [
@@ -12390,6 +12433,7 @@
     "suggest-next-steps",
     "suggest-prompts",
     "summary",
+    "usage",
     "use"
   ],
   "schema_version": 1,
@@ -12414,6 +12458,7 @@
       "auth",
       "use",
       "status",
+      "usage",
       "clear"
     ]
   },

--- a/tests/integration/cli_vcr/test_usage.py
+++ b/tests/integration/cli_vcr/test_usage.py
@@ -29,7 +29,7 @@ pytestmark = [
 @pytest.mark.parametrize("json_output", [False, True])
 def test_usage_snapshot(runner, mock_auth_for_vcr, cassette_name, json_output):
     """Real CLI/client decoding produces both windows without notebook context."""
-    args = ["usage", "--json"] if json_output else ["usage", "--actions"]
+    args = ["usage", "--json"] if json_output else ["usage", "--categories"]
     with notebooklm_vcr.use_cassette(cassette_name, record_mode="none") as cassette:
         result = runner.invoke(cli, args)
 
@@ -54,4 +54,4 @@ def test_usage_snapshot(runner, mock_auth_for_vcr, cassette_name, json_output):
     else:
         assert "Five-hour" in result.stdout
         assert "Weekly" in result.stdout
-        assert "Action availability" in result.stdout
+        assert "Usage categories" in result.stdout

--- a/tests/integration/cli_vcr/test_usage.py
+++ b/tests/integration/cli_vcr/test_usage.py
@@ -1,0 +1,57 @@
+"""Replay the CLI over the separately recorded Standard and Pro usage reads.
+
+These tests reuse API cassettes in replay-only mode. Re-record them with the
+profile-specific commands in ``tests/integration/test_usage_vcr.py``.
+"""
+
+import json
+import math
+from datetime import datetime, timedelta
+
+import pytest
+
+from notebooklm.notebooklm_cli import cli
+from tests.integration.conftest import _is_vcr_record_mode
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [
+    pytest.mark.vcr,
+    skip_no_cassettes,
+    pytest.mark.skipif(
+        _is_vcr_record_mode(),
+        reason="Replay only; record usage cassettes with the profile-specific API tests",
+    ),
+]
+
+
+@pytest.mark.parametrize("cassette_name", ["usage_standard.yaml", "usage_pro.yaml"])
+@pytest.mark.parametrize("json_output", [False, True])
+def test_usage_snapshot(runner, mock_auth_for_vcr, cassette_name, json_output):
+    """Real CLI/client decoding produces both windows without notebook context."""
+    args = ["usage", "--json"] if json_output else ["usage", "--actions"]
+    with notebooklm_vcr.use_cassette(cassette_name, record_mode="none") as cassette:
+        result = runner.invoke(cli, args)
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    # Auth bootstrap is mocked; both usage RPCs must still be replayed once.
+    assert len(cassette.play_counts) == 2
+    assert all(count == 1 for count in cassette.play_counts.values())
+    if json_output:
+        data = json.loads(result.stdout)
+        assert data["status"] == "ready"
+        assert data["enabled"] is True
+        assert data["available"] is True
+        assert {window["kind"] for window in data["windows"]} == {"five_hour", "weekly"}
+        for window in data["windows"]:
+            assert math.isfinite(window["used_percent"])
+            assert math.isfinite(window["remaining_percent"])
+            assert datetime.fromisoformat(window["resets_at"]).utcoffset() == timedelta(0)
+        assert {"flashcards", "quiz", "deep_research"} <= {
+            action["kind"] for action in data["actions"]
+        }
+    else:
+        assert "Five-hour" in result.stdout
+        assert "Weekly" in result.stdout
+        assert "Action availability" in result.stdout

--- a/tests/unit/cli/test_cli_contract.py
+++ b/tests/unit/cli/test_cli_contract.py
@@ -44,6 +44,7 @@ BASELINE_PATH = _find_repo_root() / "tests/fixtures/cli_contract_baseline.json"
 HELP_SNIPPETS = {
     "": ("NotebookLM CLI", "notebooklm login", "completion"),
     "completion": ("Print the shell completion script", "bash", "zsh", "fish"),
+    "usage": ("Show live compute usage", "--actions", "--json", "No active notebook"),
     "download": ("Download generated content", "cinematic-video", "flashcards"),
     "download audio": ("Download audio", "--latest", "--no-clobber"),
     "source add": ("--follow-symlinks", "--mime-type", "--json"),

--- a/tests/unit/cli/test_cli_contract.py
+++ b/tests/unit/cli/test_cli_contract.py
@@ -44,7 +44,13 @@ BASELINE_PATH = _find_repo_root() / "tests/fixtures/cli_contract_baseline.json"
 HELP_SNIPPETS = {
     "": ("NotebookLM CLI", "notebooklm login", "completion"),
     "completion": ("Print the shell completion script", "bash", "zsh", "fish"),
-    "usage": ("Show live compute usage", "--actions", "--json", "No active notebook"),
+    "usage": (
+        "Show live compute usage",
+        "--categories",
+        "--actions",
+        "--json",
+        "No active notebook",
+    ),
     "download": ("Download generated content", "cinematic-video", "flashcards"),
     "download audio": ("Download audio", "--latest", "--no-clobber"),
     "source add": ("--follow-symlinks", "--mime-type", "--json"),

--- a/tests/unit/cli/test_usage.py
+++ b/tests/unit/cli/test_usage.py
@@ -123,7 +123,7 @@ def test_json_preserves_snapshot_and_unknown_fields(runner, usage_client):
 @pytest.mark.parametrize("actions", [False, True])
 def test_text_windows_and_optional_actions(runner, usage_client, actions):
     """Text shows both windows and only expands action rows on request."""
-    args = ["usage", "--actions"] if actions else ["usage"]
+    args = ["usage", "--categories"] if actions else ["usage"]
     result = runner.invoke(cli, args, obj=inject_client(usage_client), env={"COLUMNS": "140"})
 
     assert result.exit_code == 0, result.output
@@ -133,11 +133,54 @@ def test_text_windows_and_optional_actions(runner, usage_client, actions):
     assert "80.12%" in result.stdout
     assert "2026-09-05T18:30:01.123456+00:00" in result.stdout
     if actions:
-        for text in ("audio overview", "Sufficient", "Insufficient", "Unknown", "23", "0.00%"):
+        for text in (
+            "Audio overview",
+            "Sufficient",
+            "Insufficient",
+            "Unknown category (23)",
+            "0.00%",
+            "Est. cost*",
+            "five-hour budget in recorded tests",
+            "server does not name the window",
+        ):
             assert text in result.stdout
     else:
-        assert "--actions" in result.stdout
-        assert "audio overview" not in result.stdout
+        assert "--categories" in result.stdout
+        assert "Audio overview" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("kind", "label"),
+    [
+        (UsageActionKind.BREAKDOWNS_VIDEO, "Cinematic video"),
+        (UsageActionKind.SHORTS_VIDEO, "Short video"),
+        (UsageActionKind.SLIDES, "Slide deck"),
+        (UsageActionKind.TABLES, "Data table"),
+        (UsageActionKind.MINDMAP, "Mind map"),
+        (UsageActionKind.NOS, "Unmapped category (NOS)"),
+        (UsageActionKind.QNA, "Chat Q&A"),
+        (UsageActionKind.NOS_IMAGE_GENERATION, "Image generation (NOS)"),
+        (UsageActionKind.DOCUMENT_GUIDE, "Source guide"),
+        (UsageActionKind.SUGGESTION_CHIPS, "Suggested questions"),
+    ],
+)
+def test_readable_category_labels_preserve_protocol_json(
+    runner, usage_client, summary, kind, label
+):
+    """Text names features clearly while JSON keeps the exact server enum identity."""
+    action = replace(summary.actions[0], code=kind.value, kind=kind)
+    usage_client.settings.get_usage.return_value = replace(summary, actions=(action,))
+    result = runner.invoke(
+        cli, ["usage", "--categories"], obj=inject_client(usage_client), env={"COLUMNS": "140"}
+    )
+    assert result.exit_code == 0, result.output
+    assert label in result.stdout
+    if kind in (UsageActionKind.NOS, UsageActionKind.NOS_IMAGE_GENERATION):
+        assert "public feature mapping is unverified" in result.stdout
+
+    result = runner.invoke(cli, ["usage", "--json"], obj=inject_client(usage_client))
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["actions"][0]["kind"] == kind.name.lower()
 
 
 @pytest.mark.parametrize("status", [UsageSummaryStatus.DISABLED, UsageSummaryStatus.SKIPPED])
@@ -145,7 +188,7 @@ def test_text_windows_and_optional_actions(runner, usage_client, actions):
 def test_unavailable_meter_is_not_zero_usage(runner, usage_client, status, json_output):
     """Unavailable meters exit successfully without fabricated window data."""
     usage_client.settings.get_usage.return_value = UsageSummary(status=status)
-    args = ["usage", "--json"] if json_output else ["usage", "--actions"]
+    args = ["usage", "--json"] if json_output else ["usage", "--categories"]
     result = runner.invoke(cli, args, obj=inject_client(usage_client))
 
     assert result.exit_code == 0, result.output
@@ -188,15 +231,27 @@ def test_exhaustion_uses_public_active_window(runner, usage_client, summary, win
 def test_empty_actions(runner, usage_client, summary):
     """A ready meter can legitimately omit action details."""
     usage_client.settings.get_usage.return_value = replace(summary, actions=())
-    result = runner.invoke(cli, ["usage", "--actions"], obj=inject_client(usage_client))
+    result = runner.invoke(cli, ["usage", "--categories"], obj=inject_client(usage_client))
     assert result.exit_code == 0, result.output
-    assert "No action usage details" in result.stdout
+    assert "No usage category details" in result.stdout
+
+
+def test_actions_remains_an_alias_for_categories(runner, usage_client):
+    """Existing --actions invocations keep the same output as --categories."""
+    results = [
+        runner.invoke(cli, ["usage", flag], obj=inject_client(usage_client))
+        for flag in ("--categories", "--actions")
+    ]
+    assert all(result.exit_code == 0 for result in results)
+    assert results[0].stdout == results[1].stdout
+    assert "Usage categories" in results[0].stdout
+    assert "Category" in results[0].stdout
 
 
 @pytest.mark.parametrize("json_output", [False, True])
 def test_quiet_preserves_json(runner, usage_client, json_output):
     """Quiet suppresses prose while keeping machine-readable data."""
-    args = ["--quiet", "usage", "--actions"] + (["--json"] if json_output else [])
+    args = ["--quiet", "usage", "--categories"] + (["--json"] if json_output else [])
     result = runner.invoke(cli, args, obj=inject_client(usage_client))
     assert result.exit_code == 0, result.output
     assert result.stderr == ""

--- a/tests/unit/cli/test_usage.py
+++ b/tests/unit/cli/test_usage.py
@@ -1,0 +1,236 @@
+"""Usage CLI output, account scope, and failure contracts."""
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import notebooklm.cli.helpers as helpers_module
+import notebooklm.client as client_module
+from notebooklm.exceptions import AuthError, DecodingError, NetworkError, ServerError
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import (
+    UsageAction,
+    UsageActionCostTier,
+    UsageActionKind,
+    UsageSummary,
+    UsageSummaryStatus,
+    UsageWindow,
+    UsageWindowKind,
+)
+
+from .conftest import create_mock_client, inject_client
+
+
+@pytest.fixture
+def summary():
+    """A snapshot with non-complementary percentages and a future action."""
+    return UsageSummary(
+        status=UsageSummaryStatus.READY,
+        windows=(
+            UsageWindow(
+                UsageWindowKind.FIVE_HOUR,
+                12.345,
+                80.125,
+                datetime(2026, 9, 5, 18, 30, 1, 123456, tzinfo=timezone.utc),
+            ),
+            UsageWindow(
+                UsageWindowKind.WEEKLY,
+                0.0,
+                100.0,
+                datetime(2026, 9, 12, 18, 30, tzinfo=timezone.utc),
+            ),
+        ),
+        actions=(
+            UsageAction(1, UsageActionKind.AUDIO_OVERVIEW, True, UsageActionCostTier.LOW, 0, 0.0),
+            UsageAction(23, None, False, None, None, None),
+        ),
+    )
+
+
+@pytest.fixture
+def usage_client(summary, mock_auth, mock_fetch_tokens):
+    """Inject a usage-only response through the shared client factory seam."""
+    client = create_mock_client()
+    client.settings.get_usage = AsyncMock(return_value=summary)
+    return client
+
+
+def test_json_preserves_snapshot_and_unknown_fields(runner, usage_client):
+    """JSON keeps precision, zero versus null, enum names, and reset offsets."""
+    result = runner.invoke(cli, ["usage", "--json"], obj=inject_client(usage_client))
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    assert json.loads(result.stdout) == {
+        "status": "ready",
+        "enabled": True,
+        "available": True,
+        "is_exhausted": False,
+        "active_window": "five_hour",
+        "windows": [
+            {
+                "kind": "five_hour",
+                "used_percent": 12.345,
+                "remaining_percent": 80.125,
+                "resets_at": "2026-09-05T18:30:01.123456+00:00",
+            },
+            {
+                "kind": "weekly",
+                "used_percent": 0.0,
+                "remaining_percent": 100.0,
+                "resets_at": "2026-09-12T18:30:00+00:00",
+            },
+        ],
+        "actions": [
+            {
+                "code": 1,
+                "kind": "audio_overview",
+                "has_sufficient_quota": True,
+                "cost_tier": "low",
+                "remaining_deferred_artifact_generations": 0,
+                "estimated_cost_percent": 0.0,
+            },
+            {
+                "code": 23,
+                "kind": None,
+                "has_sufficient_quota": False,
+                "cost_tier": None,
+                "remaining_deferred_artifact_generations": None,
+                "estimated_cost_percent": None,
+            },
+        ],
+    }
+    usage_client.settings.get_usage.assert_awaited_once_with()
+    usage_client.notebooks.list.assert_not_called()
+    usage_client.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.parametrize("actions", [False, True])
+def test_text_windows_and_optional_actions(runner, usage_client, actions):
+    """Text shows both windows and only expands action rows on request."""
+    args = ["usage", "--actions"] if actions else ["usage"]
+    result = runner.invoke(cli, args, obj=inject_client(usage_client), env={"COLUMNS": "140"})
+
+    assert result.exit_code == 0, result.output
+    assert "Five-hour" in result.stdout
+    assert "Weekly" in result.stdout
+    assert "12.35%" in result.stdout
+    assert "80.12%" in result.stdout
+    assert "2026-09-05T18:30:01.123456+00:00" in result.stdout
+    if actions:
+        for text in ("audio overview", "Sufficient", "Insufficient", "Unknown", "23", "0.00%"):
+            assert text in result.stdout
+    else:
+        assert "--actions" in result.stdout
+        assert "audio overview" not in result.stdout
+
+
+@pytest.mark.parametrize("status", [UsageSummaryStatus.DISABLED, UsageSummaryStatus.SKIPPED])
+@pytest.mark.parametrize("json_output", [False, True])
+def test_unavailable_meter_is_not_zero_usage(runner, usage_client, status, json_output):
+    """Unavailable meters exit successfully without fabricated window data."""
+    usage_client.settings.get_usage.return_value = UsageSummary(status=status)
+    args = ["usage", "--json"] if json_output else ["usage", "--actions"]
+    result = runner.invoke(cli, args, obj=inject_client(usage_client))
+
+    assert result.exit_code == 0, result.output
+    if json_output:
+        assert json.loads(result.stdout) == {
+            "status": status.value,
+            "enabled": status is UsageSummaryStatus.SKIPPED,
+            "available": False,
+            "is_exhausted": None,
+            "active_window": None,
+            "windows": [],
+            "actions": [],
+        }
+    else:
+        assert status.value in result.stdout
+        assert "%" not in result.stdout
+
+
+@pytest.mark.parametrize("window_index", [0, 1])
+def test_exhaustion_uses_public_active_window(runner, usage_client, summary, window_index):
+    """Exhaustion and weekly precedence come from the public snapshot model."""
+    windows = list(summary.windows)
+    windows[window_index] = replace(
+        windows[window_index], used_percent=105.0, remaining_percent=-5.0
+    )
+    usage_client.settings.get_usage.return_value = replace(summary, windows=tuple(windows))
+    result = runner.invoke(cli, ["usage", "--json"], obj=inject_client(usage_client))
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["is_exhausted"] is True
+    assert data["active_window"] == ("five_hour" if window_index == 0 else "weekly")
+    assert data["windows"][window_index]["remaining_percent"] == -5.0
+
+    result = runner.invoke(cli, ["usage"], obj=inject_client(usage_client))
+    assert "exhausted" in result.stdout
+    assert "105.00%" in result.stdout
+    assert "-5.00%" in result.stdout
+
+
+def test_empty_actions(runner, usage_client, summary):
+    """A ready meter can legitimately omit action details."""
+    usage_client.settings.get_usage.return_value = replace(summary, actions=())
+    result = runner.invoke(cli, ["usage", "--actions"], obj=inject_client(usage_client))
+    assert result.exit_code == 0, result.output
+    assert "No action usage details" in result.stdout
+
+
+@pytest.mark.parametrize("json_output", [False, True])
+def test_quiet_preserves_json(runner, usage_client, json_output):
+    """Quiet suppresses prose while keeping machine-readable data."""
+    args = ["--quiet", "usage", "--actions"] + (["--json"] if json_output else [])
+    result = runner.invoke(cli, args, obj=inject_client(usage_client))
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+    if json_output:
+        assert json.loads(result.stdout)["status"] == "ready"
+    else:
+        assert result.stdout == ""
+
+
+@pytest.mark.parametrize("error", [AuthError, NetworkError, ServerError, DecodingError])
+@pytest.mark.parametrize("json_output", [False, True])
+def test_errors_stay_errors(runner, usage_client, error, json_output):
+    """Transport/auth/schema failures never turn into disabled or skipped meters."""
+    usage_client.settings.get_usage.side_effect = error("usage read failed")
+    args = ["--quiet", "usage"] + (["--json"] if json_output else [])
+    result = runner.invoke(cli, args, obj=inject_client(usage_client))
+    assert result.exit_code == 1, result.output
+    if json_output:
+        data = json.loads(result.stdout)
+        assert data["error"] is True
+        assert data["code"]
+        assert "usage read failed" in data["message"]
+        assert "status" not in data
+        assert result.stderr == ""
+    else:
+        assert "usage read failed" in result.stderr
+    usage_client.__aexit__.assert_awaited_once()
+
+
+@pytest.mark.parametrize("backend", ["web", "android"])
+def test_selected_profile_storage_and_backend_reach_runtime(
+    runner, usage_client, backend, tmp_path
+):
+    """Account usage honors global auth selectors without notebook resolution."""
+    storage = tmp_path / "custom" / "storage_state.json"
+    with (
+        patch.object(helpers_module, "get_auth_tokens", return_value=object()) as auth,
+        patch.object(client_module, "NotebookLMClient", return_value=usage_client) as factory,
+    ):
+        result = runner.invoke(
+            cli,
+            ["-p", "work", "--storage", str(storage), "--backend", backend, "usage", "--json"],
+        )
+    assert result.exit_code == 0, result.output
+    ctx = auth.call_args.args[0]
+    assert ctx.obj["profile"] == "work"
+    assert ctx.obj["storage_path"] == storage
+    assert factory.call_args.kwargs["backend"] == backend
+    usage_client.settings.get_usage.assert_awaited_once_with()

--- a/tests/unit/cli/test_usage.py
+++ b/tests/unit/cli/test_usage.py
@@ -1,5 +1,6 @@
 """Usage CLI output, account scope, and failure contracts."""
 
+import inspect
 import json
 import logging
 from dataclasses import replace
@@ -7,6 +8,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 import notebooklm.cli.helpers as helpers_module
 import notebooklm.client as client_module
@@ -23,6 +25,14 @@ from notebooklm.types import (
 )
 
 from .conftest import create_mock_client, inject_client
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Capture stdout and stderr separately across supported Click versions."""
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/cli/test_usage.py
+++ b/tests/unit/cli/test_usage.py
@@ -1,6 +1,7 @@
 """Usage CLI output, account scope, and failure contracts."""
 
 import json
+import logging
 from dataclasses import replace
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
@@ -22,6 +23,17 @@ from notebooklm.types import (
 )
 
 from .conftest import create_mock_client, inject_client
+
+
+@pytest.fixture(autouse=True)
+def _restore_logger_level():
+    """Keep --quiet invocations from suppressing later tests' warning logs."""
+    logger = logging.getLogger("notebooklm")
+    saved_level = logger.level
+    try:
+        yield
+    finally:
+        logger.setLevel(saved_level)
 
 
 @pytest.fixture

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -208,6 +208,11 @@ def _fail_chat_ask(client: MagicMock) -> None:
     client.chat.ask = AsyncMock(side_effect=RuntimeError("network unreachable"))
 
 
+def _fail_usage(client: MagicMock) -> None:
+    """Exercise the usage command's structured unexpected-error envelope."""
+    client.settings.get_usage = AsyncMock(side_effect=RuntimeError("usage read failed"))
+
+
 def _fail_suggest_prompts(client: MagicMock) -> None:
     client.notebooks.suggest_prompts = AsyncMock(side_effect=RuntimeError("network unreachable"))
 
@@ -397,6 +402,7 @@ def _fail_notebook_copy(client: MagicMock) -> None:
 
 # (case_id, argv, customize_fn-or-None)
 JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
+    ("usage_failure", ["usage", "--json"], _fail_usage),
     # source group: client raises -> @with_client routes to json_error_response.
     ("source_list_unauthorized", ["source", "list", "-n", "abc", "--json"], _fail_source_list),
     (

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -22,7 +22,7 @@ import json
 import math
 import sys
 from collections.abc import Generator
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -58,6 +58,10 @@ from notebooklm.types import (
     ShareStatus,
     Source,
     SourceGuide,
+    UsageSummary,
+    UsageSummaryStatus,
+    UsageWindow,
+    UsageWindowKind,
 )
 
 
@@ -622,7 +626,21 @@ _FS_SETUPS = {
 }
 
 
+def _customize_usage(client: MagicMock) -> None:
+    """Exercise ready usage JSON, including timezone-aware reset timestamps."""
+    client.settings.get_usage = AsyncMock(
+        return_value=UsageSummary(
+            status=UsageSummaryStatus.READY,
+            windows=tuple(
+                UsageWindow(kind, 25.0, 75.0, datetime(2026, 9, 5, tzinfo=timezone.utc))
+                for kind in (UsageWindowKind.FIVE_HOUR, UsageWindowKind.WEEKLY)
+            ),
+        )
+    )
+
+
 JSON_COMMANDS: list[tuple[str, list[str], object]] = [
+    ("usage", ["usage", "--json"], _customize_usage),
     # source group
     ("source_list", ["source", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
     (


### PR DESCRIPTION
## Summary

Expose the live compute meter added in #2357 through `notebooklm usage`. The default output shows five-hour and weekly usage and server reset times; `--categories` (alias `--actions`) adds category availability and estimated costs, and `--json` always returns the complete snapshot.

The command is account-scoped and uses the shared authentication, backend selection, client lifetime, and error handling. It preserves disabled and skipped states, unknown action codes, absent versus zero values, full JSON percentage precision, and ISO 8601 UTC timestamps. It does not infer a credit balance or enforce quotas.

## Related Issue

Follow-up to #2357; implements the CLI projection in ADR-0037. Related to #2283.

## Changes

- Add the command to Session help and document its options and JSON fields, including a brief SKILL.md command example.
- Use readable category labels (Cinematic video, Chat Q&A, Suggested questions, etc.) while keeping exact protocol identities in JSON. Mark the unverified NOS feature mapping explicitly.
- Explain that cost estimates matched the five-hour budget in recorded probes, while the response does not identify the estimate window and quota availability is account-scoped.
- Cover unavailable/exhausted snapshots, unknown action data, errors, quiet output, account selectors, and both backend selections.
- Replay the existing separate Standard and Pro fixtures through the CLI without new recordings.
- Update the CLI contract and architecture import baselines for the new adapter and its public type imports.

## Test Plan

- [x] Current focused usage, CLI contract, JSON success/error inventory, and Standard/Pro replay suite: **287 passed**, with **100% line and branch coverage** for the usage command.
- [x] Click 8.1.8 compatibility: reproduced the quiet-test failure before the fix; all **33 usage unit tests** pass after it.
- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy src/notebooklm scripts/_live_auth_scenarios --ignore-missing-imports`
- [x] Architecture map and documentation reference checks.
- [x] Full CI matrix on final commit `54d3e0ef3`: all seven test jobs passed across Python 3.10–3.14, macOS, and Windows. Code Quality and CodeQL also passed.

## Notes

Local implementation review completed. The CodeRabbit Click 8.1 runner finding is fixed and its thread resolved. Codex and CodeRabbit completed review of the final commit `54d3e0ef3`; no unresolved review threads remain. Web and Android transport behavior is reused from #2357; this change adds a CLI projection without live generation or additional metered operations.

Reviewer availability: the [Claude workflow](https://github.com/teng-lin/notebooklm-py/actions/runs/33974602863) failed before reviewing code on both attempts (`is_error: true`, no model usage). Copilot reported a reviewer quota limit. These services did not produce code reviews. The [final-commit Claude attempt](https://github.com/teng-lin/notebooklm-py/actions/runs/33976834579) failed identically before reviewing code. Merge validation uses local review, Codex, CodeRabbit, and the full CI matrix; no Claude review is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `notebooklm usage` command to view live compute usage, quota windows, reset times, and exhaustion status.
  * Added `--categories` to show usage categories, availability, and estimated costs; `--actions` remains supported as an alias.
  * Added `--json` for complete usage snapshots with ISO 8601 reset timestamps.

* **Documentation**
  * Updated CLI, quota, architecture, README, and usage references with command options and category details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




