### PR TITLE
fix(auth): keep OAuth cookie capture alive after login tab closes

### DIFF
--- a/src/notebooklm/_browser/oauth_token.py
+++ b/src/notebooklm/_browser/oauth_token.py
@@ -8,6 +8,7 @@ code; callers receive only the captured token string or a canonical
 
 from __future__ import annotations
 
+import time
 from ipaddress import ip_address
 from urllib.parse import SplitResult, urlsplit
 
@@ -117,15 +118,18 @@ def capture_oauth_token(
 
                 page = context.new_page()
                 page.goto(_EMBEDDED_SETUP_URL)
-                deadline = page.evaluate("Date.now()") + timeout_s * 1000
-                while page.evaluate("Date.now()") < deadline:
+                # Cookies outlive the login tab. Keep polling independent of
+                # its JavaScript context, which can navigate or close during
+                # sign-in; each cookies() call pumps Playwright's sync loop.
+                deadline = time.monotonic() + timeout_s
+                while time.monotonic() < deadline:
                     for cookie in context.cookies():
                         if cookie.get("name") == "oauth_token" and cookie.get("value"):
                             token = cookie["value"]
                             break
                     if token:
                         break
-                    page.wait_for_timeout(1000)
+                    time.sleep(min(1.0, max(0.0, deadline - time.monotonic())))
             finally:
                 if page is not None:
                     page.close()

--- a/tests/fixtures/baselines/auth_family_patch_scorecard.json
+++ b/tests/fixtures/baselines/auth_family_patch_scorecard.json
@@ -6276,6 +6276,16 @@
       "idiom": "monkeypatch.setattr",
       "module": "oauth_token",
       "owner_kind": "test",
+      "owner_qualname": "test_capture_reads_cookie_after_login_page_closes_in_real_chromium",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "attribute": "sync_playwright_context",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
       "owner_qualname": "test_capture_rejected_cdp_scrubs_retained_frame_and_exception_chain",
       "package": "notebooklm._browser",
       "path": "tests/unit/test_browser_oauth_token.py"
@@ -6301,6 +6311,26 @@
       "path": "tests/unit/test_browser_oauth_token.py"
     },
     {
+      "attribute": "sync_playwright_context",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
+      "owner_qualname": "test_capture_timeout_uses_host_clock_and_bounds_sleep",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "attribute": "time",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
+      "owner_qualname": "test_capture_timeout_uses_host_clock_and_bounds_sleep",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
       "attribute": "write_master_token",
       "count": 1,
       "idiom": "monkeypatch.setattr",
@@ -6313,17 +6343,17 @@
   ],
   "packages": {
     "notebooklm._auth": 85,
-    "notebooklm._browser": 21,
+    "notebooklm._browser": 24,
     "notebooklm.auth": 526
   },
   "summary": {
     "assignments": 0,
-    "distinct_targets": 61,
+    "distinct_targets": 62,
     "files": 84,
-    "lexical_owners": 595,
+    "lexical_owners": 597,
     "private": 50,
-    "public": 582,
-    "total": 632
+    "public": 585,
+    "total": 635
   },
   "version": 1
 }

--- a/tests/fixtures/baselines/backend_static_coupling.json
+++ b/tests/fixtures/baselines/backend_static_coupling.json
@@ -2930,7 +2930,7 @@
     },
     {
       "kind": "from",
-      "lineno": 14,
+      "lineno": 15,
       "scope": null,
       "scope_kind": "module",
       "source": "notebooklm._browser.oauth_token",
@@ -9755,7 +9755,7 @@
       "modules": 37
     },
     "root": {
-      "lines": 22750,
+      "lines": 22754,
       "modules": 76
     },
     "rpc": {
@@ -9780,7 +9780,7 @@
     }
   },
   "summary": {
-    "authored_lines": 143055,
+    "authored_lines": 143059,
     "authored_modules": 453,
     "class_local_edges": 0,
     "cross_subsystem_edges": 1070,

--- a/tests/fixtures/baselines/browser_import_graph.json
+++ b/tests/fixtures/baselines/browser_import_graph.json
@@ -123,7 +123,7 @@
       "path": "src/notebooklm/_browser/navigation_errors.py"
     },
     {
-      "lines": 163,
+      "lines": 167,
       "name": "oauth_token",
       "path": "src/notebooklm/_browser/oauth_token.py"
     }
@@ -136,7 +136,7 @@
     "function_local_edges": 1,
     "module_edges": 18,
     "modules": 6,
-    "total_lines": 2953,
+    "total_lines": 2957,
     "unique_edges": 19
   },
   "version": 1

--- a/tests/fixtures/baselines/browser_patch_sites.json
+++ b/tests/fixtures/baselines/browser_patch_sites.json
@@ -21,7 +21,7 @@
       "path": "tests/unit/test_auth_session_refresh_cmd.py"
     },
     {
-      "count": 7,
+      "count": 10,
       "path": "tests/unit/test_browser_oauth_token.py"
     }
   ],
@@ -212,6 +212,16 @@
       "idiom": "monkeypatch.setattr",
       "module": "oauth_token",
       "owner_kind": "test",
+      "owner_qualname": "test_capture_reads_cookie_after_login_page_closes_in_real_chromium",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "attribute": "sync_playwright_context",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
       "owner_qualname": "test_capture_rejected_cdp_scrubs_retained_frame_and_exception_chain",
       "package": "notebooklm._browser",
       "path": "tests/unit/test_browser_oauth_token.py"
@@ -233,6 +243,26 @@
       "module": "oauth_token",
       "owner_kind": "test",
       "owner_qualname": "test_capture_timeout_preserves_active_context_and_scrubs_resources",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "attribute": "sync_playwright_context",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
+      "owner_qualname": "test_capture_timeout_uses_host_clock_and_bounds_sleep",
+      "package": "notebooklm._browser",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "attribute": "time",
+      "count": 1,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token",
+      "owner_kind": "test",
+      "owner_qualname": "test_capture_timeout_uses_host_clock_and_bounds_sleep",
       "package": "notebooklm._browser",
       "path": "tests/unit/test_browser_oauth_token.py"
     }
@@ -349,6 +379,12 @@
     {
       "count": 1,
       "owner_kind": "test",
+      "owner_qualname": "test_capture_reads_cookie_after_login_page_closes_in_real_chromium",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "count": 1,
+      "owner_kind": "test",
       "owner_qualname": "test_capture_rejected_cdp_scrubs_retained_frame_and_exception_chain",
       "path": "tests/unit/test_browser_oauth_token.py"
     },
@@ -362,6 +398,12 @@
       "count": 1,
       "owner_kind": "test",
       "owner_qualname": "test_capture_timeout_preserves_active_context_and_scrubs_resources",
+      "path": "tests/unit/test_browser_oauth_token.py"
+    },
+    {
+      "count": 2,
+      "owner_kind": "test",
+      "owner_qualname": "test_capture_timeout_uses_host_clock_and_bounds_sleep",
       "path": "tests/unit/test_browser_oauth_token.py"
     }
   ],
@@ -399,7 +441,13 @@
     },
     {
       "attribute": "sync_playwright_context",
-      "count": 7,
+      "count": 9,
+      "idiom": "monkeypatch.setattr",
+      "module": "oauth_token"
+    },
+    {
+      "attribute": "time",
+      "count": 1,
       "idiom": "monkeypatch.setattr",
       "module": "oauth_token"
     }
@@ -407,8 +455,8 @@
   "summary": {
     "TOTAL": {
       "private": 0,
-      "public": 21,
-      "total": 21
+      "public": 24,
+      "total": 24
     },
     "browser_capture": {
       "private": 0,
@@ -422,8 +470,8 @@
     },
     "oauth_token": {
       "private": 0,
-      "public": 8,
-      "total": 8
+      "public": 11,
+      "total": 11
     }
   },
   "version": 2

--- a/tests/unit/test_browser_oauth_token.py
+++ b/tests/unit/test_browser_oauth_token.py
@@ -65,6 +65,7 @@ def test_capture_missing_browser_extra_preserves_explicit_cause_and_scrubs(monke
 
 
 def test_capture_timeout_preserves_active_context_and_scrubs_resources(monkeypatch):
+    """Timeout cleanup preserves the caller's exception context and scrubs resources."""
     page = Mock()
     context = Mock()
     context.new_page.return_value = page
@@ -200,6 +201,7 @@ def test_capture_passes_valid_cdp_unchanged_and_preserves_connector_error(monkey
 def test_capture_cdp_preserves_external_ownership_and_closes_created_resources(
     monkeypatch, existing_context
 ):
+    """CDP capture closes only the resources it creates in the attached browser."""
     page = Mock()
     context = Mock()
     context.new_page.return_value = page
@@ -232,6 +234,7 @@ def test_capture_cdp_preserves_external_ownership_and_closes_created_resources(
 
 
 def test_capture_local_launch_closes_owned_page_context_and_browser(monkeypatch):
+    """Successful local capture releases its owned page, context, and browser."""
     page = Mock()
     context = Mock()
     context.new_page.return_value = page
@@ -259,6 +262,7 @@ def test_capture_local_launch_closes_owned_page_context_and_browser(monkeypatch)
 
 
 def test_capture_cleanup_failure_preserves_parent_precedence(monkeypatch):
+    """A page cleanup failure retains its existing exception and cleanup precedence."""
     cleanup_failure = RuntimeError("page close")
     page = Mock()
     page.close.side_effect = cleanup_failure
@@ -285,9 +289,11 @@ def test_capture_cleanup_failure_preserves_parent_precedence(monkeypatch):
 
 @pytest.mark.parametrize("poll_duration", [0.0, 2.0], ids=["empty-polls", "slow-poll"])
 def test_capture_timeout_uses_host_clock_and_bounds_sleep(monkeypatch, poll_duration):
+    """Empty or slow cookie polls expire without relying on a live login page."""
     clock = SimpleNamespace(now=1000.0)
 
     def sleep(seconds):
+        """Advance simulated time and reject negative waits."""
         assert seconds >= 0
         clock.now += seconds
 
@@ -301,6 +307,7 @@ def test_capture_timeout_uses_host_clock_and_bounds_sleep(monkeypatch, poll_dura
     context.new_page.return_value = page
 
     def cookies():
+        """Model a cookie read that consumes time without finding a token."""
         clock.now += poll_duration
         return []
 
@@ -311,6 +318,7 @@ def test_capture_timeout_uses_host_clock_and_bounds_sleep(monkeypatch, poll_dura
 
     @contextmanager
     def playwright_context():
+        """Supply the fake browser while retaining the real capture loop."""
         yield SimpleNamespace(chromium=chromium)
 
     monkeypatch.setattr(capture_service, "sync_playwright_context", playwright_context)
@@ -342,6 +350,7 @@ def test_capture_reads_cookie_after_login_page_closes_in_real_chromium(monkeypat
             closed_pages = []
 
             def cookies():
+                """Set a dummy token and close the tab after the first cookie snapshot."""
                 snapshot = read_cookies()
                 if not closed_pages:
                     # Complete sign-in just after the first cookie snapshot,
@@ -368,6 +377,7 @@ def test_capture_reads_cookie_after_login_page_closes_in_real_chromium(monkeypat
 
             @contextmanager
             def playwright_context():
+                """Expose real browser objects through either capture ownership path."""
                 yield SimpleNamespace(chromium=chromium)
 
             monkeypatch.setattr(capture_service, "sync_playwright_context", playwright_context)

--- a/tests/unit/test_browser_oauth_token.py
+++ b/tests/unit/test_browser_oauth_token.py
@@ -66,7 +66,6 @@ def test_capture_missing_browser_extra_preserves_explicit_cause_and_scrubs(monke
 
 def test_capture_timeout_preserves_active_context_and_scrubs_resources(monkeypatch):
     page = Mock()
-    page.evaluate.return_value = 0
     context = Mock()
     context.new_page.return_value = page
     browser_obj = Mock()
@@ -202,7 +201,6 @@ def test_capture_cdp_preserves_external_ownership_and_closes_created_resources(
     monkeypatch, existing_context
 ):
     page = Mock()
-    page.evaluate.return_value = 0
     context = Mock()
     context.new_page.return_value = page
     context.cookies.return_value = [{"name": "oauth_token", "value": "CAPTURED"}]
@@ -235,7 +233,6 @@ def test_capture_cdp_preserves_external_ownership_and_closes_created_resources(
 
 def test_capture_local_launch_closes_owned_page_context_and_browser(monkeypatch):
     page = Mock()
-    page.evaluate.return_value = 0
     context = Mock()
     context.new_page.return_value = page
     context.cookies.return_value = [{"name": "oauth_token", "value": "CAPTURED"}]
@@ -264,7 +261,6 @@ def test_capture_local_launch_closes_owned_page_context_and_browser(monkeypatch)
 def test_capture_cleanup_failure_preserves_parent_precedence(monkeypatch):
     cleanup_failure = RuntimeError("page close")
     page = Mock()
-    page.evaluate.return_value = 0
     page.close.side_effect = cleanup_failure
     context = Mock()
     context.new_page.return_value = page
@@ -285,3 +281,107 @@ def test_capture_cleanup_failure_preserves_parent_precedence(monkeypatch):
     assert raised.value is cleanup_failure
     context.close.assert_not_called()
     browser_obj.close.assert_not_called()
+
+
+@pytest.mark.parametrize("poll_duration", [0.0, 2.0], ids=["empty-polls", "slow-poll"])
+def test_capture_timeout_uses_host_clock_and_bounds_sleep(monkeypatch, poll_duration):
+    clock = SimpleNamespace(now=1000.0)
+
+    def sleep(seconds):
+        assert seconds >= 0
+        clock.now += seconds
+
+    monkeypatch.setattr(
+        capture_service, "time", SimpleNamespace(monotonic=lambda: clock.now, sleep=sleep)
+    )
+    page = Mock()
+    page.evaluate.side_effect = AssertionError("The login page cannot supply the clock")
+    page.wait_for_timeout.side_effect = AssertionError("The login page cannot supply the wait")
+    context = Mock()
+    context.new_page.return_value = page
+
+    def cookies():
+        clock.now += poll_duration
+        return []
+
+    context.cookies.side_effect = cookies
+    browser = Mock()
+    browser.new_context.return_value = context
+    chromium = SimpleNamespace(launch=Mock(return_value=browser))
+
+    @contextmanager
+    def playwright_context():
+        yield SimpleNamespace(chromium=chromium)
+
+    monkeypatch.setattr(capture_service, "sync_playwright_context", playwright_context)
+
+    with pytest.raises(MasterTokenError, match="Did not observe an oauth_token cookie"):
+        capture_service.capture_oauth_token(timeout_s=1.5)
+
+    assert clock.now == 1000.0 + max(1.5, poll_duration)
+    page.close.assert_called_once_with()
+    context.close.assert_called_once_with()
+    browser.close.assert_called_once_with()
+
+
+@pytest.mark.requires_chromium
+@pytest.mark.parametrize("attached", [False, True], ids=["launched", "attached"])
+def test_capture_reads_cookie_after_login_page_closes_in_real_chromium(monkeypatch, attached):
+    """A closed login tab must not discard a cookie in its still-live context."""
+    with capture_service.sync_playwright_context() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        try:
+            context = browser.new_context()
+            context.route(
+                "**/*",
+                lambda route: route.fulfill(
+                    content_type="text/html", body="<title>Synthetic sign-in</title>"
+                ),
+            )
+            read_cookies = context.cookies
+            closed_pages = []
+
+            def cookies():
+                snapshot = read_cookies()
+                if not closed_pages:
+                    # Complete sign-in just after the first cookie snapshot,
+                    # before capture gets another chance to observe the token.
+                    context.add_cookies(
+                        [
+                            {
+                                "name": "oauth_token",
+                                "value": "SYNTHETIC-NONCREDENTIAL",
+                                "url": "https://accounts.google.com/",
+                            }
+                        ]
+                    )
+                    page = context.pages[0]
+                    page.close()
+                    closed_pages.append(page)
+                return snapshot
+
+            monkeypatch.setattr(context, "cookies", cookies)
+            monkeypatch.setattr(browser, "new_context", Mock(return_value=context))
+            chromium = SimpleNamespace(
+                launch=Mock(return_value=browser), connect_over_cdp=Mock(return_value=browser)
+            )
+
+            @contextmanager
+            def playwright_context():
+                yield SimpleNamespace(chromium=chromium)
+
+            monkeypatch.setattr(capture_service, "sync_playwright_context", playwright_context)
+
+            assert (
+                capture_service.capture_oauth_token(
+                    cdp_url="http://localhost:9222" if attached else None, timeout_s=5
+                )
+                == "SYNTHETIC-NONCREDENTIAL"
+            )
+            assert len(closed_pages) == 1
+            assert closed_pages[0].is_closed()
+            assert browser.is_connected() is attached
+            if attached:
+                assert read_cookies()[0]["name"] == "oauth_token"
+        finally:
+            browser.close()


### PR DESCRIPTION
## Summary

During `login --master-token`, closing the login tab between cookie polls raises `TargetClosedError`, even when the OAuth cookie is already present in a healthy browser context. Capture then aborts before token exchange can start.

Use a host-side monotonic clock and bounded sleeps so cookie polling can continue after the tab closes.

## Related Issue

Related to #2350. This fixes a deterministic page-lifetime bug found during investigation. The reporter's Windows post-ToS failure and GCM `DEPRECATED_ENDPOINT` messages have not been reproduced, so this PR does not establish or resolve that issue's root cause.

## Changes

- Remove the polling loop's dependency on page JavaScript and page-scoped waits.
- Bound each sleep by the remaining capture timeout.
- Add real-Chromium regressions that close the login tab after a cookie snapshot, covering both owned and borrowed browser lifetimes, plus empty/slow-poll timeout coverage.
- Refresh the four generated audit snapshots affected by the source changes and new regression tests.
- Document all 12 functions touched by the code/test diff.

## Test Plan

Validated with the lockfile-pinned Python 3.12 CI dependencies:

- [x] `uv run --no-sync pytest tests/unit/test_browser_oauth_token.py tests/unit/cli/test_login_master_token.py tests/unit/test_app_master_token.py -q` — 64 passed.
- [x] The complete `Run critical contract guards` command from `.github/workflows/test.yml`, using four xdist workers — 39 passed, including all baseline comparisons.
- [x] Both real-Chromium regression cases failed with `TargetClosedError` before the fix and passed afterward.
- [x] `ruff check .` and formatting checks.
- [x] `pre-commit run --files` for the changed Python and baseline JSON files, including the fixture credential scan.
- [x] The full CI type-check command (`mypy src/notebooklm scripts/_live_auth_scenarios` plus the five audited scripts, with `--ignore-missing-imports`) — no issues in 467 files.
- [x] AST comparison against `main` confirms docstrings on all 12 changed functions.

## Notes

The full test suite and authenticated Windows Google sign-in were not run locally. The Chromium regressions use a synthetic page and dummy cookie without Google authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token capture reliability when the login page navigates or closes.
  * Cookie updates that occur after the login page closes can now still be detected.
  * OAuth polling now uses more reliable timing, improving timeout handling and reducing dependence on page-side timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->