### PR TITLE
fix(cli): resolve ask --source before --new deletes history

### DIFF
--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -165,6 +165,33 @@ _format_single_qa = format_single_qa
 _format_history = format_history
 
 
+def _confirm_new_conversation_deletion(
+    conversation_id: str, *, assume_yes: bool, json_output: bool
+) -> None:
+    """Prompt for ``ask --new`` history deletion.
+
+    Sync and client-free so confirmation never sits inside a client
+    ``operation()`` scope. ``--json`` implies ``--yes`` so scripted callers
+    don't hang on stdin (which would also clobber JSON stdout purity). See
+    ``cli/artifact_cmd.py::artifact_delete`` for the same pattern.
+    """
+    if assume_yes or json_output:
+        return
+    if click.confirm(
+        f"This will permanently delete conversation "
+        f"{conversation_id[:8]}... and all its turns. Continue?",
+        default=False,
+    ):
+        return
+    # Exit 1 (BaseException-bypassing ``SystemExit``) so scripts can
+    # distinguish "user said no" from "ask succeeded" — the intended
+    # ``ask`` did not run. ``click.exceptions.Exit`` and ``ctx.exit``
+    # both raise ``RuntimeError`` subclasses that the ``handle_errors``
+    # catch-all (error_handler.py) would remap to exit 2.
+    console.print("[yellow]Aborted — no conversation deleted.[/yellow]")
+    exit_with_code(1)
+
+
 def _determine_conversation_id(
     *,
     explicit_conversation_id: str | None,
@@ -342,6 +369,7 @@ def register_chat_commands(cli):
         async def _run():
             async with resolve_client_factory(ctx)(client_auth, **client_kwargs) as client:
                 nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+                last_conv_id: str | None = None
                 if new_conversation:
                     # Dropping ``conversation_id`` alone extends the most-recent
                     # conversation (see ChatAPI.ask Note). Deleting it first
@@ -349,30 +377,6 @@ def register_chat_commands(cli):
                     # conversation is fine — skip both the prompt and the
                     # delete; ``ask`` then creates the notebook's first one.
                     last_conv_id = await client.chat.get_conversation_id(nb_id_resolved)
-                    if last_conv_id:
-                        # ``--json`` implies ``--yes`` so scripted callers don't
-                        # hang on stdin (which would also clobber JSON stdout
-                        # purity). See ``cli/artifact_cmd.py::artifact_delete``
-                        # for the same pattern.
-                        if (
-                            not assume_yes
-                            and not json_output
-                            and not click.confirm(
-                                f"This will permanently delete conversation "
-                                f"{last_conv_id[:8]}... and all its turns. Continue?",
-                                default=False,
-                            )
-                        ):
-                            # Exit 1 (BaseException-bypassing ``SystemExit``)
-                            # so scripts can distinguish "user said no" from
-                            # "ask succeeded" — the intended ``ask`` did not
-                            # run. ``click.exceptions.Exit`` and ``ctx.exit``
-                            # both raise ``RuntimeError`` subclasses that the
-                            # ``handle_errors`` catch-all (error_handler.py)
-                            # would remap to exit 2.
-                            console.print("[yellow]Aborted — no conversation deleted.[/yellow]")
-                            exit_with_code(1)
-                        await client.chat.delete_conversation(nb_id_resolved, last_conv_id)
                     effective_conv_id: str | None = None
                 else:
                     effective_conv_id = _determine_conversation_id(
@@ -391,9 +395,18 @@ def register_chat_commands(cli):
                     if effective_conv_id:
                         resumed_from_server = True
 
+                # ``--source`` resolution can still abort; finish it before any
+                # ``--new`` delete so a bad/ambiguous reference cannot destroy
+                # the current conversation. Confirm stays a sync prompt (no
+                # client ``operation()`` held across stdin).
                 sources = await resolve_source_ids(
                     client, nb_id_resolved, source_ids, json_output=json_output
                 )
+                if new_conversation and last_conv_id:
+                    _confirm_new_conversation_deletion(
+                        last_conv_id, assume_yes=assume_yes, json_output=json_output
+                    )
+                    await client.chat.delete_conversation(nb_id_resolved, last_conv_id)
                 result = await client.chat.ask(
                     nb_id_resolved,
                     question,

--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -400,7 +400,11 @@ def register_chat_commands(cli):
                 # the current conversation. Confirm stays a sync prompt (no
                 # client ``operation()`` held across stdin).
                 sources = await resolve_source_ids(
-                    client, nb_id_resolved, source_ids, json_output=json_output
+                    client,
+                    nb_id_resolved,
+                    source_ids,
+                    json_output=json_output,
+                    require_existing=new_conversation,
                 )
                 if new_conversation and last_conv_id:
                     _confirm_new_conversation_deletion(

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 import re
 import sys
@@ -499,6 +498,7 @@ async def resolve_source_ids(
     source_ids: tuple[str, ...],
     *,
     json_output: bool = False,
+    require_existing: bool = False,
     stdout_console: Console | None = None,
     stderr_output_console: Console | None = None,
 ) -> list[str] | None:
@@ -508,6 +508,7 @@ async def resolve_source_ids(
         client: NotebookLM client.
         notebook_id: Resolved notebook ID.
         source_ids: Tuple of partial source IDs from CLI.
+        require_existing: Verify even full UUIDs against the notebook inventory.
         json_output: When true, "Matched..." diagnostics for partial matches
             route to stderr so stdout stays parseable JSON.
         stdout_console: Console for human-mode diagnostics.
@@ -520,28 +521,26 @@ async def resolve_source_ids(
         return None
 
     validated_source_ids = tuple(validate_id(source_id, "source") for source_id in source_ids)
-    if all(_is_full_id_candidate(source_id) for source_id in validated_source_ids):
+    if not require_existing and all(
+        _is_full_id_candidate(source_id) for source_id in validated_source_ids
+    ):
         return list(validated_source_ids)
 
     sources = await client.sources.list(notebook_id)
 
-    async def list_sources():
-        return sources
-
     unique_source_ids = tuple(dict.fromkeys(validated_source_ids))
-    resolved_unique = await asyncio.gather(
-        *(
-            _resolve_partial_id(
-                source_id,
-                list_fn=list_sources,
-                entity_name="source",
-                list_command="source list",
-                json_output=json_output,
-                stdout_console=stdout_console,
-                stderr_output_console=stderr_output_console,
-            )
-            for source_id in unique_source_ids
+    resolved_unique = [
+        resolve_partial_id_in_items(
+            source_id,
+            sources,
+            entity_name="source",
+            list_command="source list",
+            json_output=json_output,
+            stdout_console=stdout_console,
+            stderr_output_console=stderr_output_console,
+            allow_full_id_passthrough=not require_existing,
         )
-    )
+        for source_id in unique_source_ids
+    ]
     resolved_by_input = dict(zip(unique_source_ids, resolved_unique, strict=True))
     return [resolved_by_input[source_id] for source_id in validated_source_ids]

--- a/tests/fixtures/baselines/backend_static_coupling.json
+++ b/tests/fixtures/baselines/backend_static_coupling.json
@@ -8708,7 +8708,7 @@
     },
     {
       "kind": "from",
-      "lineno": 16,
+      "lineno": 15,
       "scope": null,
       "scope_kind": "module",
       "source": "notebooklm.cli.resolve",
@@ -11268,7 +11268,7 @@
       "modules": 33
     },
     "cli": {
-      "lines": 22743,
+      "lines": 22759,
       "modules": 76
     },
     "mcp": {
@@ -11301,7 +11301,7 @@
     }
   },
   "summary": {
-    "authored_lines": 150037,
+    "authored_lines": 150053,
     "authored_modules": 476,
     "class_local_edges": 0,
     "cross_subsystem_edges": 1239,

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -891,7 +891,12 @@ class TestAskNewFlag:
         call = mock_client.chat.ask.call_args
         assert call.kwargs.get("conversation_id") is None
 
-    def test_ask_new_invalid_source_preserves_conversation(self, runner, mock_auth, tmp_path):
+    @pytest.mark.parametrize(
+        "source_id", ["not-a-real-source", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]
+    )
+    def test_ask_new_invalid_source_preserves_conversation(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path, source_id
+    ):
         """``--new --source`` that does not resolve must not delete the conversation.
 
         Source resolution is a real ``resolve_source_ids`` call (via
@@ -906,13 +911,9 @@ class TestAskNewFlag:
         mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
 
         with (
-            patch.object(
-                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch,
             patch.object(helpers_module, "get_context_path", return_value=context_file),
             patch.object(context_module, "get_context_path", return_value=context_file),
         ):
-            mock_fetch.return_value = ("csrf", "session")
             result = runner.invoke(
                 cli,
                 [
@@ -921,7 +922,7 @@ class TestAskNewFlag:
                     "nb_123",
                     "--new",
                     "--source",
-                    "not-a-real-source",
+                    source_id,
                     "question",
                 ],
                 obj=inject_client(mock_client),
@@ -936,7 +937,9 @@ class TestAskNewFlag:
         mock_client.chat.delete_conversation.assert_not_awaited()
         mock_client.chat.ask.assert_not_awaited()
 
-    def test_ask_new_ambiguous_source_preserves_conversation(self, runner, mock_auth, tmp_path):
+    def test_ask_new_ambiguous_source_preserves_conversation(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
         """An ambiguous ``--source`` prefix must abort before deleting history."""
         context_file = tmp_path / "context.json"
         context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
@@ -946,13 +949,9 @@ class TestAskNewFlag:
         mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
 
         with (
-            patch.object(
-                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch,
             patch.object(helpers_module, "get_context_path", return_value=context_file),
             patch.object(context_module, "get_context_path", return_value=context_file),
         ):
-            mock_fetch.return_value = ("csrf", "session")
             result = runner.invoke(
                 cli,
                 ["ask", "-n", "nb_123", "--new", "-y", "--source", "src_", "question"],
@@ -967,7 +966,9 @@ class TestAskNewFlag:
         mock_client.chat.delete_conversation.assert_not_awaited()
         mock_client.chat.ask.assert_not_awaited()
 
-    def test_ask_new_with_valid_source_deletes_once_then_asks(self, runner, mock_auth, tmp_path):
+    def test_ask_new_with_valid_source_deletes_once_then_asks(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
         """``--new`` with a resolvable ``--source`` still deletes once, then asks."""
         context_file = tmp_path / "context.json"
         context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
@@ -987,13 +988,9 @@ class TestAskNewFlag:
         )
 
         with (
-            patch.object(
-                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch,
             patch.object(helpers_module, "get_context_path", return_value=context_file),
             patch.object(context_module, "get_context_path", return_value=context_file),
         ):
-            mock_fetch.return_value = ("csrf", "session")
             result = runner.invoke(
                 cli,
                 ["ask", "-n", "nb_123", "--new", "-y", "--source", "src_001", "question"],
@@ -1011,8 +1008,11 @@ class TestAskNewFlag:
         assert ask_call.kwargs.get("source_ids") == ["src_001"]
         assert "New conversation: conv-fresh-xyz" in result.output
 
+    @pytest.mark.parametrize(
+        "source_id", ["not-a-real-source", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]
+    )
     def test_ask_new_json_yes_invalid_source_preserves_conversation(
-        self, runner, mock_auth, tmp_path
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path, source_id
     ):
         """``--json --yes --new`` with a bad source must not prompt or delete."""
         context_file = tmp_path / "context.json"
@@ -1023,13 +1023,9 @@ class TestAskNewFlag:
         mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
 
         with (
-            patch.object(
-                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch,
             patch.object(helpers_module, "get_context_path", return_value=context_file),
             patch.object(context_module, "get_context_path", return_value=context_file),
         ):
-            mock_fetch.return_value = ("csrf", "session")
             result = runner.invoke(
                 cli,
                 [
@@ -1040,7 +1036,7 @@ class TestAskNewFlag:
                     "--yes",
                     "--new",
                     "--source",
-                    "not-a-real-source",
+                    source_id,
                     "question",
                 ],
                 obj=inject_client(mock_client),
@@ -1053,6 +1049,30 @@ class TestAskNewFlag:
         assert conversation["id"] == "conv-server-abc"
         mock_client.chat.delete_conversation.assert_not_awaited()
         mock_client.chat.ask.assert_not_awaited()
+
+    def test_ask_new_existing_uuid_is_verified_before_deletion(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        source_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        mock_client = create_mock_client()
+        mock_client.sources.list = AsyncMock(
+            return_value=[MagicMock(id=source_id, title="Selected source")]
+        )
+        mock_client.chat.get_conversation_id = AsyncMock(return_value="conv-old")
+        mock_client.chat.delete_conversation = AsyncMock(return_value=True)
+        mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+        result = runner.invoke(
+            cli,
+            ["ask", "question", "-n", "nb_123", "--new", "--yes", "--source", source_id],
+            obj=inject_client(mock_client),
+        )
+        assert result.exit_code == 0, result.output
+        mock_client.sources.list.assert_awaited_once_with("nb_123")
+        mock_client.chat.delete_conversation.assert_awaited_once_with("nb_123", "conv-old")
+        assert mock_client.chat.ask.await_args.kwargs["source_ids"] == [source_id]
+        calls = [call[0] for call in mock_client.mock_calls]
+        assert calls.index("sources.list") < calls.index("chat.delete_conversation")
+        assert calls.index("chat.delete_conversation") < calls.index("chat.ask")
 
 
 # =============================================================================

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -662,6 +662,38 @@ class TestAskServerResumed:
         assert "Resumed" not in result.output
 
 
+def _track_ask_new_client(
+    *,
+    conversation: dict[str, str | None],
+    calls: list[str],
+    ask_result: AskResult | None = None,
+) -> MagicMock:
+    """Mock client that records source resolution vs ``--new`` delete order."""
+    mock_client = create_mock_client()
+    underlying_list = mock_client.sources.list
+
+    async def tracked_list(*args, **kwargs):
+        calls.append("sources.list")
+        return await underlying_list(*args, **kwargs)
+
+    async def delete_conversation(_notebook_id, _conversation_id):
+        calls.append("delete_conversation")
+        conversation["id"] = None
+        return True
+
+    async def ask(*_args, **_kwargs):
+        calls.append("ask")
+        if ask_result is None:
+            raise AssertionError("chat.ask should not run when --source preflight fails")
+        return ask_result
+
+    mock_client.sources.list = AsyncMock(side_effect=tracked_list)
+    mock_client.chat.get_conversation_id = AsyncMock(return_value=conversation["id"])
+    mock_client.chat.delete_conversation = AsyncMock(side_effect=delete_conversation)
+    mock_client.chat.ask = AsyncMock(side_effect=ask)
+    return mock_client
+
+
 class TestAskNewFlag:
     """Tests for `ask --new` flag.
 
@@ -858,6 +890,169 @@ class TestAskNewFlag:
         mock_client.chat.delete_conversation.assert_not_awaited()
         call = mock_client.chat.ask.call_args
         assert call.kwargs.get("conversation_id") is None
+
+    def test_ask_new_invalid_source_preserves_conversation(self, runner, mock_auth, tmp_path):
+        """``--new --source`` that does not resolve must not delete the conversation.
+
+        Source resolution is a real ``resolve_source_ids`` call (via
+        ``sources.list``), not a mocked resolver, and it must run before
+        ``delete_conversation``.
+        """
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
+
+        conversation: dict[str, str | None] = {"id": "conv-server-abc"}
+        calls: list[str] = []
+        mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
+
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(helpers_module, "get_context_path", return_value=context_file),
+            patch.object(context_module, "get_context_path", return_value=context_file),
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                [
+                    "ask",
+                    "-n",
+                    "nb_123",
+                    "--new",
+                    "--source",
+                    "not-a-real-source",
+                    "question",
+                ],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code != 0, result.output
+        assert "No source found" in result.output
+        assert "permanently delete conversation" not in result.output
+        assert "sources.list" in calls
+        assert "delete_conversation" not in calls
+        assert conversation["id"] == "conv-server-abc"
+        mock_client.chat.delete_conversation.assert_not_awaited()
+        mock_client.chat.ask.assert_not_awaited()
+
+    def test_ask_new_ambiguous_source_preserves_conversation(self, runner, mock_auth, tmp_path):
+        """An ambiguous ``--source`` prefix must abort before deleting history."""
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
+
+        conversation: dict[str, str | None] = {"id": "conv-server-abc"}
+        calls: list[str] = []
+        mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
+
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(helpers_module, "get_context_path", return_value=context_file),
+            patch.object(context_module, "get_context_path", return_value=context_file),
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["ask", "-n", "nb_123", "--new", "-y", "--source", "src_", "question"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code != 0, result.output
+        assert "Ambiguous" in result.output
+        assert "sources.list" in calls
+        assert "delete_conversation" not in calls
+        assert conversation["id"] == "conv-server-abc"
+        mock_client.chat.delete_conversation.assert_not_awaited()
+        mock_client.chat.ask.assert_not_awaited()
+
+    def test_ask_new_with_valid_source_deletes_once_then_asks(self, runner, mock_auth, tmp_path):
+        """``--new`` with a resolvable ``--source`` still deletes once, then asks."""
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
+
+        fresh_result = AskResult(
+            answer="Fresh answer.",
+            conversation_id="conv-fresh-xyz",
+            turn_number=1,
+            is_follow_up=False,
+            references=[],
+            raw_response="",
+        )
+        conversation: dict[str, str | None] = {"id": "conv-server-abc"}
+        calls: list[str] = []
+        mock_client = _track_ask_new_client(
+            conversation=conversation, calls=calls, ask_result=fresh_result
+        )
+
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(helpers_module, "get_context_path", return_value=context_file),
+            patch.object(context_module, "get_context_path", return_value=context_file),
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["ask", "-n", "nb_123", "--new", "-y", "--source", "src_001", "question"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        assert calls.index("sources.list") < calls.index("delete_conversation")
+        assert calls.index("delete_conversation") < calls.index("ask")
+        assert calls.count("delete_conversation") == 1
+        mock_client.chat.delete_conversation.assert_awaited_once_with("nb_123", "conv-server-abc")
+        mock_client.chat.ask.assert_awaited_once()
+        ask_call = mock_client.chat.ask.call_args
+        assert ask_call.kwargs.get("conversation_id") is None
+        assert ask_call.kwargs.get("source_ids") == ["src_001"]
+        assert "New conversation: conv-fresh-xyz" in result.output
+
+    def test_ask_new_json_yes_invalid_source_preserves_conversation(
+        self, runner, mock_auth, tmp_path
+    ):
+        """``--json --yes --new`` with a bad source must not prompt or delete."""
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_123", "conversation_id": "conv-cached-abc"}')
+
+        conversation: dict[str, str | None] = {"id": "conv-server-abc"}
+        calls: list[str] = []
+        mock_client = _track_ask_new_client(conversation=conversation, calls=calls)
+
+        with (
+            patch.object(
+                auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+            patch.object(helpers_module, "get_context_path", return_value=context_file),
+            patch.object(context_module, "get_context_path", return_value=context_file),
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                [
+                    "ask",
+                    "-n",
+                    "nb_123",
+                    "--json",
+                    "--yes",
+                    "--new",
+                    "--source",
+                    "not-a-real-source",
+                    "question",
+                ],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code != 0, result.output
+        assert "permanently delete conversation" not in result.output
+        assert "sources.list" in calls
+        assert "delete_conversation" not in calls
+        assert conversation["id"] == "conv-server-abc"
+        mock_client.chat.delete_conversation.assert_not_awaited()
+        mock_client.chat.ask.assert_not_awaited()
 
 
 # =============================================================================


### PR DESCRIPTION
`ask --new` now resolves source references before confirming and deleting the previous conversation. It verifies full UUIDs against the notebook inventory as well, so stale, foreign, and ambiguous source IDs leave history intact. Confirmation runs outside a client operation.

Fixes #2381.

Validation: 109 CLI chat/resolver tests passed; Ruff check/format and mypy passed. The committed coupling baseline includes the merged history and security fixes.
