### PR TITLE
fix(cli): project save-as-note failure commit evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CLI `ask --save-as-note --json` keeps save-failure commit evidence.** Optional
+  note-save remains non-fatal, but JSON now projects `SaveNoteOutcome.failure`
+  through the same commit-state / recovery-action / known-id fields as other CLI
+  errors instead of dropping them on a redacted `note_save_error` string (#2383).
 - **Retry-unsafe writes no longer replay after transmission.** Notebook and
   source creates, file registration, research imports, collection creates, and
   chat POSTs now require explicit commit evidence before any outer replay.

--- a/src/notebooklm/cli/chat_cmd.py
+++ b/src/notebooklm/cli/chat_cmd.py
@@ -32,7 +32,7 @@ from .._app.views import ask_result_view
 from ..exceptions import ValidationError
 from .auth_runtime import resolve_client_factory, with_client
 from .context import get_current_conversation, get_current_notebook, set_current_conversation
-from .error_handler import _output_error, exit_with_code
+from .error_handler import _output_error, exception_json_fields, exit_with_code
 from .input import resolve_prompt
 from .options import _complete_sources, json_option, notebook_option, prompt_file_option
 from .rendering import (
@@ -426,6 +426,7 @@ def register_chat_commands(cli):
 
                 note_save_result: dict[str, str] | None = None
                 note_save_error: str | None = None
+                note_save_failure: Exception | None = None
 
                 if save_as_note:
                     # The save-as-note workflow (citation-rich vs plain-text
@@ -433,7 +434,8 @@ def register_chat_commands(cli):
                     # ``_app.chat.save_answer_as_note``. Its Rich-markup status
                     # lines route through ``_EmitStatusSink`` (stderr under
                     # ``--json``, honoring root ``--quiet``); the outcome's note
-                    # / error are merged into the JSON envelope below.
+                    # / error / failure evidence are merged into the JSON
+                    # envelope below.
                     outcome = await save_answer_as_note(
                         client,
                         nb_id_resolved,
@@ -444,6 +446,7 @@ def register_chat_commands(cli):
                     )
                     note_save_result = outcome.note
                     note_save_error = outcome.error
+                    note_save_failure = outcome.failure
 
                 if json_output:
                     # Go through the shared projection rather than a local
@@ -455,11 +458,19 @@ def register_chat_commands(cli):
                     if save_as_note:
                         # Merge note-save outcome into the envelope so the
                         # caller can observe success/failure from stdout
-                        # alone without parsing stderr text.
+                        # alone without parsing stderr text. Keep save-as-note
+                        # non-fatal: the ask answer stays even when the
+                        # secondary write folded. Project ``failure`` through
+                        # the same JSON extra fields other CLI errors use
+                        # (commit state, recovery action, known ids) instead
+                        # of dropping ``operation_metadata`` on the redacted
+                        # ``note_save_error`` string.
                         if note_save_result is not None:
                             data["note"] = note_save_result
                         if note_save_error is not None:
                             data["note_save_error"] = note_save_error
+                        if note_save_failure is not None:
+                            data.update(exception_json_fields(note_save_failure))
                     json_output_response(data)
 
         return _run()

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -127,6 +127,21 @@ def _unconfirmed_write_note(exc: BaseException | None) -> str:
     return _UNCONFIRMED_WRITE_NOTE if exc is None else unconfirmed_hint(exc)
 
 
+def exception_json_fields(exc: BaseException | None) -> dict[str, Any]:
+    """Return JSON extra fields other CLI errors merge from ``exc``.
+
+    Projects the bounded ``operation_metadata`` payload (commit state,
+    recovery action, known ids) and, when the write may already exist,
+    ``unconfirmed`` plus inspect-vs-retry ``hint``. Empty when ``exc``
+    carries no mutation evidence.
+    """
+    extra: dict[str, Any] = dict(operation_metadata_payload(exc))
+    if getattr(exc, "unconfirmed", False):
+        extra["unconfirmed"] = True
+        extra["hint"] = _unconfirmed_write_note(exc)
+    return extra
+
+
 def _retained_source_note(source_id: str, stage: str) -> str:
     """Recovery line naming the source row a partial upload left behind.
 
@@ -313,24 +328,22 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
             if extra:
                 # Same reason: a stale ``retry_after`` is an instruction.
                 extra = {k: v for k, v in extra.items() if k != "retry_after"}
-            if json_out:
-                note = _unconfirmed_write_note(exc)
-                extra = {**(extra or {}), "unconfirmed": True, "hint": note}
-            else:
-                # Text mode prints ``hint`` after ``message``; JSON ignores it,
-                # which is why the JSON branch above carries it in ``extra``.
+            if not json_out:
+                # Text mode prints ``hint`` after ``message``; JSON carries the
+                # same inspect-vs-retry guidance via :func:`exception_json_fields`.
                 hint = _unconfirmed_write_note(exc)
         operation_payload = operation_metadata_payload(exc)
-        if operation_payload:
-            if json_out:
-                extra = {**(extra or {}), **operation_payload}
-            else:
-                rendered_metadata = json.dumps(
-                    operation_payload,
-                    ensure_ascii=False,
-                    separators=(",", ":"),
-                )
-                message = f"{message}\nOperation metadata: {rendered_metadata}"
+        json_fields = exception_json_fields(exc)
+        if json_out:
+            if json_fields:
+                extra = {**(extra or {}), **json_fields}
+        elif operation_payload:
+            rendered_metadata = json.dumps(
+                operation_payload,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            message = f"{message}\nOperation metadata: {rendered_metadata}"
         source_id = operation_payload.get("source_id")
         stage = operation_payload.get("stage")
         if isinstance(source_id, str) and isinstance(stage, str):

--- a/tests/fixtures/baselines/backend_static_coupling.json
+++ b/tests/fixtures/baselines/backend_static_coupling.json
@@ -11268,7 +11268,7 @@
       "modules": 33
     },
     "cli": {
-      "lines": 22743,
+      "lines": 22767,
       "modules": 76
     },
     "mcp": {
@@ -11301,7 +11301,7 @@
     }
   },
   "summary": {
-    "authored_lines": 150037,
+    "authored_lines": 150061,
     "authored_modules": 476,
     "class_local_edges": 0,
     "cross_subsystem_edges": 1239,

--- a/tests/server/test_notes.py
+++ b/tests/server/test_notes.py
@@ -54,6 +54,38 @@ def test_create_defaults(authed_client: TestClient) -> None:
     assert resp.json()["title"] == "New Note"
 
 
+def test_create_unconfirmed_preserves_operation_metadata(
+    authed_client: TestClient, fake_client: FakeClient
+) -> None:
+    """REST note create raises, so the error envelope keeps commit evidence."""
+    from notebooklm._idempotency import attach_operation_metadata
+    from notebooklm.exceptions import NetworkError
+    from notebooklm.outcomes import CommitState, OperationMetadata, RecoveryAction
+
+    failure = NetworkError("lost after dispatch")
+    attach_operation_metadata(
+        failure,
+        OperationMetadata(
+            commit_state=CommitState.UNKNOWN,
+            known_resource_ids=("note-accepted",),
+            recovery_action=RecoveryAction.INSPECT_AND_RECONCILE,
+            operation="notes.create",
+        ),
+    )
+
+    async def _raise(*_args: object, **_kwargs: object) -> None:
+        raise failure
+
+    fake_client.notes.create = _raise  # type: ignore[method-assign]
+    resp = authed_client.post("/v1/notebooks/nb-1/notes", json={"title": "T", "content": "C"})
+    assert resp.status_code == 502
+    body = resp.json()["error"]
+    assert body["commit_state"] == "unknown"
+    assert body["recovery_action"] == "inspect_and_reconcile"
+    assert body["known_resource_ids"] == ["note-accepted"]
+    assert body["unconfirmed"] is True
+
+
 def test_get_existing_note(authed_client: TestClient, fake_client: FakeClient) -> None:
     _seed(fake_client, Note(id="n-9", notebook_id="nb-1", title="Nine", content="x"))
     resp = authed_client.get("/v1/notebooks/nb-1/notes/n-9")

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -234,22 +234,20 @@ class TestAskSaveAsNote:
         mock_client.notes.create.assert_awaited_once()
         mock_client.chat.save_answer_as_note.assert_not_awaited()
 
-    def test_ask_save_as_note_text_failure_redacts_secrets(self, runner, mock_auth):
+    def test_ask_save_as_note_text_failure_redacts_secrets(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
         """Text mode keeps the redacted warning and does not dump secrets."""
         mock_client = create_mock_client()
         mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
         mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
         mock_client.notes.create = AsyncMock(side_effect=_unconfirmed_note_save_error())
 
-        with patch.object(
-            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-        ) as mock_fetch:
-            mock_fetch.return_value = ("csrf", "session")
-            result = runner.invoke(
-                cli,
-                ["ask", "What is 42?", "--save-as-note", "-n", "nb_123"],
-                obj=inject_client(mock_client),
-            )
+        result = runner.invoke(
+            cli,
+            ["ask", "What is 42?", "--save-as-note", "-n", "nb_123"],
+            obj=inject_client(mock_client),
+        )
 
         assert result.exit_code == 0, result.output
         combined = result.output + result.stdout + result.stderr
@@ -1196,7 +1194,7 @@ class TestChatJsonStdoutContract:
         assert "Warning" not in result.stdout
 
     def test_ask_json_save_as_note_unconfirmed_failure_projects_commit_evidence(
-        self, runner, mock_auth
+        self, runner, mock_auth, mock_fetch_tokens
     ):
         """A folded unconfirmed save keeps the ask answer and commit evidence.
 
@@ -1210,15 +1208,11 @@ class TestChatJsonStdoutContract:
         mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
         mock_client.notes.create = AsyncMock(side_effect=_unconfirmed_note_save_error())
 
-        with patch.object(
-            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
-        ) as mock_fetch:
-            mock_fetch.return_value = ("csrf", "session")
-            result = runner.invoke(
-                cli,
-                ["ask", "What is 42?", "--save-as-note", "-n", "nb_123", "--json"],
-                obj=inject_client(mock_client),
-            )
+        result = runner.invoke(
+            cli,
+            ["ask", "What is 42?", "--save-as-note", "-n", "nb_123", "--json"],
+            obj=inject_client(mock_client),
+        )
 
         assert result.exit_code == 0, result.stderr or result.output
         data = json.loads(result.stdout)

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -1,5 +1,6 @@
 """Tests for chat CLI commands (save-as-note, enhanced history)."""
 
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -8,8 +9,11 @@ from click.testing import CliRunner
 
 import notebooklm.auth as auth_module
 import notebooklm.cli.context as context_module
+from notebooklm._idempotency import attach_operation_metadata
 from notebooklm.cli import helpers as helpers_module
+from notebooklm.exceptions import NetworkError
 from notebooklm.notebooklm_cli import cli
+from notebooklm.outcomes import CommitState, OperationMetadata, RecoveryAction
 from notebooklm.types import (
     AskResult,
     ChatGoal,
@@ -21,6 +25,28 @@ from notebooklm.types import (
 )
 
 from .conftest import create_mock_client, inject_client
+
+_LEAKY_SAVE_DETAIL = "lost after dispatch at /home/alice/private.log?access_token=top-secret"
+_KNOWN_NOTE_ID = "note-accepted"
+
+
+def _unconfirmed_note_save_error(
+    *,
+    message: str = _LEAKY_SAVE_DETAIL,
+    note_id: str = _KNOWN_NOTE_ID,
+) -> NetworkError:
+    """Build a folded save failure that still carries commit evidence."""
+    failure = NetworkError(message)
+    attach_operation_metadata(
+        failure,
+        OperationMetadata(
+            commit_state=CommitState.UNKNOWN,
+            known_resource_ids=(note_id,),
+            recovery_action=RecoveryAction.INSPECT_AND_RECONCILE,
+            operation="notes.create",
+        ),
+    )
+    return failure
 
 
 def make_note(id="note_abc", title="Chat Note", content="The answer") -> Note:
@@ -207,6 +233,34 @@ class TestAskSaveAsNote:
         assert "No citations in answer" in result.output
         mock_client.notes.create.assert_awaited_once()
         mock_client.chat.save_answer_as_note.assert_not_awaited()
+
+    def test_ask_save_as_note_text_failure_redacts_secrets(self, runner, mock_auth):
+        """Text mode keeps the redacted warning and does not dump secrets."""
+        mock_client = create_mock_client()
+        mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+        mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+        mock_client.notes.create = AsyncMock(side_effect=_unconfirmed_note_save_error())
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["ask", "What is 42?", "--save-as-note", "-n", "nb_123"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.output
+        combined = result.output + result.stdout + result.stderr
+        assert "The answer is 42." in result.output
+        assert "Failed to save note" in combined
+        assert "top-secret" not in combined
+        assert "/home/alice" not in combined
+        # Structured commit evidence stays on the JSON path; text keeps the
+        # historical redacted warning and does not dump operation metadata.
+        assert "Operation metadata" not in combined
+        assert '"commit_state"' not in combined
 
 
 class TestHistoryCommand:
@@ -1139,6 +1193,45 @@ class TestChatJsonStdoutContract:
         data = json.loads(result.stdout)
         assert data["answer"] == "The answer is 42."
         assert "boom" in data["note_save_error"]
+        assert "Warning" not in result.stdout
+
+    def test_ask_json_save_as_note_unconfirmed_failure_projects_commit_evidence(
+        self, runner, mock_auth
+    ):
+        """A folded unconfirmed save keeps the ask answer and commit evidence.
+
+        ``SaveNoteOutcome`` retains the original exception after operation
+        settlement. JSON callers must see ``note_save_error`` plus the same
+        commit/unknown/known-id fields other CLI JSON errors project, without
+        turning the chat payload into a fatal error envelope.
+        """
+        mock_client = create_mock_client()
+        mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+        mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+        mock_client.notes.create = AsyncMock(side_effect=_unconfirmed_note_save_error())
+
+        with patch.object(
+            auth_module, "fetch_tokens_with_domains", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(
+                cli,
+                ["ask", "What is 42?", "--save-as-note", "-n", "nb_123", "--json"],
+                obj=inject_client(mock_client),
+            )
+
+        assert result.exit_code == 0, result.stderr or result.output
+        data = json.loads(result.stdout)
+        assert data["answer"] == "The answer is 42."
+        assert "note" not in data
+        assert "note_save_error" in data
+        assert data["commit_state"] == CommitState.UNKNOWN.value
+        assert data["recovery_action"] == RecoveryAction.INSPECT_AND_RECONCILE.value
+        assert data["known_resource_ids"] == [_KNOWN_NOTE_ID]
+        assert data["unconfirmed"] is True
+        serialized = json.dumps(data)
+        assert "top-secret" not in serialized
+        assert "/home/alice" not in serialized
         assert "Warning" not in result.stdout
 
     def test_history_json_clear_emits_pure_json(self, runner, mock_auth):

--- a/tests/unit/mcp/test_notes.py
+++ b/tests/unit/mcp/test_notes.py
@@ -18,7 +18,18 @@ pytest.importorskip("fastmcp")
 
 from fastmcp.exceptions import ToolError  # noqa: E402 - after importorskip guard
 
-from notebooklm.exceptions import NoteNotFoundError  # noqa: E402 - after importorskip guard
+from notebooklm._idempotency import (  # noqa: E402 - after importorskip guard
+    attach_operation_metadata,
+)
+from notebooklm.exceptions import (  # noqa: E402 - after importorskip guard
+    NetworkError,
+    NoteNotFoundError,
+)
+from notebooklm.outcomes import (  # noqa: E402 - after importorskip guard
+    CommitState,
+    OperationMetadata,
+    RecoveryAction,
+)
 
 from .conftest import AsyncMock  # noqa: E402 - after importorskip guard
 
@@ -49,6 +60,32 @@ async def test_note_save_create(mcp_call, mock_client) -> None:
         "created": True,
     }
     mock_client.notes.create.assert_awaited_once_with(NB_ID, "Idea", "body")
+
+
+async def test_note_save_create_unconfirmed_preserves_operation_metadata(
+    mcp_call, mock_client
+) -> None:
+    """MCP note_save raises through mcp_errors, so commit evidence stays on the wire."""
+    failure = NetworkError("lost after dispatch")
+    attach_operation_metadata(
+        failure,
+        OperationMetadata(
+            commit_state=CommitState.UNKNOWN,
+            known_resource_ids=("note-accepted",),
+            recovery_action=RecoveryAction.INSPECT_AND_RECONCILE,
+            operation="notes.create",
+        ),
+    )
+    mock_client.notes.create = AsyncMock(side_effect=failure)
+
+    with pytest.raises(ToolError) as excinfo:
+        await mcp_call("note_save", {"notebook": NB_ID, "title": "Idea", "content": "body"})
+
+    message = str(excinfo.value)
+    assert "unconfirmed=true" in message
+    assert "note-accepted" in message
+    assert '"commit_state": "unknown"' in message or '"commit_state":"unknown"' in message
+    assert "inspect_and_reconcile" in message
 
 
 @pytest.mark.parametrize("payload", [{"title": "T"}, {"content": "C"}, {}])


### PR DESCRIPTION
## Summary
Optional `ask --save-as-note` is non-fatal by design (`SaveNoteOutcome` folds the exception), but the CLI then projected only `outcome.note` / `outcome.error` and dropped `outcome.failure`. JSON callers could not tell "save never sent" from "save may have committed" and could not see a created note id if a later step failed.

This projects `SaveNoteOutcome.failure` through the existing CLI JSON extra fields (`operation_metadata_payload` plus `unconfirmed` / inspect-vs-retry `hint`) **alongside** the ask answer. Save-as-note stays non-fatal for the chat payload. Text mode still uses the redacted warning and does not dump secrets.

MCP `note_save` and REST `POST /notes` already raise through their error projectors (they do not take only `outcome.error`); tests now pin that they keep commit evidence.

## Related Issue
Fixes #2383

## Changes
- Merge `outcome.failure` into `ask --json --save-as-note` via `exception_json_fields` (commit state, recovery action, known ids, unconfirmed/hint).
- Keep `note: {id, title}` on confirmed save and `note_save_error` as the redacted string.
- Extract `exception_json_fields` so fatal CLI JSON errors and this non-fatal fold share one metadata projection.
- Add CLI, MCP, and REST tests for unconfirmed save/create evidence and text-mode redaction.

## Test Plan
- [x] Targeted pytest: `tests/unit/cli/test_chat.py`, `tests/unit/cli/test_error_handler.py`, `tests/unit/mcp/test_notes.py`, `tests/server/test_notes.py`, `tests/unit/app/test_app_chat.py`, `tests/unit/test_app_operation_scopes.py` (184 passed)
- [x] ruff format/check on touched files
- [x] mypy `src/notebooklm --ignore-missing-imports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `ask --save-as-note --json` responses when note saving fails. Responses now retain structured commit status, recovery guidance, and known resource IDs alongside the answer and error information.
  - Preserved useful reconciliation details for note-creation failures across supported interfaces, including cases where it is unclear whether the note was created.
  - Continued to redact sensitive failure details while retaining actionable warnings and metadata.

- **Documentation**
  - Added an Unreleased changelog entry describing the improved note-save failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->