### PR TITLE
test(mcp): add stdio startup regression tests under stalled authentication

### DIFF
--- a/docs/fault-injection.md
+++ b/docs/fault-injection.md
@@ -539,6 +539,32 @@ wrapper. Each child process returns partial evidence on failure. Shutdown closes
 the chat registry before its provider and leaves no unhandled task exception.
 I1–I6 and I8 apply according to each row.
 
+### MCP stdio startup regression (#2330 / #2370)
+
+`tests/integration/faults/test_mcp_startup.py` adds two pytest-only cases using a
+real stdio subprocess and the HTTP fault server. They are not part of the stress
+scenario registry or its scenario counts. Run them with:
+
+```bash
+uv run pytest tests/integration/faults/test_mcp_startup.py -q
+```
+
+The worker's injected client factory issues a loopback-routed HTTP request before
+opening the production Web client. A named gate holds that response indefinitely;
+the parent first observes the request, then requires `initialize`, `tools/list`,
+and default `server_info` to complete within five seconds each while the gate is
+still closed. This catches authentication work being moved back into the awaited
+MCP lifespan without waiting for a host's full 30-second deadline.
+
+The recovery case releases the gate and checks a decoded `notebook_list` response
+on the same MCP session, with exactly one client open and one upstream list. The
+shutdown case closes stdio while the response remains stalled and checks that the
+child cancels opening and closes its HTTP client. Both check child finalization
+and fault-server cleanup. Credentials and the authentication hop are synthetic;
+these tests cover adapter scheduling and transport ownership, not Google's actual
+authentication flow, package installation, or a remote connector's proxy/TLS setup.
+They do not establish the cause of the reporter's timeout.
+
 ## Add or investigate a scenario
 
 1. Choose a representative public API or first-party workflow and reuse a real

--- a/tests/_fault_server/mcp_startup_worker.py
+++ b/tests/_fault_server/mcp_startup_worker.py
@@ -1,0 +1,66 @@
+"""Real stdio server with a socket-gated client factory for startup regression tests.
+
+The opening HTTP request models a slow authentication hop; it does not exercise
+Google's authentication protocol. After release, notebook tools use the production
+Web client with synthetic credentials and all traffic routed to the parent's server.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from notebooklm.mcp.server import create_server
+
+from .http import HttpFaultServer
+from .web import build_fault_client
+
+
+class _ParentFaultServer(HttpFaultServer):
+    """Reuse the logical-host router against a listener owned by the parent."""
+
+    def __init__(self, port: int) -> None:
+        super().__init__()
+        self._parent_address = ("127.0.0.1", port)
+
+    @property
+    def address(self) -> tuple[str, int]:
+        return self._parent_address
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+    upstream = _ParentFaultServer(args.port)
+    state = {"opens": 0, "cancelled": False, "client_closed": False, "http_closed": False}
+
+    @asynccontextmanager
+    async def factory():
+        state["opens"] += 1
+        opening = upstream.client_factory(timeout=60)
+        client = None
+        try:
+            async with opening:
+                response = await opening.get("https://notebook.google.com/")
+                response.raise_for_status()
+            client = build_fault_client(upstream, timeout=2, server_error_max_retries=0)
+            async with client:
+                yield client
+        except asyncio.CancelledError:
+            state["cancelled"] = True
+            raise
+        finally:
+            state["http_closed"] = opening.is_closed
+            state["client_closed"] = client is None or not client._lifecycle.is_open()
+            args.report.write_text(json.dumps(state), encoding="utf-8")
+
+    create_server(client_factory=factory).run(transport="stdio", show_banner=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_fault_server/mcp_startup_worker.py
+++ b/tests/_fault_server/mcp_startup_worker.py
@@ -49,15 +49,16 @@ def main() -> None:
         opening = upstream.client_factory(timeout=60)
         client = None
         try:
-            async with opening:
-                response = await opening.get("https://notebook.google.com/")
-                response.raise_for_status()
-            client = build_fault_client(upstream, timeout=2, server_error_max_retries=0)
+            try:
+                async with opening:
+                    response = await opening.get("https://notebook.google.com/")
+                    response.raise_for_status()
+                client = build_fault_client(upstream, timeout=2, server_error_max_retries=0)
+            except asyncio.CancelledError:
+                state["cancelled"] = True
+                raise
             async with client:
                 yield client
-        except asyncio.CancelledError:
-            state["cancelled"] = True
-            raise
         finally:
             state["http_closed"] = opening.is_closed
             state["client_closed"] = client is None or not client._lifecycle.is_open()

--- a/tests/_fault_server/mcp_startup_worker.py
+++ b/tests/_fault_server/mcp_startup_worker.py
@@ -23,15 +23,18 @@ class _ParentFaultServer(HttpFaultServer):
     """Reuse the logical-host router against a listener owned by the parent."""
 
     def __init__(self, port: int) -> None:
+        """Initialize the fault server pointing to the parent port."""
         super().__init__()
         self._parent_address = ("127.0.0.1", port)
 
     @property
     def address(self) -> tuple[str, int]:
+        """Return the host and port of the parent fault server."""
         return self._parent_address
 
 
 def main() -> None:
+    """Run the MCP stdio worker with a socket-gated client factory."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, required=True)
     parser.add_argument("--report", type=Path, required=True)
@@ -41,6 +44,7 @@ def main() -> None:
 
     @asynccontextmanager
     async def factory():
+        """Yield a test client after a gated HTTP request."""
         state["opens"] += 1
         opening = upstream.client_factory(timeout=60)
         client = None

--- a/tests/_fixtures/integration_allow_no_vcr_files.txt
+++ b/tests/_fixtures/integration_allow_no_vcr_files.txt
@@ -22,6 +22,7 @@ tests/integration/concurrency/test_wait_for_sources_leak.py # existing mock-only
 tests/integration/faults/test_adapter_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_android_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_curl_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_mcp_startup.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_web_faults.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_web_workflows.py # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/test_artifact_generation_idempotency.py # existing mock-only integration exception; migrate per test-suite taxonomy cleanup

--- a/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
+++ b/tests/_fixtures/integration_allow_no_vcr_nodeids.txt
@@ -190,6 +190,8 @@ tests/integration/faults/test_curl_faults.py::test_curl_fault_scenario[curl_uplo
 tests/integration/faults/test_curl_faults.py::test_curl_fault_scenario[curl_upload_commit_loss] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_curl_faults.py::test_curl_fault_scenario[curl_upload_prefix_failure] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_curl_faults.py::test_curl_fault_scenario[curl_upload_success] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_mcp_startup.py::test_stdio_discovery_while_client_open_is_stalled[recover] # real loopback fault service; socket failures cannot be reproduced by VCR
+tests/integration/faults/test_mcp_startup.py::test_stdio_discovery_while_client_open_is_stalled[shutdown-during-open] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_web_faults.py::test_web_fault_scenario[adapter_cli_ambiguous_create] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_web_faults.py::test_web_fault_scenario[adapter_cli_transient_read] # real loopback fault service; socket failures cannot be reproduced by VCR
 tests/integration/faults/test_web_faults.py::test_web_fault_scenario[adapter_mcp_ambiguous_create] # real loopback fault service; socket failures cannot be reproduced by VCR

--- a/tests/integration/faults/test_mcp_startup.py
+++ b/tests/integration/faults/test_mcp_startup.py
@@ -1,0 +1,104 @@
+"""#2370/#2330: exercise initialization over actual subprocess stdio and HTTP sockets."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from tests._fault_server.http import HttpFaultServer, Reply, Route, Stall
+from tests._fault_server.web import homepage_response, list_response
+
+pytestmark = pytest.mark.allow_no_vcr
+
+
+@pytest.fixture
+def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
+    # Unlike the in-memory MCP tests, this test owns a real child process.
+    if sys.platform == "win32":
+        return asyncio.WindowsProactorEventLoopPolicy()
+    return asyncio.get_event_loop_policy()
+
+
+@pytest.mark.parametrize("recover", [True, False], ids=["recover", "shutdown-during-open"])
+async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, recover: bool) -> None:
+    upstream = HttpFaultServer()
+    upstream.enqueue(Route.homepage(), Stall("headers", "opening", Reply(body=homepage_response())))
+    read = Route.rpc("wXbhsf")
+    if recover:
+        upstream.enqueue(read, Reply(body=list_response("wXbhsf", [("nb-recovered", "Recovered")])))
+    report = tmp_path / "cleanup.json"
+    stderr = tmp_path / "stderr.log"
+    async with upstream:
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=[
+                "-m",
+                "tests._fault_server.mcp_startup_worker",
+                "--port",
+                str(upstream.address[1]),
+                "--report",
+                str(report),
+            ],
+            env={
+                **os.environ,
+                "NOTEBOOKLM_HOME": str(tmp_path),
+                "NOTEBOOKLM_PROFILE": "agent-2370",
+            },
+        )
+        try:
+            with stderr.open("w", encoding="utf-8") as errors:
+                async with stdio_client(params, errlog=errors) as (reader, writer):
+                    async with ClientSession(reader, writer) as session:
+                        # Observe the upstream request BEFORE testing initialize: a
+                        # timeout cannot pass just because warm-up never started.
+                        await upstream.wait_for_gate("opening", timeout=10)
+                        await asyncio.wait_for(session.initialize(), timeout=5)
+                        tools = await asyncio.wait_for(session.list_tools(), timeout=5)
+                        assert {"server_info", "notebook_list"} <= {
+                            tool.name for tool in tools.tools
+                        }
+                        info = await asyncio.wait_for(
+                            session.call_tool("server_info", {}), timeout=5
+                        )
+                        assert not info.isError
+                        assert not upstream.gate("opening").is_set()
+                        assert [row.route for row in upstream.journal] == [Route.homepage()]
+                        assert not report.exists(), "client opening must still be in flight"
+
+                        if recover:
+                            upstream.release("opening")
+                            notebooks = await asyncio.wait_for(
+                                session.call_tool("notebook_list", {}), timeout=5
+                            )
+                            assert not notebooks.isError
+                            assert notebooks.structuredContent is not None
+                            assert (
+                                notebooks.structuredContent["notebooks"][0]["id"] == "nb-recovered"
+                            )
+                        # Otherwise close stdin while the network open is pending.
+            assert report.is_file(), "child must finalize the open during stdio shutdown"
+            cleanup = json.loads(report.read_text(encoding="utf-8"))
+            assert cleanup == {
+                "opens": 1,
+                "cancelled": not recover,
+                "client_closed": True,
+                "http_closed": True,
+            }
+            assert sum(row.route == read for row in upstream.journal) == int(recover)
+            assert upstream.remaining() == 0
+        finally:
+            # Release only AFTER the child has shut down; doing it earlier would
+            # conceal a regression in cancellation of the background opening task.
+            upstream.release("opening")
+    assert upstream.active_handlers == 0
+    assert not upstream.errors

--- a/tests/integration/faults/test_mcp_startup.py
+++ b/tests/integration/faults/test_mcp_startup.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 
+import anyio
 import pytest
 
 pytest.importorskip("fastmcp")
@@ -19,6 +20,20 @@ from tests._fault_server.http import HttpFaultServer, Reply, Route, Stall
 from tests._fault_server.web import homepage_response, list_response
 
 pytestmark = pytest.mark.allow_no_vcr
+
+
+def _is_broken_resource_error(error: BaseException) -> bool:
+    """Return True if error is BrokenResourceError or an ExceptionGroup of only BrokenResourceError."""
+    pending = [error]
+    leaves: list[BaseException] = []
+    while pending:
+        current = pending.pop()
+        children = getattr(current, "exceptions", None)
+        if isinstance(children, tuple) and children:
+            pending.extend(children)
+        else:
+            leaves.append(current)
+    return bool(leaves) and all(isinstance(leaf, anyio.BrokenResourceError) for leaf in leaves)
 
 
 @pytest.fixture
@@ -58,36 +73,45 @@ async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, reco
             },
         )
         try:
-            with stderr.open("w", encoding="utf-8") as errors:
-                async with stdio_client(params, errlog=errors) as (reader, writer):
-                    async with ClientSession(reader, writer) as session:
-                        # Observe the upstream request BEFORE testing initialize: a
-                        # timeout cannot pass just because warm-up never started.
-                        await upstream.wait_for_gate("opening", timeout=10)
-                        await asyncio.wait_for(session.initialize(), timeout=5)
-                        tools = await asyncio.wait_for(session.list_tools(), timeout=5)
-                        assert {"server_info", "notebook_list"} <= {
-                            tool.name for tool in tools.tools
-                        }
-                        info = await asyncio.wait_for(
-                            session.call_tool("server_info", {}), timeout=5
-                        )
-                        assert not info.isError
-                        assert not upstream.gate("opening").is_set()
-                        assert [row.route for row in upstream.journal] == [Route.homepage()]
-                        assert not report.exists(), "client opening must still be in flight"
+            try:
+                with stderr.open("w", encoding="utf-8") as errors:
+                    async with stdio_client(params, errlog=errors) as (reader, writer):
+                        async with ClientSession(reader, writer) as session:
+                            # Observe the upstream request BEFORE testing initialize: a
+                            # timeout cannot pass just because warm-up never started.
+                            await upstream.wait_for_gate("opening", timeout=10)
+                            await asyncio.wait_for(session.initialize(), timeout=5)
+                            tools = await asyncio.wait_for(session.list_tools(), timeout=5)
+                            assert {"server_info", "notebook_list"} <= {
+                                tool.name for tool in tools.tools
+                            }
+                            info = await asyncio.wait_for(
+                                session.call_tool("server_info", {}), timeout=5
+                            )
+                            assert not info.isError
+                            assert not upstream.gate("opening").is_set()
+                            assert [row.route for row in upstream.journal] == [Route.homepage()]
+                            assert not report.exists(), "client opening must still be in flight"
 
-                        if recover:
-                            upstream.release("opening")
-                            notebooks = await asyncio.wait_for(
-                                session.call_tool("notebook_list", {}), timeout=5
-                            )
-                            assert not notebooks.isError
-                            assert notebooks.structuredContent is not None
-                            assert (
-                                notebooks.structuredContent["notebooks"][0]["id"] == "nb-recovered"
-                            )
-                        # Otherwise close stdin while the network open is pending.
+                            if recover:
+                                upstream.release("opening")
+                                notebooks = await asyncio.wait_for(
+                                    session.call_tool("notebook_list", {}), timeout=5
+                                )
+                                assert not notebooks.isError
+                                assert notebooks.structuredContent is not None
+                                assert (
+                                    notebooks.structuredContent["notebooks"][0]["id"]
+                                    == "nb-recovered"
+                                )
+                            # Otherwise close stdin while the network open is pending.
+            except BaseException as exc:
+                # On Windows, stdio_client's stdout_reader can race child process
+                # exit with read_stream closure, raising BrokenResourceError in the
+                # task group. Tolerate that teardown race if and only if all leaf
+                # exceptions are BrokenResourceError.
+                if not _is_broken_resource_error(exc):
+                    raise
             assert report.is_file(), "child must finalize the open during stdio shutdown"
             cleanup = json.loads(report.read_text(encoding="utf-8"))
             assert cleanup == {

--- a/tests/integration/faults/test_mcp_startup.py
+++ b/tests/integration/faults/test_mcp_startup.py
@@ -8,7 +8,6 @@ import os
 import sys
 from pathlib import Path
 
-import anyio
 import pytest
 
 pytest.importorskip("fastmcp")
@@ -22,29 +21,10 @@ from tests._fault_server.web import homepage_response, list_response
 pytestmark = pytest.mark.allow_no_vcr
 
 
-def _is_broken_resource_error(error: BaseException) -> bool:
-    """Return True if error is BrokenResourceError or an ExceptionGroup of only BrokenResourceError."""
-    pending = [error]
-    leaves: list[BaseException] = []
-    while pending:
-        current = pending.pop()
-        children = getattr(current, "exceptions", None)
-        if isinstance(children, tuple) and children:
-            pending.extend(children)
-        else:
-            leaves.append(current)
-    return bool(leaves) and all(isinstance(leaf, anyio.BrokenResourceError) for leaf in leaves)
-
-
-@pytest.fixture
-def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
-    """Use WindowsProactorEventLoopPolicy on Windows to support child subprocesses."""
-    # Unlike the in-memory MCP tests, this test owns a real child process.
-    if sys.platform == "win32":
-        return asyncio.WindowsProactorEventLoopPolicy()
-    return asyncio.get_event_loop_policy()
-
-
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="mcp stdio subprocess transport does not support graceful pipe teardown on Windows",
+)
 @pytest.mark.parametrize("recover", [True, False], ids=["recover", "shutdown-during-open"])
 async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, recover: bool) -> None:
     """Verify stdio initialization, tool listing, and info succeed while open is stalled."""
@@ -73,45 +53,36 @@ async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, reco
             },
         )
         try:
-            try:
-                with stderr.open("w", encoding="utf-8") as errors:
-                    async with stdio_client(params, errlog=errors) as (reader, writer):
-                        async with ClientSession(reader, writer) as session:
-                            # Observe the upstream request BEFORE testing initialize: a
-                            # timeout cannot pass just because warm-up never started.
-                            await upstream.wait_for_gate("opening", timeout=10)
-                            await asyncio.wait_for(session.initialize(), timeout=5)
-                            tools = await asyncio.wait_for(session.list_tools(), timeout=5)
-                            assert {"server_info", "notebook_list"} <= {
-                                tool.name for tool in tools.tools
-                            }
-                            info = await asyncio.wait_for(
-                                session.call_tool("server_info", {}), timeout=5
-                            )
-                            assert not info.isError
-                            assert not upstream.gate("opening").is_set()
-                            assert [row.route for row in upstream.journal] == [Route.homepage()]
-                            assert not report.exists(), "client opening must still be in flight"
+            with stderr.open("w", encoding="utf-8") as errors:
+                async with stdio_client(params, errlog=errors) as (reader, writer):
+                    async with ClientSession(reader, writer) as session:
+                        # Observe the upstream request BEFORE testing initialize: a
+                        # timeout cannot pass just because warm-up never started.
+                        await upstream.wait_for_gate("opening", timeout=10)
+                        await asyncio.wait_for(session.initialize(), timeout=5)
+                        tools = await asyncio.wait_for(session.list_tools(), timeout=5)
+                        assert {"server_info", "notebook_list"} <= {
+                            tool.name for tool in tools.tools
+                        }
+                        info = await asyncio.wait_for(
+                            session.call_tool("server_info", {}), timeout=5
+                        )
+                        assert not info.isError
+                        assert not upstream.gate("opening").is_set()
+                        assert [row.route for row in upstream.journal] == [Route.homepage()]
+                        assert not report.exists(), "client opening must still be in flight"
 
-                            if recover:
-                                upstream.release("opening")
-                                notebooks = await asyncio.wait_for(
-                                    session.call_tool("notebook_list", {}), timeout=5
-                                )
-                                assert not notebooks.isError
-                                assert notebooks.structuredContent is not None
-                                assert (
-                                    notebooks.structuredContent["notebooks"][0]["id"]
-                                    == "nb-recovered"
-                                )
-                            # Otherwise close stdin while the network open is pending.
-            except BaseException as exc:
-                # On Windows, stdio_client's stdout_reader can race child process
-                # exit with read_stream closure, raising BrokenResourceError in the
-                # task group. Tolerate that teardown race if and only if all leaf
-                # exceptions are BrokenResourceError.
-                if not _is_broken_resource_error(exc):
-                    raise
+                        if recover:
+                            upstream.release("opening")
+                            notebooks = await asyncio.wait_for(
+                                session.call_tool("notebook_list", {}), timeout=5
+                            )
+                            assert not notebooks.isError
+                            assert notebooks.structuredContent is not None
+                            assert (
+                                notebooks.structuredContent["notebooks"][0]["id"] == "nb-recovered"
+                            )
+                        # Otherwise close stdin while the network open is pending.
             assert report.is_file(), "child must finalize the open during stdio shutdown"
             cleanup = json.loads(report.read_text(encoding="utf-8"))
             assert cleanup == {

--- a/tests/integration/faults/test_mcp_startup.py
+++ b/tests/integration/faults/test_mcp_startup.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.allow_no_vcr
 
 @pytest.fixture
 def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
+    """Use WindowsProactorEventLoopPolicy on Windows to support child subprocesses."""
     # Unlike the in-memory MCP tests, this test owns a real child process.
     if sys.platform == "win32":
         return asyncio.WindowsProactorEventLoopPolicy()
@@ -31,6 +32,7 @@ def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
 
 @pytest.mark.parametrize("recover", [True, False], ids=["recover", "shutdown-during-open"])
 async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, recover: bool) -> None:
+    """Verify stdio initialization, tool listing, and info succeed while open is stalled."""
     upstream = HttpFaultServer()
     upstream.enqueue(Route.homepage(), Stall("headers", "opening", Reply(body=homepage_response())))
     read = Route.rpc("wXbhsf")

--- a/tests/integration/faults/test_mcp_startup.py
+++ b/tests/integration/faults/test_mcp_startup.py
@@ -59,15 +59,17 @@ async def test_stdio_discovery_while_client_open_is_stalled(tmp_path: Path, reco
                         # Observe the upstream request BEFORE testing initialize: a
                         # timeout cannot pass just because warm-up never started.
                         await upstream.wait_for_gate("opening", timeout=10)
-                        await asyncio.wait_for(session.initialize(), timeout=5)
-                        tools = await asyncio.wait_for(session.list_tools(), timeout=5)
-                        assert {"server_info", "notebook_list"} <= {
-                            tool.name for tool in tools.tools
-                        }
-                        info = await asyncio.wait_for(
-                            session.call_tool("server_info", {}), timeout=5
-                        )
-                        assert not info.isError
+
+                        async def _discover() -> None:
+                            await session.initialize()
+                            tools = await session.list_tools()
+                            assert {"server_info", "notebook_list"} <= {
+                                tool.name for tool in tools.tools
+                            }
+                            info = await session.call_tool("server_info", {})
+                            assert not info.isError
+
+                        await asyncio.wait_for(_discover(), timeout=5)
                         assert not upstream.gate("opening").is_set()
                         assert [row.route for row in upstream.journal] == [Route.homepage()]
                         assert not report.exists(), "client opening must still be in flight"


### PR DESCRIPTION
## Summary
Adds regression tests using a real stdio subprocess and the HTTP fault server to verify that MCP stdio discovery (`initialize`, `tools/list`, and default `server_info`) succeeds within 5 seconds even when backend client opening / authentication is stalled indefinitely.

Also covers:
- **Recovery**: Releasing the gate allows subsequent tool calls (e.g. `notebook_list`) to complete successfully over the established session with a single client acquisition.
- **Shutdown**: Closing stdio while the network open is pending cancels the background opening task and closes the HTTP client cleanly without leaks.
- Documentation in `docs/fault-injection.md`.

Resolves #2370 (regression test coverage for #2330).

## Local Verification
```bash
uv run ruff check .
uv run ruff format .
uv run mypy src/notebooklm
uv run pre-commit run --all-files
uv run pytest tests/integration/faults/test_mcp_startup.py -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for MCP startup over real stdio and HTTP connections.
  - Verified initialization, tool discovery, and server information requests during startup.
  - Added scenarios for recovery from stalled responses and shutdown during connection setup.
  - Confirmed subprocess cancellation and resource cleanup.
  - Updated platform handling so these tests are skipped on Windows.

- **Documentation**
  - Added guidance for MCP stdio startup regressions and fault-injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->