### PR TITLE
test: add local HTTP and Android fault-injection stress harness

### DIFF
--- a/.github/workflows/fault-stress.yml
+++ b/.github/workflows/fault-stress.yml
@@ -1,0 +1,48 @@
+name: Fault Server Stress
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '45 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fault-stress-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stress:
+    name: Local HTTP and gRPC stress
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FAULT_ITERATIONS: ${{ github.event_name == 'pull_request' && '64' || '400' }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@v7
+      with:
+        python-version: '3.12'
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+    - name: Install test dependencies
+      run: uv sync --frozen --extra browser --extra dev --extra markdown --extra android
+    - name: Run concurrent fault scenarios without live credentials
+      run: >-
+        uv run python scripts/stress_fault_server.py
+        --backend both --seed "$GITHUB_RUN_ID"
+        --iterations "$FAULT_ITERATIONS" --concurrency 4
+        --timeout 600 --scenario-timeout 15
+        --json-report fault-stress-report.json
+    - name: Preserve assignments and diagnostic traces
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: fault-stress-${{ github.run_id }}-${{ github.run_attempt }}
+        path: fault-stress-report.json
+        if-no-files-found: warn
+        retention-days: 14

--- a/docs/adr/0038-local-fault-injection-harness.md
+++ b/docs/adr/0038-local-fault-injection-harness.md
@@ -55,3 +55,19 @@ workflow that preserves reports as artifacts.
 
 See [the harness guide](../fault-injection.md) for commands, coverage, and
 scenario extension rules.
+
+## Alternatives considered
+
+- Extend transport mocks and cassettes alone. They remain useful for protocol
+  fidelity, but cannot show whether cancellation reaches a real server or
+  distinguish a committed mutation from a response lost on the socket.
+- Add a network proxy or kernel fault injector as the primary harness. Those
+  can model packet loss and connection faults, but cannot directly script
+  authentication generations, partial application responses, or committed
+  objects. They would also add setup requirements to ordinary test runs.
+- Build a complete upstream emulator. Maintaining every API and backend
+  would duplicate protocol work without strengthening the selected resilience
+  invariants. Representative public operations keep the harness bounded.
+- Run stress scenarios against live accounts. Live tests are still needed to
+  verify upstream agreement, but cannot reliably force authentication races
+  or commit-before-disconnect ordering and require credentials and quotas.

--- a/docs/adr/0038-local-fault-injection-harness.md
+++ b/docs/adr/0038-local-fault-injection-harness.md
@@ -1,0 +1,57 @@
+# ADR-0038: Local fault-injection services
+
+## Status
+
+Accepted.
+
+## Context
+
+Transport mocks and recorded responses pin protocol and retry behavior, but
+they do not exercise socket deadlines, truncated bodies, cancellation reaching
+the server, or ambiguous writes whose response is lost. The repository already
+has small local HTTP and gRPC servers inside individual tests. Authentication
+and lifecycle regressions need reusable scenarios that combine those boundaries
+with concurrent calls through the library.
+
+## Decision
+
+Keep reusable services and scenario definitions in `tests/_fault_server/`.
+Use ephemeral loopback sockets, synthetic credentials, and a small stateful
+subset of the upstream protocol. Run scenarios through production client
+assembly and public feature APIs. Substitute transport routing and credential
+issuance at construction; retain the real decoders, auth refresh coordinator,
+bearer provider, retry policy, and lifecycle owners.
+
+Web requests retain their logical HTTPS URL, Host, and cookie semantics while
+the test transport connects to local HTTP. The Android loader verifies the
+production target and opens a local insecure gRPC channel. Neither path changes
+production hostname restrictions. These services test socket and protocol
+behavior; they do not emulate TLS, DNS, browser login, or kernel packet loss.
+
+Each scenario owns a server/client cohort, scripts faults explicitly, and
+records requests, credential generations, committed state, invariant checks,
+and cleanup. Gates establish concurrency ordering. A separate source-checkout
+runner schedules bounded concurrent cohorts from a precomputed seed-based
+assignment plan and writes diagnostic JSON, including incomplete operations.
+A seed reproduces logical fault assignments, not operating-system scheduling.
+
+Real-socket regression tests live under `tests/integration/faults/`, with
+documented `allow_no_vcr` inventory entries. They run in the ordinary test
+matrix. The runner also runs in a credential-free PR and scheduled/manual
+workflow that preserves reports as artifacts.
+
+## Consequences
+
+- Server-side state distinguishes a rejected write from a committed write
+  whose response was lost, so retry safety is checked independently of the
+  exception observed by the client.
+- Auth tests exercise production recovery with synthetic issuers, without
+  depending on live accounts or weakening client security policy.
+- Shared scenarios make stress failures available as ordinary regressions.
+- The fake service intentionally implements a representative protocol subset.
+  Recorded fixtures and live tests remain the evidence for upstream fidelity.
+- No runtime dependency or installed command is added. Developing or running
+  the harness requires a source checkout and development dependencies.
+
+See [the harness guide](../fault-injection.md) for commands, coverage, and
+scenario extension rules.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ The ADR Index table utilizes five eras of Status notation to reflect the lifecyc
 | [0035](0035-mobile-resilience-transport.md) | Mobile backend as a resilience transport | Accepted |
 | [0036](0036-browser-acquisition-package.md) | Browser acquisition package and neutral login orchestration | Accepted |
 | [0037](0037-live-usage-and-quota-api.md) | Live usage and quota API | Accepted |
+| [0038](0038-local-fault-injection-harness.md) | Local fault-injection services and concurrent resilience scenarios | Accepted |
 
 ADR-0007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_guardrails/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1406,10 +1406,17 @@ NotebookLM has undocumented rate limits. Generation tests may be skipped when ra
 
 ### Writing New Tests
 
+Use the [local fault-injection harness](fault-injection.md) for network,
+authentication, and lifecycle failures that need real socket behavior without
+a live account. Its deterministic scenarios also feed the concurrent stress
+runner.
+
 ```
 Need network?
 ├── No → tests/unit/
-├── Mocked → tests/integration/
+├── Mocked transport → tests/unit/
+├── Recorded upstream traffic → tests/integration/
+├── Local fault server → tests/integration/faults/
 └── Real API → tests/e2e/
     └── What notebook?
         ├── Read-only → read_only_notebook_id + @pytest.mark.readonly
@@ -1508,6 +1515,7 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `test.yml` | Push/PR | Reduced 7-cell compatibility matrix (Ubuntu × Python 3.10–3.14, plus macOS/Windows on 3.12), linting, type checking |
+| `fault-stress.yml` | PR, daily 5:45 AM UTC, manual dispatch | Local HTTP/gRPC fault workloads with synthetic credentials and diagnostic report artifacts |
 | `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Full compatibility/coverage plus managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E; an owner may qualify an open same-repository PR at its pinned head SHA |
 | `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on a disposable fallback copy plus the template-read-only [Android gRPC canary](#android-grpc-canary); an owner may qualify an open same-repository PR at its pinned head SHA |
 | `testpypi-publish.yml` | Manual dispatch | Publish to TestPyPI |

--- a/docs/fault-injection.md
+++ b/docs/fault-injection.md
@@ -1,0 +1,121 @@
+# Local fault-injection tests
+
+The harness runs the real library against local HTTP and gRPC services with
+scripted failures. It needs no NotebookLM account. Requests cross real sockets;
+the services record both requests and committed state so a test can distinguish
+a failed request from a write that succeeded before its response disappeared.
+
+## Run the regression suite
+
+From a source checkout:
+
+```bash
+uv sync --frozen --extra browser --extra dev --extra markdown --extra android
+uv run pytest tests/integration/faults -q
+```
+
+The tests also run in the ordinary Python/OS compatibility matrix. Their
+`allow_no_vcr` marker means they use local sockets rather than recorded
+upstream traffic. No cassette recording or login is necessary.
+
+## Run concurrent workloads
+
+```bash
+uv run python scripts/stress_fault_server.py --list-scenarios
+uv run python scripts/stress_fault_server.py \
+  --backend both --seed 42 --iterations 100 --concurrency 4 \
+  --timeout 120 --scenario-timeout 15 \
+  --json-report /tmp/fault-stress-report.json
+```
+
+`--backend` accepts `web`, `android`, or `both`. An iteration runs one scenario
+cohort with its own client and server. Cohorts for authentication races issue
+concurrent requests through a shared client. `--concurrency` limits active
+cohorts, rather than counting every RPC they issue. Increase iterations for a
+longer run; keep finite per-scenario and aggregate deadlines.
+
+Fault choices are assigned before workers start, using a private seeded random
+generator. The report preserves the assignments, scenario plans, events,
+checks, and outcomes, including incomplete operations. The seed reproduces
+logical assignments for the same scenario registry and code revision. It does
+not reproduce OS scheduling, exact timing, or a later version of a scenario.
+
+The process returns nonzero if an invariant fails, an unexpected exception
+occurs, or a deadline expires. An injected network/auth exception is an expected
+outcome only when the scenario verifies its category and associated behavior.
+Successful completion alone is insufficient: scenarios also check request
+counts, credential transitions, committed state, and cleanup.
+
+The **Fault Server Stress** workflow runs a bounded workload on pull requests
+and a longer workload daily or on manual dispatch. Its report artifact contains
+the seed and event trace even when the runner reports a failure.
+
+## What the harness covers
+
+| Boundary | Faults and evidence |
+| --- | --- |
+| HTTP retry policy | 429 with Retry-After, 503, recovery and exhausted budgets; observed attempts and backoff |
+| HTTP protocol and deadlines | Invalid RPC bodies, truncated responses, delayed headers and stalled bodies; public errors and bounded completion |
+| Web authentication | Stale CSRF/session/cookies, homepage refresh, login redirects and failed bootstrap; actual refresh parsing and concurrent refresh coordination |
+| gRPC retries and authentication | UNAVAILABLE, RESOURCE_EXHAUSTED and UNAUTHENTICATED; real bearer generations, coordinated token minting and bounded replay |
+| Streaming | Partial responses, stalled streams and authentication failure after delivery; cancellation and no stream replay |
+| Mutation outcomes | Commit before losing the response; one server-side object and no unsafe create retry |
+| Lifecycle | Cancel active calls, close under load and reopen; server handlers, channels and client scopes released |
+
+Web routing preserves logical HTTPS URLs and Host/cookie behavior while a
+test-only transport connects to local HTTP/1.1. Android uses a real local
+insecure gRPC channel and the production bearer provider with a synthetic token
+issuer. The production Google hostname allowlist remains enforced.
+
+TLS certificate verification, DNS failures, browser login, actual Google token
+issuance, and kernel packet loss are outside this harness. These tests establish
+library resilience to the modeled protocol/socket faults; cassettes and live
+tests establish agreement with the real upstream service.
+
+## Add a scenario
+
+The implementation lives in `tests/_fault_server/`; `web_scenarios.py` and
+`android_scenarios.py` expose sorted `SCENARIOS` tuples and `run_scenario`.
+The stress runner and integration tests call the same functions.
+
+1. Add an explicit fault script for a representative public API operation.
+   Use synchronization gates to force race ordering. If several operations
+   share a server, assign faults by operation identity or a gated batch whose
+   members deliberately receive the same action.
+2. Record a `plan` event before allocating resources, including faults and
+   cohort operation identifiers. Use the supplied `ScenarioResult` throughout
+   so partial evidence survives cancellation and unexpected errors.
+3. Assert public outcomes and independent server evidence with
+   `result.require("unique_check_name", condition)`. Check successful payloads,
+   retry counts, credential generations, or committed-object counts as
+   appropriate. Unexpected requests and unused required script actions fail.
+4. Close clients and servers in `finally`, record cleanup evidence, and bound
+   waits. A failed assertion must still drain the resources it created.
+5. Register the name in `SCENARIOS`, run its integration case, then exercise it
+   concurrently with other scenarios. Add helper-level tests when a new fault
+   mechanism needs its own behavioral coverage.
+
+`ScenarioResult.record(kind, **payload)` snapshots JSON-safe evidence; it
+rejects nonfinite numeric values. Check names are unique. A false requirement
+raises `ScenarioFailure` carrying the result and trace. Avoid credentials in
+events: generation labels and synthetic identifiers are sufficient.
+
+Keep construction substitutions local and synchronous. Do not mutate process
+environment or patch production module bindings across an `await` in a cohort:
+the runner can execute other cohorts at that point. Keep all credentials inline
+and synthetic, and reject any unmapped network destination before connecting.
+
+## Investigate a failure
+
+Start with the failed operation's scenario and checks, then inspect its plan,
+request/credential events and cleanup evidence. Compare the server's committed
+state and request count with the client's exception before deciding a retry
+would be safe. Preserve the full report, code revision, and command when
+reporting a bug.
+
+Re-run with the same revision, seed and workload configuration. For a race,
+reduce the failure to an explicit gate sequence and add it as a deterministic
+regression; repeating random timing until a test passes does not resolve it.
+
+The architectural rationale is in
+[ADR-0038](adr/0038-local-fault-injection-harness.md).

--- a/docs/fault-injection.md
+++ b/docs/fault-injection.md
@@ -72,6 +72,10 @@ issuance, and kernel packet loss are outside this harness. These tests establish
 library resilience to the modeled protocol/socket faults; cassettes and live
 tests establish agreement with the real upstream service.
 
+The HTTP service closes each response connection. This version exercises the
+HTTPX transport's new-connection recovery; stale pooled keep-alive connections
+and the optional curl-cffi transport need separate scenarios.
+
 ## Add a scenario
 
 The implementation lives in `tests/_fault_server/`; `web_scenarios.py` and

--- a/scripts/stress_fault_server.py
+++ b/scripts/stress_fault_server.py
@@ -271,6 +271,17 @@ async def run_stress(config: RunConfig, registry: Registry) -> dict[str, Any]:
 def _run_cli(config: RunConfig, registry: Registry) -> dict[str, Any]:
     """Own the CLI loop so broken scenario cleanup cannot hang asyncio.run()."""
     loop = asyncio.new_event_loop()
+    loop_errors: list[str] = []
+
+    def exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        error = context.get("exception")
+        loop_errors.append(
+            f"event loop error: {context.get('message', 'unknown')}: "
+            f"{type(error).__name__}: {str(error)[:1000]}"
+        )
+        loop.default_exception_handler(context)
+
+    loop.set_exception_handler(exception_handler)
     report: dict[str, Any] | None = None
     main_task = loop.create_task(run_stress(config, registry))
     try:
@@ -301,6 +312,9 @@ def _run_cli(config: RunConfig, registry: Registry) -> dict[str, Any]:
                     "CLI shutdown left pending tasks: " + ", ".join(t.get_name() for t in survivors)
                 )
                 report["summary"]["ok"] = False
+        if loop_errors and report is not None:
+            report["failures"].extend(loop_errors)
+            report["summary"]["ok"] = False
         loop.close()
 
 

--- a/scripts/stress_fault_server.py
+++ b/scripts/stress_fault_server.py
@@ -129,6 +129,26 @@ def _source_revision() -> str | None:
         return None
 
 
+def _validate_evidence(result: ScenarioResult) -> None:
+    """Require recorded plans and checks, not only a claimed passing summary."""
+    if not result.checks or not all(value is True for value in result.checks.values()):
+        raise ValueError("scenario completed without nonempty passing invariant checks")
+    if not any(event.get("kind") == "plan" for event in result.events):
+        raise ValueError("scenario completed without a recorded fault plan")
+    recorded: dict[str, bool] = {}
+    for event in result.events:
+        if event.get("kind") != "check":
+            continue
+        name = event.get("name")
+        if not isinstance(name, str) or name in recorded or event.get("passed") is not True:
+            raise ValueError("scenario has duplicate, invalid, or failed check evidence")
+        recorded[name] = True
+    if recorded != result.checks:
+        raise ValueError("scenario check summary does not match recorded evidence")
+    # Validate even direct event-list mutations by scenario code.
+    json.dumps({"events": result.events, "checks": result.checks}, allow_nan=False)
+
+
 async def run_stress(config: RunConfig, registry: Registry) -> dict[str, Any]:
     """Run a fixed worker pool and retain diagnostics for every planned cohort."""
     plans = build_plan(config, registry)
@@ -176,10 +196,7 @@ async def run_stress(config: RunConfig, registry: Registry) -> dict[str, Any]:
                 plan.operation_id,
             ):
                 raise ValueError("scenario returned an inconsistent result identity")
-            if not result.checks or not all(value is True for value in result.checks.values()):
-                raise ValueError("scenario completed without nonempty passing invariant checks")
-            # Validate even direct event-list mutations by scenario code.
-            json.dumps({"events": result.events, "checks": result.checks}, allow_nan=False)
+            _validate_evidence(result)
             operation["status"] = "passed"
         except asyncio.TimeoutError:
             operation["status"] = "timed_out"

--- a/scripts/stress_fault_server.py
+++ b/scripts/stress_fault_server.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Run seeded local fault cohorts through the production clients and real sockets.
+
+Run from a source checkout with the dev extra installed::
+
+    python scripts/stress_fault_server.py --backend both --iterations 100 \
+        --seed 17 --concurrency 4 --json-report fault-report.json
+
+A seed fixes the ordered scenario assignments, not OS scheduling or latency.
+Each cohort owns its server/client; concurrency scenarios also drive multiple
+operations through one shared client. No account or remote service is used.
+Exit 0 means every cohort passed; 1 means a failure/timeout; 2 means bad arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import math
+import os
+import platform
+import random
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Coroutine, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+# The helpers are intentionally source-only, not part of the installed package.
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from tests._fault_server.common import ScenarioFailure, ScenarioResult  # noqa: E402
+from tests._fault_server.environment import isolated_environment  # noqa: E402
+
+Scenario = Callable[..., Coroutine[Any, Any, ScenarioResult]]
+Registry = Mapping[tuple[str, str], Scenario]
+_MAX_ITERATIONS = 100_000
+_MAX_CONCURRENCY = 64
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    backend: str = "both"
+    seed: int = 0
+    iterations: int = 100
+    concurrency: int = 4
+    timeout: float = 120.0
+    scenario_timeout: float = 15.0
+    cleanup_timeout: float = 5.0
+    scenarios: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.backend not in {"web", "android", "both"}:
+            raise ValueError("backend must be web, android, or both")
+        for name, maximum in (("iterations", _MAX_ITERATIONS), ("concurrency", _MAX_CONCURRENCY)):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= maximum:
+                raise ValueError(f"{name} must be an integer between 1 and {maximum}")
+        for name in ("timeout", "scenario_timeout", "cleanup_timeout"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not math.isfinite(value) or value <= 0:
+                raise ValueError(f"{name} must be a positive finite number")
+
+
+@dataclass(frozen=True)
+class OperationPlan:
+    operation_id: str
+    backend: str
+    scenario: str
+
+
+def load_registry(backend: str) -> dict[tuple[str, str], Scenario]:
+    """Import only selected transports, after environment isolation is active."""
+    registry: dict[tuple[str, str], Scenario] = {}
+    for selected in ("web", "android") if backend == "both" else (backend,):
+        module = importlib.import_module(f"tests._fault_server.{selected}_scenarios")
+        names = module.SCENARIOS
+        if not isinstance(names, tuple) or not names or tuple(sorted(set(names))) != names:
+            raise ValueError(f"{selected} SCENARIOS must be a nonempty sorted unique tuple")
+        for name in names:
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"invalid {selected} scenario name")
+            registry[selected, name] = module.run_scenario
+    return registry
+
+
+def build_plan(config: RunConfig, registry: Registry) -> list[OperationPlan]:
+    """Shuffle complete decks so every available fault recurs under load."""
+    candidates = sorted(
+        key for key in registry if config.backend == "both" or key[0] == config.backend
+    )
+    if config.scenarios:
+        unknown = set(config.scenarios) - {name for _, name in candidates}
+        if unknown:
+            raise ValueError(f"unknown scenario(s): {', '.join(sorted(unknown))}")
+        candidates = [key for key in candidates if key[1] in config.scenarios]
+    if not candidates:
+        raise ValueError("no scenarios selected")
+    rng = random.Random(config.seed)
+    plan: list[OperationPlan] = []
+    while len(plan) < config.iterations:
+        deck = candidates.copy()
+        rng.shuffle(deck)
+        for backend, scenario in deck:
+            plan.append(OperationPlan(f"operation-{len(plan):06d}", backend, scenario))
+            if len(plan) == config.iterations:
+                break
+    return plan
+
+
+def _source_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+async def run_stress(config: RunConfig, registry: Registry) -> dict[str, Any]:
+    """Run a fixed worker pool and retain diagnostics for every planned cohort."""
+    plans = build_plan(config, registry)
+    results = [ScenarioResult(p.backend, p.scenario, p.operation_id) for p in plans]
+    operations: list[dict[str, Any]] = [
+        {**asdict(plan), "status": "not_started", "events": result.events, "checks": result.checks}
+        for plan, result in zip(plans, results, strict=True)
+    ]
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "source_revision": _source_revision(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "config": asdict(config),
+        "registry": [{"backend": b, "scenario": s} for b, s in sorted(registry)],
+        "plan": [asdict(plan) for plan in plans],
+        "operations": operations,
+        "failures": [],
+        "reproducibility": "Seed and plan fix logical faults, not OS scheduling or latency.",
+    }
+    started = time.monotonic()
+    remaining = iter(range(len(plans)))
+    scenario_tasks: set[asyncio.Task[ScenarioResult]] = set()
+
+    async def execute(index: int) -> None:
+        plan, result, operation = plans[index], results[index], operations[index]
+        operation["status"] = "running"
+        began = time.monotonic()
+        result.record("started", **asdict(plan))
+        task = asyncio.create_task(
+            registry[plan.backend, plan.scenario](
+                plan.scenario, operation_id=plan.operation_id, result=result
+            ),
+            name=f"fault-scenario-{plan.operation_id}",
+        )
+        scenario_tasks.add(task)
+        try:
+            done, _ = await asyncio.wait((task,), timeout=config.scenario_timeout)
+            if not done:
+                raise asyncio.TimeoutError
+            returned = task.result()
+            if returned is not result or (result.backend, result.scenario, result.operation_id) != (
+                plan.backend,
+                plan.scenario,
+                plan.operation_id,
+            ):
+                raise ValueError("scenario returned an inconsistent result identity")
+            if not result.checks or not all(value is True for value in result.checks.values()):
+                raise ValueError("scenario completed without nonempty passing invariant checks")
+            # Validate even direct event-list mutations by scenario code.
+            json.dumps({"events": result.events, "checks": result.checks}, allow_nan=False)
+            operation["status"] = "passed"
+        except asyncio.TimeoutError:
+            operation["status"] = "timed_out"
+            operation["error"] = f"scenario exceeded {config.scenario_timeout:g}s deadline"
+        except asyncio.CancelledError:
+            operation["status"] = "canceled"
+            operation["error"] = "run canceled before scenario completed"
+            raise
+        except Exception as exc:
+            operation["status"] = "failed"
+            operation["error"] = f"{type(exc).__name__}: {str(exc)[:1000]}"
+            if isinstance(exc, ScenarioFailure) and exc.result is not result:
+                operation["error"] += " (ScenarioFailure carried a different result)"
+        finally:
+            if not task.done():
+                task.cancel()
+                _, pending = await asyncio.wait((task,), timeout=config.cleanup_timeout)
+                if pending:
+                    operation["status"] = "failed"
+                    operation["error"] = "scenario did not finish cancellation cleanup"
+                    operation["elapsed_seconds"] = time.monotonic() - began
+                    # This worker's cohort still occupies its slot. Stop this
+                    # worker rather than admitting another cohort over the cap.
+                    raise RuntimeError("scenario cleanup timed out")
+            if task.done():
+                # Retrieve cleanup exceptions even after timeout/cancellation.
+                if not task.cancelled() and task.exception() is not None:
+                    error = task.exception()
+                    if operation["status"] in {"timed_out", "canceled"}:
+                        operation["cleanup_error"] = f"{type(error).__name__}: {str(error)[:1000]}"
+                scenario_tasks.discard(task)
+            operation["elapsed_seconds"] = time.monotonic() - began
+
+    async def worker() -> None:
+        for index in remaining:
+            await execute(index)
+
+    workers = [
+        asyncio.create_task(worker(), name=f"fault-worker-{index}")
+        for index in range(min(config.concurrency, len(plans)))
+    ]
+    try:
+        _, pending = await asyncio.wait(workers, timeout=config.timeout)
+        if pending:
+            report["failures"].append(f"run exceeded {config.timeout:g}s deadline")
+    except asyncio.CancelledError:
+        report["failures"].append("run interrupted")
+    finally:
+        for task in workers:
+            if not task.done():
+                task.cancel()
+        done, pending = await asyncio.wait(workers, timeout=config.cleanup_timeout)
+        for task in done:
+            if not task.cancelled() and task.exception() is not None:
+                report["failures"].append(f"worker failed: {task.exception()}")
+        if pending:
+            report["failures"].append(
+                f"{len(pending)} workers did not finish cleanup within {config.cleanup_timeout:g}s"
+            )
+            for task in pending:
+                task.cancel()
+        if scenario_tasks:
+            for scenario_task in scenario_tasks:
+                if not scenario_task.done():
+                    scenario_task.cancel()
+            done_scenarios, pending_scenarios = await asyncio.wait(
+                scenario_tasks, timeout=config.cleanup_timeout
+            )
+            for scenario_task in done_scenarios:
+                if not scenario_task.cancelled():
+                    scenario_task.exception()
+            if pending_scenarios:
+                report["failures"].append(
+                    f"{len(pending_scenarios)} scenarios resisted cancellation; cleanup incomplete"
+                )
+    counts = {
+        status: sum(operation["status"] == status for operation in operations)
+        for status in ("passed", "failed", "timed_out", "canceled", "not_started", "running")
+    }
+    report["summary"] = {
+        **counts,
+        "total": len(plans),
+        "elapsed_seconds": time.monotonic() - started,
+        "ok": counts["passed"] == len(plans) and not report["failures"],
+    }
+    return report
+
+
+def _run_cli(config: RunConfig, registry: Registry) -> dict[str, Any]:
+    """Own the CLI loop so broken scenario cleanup cannot hang asyncio.run()."""
+    loop = asyncio.new_event_loop()
+    report: dict[str, Any] | None = None
+    main_task = loop.create_task(run_stress(config, registry))
+    try:
+        try:
+            report = loop.run_until_complete(main_task)
+        except KeyboardInterrupt:
+            main_task.cancel()
+            report = loop.run_until_complete(main_task)
+        return report
+    finally:
+        pending = asyncio.all_tasks(loop)
+        if pending and report is not None:
+            report["failures"].append(
+                "CLI found leaked tasks after run: " + ", ".join(t.get_name() for t in pending)
+            )
+            report["summary"]["ok"] = False
+        for task in pending:
+            task.cancel()
+        if pending:
+            done, survivors = loop.run_until_complete(
+                asyncio.wait(pending, timeout=config.cleanup_timeout)
+            )
+            for task in done:
+                if not task.cancelled():
+                    task.exception()
+            if survivors and report is not None:
+                report["failures"].append(
+                    "CLI shutdown left pending tasks: " + ", ".join(t.get_name() for t in survivors)
+                )
+                report["summary"]["ok"] = False
+        loop.close()
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    """Atomically replace the report so interruption leaves the previous file usable."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as stream:
+            temporary = stream.name
+            json.dump(report, stream, indent=2, allow_nan=False)
+            stream.write("\n")
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None and os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=("web", "android", "both"), default="both")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--timeout", type=float, default=120)
+    parser.add_argument("--scenario-timeout", type=float, default=15)
+    parser.add_argument("--json-report", type=Path, default=Path("fault-report.json"))
+    parser.add_argument("--scenario", action="append", default=[])
+    parser.add_argument("--list-scenarios", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        config = RunConfig(
+            backend=args.backend,
+            seed=args.seed,
+            iterations=args.iterations,
+            concurrency=args.concurrency,
+            timeout=args.timeout,
+            scenario_timeout=args.scenario_timeout,
+            scenarios=tuple(args.scenario),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    try:
+        with isolated_environment():
+            registry = load_registry(config.backend)
+            # Validate selection before creating an event loop or opening sockets.
+            build_plan(config, registry)
+            if args.list_scenarios:
+                for backend, scenario in sorted(registry):
+                    print(f"{backend}/{scenario}")
+                return 0
+            report = _run_cli(config, registry)
+    except ValueError as exc:
+        parser.error(str(exc))
+    except (Exception, KeyboardInterrupt) as exc:
+        report = {
+            "schema_version": 1,
+            "config": asdict(config),
+            "failures": [f"{type(exc).__name__}: {str(exc)[:1000]}"],
+            "summary": {"ok": False},
+        }
+    try:
+        write_report(args.json_report, report)
+    except (OSError, TypeError, ValueError) as exc:
+        print(f"Could not write fault report: {exc}", file=sys.stderr)
+        return 1
+    summary = report["summary"]
+    print(
+        f"{'PASS' if summary['ok'] else 'FAIL'} seed={config.seed} "
+        f"passed={summary.get('passed', 0)}/{config.iterations} report={args.json_report}"
+    )
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_taxonomy_inventory.py
+++ b/scripts/test_taxonomy_inventory.py
@@ -41,9 +41,9 @@ class ItemRecord:
 
 class CollectionRecorder:
     def __init__(self) -> None:
-        self.items: list[object] = []
+        self.items: list[pytest.Item] = []
 
-    def pytest_collection_modifyitems(self, config, items) -> None:
+    def pytest_collection_modifyitems(self, config: pytest.Config, items: list[pytest.Item]) -> None:
         self.items = list(items)
 
 
@@ -379,8 +379,8 @@ def check_outputs(outputs: dict[Path, str]) -> int:
             stale.append(_repo_relative(path))
     if stale:
         print("taxonomy inventory outputs are stale:", file=sys.stderr)
-        for path in stale:
-            print(f"  {path}", file=sys.stderr)
+        for stale_path in stale:
+            print(f"  {stale_path}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/test_taxonomy_inventory.py
+++ b/scripts/test_taxonomy_inventory.py
@@ -43,7 +43,9 @@ class CollectionRecorder:
     def __init__(self) -> None:
         self.items: list[pytest.Item] = []
 
-    def pytest_collection_modifyitems(self, config: pytest.Config, items: list[pytest.Item]) -> None:
+    def pytest_collection_modifyitems(
+        self, config: pytest.Config, items: list[pytest.Item]
+    ) -> None:
         self.items = list(items)
 
 

--- a/scripts/test_taxonomy_inventory.py
+++ b/scripts/test_taxonomy_inventory.py
@@ -8,6 +8,7 @@ import contextlib
 import io
 import sys
 from collections import Counter, defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -142,10 +143,22 @@ def _markdown_list(values: list[str], *, empty: str = "None.") -> str:
     return "\n".join(f"- `{value}`" for value in values)
 
 
-def _allowlist(entries: list[str], rationale: str) -> str:
+def _allowlist(entries: list[str], rationale: str | Callable[[str], str]) -> str:
     if not entries:
         return "# No entries.\n"
-    return "\n".join(f"{entry} # {rationale}" for entry in sorted(entries)) + "\n"
+    return (
+        "\n".join(
+            f"{entry} # {rationale(entry) if callable(rationale) else rationale}"
+            for entry in sorted(entries)
+        )
+        + "\n"
+    )
+
+
+def _no_vcr_rationale(entry: str) -> str:
+    if entry.startswith("tests/integration/faults/"):
+        return "real loopback fault service; socket failures cannot be reproduced by VCR"
+    return ALLOW_NO_VCR_RATIONALE
 
 
 def allowlist_entries_from_text(content: str) -> list[str]:
@@ -338,11 +351,11 @@ def rendered_baseline_outputs(records: list[ItemRecord]) -> dict[Path, str]:
     return {
         ALLOW_NO_VCR_FILES_PATH: _allowlist(
             _sorted_paths({record.path for record in allow_no_vcr}),
-            ALLOW_NO_VCR_RATIONALE,
+            _no_vcr_rationale,
         ),
         ALLOW_NO_VCR_NODEIDS_PATH: _allowlist(
             [record.nodeid for record in allow_no_vcr],
-            ALLOW_NO_VCR_RATIONALE,
+            _no_vcr_rationale,
         ),
         VCR_ALLOW_NO_VCR_NODEIDS_PATH: _allowlist(
             [record.nodeid for record in overlap],

--- a/tests/_fault_server/__init__.py
+++ b/tests/_fault_server/__init__.py
@@ -1,0 +1,4 @@
+"""Local, real-socket fault services for library resilience qualification.
+
+These helpers are source-checkout development tools, not an installed API.
+"""

--- a/tests/_fault_server/android.py
+++ b/tests/_fault_server/android.py
@@ -131,7 +131,9 @@ def build_android_client(
     with patch.object(android_assembly, "AndroidSession", local_session):
         client = build_client_shell_for_tests(
             AuthTokens(
-                cookies={"SID": "fault-cookie"}, csrf_token="fault-csrf", session_id="fault"
+                cookies={("SID", ".google.com", "/"): "fault-cookie"},
+                csrf_token="fault-csrf",
+                session_id="fault",
             ),
             backend="android",
             timeout=timeout,
@@ -141,6 +143,7 @@ def build_android_client(
             master_token_reader=SyntheticMasterTokenReader(),
             oauth_minter=selected_minter,
         )
+    assert client._android_runtime is not None
     return AndroidHarness(
         client=client,
         minter=selected_minter,

--- a/tests/_fault_server/android.py
+++ b/tests/_fault_server/android.py
@@ -1,0 +1,159 @@
+"""Production-assembly Android client bound to :mod:`.grpc` loopback servers."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import grpc
+
+from notebooklm._android import assembly as android_assembly
+from notebooklm._android.auth import NOTEBOOKLM_OAUTH_SPEC
+from notebooklm._android.session import ANDROID_GRPC_TARGET, AndroidSession
+from notebooklm._auth.master_token_types import MasterToken
+from notebooklm._auth.mint_service import MintedOAuthToken
+from notebooklm.auth import AuthTokens
+from tests._helpers.client_factory import build_client_shell_for_tests
+
+from .grpc import GrpcFaultServer
+
+
+@dataclass
+class SyntheticMasterTokenReader:
+    """A real BearerProvider input with no disk or user-profile dependency."""
+
+    reads: int = 0
+
+    def read_master_token(self) -> MasterToken:
+        self.reads += 1
+        return MasterToken(
+            email="fault@example.test", android_id="fault-device", secret="fault-master"
+        )
+
+
+@dataclass
+class SyntheticOAuthMinter:
+    tokens: list[str] = field(default_factory=lambda: ["fault-bearer-1", "fault-bearer-2"])
+    error: Exception | None = None
+    block_after: int | None = None
+    release: asyncio.Event | None = None
+    calls: int = 0
+
+    async def mint_oauth(self, token: MasterToken, spec: object) -> MintedOAuthToken:
+        assert token.email == "fault@example.test"
+        assert spec == NOTEBOOKLM_OAUTH_SPEC
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        if self.block_after is not None and self.calls >= self.block_after:
+            assert self.release is not None
+            await self.release.wait()
+        value = self.tokens[min(self.calls - 1, len(self.tokens) - 1)]
+        return MintedOAuthToken(value, int(time.time()) + 3600)
+
+
+@dataclass
+class AndroidHarness:
+    client: Any
+    minter: SyntheticOAuthMinter
+    bearer: Any
+    channels: list[Any]
+    targets: list[str]
+
+
+async def no_sleep(_seconds: float) -> None:
+    """Keep retry-count scenarios bounded while retaining real socket attempts."""
+
+
+def build_android_client(
+    server: GrpcFaultServer,
+    *,
+    timeout: float = 0.5,
+    rate_limit_max_retries: int = 1,
+    server_error_max_retries: int = 1,
+    minter: SyntheticOAuthMinter | None = None,
+    sleep: Callable[[float], Awaitable[Any]] = no_sleep,
+) -> AndroidHarness:
+    """Synchronously assemble a public client with its real bearer provider.
+
+    The temporary class patch lasts only for synchronous production assembly;
+    each constructed session captures its local-channel loader before the
+    module binding is restored.  This keeps concurrent scenario cohorts from
+    sharing global test state or changing production endpoint routing.
+    """
+
+    channels: list[Any] = []
+    targets: list[str] = []
+
+    def secure_channel(target: str, _credentials: object, *, options: Any) -> Any:
+        targets.append(target)
+        if target != ANDROID_GRPC_TARGET:
+            raise AssertionError(f"production Android target changed: {target}")
+        channel = grpc.aio.insecure_channel(server.target, options=options)
+        channels.append(channel)
+        return channel
+
+    grpc_loader = SimpleNamespace(
+        ssl_channel_credentials=lambda: object(),
+        aio=SimpleNamespace(secure_channel=secure_channel),
+    )
+    production_session = AndroidSession
+
+    def local_session(
+        bearer_provider: Any,
+        supervisor: Any,
+        *,
+        timeout: float | None,
+        rate_limit_max_retries: int,
+        server_error_max_retries: int,
+        refresh_retry_delay: float,
+        metrics: Any,
+        sleep: Any,
+    ) -> AndroidSession:
+        return production_session(
+            bearer_provider,
+            supervisor,
+            timeout=timeout,
+            rate_limit_max_retries=rate_limit_max_retries,
+            server_error_max_retries=server_error_max_retries,
+            refresh_retry_delay=refresh_retry_delay,
+            metrics=metrics,
+            sleep=sleep,
+            grpc_loader=lambda: grpc_loader,
+        )
+
+    selected_minter = minter or SyntheticOAuthMinter()
+    with patch.object(android_assembly, "AndroidSession", local_session):
+        client = build_client_shell_for_tests(
+            AuthTokens(
+                cookies={"SID": "fault-cookie"}, csrf_token="fault-csrf", session_id="fault"
+            ),
+            backend="android",
+            timeout=timeout,
+            rate_limit_max_retries=rate_limit_max_retries,
+            server_error_max_retries=server_error_max_retries,
+            sleep=sleep,
+            master_token_reader=SyntheticMasterTokenReader(),
+            oauth_minter=selected_minter,
+        )
+    return AndroidHarness(
+        client=client,
+        minter=selected_minter,
+        bearer=client._android_runtime.bearer_provider,
+        channels=channels,
+        targets=targets,
+    )
+
+
+__all__ = [
+    "AndroidHarness",
+    "SyntheticMasterTokenReader",
+    "SyntheticOAuthMinter",
+    "build_android_client",
+    "no_sleep",
+]

--- a/tests/_fault_server/android_scenarios.py
+++ b/tests/_fault_server/android_scenarios.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 import grpc
@@ -60,7 +60,11 @@ _FAULTS = {
         "GetProject:RESOURCE_EXHAUSTED->reply",
         "GetProject:RESOURCE_EXHAUSTED exhaustion",
     ),
-    "stream_auth": ("chat stream:partial->UNAUTHENTICATED", "later GetProject:fresh bearer"),
+    "stream_auth": (
+        "chat stream:partial->UNAUTHENTICATED",
+        "raw stream:observe partial->UNAUTHENTICATED",
+        "later GetProject:fresh bearer",
+    ),
     "unavailable": ("GetProject:UNAVAILABLE->reply", "GetProject:UNAVAILABLE exhaustion"),
 }
 
@@ -96,6 +100,7 @@ async def _run_server(
     try:
         async with server:
             await setup(server)
+            await server.wait_for_idle()
             server.assert_consumed()
     finally:
         result.record(
@@ -277,8 +282,16 @@ async def _stream_auth(result: ScenarioResult) -> None:
         server.plan(
             GENERATE_STREAMED,
             stream([_frame("partial")], after=abort(grpc.StatusCode.UNAUTHENTICATED)),
+            stream([_frame("raw partial")], after=abort(grpc.StatusCode.UNAUTHENTICATED)),
         )
         harness = build_android_client(server)
+        raw_method: GrpcUnaryStreamMethod[
+            chat_pb2.GenerateFreeFormStreamedRequest,
+            chat_pb2.GenerateFreeFormStreamedResponse,
+        ] = GrpcUnaryStreamMethod(
+            path=GENERATE_STREAMED,
+            response_type=chat_pb2.GenerateFreeFormStreamedResponse,
+        )
         async with harness.client as client:
             try:
                 await client.chat.ask("notebook-1", "Question?")
@@ -286,8 +299,32 @@ async def _stream_auth(result: ScenarioResult) -> None:
                 pass
             else:
                 result.require("stream_auth_raises", False)
+            raw_stream: AsyncIterator[chat_pb2.GenerateFreeFormStreamedResponse] = (
+                client.raw.unary_stream(
+                    raw_method,
+                    chat_pb2.GenerateFreeFormStreamedRequest(project_id="notebook-1"),
+                    metadata=(("x-fault-call", "raw-partial"),),
+                )
+            )
+            partial = await anext(raw_stream)
+            result.require("raw_stream_delivers_partial", partial.answer.response == "raw partial")
+            try:
+                await anext(raw_stream)
+            except AuthError:
+                pass
+            else:
+                result.require("raw_stream_auth_raises_after_partial", False)
             await client.notebooks.get("notebook-1")
-        result.require("stream_never_replays", len(_authorizations(server, GENERATE_STREAMED)) == 1)
+        raw_requests = [
+            request
+            for request in server.requests
+            if request.method == GENERATE_STREAMED
+            and dict(request.metadata).get("x-fault-call") == "raw-partial"
+        ]
+        result.require("feature_and_raw_stream_never_replay", len(raw_requests) == 1)
+        result.require(
+            "two_single_attempt_streams", len(_authorizations(server, GENERATE_STREAMED)) == 2
+        )
         result.require(
             "next_unary_gets_fresh_bearer",
             _authorizations(server, GET_PROJECT)[-1] == "Bearer fault-bearer-2",
@@ -333,19 +370,29 @@ async def _deadline_and_cancellation(result: ScenarioResult) -> None:
             stream([_frame("one")], gate="stream-cancel"),
         )
         harness = build_android_client(server, timeout=0.5)
-        raw_stream = GrpcUnaryStreamMethod(
+        raw_stream: GrpcUnaryStreamMethod[
+            chat_pb2.GenerateFreeFormStreamedRequest,
+            chat_pb2.GenerateFreeFormStreamedResponse,
+        ] = GrpcUnaryStreamMethod(
             path=GENERATE_STREAMED,
             response_type=chat_pb2.GenerateFreeFormStreamedResponse,
         )
         async with harness.client as client:
+            first_supervisor = client._collaborators.call_supervisor
+            first_generation = first_supervisor._current
+            assert first_generation is not None
             try:
                 await client.notebooks.get("notebook-1")
             except RPCTimeoutError:
                 pass
             else:
                 result.require("deadline_raises", False)
+            deadline_request = server.requests[-1]
+            await server.wait_for_cancellation(deadline_request)
+            result.require("deadline_cancels_exact_unary", deadline_request.cancelled)
             blocked = asyncio.create_task(client.notebooks.get("notebook-1"))
             await _wait_for(lambda: len(_authorizations(server, GET_PROJECT)) == 2)
+            cancelled_request = server.requests[-1]
             blocked.cancel()
             try:
                 await blocked
@@ -353,6 +400,8 @@ async def _deadline_and_cancellation(result: ScenarioResult) -> None:
                 pass
             else:
                 result.require("cancellation_propagates", False)
+            await server.wait_for_cancellation(cancelled_request)
+            result.require("caller_cancels_exact_unary", cancelled_request.cancelled)
             timed_stream = client.raw.unary_stream(
                 raw_stream,
                 chat_pb2.GenerateFreeFormStreamedRequest(project_id="notebook-1"),
@@ -364,21 +413,22 @@ async def _deadline_and_cancellation(result: ScenarioResult) -> None:
                 pass
             else:
                 result.require("stream_deadline_raises", False)
+            stream_deadline_request = server.requests[-1]
+            await server.wait_for_cancellation(stream_deadline_request)
+            result.require("deadline_cancels_exact_stream", stream_deadline_request.cancelled)
             cancelling_stream = client.raw.unary_stream(
                 raw_stream,
                 chat_pb2.GenerateFreeFormStreamedRequest(project_id="notebook-1"),
                 timeout=0.5,
             )
             assert (await anext(cancelling_stream)).answer.response == "one"
+            stream_cancel_request = server.requests[-1]
             await cancelling_stream.aclose()
-            await _wait_for(
-                lambda: (
-                    sum(request.method == GENERATE_STREAMED for request in server.cancellations)
-                    == 2
-                )
-            )
+            await server.wait_for_cancellation(stream_cancel_request)
+            result.require("aclose_cancels_exact_stream", stream_cancel_request.cancelled)
             closing = asyncio.create_task(client.notebooks.get("notebook-1"))
             await _wait_for(lambda: len(_authorizations(server, GET_PROJECT)) == 3)
+            close_request = server.requests[-1]
             await client.close(drain=False)
             try:
                 await closing
@@ -386,10 +436,35 @@ async def _deadline_and_cancellation(result: ScenarioResult) -> None:
                 pass
             else:
                 result.require("close_cancels_active_call", False)
+            await server.wait_for_cancellation(close_request)
+            result.require("close_cancels_exact_unary", close_request.cancelled)
+            result.require(
+                "forced_close_shuts_channel",
+                harness.channels[0].get_state() is grpc.ChannelConnectivity.SHUTDOWN,
+            )
+            await _wait_for(lambda: _admission_settled(harness.client, first_generation))
+            result.require(
+                "forced_close_settles_admission",
+                _admission_settled(harness.client, first_generation),
+            )
         # A reopen is a public lifecycle operation and must construct a fresh channel.
         async with harness.client as client:
+            second_generation = client._collaborators.call_supervisor._current
+            assert second_generation is not None
             await client.notebooks.get("notebook-1")
         result.require("fresh_channel_after_reopen", len(harness.channels) == 2)
+        result.require(
+            "all_channels_closed",
+            all(
+                channel.get_state() is grpc.ChannelConnectivity.SHUTDOWN
+                for channel in harness.channels
+            ),
+        )
+        await _wait_for(lambda: _admission_settled(harness.client, second_generation))
+        result.require(
+            "final_close_settles_admission",
+            _admission_settled(harness.client, second_generation),
+        )
         result.require(
             "deadline_and_cancel_are_one_attempt", len(_authorizations(server, GET_PROJECT)) == 4
         )
@@ -421,6 +496,16 @@ async def _wait_for(predicate: Callable[[], bool]) -> None:
             await asyncio.sleep(0)
 
     await asyncio.wait_for(wait(), timeout=1.0)
+
+
+def _admission_settled(client: Any, generation: Any) -> bool:
+    supervisor = client._collaborators.call_supervisor
+    return (
+        supervisor.active_epoch() is None
+        and generation.in_flight == 0
+        and generation.epoch not in supervisor._retired
+        and not supervisor._settlement_tasks
+    )
 
 
 async def run_scenario(

--- a/tests/_fault_server/android_scenarios.py
+++ b/tests/_fault_server/android_scenarios.py
@@ -1,0 +1,450 @@
+"""Deterministic public Android resilience scenarios over local gRPC sockets."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import grpc
+
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import chat_pb2
+from notebooklm._android.proto.labs.language.tailwind.common.protos import common_pb2
+from notebooklm.exceptions import AuthError, RateLimitError, RPCTimeoutError, ServerError
+from notebooklm.outcomes import CommitState
+from notebooklm.raw import GrpcUnaryStreamMethod
+
+from .android import SyntheticOAuthMinter, build_android_client
+from .common import ScenarioResult
+from .grpc import (
+    CREATE_PROJECT,
+    GENERATE_STREAMED,
+    GET_PROJECT,
+    LIST_CHAT_SESSIONS,
+    GrpcFaultServer,
+    abort,
+    commit_abort,
+    reply,
+    stream,
+    wait_abort,
+    wait_reply,
+)
+
+SCENARIOS = (
+    "auth",
+    "auth_concurrent",
+    "commit_lost_response",
+    "deadline_and_cancellation",
+    "minter_failure",
+    "public_flows",
+    "rate_limit",
+    "stream_auth",
+    "unavailable",
+)
+
+_FAULTS = {
+    "auth": ("GetProject:UNAUTHENTICATED->reply", "GetProject:UNAUTHENTICATED->UNAUTHENTICATED"),
+    "auth_concurrent": (
+        "GetProject x2:gate(both-old)->UNAUTHENTICATED",
+        "GetProject x2:fresh reply",
+    ),
+    "commit_lost_response": ("CreateProject:commit->UNAVAILABLE",),
+    "deadline_and_cancellation": (
+        "GetProject:gate(deadline)",
+        "GenerateFreeFormStreamed:gate(deadline)",
+        "active unary/stream cancellation and close",
+    ),
+    "minter_failure": ("bearer minter failure before dispatch",),
+    "public_flows": ("GetProject:reply", "CreateProject:reply", "chat stream:final reply"),
+    "rate_limit": (
+        "GetProject:RESOURCE_EXHAUSTED->reply",
+        "GetProject:RESOURCE_EXHAUSTED exhaustion",
+    ),
+    "stream_auth": ("chat stream:partial->UNAUTHENTICATED", "later GetProject:fresh bearer"),
+    "unavailable": ("GetProject:UNAVAILABLE->reply", "GetProject:UNAVAILABLE exhaustion"),
+}
+
+
+def _result(name: str, operation_id: str, supplied: ScenarioResult | None) -> ScenarioResult:
+    if name not in SCENARIOS:
+        raise ValueError(f"unknown Android fault scenario: {name}")
+    result = supplied or ScenarioResult("android", name, operation_id)
+    if (result.backend, result.scenario, result.operation_id) != ("android", name, operation_id):
+        raise ValueError("supplied scenario result identity does not match Android scenario")
+    result.record(
+        "plan",
+        faults=_FAULTS[name],
+        cohort_ids=[operation_id],
+        phases=["assemble", "open", "call", "cleanup"],
+    )
+    return result
+
+
+def _authorizations(server: GrpcFaultServer, method: str) -> list[str]:
+    return [
+        dict(item.metadata).get("authorization", "")
+        for item in server.requests
+        if item.method == method
+    ]
+
+
+async def _run_server(
+    result: ScenarioResult,
+    setup: Callable[[GrpcFaultServer], Awaitable[None]],
+) -> ScenarioResult:
+    server = GrpcFaultServer()
+    try:
+        async with server:
+            await setup(server)
+            server.assert_consumed()
+    finally:
+        result.record(
+            "grpc_journal",
+            methods=[request.method.rpartition("/")[2] for request in server.requests],
+            authorization_generations=[
+                dict(request.metadata).get("authorization", "").rsplit("-", 1)[-1]
+                for request in server.requests
+            ],
+        )
+        result.record(
+            "cleanup",
+            requests=len(server.requests),
+            cancellations=[request.method.rpartition("/")[2] for request in server.cancellations],
+            handler_errors=server.handler_errors,
+        )
+        result.require(f"server_handlers_released_{len(result.events)}", not server._active)
+    return result
+
+
+async def _public_flows(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(GET_PROJECT, reply(), reply())
+        server.plan(CREATE_PROJECT, reply())
+        server.plan(LIST_CHAT_SESSIONS, reply(), reply(_chat_sessions("conversation-1")))
+        server.plan(GENERATE_STREAMED, stream([_frame("Fault answer", final=True)]))
+        harness = build_android_client(server)
+        async with harness.client as client:
+            notebook = await client.notebooks.get("notebook-1")
+            created = await client.notebooks.create("Created by fault test")
+            answer = await client.chat.ask("notebook-1", "Question?")
+        result.require("get_decodes", notebook.id == "notebook-1")
+        result.require("create_decodes", created.id == "created-1")
+        result.require("chat_decodes", answer.answer == "Fault answer")
+        result.require("production_target", harness.targets == ["notebooklm-pa.googleapis.com:443"])
+        result.require(
+            "initial_bearer",
+            all(v == "Bearer fault-bearer-1" for v in _authorizations(server, GET_PROJECT)),
+        )
+
+    await _run_server(result, setup)
+
+
+async def _unavailable(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(GET_PROJECT, abort(grpc.StatusCode.UNAVAILABLE), reply())
+        harness = build_android_client(server, timeout=5.0, server_error_max_retries=1)
+        async with harness.client as client:
+            assert (await client.notebooks.get("notebook-1")).id == "notebook-1"
+        result.require("unavailable_retries_once", len(_authorizations(server, GET_PROJECT)) == 2)
+
+    await _run_server(result, setup)
+
+    async def exhaustion(server: GrpcFaultServer) -> None:
+        server.plan(
+            GET_PROJECT, abort(grpc.StatusCode.UNAVAILABLE), abort(grpc.StatusCode.UNAVAILABLE)
+        )
+        harness = build_android_client(server, timeout=5.0, server_error_max_retries=1)
+        async with harness.client as client:
+            try:
+                await client.notebooks.get("notebook-1")
+            except ServerError:
+                pass
+            else:
+                result.require("unavailable_exhaustion_raises", False)
+        result.require(
+            "unavailable_exhausts_budget", len(_authorizations(server, GET_PROJECT)) == 2
+        )
+
+    await _run_server(result, exhaustion)
+
+
+async def _rate_limit(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(GET_PROJECT, abort(grpc.StatusCode.RESOURCE_EXHAUSTED), reply())
+        harness = build_android_client(server, timeout=5.0, rate_limit_max_retries=1)
+        async with harness.client as client:
+            await client.notebooks.get("notebook-1")
+        result.require("rate_limit_retries_once", len(_authorizations(server, GET_PROJECT)) == 2)
+
+    await _run_server(result, setup)
+
+    async def exhaustion(server: GrpcFaultServer) -> None:
+        server.plan(
+            GET_PROJECT,
+            abort(grpc.StatusCode.RESOURCE_EXHAUSTED),
+            abort(grpc.StatusCode.RESOURCE_EXHAUSTED),
+        )
+        harness = build_android_client(server, timeout=5.0, rate_limit_max_retries=1)
+        async with harness.client as client:
+            try:
+                await client.notebooks.get("notebook-1")
+            except RateLimitError:
+                pass
+            else:
+                result.require("rate_limit_exhaustion_raises", False)
+        result.require("rate_limit_exhausts_budget", len(_authorizations(server, GET_PROJECT)) == 2)
+
+    await _run_server(result, exhaustion)
+
+
+async def _auth(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(
+            GET_PROJECT,
+            abort(grpc.StatusCode.UNAUTHENTICATED),
+            reply(),
+            abort(grpc.StatusCode.UNAUTHENTICATED),
+            abort(grpc.StatusCode.UNAUTHENTICATED),
+        )
+        harness = build_android_client(server)
+        async with harness.client as client:
+            await client.notebooks.get("notebook-1")
+            try:
+                await client.notebooks.get("notebook-1")
+            except AuthError:
+                pass
+            else:
+                result.require("repeated_auth_raises", False)
+        auth = _authorizations(server, GET_PROJECT)
+        result.require(
+            "auth_replays_once", auth[:2] == ["Bearer fault-bearer-1", "Bearer fault-bearer-2"]
+        )
+        result.require("repeated_auth_bounded", len(auth) == 4)
+        result.require("three_mints", harness.minter.calls == 3)
+
+    await _run_server(result, setup)
+
+
+async def _auth_concurrent(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(
+            GET_PROJECT,
+            wait_abort("both-old", grpc.StatusCode.UNAUTHENTICATED),
+            wait_abort("both-old", grpc.StatusCode.UNAUTHENTICATED),
+            reply(),
+            reply(),
+        )
+        release = asyncio.Event()
+        minter = SyntheticOAuthMinter(block_after=2, release=release)
+        harness = build_android_client(server, minter=minter)
+        async with harness.client as client:
+            first = asyncio.create_task(client.notebooks.get("notebook-1"))
+            second = asyncio.create_task(client.notebooks.get("notebook-1"))
+            await _wait_for(lambda: len(_authorizations(server, GET_PROJECT)) == 2)
+            server.gate("both-old").set()
+            await _wait_for(lambda: harness.minter.calls == 2 and harness.bearer._mint_waiters == 2)
+            release.set()
+            await asyncio.gather(first, second)
+        auth = _authorizations(server, GET_PROJECT)
+        result.require("concurrent_initial_token", auth[:2] == ["Bearer fault-bearer-1"] * 2)
+        result.require("concurrent_replay_token", auth[2:] == ["Bearer fault-bearer-2"] * 2)
+        result.require("refresh_mint_coalesced", harness.minter.calls == 2)
+
+    await _run_server(result, setup)
+
+
+async def _minter_failure(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        minter = SyntheticOAuthMinter(error=RuntimeError("synthetic mint failure"))
+        harness = build_android_client(server, minter=minter)
+        async with harness.client as client:
+            try:
+                await client.notebooks.get("notebook-1")
+            except AuthError:
+                pass
+            else:
+                result.require("mint_failure_raises", False)
+        result.require("mint_failure_never_reaches_server", not server.requests)
+        result.require("mint_failure_bounded", minter.calls == 1)
+
+    await _run_server(result, setup)
+
+
+async def _stream_auth(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(GET_PROJECT, reply(), reply())
+        server.plan(LIST_CHAT_SESSIONS, reply())
+        server.plan(
+            GENERATE_STREAMED,
+            stream([_frame("partial")], after=abort(grpc.StatusCode.UNAUTHENTICATED)),
+        )
+        harness = build_android_client(server)
+        async with harness.client as client:
+            try:
+                await client.chat.ask("notebook-1", "Question?")
+            except AuthError:
+                pass
+            else:
+                result.require("stream_auth_raises", False)
+            await client.notebooks.get("notebook-1")
+        result.require("stream_never_replays", len(_authorizations(server, GENERATE_STREAMED)) == 1)
+        result.require(
+            "next_unary_gets_fresh_bearer",
+            _authorizations(server, GET_PROJECT)[-1] == "Bearer fault-bearer-2",
+        )
+
+    await _run_server(result, setup)
+
+
+async def _commit_lost_response(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(CREATE_PROJECT, commit_abort(grpc.StatusCode.UNAVAILABLE))
+        harness = build_android_client(server, server_error_max_retries=3)
+        error: ServerError | None = None
+        async with harness.client as client:
+            try:
+                await client.notebooks.create("commit once")
+            except ServerError as caught:
+                error = caught
+            else:
+                result.require("lost_response_raises", False)
+        result.require("one_committed_create", server.state[CREATE_PROJECT] == ["commit once"])
+        result.require("mutation_never_replayed", len(_authorizations(server, CREATE_PROJECT)) == 1)
+        result.require(
+            "mutation_commit_unknown",
+            error is not None and error.commit_state is CommitState.UNKNOWN,
+        )
+
+    await _run_server(result, setup)
+
+
+async def _deadline_and_cancellation(result: ScenarioResult) -> None:
+    async def setup(server: GrpcFaultServer) -> None:
+        server.plan(
+            GET_PROJECT,
+            wait_reply("deadline"),
+            wait_reply("cancel"),
+            wait_reply("close"),
+            reply(),
+        )
+        server.plan(
+            GENERATE_STREAMED,
+            stream([], gate="stream-deadline"),
+            stream([_frame("one")], gate="stream-cancel"),
+        )
+        harness = build_android_client(server, timeout=0.5)
+        raw_stream = GrpcUnaryStreamMethod(
+            path=GENERATE_STREAMED,
+            response_type=chat_pb2.GenerateFreeFormStreamedResponse,
+        )
+        async with harness.client as client:
+            try:
+                await client.notebooks.get("notebook-1")
+            except RPCTimeoutError:
+                pass
+            else:
+                result.require("deadline_raises", False)
+            blocked = asyncio.create_task(client.notebooks.get("notebook-1"))
+            await _wait_for(lambda: len(_authorizations(server, GET_PROJECT)) == 2)
+            blocked.cancel()
+            try:
+                await blocked
+            except asyncio.CancelledError:
+                pass
+            else:
+                result.require("cancellation_propagates", False)
+            timed_stream = client.raw.unary_stream(
+                raw_stream,
+                chat_pb2.GenerateFreeFormStreamedRequest(project_id="notebook-1"),
+                timeout=0.2,
+            )
+            try:
+                await anext(timed_stream)
+            except RPCTimeoutError:
+                pass
+            else:
+                result.require("stream_deadline_raises", False)
+            cancelling_stream = client.raw.unary_stream(
+                raw_stream,
+                chat_pb2.GenerateFreeFormStreamedRequest(project_id="notebook-1"),
+                timeout=0.5,
+            )
+            assert (await anext(cancelling_stream)).answer.response == "one"
+            await cancelling_stream.aclose()
+            await _wait_for(
+                lambda: (
+                    sum(request.method == GENERATE_STREAMED for request in server.cancellations)
+                    == 2
+                )
+            )
+            closing = asyncio.create_task(client.notebooks.get("notebook-1"))
+            await _wait_for(lambda: len(_authorizations(server, GET_PROJECT)) == 3)
+            await client.close(drain=False)
+            try:
+                await closing
+            except asyncio.CancelledError:
+                pass
+            else:
+                result.require("close_cancels_active_call", False)
+        # A reopen is a public lifecycle operation and must construct a fresh channel.
+        async with harness.client as client:
+            await client.notebooks.get("notebook-1")
+        result.require("fresh_channel_after_reopen", len(harness.channels) == 2)
+        result.require(
+            "deadline_and_cancel_are_one_attempt", len(_authorizations(server, GET_PROJECT)) == 4
+        )
+        result.require(
+            "stream_deadline_and_cancel_release",
+            sum(request.method == GENERATE_STREAMED for request in server.cancellations) == 2,
+        )
+
+    await _run_server(result, setup)
+
+
+def _frame(answer: str, *, final: bool = False) -> Any:
+    return chat_pb2.GenerateFreeFormStreamedResponse(
+        answer=chat_pb2.AnswerResponse(response=answer), is_final_response=final
+    )
+
+
+def _chat_sessions(session_id: str) -> Any:
+    return chat_pb2.ListChatSessionsResponse(
+        sessions=[common_pb2.ChatSession(chat_session_id=session_id)]
+    )
+
+
+async def _wait_for(predicate: Callable[[], bool]) -> None:
+    """Yield only until a deterministic server-journal condition becomes true."""
+
+    async def wait() -> None:
+        while not predicate():
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait(), timeout=1.0)
+
+
+async def run_scenario(
+    name: str, *, operation_id: str, result: ScenarioResult | None = None
+) -> ScenarioResult:
+    """Run one fresh Android fault cohort and preserve its evidence trace."""
+
+    evidence = _result(name, operation_id, result)
+    handlers: dict[str, Callable[[ScenarioResult], Awaitable[None]]] = {
+        "public_flows": _public_flows,
+        "unavailable": _unavailable,
+        "rate_limit": _rate_limit,
+        "auth": _auth,
+        "auth_concurrent": _auth_concurrent,
+        "minter_failure": _minter_failure,
+        "stream_auth": _stream_auth,
+        "commit_lost_response": _commit_lost_response,
+        "deadline_and_cancellation": _deadline_and_cancellation,
+    }
+    try:
+        await handlers[name](evidence)
+    finally:
+        evidence.record("finished", checks=len(evidence.checks))
+    return evidence
+
+
+__all__ = ["SCENARIOS", "run_scenario"]

--- a/tests/_fault_server/common.py
+++ b/tests/_fault_server/common.py
@@ -1,0 +1,49 @@
+"""Small, transport-neutral evidence contract for the local fault scenarios."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ScenarioResult:
+    """Mutable evidence shared with the runner, including during cancellation."""
+
+    backend: str
+    scenario: str
+    operation_id: str
+    events: list[dict[str, Any]] = field(default_factory=list)
+    checks: dict[str, bool] = field(default_factory=dict)
+
+    def record(self, kind: str, **payload: Any) -> None:
+        """Append a snapshot of JSON-safe evidence in observation order."""
+        if not isinstance(kind, str) or not kind:
+            raise ValueError("event kind must be a nonempty string")
+        # Copy nested containers so subsequent mutation cannot rewrite history.
+        # Reject NaN/infinity too: reports are portable JSON, not Python reprs.
+        event = json.loads(json.dumps({"kind": kind, **payload}, allow_nan=False))
+        self.events.append(event)
+
+    def require(self, name: str, condition: bool) -> None:
+        """Record one invariant and preserve all evidence when it fails."""
+        if not isinstance(name, str) or not name:
+            raise ValueError("check name must be a nonempty string")
+        if name in self.checks:
+            raise ValueError(f"duplicate scenario check: {name}")
+        if not isinstance(condition, bool):
+            raise TypeError("scenario check condition must be bool")
+        self.checks[name] = condition
+        self.record("check", name=name, passed=condition)
+        if not condition:
+            raise ScenarioFailure(self)
+
+
+class ScenarioFailure(AssertionError):
+    """An invariant failed; ``result`` includes evidence up to that failure."""
+
+    def __init__(self, result: ScenarioResult) -> None:
+        self.result = result
+        failed = ", ".join(name for name, passed in result.checks.items() if not passed)
+        super().__init__(f"{result.backend}/{result.scenario} [{result.operation_id}]: {failed}")

--- a/tests/_fault_server/environment.py
+++ b/tests/_fault_server/environment.py
@@ -1,0 +1,29 @@
+"""Session-level isolation for synthetic local scenarios and their CLI runner."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def isolated_environment() -> Iterator[None]:
+    """Isolate once outside concurrent cohorts, preserving the process HOME."""
+    previous = {key: value for key, value in os.environ.items() if key.startswith("NOTEBOOKLM_")}
+    with tempfile.TemporaryDirectory(prefix="notebooklm-fault-stress-") as directory:
+        try:
+            for key in previous:
+                os.environ.pop(key, None)
+            os.environ.update(
+                NOTEBOOKLM_HOME=directory,
+                NOTEBOOKLM_PROFILE="agent-fault-stress",
+                NOTEBOOKLM_DISABLE_KEEPALIVE_POKE="1",
+            )
+            yield
+        finally:
+            for key in list(os.environ):
+                if key.startswith("NOTEBOOKLM_"):
+                    os.environ.pop(key)
+            os.environ.update(previous)

--- a/tests/_fault_server/grpc.py
+++ b/tests/_fault_server/grpc.py
@@ -1,0 +1,235 @@
+"""Small real-socket gRPC fault server for Android transport scenarios.
+
+The server intentionally supports only the handful of public Android flows
+used by the fault suite.  A missing scripted action is a test error, not a
+fallback to a plausible response.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from collections.abc import AsyncIterator, Iterable
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass, field
+from typing import Any
+
+import grpc
+
+from notebooklm._android.proto.google.internal.labs.tailwind.orchestration.v1 import (
+    chat_pb2,
+    notebooks_pb2,
+    read_pb2,
+)
+from notebooklm._android.proto.notebooklm.internal.android.wire.v1 import (
+    notebooks_pb2 as wire_notebooks_pb2,
+)
+
+SERVICE = "google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService"
+GET_PROJECT = f"/{SERVICE}/GetProject"
+CREATE_PROJECT = f"/{SERVICE}/CreateProject"
+LIST_CHAT_SESSIONS = f"/{SERVICE}/ListChatSessions"
+GENERATE_STREAMED = f"/{SERVICE}/GenerateFreeFormStreamed"
+
+
+@dataclass(frozen=True)
+class GrpcAction:
+    """One deterministic handler result."""
+
+    kind: str
+    status: grpc.StatusCode | None = None
+    response: Any | None = None
+    gate: str | None = None
+
+
+def reply(response: Any | None = None) -> GrpcAction:
+    return GrpcAction("reply", response=response)
+
+
+def abort(status: grpc.StatusCode) -> GrpcAction:
+    return GrpcAction("abort", status=status)
+
+
+def wait_reply(gate: str, response: Any | None = None) -> GrpcAction:
+    return GrpcAction("wait_reply", response=response, gate=gate)
+
+
+def commit_abort(status: grpc.StatusCode) -> GrpcAction:
+    return GrpcAction("commit_abort", status=status)
+
+
+def stream(
+    frames: Iterable[Any], *, after: GrpcAction | None = None, gate: str | None = None
+) -> GrpcAction:
+    return GrpcAction("stream", response=tuple(frames), gate=gate or (after.gate if after else None), status=(after.status if after else None))
+
+
+@dataclass
+class GrpcRequest:
+    method: str
+    request: Any
+    metadata: tuple[tuple[str, str], ...]
+
+
+@dataclass
+class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
+    """An ephemeral loopback service with journals, gates and action queues."""
+
+    actions: dict[str, deque[GrpcAction]] = field(default_factory=lambda: defaultdict(deque))
+    requests: list[GrpcRequest] = field(default_factory=list)
+    state: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+    cancellations: set[str] = field(default_factory=set)
+    _gates: dict[str, asyncio.Event] = field(default_factory=dict)
+    _server: grpc.aio.Server | None = None
+    _port: int | None = None
+    _active: set[asyncio.Task[Any]] = field(default_factory=set)
+
+    @property
+    def target(self) -> str:
+        assert self._port is not None
+        return f"127.0.0.1:{self._port}"
+
+    def gate(self, name: str) -> asyncio.Event:
+        return self._gates.setdefault(name, asyncio.Event())
+
+    def plan(self, method: str, *actions: GrpcAction) -> None:
+        if method not in {GET_PROJECT, CREATE_PROJECT, LIST_CHAT_SESSIONS, GENERATE_STREAMED}:
+            raise ValueError(f"unsupported Android gRPC method: {method}")
+        if self.actions[method]:
+            raise ValueError(f"method already planned: {method}")
+        self.actions[method].extend(actions)
+
+    def assert_consumed(self) -> None:
+        pending = {method: len(items) for method, items in self.actions.items() if items}
+        if pending:
+            raise AssertionError(f"unconsumed gRPC actions: {pending}")
+        if self._active:
+            raise AssertionError(f"active gRPC handlers leaked: {len(self._active)}")
+
+    async def __aenter__(self) -> "GrpcFaultServer":
+        self._server = grpc.aio.server()
+        self._server.add_generic_rpc_handlers((self._handler(),))
+        self._port = self._server.add_insecure_port("127.0.0.1:0")
+        await self._server.start()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        try:
+            if self._active:
+                await asyncio.gather(*tuple(self._active), return_exceptions=True)
+        finally:
+            if self._server is not None:
+                await self._server.stop(0)
+                await self._server.wait_for_termination()
+
+    def _handler(self) -> grpc.GenericRpcHandler:
+        return grpc.method_handlers_generic_handler(
+            SERVICE,
+            {
+                "GetProject": grpc.unary_unary_rpc_method_handler(
+                    self._get_project,
+                    request_deserializer=read_pb2.GetProjectRequest.FromString,
+                    response_serializer=wire_notebooks_pb2.WireGetProjectResponse.SerializeToString,
+                ),
+                "CreateProject": grpc.unary_unary_rpc_method_handler(
+                    self._create_project,
+                    request_deserializer=notebooks_pb2.CreateProjectRequest.FromString,
+                    response_serializer=read_pb2.Project.SerializeToString,
+                ),
+                "ListChatSessions": grpc.unary_unary_rpc_method_handler(
+                    self._list_chat_sessions,
+                    request_deserializer=chat_pb2.ListChatSessionsRequest.FromString,
+                    response_serializer=chat_pb2.ListChatSessionsResponse.SerializeToString,
+                ),
+                "GenerateFreeFormStreamed": grpc.unary_stream_rpc_method_handler(
+                    self._generate_streamed,
+                    request_deserializer=chat_pb2.GenerateFreeFormStreamedRequest.FromString,
+                    response_serializer=chat_pb2.GenerateFreeFormStreamedResponse.SerializeToString,
+                ),
+            },
+        )
+
+    def _next(self, method: str) -> GrpcAction:
+        try:
+            return self.actions[method].popleft()
+        except IndexError as error:
+            raise AssertionError(f"unexpected gRPC request: {method}") from error
+
+    def _record(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> None:
+        self.requests.append(
+            GrpcRequest(method, request, tuple((str(k), str(v)) for k, v in context.invocation_metadata()))
+        )
+
+    @staticmethod
+    def _project(project_id: str = "notebook-1", title: str = "Fault notebook") -> Any:
+        return read_pb2.Project(id=project_id, title=title)
+
+    async def _apply_unary(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> Any:
+        self._record(method, request, context)
+        action = self._next(method)
+        try:
+            if action.kind == "wait_reply":
+                assert action.gate is not None
+                await self.gate(action.gate).wait()
+            if action.kind == "commit_abort":
+                self.state[method].append(str(getattr(request, "name", "committed")))
+                assert action.status is not None
+                await context.abort(action.status, "synthetic lost response")
+            if action.kind == "abort":
+                assert action.status is not None
+                await context.abort(action.status, "synthetic fault")
+            if action.response is not None:
+                return action.response
+            if method == GET_PROJECT:
+                return wire_notebooks_pb2.WireGetProjectResponse(
+                    project=wire_notebooks_pb2.WireProjectWithAdvancedSettings(
+                        id=request.project_id, title="Fault notebook"
+                    )
+                )
+            if method == CREATE_PROJECT:
+                return self._project("created-1", request.name)
+            return chat_pb2.ListChatSessionsResponse()
+        except asyncio.CancelledError:
+            self.cancellations.add(method)
+            raise
+
+    async def _get_project(self, request: Any, context: grpc.aio.ServicerContext) -> Any:
+        return await self._apply_unary(GET_PROJECT, request, context)
+
+    async def _create_project(self, request: Any, context: grpc.aio.ServicerContext) -> Any:
+        return await self._apply_unary(CREATE_PROJECT, request, context)
+
+    async def _list_chat_sessions(self, request: Any, context: grpc.aio.ServicerContext) -> Any:
+        return await self._apply_unary(LIST_CHAT_SESSIONS, request, context)
+
+    async def _generate_streamed(
+        self, request: Any, context: grpc.aio.ServicerContext
+    ) -> AsyncIterator[Any]:
+        self._record(GENERATE_STREAMED, request, context)
+        action = self._next(GENERATE_STREAMED)
+        try:
+            for frame in action.response or ():
+                yield frame
+            if action.gate is not None:
+                await self.gate(action.gate).wait()
+            if action.status is not None:
+                await context.abort(action.status, "synthetic stream fault")
+        except asyncio.CancelledError:
+            self.cancellations.add(GENERATE_STREAMED)
+            raise
+
+
+__all__ = [
+    "CREATE_PROJECT",
+    "GENERATE_STREAMED",
+    "GET_PROJECT",
+    "LIST_CHAT_SESSIONS",
+    "GrpcAction",
+    "GrpcFaultServer",
+    "GrpcRequest",
+    "abort",
+    "commit_abort",
+    "reply",
+    "stream",
+    "wait_reply",
+]

--- a/tests/_fault_server/grpc.py
+++ b/tests/_fault_server/grpc.py
@@ -30,6 +30,13 @@ GET_PROJECT = f"/{SERVICE}/GetProject"
 CREATE_PROJECT = f"/{SERVICE}/CreateProject"
 LIST_CHAT_SESSIONS = f"/{SERVICE}/ListChatSessions"
 GENERATE_STREAMED = f"/{SERVICE}/GenerateFreeFormStreamed"
+_METHOD_KINDS = {
+    GET_PROJECT: frozenset({"reply", "abort", "wait_reply", "wait_abort"}),
+    CREATE_PROJECT: frozenset({"reply", "abort", "wait_reply", "wait_abort", "commit_abort"}),
+    LIST_CHAT_SESSIONS: frozenset({"reply", "abort", "wait_reply", "wait_abort"}),
+    GENERATE_STREAMED: frozenset({"stream"}),
+}
+_CLEANUP_TIMEOUT = 1.0
 
 
 @dataclass(frozen=True)
@@ -75,10 +82,12 @@ def stream(
 
 @dataclass
 class GrpcRequest:
+    sequence: int
     method: str
     request: Any
     metadata: tuple[tuple[str, str], ...]
     cancelled: bool = False
+    _cancelled_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
 
 
 @dataclass
@@ -104,11 +113,36 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         return self._gates.setdefault(name, asyncio.Event())
 
     def plan(self, method: str, *actions: GrpcAction) -> None:
-        if method not in {GET_PROJECT, CREATE_PROJECT, LIST_CHAT_SESSIONS, GENERATE_STREAMED}:
+        if method not in _METHOD_KINDS:
             raise ValueError(f"unsupported Android gRPC method: {method}")
+        if not actions:
+            raise ValueError(f"at least one action is required for {method}")
         if self.actions[method]:
             raise ValueError(f"method already planned: {method}")
+        for action in actions:
+            self._validate_action(method, action)
         self.actions[method].extend(actions)
+
+    @staticmethod
+    def _validate_action(method: str, action: GrpcAction) -> None:
+        if action.kind not in _METHOD_KINDS[method]:
+            raise ValueError(f"action {action.kind!r} is invalid for {method}")
+        needs_status = action.kind in {"abort", "wait_abort", "commit_abort"}
+        if action.kind != "stream" and needs_status != (action.status is not None):
+            raise ValueError(f"action {action.kind!r} has invalid status for {method}")
+        if action.status is not None and (
+            not isinstance(action.status, grpc.StatusCode) or action.status is grpc.StatusCode.OK
+        ):
+            raise ValueError(f"action {action.kind!r} requires a non-OK gRPC status")
+        needs_gate = action.kind in {"wait_reply", "wait_abort"}
+        if action.kind != "stream" and needs_gate != (action.gate is not None):
+            raise ValueError(f"action {action.kind!r} has invalid gate for {method}")
+        if action.gate is not None and (not isinstance(action.gate, str) or not action.gate):
+            raise ValueError(f"action {action.kind!r} requires a non-empty gate")
+        if action.kind in {"abort", "wait_abort", "commit_abort"} and action.response is not None:
+            raise ValueError(f"action {action.kind!r} cannot include a response")
+        if action.kind == "stream" and not isinstance(action.response, tuple):
+            raise ValueError("stream action frames must be an immutable tuple")
 
     def assert_consumed(self) -> None:
         if self.handler_errors:
@@ -119,24 +153,64 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         if self._active:
             raise AssertionError(f"active gRPC handlers leaked: {len(self._active)}")
 
+    async def wait_for_idle(self, *, timeout: float = 1.0) -> None:
+        async def wait() -> None:
+            while self._active:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait(), timeout=timeout)
+
     async def __aenter__(self) -> GrpcFaultServer:
         self._server = grpc.aio.server()
-        self._server.add_generic_rpc_handlers((self._handler(),))
-        self._port = self._server.add_insecure_port("127.0.0.1:0")
-        await self._server.start()
+        try:
+            self._server.add_generic_rpc_handlers((self._handler(), self._unknown_handler()))
+            port = self._server.add_insecure_port("127.0.0.1:0")
+            if not port:
+                raise RuntimeError("gRPC fault server failed to bind a loopback port")
+            self._port = port
+            await self._server.start()
+        except BaseException:
+            await self._cleanup_after_failed_enter()
+            raise
         return self
 
     async def __aexit__(self, *exc_info: object) -> None:
+        await self._shutdown()
+
+    async def _cleanup_after_failed_enter(self) -> None:
+        cleanup = asyncio.create_task(self._shutdown(), name="grpc-fault-server-enter-cleanup")
         try:
-            if self._server is not None:
-                await asyncio.wait_for(self._server.stop(0), timeout=1.0)
-            if self._active:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            # A second cancellation may detach this caller, but the strongly held
+            # task still completes the bounded cleanup before its own deadline.
+            await asyncio.gather(cleanup, return_exceptions=True)
+        except BaseException as error:
+            self.handler_errors.append(f"enter cleanup failed: {type(error).__name__}: {error}")
+
+    async def _shutdown(self) -> None:
+        server = self._server
+        if server is None:
+            return
+        errors: list[BaseException] = []
+        try:
+            await asyncio.wait_for(server.stop(0), timeout=_CLEANUP_TIMEOUT)
+        except BaseException as error:
+            errors.append(error)
+        if self._active:
+            try:
                 await asyncio.wait_for(
-                    asyncio.gather(*tuple(self._active), return_exceptions=True), timeout=1.0
+                    asyncio.gather(*tuple(self._active), return_exceptions=True),
+                    timeout=_CLEANUP_TIMEOUT,
                 )
-        finally:
-            if self._server is not None:
-                await asyncio.wait_for(self._server.wait_for_termination(), timeout=1.0)
+            except BaseException as error:
+                errors.append(error)
+        try:
+            await asyncio.wait_for(server.wait_for_termination(), timeout=_CLEANUP_TIMEOUT)
+        except BaseException as error:
+            errors.append(error)
+        if errors:
+            raise errors[0]
 
     def _handler(self) -> grpc.GenericRpcHandler:
         return grpc.method_handlers_generic_handler(
@@ -165,6 +239,23 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
             },
         )
 
+    def _unknown_handler(self) -> grpc.GenericRpcHandler:
+        server = self
+
+        class UnknownHandler(grpc.GenericRpcHandler):
+            def service(
+                self, handler_call_details: grpc.HandlerCallDetails
+            ) -> grpc.RpcMethodHandler:
+                method = handler_call_details.method
+                server.handler_errors.append(f"unexpected request: {method}")
+
+                async def reject(_request: bytes, context: grpc.aio.ServicerContext) -> None:
+                    await context.abort(grpc.StatusCode.UNIMPLEMENTED, "unexpected test RPC")
+
+                return grpc.unary_unary_rpc_method_handler(reject)
+
+        return UnknownHandler()
+
     def _next(self, method: str) -> GrpcAction:
         try:
             return self.actions[method].popleft()
@@ -174,10 +265,28 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
 
     def _record(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> GrpcRequest:
         recorded = GrpcRequest(
-            method, request, tuple((str(k), str(v)) for k, v in context.invocation_metadata())
+            len(self.requests) + 1,
+            method,
+            request,
+            tuple((str(k), str(v)) for k, v in context.invocation_metadata()),
         )
         self.requests.append(recorded)
         return recorded
+
+    async def wait_for_cancellation(self, request: GrpcRequest, *, timeout: float = 1.0) -> None:
+        if not any(item is request for item in self.requests):
+            raise ValueError("request does not belong to this gRPC fault server")
+        await asyncio.wait_for(request._cancelled_event.wait(), timeout=timeout)
+
+    def _mark_cancelled(self, recorded: GrpcRequest) -> None:
+        if recorded.cancelled:
+            return
+        recorded.cancelled = True
+        recorded._cancelled_event.set()
+        self.cancellations.append(recorded)
+
+    def _record_handler_error(self, method: str, error: BaseException) -> None:
+        self.handler_errors.append(f"{method}: {type(error).__name__}: {error}")
 
     @staticmethod
     def _project(project_id: str = "notebook-1", title: str = "Fault notebook") -> Any:
@@ -189,6 +298,7 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         task = asyncio.current_task()
         if task is not None:
             self._active.add(task)
+        recorded: GrpcRequest | None = None
         try:
             recorded = self._record(method, request, context)
             action = self._next(method)
@@ -218,8 +328,13 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
                 return self._project("created-1", request.name)
             return chat_pb2.ListChatSessionsResponse()
         except asyncio.CancelledError:
-            recorded.cancelled = True
-            self.cancellations.append(recorded)
+            if recorded is not None:
+                self._mark_cancelled(recorded)
+            raise
+        except grpc.aio.AbortError:
+            raise
+        except BaseException as error:
+            self._record_handler_error(method, error)
             raise
         finally:
             if task is not None:
@@ -240,6 +355,7 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         task = asyncio.current_task()
         if task is not None:
             self._active.add(task)
+        recorded: GrpcRequest | None = None
         try:
             recorded = self._record(GENERATE_STREAMED, request, context)
             action = self._next(GENERATE_STREAMED)
@@ -250,8 +366,13 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
             if action.status is not None:
                 await context.abort(action.status, "synthetic stream fault")
         except asyncio.CancelledError:
-            recorded.cancelled = True
-            self.cancellations.append(recorded)
+            if recorded is not None:
+                self._mark_cancelled(recorded)
+            raise
+        except grpc.aio.AbortError:
+            raise
+        except BaseException as error:
+            self._record_handler_error(GENERATE_STREAMED, error)
             raise
         finally:
             if task is not None:

--- a/tests/_fault_server/grpc.py
+++ b/tests/_fault_server/grpc.py
@@ -54,6 +54,10 @@ def wait_reply(gate: str, response: Any | None = None) -> GrpcAction:
     return GrpcAction("wait_reply", response=response, gate=gate)
 
 
+def wait_abort(gate: str, status: grpc.StatusCode) -> GrpcAction:
+    return GrpcAction("wait_abort", status=status, gate=gate)
+
+
 def commit_abort(status: grpc.StatusCode) -> GrpcAction:
     return GrpcAction("commit_abort", status=status)
 
@@ -61,7 +65,12 @@ def commit_abort(status: grpc.StatusCode) -> GrpcAction:
 def stream(
     frames: Iterable[Any], *, after: GrpcAction | None = None, gate: str | None = None
 ) -> GrpcAction:
-    return GrpcAction("stream", response=tuple(frames), gate=gate or (after.gate if after else None), status=(after.status if after else None))
+    return GrpcAction(
+        "stream",
+        response=tuple(frames),
+        gate=gate or (after.gate if after else None),
+        status=(after.status if after else None),
+    )
 
 
 @dataclass
@@ -69,6 +78,7 @@ class GrpcRequest:
     method: str
     request: Any
     metadata: tuple[tuple[str, str], ...]
+    cancelled: bool = False
 
 
 @dataclass
@@ -78,7 +88,8 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
     actions: dict[str, deque[GrpcAction]] = field(default_factory=lambda: defaultdict(deque))
     requests: list[GrpcRequest] = field(default_factory=list)
     state: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
-    cancellations: set[str] = field(default_factory=set)
+    cancellations: list[GrpcRequest] = field(default_factory=list)
+    handler_errors: list[str] = field(default_factory=list)
     _gates: dict[str, asyncio.Event] = field(default_factory=dict)
     _server: grpc.aio.Server | None = None
     _port: int | None = None
@@ -100,13 +111,15 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         self.actions[method].extend(actions)
 
     def assert_consumed(self) -> None:
+        if self.handler_errors:
+            raise AssertionError(f"gRPC handler errors: {self.handler_errors}")
         pending = {method: len(items) for method, items in self.actions.items() if items}
         if pending:
             raise AssertionError(f"unconsumed gRPC actions: {pending}")
         if self._active:
             raise AssertionError(f"active gRPC handlers leaked: {len(self._active)}")
 
-    async def __aenter__(self) -> "GrpcFaultServer":
+    async def __aenter__(self) -> GrpcFaultServer:
         self._server = grpc.aio.server()
         self._server.add_generic_rpc_handlers((self._handler(),))
         self._port = self._server.add_insecure_port("127.0.0.1:0")
@@ -115,12 +128,15 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
 
     async def __aexit__(self, *exc_info: object) -> None:
         try:
+            if self._server is not None:
+                await asyncio.wait_for(self._server.stop(0), timeout=1.0)
             if self._active:
-                await asyncio.gather(*tuple(self._active), return_exceptions=True)
+                await asyncio.wait_for(
+                    asyncio.gather(*tuple(self._active), return_exceptions=True), timeout=1.0
+                )
         finally:
             if self._server is not None:
-                await self._server.stop(0)
-                await self._server.wait_for_termination()
+                await asyncio.wait_for(self._server.wait_for_termination(), timeout=1.0)
 
     def _handler(self) -> grpc.GenericRpcHandler:
         return grpc.method_handlers_generic_handler(
@@ -153,24 +169,36 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
         try:
             return self.actions[method].popleft()
         except IndexError as error:
+            self.handler_errors.append(f"unexpected request: {method}")
             raise AssertionError(f"unexpected gRPC request: {method}") from error
 
-    def _record(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> None:
-        self.requests.append(
-            GrpcRequest(method, request, tuple((str(k), str(v)) for k, v in context.invocation_metadata()))
+    def _record(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> GrpcRequest:
+        recorded = GrpcRequest(
+            method, request, tuple((str(k), str(v)) for k, v in context.invocation_metadata())
         )
+        self.requests.append(recorded)
+        return recorded
 
     @staticmethod
     def _project(project_id: str = "notebook-1", title: str = "Fault notebook") -> Any:
         return read_pb2.Project(id=project_id, title=title)
 
-    async def _apply_unary(self, method: str, request: Any, context: grpc.aio.ServicerContext) -> Any:
-        self._record(method, request, context)
-        action = self._next(method)
+    async def _apply_unary(
+        self, method: str, request: Any, context: grpc.aio.ServicerContext
+    ) -> Any:
+        task = asyncio.current_task()
+        if task is not None:
+            self._active.add(task)
         try:
+            recorded = self._record(method, request, context)
+            action = self._next(method)
             if action.kind == "wait_reply":
                 assert action.gate is not None
                 await self.gate(action.gate).wait()
+            if action.kind == "wait_abort":
+                assert action.gate is not None and action.status is not None
+                await self.gate(action.gate).wait()
+                await context.abort(action.status, "synthetic gated fault")
             if action.kind == "commit_abort":
                 self.state[method].append(str(getattr(request, "name", "committed")))
                 assert action.status is not None
@@ -190,8 +218,12 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
                 return self._project("created-1", request.name)
             return chat_pb2.ListChatSessionsResponse()
         except asyncio.CancelledError:
-            self.cancellations.add(method)
+            recorded.cancelled = True
+            self.cancellations.append(recorded)
             raise
+        finally:
+            if task is not None:
+                self._active.discard(task)
 
     async def _get_project(self, request: Any, context: grpc.aio.ServicerContext) -> Any:
         return await self._apply_unary(GET_PROJECT, request, context)
@@ -205,9 +237,12 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
     async def _generate_streamed(
         self, request: Any, context: grpc.aio.ServicerContext
     ) -> AsyncIterator[Any]:
-        self._record(GENERATE_STREAMED, request, context)
-        action = self._next(GENERATE_STREAMED)
+        task = asyncio.current_task()
+        if task is not None:
+            self._active.add(task)
         try:
+            recorded = self._record(GENERATE_STREAMED, request, context)
+            action = self._next(GENERATE_STREAMED)
             for frame in action.response or ():
                 yield frame
             if action.gate is not None:
@@ -215,8 +250,12 @@ class GrpcFaultServer(AbstractAsyncContextManager["GrpcFaultServer"]):
             if action.status is not None:
                 await context.abort(action.status, "synthetic stream fault")
         except asyncio.CancelledError:
-            self.cancellations.add(GENERATE_STREAMED)
+            recorded.cancelled = True
+            self.cancellations.append(recorded)
             raise
+        finally:
+            if task is not None:
+                self._active.discard(task)
 
 
 __all__ = [
@@ -231,5 +270,6 @@ __all__ = [
     "commit_abort",
     "reply",
     "stream",
+    "wait_abort",
     "wait_reply",
 ]

--- a/tests/_fault_server/http.py
+++ b/tests/_fault_server/http.py
@@ -1,0 +1,431 @@
+"""Bounded real-socket HTTP/1.1 fault server and logical-host router."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ipaddress
+from collections import defaultdict, deque
+from collections.abc import AsyncIterator, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+
+_MAX_HEADERS = 64 * 1024
+_MAX_BODY = 2 * 1024 * 1024
+_READ_TIMEOUT = 2.0
+_CLOSE_TIMEOUT = 2.0
+
+
+@dataclass(frozen=True)
+class Route:
+    """Exact logical request route; query parameters are inspected separately."""
+
+    method: str
+    host: str
+    path: str
+    rpc_id: str | None = None
+
+    @classmethod
+    def rpc(cls, rpc_id: str) -> Route:
+        return cls(
+            "POST",
+            "notebook.google.com",
+            "/_/LabsTailwindUi/data/batchexecute",
+            rpc_id,
+        )
+
+    @classmethod
+    def homepage(cls) -> Route:
+        return cls("GET", "notebook.google.com", "/")
+
+    @classmethod
+    def login(cls) -> Route:
+        return cls("GET", "accounts.google.com", "/ServiceLogin")
+
+
+@dataclass(frozen=True)
+class Reply:
+    status: int = 200
+    body: bytes = b""
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Disconnect:
+    """Close after reading the full request, before response headers."""
+
+    commit_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Truncate:
+    """Advertise a longer body than is written, then close the socket."""
+
+    body: bytes
+    declared_length: int
+    status: int = 200
+
+
+@dataclass(frozen=True)
+class Stall:
+    """Wait on a named gate before headers or after a response prefix."""
+
+    phase: Literal["headers", "body"]
+    gate: str
+    reply: Reply
+    prefix: bytes = b""
+
+
+Action = Reply | Disconnect | Truncate | Stall
+
+
+@dataclass(frozen=True)
+class RequestRecord:
+    sequence: int
+    route: Route
+    query: Mapping[str, tuple[str, ...]]
+    form: Mapping[str, tuple[str, ...]]
+    cookie_names: tuple[str, ...]
+    cookie_values: Mapping[str, str]
+    action: str
+
+    @property
+    def csrf(self) -> str | None:
+        values = self.form.get("at", ())
+        return values[0] if values else None
+
+    @property
+    def session_id(self) -> str | None:
+        values = self.query.get("f.sid", ())
+        return values[0] if values else None
+
+
+class LogicalHostTransport(httpx.AsyncBaseTransport):
+    """Keep logical URL semantics while connecting only to a local server."""
+
+    def __init__(self, routes: Mapping[str, tuple[str, int]]) -> None:
+        self._routes = dict(routes)
+        for logical_host, (physical_host, physical_port) in self._routes.items():
+            if not logical_host or not ipaddress.ip_address(physical_host).is_loopback:
+                raise ValueError("fault transport routes must target numeric loopback addresses")
+            if not 1 <= physical_port <= 65535:
+                raise ValueError("fault transport route port is invalid")
+        self._inner = httpx.AsyncHTTPTransport(proxy=None, trust_env=False)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if request.url.scheme != "https" or request.url.port not in (None, 443):
+            raise httpx.ConnectError(
+                f"fault transport refuses non-HTTPS logical URL {request.url!s}",
+                request=request,
+            )
+        target = self._routes.get(request.url.host)
+        if target is None:
+            raise httpx.ConnectError(
+                f"fault transport refuses unmapped logical host {request.url.host!r}",
+                request=request,
+            )
+        physical_host, physical_port = target
+        physical_url = request.url.copy_with(
+            scheme="http",
+            host=physical_host,
+            port=physical_port,
+        )
+        headers = list(request.headers.raw)
+        logical_host = request.url.host.encode("ascii")
+        headers = [
+            (name, logical_host if name.lower() == b"host" else value) for name, value in headers
+        ]
+        physical_request = httpx.Request(
+            request.method,
+            physical_url,
+            headers=headers,
+            stream=request.stream,
+            extensions=request.extensions,
+        )
+        response = await self._inner.handle_async_request(physical_request)
+        return httpx.Response(
+            response.status_code,
+            headers=response.headers,
+            stream=response.stream,
+            extensions=response.extensions,
+            request=request,
+        )
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+class HttpFaultServer:
+    """One-use scripted server with explicit journals, gates, and cleanup."""
+
+    def __init__(self) -> None:
+        self._server: asyncio.Server | None = None
+        self._scripts: dict[Route, deque[Action]] = defaultdict(deque)
+        self._gates: dict[str, asyncio.Event] = {}
+        self._writers: set[asyncio.StreamWriter] = set()
+        self._handlers: set[asyncio.Task[None]] = set()
+        self._changed = asyncio.Condition()
+        self.journal: list[RequestRecord] = []
+        self.committed: list[str] = []
+        self.errors: list[str] = []
+
+    @property
+    def address(self) -> tuple[str, int]:
+        if self._server is None or not self._server.sockets:
+            raise RuntimeError("HTTP fault server is not running")
+        host, port = self._server.sockets[0].getsockname()[:2]
+        return str(host), int(port)
+
+    def enqueue(self, route: Route, *actions: Action) -> None:
+        if self._server is not None:
+            raise RuntimeError("enqueue scripts before starting the server")
+        if not actions:
+            raise ValueError("at least one action is required")
+        self._scripts[route].extend(actions)
+
+    def gate(self, name: str) -> asyncio.Event:
+        if not name:
+            raise ValueError("gate name must be nonempty")
+        return self._gates.setdefault(name, asyncio.Event())
+
+    def release(self, name: str) -> None:
+        self.gate(name).set()
+
+    async def wait_for_requests(self, route: Route, count: int, *, timeout: float = 2.0) -> None:
+        async def _wait() -> None:
+            async with self._changed:
+                await self._changed.wait_for(
+                    lambda: sum(record.route == route for record in self.journal) >= count
+                )
+
+        await asyncio.wait_for(_wait(), timeout)
+
+    def client_factory(self, **kwargs: Any) -> httpx.AsyncClient:
+        """Factory compatible with the production kernel construction seam."""
+        if "transport" in kwargs:
+            raise TypeError("fault client factory owns the transport")
+        kwargs["transport"] = LogicalHostTransport(
+            {
+                "notebook.google.com": self.address,
+                "accounts.google.com": self.address,
+            }
+        )
+        kwargs["trust_env"] = False
+        return httpx.AsyncClient(**kwargs)
+
+    async def __aenter__(self) -> HttpFaultServer:
+        if self._server is not None:
+            raise RuntimeError("HTTP fault server already started")
+        self._server = await asyncio.start_server(self._accept, "127.0.0.1", 0)
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        server = self._server
+        self._server = None
+        if server is not None:
+            server.close()
+            await asyncio.wait_for(server.wait_closed(), _CLOSE_TIMEOUT)
+        for writer in tuple(self._writers):
+            writer.close()
+        for task in tuple(self._handlers):
+            task.cancel()
+        if self._handlers:
+            await asyncio.wait_for(
+                asyncio.gather(*tuple(self._handlers), return_exceptions=True),
+                _CLOSE_TIMEOUT,
+            )
+        if self._writers:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(writer.wait_closed() for writer in tuple(self._writers)),
+                    return_exceptions=True,
+                ),
+                _CLOSE_TIMEOUT,
+            )
+
+    @property
+    def active_handlers(self) -> int:
+        return sum(not task.done() for task in self._handlers)
+
+    def remaining(self) -> int:
+        return sum(len(actions) for actions in self._scripts.values())
+
+    def assert_drained(self) -> None:
+        if self.errors:
+            raise AssertionError("HTTP fault server errors: " + "; ".join(self.errors))
+        remaining = {route: len(actions) for route, actions in self._scripts.items() if actions}
+        if remaining:
+            raise AssertionError(f"unconsumed HTTP actions: {remaining!r}")
+
+    def _accept(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        task = asyncio.create_task(self._handle(reader, writer))
+        self._handlers.add(task)
+        self._writers.add(writer)
+        task.add_done_callback(self._handlers.discard)
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        expected_disconnect = False
+        try:
+            route, query, form, cookie_values = await self._read_request(reader)
+            actions = self._scripts.get(route)
+            if not actions:
+                raise AssertionError(f"unexpected request: {route!r}")
+            action = actions.popleft()
+            record = RequestRecord(
+                sequence=len(self.journal) + 1,
+                route=route,
+                query=query,
+                form=form,
+                cookie_names=tuple(sorted(cookie_values)),
+                cookie_values=cookie_values,
+                action=type(action).__name__,
+            )
+            self.journal.append(record)
+            async with self._changed:
+                self._changed.notify_all()
+            expected_disconnect = isinstance(action, (Disconnect, Truncate, Stall))
+            await self._run_action(action, writer)
+        except asyncio.CancelledError:
+            raise
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            if not expected_disconnect:
+                self.errors.append(f"{type(exc).__name__}: {exc}")
+        except Exception as exc:
+            self.errors.append(f"{type(exc).__name__}: {exc}")
+            with contextlib.suppress(Exception):
+                await self._write_reply(writer, Reply(500, str(exc).encode()))
+        finally:
+            self._writers.discard(writer)
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def _read_request(
+        self, reader: asyncio.StreamReader
+    ) -> tuple[
+        Route,
+        Mapping[str, tuple[str, ...]],
+        Mapping[str, tuple[str, ...]],
+        Mapping[str, str],
+    ]:
+        raw_headers = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), _READ_TIMEOUT)
+        if len(raw_headers) > _MAX_HEADERS:
+            raise ValueError("request headers exceed limit")
+        lines = raw_headers[:-4].split(b"\r\n")
+        method_raw, target_raw, version = lines[0].split(b" ", 2)
+        if version != b"HTTP/1.1":
+            raise ValueError("only HTTP/1.1 is supported")
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            name, separator, value = line.partition(b":")
+            if not separator:
+                raise ValueError("malformed request header")
+            headers[name.decode("ascii").lower()] = value.decode("latin-1").strip()
+        if "transfer-encoding" in headers:
+            raise ValueError("chunked requests are unsupported")
+        length = int(headers.get("content-length", "0"))
+        if length < 0 or length > _MAX_BODY:
+            raise ValueError("request body exceeds limit")
+        body = await asyncio.wait_for(reader.readexactly(length), _READ_TIMEOUT) if length else b""
+        target = urlsplit(target_raw.decode("ascii"))
+        query_raw = parse_qs(target.query, keep_blank_values=True)
+        form_raw = parse_qs(body.decode("utf-8"), keep_blank_values=True) if body else {}
+        query = {key: tuple(values) for key, values in query_raw.items()}
+        form = {key: tuple(values) for key, values in form_raw.items()}
+        cookie_values: dict[str, str] = {}
+        for part in headers.get("cookie", "").split(";"):
+            name, separator, value = part.strip().partition("=")
+            if separator and name:
+                cookie_values[name] = value
+        rpc_values = query.get("rpcids", ())
+        route = Route(
+            method_raw.decode("ascii"),
+            headers.get("host", ""),
+            target.path,
+            rpc_values[0] if rpc_values else None,
+        )
+        return route, query, form, cookie_values
+
+    async def _run_action(self, action: Action, writer: asyncio.StreamWriter) -> None:
+        if isinstance(action, Reply):
+            await self._write_reply(writer, action)
+        elif isinstance(action, Disconnect):
+            if action.commit_id is not None:
+                self.committed.append(action.commit_id)
+        elif isinstance(action, Truncate):
+            headers = {"Content-Length": str(action.declared_length), "Connection": "close"}
+            await self._write_head(writer, action.status, headers)
+            writer.write(action.body)
+            await writer.drain()
+        else:
+            if action.phase == "headers":
+                await self.gate(action.gate).wait()
+                await self._write_reply(writer, action.reply)
+            else:
+                declared = len(action.reply.body)
+                headers = dict(action.reply.headers)
+                headers["Content-Length"] = str(declared)
+                headers["Connection"] = "close"
+                await self._write_head(writer, action.reply.status, headers)
+                writer.write(action.prefix)
+                await writer.drain()
+                await self.gate(action.gate).wait()
+                writer.write(action.reply.body[len(action.prefix) :])
+                await writer.drain()
+
+    async def _write_reply(self, writer: asyncio.StreamWriter, reply: Reply) -> None:
+        headers = dict(reply.headers)
+        headers.setdefault("Content-Length", str(len(reply.body)))
+        headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+        headers.setdefault("Connection", "close")
+        await self._write_head(writer, reply.status, headers)
+        writer.write(reply.body)
+        await writer.drain()
+
+    @staticmethod
+    async def _write_head(
+        writer: asyncio.StreamWriter, status: int, headers: Mapping[str, str]
+    ) -> None:
+        reason = {
+            200: "OK",
+            302: "Found",
+            400: "Bad Request",
+            401: "Unauthorized",
+            403: "Forbidden",
+            429: "Too Many Requests",
+            500: "Internal Server Error",
+            503: "Service Unavailable",
+        }.get(status, "Response")
+        lines: Iterable[str] = (
+            f"HTTP/1.1 {status} {reason}",
+            *(f"{name}: {value}" for name, value in headers.items()),
+            "",
+            "",
+        )
+        writer.write("\r\n".join(lines).encode("latin-1"))
+        await writer.drain()
+
+
+async def iter_records(server: HttpFaultServer, route: Route) -> AsyncIterator[RequestRecord]:
+    """Yield the current route-specific journal without exposing its list shape."""
+    for record in server.journal:
+        if record.route == route:
+            yield record
+
+
+__all__ = [
+    "Disconnect",
+    "HttpFaultServer",
+    "LogicalHostTransport",
+    "Reply",
+    "RequestRecord",
+    "Route",
+    "Stall",
+    "Truncate",
+]

--- a/tests/_fault_server/web.py
+++ b/tests/_fault_server/web.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
+from contextlib import nullcontext
+from functools import partial
 from typing import Any
+from unittest.mock import patch
 
 from notebooklm._auth.cookie_types import Cookie, CookieJar
 from notebooklm._client_assembly import _assemble_client
 from notebooklm._client_options import normalize_legacy_client_options
+from notebooklm._web.transport.middleware import chain as middleware_chain
 from notebooklm._web.transport.middleware.retry import RetryMiddleware
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -90,22 +94,23 @@ def build_fault_client(
         server_error_max_retries=server_error_max_retries,
         backend="web",
     )
-    _assemble_client(
-        client,
-        auth=synthetic_auth(),
-        options=options,
-        async_client_factory=server.client_factory,
-        sleep=sleep,
-        refresh_retry_delay=0.0,
+    # The chain builder does not forward the legacy sleep seam to retries.
+    # Supply the sleeper through the middleware's constructor during synchronous
+    # assembly, restoring the binding before any concurrent cohort can run.
+    construction = (
+        patch.object(middleware_chain, "RetryMiddleware", partial(RetryMiddleware, sleep=sleep))
+        if sleep is not None
+        else nullcontext()
     )
-    if sleep is not None:
-        retry = client._web_runtime.composed.middlewares[0]
-        if not isinstance(retry, RetryMiddleware):
-            raise AssertionError("production Web middleware order changed")
-        # RetryMiddleware exposes this constructor seam, but production assembly
-        # intentionally resolves its default internally. Bind it per instance so
-        # concurrent cohorts can record delay decisions without global patches.
-        retry._sleep = sleep
+    with construction:
+        _assemble_client(
+            client,
+            auth=synthetic_auth(),
+            options=options,
+            async_client_factory=server.client_factory,
+            sleep=sleep,
+            refresh_retry_delay=0.0,
+        )
     return client
 
 

--- a/tests/_fault_server/web.py
+++ b/tests/_fault_server/web.py
@@ -1,0 +1,126 @@
+"""Web-client assembly and wire fixtures for the local HTTP fault server."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from notebooklm._auth.cookie_types import Cookie, CookieJar
+from notebooklm._client_assembly import _assemble_client
+from notebooklm._client_options import normalize_legacy_client_options
+from notebooklm._web.transport.middleware.retry import RetryMiddleware
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+
+from .http import HttpFaultServer
+
+OLD_CSRF = "csrf-generation-1"
+OLD_SESSION = "session-generation-1"
+NEW_CSRF = "csrf-generation-2"
+NEW_SESSION = "session-generation-2"
+COOKIE_NAME = "NLM_FAULT_SESSION"
+OLD_COOKIE = "cookie-generation-1"
+NEW_COOKIE = "cookie-generation-2"
+
+
+def rpc_response(rpc_id: str, payload: object) -> bytes:
+    """Encode one real batchexecute response frame."""
+    inner = json.dumps(payload, separators=(",", ":"))
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]], separators=(",", ":"))
+    return f")]}}'\n{len(chunk)}\n{chunk}\n".encode()
+
+
+def notebook_row(notebook_id: str, title: str) -> list[Any]:
+    return [
+        title,
+        None,
+        notebook_id,
+        "📘",
+        None,
+        [1, False, True, None, None, [1704067200, 0]],
+    ]
+
+
+def list_response(rpc_id: str, notebooks: list[tuple[str, str]]) -> bytes:
+    return rpc_response(
+        rpc_id, [[notebook_row(notebook_id, title) for notebook_id, title in notebooks]]
+    )
+
+
+def create_response(rpc_id: str, notebook_id: str, title: str) -> bytes:
+    return rpc_response(rpc_id, notebook_row(notebook_id, title))
+
+
+def homepage_response(*, csrf: str = NEW_CSRF, session: str = NEW_SESSION) -> bytes:
+    return (
+        "<html><script>window.WIZ_global_data={"
+        f'"SNlM0e":"{csrf}","FdrFJe":"{session}"'
+        "};</script></html>"
+    ).encode()
+
+
+def synthetic_auth() -> AuthTokens:
+    jar = CookieJar((Cookie(COOKIE_NAME, ".google.com", "/", OLD_COOKIE, secure=True),)).to_httpx()
+    return AuthTokens(
+        cookies={(COOKIE_NAME, ".google.com", "/"): OLD_COOKIE},
+        csrf_token=OLD_CSRF,
+        session_id=OLD_SESSION,
+        cookie_jar=jar,
+    )
+
+
+def build_fault_client(
+    server: HttpFaultServer,
+    *,
+    timeout: float = 0.5,
+    rate_limit_max_retries: int = 2,
+    server_error_max_retries: int = 2,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+) -> NotebookLMClient:
+    """Assemble a production Web graph while varying only private test seams.
+
+    ``refresh_callback`` is intentionally omitted: `_assemble_client`'s sentinel
+    selects the real ``WebSessionAuth.refresh_base`` coordinator callback.
+    """
+    client = NotebookLMClient.__new__(NotebookLMClient)
+    options = normalize_legacy_client_options(
+        timeout=timeout,
+        rate_limit_max_retries=rate_limit_max_retries,
+        server_error_max_retries=server_error_max_retries,
+        backend="web",
+    )
+    _assemble_client(
+        client,
+        auth=synthetic_auth(),
+        options=options,
+        async_client_factory=server.client_factory,
+        sleep=sleep,
+        refresh_retry_delay=0.0,
+    )
+    if sleep is not None:
+        retry = client._web_runtime.composed.middlewares[0]
+        if not isinstance(retry, RetryMiddleware):
+            raise AssertionError("production Web middleware order changed")
+        # RetryMiddleware exposes this constructor seam, but production assembly
+        # intentionally resolves its default internally. Bind it per instance so
+        # concurrent cohorts can record delay decisions without global patches.
+        retry._sleep = sleep
+    return client
+
+
+__all__ = [
+    "COOKIE_NAME",
+    "NEW_COOKIE",
+    "NEW_CSRF",
+    "NEW_SESSION",
+    "OLD_COOKIE",
+    "OLD_CSRF",
+    "OLD_SESSION",
+    "build_fault_client",
+    "create_response",
+    "homepage_response",
+    "list_response",
+    "notebook_row",
+    "rpc_response",
+]

--- a/tests/_fault_server/web_scenarios.py
+++ b/tests/_fault_server/web_scenarios.py
@@ -152,6 +152,7 @@ async def _cohort(
             raise close_error
         if server_close_error is not None:
             raise server_close_error
+        result.require("client_closed", client is None or not client._lifecycle.is_open())
 
 
 def _requests(server: HttpFaultServer, route: Route) -> list[Any]:
@@ -540,6 +541,7 @@ async def _close_reopen(result: ScenarioResult) -> None:
             raise cleanup_error
         if server_close_error is not None:
             raise server_close_error
+        result.require("client_closed", not client._lifecycle.is_open())
     _record_error(result, first_error)
     result.require("active_read_terminated", isinstance(first_error, NotebookLMError))
     result.require("reopen_succeeded", [item.id for item in reopened] == ["nb-reopen"])

--- a/tests/_fault_server/web_scenarios.py
+++ b/tests/_fault_server/web_scenarios.py
@@ -240,7 +240,7 @@ async def _rate_limit_recovery(result: ScenarioResult) -> None:
         notebooks = await client.notebooks.list()
     sleeps = [event["seconds"] for event in result.events if event["kind"] == "sleep"]
     result.require("rate_limit_recovered", [item.id for item in notebooks] == ["nb-rate"])
-    result.require("retry_after_recorded", sleeps == [1])
+    result.require("fractional_retry_after_rounded_up", sleeps == [1])
     result.require("rate_limit_request_count", len(_requests(server, _READ)) == 2)
     _require_clean(result, server)
 

--- a/tests/_fault_server/web_scenarios.py
+++ b/tests/_fault_server/web_scenarios.py
@@ -1,0 +1,594 @@
+"""Deterministic public-Web-API cohorts for the local fault harness."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any, Literal
+
+import httpx
+
+from notebooklm import (
+    DecodingError,
+    NetworkError,
+    NotebookLMError,
+    RateLimitError,
+    RPCTimeoutError,
+    ServerError,
+)
+from notebooklm.client import NotebookLMClient
+from notebooklm.outcomes import CommitState
+from notebooklm.rpc import RPCMethod
+
+from .common import ScenarioResult
+from .http import Disconnect, HttpFaultServer, Reply, Route, Stall, Truncate
+from .web import (
+    COOKIE_NAME,
+    NEW_COOKIE,
+    NEW_CSRF,
+    NEW_SESSION,
+    OLD_COOKIE,
+    OLD_CSRF,
+    OLD_SESSION,
+    build_fault_client,
+    create_response,
+    homepage_response,
+    list_response,
+    rpc_response,
+)
+
+_READ = Route.rpc(RPCMethod.LIST_NOTEBOOKS.value)
+_CREATE = Route.rpc(RPCMethod.CREATE_NOTEBOOK.value)
+_HOME = Route.homepage()
+_LOGIN = Route.login()
+
+SCENARIOS: tuple[str, ...] = tuple(
+    sorted(
+        (
+            "auth_refresh",
+            "auth_refresh_coalesced",
+            "auth_refresh_login_redirect",
+            "auth_refresh_malformed",
+            "cancel_blocked_read",
+            "close_reopen",
+            "committed_create_disconnect",
+            "delayed_headers",
+            "malformed_payload",
+            "rate_limit_exhaustion",
+            "rate_limit_recovery",
+            "server_error_exhaustion",
+            "server_error_recovery",
+            "stalled_body",
+            "truncated_body",
+            "valid_read_create",
+        )
+    )
+)
+
+_PLANS: dict[str, tuple[tuple[str, ...], int]] = {
+    "auth_refresh": (("rpc:400", "homepage:tokens+secure-cookie", "rpc:200"), 1),
+    "auth_refresh_coalesced": (
+        ("rpc:400x6@gate", "homepage:tokens+secure-cookie", "rpc:200x6"),
+        6,
+    ),
+    "auth_refresh_login_redirect": (
+        ("rpc:400", "homepage:302-login", "login:html"),
+        1,
+    ),
+    "auth_refresh_malformed": (("rpc:400", "homepage:malformed"), 1),
+    "cancel_blocked_read": (("rpc:stall-headers", "caller:cancel"), 1),
+    "close_reopen": (("rpc:stall-headers", "client:close", "client:reopen", "rpc:200"), 1),
+    "committed_create_disconnect": (("create:commit", "socket:disconnect"), 1),
+    "delayed_headers": (("rpc:stall-headers", "deadline:expire"), 1),
+    "malformed_payload": (("rpc:200-malformed-payload",), 1),
+    "rate_limit_exhaustion": (("rpc:429x3", "retry:exhaust"), 1),
+    "rate_limit_recovery": (("rpc:429-retry-after", "rpc:200"), 1),
+    "server_error_exhaustion": (("rpc:503x3", "retry:exhaust"), 1),
+    "server_error_recovery": (("rpc:503", "rpc:200"), 1),
+    "stalled_body": (("rpc:headers+partial-body", "deadline:expire"), 1),
+    "truncated_body": (("rpc:truncated-body-x3", "retry:exhaust"), 1),
+    "valid_read_create": (("read:200", "create:200"), 1),
+}
+
+_CLOSE_TIMEOUT = 2.0
+
+
+async def _recording_sleep(result: ScenarioResult, seconds: float) -> None:
+    result.record("sleep", seconds=seconds)
+
+
+@asynccontextmanager
+async def _cohort(
+    result: ScenarioResult,
+    server: HttpFaultServer,
+    *,
+    timeout: float = 0.5,
+    rate_retries: int = 2,
+    server_retries: int = 2,
+    record_sleep: bool = True,
+) -> AsyncIterator[NotebookLMClient]:
+    client: NotebookLMClient | None = None
+    close_error: BaseException | None = None
+    server_close_error: BaseException | None = None
+    await server.__aenter__()
+    try:
+
+        async def sleep(seconds: float) -> None:
+            await _recording_sleep(result, seconds)
+
+        client = build_fault_client(
+            server,
+            timeout=timeout,
+            rate_limit_max_retries=rate_retries,
+            server_error_max_retries=server_retries,
+            sleep=sleep if record_sleep else None,
+        )
+        await client.__aenter__()
+        yield client
+    finally:
+        if client is not None:
+            try:
+                await asyncio.wait_for(client.close(drain=False), _CLOSE_TIMEOUT)
+            except BaseException as exc:
+                close_error = exc
+        try:
+            await asyncio.wait_for(server.aclose(), _CLOSE_TIMEOUT)
+        except BaseException as exc:
+            server_close_error = exc
+        _record_http_trace(result, server)
+        result.record(
+            "cleanup",
+            client_closed=client is None or not client._lifecycle.is_open(),
+            active_handlers=server.active_handlers,
+            close_error=None if close_error is None else type(close_error).__name__,
+            server_close_error=(
+                None if server_close_error is None else type(server_close_error).__name__
+            ),
+            server_errors=list(server.errors),
+            remaining_actions=server.remaining(),
+        )
+        if close_error is not None:
+            raise close_error
+        if server_close_error is not None:
+            raise server_close_error
+
+
+def _requests(server: HttpFaultServer, route: Route) -> list[Any]:
+    return [record for record in server.journal if record.route == route]
+
+
+def _record_error(result: ScenarioResult, exc: BaseException | None) -> None:
+    result.record(
+        "outcome",
+        error=None if exc is None else type(exc).__name__,
+        message=None if exc is None else str(exc),
+    )
+
+
+def _generation(value: str | None, *, old: str, new: str) -> int | str | None:
+    if value is None:
+        return None
+    if value == old:
+        return 1
+    if value == new:
+        return 2
+    return "other-synthetic"
+
+
+def _record_http_trace(result: ScenarioResult, server: HttpFaultServer) -> None:
+    result.record(
+        "http_trace",
+        requests=[
+            {
+                "sequence": record.sequence,
+                "method": record.route.method,
+                "logical_host": record.route.host,
+                "path": record.route.path,
+                "rpc_id": record.route.rpc_id,
+                "action": record.action,
+                "csrf_generation": _generation(record.csrf, old=OLD_CSRF, new=NEW_CSRF),
+                "session_generation": _generation(
+                    record.session_id, old=OLD_SESSION, new=NEW_SESSION
+                ),
+                "cookie_generation": _generation(
+                    record.cookie_values.get(COOKIE_NAME), old=OLD_COOKIE, new=NEW_COOKIE
+                ),
+            }
+            for record in server.journal
+        ],
+        committed=list(server.committed),
+    )
+
+
+def _require_clean(result: ScenarioResult, server: HttpFaultServer) -> None:
+    result.require("server_plan_consumed", server.remaining() == 0)
+    result.require("server_had_no_errors", not server.errors)
+    result.require("server_handlers_drained", server.active_handlers == 0)
+
+
+async def _valid_read_create(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, Reply(body=list_response(_READ.rpc_id or "", [("nb-1", "Fault Lab")])))
+    server.enqueue(
+        _CREATE,
+        Reply(body=create_response(_CREATE.rpc_id or "", "nb-created", "Created locally")),
+    )
+    async with _cohort(result, server, timeout=10.0) as client:
+        notebooks = await client.notebooks.list()
+        created = await client.notebooks.create("Created locally")
+        result.record(
+            "decoded",
+            list_ids=[notebook.id for notebook in notebooks],
+            created_id=created.id,
+        )
+    result.require("read_decoded", [notebook.id for notebook in notebooks] == ["nb-1"])
+    result.require("create_decoded", created.id == "nb-created")
+    result.require("one_request_each", len(server.journal) == 2)
+    _require_clean(result, server)
+
+
+async def _rate_limit_recovery(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(
+        _READ,
+        Reply(429, headers={"Retry-After": "0.25"}),
+        Reply(body=list_response(_READ.rpc_id or "", [("nb-rate", "Recovered")])),
+    )
+    async with _cohort(result, server, timeout=10.0) as client:
+        notebooks = await client.notebooks.list()
+    sleeps = [event["seconds"] for event in result.events if event["kind"] == "sleep"]
+    result.require("rate_limit_recovered", [item.id for item in notebooks] == ["nb-rate"])
+    result.require("retry_after_recorded", sleeps == [1])
+    result.require("rate_limit_request_count", len(_requests(server, _READ)) == 2)
+    _require_clean(result, server)
+
+
+async def _rate_limit_exhaustion(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, *(Reply(429, headers={"Retry-After": "0"}) for _ in range(3)))
+    error: BaseException | None = None
+    async with _cohort(result, server, timeout=10.0) as client:
+        try:
+            await client.notebooks.list()
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    result.require("rate_limit_public_error", isinstance(error, RateLimitError))
+    result.require("rate_limit_budget_bounded", len(_requests(server, _READ)) == 3)
+    _require_clean(result, server)
+
+
+async def _server_error_recovery(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(
+        _READ,
+        Reply(503),
+        Reply(body=list_response(_READ.rpc_id or "", [("nb-503", "Recovered")])),
+    )
+    async with _cohort(result, server, timeout=10.0) as client:
+        notebooks = await client.notebooks.list()
+    result.require("server_error_recovered", [item.id for item in notebooks] == ["nb-503"])
+    result.require("server_error_request_count", len(_requests(server, _READ)) == 2)
+    _require_clean(result, server)
+
+
+async def _server_error_exhaustion(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, *(Reply(503) for _ in range(3)))
+    error: BaseException | None = None
+    async with _cohort(result, server, timeout=10.0) as client:
+        try:
+            await client.notebooks.list()
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    result.require("server_error_public_error", isinstance(error, ServerError))
+    result.require("server_error_budget_bounded", len(_requests(server, _READ)) == 3)
+    _require_clean(result, server)
+
+
+async def _malformed_payload(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, Reply(body=rpc_response(_READ.rpc_id or "", "not-a-list")))
+    error: BaseException | None = None
+    async with _cohort(result, server) as client:
+        try:
+            await client.notebooks.list()
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    result.require("malformed_public_decode_error", isinstance(error, DecodingError))
+    result.require("malformed_not_retried", len(_requests(server, _READ)) == 1)
+    _require_clean(result, server)
+
+
+async def _truncated_body(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, *(Truncate(b"partial", 100) for _ in range(3)))
+    error: BaseException | None = None
+    async with _cohort(result, server, timeout=10.0) as client:
+        try:
+            await client.notebooks.list()
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    result.require("truncated_public_network_error", isinstance(error, NetworkError))
+    result.require("truncated_retry_budget", len(_requests(server, _READ)) == 3)
+    _require_clean(result, server)
+
+
+async def _timeout_scenario(result: ScenarioResult, *, phase: Literal["headers", "body"]) -> None:
+    server = HttpFaultServer()
+    gate = f"stall-{phase}"
+    reply = Reply(body=list_response(_READ.rpc_id or "", []))
+    server.enqueue(_READ, Stall(phase, gate, reply, prefix=b")]}'"))
+    error: BaseException | None = None
+    async with _cohort(result, server, timeout=0.08) as client:
+        try:
+            await asyncio.wait_for(client.notebooks.list(), 1.5)
+        except Exception as exc:
+            error = exc
+        finally:
+            server.release(gate)
+            await asyncio.sleep(0)
+    _record_error(result, error)
+    result.require(f"{phase}_public_timeout", isinstance(error, RPCTimeoutError))
+    result.require(f"{phase}_aggregate_deadline_bounded", len(_requests(server, _READ)) == 1)
+    _require_clean(result, server)
+
+
+async def _auth_refresh(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(
+        _READ,
+        Reply(400),
+        Reply(body=list_response(_READ.rpc_id or "", [("nb-auth", "Fresh")])),
+    )
+    server.enqueue(
+        _HOME,
+        Reply(
+            body=homepage_response(),
+            headers={
+                "Set-Cookie": (f"{COOKIE_NAME}={NEW_COOKIE}; Domain=.google.com; Path=/; Secure")
+            },
+        ),
+    )
+    async with _cohort(result, server) as client:
+        notebooks = await client.notebooks.list()
+        auth = client.auth
+    calls = _requests(server, _READ)
+    result.record(
+        "auth_generations",
+        csrf=[call.csrf for call in calls],
+        session=[call.session_id for call in calls],
+        cookie=[call.cookie_values.get(COOKIE_NAME) for call in calls],
+    )
+    result.require("auth_refresh_succeeded", [item.id for item in notebooks] == ["nb-auth"])
+    result.require("one_homepage_refresh", len(_requests(server, _HOME)) == 1)
+    result.require("csrf_changed", [call.csrf for call in calls] == [OLD_CSRF, NEW_CSRF])
+    result.require(
+        "session_changed", [call.session_id for call in calls] == [OLD_SESSION, NEW_SESSION]
+    )
+    result.require(
+        "cookie_changed",
+        [call.cookie_values.get(COOKIE_NAME) for call in calls] == [OLD_COOKIE, NEW_COOKIE],
+    )
+    result.require(
+        "public_auth_updated", (auth.csrf_token, auth.session_id) == (NEW_CSRF, NEW_SESSION)
+    )
+    _require_clean(result, server)
+
+
+async def _auth_refresh_coalesced(result: ScenarioResult) -> None:
+    count = 6
+    server = HttpFaultServer()
+    stale = Stall("headers", "stale-batch", Reply(400))
+    fresh = Reply(body=list_response(_READ.rpc_id or "", [("nb-shared", "Shared")]))
+    server.enqueue(_READ, *(stale for _ in range(count)), *(fresh for _ in range(count)))
+    server.enqueue(
+        _HOME,
+        Reply(
+            body=homepage_response(),
+            headers={
+                "Set-Cookie": (f"{COOKIE_NAME}={NEW_COOKIE}; Domain=.google.com; Path=/; Secure")
+            },
+        ),
+    )
+    calls: list[asyncio.Task[list[Any]]] = []
+    async with _cohort(result, server) as client:
+        try:
+            calls = [asyncio.create_task(client.notebooks.list()) for _ in range(count)]
+            await server.wait_for_requests(_READ, count)
+            server.release("stale-batch")
+            notebooks = await asyncio.wait_for(asyncio.gather(*calls), _CLOSE_TIMEOUT)
+        finally:
+            server.release("stale-batch")
+            for call in calls:
+                if not call.done():
+                    call.cancel()
+            if calls:
+                await asyncio.gather(*calls, return_exceptions=True)
+    requests = _requests(server, _READ)
+    result.require("coalesced_results", all(rows[0].id == "nb-shared" for rows in notebooks))
+    result.require("coalesced_one_refresh", len(_requests(server, _HOME)) == 1)
+    result.require("coalesced_request_count", len(requests) == count * 2)
+    result.require(
+        "coalesced_fresh_replays", sum(call.csrf == NEW_CSRF for call in requests) == count
+    )
+    _require_clean(result, server)
+
+
+async def _failed_refresh(result: ScenarioResult, *, redirect: bool) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_READ, Reply(400))
+    if redirect:
+        server.enqueue(
+            _HOME,
+            Reply(302, headers={"Location": "https://accounts.google.com/ServiceLogin"}),
+        )
+        server.enqueue(_LOGIN, Reply(body=b"<html>sign in</html>"))
+    else:
+        server.enqueue(_HOME, Reply(body=b"<html>missing bootstrap fields</html>"))
+    error: BaseException | None = None
+    async with _cohort(result, server) as client:
+        try:
+            await client.notebooks.list()
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    label = "login" if redirect else "malformed"
+    result.require(f"{label}_refresh_original_status", isinstance(error, httpx.HTTPStatusError))
+    result.require(f"{label}_refresh_failure_cause", isinstance(error.__cause__, ValueError))
+    result.require(f"{label}_refresh_no_replay", len(_requests(server, _READ)) == 1)
+    result.require(f"{label}_one_homepage", len(_requests(server, _HOME)) == 1)
+    if redirect:
+        result.require("logical_login_followed", len(_requests(server, _LOGIN)) == 1)
+    _require_clean(result, server)
+
+
+async def _committed_create_disconnect(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(_CREATE, Disconnect(commit_id="nb-committed"))
+    error: BaseException | None = None
+    async with _cohort(result, server, server_retries=5) as client:
+        try:
+            await client.notebooks.create("Committed once")
+        except Exception as exc:
+            error = exc
+    _record_error(result, error)
+    result.require("create_public_network_error", isinstance(error, NetworkError))
+    result.require(
+        "create_unknown_commit", getattr(error, "commit_state", None) is CommitState.UNKNOWN
+    )
+    result.require("create_unconfirmed", bool(getattr(error, "unconfirmed", False)))
+    result.require("create_sent_once", len(_requests(server, _CREATE)) == 1)
+    result.require("create_committed_once", server.committed == ["nb-committed"])
+    _require_clean(result, server)
+
+
+async def _cancel_blocked_read(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(
+        _READ, Stall("headers", "cancel-read", Reply(body=list_response(_READ.rpc_id or "", [])))
+    )
+    cancelled = False
+    async with _cohort(result, server, server_retries=0) as client:
+        task = asyncio.create_task(client.notebooks.list())
+        await server.wait_for_requests(_READ, 1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            cancelled = True
+        server.release("cancel-read")
+        await asyncio.sleep(0)
+    result.require("blocked_read_cancelled", cancelled)
+    result.require("cancel_sent_once", len(_requests(server, _READ)) == 1)
+    _require_clean(result, server)
+
+
+async def _close_reopen(result: ScenarioResult) -> None:
+    server = HttpFaultServer()
+    server.enqueue(
+        _READ,
+        Stall("headers", "close-read", Reply(body=list_response(_READ.rpc_id or "", []))),
+        Reply(body=list_response(_READ.rpc_id or "", [("nb-reopen", "Reopened")])),
+    )
+    first_error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+    server_close_error: BaseException | None = None
+    reopened: list[Any] = []
+    await server.__aenter__()
+    client = build_fault_client(server, server_error_max_retries=0)
+    try:
+        await client.__aenter__()
+        task = asyncio.create_task(client.notebooks.list())
+        await server.wait_for_requests(_READ, 1)
+        await asyncio.wait_for(client.close(drain=False), _CLOSE_TIMEOUT)
+        try:
+            await asyncio.wait_for(task, _CLOSE_TIMEOUT)
+        except BaseException as exc:
+            first_error = exc
+        server.release("close-read")
+        await client.__aenter__()
+        reopened = await client.notebooks.list()
+        await asyncio.wait_for(client.close(drain=False), _CLOSE_TIMEOUT)
+    finally:
+        server.release("close-read")
+        try:
+            await asyncio.wait_for(client.close(drain=False), _CLOSE_TIMEOUT)
+        except BaseException as exc:
+            cleanup_error = exc
+        try:
+            await asyncio.wait_for(server.aclose(), _CLOSE_TIMEOUT)
+        except BaseException as exc:
+            server_close_error = exc
+        _record_http_trace(result, server)
+        result.record(
+            "cleanup",
+            client_closed=not client._lifecycle.is_open(),
+            active_handlers=server.active_handlers,
+            close_error=None if cleanup_error is None else type(cleanup_error).__name__,
+            server_close_error=(
+                None if server_close_error is None else type(server_close_error).__name__
+            ),
+            server_errors=list(server.errors),
+            remaining_actions=server.remaining(),
+        )
+        if cleanup_error is not None:
+            raise cleanup_error
+        if server_close_error is not None:
+            raise server_close_error
+    _record_error(result, first_error)
+    result.require("active_read_terminated", isinstance(first_error, NotebookLMError))
+    result.require("reopen_succeeded", [item.id for item in reopened] == ["nb-reopen"])
+    result.require("close_reopen_request_count", len(_requests(server, _READ)) == 2)
+    _require_clean(result, server)
+
+
+_IMPLEMENTATIONS: dict[str, Callable[[ScenarioResult], Awaitable[None]]] = {
+    "auth_refresh": _auth_refresh,
+    "auth_refresh_coalesced": _auth_refresh_coalesced,
+    "auth_refresh_login_redirect": lambda result: _failed_refresh(result, redirect=True),
+    "auth_refresh_malformed": lambda result: _failed_refresh(result, redirect=False),
+    "cancel_blocked_read": _cancel_blocked_read,
+    "close_reopen": _close_reopen,
+    "committed_create_disconnect": _committed_create_disconnect,
+    "delayed_headers": lambda result: _timeout_scenario(result, phase="headers"),
+    "malformed_payload": _malformed_payload,
+    "rate_limit_exhaustion": _rate_limit_exhaustion,
+    "rate_limit_recovery": _rate_limit_recovery,
+    "server_error_exhaustion": _server_error_exhaustion,
+    "server_error_recovery": _server_error_recovery,
+    "stalled_body": lambda result: _timeout_scenario(result, phase="body"),
+    "truncated_body": _truncated_body,
+    "valid_read_create": _valid_read_create,
+}
+
+
+async def run_scenario(
+    name: str,
+    *,
+    operation_id: str,
+    result: ScenarioResult | None = None,
+) -> ScenarioResult:
+    """Run one bounded Web cohort and retain evidence on every failure path."""
+    implementation = _IMPLEMENTATIONS.get(name)
+    if implementation is None:
+        raise ValueError(f"unknown web fault scenario {name!r}; choose from {SCENARIOS!r}")
+    if result is None:
+        result = ScenarioResult("web", name, operation_id)
+    elif (result.backend, result.scenario, result.operation_id) != ("web", name, operation_id):
+        raise ValueError("supplied ScenarioResult identity does not match this web operation")
+    faults, cohort_count = _PLANS[name]
+    result.record(
+        "plan",
+        faults=list(faults),
+        cohort_ids=[f"{operation_id}:{index}" for index in range(cohort_count)],
+    )
+    await implementation(result)
+    return result
+
+
+__all__ = ["SCENARIOS", "run_scenario"]

--- a/tests/_fixtures/integration_allow_no_vcr_files.txt
+++ b/tests/_fixtures/integration_allow_no_vcr_files.txt
@@ -19,6 +19,8 @@ tests/integration/concurrency/test_upload_blocks_loop.py # existing mock-only in
 tests/integration/concurrency/test_upload_cancel_dangling_session.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/concurrency/test_upload_timeout_config.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/concurrency/test_wait_for_sources_leak.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
+tests/integration/faults/test_android_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/test_artifact_generation_idempotency.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifacts_integration.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_auto_refresh.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup

--- a/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
+++ b/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
@@ -102,6 +102,31 @@ tests/integration/concurrency/test_upload_timeout_config.py::test_default_upload
 tests/integration/concurrency/test_upload_timeout_config.py::test_default_upload_timeout_preserves_back_compat_start # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/concurrency/test_upload_timeout_config.py::test_from_storage_accepts_upload_timeout # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/concurrency/test_wait_for_sources_leak.py::test_wait_for_sources_cancels_sibling_on_first_failure # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[auth] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[auth_concurrent] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[commit_lost_response] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[deadline_and_cancellation] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[minter_failure] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[public_flows] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[rate_limit] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[stream_auth] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_android_faults.py::test_android_fault_scenario[unavailable] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[auth_refresh] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[auth_refresh_coalesced] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[auth_refresh_login_redirect] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[auth_refresh_malformed] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[cancel_blocked_read] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[close_reopen] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[committed_create_disconnect] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[delayed_headers] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[malformed_payload] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[rate_limit_exhaustion] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[rate_limit_recovery] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[server_error_exhaustion] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[server_error_recovery] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[stalled_body] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[truncated_body] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_web_faults.py::test_web_fault_scenario[valid_read_create] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/test_artifact_generation_idempotency.py::TestRegistryClassification::test_create_artifact_classified_as_non_idempotent_no_retry # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifact_generation_idempotency.py::TestRegistryClassification::test_create_artifact_variant_none_explicit # existing mock-only integration exception; migrate per test-suite taxonomy cleanup
 tests/integration/test_artifact_generation_idempotency.py::TestRegistryClassification::test_generate_mind_map_classified_as_non_idempotent_no_retry # existing mock-only integration exception; migrate per test-suite taxonomy cleanup

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -175,8 +175,9 @@ or E2E.
 ## When to use `allow_no_vcr`
 
 `allow_no_vcr` exists for tests that legitimately live under
-`tests/integration/` for tree-organization reasons but make no real (or
-recorded) HTTP calls. The authoritative allowlists live in:
+`tests/integration/` without replaying upstream traffic. This includes local
+real-socket fault services and the legacy mock-only exceptions below. The
+authoritative allowlists live in:
 
 - `tests/_fixtures/integration_allow_no_vcr_files.txt`
 - `tests/_fixtures/integration_allow_no_vcr_nodeids.txt`
@@ -185,6 +186,11 @@ recorded) HTTP calls. The authoritative allowlists live in:
 
 Current categories include:
 
+- `faults/` — real loopback HTTP/gRPC services exercising protocol faults,
+  authentication recovery, mutation outcomes, and lifecycle cleanup. These
+  scenarios deliberately control live socket behavior that cassettes cannot
+  reproduce. See the [fault-injection guide](../../docs/fault-injection.md)
+  for the concurrent runner and extension rules.
 - `test_auto_refresh.py` — asserts that the refresh callback is *wired*;
   doesn't fire a real refresh.
 - `test_session_integration.py` — `httpx.MockTransport` + `AsyncMock` exercising error

--- a/tests/integration/faults/__init__.py
+++ b/tests/integration/faults/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic library resilience scenarios against local fault services."""

--- a/tests/integration/faults/conftest.py
+++ b/tests/integration/faults/conftest.py
@@ -1,0 +1,15 @@
+"""Keep local fault scenarios independent of ambient NotebookLM settings."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from tests._fault_server.environment import isolated_environment
+
+
+@pytest.fixture(autouse=True)
+def isolated_fault_environment() -> Iterator[None]:
+    # Pytest executes tests serially within each worker. One scope encloses
+    # every concurrent cohort in a test; no task changes process environment.
+    with isolated_environment():
+        yield

--- a/tests/integration/faults/test_android_faults.py
+++ b/tests/integration/faults/test_android_faults.py
@@ -1,0 +1,18 @@
+"""Real-loopback Android resilience scenarios without a VCR cassette."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._fault_server.android_scenarios import SCENARIOS, run_scenario
+
+
+@pytest.mark.allow_no_vcr(reason="real local grpc.aio fault server; no remote traffic")
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", SCENARIOS)
+async def test_android_fault_scenario(scenario: str) -> None:
+    result = await run_scenario(scenario, operation_id=f"pytest-{scenario}")
+
+    assert result.events
+    assert result.checks
+    assert all(result.checks.values()), result.events

--- a/tests/integration/faults/test_web_faults.py
+++ b/tests/integration/faults/test_web_faults.py
@@ -1,0 +1,28 @@
+"""Real-loopback Web resilience scenarios (intentionally outside VCR)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests._fault_server.web_scenarios import SCENARIOS, run_scenario
+
+pytestmark = pytest.mark.allow_no_vcr
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS)
+async def test_web_fault_scenario(scenario: str) -> None:
+    result = await asyncio.wait_for(
+        run_scenario(scenario, operation_id=f"pytest-{scenario}"),
+        timeout=8.0,
+    )
+
+    assert result.checks
+    assert all(result.checks.values())
+    assert result.events[0]["kind"] == "plan"
+    assert result.events[0]["faults"]
+    assert all(
+        cohort_id.startswith(f"pytest-{scenario}:") for cohort_id in result.events[0]["cohort_ids"]
+    )
+    assert any(event["kind"] == "http_trace" for event in result.events)

--- a/tests/unit/android/test_session.py
+++ b/tests/unit/android/test_session.py
@@ -876,11 +876,14 @@ async def test_real_android_unary_cancellation_keeps_every_batch_attempt_unknown
 @pytest.mark.asyncio
 async def test_operation_timeout_auto_journals_unbound_android_mutation() -> None:
     channel = _Channel()
-    channel.unary_outcomes = [asyncio.Future()]
-    session, _, _, _, supervisor = await _open(channel=channel)
+    pending: asyncio.Future[bytes] = asyncio.Future()
+    channel.unary_outcomes = [pending]
+    session, _, _, _, supervisor = await _open(channel=channel, timeout=5.0)
 
-    with pytest.raises(OperationTimeoutError) as raised:
-        async with supervisor.operation_scope("raw mutation", timeout=0.01):
+    async def _mutate() -> None:
+        # Allow slow platforms/instrumentation to dispatch before the real
+        # operation deadline; expiry before dispatch tests a different state.
+        async with supervisor.operation_scope("raw mutation", timeout=1.0):
             await session.unary(
                 MUTATION_METHOD,
                 _Message(b"request"),
@@ -888,6 +891,19 @@ async def test_operation_timeout_auto_journals_unbound_android_mutation() -> Non
                 response_type=_Message,
             )
 
+    try:
+        with pytest.raises(OperationTimeoutError) as raised:
+            await asyncio.wait_for(_mutate(), timeout=5.0)
+        assert pending.cancelled()
+    finally:
+        if not pending.done():
+            pending.cancel()
+        await supervisor.begin_closing(1)
+        await session.prepare_close()
+        await session.close_resources()
+        supervisor.mark_closed(1)
+
+    assert [invocation[0] for invocation in channel.invocations] == [MUTATION_METHOD]
     metadata = raised.value.operation_metadata
     assert metadata is not None
     assert metadata.method == MUTATION_METHOD

--- a/tests/unit/mcp/test_chat_start.py
+++ b/tests/unit/mcp/test_chat_start.py
@@ -217,36 +217,35 @@ def _supervised_client() -> tuple[Any, CallSupervisor]:
 
 
 async def test_registry_job_timeout_includes_queue_and_prevents_dispatch() -> None:
-    registry = ChatTaskRegistry(concurrency=1, job_timeout=0.01)
+    registry = ChatTaskRegistry(concurrency=1, job_timeout=0.1)
     client, _supervisor = _supervised_client()
-    first_started = asyncio.Event()
-    second_calls = 0
+    calls = 0
 
-    async def _first() -> dict[str, Any]:
-        first_started.set()
-        await asyncio.Event().wait()
+    async def _work() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
         return {}
 
-    async def _second() -> dict[str, Any]:
-        nonlocal second_calls
-        second_calls += 1
-        return {}
-
-    first, _ = registry.start("deadline-1", _first, client=client)
-    second, _ = registry.start("deadline-2", _second, client=client)
-    await first_started.wait()
-    assert first.task is not None and second.task is not None
-    await asyncio.gather(first.task, second.task)
-    assert isinstance(first.error, OperationTimeoutError)
-    assert isinstance(second.error, OperationTimeoutError)
-    assert second.started_at is None
-    assert second_calls == 0
+    # Hold the slot independently of another job's deadline. Two jobs accepted
+    # in succession have different deadlines, so the first may legitimately
+    # time out and release its slot before the second's deadline expires.
+    registry.set_bound_loop(asyncio.get_running_loop())
+    async with registry._gate:
+        entry, _ = registry.start("queued-deadline", _work, client=client)
+        assert entry.task is not None
+        await asyncio.wait_for(entry.task, timeout=5.0)
+    assert isinstance(entry.error, OperationTimeoutError)
+    assert entry.started_at is None
+    assert calls == 0
 
 
 async def test_registry_preserves_metadata_timeout_from_fresh_client_operation() -> None:
-    registry = ChatTaskRegistry(concurrency=1, job_timeout=0.01)
+    # Allow instrumentation/setup to enter the operation before its real timer
+    # expires: this test checks dispatched-mutation metadata, not queue expiry.
+    registry = ChatTaskRegistry(concurrency=1, job_timeout=1.0)
     client, supervisor = _supervised_client()
     observed_deadlines: list[float | None] = []
+    mutation_entered = asyncio.Event()
 
     async def _mutation() -> dict[str, Any]:
         context = current_operation_context(supervisor)
@@ -259,12 +258,19 @@ async def test_registry_preserves_metadata_timeout_from_fresh_client_operation()
         )
         assert journal_entry is not None
         journal_entry.mark_dispatched()
+        mutation_entered.set()
         await asyncio.Event().wait()
         raise AssertionError("unreachable")
 
     entry, _ = registry.start("metadata-timeout", _mutation, client=client)
     assert entry.task is not None
-    await entry.task
+    try:
+        await asyncio.wait_for(mutation_entered.wait(), timeout=5.0)
+        await asyncio.wait_for(entry.task, timeout=5.0)
+    finally:
+        if not entry.task.done():
+            entry.task.cancel()
+        await asyncio.gather(entry.task, return_exceptions=True)
 
     assert isinstance(entry.error, OperationTimeoutError)
     assert observed_deadlines == [entry.absolute_deadline]

--- a/tests/unit/test_android_fault_scenarios.py
+++ b/tests/unit/test_android_fault_scenarios.py
@@ -2,10 +2,53 @@
 
 from __future__ import annotations
 
+import asyncio
+
+import grpc
 import pytest
 
 from tests._fault_server.android_scenarios import SCENARIOS, run_scenario
 from tests._fault_server.common import ScenarioResult
+from tests._fault_server.grpc import GENERATE_STREAMED, GET_PROJECT, GrpcAction, GrpcFaultServer
+
+
+class _LifecycleServer:
+    def __init__(
+        self,
+        *,
+        bind_error: BaseException | None = None,
+        block_start: bool = False,
+        stop_error: BaseException | None = None,
+    ) -> None:
+        self.bind_error = bind_error
+        self.block_start = block_start
+        self.stop_error = stop_error
+        self.start_entered = asyncio.Event()
+        self.release_start = asyncio.Event()
+        self.stop_calls = 0
+        self.termination_waits = 0
+
+    def add_generic_rpc_handlers(self, _handlers: object) -> None:
+        return None
+
+    def add_insecure_port(self, _address: str) -> int:
+        if self.bind_error is not None:
+            raise self.bind_error
+        return 12345
+
+    async def start(self) -> None:
+        self.start_entered.set()
+        if self.block_start:
+            await self.release_start.wait()
+
+    async def stop(self, _grace: float) -> None:
+        self.stop_calls += 1
+        self.release_start.set()
+        if self.stop_error is not None:
+            raise self.stop_error
+
+    async def wait_for_termination(self) -> None:
+        self.termination_waits += 1
 
 
 @pytest.mark.asyncio
@@ -20,3 +63,112 @@ async def test_android_fault_scenarios_require_matching_supplied_result_identity
 
     with pytest.raises(ValueError, match="identity"):
         await run_scenario(SCENARIOS[0], operation_id="unit-operation", result=result)
+
+
+@pytest.mark.parametrize(
+    ("method", "action", "match"),
+    [
+        (GET_PROJECT, GrpcAction("bogus"), "invalid"),
+        (GET_PROJECT, GrpcAction("abort"), "status"),
+        (GET_PROJECT, GrpcAction("reply", status=grpc.StatusCode.INTERNAL), "status"),
+        (GET_PROJECT, GrpcAction("wait_reply", gate=""), "gate"),
+        (GENERATE_STREAMED, GrpcAction("reply"), "invalid"),
+        (GET_PROJECT, GrpcAction("stream", response=()), "invalid"),
+    ],
+)
+def test_grpc_fault_plan_rejects_invalid_action_before_server_open(
+    method: str, action: GrpcAction, match: str
+) -> None:
+    server = GrpcFaultServer()
+
+    with pytest.raises(ValueError, match=match):
+        server.plan(method, action)
+
+    assert not server.actions[method]
+
+
+@pytest.mark.asyncio
+async def test_grpc_fault_server_cleans_up_when_binding_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle = _LifecycleServer(bind_error=RuntimeError("synthetic bind failure"))
+    monkeypatch.setattr(grpc.aio, "server", lambda: lifecycle)
+
+    with pytest.raises(RuntimeError, match="synthetic bind failure"):
+        await GrpcFaultServer().__aenter__()
+
+    assert lifecycle.stop_calls == 1
+    assert lifecycle.termination_waits == 1
+
+
+@pytest.mark.asyncio
+async def test_grpc_fault_server_cleans_up_when_start_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lifecycle = _LifecycleServer(block_start=True)
+    monkeypatch.setattr(grpc.aio, "server", lambda: lifecycle)
+    task = asyncio.create_task(GrpcFaultServer().__aenter__())
+    await lifecycle.start_entered.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lifecycle.stop_calls == 1
+    assert lifecycle.termination_waits == 1
+
+
+@pytest.mark.asyncio
+async def test_grpc_fault_server_still_waits_for_termination_when_stop_fails() -> None:
+    lifecycle = _LifecycleServer(stop_error=RuntimeError("synthetic stop failure"))
+    server = GrpcFaultServer()
+    server._server = lifecycle  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="synthetic stop failure"):
+        await server.__aexit__(None, None, None)
+
+    assert lifecycle.stop_calls == 1
+    assert lifecycle.termination_waits == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_grpc_path_is_journaled_as_a_harness_failure() -> None:
+    server = GrpcFaultServer()
+    async with server:
+        channel = grpc.aio.insecure_channel(server.target)
+        call = channel.unary_unary(
+            "/fault.Unknown/Method",
+            request_serializer=lambda value: value,
+            response_deserializer=lambda value: value,
+        )
+        try:
+            with pytest.raises(grpc.aio.AioRpcError) as raised:
+                await call(b"request")
+            assert raised.value.code() is grpc.StatusCode.UNIMPLEMENTED
+        finally:
+            await channel.close()
+
+        with pytest.raises(AssertionError, match="unexpected request: /fault.Unknown/Method"):
+            server.assert_consumed()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_handler_exception_is_retained(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = GrpcFaultServer()
+    server.plan(GET_PROJECT, GrpcAction("reply"))
+
+    def explode(_method: str) -> GrpcAction:
+        raise RuntimeError("synthetic handler bug")
+
+    monkeypatch.setattr(server, "_next", explode)
+    async with server:
+        channel = grpc.aio.insecure_channel(server.target)
+        call = channel.unary_unary(GET_PROJECT)
+        try:
+            with pytest.raises(grpc.aio.AioRpcError):
+                await call(b"")
+        finally:
+            await channel.close()
+
+        with pytest.raises(AssertionError, match="synthetic handler bug"):
+            server.assert_consumed()

--- a/tests/unit/test_android_fault_scenarios.py
+++ b/tests/unit/test_android_fault_scenarios.py
@@ -1,0 +1,22 @@
+"""Contract checks for the Android fault scenario entry point."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests._fault_server.android_scenarios import SCENARIOS, run_scenario
+from tests._fault_server.common import ScenarioResult
+
+
+@pytest.mark.asyncio
+async def test_android_fault_scenarios_reject_unknown_name_before_opening_resources() -> None:
+    with pytest.raises(ValueError, match="unknown Android fault scenario"):
+        await run_scenario("not-a-scenario", operation_id="unit-unknown")
+
+
+@pytest.mark.asyncio
+async def test_android_fault_scenarios_require_matching_supplied_result_identity() -> None:
+    result = ScenarioResult("android", SCENARIOS[0], "different-operation")
+
+    with pytest.raises(ValueError, match="identity"):
+        await run_scenario(SCENARIOS[0], operation_id="unit-operation", result=result)

--- a/tests/unit/test_http_fault_server.py
+++ b/tests/unit/test_http_fault_server.py
@@ -1,0 +1,102 @@
+"""Safety checks for the test-only logical-host socket router."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import tests._fault_server.web_scenarios as web_scenarios
+from tests._fault_server.common import ScenarioResult
+from tests._fault_server.http import HttpFaultServer, LogicalHostTransport
+
+
+class _FakeLifecycle:
+    def __init__(self) -> None:
+        self.open = False
+
+    def is_open(self) -> bool:
+        return self.open
+
+
+class _FakeClient:
+    def __init__(self, *, close_error: Exception | None = None) -> None:
+        self._lifecycle = _FakeLifecycle()
+        self._close_error = close_error
+
+    async def __aenter__(self) -> _FakeClient:
+        self._lifecycle.open = True
+        return self
+
+    async def close(self, *, drain: bool) -> None:
+        if self._close_error is not None:
+            raise self._close_error
+        self._lifecycle.open = False
+
+
+async def test_logical_transport_refuses_unmapped_host_and_http_downgrade() -> None:
+    async with HttpFaultServer() as server:
+        transport = LogicalHostTransport({"notebook.google.com": server.address})
+        async with httpx.AsyncClient(transport=transport) as client:
+            with pytest.raises(httpx.ConnectError, match="unmapped logical host"):
+                await client.get("https://example.com/")
+            with pytest.raises(httpx.ConnectError, match="non-HTTPS logical URL"):
+                await client.get("http://notebook.google.com/")
+
+    assert server.journal == []
+
+
+def test_logical_transport_refuses_non_loopback_target() -> None:
+    with pytest.raises(ValueError, match="numeric loopback"):
+        LogicalHostTransport({"notebook.google.com": ("192.0.2.1", 80)})
+
+
+async def test_unexpected_request_is_visible_in_server_errors() -> None:
+    async with HttpFaultServer() as server:
+        transport = LogicalHostTransport({"notebook.google.com": server.address})
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://notebook.google.com/unplanned")
+
+    assert response.status_code == 500
+    assert len(server.errors) == 1
+    assert "unexpected request" in server.errors[0]
+
+
+async def test_cohort_records_client_cleanup_failure_and_still_closes_server(monkeypatch) -> None:
+    result = ScenarioResult("web", "cleanup", "client-close")
+    server = HttpFaultServer()
+    fake = _FakeClient(close_error=RuntimeError("client close failed"))
+    monkeypatch.setattr(web_scenarios, "build_fault_client", lambda *_args, **_kwargs: fake)
+
+    with pytest.raises(RuntimeError, match="client close failed"):
+        async with web_scenarios._cohort(result, server):
+            pass
+
+    cleanup = result.events[-1]
+    assert cleanup["kind"] == "cleanup"
+    assert cleanup["close_error"] == "RuntimeError"
+    assert cleanup["server_close_error"] is None
+    with pytest.raises(RuntimeError, match="not running"):
+        _ = server.address
+
+
+async def test_cohort_records_server_cleanup_failure(monkeypatch) -> None:
+    result = ScenarioResult("web", "cleanup", "server-close")
+    server = HttpFaultServer()
+    fake = _FakeClient()
+    monkeypatch.setattr(web_scenarios, "build_fault_client", lambda *_args, **_kwargs: fake)
+    original_close = server.aclose
+
+    async def fail_close() -> None:
+        raise RuntimeError("server close failed")
+
+    monkeypatch.setattr(server, "aclose", fail_close)
+    with pytest.raises(RuntimeError, match="server close failed"):
+        async with web_scenarios._cohort(result, server):
+            pass
+
+    cleanup = result.events[-1]
+    assert cleanup["kind"] == "cleanup"
+    assert cleanup["close_error"] is None
+    assert cleanup["server_close_error"] == "RuntimeError"
+
+    await original_close()

--- a/tests/unit/test_http_fault_server.py
+++ b/tests/unit/test_http_fault_server.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 import tests._fault_server.web_scenarios as web_scenarios
-from tests._fault_server.common import ScenarioResult
+from tests._fault_server.common import ScenarioFailure, ScenarioResult
 from tests._fault_server.http import HttpFaultServer, LogicalHostTransport
 
 
@@ -100,3 +100,19 @@ async def test_cohort_records_server_cleanup_failure(monkeypatch) -> None:
     assert cleanup["server_close_error"] == "RuntimeError"
 
     await original_close()
+
+
+async def test_cohort_rejects_client_that_silently_remains_open(monkeypatch) -> None:
+    class UnclosedClient(_FakeClient):
+        async def close(self, *, drain: bool) -> None:
+            pass
+
+    result = ScenarioResult("web", "cleanup", "silent-close")
+    server = HttpFaultServer()
+    monkeypatch.setattr(web_scenarios, "build_fault_client", lambda *_a, **_kw: UnclosedClient())
+    with pytest.raises(ScenarioFailure, match="client_closed"):
+        async with web_scenarios._cohort(result, server):
+            pass
+    assert result.checks["client_closed"] is False
+    with pytest.raises(RuntimeError, match="not running"):
+        _ = server.address

--- a/tests/unit/test_operation_context.py
+++ b/tests/unit/test_operation_context.py
@@ -292,13 +292,20 @@ async def test_external_cancellation_is_not_translated() -> None:
 
 async def test_timeout_carries_dispatched_mutation_evidence() -> None:
     supervisor = _supervisor()
+    dispatched = False
 
-    with pytest.raises(OperationTimeoutError) as caught:
-        async with supervisor.operation_scope("create", timeout=0.01):
+    async def _create() -> None:
+        nonlocal dispatched
+        async with supervisor.operation_scope("create", timeout=1.0):
             entry = OperationJournal("notebooks.create").new_entry(method="CREATE_NOTEBOOK")
             entry.mark_dispatched()
+            dispatched = True
             await asyncio.sleep(10)
 
+    with pytest.raises(OperationTimeoutError) as caught:
+        await asyncio.wait_for(_create(), timeout=5.0)
+
+    assert dispatched
     metadata = caught.value.operation_metadata
     assert metadata is not None
     assert metadata.commit_state is CommitState.UNKNOWN
@@ -326,24 +333,32 @@ async def test_web_terminal_auto_adopts_active_operation_journal(
         AuthTokens(csrf_token="csrf", session_id="session", cookies={})
     )
     never = asyncio.Event()
+    post_entered = asyncio.Event()
 
     async with client:
 
         async def _post(*args: object, **kwargs: object) -> httpx.Response:
             del args, kwargs
+            post_entered.set()
             await never.wait()
             raise AssertionError("unreachable")
 
         terminal = client._web_runtime.composed.transport
         monkeypatch.setattr(terminal._kernel, "post", _post)
 
-        with pytest.raises(OperationTimeoutError) as caught:
-            async with client.operation(timeout=0.01):
+        async def _create() -> None:
+            # Keep this a post-dispatch metadata test on slow/instrumented
+            # platforms, rather than expiring during request preparation.
+            async with client.operation(timeout=1.0):
                 await client._web_runtime.executor.rpc_call(
                     RPCMethod.CREATE_NOTEBOOK,
                     ["title", None],
                 )
 
+        with pytest.raises(OperationTimeoutError) as caught:
+            await asyncio.wait_for(_create(), timeout=5.0)
+
+    assert post_entered.is_set()
     metadata = caught.value.operation_metadata
     assert metadata is not None
     assert metadata.commit_state is CommitState.UNKNOWN

--- a/tests/unit/test_stress_fault_server.py
+++ b/tests/unit/test_stress_fault_server.py
@@ -318,6 +318,21 @@ def test_cli_reports_a_leaked_child_even_when_it_cancels_cleanly() -> None:
     assert cleaned
 
 
+def test_cli_records_unhandled_background_failure() -> None:
+    async def fails() -> None:
+        raise RuntimeError("orphaned handler failed")
+
+    async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        asyncio.create_task(fails(), name="unowned-handler")
+        await asyncio.sleep(0)
+        result.require("misleading success", True)
+        return result
+
+    report = stress._run_cli(stress.RunConfig(iterations=1), {("web", "broken"): scenario})
+    assert not report["summary"]["ok"]
+    assert any("orphaned handler failed" in failure for failure in report["failures"])
+
+
 def test_cli_bounds_cancellation_resistant_cleanup_in_subprocess() -> None:
     # A broken coroutine must not strand pytest's own event loop. The CLI owns
     # its loop and reports shutdown failure even when a scenario swallows cancel.

--- a/tests/unit/test_stress_fault_server.py
+++ b/tests/unit/test_stress_fault_server.py
@@ -131,6 +131,28 @@ async def test_failed_scenarios_preserve_trace_and_fail_report(mode: str) -> Non
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["missing_plan", "unrecorded", "duplicate", "mismatched"])
+async def test_passing_claim_without_matching_evidence_fails(mode: str) -> None:
+    async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        if mode != "missing_plan":
+            result.record("plan", faults=["commit_then_disconnect"])
+        if mode == "unrecorded":
+            result.checks["one commit"] = True
+        else:
+            result.require("one commit", True)
+        if mode == "duplicate":
+            result.record("check", name="one commit", passed=True)
+        if mode == "mismatched":
+            result.checks = {"unobserved condition": True}
+        return result
+
+    report = await stress.run_stress(stress.RunConfig(iterations=1), {("web", "read"): scenario})
+    assert report["summary"]["failed"] == 1
+    assert not report["summary"]["ok"]
+    assert "ValueError" in report["operations"][0]["error"]
+
+
+@pytest.mark.asyncio
 async def test_scenario_timeout_cancels_work_and_retains_cleanup_events() -> None:
     cleaned = asyncio.Event()
 
@@ -308,6 +330,7 @@ def test_cli_reports_a_leaked_child_even_when_it_cancels_cleanly() -> None:
             cleaned = True
 
     async def leaks(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["leaked_child"])
         asyncio.create_task(child(), name="unexpected-child")
         result.require("misleading cleanup claim", True)
         return result
@@ -323,6 +346,7 @@ def test_cli_records_unhandled_background_failure() -> None:
         raise RuntimeError("orphaned handler failed")
 
     async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["unhandled_background_failure"])
         asyncio.create_task(fails(), name="unowned-handler")
         await asyncio.sleep(0)
         result.require("misleading success", True)

--- a/tests/unit/test_stress_fault_server.py
+++ b/tests/unit/test_stress_fault_server.py
@@ -1,0 +1,350 @@
+"""Fault runner scheduling, failure reporting, and cleanup without remote traffic."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import stress_fault_server as stress
+from tests._fault_server.common import ScenarioFailure, ScenarioResult
+
+
+async def _passing(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+    assert result.operation_id == operation_id
+    result.record("plan", faults=[name])
+    result.require("work completed", True)
+    return result
+
+
+def test_evidence_snapshots_payload_and_retains_failed_check() -> None:
+    result = ScenarioResult("web", "test", "operation-1")
+    payload = ["first"]
+    result.record("request", values=payload)
+    payload.append("second")
+    assert result.events == [{"kind": "request", "values": ["first"]}]
+    with pytest.raises(ScenarioFailure, match="one commit") as captured:
+        result.require("one commit", False)
+    assert captured.value.result is result
+    assert result.checks == {"one commit": False}
+    with pytest.raises(ValueError, match="duplicate"):
+        result.require("one commit", True)
+    with pytest.raises(TypeError):
+        result.record("bad", value=object())
+    with pytest.raises(ValueError):
+        result.record("bad", value=float("nan"))
+    with pytest.raises(TypeError, match="bool"):
+        result.require("truthy", 1)  # type: ignore[arg-type]
+    assert len(result.events) == 2
+
+
+def test_seeded_decks_are_stable_and_cover_each_scenario() -> None:
+    registry = {(b, s): _passing for b in ("web", "android") for s in ("read", "retry")}
+    config = stress.RunConfig(iterations=12, seed=123)
+    plan = stress.build_plan(config, registry)
+    assert plan == stress.build_plan(config, dict(reversed(list(registry.items()))))
+    for offset in range(0, 12, 4):
+        assert {(p.backend, p.scenario) for p in plan[offset : offset + 4]} == set(registry)
+    assert len({p.operation_id for p in plan}) == 12
+    assert plan != stress.build_plan(stress.RunConfig(iterations=12, seed=124), registry)
+    selected = stress.build_plan(
+        stress.RunConfig(backend="web", scenarios=("retry",), iterations=3), registry
+    )
+    assert {(p.backend, p.scenario) for p in selected} == {("web", "retry")}
+    with pytest.raises(ValueError, match="unknown scenario"):
+        stress.build_plan(stress.RunConfig(scenarios=("missing",)), registry)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"iterations": 0},
+        {"iterations": 100_001},
+        {"concurrency": 65},
+        {"timeout": float("inf")},
+        {"scenario_timeout": float("nan")},
+        {"cleanup_timeout": -1},
+    ],
+)
+def test_invalid_config_is_rejected(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        stress.RunConfig(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_worker_pool_bounds_concurrency_and_keeps_complete_plan() -> None:
+    active = maximum = 0
+    two_started = asyncio.Event()
+
+    async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        nonlocal active, maximum
+        active += 1
+        maximum = max(maximum, active)
+        if active == 2:
+            two_started.set()
+        try:
+            await two_started.wait()
+            await asyncio.sleep(0)
+            return await _passing(name, operation_id=operation_id, result=result)
+        finally:
+            active -= 1
+
+    report = await stress.run_stress(
+        stress.RunConfig(iterations=7, concurrency=2), {("web", "read"): scenario}
+    )
+    assert maximum == 2 and active == 0
+    assert report["summary"]["passed"] == 7 and report["summary"]["ok"]
+    assert len(report["plan"]) == len(report["operations"]) == 7
+    assert all(op["events"][1]["kind"] == "plan" for op in report["operations"])
+    json.dumps(report, allow_nan=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["check", "exception", "empty", "identity", "false"])
+async def test_failed_scenarios_preserve_trace_and_fail_report(mode: str) -> None:
+    async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("server_received", attempt=1)
+        try:
+            if mode == "check":
+                result.require("no replay", False)
+            if mode == "exception":
+                raise RuntimeError("handler crashed")
+            if mode == "identity":
+                return ScenarioResult("web", name, operation_id)
+            if mode == "false":
+                result.checks["no replay"] = False
+            return result
+        finally:
+            result.record("cleanup", completed=True)
+
+    report = await stress.run_stress(stress.RunConfig(iterations=1), {("web", "read"): scenario})
+    assert report["summary"]["failed"] == 1 and not report["summary"]["ok"]
+    operation = report["operations"][0]
+    assert operation["events"][-1] == {"kind": "cleanup", "completed": True}
+    assert operation["error"]
+
+
+@pytest.mark.asyncio
+async def test_scenario_timeout_cancels_work_and_retains_cleanup_events() -> None:
+    cleaned = asyncio.Event()
+
+    async def stalled(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["stall"])
+        try:
+            await asyncio.Event().wait()
+        finally:
+            result.record("cleanup", completed=True)
+            cleaned.set()
+        return result
+
+    report = await stress.run_stress(
+        stress.RunConfig(iterations=2, concurrency=1, scenario_timeout=0.02),
+        {("web", "stall"): stalled},
+    )
+    assert cleaned.is_set()
+    assert report["summary"]["timed_out"] == 2 and not report["summary"]["ok"]
+    assert all(op["events"][-1]["kind"] == "cleanup" for op in report["operations"])
+    assert not [t for t in asyncio.all_tasks() if t.get_name().startswith("fault-")]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_timeout_preserves_unstarted_plan_and_cancels_active_work() -> None:
+    cleaned: list[str] = []
+
+    async def stalled(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["stall"])
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleaned.append(operation_id)
+            result.record("cleanup", completed=True)
+        return result
+
+    report = await stress.run_stress(
+        stress.RunConfig(iterations=5, concurrency=2, timeout=0.02), {("web", "stall"): stalled}
+    )
+    assert len(cleaned) == 2
+    assert report["summary"]["canceled"] == 2
+    assert report["summary"]["not_started"] == 3
+    assert not report["summary"]["ok"] and report["failures"]
+    assert len(report["plan"]) == 5
+    assert not [t for t in asyncio.all_tasks() if t.get_name().startswith("fault-")]
+
+
+@pytest.mark.asyncio
+async def test_external_cancellation_returns_partial_failure_report() -> None:
+    started = asyncio.Event()
+
+    async def stalled(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            result.record("cleanup")
+        return result
+
+    task = asyncio.create_task(
+        stress.run_stress(stress.RunConfig(iterations=2), {("web", "stall"): stalled})
+    )
+    await started.wait()
+    task.cancel()
+    report = await task
+    assert report["failures"] == ["run interrupted"]
+    assert not report["summary"]["ok"]
+
+
+def test_environment_isolated_once_and_restored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", "do-not-run")
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://do-not-contact.invalid")
+    monkeypatch.setenv("NOTEBOOKLM_PROFILE", "original")
+    original_home = os.environ.get("HOME")
+    with stress.isolated_environment():
+        assert "NOTEBOOKLM_REFRESH_CMD" not in os.environ
+        assert "NOTEBOOKLM_BASE_URL" not in os.environ
+        assert os.environ["NOTEBOOKLM_PROFILE"] == "agent-fault-stress"
+        isolated = Path(os.environ["NOTEBOOKLM_HOME"])
+        assert isolated.is_dir()
+        assert os.environ.get("HOME") == original_home
+        os.environ["NOTEBOOKLM_ADDED_DURING_TEST"] = "temporary"
+    assert not isolated.exists()
+    assert os.environ["NOTEBOOKLM_REFRESH_CMD"] == "do-not-run"
+    assert os.environ["NOTEBOOKLM_PROFILE"] == "original"
+    assert "NOTEBOOKLM_ADDED_DURING_TEST" not in os.environ
+
+
+@pytest.mark.parametrize("failure", [False, True])
+def test_cli_writes_report_and_returns_failed_invariant_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, failure: bool
+) -> None:
+    async def scenario(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["commit_then_disconnect"])
+        result.require("one commit", not failure)
+        return result
+
+    monkeypatch.setattr(stress, "load_registry", lambda _: {("web", "read"): scenario})
+    destination = tmp_path / "nested" / "report.json"
+    code = stress.main(["--iterations", "2", "--json-report", str(destination)])
+    report = json.loads(destination.read_text())
+    assert code == int(failure)
+    assert report["summary"]["ok"] is not failure
+    assert len(report["plan"]) == 2
+    assert not list(destination.parent.glob(".report.json.*"))
+
+
+def test_cli_rejects_invalid_arguments_before_loading_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected(_: str) -> Any:
+        raise AssertionError("backend loaded for invalid arguments")
+
+    monkeypatch.setattr(stress, "load_registry", unexpected)
+    with pytest.raises(SystemExit) as captured:
+        stress.main(["--timeout", "nan"])
+    assert captured.value.code == 2
+
+
+def test_cli_backend_loading_failure_still_writes_failure_report(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def missing_dependency(_: str) -> Any:
+        raise ImportError("install dev dependencies")
+
+    monkeypatch.setattr(stress, "load_registry", missing_dependency)
+    destination = tmp_path / "report.json"
+    assert stress.main(["--json-report", str(destination)]) == 1
+    report = json.loads(destination.read_text())
+    assert not report["summary"]["ok"]
+    assert "ImportError" in report["failures"][0]
+
+
+def test_cli_aggregate_timeout_writes_partial_report(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def stalled(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        result.record("plan", faults=["stall"])
+        try:
+            await asyncio.Event().wait()
+        finally:
+            result.record("cleanup", completed=True)
+        return result
+
+    monkeypatch.setattr(stress, "load_registry", lambda _: {("web", "stall"): stalled})
+    destination = tmp_path / "report.json"
+    assert (
+        stress.main(
+            [
+                "--iterations",
+                "2",
+                "--concurrency",
+                "1",
+                "--timeout",
+                "0.02",
+                "--json-report",
+                str(destination),
+            ]
+        )
+        == 1
+    )
+    report = json.loads(destination.read_text())
+    assert report["summary"]["canceled"] == 1
+    assert report["summary"]["not_started"] == 1
+    assert report["operations"][0]["events"][-1]["kind"] == "cleanup"
+
+
+def test_cli_reports_a_leaked_child_even_when_it_cancels_cleanly() -> None:
+    cleaned = False
+
+    async def child() -> None:
+        nonlocal cleaned
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleaned = True
+
+    async def leaks(name: str, *, operation_id: str, result: ScenarioResult) -> ScenarioResult:
+        asyncio.create_task(child(), name="unexpected-child")
+        result.require("misleading cleanup claim", True)
+        return result
+
+    report = stress._run_cli(stress.RunConfig(iterations=1), {("web", "leak"): leaks})
+    assert not report["summary"]["ok"]
+    assert any("leaked tasks" in failure for failure in report["failures"])
+    assert cleaned
+
+
+def test_cli_bounds_cancellation_resistant_cleanup_in_subprocess() -> None:
+    # A broken coroutine must not strand pytest's own event loop. The CLI owns
+    # its loop and reports shutdown failure even when a scenario swallows cancel.
+    source = """
+import asyncio
+from scripts import stress_fault_server as stress
+
+async def broken(name, *, operation_id, result):
+    result.record('plan', faults=['cancellation-resistant'])
+    while True:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pass
+
+config = stress.RunConfig(iterations=1, timeout=0.02, scenario_timeout=0.01, cleanup_timeout=0.02)
+report = stress._run_cli(config, {('web', 'broken'): broken})
+assert not report['summary']['ok']
+assert any('pending tasks' in failure for failure in report['failures'])
+print('bounded cleanup failure recorded')
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", source],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "bounded cleanup failure recorded" in completed.stdout


### PR DESCRIPTION
## Summary

Add a local fault-injection harness that runs the real Web and Android clients against scripted HTTP and gRPC services. It verifies retry budgets, authentication recovery, streaming failures, cancellation, cleanup, and writes that commit before their response is lost, without a NotebookLM account or live service.

## Changes

- Add 16 Web and 9 Android scenarios shared by integration tests and a seeded concurrent stress runner. Real socket traffic and independent server request/commit journals verify public results, bounded replay, credential transitions, and cleanup.
- Exercise production Web session refresh and Android bearer authentication using synthetic credentials. Reject unmapped network destinations and isolate configuration from local profiles.
- Preserve scenario assignments, plans, checks, partial traces, and cleanup failures in JSON reports. Return nonzero on failed invariants, deadlines, leaked tasks, or unhandled background exceptions.
- Run 64 cohorts on each PR and 400 daily or on manual dispatch, with report artifacts and no secrets.
- Stabilize five existing deadline tests found during full coverage and Windows validation: explicitly hold MCP queue ordering and allow operations to reach dispatch before their real deadline. Preserve timeout/commit-metadata assertions and verify dispatch and cancellation evidence.
- Document usage, extension points, and limits in `docs/fault-injection.md` and ADR-0038; register real-socket integration exceptions in the existing taxonomy.

## Test Plan

- [x] Full ordinary suite with coverage: 18,932 passed, 73 skipped.
- [x] 400 concurrent cohorts: all 25 scenarios, 256 Web and 144 Android, zero failures or leaked tasks.
- [x] Repository lint and refactor qualification: 2,449 passed, one skipped, one expected failure.
- [x] GitHub compatibility matrix: Python 3.10–3.14 on Linux, Python 3.12 on macOS and Windows; all seven jobs passed. Code Quality and CodeQL passed.
- [x] GitHub fault-stress job: all 64 cohorts and all 25 scenarios passed; diagnostic artifact verified.
- [x] Python 3.10: 74 fault integration/helper/runner tests passed.
- [x] All 32 MCP chat-start tests and 102 Android session/operation-context tests passed with and without coverage after correcting their timing assumptions.
- [x] Browser lane: 86 passed, one platform skip; both required external-reality probes passed.
- [x] Coverage: 95.26%; all five per-file floors met.
- [x] Pre-commit, configured mypy, taxonomy, workflow policy, API compatibility, fixture sanitization, and base-wheel smoke checks passed.
- [x] Android contributor instructions include `--extra android`; architectural rationale is recorded in ADR-0038.

## Notes

This changes tests, development tooling, documentation, and CI; it does not change production code or installed commands. HTTP uses the HTTPX transport over local HTTP/1.1 with connection-close responses. Android uses local insecure gRPC with generated protobufs and the real bearer provider backed by a synthetic issuer. TLS/DNS failures, stale pooled HTTP connections, curl-cffi, browser login, real Google issuance, and kernel packet loss remain outside the modeled faults.
