### PR TITLE
docs: document MCP/REST hosting threat model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Ubuntu/macOS/Windows × Python 3.10–3.14 matrix now runs only in the nightly
   workflow, and manual nightly dispatches include it by default.
 
+### Documentation
+
+- **MCP/REST hosting threat model (`SECURITY.md`).** Operator-facing security
+  docs no longer claim the CLI has "no long-lived API keys or OAuth tokens".
+  They now document that `master_token.json` is account-equivalent, MCP OAuth
+  refresh tokens are long-lived (rotating `NOTEBOOKLM_MCP_OAUTH_PASSWORD` does
+  not revoke them), stdio `source_add(path)` reads server-host files, `/files/dl`
+  and `/files/ul` are HMAC-URL auth only, open OAuth DCR does not bypass the
+  login password, MCP loopback HTTP may be tokenless while REST always requires
+  `NOTEBOOKLM_SERVER_TOKEN`, `GET /healthz` is liveness not readiness, and
+  `pip-audit` in CI still exports `browser+dev+markdown` by default.
+  ([#2387](https://github.com/teng-lin/notebooklm-py/issues/2387))
+
 ### Removed
 
 - Removed six deprecated private `_auth` compatibility modules earlier than their documented

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,7 @@ By default, files are stored per-profile under `~/.notebooklm/profiles/<profile>
 
 4. **If credentials are compromised**
    - Immediately revoke access at [Google Security Settings](https://myaccount.google.com/permissions)
+   - For a leaked master token, remove its associated device/session in [Google Account security](https://myaccount.google.com/device-activity). A password change or deleting local files alone does not revoke an attacker's copy; see [master-token troubleshooting](docs/troubleshooting.md#authentication-errors)
    - Delete the `~/.notebooklm/` directory **and** any MCP OAuth state file (`<home>/oauth/*.json` or `NOTEBOOKLM_MCP_OAUTH_STATE_PATH`)
    - Restart any `notebooklm-mcp` / `notebooklm-server` process that had the files open
    - Re-authenticate with `notebooklm login`
@@ -135,8 +136,9 @@ is not implemented here.
 MCP `/files/dl` and `/files/ul` are HMAC-URL auth only (not bearer/OAuth). A
 browser opening a signed link cannot carry the MCP credential, and FastMCP does
 not wrap these custom routes with the MCP bearer/OAuth gate. A leaked URL is a
-timed capability (upload TTL 15 min, download TTL 30 min; tokens die on process
-restart because the signing key is ephemeral). See
+timed capability: ordinary upload links last 15 minutes, widget upload pools
+last 60 minutes, and download links last 30 minutes. Upload links can be consumed
+earlier; all tokens die on process restart because the signing key is ephemeral. See
 [ADR-0024](docs/adr/0024-mcp-remote-file-transfer.md).
 
 ### Loopback vs token
@@ -146,16 +148,22 @@ restart because the signing key is ephemeral). See
   server can run without a bearer. The Host-header DNS-rebinding guard remains
   (requests whose `Host` is not a loopback literal are rejected). The
   `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` flag alone does not drop that guard.
-- **REST always requires `NOTEBOOKLM_SERVER_TOKEN`.** `notebooklm-server` refuses
-  to start without it. Every `/v1` route also requires a loopback `Host` (and
-  loopback peer unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1`).
+- **REST always requires a bearer token.** Configure it with `--token-file` /
+  `NOTEBOOKLM_SERVER_TOKEN_FILE` (preferred), or `NOTEBOOKLM_SERVER_TOKEN`.
+  `notebooklm-server` refuses to start without a token. By default every `/v1`
+  route requires both a loopback peer and a loopback `Host`.
+  `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1` disables both loopback checks,
+  including the Host-header rebinding guard; bearer authentication stays required.
 
 ### `GET /healthz` is liveness, not readiness
 
 REST `GET /healthz` is a public, token-less **liveness** probe. It returns
-`{"ok": true}` even when the NotebookLM client failed to open (stale auth,
-missing profile). It does not report version, account, or whether `/v1` can
-serve. Readiness would be a separate contract and is not implemented.
+`{"ok": true}` when startup catches an authentication failure (for example,
+stale credentials or a missing profile) and keeps the app running without an
+open NotebookLM client. Other startup failures, including network errors,
+abort startup and leave the endpoint unavailable. It does not report version,
+account, or whether `/v1` can serve. Readiness would be a separate contract and
+is not implemented.
 
 ## Dependency Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,11 @@ If you discover a security vulnerability, please report it by:
 
 ## Credential Security
 
-This library stores authentication credentials locally. Please understand these security considerations:
+This library stores authentication credentials locally. Please understand these security considerations.
+
+The in-process credential model (owners, recovery, cancellation) is in
+[docs/security.md](docs/security.md). This file is the operator-facing threat model for
+those files **and** for the experimental MCP/REST hosts that open them.
 
 ### Storage Locations
 
@@ -28,20 +32,23 @@ By default, files are stored per-profile under `~/.notebooklm/profiles/<profile>
 
 | File Path | Contents | Permissions |
 |-----------|----------|-------------|
-| `profiles/<profile>/storage_state.json` | Google session cookies | `0o600` (owner-only) |
+| `profiles/<profile>/storage_state.json` | Google session cookies (Web) | `0o600` (owner-only) |
+| `profiles/<profile>/master_token.json` | Google master token (Android / headless). **Account-equivalent** — it can mint new sessions | `0o600` (owner-only) |
 | `profiles/<profile>/browser_profile/` | Playwright Chromium profile | `0o700` (owner-only) |
 | `profiles/<profile>/context.json` | Active profile context / metadata | `0o600` (owner-only) |
+| `oauth/<slug>.json` | MCP self-hosted OAuth clients + **long-lived refresh tokens** (deployment-scoped; override with `NOTEBOOKLM_MCP_OAUTH_STATE_PATH`) | `0o600` (owner-only) |
 | `config.json` | Global CLI config (e.g. language/active profile) | Default |
 | `storage_state.json` *(legacy)* | Fallback root storage state (for `default` profile) | `0o600` (owner-only) |
+| `master_token.json` *(legacy)* | Fallback root master token | `0o600` (owner-only) |
 | `browser_profile/` *(legacy)* | Fallback root Playwright profile | `0o700` (owner-only) |
 | `context.json` *(legacy)* | Fallback root active notebook context | `0o600` (owner-only, POSIX) |
 
 ### Security Best Practices
 
 1. **Protect your credentials**
-   - The `storage_state.json` file contains your Google session cookies
-   - Anyone with access to this file can impersonate your Google account to NotebookLM
-   - Never share, commit, or expose this file
+   - `storage_state.json` contains live Google session cookies
+   - `master_token.json` is Google-account equivalent (Android / headless). Anyone with that file can mint new NotebookLM sessions for the account
+   - Never share, commit, or expose either file. Treat the MCP OAuth state file the same way
 
 2. **Add to .gitignore**
    ```gitignore
@@ -49,27 +56,106 @@ By default, files are stored per-profile under `~/.notebooklm/profiles/<profile>
    ```
 
 3. **Credential rotation**
-   - Re-run `notebooklm login` periodically to refresh credentials
+   - Re-run `notebooklm login` periodically to refresh Web cookies
    - Sessions typically last days to weeks before expiring
+   - Rotate or revoke a master token immediately if its file may have been exposed
 
 4. **If credentials are compromised**
    - Immediately revoke access at [Google Security Settings](https://myaccount.google.com/permissions)
-   - Delete the `~/.notebooklm/` directory
+   - Delete the `~/.notebooklm/` directory **and** any MCP OAuth state file (`<home>/oauth/*.json` or `NOTEBOOKLM_MCP_OAUTH_STATE_PATH`)
+   - Restart any `notebooklm-mcp` / `notebooklm-server` process that had the files open
    - Re-authenticate with `notebooklm login`
 
 5. **CI/CD usage**
    - Do not commit credentials to repositories
-   - Use `NOTEBOOKLM_AUTH_JSON` environment variable for secure, file-free authentication
+   - Use `NOTEBOOKLM_AUTH_JSON` environment variable for secure, file-free Web authentication
    - Store the JSON value in GitHub Secrets or similar secure secret management
    - The env var approach keeps credentials in memory only, never written to disk
+   - Do not put a `master_token.json` or OAuth state file in CI logs or shared artifact stores
 
 ### What This Library Does NOT Do
 
 - Does not transmit credentials to any third party
-- Does not store passwords (uses browser-based OAuth)
-- Does not access data outside of NotebookLM except for user-selected local files
-  and opt-in browser-cookie extraction during login/refresh
+- Does not store Google account passwords (CLI login is browser-based; MCP OAuth uses a separate operator-set `NOTEBOOKLM_MCP_OAUTH_PASSWORD`)
+- Does not access data outside of NotebookLM except for operator-selected local files (CLI file add; MCP stdio `source_add(path=...)` reads a **server-host** path the process can open — see below), opt-in browser-cookie extraction during login/refresh, and the experimental MCP/REST hosts described below
 - Does not modify Google account settings
+
+## MCP and REST hosting
+
+`notebooklm-mcp` and `notebooklm-server` are **experimental, single-tenant** adapters. They are not a multi-tenant product and are not covered by the library's semver guarantees. Both front account-equivalent Google credentials for whoever can reach the process.
+
+Operator setup: [docs/mcp-guide.md](docs/mcp-guide.md) and
+[docs/installation.md#rest-api-server](docs/installation.md#rest-api-server).
+Signed MCP file links: [ADR-0024](docs/adr/0024-mcp-remote-file-transfer.md).
+
+### Master tokens
+
+`master_token.json` is Google-account equivalent, not a weaker sibling of
+`storage_state.json`. The Android backend mints short-lived bearers from it; headless
+Web recovery can mint cookies from it. A leaked master token is a durable account
+credential. See [docs/security.md](docs/security.md).
+
+### MCP OAuth refresh tokens
+
+`notebooklm-mcp` HTTP + OAuth (`NOTEBOOKLM_MCP_OAUTH_PASSWORD` +
+`NOTEBOOKLM_MCP_OAUTH_BASE_URL`) **does** issue long-lived tokens. Refresh tokens are
+long-lived and written `0600` under the OAuth state file (default
+`<home>/oauth/<slug>.json`, keyed on the issuer; override with
+`NOTEBOOKLM_MCP_OAUTH_STATE_PATH`). Treat that file as a full-account secret, same
+tier as `master_token.json`.
+
+Rotating `NOTEBOOKLM_MCP_OAUTH_PASSWORD` does not revoke already-issued refresh
+tokens. Real revocation is delete that file + restart. A legacy profile-dir
+`oauth_state.json` that was migrated once is renamed `.migrated` and is never
+re-read, so deleting the live file does not resurrect those tokens.
+
+Open OAuth Dynamic Client Registration (DCR) lets a caller register a client
+without the login password. Registering a client does not bypass the login
+password: phishing still requires the owner to authenticate on `/login`. The
+login page shows the (escaped) redirect target so a rogue client is visible
+before the password is typed.
+
+### Stdio `source_add(path=...)`
+
+On **stdio**, `source_add(source_type="file", path=...)` reads a file on the
+**server host**, not on the MCP client. The process opens whatever regular file
+path the server user can read (after `~` expansion and the existing
+non-symlink / regular-file checks). A prompt-injected path under
+`~/.notebooklm/` can therefore upload `storage_state.json` or `master_token.json`
+into a notebook.
+
+Remote HTTP does **not** open a host `path` for file add; it returns a signed
+upload URL instead (or `source_add(..., bytes_base64=...)` for a tiny in-channel
+file). There is currently no allowed-roots restriction on stdio; tightening that
+is tracked in [#2385](https://github.com/teng-lin/notebooklm-py/issues/2385) and
+is not implemented here.
+
+### Signed `/files/dl` and `/files/ul` URLs
+
+MCP `/files/dl` and `/files/ul` are HMAC-URL auth only (not bearer/OAuth). A
+browser opening a signed link cannot carry the MCP credential, and FastMCP does
+not wrap these custom routes with the MCP bearer/OAuth gate. A leaked URL is a
+timed capability (upload TTL 15 min, download TTL 30 min; tokens die on process
+restart because the signing key is ephemeral). See
+[ADR-0024](docs/adr/0024-mcp-remote-file-transfer.md).
+
+### Loopback vs token
+
+- **MCP loopback HTTP may be tokenless.** `NOTEBOOKLM_MCP_TOKEN` / OAuth is
+  required to bind a **non-loopback** interface. A default `127.0.0.1` HTTP
+  server can run without a bearer. The Host-header DNS-rebinding guard remains
+  (requests whose `Host` is not a loopback literal are rejected). The
+  `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` flag alone does not drop that guard.
+- **REST always requires `NOTEBOOKLM_SERVER_TOKEN`.** `notebooklm-server` refuses
+  to start without it. Every `/v1` route also requires a loopback `Host` (and
+  loopback peer unless `NOTEBOOKLM_SERVER_ALLOW_EXTERNAL_BIND=1`).
+
+### `GET /healthz` is liveness, not readiness
+
+REST `GET /healthz` is a public, token-less **liveness** probe. It returns
+`{"ok": true}` even when the NotebookLM client failed to open (stale auth,
+missing profile). It does not report version, account, or whether `/v1` can
+serve. Readiness would be a separate contract and is not implemented.
 
 ## Dependency Security
 
@@ -90,6 +176,12 @@ extras:
 
 ### Auditing Dependencies
 
+`pip-audit` in CI still exports `browser+dev+markdown` by default
+(`.github/workflows/dependency-audit.yml`). That is the CLI/contributor graph.
+The **internet-facing** graph for a hosted MCP or REST deployment is the `mcp`
+and/or `server` extras; audit those before exposing `notebooklm-mcp` or
+`notebooklm-server`.
+
 ```bash
 # Mirror CI: audit the locked selected-extra graph
 uv sync --frozen --extra browser --extra dev --extra markdown
@@ -97,7 +189,7 @@ uv run python -m pip install "pip-audit>=2.7.0,<3"
 uv export --frozen --extra browser --extra dev --extra markdown --format requirements-txt --no-emit-project \
   | uv run pip-audit --strict --require-hashes --disable-pip -r /dev/stdin
 
-# Release/security sweep: include maintained MCP + REST server extras too
+# Hosted MCP/REST (internet-facing graph) — include those extras too
 uv export --frozen --extra browser --extra dev --extra markdown --extra mcp --extra server \
   --format requirements-txt --no-emit-project \
   | uv run pip-audit --strict --require-hashes --disable-pip -r /dev/stdin
@@ -119,9 +211,10 @@ This library uses Google's internal APIs, which means:
 
 ### Session Security
 
-- Sessions are cookie-based (standard web authentication)
+- CLI/Web sessions are cookie-based (standard web authentication)
 - CSRF tokens are required and automatically handled
-- No long-lived API keys or OAuth tokens
+- The CLI does not mint Google API keys. `notebooklm-mcp` HTTP + OAuth **does**
+  issue long-lived refresh tokens (see [MCP OAuth refresh tokens](#mcp-oauth-refresh-tokens))
 
 ## Questions?
 

--- a/docs/adr/0024-mcp-remote-file-transfer.md
+++ b/docs/adr/0024-mcp-remote-file-transfer.md
@@ -4,7 +4,8 @@
 
 Accepted. Implemented (`mcp/_filelink.py`, `mcp/_fileroutes.py`,
 `mcp/_uploadwidget.py`); referenced as Accepted from
-[architecture.md](../architecture.md).
+[architecture.md](../architecture.md). Operator-facing threat model:
+[SECURITY.md](../../SECURITY.md).
 
 ## Context
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -452,7 +452,7 @@ Configuration is read from `NOTEBOOKLM_SERVER_*` env vars (overridable by the ma
 
 The concurrency knobs are route-group backpressure for expensive work. They do not gate `/healthz` or cheap read/list/poll routes.
 
-**Surface:** every route is under `/v1` and requires `Authorization: Bearer <token>` plus a loopback `Host` header (a DNS-rebinding guard). `/healthz` is the one public, token-less **liveness** probe — it returns `{"ok": true}` even when the NotebookLM client failed to open. Readiness would be a separate contract. The auto-generated `/docs` / `/openapi.json` schema UI is disabled (it would otherwise be reachable token-less). Operator threat model: [SECURITY.md](../SECURITY.md).
+**Surface:** every `/v1` route requires `Authorization: Bearer <token>` plus a loopback `Host` header (a DNS-rebinding guard). `/healthz` is the one public, token-less **liveness** probe — it returns `{"ok": true}` even when the NotebookLM client failed to open. Readiness would be a separate contract. The auto-generated `/docs` / `/openapi.json` schema UI is disabled (it would otherwise be reachable token-less). Operator threat model: [SECURITY.md](../SECURITY.md).
 
 <!-- not mirrored: REST-server curl examples (end-user/automation tooling); not part of the contributor install flow. -->
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -452,7 +452,7 @@ Configuration is read from `NOTEBOOKLM_SERVER_*` env vars (overridable by the ma
 
 The concurrency knobs are route-group backpressure for expensive work. They do not gate `/healthz` or cheap read/list/poll routes.
 
-**Surface:** every route is under `/v1` and requires `Authorization: Bearer <token>` plus a loopback `Host` header (a DNS-rebinding guard). `/healthz` is the one public, token-less route. The auto-generated `/docs` / `/openapi.json` schema UI is disabled (it would otherwise be reachable token-less).
+**Surface:** every route is under `/v1` and requires `Authorization: Bearer <token>` plus a loopback `Host` header (a DNS-rebinding guard). `/healthz` is the one public, token-less **liveness** probe — it returns `{"ok": true}` even when the NotebookLM client failed to open. Readiness would be a separate contract. The auto-generated `/docs` / `/openapi.json` schema UI is disabled (it would otherwise be reachable token-less). Operator threat model: [SECURITY.md](../SECURITY.md).
 
 <!-- not mirrored: REST-server curl examples (end-user/automation tooling); not part of the contributor install flow. -->
 ```bash

--- a/docs/mcp-guide.md
+++ b/docs/mcp-guide.md
@@ -16,6 +16,7 @@ behaves identically to `notebooklm <command>`.
 See the [MCP subsystem diagram](https://teng-lin.github.io/notebooklm-py/diagrams/17-mcp-subsystem.html) for process and
 application boundaries. Remote file movement is expanded in the
 [transfer-security data flow](https://teng-lin.github.io/notebooklm-py/diagrams/30-transfer-security-boundaries.dataflow.html).
+The operator-facing hosting threat model is [SECURITY.md](../SECURITY.md).
 
 ## Install
 
@@ -121,9 +122,13 @@ There is no `--token` flag — the HTTP bearer token is **env-only**
 `stdio` is right for Claude Desktop/Code, Cursor, and Windsurf (they launch the server as a
 subprocess). Use `http` for a local web client or to share one running server across clients on
 the same machine. The HTTP transport is loopback-only by default; binding to a non-loopback
-address requires **both** the explicit `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` override **and** a
-`NOTEBOOKLM_MCP_TOKEN` — the server fails closed (refuses to start) on a network bind without a
-token, since it fronts a full Google account.
+address requires **both** the explicit `NOTEBOOKLM_MCP_ALLOW_EXTERNAL_BIND=1` override **and**
+auth (`NOTEBOOKLM_MCP_TOKEN` and/or OAuth) — the server fails closed (refuses to start) on a
+network bind without auth, since it fronts a full Google account.
+
+**Loopback HTTP may be tokenless.** A default `127.0.0.1` bind does not require
+`NOTEBOOKLM_MCP_TOKEN`. The Host-header DNS-rebinding guard still rejects requests whose
+`Host` is not a loopback literal. See [SECURITY.md](../SECURITY.md).
 
 ## Remote deployment (Docker + a tunnel)
 
@@ -149,6 +154,11 @@ before you start: the auth model and remote file transfer.
 
 Use a **dedicated/throwaway Google account** — the mounted `master_token.json` is a durable
 full-account credential. Multi-tenant hosting is out of scope for this single-tenant setup.
+
+**OAuth tokens outlive the password.** Refresh tokens are long-lived and written `0600` to
+the OAuth state file. Rotating `NOTEBOOKLM_MCP_OAUTH_PASSWORD` does not revoke them; real
+revocation is delete that file and restart. Open DCR (registering a client) does **not**
+bypass the login password — phishing still requires the owner to authenticate.
 
 **Where OAuth state lives.** The registered clients + issued tokens persist to a
 deployment-scoped file keyed on `NOTEBOOKLM_MCP_OAUTH_BASE_URL` (the OAuth issuer), **not**
@@ -217,9 +227,12 @@ bearer-only deploy → the two file tools return a clear "not configured" error
   stream against it and rejects a corrupted transfer with a clean 400 (retryable) *before*
   adding the source.
 - Links are HMAC-signed and short-lived (upload 15 min, download 30 min) and expire on
-  a server restart. Google Drive (`source_add` with a Drive id) remains a no-browser
-  alternative for adding files. stdio (local) installs are unchanged — they still read
-  and write real local paths directly.
+  a server restart. `/files/dl` and `/files/ul` are HMAC-URL auth only (not bearer/OAuth);
+  a leaked URL is a timed capability ([ADR-0024](adr/0024-mcp-remote-file-transfer.md),
+  [SECURITY.md](../SECURITY.md)). Google Drive (`source_add` with a Drive id) remains a
+  no-browser alternative for adding files. stdio (local) installs are unchanged — they
+  still read and write real **server-host** paths directly (`source_add(path=...)` opens
+  a file on the machine running `notebooklm-mcp`, not on the MCP client).
 
 ## Core concepts
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -118,3 +118,13 @@ is pinned in [development.md](development.md); those values are evidence and not
 5. Rotate or revoke a master token immediately if its file may have been exposed.
 6. Preserve the canonical lock files and atomic writers; custom writers must retain the documented
    locking, permissions, and exact-path behavior.
+
+## Hosted adapters (MCP / REST)
+
+`storage_state.json` and `master_token.json` remain account-equivalent when an
+experimental MCP or REST process opens them. The operator-facing threat model —
+MCP OAuth refresh tokens, signed `/files/dl` and `/files/ul` HMAC URLs, stdio
+`source_add(path=...)` server-host reads, loopback vs token, and `GET /healthz`
+liveness — lives in [SECURITY.md](../SECURITY.md). See also
+[mcp-guide.md](mcp-guide.md) and
+[ADR-0024](adr/0024-mcp-remote-file-transfer.md).

--- a/tests/_guardrails/test_security_md_hosting_threat_model.py
+++ b/tests/_guardrails/test_security_md_hosting_threat_model.py
@@ -116,15 +116,14 @@ def hosting_threat_model_gaps(security_md: str) -> list[str]:
     if "rebinding" not in compact.lower():
         gaps.append("DNS-rebinding guard")
     if not (
-        "NOTEBOOKLM_SERVER_TOKEN" in compact
+        "NOTEBOOKLM_SERVER_TOKEN_FILE" in compact
         and re.search(
-            r"(REST|notebooklm-server).{0,160}NOTEBOOKLM_SERVER_TOKEN"
-            r"|NOTEBOOKLM_SERVER_TOKEN.{0,160}(required|always|refuses)",
+            r"REST.{0,80}always requires a bearer token",
             compact,
             re.IGNORECASE,
         )
     ):
-        gaps.append("REST always requires NOTEBOOKLM_SERVER_TOKEN")
+        gaps.append("REST always requires a bearer token, with token-file support")
 
     if not (
         "/healthz" in compact

--- a/tests/_guardrails/test_security_md_hosting_threat_model.py
+++ b/tests/_guardrails/test_security_md_hosting_threat_model.py
@@ -1,0 +1,244 @@
+"""Pin the operator MCP/REST hosting threat model in ``SECURITY.md`` (#2387).
+
+``SECURITY.md`` once described a CLI cookie client and claimed
+``No long-lived API keys or OAuth tokens``. That is false for
+``notebooklm-mcp`` HTTP + OAuth. This gate fails if that claim returns
+without the MCP OAuth correction, and requires the listed hosting facts
+plus links to ``docs/security.md``, ``docs/mcp-guide.md``, and ADR-0024.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.repo_lint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SECURITY_MD = REPO_ROOT / "SECURITY.md"
+DOCS_SECURITY = REPO_ROOT / "docs" / "security.md"
+MCP_GUIDE = REPO_ROOT / "docs" / "mcp-guide.md"
+ADR_0024 = REPO_ROOT / "docs" / "adr" / "0024-mcp-remote-file-transfer.md"
+
+FALSE_NO_LONG_LIVED_CLAIM = re.compile(
+    r"No long-lived API keys or OAuth tokens",
+    re.IGNORECASE,
+)
+
+
+def _normalized(text: str) -> str:
+    """Strip emphasis markers and collapse whitespace for prose matching."""
+    return re.sub(r"\s+", " ", text.replace("**", "").replace("`", ""))
+
+
+def _has_mcp_oauth_correction(text: str) -> bool:
+    """Return whether *text* documents MCP OAuth refresh-token lifetime."""
+    compact = _normalized(text)
+    has_password = "NOTEBOOKLM_MCP_OAUTH_PASSWORD" in compact
+    has_no_revoke = re.search(
+        r"NOTEBOOKLM_MCP_OAUTH_PASSWORD.{0,160}does not revoke",
+        compact,
+        re.IGNORECASE,
+    )
+    has_refresh = re.search(
+        r"refresh tokens? are long-lived",
+        compact,
+        re.IGNORECASE,
+    )
+    return bool(has_password and has_no_revoke and has_refresh)
+
+
+def uncorrected_no_long_lived_oauth_claim(text: str) -> bool:
+    """True when the old Session Security bullet is back without the correction."""
+    if not FALSE_NO_LONG_LIVED_CLAIM.search(text):
+        return False
+    return not _has_mcp_oauth_correction(text)
+
+
+def hosting_threat_model_gaps(security_md: str) -> list[str]:
+    """Return missing operator facts in an operator-facing ``SECURITY.md`` body."""
+    compact = _normalized(security_md)
+    gaps: list[str] = []
+
+    if uncorrected_no_long_lived_oauth_claim(security_md):
+        gaps.append("uncorrected no-long-lived-oauth claim")
+    if not _has_mcp_oauth_correction(security_md):
+        gaps.append("MCP OAuth refresh-token correction")
+
+    if not re.search(
+        r"master_token\.json.{0,240}account-equivalent"
+        r"|account-equivalent.{0,240}master_token\.json",
+        compact,
+        re.IGNORECASE,
+    ):
+        gaps.append("master_token.json is account-equivalent")
+
+    if not re.search(
+        r"source_add.{0,120}path.{0,160}server[- ]host"
+        r"|server[- ]host.{0,120}source_add",
+        compact,
+        re.IGNORECASE,
+    ):
+        gaps.append("stdio source_add(path) reads server-host files")
+
+    if not (
+        "/files/dl" in compact
+        and "/files/ul" in compact
+        and "HMAC" in compact
+        and re.search(
+            r"HMAC.{0,160}(not|without).{0,60}(bearer|OAuth)",
+            compact,
+            re.IGNORECASE,
+        )
+    ):
+        gaps.append("/files/dl and /files/ul are HMAC-URL auth only")
+
+    if not (
+        re.search(r"\bDCR\b", compact)
+        and re.search(
+            r"(does not|cannot) bypass.{0,80}(login )?password",
+            compact,
+            re.IGNORECASE,
+        )
+    ):
+        gaps.append("open OAuth DCR does not bypass the login password")
+
+    if not re.search(
+        r"loopback.{0,120}tokenless|tokenless.{0,120}loopback",
+        compact,
+        re.IGNORECASE,
+    ):
+        gaps.append("MCP loopback HTTP may be tokenless")
+    if not re.search(r"Host-header|Host header", compact, re.IGNORECASE):
+        gaps.append("Host-header rebinding guard")
+    if "rebinding" not in compact.lower():
+        gaps.append("DNS-rebinding guard")
+    if not (
+        "NOTEBOOKLM_SERVER_TOKEN" in compact
+        and re.search(
+            r"(REST|notebooklm-server).{0,160}NOTEBOOKLM_SERVER_TOKEN"
+            r"|NOTEBOOKLM_SERVER_TOKEN.{0,160}(required|always|refuses)",
+            compact,
+            re.IGNORECASE,
+        )
+    ):
+        gaps.append("REST always requires NOTEBOOKLM_SERVER_TOKEN")
+
+    if not (
+        "/healthz" in compact
+        and "liveness" in compact.lower()
+        and "readiness" in compact.lower()
+        and re.search(r'\{\s*"ok"\s*:\s*true\s*\}', compact)
+    ):
+        gaps.append("GET /healthz is liveness not readiness")
+
+    if not (
+        "pip-audit" in compact
+        and re.search(
+            r"browser.{0,40}dev.{0,40}markdown|browser\+dev\+markdown",
+            compact,
+            re.IGNORECASE,
+        )
+        and re.search(r"\bmcp\b", compact, re.IGNORECASE)
+        and re.search(r"\bserver\b", compact, re.IGNORECASE)
+        and re.search(
+            r"internet-facing|internet facing",
+            compact,
+            re.IGNORECASE,
+        )
+    ):
+        gaps.append("pip-audit default extras vs MCP/REST extras")
+
+    if "docs/security.md" not in security_md:
+        gaps.append("link to docs/security.md")
+    if "docs/mcp-guide.md" not in security_md:
+        gaps.append("link to docs/mcp-guide.md")
+    if "ADR-0024" not in security_md:
+        gaps.append("ADR-0024 reference")
+    if "docs/adr/0024-mcp-remote-file-transfer.md" not in security_md:
+        gaps.append("link to ADR-0024 file")
+
+    if not re.search(r"0?600", compact):
+        gaps.append("OAuth state file mode 0600")
+    if not re.search(
+        r"delete.{0,80}(that file|the (OAuth )?state file|oauth).{0,80}restart"
+        r"|real revocation",
+        compact,
+        re.IGNORECASE,
+    ):
+        gaps.append("OAuth revocation is delete state file + restart")
+
+    return gaps
+
+
+def test_uncorrected_no_long_lived_claim_detector() -> None:
+    """The old Session Security bullet must fail until MCP OAuth is documented."""
+    old_session = (
+        "### Session Security\n"
+        "- Sessions are cookie-based (standard web authentication)\n"
+        "- CSRF tokens are required and automatically handled\n"
+        "- No long-lived API keys or OAuth tokens\n"
+    )
+    assert uncorrected_no_long_lived_oauth_claim(old_session)
+    assert "uncorrected no-long-lived-oauth claim" in hosting_threat_model_gaps(old_session)
+    assert "MCP OAuth refresh-token correction" in hosting_threat_model_gaps(old_session)
+
+    corrected = (
+        old_session
+        + "MCP HTTP + OAuth refresh tokens are long-lived. "
+        + "Rotating NOTEBOOKLM_MCP_OAUTH_PASSWORD does not revoke them.\n"
+    )
+    assert not uncorrected_no_long_lived_oauth_claim(corrected)
+    assert "uncorrected no-long-lived-oauth claim" not in hosting_threat_model_gaps(corrected)
+    assert "MCP OAuth refresh-token correction" not in hosting_threat_model_gaps(corrected)
+
+    assert not uncorrected_no_long_lived_oauth_claim("Sessions are cookie-based.\n")
+
+
+def test_security_md_documents_mcp_rest_hosting_threat_model() -> None:
+    """Operator-facing SECURITY.md must carry the MCP/REST hosting facts."""
+    text = SECURITY_MD.read_text(encoding="utf-8")
+    gaps = hosting_threat_model_gaps(text)
+    assert not gaps, (
+        "SECURITY.md is missing MCP/REST hosting threat-model facts "
+        "(issue #2387):\n- " + "\n- ".join(gaps)
+    )
+
+
+def test_linked_security_pages_retain_supporting_facts() -> None:
+    """Linked pages must keep the details SECURITY.md points operators at."""
+    docs_security = DOCS_SECURITY.read_text(encoding="utf-8")
+    assert "master_token.json" in docs_security
+    assert re.search(r"account-equivalent", docs_security, re.IGNORECASE)
+    assert "SECURITY.md" in docs_security
+
+    mcp_guide = MCP_GUIDE.read_text(encoding="utf-8")
+    compact = _normalized(mcp_guide)
+    assert "SECURITY.md" in mcp_guide
+    assert "ADR-0024" in mcp_guide
+    assert re.search(
+        r"source_add.{0,160}(server host|server-host|path)",
+        compact,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"NOTEBOOKLM_MCP_OAUTH_PASSWORD.{0,200}does not revoke"
+        r"|does not revoke.{0,200}NOTEBOOKLM_MCP_OAUTH_PASSWORD",
+        compact,
+        re.IGNORECASE,
+    )
+    assert re.search(r"HMAC", mcp_guide)
+    assert "/files/dl" in mcp_guide and "/files/ul" in mcp_guide
+    assert re.search(r"loopback.{0,160}tokenless|tokenless.{0,160}loopback", compact, re.I)
+
+    adr = ADR_0024.read_text(encoding="utf-8")
+    assert "/files/dl" in adr and "/files/ul" in adr
+    assert re.search(r"HMAC", adr)
+    assert re.search(
+        r"sole.{0,40}auth|HMAC-signed token is the sole",
+        _normalized(adr),
+        re.IGNORECASE,
+    )
+    assert "SECURITY.md" in adr

--- a/tests/_guardrails/test_security_md_hosting_threat_model.py
+++ b/tests/_guardrails/test_security_md_hosting_threat_model.py
@@ -160,7 +160,11 @@ def hosting_threat_model_gaps(security_md: str) -> list[str]:
     if "docs/adr/0024-mcp-remote-file-transfer.md" not in security_md:
         gaps.append("link to ADR-0024 file")
 
-    if not re.search(r"0?600", compact):
+    if not re.search(
+        r"oauth.{0,160}(?:0o600|0600)|(?:0o600|0600).{0,160}oauth",
+        compact,
+        re.IGNORECASE,
+    ):
         gaps.append("OAuth state file mode 0600")
     if not re.search(
         r"delete.{0,80}(that file|the (OAuth )?state file|oauth).{0,80}restart"
@@ -195,6 +199,11 @@ def test_uncorrected_no_long_lived_claim_detector() -> None:
     assert "MCP OAuth refresh-token correction" not in hosting_threat_model_gaps(corrected)
 
     assert not uncorrected_no_long_lived_oauth_claim("Sessions are cookie-based.\n")
+
+    storage_only = "storage_state.json is written 0o600.\n"
+    assert "OAuth state file mode 0600" in hosting_threat_model_gaps(storage_only)
+    oauth_mode = "OAuth state file written 0600.\n"
+    assert "OAuth state file mode 0600" not in hosting_threat_model_gaps(oauth_mode)
 
 
 def test_security_md_documents_mcp_rest_hosting_threat_model() -> None:


### PR DESCRIPTION
## Summary

Operator-facing `SECURITY.md` described a CLI cookie client and claimed there were no long-lived API keys or OAuth tokens. That is false for experimental `notebooklm-mcp` HTTP + OAuth. This rewrite makes the MCP/REST hosting threat model first-class without changing those policies (stdio allowed-roots and upload jti freeze remain sibling issues).

## Related Issue

Fixes #2387

## Changes

- Rewrite `SECURITY.md` so master tokens, MCP OAuth refresh tokens, signed `/files/dl` and `/files/ul` URLs, stdio `source_add(path)` server-host reads, loopback vs token, `GET /healthz` liveness, and `pip-audit` extras are first-class.
- Cross-link `docs/security.md`, `docs/mcp-guide.md`, `docs/installation.md`, and [ADR-0024](docs/adr/0024-mcp-remote-file-transfer.md).
- Document that rotating `NOTEBOOKLM_MCP_OAUTH_PASSWORD` does not revoke refresh tokens; real revocation is delete the OAuth state file + restart.
- Note the stdio allowed-roots gap as current behavior and link #2385 (not implemented here).
- Add `tests/_guardrails/test_security_md_hosting_threat_model.py` so the false “No long-lived API keys or OAuth tokens” claim fails unless the MCP OAuth correction is present, and so the listed threat-model facts stay in `SECURITY.md`.

## Test Plan

- [x] `PYTHONPATH=$PWD/src` `pytest tests/_guardrails/test_security_md_hosting_threat_model.py tests/_guardrails/test_install_docs.py tests/_guardrails/test_docs_module_refs.py tests/_guardrails/test_adr_reference_format.py -q --tb=short` (42 passed)
- [x] `ruff format .` and `ruff check .`
- [x] `mypy src/notebooklm --ignore-missing-imports`
- [x] Guardrail detector self-test: old Session Security bullet is uncorrected; rewritten `SECURITY.md` is clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded security guidance for MCP and REST hosting, including account-equivalent credentials, OAuth refresh-token persistence and revocation, authentication requirements, and file-access behavior.
  * Clarified loopback versus external HTTP security requirements and that `/healthz` is a tokenless liveness probe.
  * Documented signed file-transfer URLs and server-host path handling for stdio connections.
  * Updated installation, MCP, and security guides with operator threat-model references.
  * Added security details to the remote file-transfer architecture documentation and clarified dependency-audit coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->