### PR TITLE
fix(ci): remove RPC provisioning and expose E2E progress

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -212,9 +212,6 @@ jobs:
         test_filter = os.environ["TEST_FILTER"]
         if selected_lane not in {"all", "web", "android", "readonly"}:
             raise SystemExit(f"unsupported e2e_lane: {selected_lane}")
-        if selected_lane == "readonly" and test_filter:
-            raise SystemExit("e2e_lane=readonly cannot be combined with test_filter")
-
         include = []
         if selected_lane in {"all", "web"}:
             include.append(
@@ -230,7 +227,7 @@ jobs:
                  "selection": "not variants", "account_slot": android["account_slot"],
                  "master_token_secret_name": android["master_token_secret_name"]}
             )
-        if selected_lane in {"all", "readonly"} and not test_filter:
+        if selected_lane == "readonly" or (selected_lane == "all" and not test_filter):
             include.append(
                 {"os": "windows-latest", "backend": "web",
                  "lane": "nightly-readonly-windows", "mode": "readonly",
@@ -421,6 +418,8 @@ jobs:
         # Lifecycle and retry scripts use Bash syntax on every runner.
         shell: bash
     env:
+      PYTHONUNBUFFERED: "1"
+      CI_E2E_PROGRESS: "1"
       NOTEBOOKLM_BACKEND: ${{ matrix.backend }}
       NOTEBOOKLM_PROFILE: ci-${{ matrix.account_slot }}-${{ matrix.lane }}
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
@@ -504,12 +503,10 @@ jobs:
       env:
         NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID }}
       run: |
-        result=$(uv run python scripts/manage_ci_e2e_notebooks.py sweep \
+        uv run python scripts/manage_ci_e2e_notebooks.py sweep \
           --backend "${{ matrix.backend }}" \
           --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
-          --manifest "$CI_E2E_MANIFEST")
-        printf '%s\n' "$result"
-        printf '### %s lifecycle\n%s\n' "${{ matrix.lane }}" "$result" >> "$GITHUB_STEP_SUMMARY"
+          --manifest "$CI_E2E_MANIFEST"
     - name: Provision managed role copies
       id: provision
       if: steps.auth.outcome == 'success' && steps.sweep.outcome == 'success'
@@ -626,7 +623,7 @@ jobs:
         python -c 'from pathlib import Path; import os; Path(os.environ["E2E_COVERAGE_FLOOR_SENTINEL"]).unlink(missing_ok=True)'
         if [ -n "$TEST_FILTER" ]; then
           unset E2E_ENFORCE_COVERAGE_FLOOR
-          uv run pytest -s -v --tb=short --reruns 1 --reruns-delay 30 -- "$TEST_FILTER"
+          uv run pytest -m "${{ matrix.selection }}" -s -v --tb=short --reruns 1 --reruns-delay 30 -- "$TEST_FILTER"
         else
           uv run pytest tests/e2e -m "${{ matrix.selection }}" -s -v --tb=short \
             --reruns 1 --reruns-delay 30
@@ -654,9 +651,12 @@ jobs:
         E2E_ENFORCE_COVERAGE_FLOOR: "1"
         TEST_FILTER: ${{ inputs.test_filter }}
       run: |
-        sleep 600
+        for minute in {1..10}; do
+          echo "E2E retry cool-down: minute $minute/10"
+          sleep 60
+        done
         if [ -n "$TEST_FILTER" ]; then unset E2E_ENFORCE_COVERAGE_FLOOR; fi
-        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -s -v --tb=short
+        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -m "${{ matrix.selection }}" -s -v --tb=short
     - name: curl_cffi transport smoke
       id: smoke
       if: steps.preflight.outcome == 'success' && matrix.lane == 'nightly-web-ubuntu'
@@ -724,13 +724,11 @@ jobs:
         steps.verifier_budget.outcome == 'success'
       continue-on-error: true
       run: |
-        result=$(uv run python scripts/verify_ci_artifacts.py \
+        uv run python scripts/verify_ci_artifacts.py \
           --mode journal --backend web \
           --manifest "$CI_E2E_MANIFEST" --role generation \
           --journal "$CI_E2E_JOURNAL" \
-          --timeout "${{ steps.verifier_budget.outputs.timeout }}")
-        printf '%s\n' "$result"
-        printf '### Generation verification\n%s\n' "$result" >> "$GITHUB_STEP_SUMMARY"
+          --timeout "${{ steps.verifier_budget.outputs.timeout }}"
     - name: Cleanup managed role copies
       id: cleanup
       if: always()
@@ -738,12 +736,10 @@ jobs:
       env:
         NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID }}
       run: |
-        result=$(uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
+        uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
           --backend "${{ matrix.backend }}" \
           --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
-          --manifest "$CI_E2E_MANIFEST")
-        printf '%s\n' "$result"
-        printf '### Managed-copy cleanup\n%s\n' "$result" >> "$GITHUB_STEP_SUMMARY"
+          --manifest "$CI_E2E_MANIFEST"
     - name: Purge local credentials and handles
       id: purge
       if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -270,7 +270,7 @@ jobs:
             echo "| nightly-android-macos | macOS | android | full | $ANDROID_SLOT | $SELECTION_MODE |"
           fi
           if [ "$E2E_LANE" = all ] || [ "$E2E_LANE" = readonly ]; then
-            if [ -n "$TEST_FILTER" ]; then
+            if [ "$E2E_LANE" = all ] && [ -n "$TEST_FILTER" ]; then
               echo "| nightly-readonly-windows | Windows | web | omitted | $READONLY_SLOT | filtered dispatch |"
             else
               echo "| nightly-readonly-windows | Windows | web | readonly | $READONLY_SLOT | $SELECTION_MODE |"

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -214,6 +214,7 @@ jobs:
     environment: protected-readonly
     timeout-minutes: 180
     env:
+      PYTHONUNBUFFERED: "1"
       NOTEBOOKLM_PROFILE: ci-${{ needs.plan-live-lanes.outputs.web_account_slot }}-rpc-health-web
 
     steps:
@@ -235,7 +236,6 @@ jobs:
       run: |
         {
           echo "NOTEBOOKLM_HOME=$RUNNER_TEMP/notebooklm-home"
-          echo "CI_E2E_MANIFEST=$RUNNER_TEMP/notebooklm-e2e/manifest.json"
         } >> "$GITHUB_ENV"
 
     - name: Set up Python
@@ -292,79 +292,6 @@ jobs:
           attempt=$((attempt + 1))
         done
 
-    - name: Sweep stale RPC copies
-      id: sweep
-      if: steps.auth.outcome == 'success'
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID }}
-      run: |
-        result=$(uv run python scripts/manage_ci_e2e_notebooks.py sweep \
-          --backend web --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
-          --manifest "$CI_E2E_MANIFEST")
-        printf '%s\n' "$result"
-        printf '### RPC copy lifecycle\n%s\n' "$result" >> "$GITHUB_STEP_SUMMARY"
-
-    - name: Provision RPC fallback copy
-      id: provision
-      if: steps.auth.outcome == 'success' && steps.sweep.outcome == 'success'
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID }}
-        SUMMARY_SLOT: ${{ needs.plan-live-lanes.outputs.web_account_slot }}
-      run: |
-        uv run python scripts/manage_ci_e2e_notebooks.py provision \
-          --backend web --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
-          --contract tests/fixtures/e2e_template_contract.json \
-          --prepared-contract tests/fixtures/e2e_prepared_role_contract.json \
-          --mode rpc --lane rpc-health-web \
-          --account-slot "${{ needs.plan-live-lanes.outputs.web_account_slot }}" \
-          --manifest "$CI_E2E_MANIFEST" --github-env "$GITHUB_ENV"
-        python - <<'PY'
-        import json
-        import os
-        import re
-        from pathlib import Path
-
-        manifest = json.loads(Path(os.environ["CI_E2E_MANIFEST"]).read_text(encoding="utf-8"))
-        expected = {
-            "backend": "web",
-            "lane": "rpc-health-web",
-            "account_slot": os.environ["SUMMARY_SLOT"],
-            "mode": "rpc",
-        }
-        if any(manifest.get(key) != value for key, value in expected.items()):
-            raise RuntimeError("manifest summary metadata mismatch")
-        copies = manifest.get("copies")
-        if not isinstance(copies, list) or len(copies) != 1 or not isinstance(copies[0], dict):
-            raise RuntimeError("manifest summary role count mismatch")
-        row = copies[0]
-        if row.get("role") != "rpc" or row.get("status") not in {"confirmed", "reconciled"}:
-            raise RuntimeError("manifest summary copy outcome mismatch")
-        if row.get("prepared") is not True:
-            raise RuntimeError("manifest summary contains an unprepared role")
-        fingerprint = manifest.get("template_fingerprint")
-        if not isinstance(fingerprint, str) or re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
-            raise RuntimeError("manifest summary fingerprint is malformed")
-        lines = [
-            "### Prepared RPC copy",
-            f"- Lane/backend/slot: rpc-health-web / web / {expected['account_slot']}",
-            f"- Template contract: version=1 fingerprint={fingerprint}",
-            f"- Copy outcomes: total=1 confirmed={int(row['status'] == 'confirmed')} reconciled={int(row['status'] == 'reconciled')}",
-            "- Clean-role residuals: rpc=0",
-        ]
-        with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as stream:
-            stream.write("\n".join(lines) + "\n")
-        PY
-
-    - name: Validate RPC fallback bindings
-      id: preflight
-      if: steps.provision.outcome == 'success'
-      continue-on-error: true
-      run: |
-        test -n "${NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID:-}"
-        test "$NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID" = "$NOTEBOOKLM_GENERATION_NOTEBOOK_ID"
-
     # Rebrand-host lane state, carried between nightly runs so the lane can
     # report a *state change* rather than re-announcing the same observation
     # forever. Restore-only + a run-scoped save key, because cache entries are
@@ -376,7 +303,7 @@ jobs:
     # disappeared; a contrary live observation is still reported as new.
     - name: Restore rebrand-host lane state
       uses: actions/cache/restore@v6
-      if: steps.preflight.outcome == 'success'
+      if: steps.auth.outcome == 'success'
       continue-on-error: true
       with:
         path: rebrand-state.json
@@ -392,7 +319,7 @@ jobs:
     # failure writes no state at all) would leave yesterday's document in place
     # and the detect step would replay yesterday's transition (#2062).
     - name: Move restored rebrand state into the previous-run slot
-      if: steps.preflight.outcome == 'success'
+      if: steps.auth.outcome == 'success'
       shell: bash
       run: |
         if [ -f rebrand-state.json ]; then
@@ -401,7 +328,7 @@ jobs:
 
     - name: Run RPC Health Check
       id: health
-      if: steps.preflight.outcome == 'success'
+      if: steps.auth.outcome == 'success'
       # Auth comes from the profile materialized above (no inline env-var
       # credential is shipped at all) so the layer-4 re-mint can engage.
       #
@@ -422,6 +349,7 @@ jobs:
         TARGET_BRANCH: main
       run: |
         echo "Testing branch: $TARGET_BRANCH"
+        echo "Full RPC check creates and cleans up its own temporary resources."
         set +e
         uv run python scripts/check_rpc_health.py --full \
           --rebrand-state-file rebrand-state.json \
@@ -471,9 +399,15 @@ jobs:
     - name: Add Summary
       if: always()
       shell: bash
+      env:
+        AUTH_OUTCOME: ${{ steps.auth.outcome }}
       run: |
         echo "## RPC Health Check Results" >> "$GITHUB_STEP_SUMMARY"
-        grep -A 10 "^SUMMARY$" health-report.txt >> "$GITHUB_STEP_SUMMARY" || echo "No summary found" >> "$GITHUB_STEP_SUMMARY"
+        if [ "$AUTH_OUTCOME" != success ]; then
+          echo "RPC probes did not run. See the authentication diagnostics and phase outcomes." >> "$GITHUB_STEP_SUMMARY"
+        elif ! grep -A 10 "^SUMMARY$" health-report.txt >> "$GITHUB_STEP_SUMMARY"; then
+          echo "RPC probes did not produce a summary. See the full RPC diagnostic report." >> "$GITHUB_STEP_SUMMARY"
+        fi
 
     # Bundle-drift monitor (capture_rpc_registry.py). NOT a PR gate — it depends
     # on Google's live external JS bundle, which can rotate at any time — so it
@@ -491,7 +425,7 @@ jobs:
       # carries no domain, so every cookie is sent to every host in the
       # redirect chain regardless of which auth source fed it — issue #2019.
       continue-on-error: true
-      if: steps.preflight.outcome == 'success'
+      if: steps.auth.outcome == 'success'
       shell: bash
       env:
         HEALTH_EXIT_CODE: ${{ steps.health.outputs.exit_code }}
@@ -965,6 +899,14 @@ jobs:
         path: health-report.txt
         retention-days: 30
 
+    - name: Link full RPC diagnostic report
+      if: always() && steps.report_upload.outputs.artifact-url != ''
+      shell: bash
+      env:
+        REPORT_URL: ${{ steps.report_upload.outputs.artifact-url }}
+      run: |
+        printf '\n[Download the full RPC diagnostic report](%s)\n' "$REPORT_URL" >> "$GITHUB_STEP_SUMMARY"
+
     - name: Capture report and issue-handling outcomes
       id: report
       if: always() && (steps.health.outcome == 'success' || steps.health.outcome == 'failure')
@@ -981,20 +923,7 @@ jobs:
           exit 1
         fi
 
-    - name: Cleanup RPC fallback copy
-      id: cleanup
-      if: always()
-      continue-on-error: true
-      env:
-        NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID }}
-      run: |
-        result=$(uv run python scripts/manage_ci_e2e_notebooks.py cleanup \
-          --backend web --template-id-env NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID \
-          --manifest "$CI_E2E_MANIFEST")
-        printf '%s\n' "$result"
-        printf '### RPC copy cleanup\n%s\n' "$result" >> "$GITHUB_STEP_SUMMARY"
-
-    - name: Purge RPC health credentials and manifest
+    - name: Purge RPC health credentials
       id: purge
       if: always()
       continue-on-error: true
@@ -1006,7 +935,6 @@ jobs:
         home = Path(os.environ["NOTEBOOKLM_HOME"])
         if home.exists():
             shutil.rmtree(home)
-        Path(os.environ["CI_E2E_MANIFEST"]).unlink(missing_ok=True)
         PY
 
     - name: Aggregate Web RPC health outcomes
@@ -1016,12 +944,8 @@ jobs:
         python scripts/aggregate_ci_e2e_outcomes.py
         --lane rpc-health-web --mode rpc --producer required
         --phase auth=${{ steps.auth.outcome == 'success' && 'success' || 'failure' }}
-        --phase sweep=${{ steps.auth.outcome == 'success' && (steps.sweep.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
-        --phase provision=${{ steps.sweep.outcome == 'success' && (steps.provision.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
-        --phase preflight=${{ steps.provision.outcome == 'success' && (steps.preflight.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
-        --phase health=${{ steps.preflight.outcome == 'success' && (steps.health.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
+        --phase health=${{ steps.auth.outcome == 'success' && (steps.health.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
         --phase report=${{ (steps.health.outcome == 'success' || steps.health.outcome == 'failure') && (steps.report.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
-        --phase cleanup=${{ steps.cleanup.outcome == 'success' && 'success' || 'failure' }}
         --phase purge=${{ steps.purge.outcome == 'success' && 'success' || 'failure' }}
 
   # ------------------------------------------------------------------

--- a/docs/development.md
+++ b/docs/development.md
@@ -1535,7 +1535,7 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 | `test.yml` | Push/PR | Reduced 7-cell compatibility matrix (Ubuntu × Python 3.10–3.14, plus macOS/Windows on 3.12), linting, type checking |
 | `fault-stress.yml` | PR, daily 5:45 AM UTC, manual dispatch | Local HTTP/gRPC fault workloads with synthetic credentials and diagnostic report artifacts |
 | `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Full compatibility/coverage plus managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E; an owner may qualify an open same-repository PR at its pinned head SHA |
-| `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on a disposable fallback copy plus the template-read-only [Android gRPC canary](#android-grpc-canary); an owner may qualify an open same-repository PR at its pinned head SHA |
+| `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on its own temporary notebook plus the template-read-only [Android gRPC canary](#android-grpc-canary); an owner may qualify an open same-repository PR at its pinned head SHA |
 | `testpypi-publish.yml` | Manual dispatch | Publish to TestPyPI |
 | `verify-package.yml` | Manual dispatch on `main` | Verify TestPyPI or PyPI install plus managed-copy E2E; artifact inventory is advisory |
 | `publish.yml` | Tag push | Publish to PyPI |
@@ -1592,10 +1592,10 @@ baseline by hand, not something the canary fixes.
 ### Managed-copy live CI
 
 Canonical CI never points pytest or full RPC health at the immutable template.
-Each authenticated lane selects one opaque account slot, materializes only that
-slot's master token, and creates workload-isolated copies. Full lanes prepare a
+Each authenticated lane selects one opaque account slot and materializes only that
+slot's master token. E2E lanes create workload-isolated copies. Full lanes prepare a
 stable `reference` copy plus one mutable copy shared by `generation` and
-`multi-source`; Web RPC health uses one `rpc` fallback copy. The Android RPC
+`multi-source`; Web RPC health creates and cleans up its own temporary notebook. The Android RPC
 canary is the only lane that reads the template directly, and it performs no
 notebook mutation.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -846,14 +846,32 @@ artifacts. Legacy quiz and flashcard rows in this public notebook have no Web va
 report, data-table, and interactive mind-map artifacts are absent. Those optional read-only checks
 skip when unavailable, while the full E2E lanes generate and exercise every family on disposable
 notebooks. Copying is asynchronous: provisioning dispatches every physical copy first, then polls
-each copied source and artifact state for up to ten minutes before preparation. Full lanes use a
-stable reference copy plus one clean mutable workspace shared by generation and multi-source
-tests; RPC health uses one clean fallback copy. Waiting for inherited artifacts before deletion is
-required because artifact propagation can lag behind the initial copy response. The checked-in
-template shape is
+copied sources until ready. Full lanes use a reference copy plus one clean mutable workspace
+shared by generation and multi-source tests. Clean
+workspaces wait for the required inherited artifact families to appear, delete them even when
+unfinished, then prove a stable empty inventory over the existing 90-second quiet window.
+Reference artifact completion is checked separately by
+`test_copied_reference_artifacts_become_ready`, with a ten-minute budget. Missing copied artifacts
+fail that test with the missing families listed while allowing the other E2E tests to run.
+The checked-in template shape is
 `tests/fixtures/e2e_template_contract.json`. Notes and chat history are deliberately absent from
 that contract. Provisioning creates and validates those on the disposable `reference` copy using
 `tests/fixtures/e2e_prepared_role_contract.json`.
+
+Nightly logs show each preparation stage, per-test start/result lines, and a heartbeat every
+30 seconds while a test is running. Artifact verification reports pending families, producer
+tests, and missing download URLs during polling. The job summary retains preparation failures,
+E2E result counts and failed test names, and a table of phase outcomes even after cleanup.
+These reports omit notebook handles, titles, parametrized resource values, and upstream response
+bodies. To enable the same test progress locally, set `CI_E2E_PROGRESS=1` when running pytest.
+For a short workflow smoke test, dispatch nightly with `e2e_lane=readonly`, a read-only pytest
+node in `test_filter`, and `run_compatibility=false`. The filter and retries still enforce the
+read-only marker selection.
+
+Web RPC health does not provision an E2E copy. After authentication, `check_rpc_health.py --full`
+creates its own temporary notebook and resources, probes the RPCs, then exercises deletion RPCs
+in its cleanup block. A failed notebook-creation probe remains a reported RPC failure; account
+checks that do not need a notebook still run. The job summary links the full diagnostic report.
 The configured template is the public notebook titled
 `Make Your Writing More Powerful and Persuasive`. Its title cannot be changed; replacing the
 template requires updating the title contract and template-ID secret together.

--- a/scripts/_ci_progress.py
+++ b/scripts/_ci_progress.py
@@ -1,0 +1,42 @@
+"""Live-CI reporting for caller-validated, resource-free diagnostics.
+
+Callers must supply only owned labels, counts and allowlisted status values;
+credential scrubbing alone cannot make upstream exception bodies safe to publish.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def safe_test_name(node_id: str) -> str:
+    """Keep source identifiers, excluding parametrized resource handles."""
+    name = node_id.split("[", 1)[0]
+    if re.fullmatch(r"tests/e2e/(?:\w+/)*test_\w+\.py(?:::\w+)*", name):
+        return name
+    return "unavailable test name"
+
+
+def write_summary(markdown: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        try:
+            with Path(path).open("a", encoding="utf-8") as stream:
+                stream.write(markdown + "\n")
+        except OSError:
+            # Reporting must never replace the command's original failure.
+            print("WARNING: could not write CI step summary", file=sys.stderr, flush=True)
+
+
+def report(message: str, *, summary: bool = False, error: bool = False) -> None:
+    timestamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+    print(f"[{timestamp}] {message}", file=sys.stderr if error else sys.stdout, flush=True)
+    if summary or error:
+        write_summary(f"- {message}")
+    if error and os.environ.get("GITHUB_ACTIONS") == "true":
+        escaped = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::error::{escaped}", flush=True)

--- a/scripts/aggregate_ci_e2e_outcomes.py
+++ b/scripts/aggregate_ci_e2e_outcomes.py
@@ -7,6 +7,8 @@ import argparse
 import sys
 from dataclasses import dataclass
 
+from _ci_progress import write_summary
+
 STATES = {"success", "failure", "not_applicable"}
 
 
@@ -108,21 +110,9 @@ POLICIES = {
     ),
     "rpc-health-web": LanePolicy(
         mode="rpc",
-        applicable=frozenset(
-            {
-                "auth",
-                "sweep",
-                "provision",
-                "preflight",
-                "health",
-                "report",
-                "cleanup",
-                "purge",
-            }
-        ),
+        applicable=frozenset({"auth", "health", "report", "purge"}),
         dependencies={
-            **_BASE_COPY_DEPENDENCIES,
-            "health": ("preflight",),
+            "health": ("auth",),
             "report": ("health",),
         },
     ),
@@ -303,6 +293,13 @@ def main(argv: list[str] | None = None) -> int:
     except OutcomeError as exc:
         print(f"CONFIGURATION: {exc}", file=sys.stderr)
         return 2
+    write_summary(f"\n### CI phases: {args.lane}\n\n| Phase | Outcome |\n| --- | --- |")
+    for phase, state in states.items():
+        if phase in POLICIES[args.lane].applicable and state in STATES:
+            write_summary(f"| {phase} | {state.replace('not_applicable', 'not run')} |")
+    execution_phase = "primary" if "primary" in POLICIES[args.lane].applicable else "health"
+    if states.get(execution_phase) == "not_applicable":
+        write_summary("\nTests/probes did not run. See the failed prerequisite above.")
     if errors:
         print("CI E2E outcome failed: " + ", ".join(errors), file=sys.stderr)
         return 1

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -58,7 +58,6 @@ from notebooklm import (
     ServerError,
     SharePermission,
 )
-from notebooklm._logging import scrub_secrets
 
 TEMPLATE_ID_ENV = "NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID"
 DEFAULT_TEMPLATE_ID = "a109ad5c-834d-4f3d-82a0-fe41aa72318e"
@@ -185,9 +184,10 @@ class SweepResult:
 
 
 def _safe_exception_name(exc: BaseException) -> str:
-    """Return a scrubbed class name, never an exception body."""
+    """Return a Python class identifier, never an exception body."""
 
-    return scrub_secrets(type(exc).__name__).replace("\n", " ")[:100]
+    name = type(exc).__name__
+    return name if re.fullmatch(r"[A-Za-z_]\w{0,99}", name) else "Exception"
 
 
 def _category_for(exc: BaseException) -> str:

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -45,6 +45,7 @@ from _ci_e2e_notebooks import (
     parse_title,
     validate_manifest,
 )
+from _ci_progress import report
 
 from notebooklm import (
     AuthError,
@@ -431,6 +432,18 @@ class NotebookLifecycleManager:
         self.clock = clock
         self.sleep = sleep
         self.nonce = nonce
+        self._started = clock()
+        self._role = "template"
+        self._content_deficiencies: list[str] = []
+        self._last_progress = "not started"
+
+    def _progress(self, phase: str, detail: str, *, summary: bool = False) -> None:
+        self._last_progress = f"role={self._role} phase={phase}; {detail}"
+        report(
+            f"Provision {self._role}: {phase} ({self.clock() - self._started:.0f}s elapsed); "
+            f"{detail}",
+            summary=summary,
+        )
 
     async def _read(self, operation: Callable[[], Awaitable[T]]) -> T:
         return await retry_idempotent(
@@ -500,6 +513,7 @@ class NotebookLifecycleManager:
         *,
         tolerate_incomplete: bool,
         require_artifacts: bool,
+        require_completed_artifacts: bool = True,
     ) -> dict[str, int] | None:
         """Validate sources and artifacts without repeating notebook identity reads."""
 
@@ -515,16 +529,25 @@ class NotebookLifecycleManager:
                 if _kind_value(getattr(source, "kind", None)) not in non_text_kinds
             ]
             if len(text_ready) < source_contract["minimum_ready"]:
-                incomplete.append("template has too few text-addressable ready sources")
+                incomplete.append(
+                    "template has too few text-addressable ready sources "
+                    f"({len(text_ready)}/{source_contract['minimum_ready']})"
+                )
         distinct_titles = {
             str(getattr(source, "title", "")).strip().casefold()
             for source in ready_sources
             if str(getattr(source, "title", "")).strip()
         }
         if len(ready_sources) < source_contract["minimum_ready"]:
-            incomplete.append("template has too few ready sources")
+            incomplete.append(
+                "template has too few ready sources "
+                f"({len(ready_sources)}/{source_contract['minimum_ready']})"
+            )
         if len(distinct_titles) < source_contract["minimum_distinct_titles"]:
-            incomplete.append("template source topics are not sufficiently distinct")
+            incomplete.append(
+                "template source topics are not sufficiently distinct "
+                f"({len(distinct_titles)}/{source_contract['minimum_distinct_titles']})"
+            )
 
         completed: list[Any] = []
         families: set[str] = set()
@@ -535,20 +558,23 @@ class NotebookLifecycleManager:
             # variant cannot distinguish quiz, flashcards, or mind map. Skip
             # those known-unclassifiable rows before ``.kind`` warns; they
             # cannot satisfy any concrete required family.
+            eligible = completed if require_completed_artifacts else artifacts
             classified = [
                 artifact
-                for artifact in completed
+                for artifact in eligible
                 if not bool(getattr(artifact, "is_unclassified_type4", False))
             ]
             families = {_kind_value(getattr(artifact, "kind", None)) for artifact in classified}
             required = set(self.template_contract["artifacts"]["required_completed_families"])
             missing = sorted(required - families)
             if missing:
-                incomplete.append("template is missing completed families: " + ",".join(missing))
+                state = "completed" if require_completed_artifacts else "copied"
+                incomplete.append(f"template is missing {state} families: " + ",".join(missing))
             if self.template_contract["artifacts"]["require_interactive_mind_map"] and not any(
-                getattr(artifact, "is_interactive_mind_map", False) for artifact in completed
+                getattr(artifact, "is_interactive_mind_map", False) for artifact in eligible
             ):
                 incomplete.append("template is missing a completed interactive mind map")
+        self._content_deficiencies = incomplete
         if incomplete:
             if tolerate_incomplete:
                 return None
@@ -564,6 +590,7 @@ class NotebookLifecycleManager:
         notebook_id: str,
         *,
         require_artifacts: bool = True,
+        require_completed_artifacts: bool = True,
     ) -> dict[str, int]:
         original = self.template_id
         self.template_id = notebook_id
@@ -577,18 +604,31 @@ class NotebookLifecycleManager:
                     counts = await self._validate_template_content(
                         tolerate_incomplete=True,
                         require_artifacts=require_artifacts,
+                        require_completed_artifacts=require_completed_artifacts,
                     )
                 except RateLimitError:
                     now = self.clock()
                     if now >= deadline:
                         raise
+                    self._progress("copy settlement", "inventory rate limited; retrying in 60s")
                     await self.sleep(min(_COPY_SETTLE_QUOTA_BACKOFF_SECONDS, deadline - now))
                     continue
                 if counts is not None:
+                    self._progress(
+                        "copy ready",
+                        " ".join(f"{key}={value}" for key, value in counts.items()),
+                        summary=True,
+                    )
                     return counts
                 now = self.clock()
+                detail = "; ".join(self._content_deficiencies)
+                self._progress(
+                    "copy settlement", f"remaining={max(0, deadline - now):.0f}s; {detail}"
+                )
                 if now >= deadline:
-                    raise ContractError("copied template state did not settle within ten minutes")
+                    raise ContractError(
+                        "copied template state did not settle within ten minutes: " + detail
+                    )
                 await self.sleep(min(_COPY_SETTLE_POLL_SECONDS, deadline - now))
         finally:
             self.template_id = original
@@ -692,6 +732,13 @@ class NotebookLifecycleManager:
             else:
                 consecutive_empty += 1
             ready_count = sum(bool(getattr(source, "is_ready", False)) for source in sources)
+            self._progress(
+                "clean preparation",
+                f"artifacts={len(current.artifacts)} notes={len(current.notes)} "
+                f"mind_maps={len(current.mind_maps)} ready_sources={ready_count}; "
+                f"quiet={max(0, self.clock() - last_nonempty):.0f}/{policy.quiet_period:.0f}s; "
+                f"remaining={max(0, deadline - self.clock()):.0f}s",
+            )
             ready = ready_count >= clean["minimum_ready_sources"]
             quiet = now - last_nonempty >= policy.quiet_period
             if not current.ids and consecutive_empty >= 3 and quiet and ready:
@@ -730,6 +777,7 @@ class NotebookLifecycleManager:
         """Seed and validate deterministic disposable note/conversation state."""
 
         reference = self.prepared_contract["reference"]
+        self._progress("reference preparation", "creating the marker note")
         note = await self.client.notes.create(
             notebook_id,
             reference["note_title"],
@@ -738,8 +786,10 @@ class NotebookLifecycleManager:
         note_id = getattr(note, "id", None)
         if not is_valid_notebook_id(note_id):
             raise ContractError("prepared reference note returned a malformed ID")
+        self._progress("reference preparation", "seeding conversation history")
         await self.client.chat.ask(notebook_id, reference["question"])
         deadline = self.clock() + 90.0
+        last_report = float("-inf")
         while True:
             notes = await self._read(lambda: self.client.notes.list(notebook_id))
             markers = [
@@ -773,6 +823,14 @@ class NotebookLifecycleManager:
                 and getattr(readable, "content", None) == reference["note_body"]
             )
             now = self.clock()
+            if now - last_report >= 30 or now >= deadline:
+                self._progress(
+                    "reference preparation",
+                    f"note_readable={readable_valid} conversation={bool(conversation_id)} "
+                    f"history_pairs={history_pairs} turns_readable={_turn_has_content(turns)}; "
+                    f"remaining={max(0, deadline - now):.0f}s",
+                )
+                last_report = now
             if now > deadline:
                 raise ContractError("prepared reference state exceeded its deadline")
             if (
@@ -1077,6 +1135,9 @@ class NotebookLifecycleManager:
 
         if self.store.path.exists():
             raise PersistenceError("manifest already exists; refusing to overwrite lifecycle state")
+        self._progress(
+            "validation", "checking template sources and completed artifacts", summary=True
+        )
         await self.validate_template()
         manifest = new_manifest(
             run_id=run_id,
@@ -1090,26 +1151,43 @@ class NotebookLifecycleManager:
         self._persist_manifest(manifest)
         role_ids: dict[str, str] = {}
         for role in MODE_ROLES[mode]:
+            self._role = role
+            self._progress("copy", "dispatching one managed copy", summary=True)
             row = await self.copy_one(manifest, role)
             notebook_id = str(row["notebook_id"])
             role_ids[role] = notebook_id
             if mask is not None:
                 mask(notebook_id)
+            self._progress("copy confirmed", f"outcome={row['status']}", summary=True)
 
         # CopyProject returns before its asynchronous source/artifact propagation
         # completes. Dispatch every exactly-once copy first so that propagation
         # overlaps while the roles remain durably tracked and immediately masked.
         for role, notebook_id in role_ids.items():
-            await self._validate_copy_shape(
-                notebook_id,
-                require_artifacts=True,
-            )
-            if role == "reference":
-                await self.prepare_reference(notebook_id)
-            else:
-                await self.prepare_clean_role(notebook_id, role)
-            await self.validate_prepared_role(notebook_id, role)
+            self._role = role
+            self._progress("copy settlement", "waiting for required copied content", summary=True)
+            try:
+                await self._validate_copy_shape(
+                    notebook_id,
+                    # Wait for clean roles' inherited families to arrive before
+                    # deleting them, without waiting for unfinished work to complete.
+                    # Reference completion is asserted by a dedicated E2E test.
+                    require_artifacts=role != "reference",
+                    require_completed_artifacts=False,
+                )
+                self._progress("preparation", "preparing role state", summary=True)
+                if role == "reference":
+                    await self.prepare_reference(notebook_id)
+                else:
+                    await self.prepare_clean_role(notebook_id, role)
+                await self.validate_prepared_role(notebook_id, role)
+            except BaseException as exc:
+                report(f"Provision failed; last observation: {self._last_progress}", error=True)
+                if isinstance(exc, ContractError):
+                    exc.category = "PROVISIONING"
+                raise
             self._update_row(manifest, role, prepared=True)
+            self._progress("ready", "prepared role validated", summary=True)
 
         validate_manifest(manifest, template_id=self.template_id)
         role_ids = [str(row["notebook_id"]) for row in manifest["copies"]]
@@ -1431,7 +1509,7 @@ async def _run(args: argparse.Namespace) -> int:
     if args.command == "cleanup" and not args.manifest.exists():
         if args.template_id_env != TEMPLATE_ID_ENV:
             raise ManifestError("template ID environment name is not allowlisted")
-        print("nothing to clean; manifest is absent")
+        report("nothing to clean; manifest is absent", summary=True)
         return 0
     template_id = _template_id_from_env(args.template_id_env)
     template_contract: dict[str, Any] = {}
@@ -1474,19 +1552,21 @@ async def _run(args: argparse.Namespace) -> int:
                 github_env=args.github_env,
                 mask=_mask_for_github,
             )
-            print(
+            report(
                 f"provisioned {len(manifest['copies'])} prepared role(s); "
-                f"mode={args.mode} backend={args.backend} slot={args.account_slot}"
+                f"mode={args.mode} backend={args.backend} slot={args.account_slot}",
+                summary=True,
             )
             return 0
         if args.command == "validate":
             if args.role is None:
                 counts = await manager.validate_template()
-                print(
+                report(
                     "template contract valid; "
                     f"ready_sources={counts['ready_sources']} "
                     f"completed_artifacts={counts['completed_artifacts']} "
-                    f"fingerprint={fingerprint}"
+                    f"fingerprint={fingerprint}",
+                    summary=True,
                 )
                 return 0
             if args.manifest is None:
@@ -1499,13 +1579,14 @@ async def _run(args: argparse.Namespace) -> int:
             if row is None or row["notebook_id"] is None or row["prepared"] is not True:
                 raise ManifestError("prepared role is absent from the manifest")
             counts = await manager.validate_prepared_role(str(row["notebook_id"]), args.role)
-            print(f"prepared role valid; role={args.role} checks={len(counts)}")
+            report(f"prepared role valid; role={args.role} checks={len(counts)}", summary=True)
             return 0
         if args.command == "cleanup":
             counts = await manager.cleanup(expected_backend=args.backend)
-            print(
+            report(
                 f"cleanup complete; deleted={counts['deleted']} "
-                f"already_missing={counts['already_missing']} failed={counts['failed']}"
+                f"already_missing={counts['already_missing']} failed={counts['failed']}",
+                summary=True,
             )
             return 0
         if args.command == "sweep":
@@ -1526,9 +1607,10 @@ async def _run(args: argparse.Namespace) -> int:
                 max_age=timedelta(hours=args.max_age_hours),
                 deletion_cap=args.deletion_cap,
             )
-            print(
+            report(
                 f"sweep complete; eligible={result.eligible} deleted={result.deleted} "
-                f"skipped={result.skipped} failed={result.failed}"
+                f"skipped={result.skipped} failed={result.failed}",
+                summary=True,
             )
             return 0
     raise AssertionError("unreachable command")
@@ -1543,9 +1625,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             category = "REGRESSION"
         else:
             category = _category_for(exc)
-        print(
-            f"ERROR[{category}]: lifecycle command failed ({_safe_exception_name(exc)})",
-            file=sys.stderr,
+        # LifecycleError messages are owned by this script and summary-safe.
+        # Never publish arbitrary SDK/HTTP exception text or chained causes.
+        detail = str(exc) if isinstance(exc, LifecycleError) else _safe_exception_name(exc)
+        report(
+            f"ERROR[{category}]: lifecycle {args.command} failed: {detail}",
+            error=True,
         )
         return 1
 

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -573,7 +573,8 @@ class NotebookLifecycleManager:
             if self.template_contract["artifacts"]["require_interactive_mind_map"] and not any(
                 getattr(artifact, "is_interactive_mind_map", False) for artifact in eligible
             ):
-                incomplete.append("template is missing a completed interactive mind map")
+                state = "completed" if require_completed_artifacts else "copied"
+                incomplete.append(f"template is missing a {state} interactive mind map")
         self._content_deficiencies = incomplete
         if incomplete:
             if tolerate_incomplete:

--- a/scripts/verify_ci_artifacts.py
+++ b/scripts/verify_ci_artifacts.py
@@ -9,13 +9,14 @@ import json
 import math
 import os
 import stat
-import sys
 import time
 import uuid
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from _ci_progress import report, safe_test_name
 
 from notebooklm import NotebookLMClient
 from notebooklm._logging import scrub_secrets
@@ -180,6 +181,10 @@ class JournalOperation:
     @property
     def family(self) -> str:
         return self.immutable[1]
+
+    @property
+    def node_id(self) -> str:
+        return self.immutable[5]
 
     @property
     def id_kind(self) -> str:
@@ -456,6 +461,10 @@ async def _discover_quiet_inventory(
         else:
             stable = 0
         previous = signature
+        report(
+            f"Artifact discovery: observed={len(latest)} quiet_polls={stable}/{quiet_polls}; "
+            f"elapsed={clock() - started:.0f}s remaining={max(0, deadline - clock()):.0f}s"
+        )
         if stable >= quiet_polls:
             return latest
         if clock() + poll_interval > deadline:
@@ -480,6 +489,7 @@ async def verify_journal(
         raise InsufficientTimeError("effective verifier budget is below 240 seconds")
     operations = parse_journal(journal_path, notebook_id=notebook_id)
     deadline = clock() + timeout
+    report(f"Generation verification started; budget={timeout:.0f}s", summary=True)
     inventory = await _discover_quiet_inventory(
         client,
         notebook_id,
@@ -632,6 +642,7 @@ async def verify_journal(
                 raise JournalError("journaled artifact family does not match inventory")
 
         statuses.clear()
+        pending_details: Counter[str] = Counter()
         for resource_id in monitored_ids:
             artifact = current_by_id.get(resource_id)
             if artifact is None:
@@ -643,6 +654,16 @@ async def verify_journal(
                 missing_counts[resource_id] = 0
                 status = _snapshot_status(artifact)
             statuses[resource_id] = status
+            if status not in {"removed", "failed", "completed"}:
+                operation = tracked[resource_id]
+                observed = (
+                    status if status in {"pending", "in_progress", "not_found"} else "unknown"
+                )
+                if artifact is not None and artifact.status_str == "completed":
+                    observed = "awaiting_download_url"
+                pending_details[
+                    f"{operation.family}/{observed} ({safe_test_name(operation.node_id)})"
+                ] += 1
 
         removed = sum(status == "removed" for status in statuses.values())
         failed = sum(status == "failed" for status in statuses.values())
@@ -686,8 +707,18 @@ async def verify_journal(
             failed += selected_failed
             completed += terminal - selected_failed
             pending += required - terminal
+            if required > terminal:
+                pending_details[f"{target.family}/reconciling_interrupted_producer"] += (
+                    required - terminal
+                )
 
         ever_visible_ids.update(current_ids)
+        detail = "; ".join(f"{label}={count}" for label, count in sorted(pending_details.items()))
+        report(
+            f"Artifact settlement: completed={completed} failed={failed} pending={pending}; "
+            f"remaining={max(0, deadline - clock()):.0f}s" + (f"; {detail}" if detail else ""),
+            summary=pending == 0,
+        )
         if pending == 0:
             never_visible = (set(tracked) - authorized_deleted) - ever_visible_ids
             if never_visible:
@@ -723,7 +754,7 @@ async def verify_journal(
         if clock() + poll_interval > deadline:
             raise SettlementTimeoutError(
                 f"artifact settlement timed out (completed={completed} failed={failed} "
-                f"pending={pending})"
+                f"pending={pending}); {detail}"
             )
         await sleep(poll_interval)
 
@@ -817,12 +848,12 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         asyncio.run(_run_client(args))
     except VerificationError as exc:
-        print(f"{exc.category}: {scrub_secrets(exc)}", file=sys.stderr)
+        report(f"{exc.category}: {scrub_secrets(exc)}", error=True)
         return exc.exit_code
     except Exception:
         # Arbitrary upstream exception text can carry resource IDs even after
         # credential scrubbing. The category is actionable without echoing it.
-        print("read_or_auth: artifact inventory request failed", file=sys.stderr)
+        report("read_or_auth: artifact inventory request failed", error=True)
         return EXIT_READ_AUTH
     return 0
 

--- a/scripts/verify_ci_artifacts.py
+++ b/scripts/verify_ci_artifacts.py
@@ -19,7 +19,6 @@ from typing import Any
 from _ci_progress import report, safe_test_name
 
 from notebooklm import NotebookLMClient
-from notebooklm._logging import scrub_secrets
 
 EXPECTED_FAMILIES = {
     "audio",
@@ -848,7 +847,9 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         asyncio.run(_run_client(args))
     except VerificationError as exc:
-        report(f"{exc.category}: {scrub_secrets(exc)}", error=True)
+        # These diagnostics are constructed here from owned labels, counts and
+        # validated test names. Arbitrary upstream exceptions take the branch below.
+        report(f"{exc.category}: {exc}", error=True)
         return exc.exit_code
     except Exception:
         # Arbitrary upstream exception text can carry resource IDs even after

--- a/tests/_fault_server/web_resilience_scenarios.py
+++ b/tests/_fault_server/web_resilience_scenarios.py
@@ -416,7 +416,10 @@ async def _configured_queue_expiry_no_dispatch(result: ScenarioResult) -> None:
             error = caught
         server.release("held-rpc")
         await held
-        probe = await client.notebooks.list()
+        # Only the queued create tests the 50 ms default. Recovery must tolerate
+        # scheduler delays while other fault scenarios run concurrently.
+        async with client.operation(timeout=None):
+            probe = await client.notebooks.list()
     metadata = getattr(error, "operation_metadata", None)
     result.require("configured_queue_timeout", isinstance(error, OperationTimeoutError))
     result.require(

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -74,17 +74,29 @@ async def assert_copied_reference_artifacts(
             artifact.kind.value for artifact in completed if not artifact.is_unclassified_type4
         }
         missing = sorted(required_families - families)
+        missing_payloads = sorted(
+            family
+            for family in required_families & families & URL_BACKED_ARTIFACT_FAMILIES
+            if not completed_download_candidates(
+                completed, family, backend=client.backends["artifacts"]
+            )
+        )
         if require_interactive_mind_map and not any(
             artifact.is_interactive_mind_map for artifact in completed
         ):
             missing.append("interactive_mind_map")
+        issues = []
+        if missing:
+            issues.append("missing completed families: " + ", ".join(missing))
+        if missing_payloads:
+            issues.append("missing download payload families: " + ", ".join(missing_payloads))
         remaining = max(0.0, deadline - clock())
-        detail = "missing completed families: " + ", ".join(missing) if missing else "ready"
+        detail = "; ".join(issues) if issues else "ready"
         report(
             f"Copied reference artifacts: {detail}; remaining={remaining:.0f}s",
-            summary=not missing or remaining == 0,
+            summary=not issues or remaining == 0,
         )
-        if not missing:
+        if not issues:
             return
         assert remaining > 0, "Copied reference " + detail
         await sleep(min(30, remaining))

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+
+from scripts._ci_progress import report
+
 from notebooklm import Artifact
+from notebooklm.client import NotebookLMClient
 
 URL_BACKED_ARTIFACT_FAMILIES = frozenset({"audio", "video", "infographic", "slide_deck"})
 URL_BACKED_STUDIO_TYPES = frozenset(
@@ -46,3 +53,38 @@ def completed_interactive_mind_maps(artifacts: list[Artifact]) -> list[Artifact]
         for artifact in artifacts
         if artifact.is_interactive_mind_map and artifact.is_completed
     ]
+
+
+async def assert_copied_reference_artifacts(
+    client: NotebookLMClient,
+    notebook_id: str,
+    *,
+    required_families: set[str],
+    require_interactive_mind_map: bool,
+    timeout: float = 600,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    """Keep copied-content failures visible without preventing other E2E tests."""
+    deadline = clock() + timeout
+    while True:
+        artifacts = await client.artifacts.list(notebook_id)
+        completed = [artifact for artifact in artifacts if artifact.is_completed]
+        families = {
+            artifact.kind.value for artifact in completed if not artifact.is_unclassified_type4
+        }
+        missing = sorted(required_families - families)
+        if require_interactive_mind_map and not any(
+            artifact.is_interactive_mind_map for artifact in completed
+        ):
+            missing.append("interactive_mind_map")
+        remaining = max(0.0, deadline - clock())
+        detail = "missing completed families: " + ", ".join(missing) if missing else "ready"
+        report(
+            f"Copied reference artifacts: {detail}; remaining={remaining:.0f}s",
+            summary=not missing or remaining == 0,
+        )
+        if not missing:
+            return
+        assert remaining > 0, "Copied reference " + detail
+        await sleep(min(30, remaining))

--- a/tests/e2e/_progress.py
+++ b/tests/e2e/_progress.py
@@ -1,0 +1,99 @@
+"""CI-only E2E progress, including a heartbeat while a test awaits the service."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import Counter
+
+from scripts._ci_progress import report, safe_test_name, write_summary
+
+
+class E2EProgress:
+    def __init__(self) -> None:
+        self.total = 0
+        self.started = time.monotonic()
+        self.current: tuple[str, float] | None = None
+        self.results: dict[str, str] = {}
+        self.failures: set[tuple[str, str]] = set()
+        self.reruns = 0
+        self.collection_errors = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def pytest_sessionstart(self, session) -> None:
+        self._thread = threading.Thread(target=self._heartbeat, daemon=True, name="e2e-progress")
+        self._thread.start()
+
+    def _heartbeat(self) -> None:
+        while not self._stop.wait(30):
+            self._report_current()
+
+    def _report_current(self) -> None:
+        current = self.current
+        if current is not None:
+            name, started = current
+            report(f"E2E still running: {name}; test elapsed={time.monotonic() - started:.0f}s")
+        else:
+            report("E2E waiting for collection or session teardown")
+
+    def pytest_collection_finish(self, session) -> None:
+        self.total = len(session.items)
+        report(f"E2E collected {self.total} selected tests", summary=True)
+
+    def pytest_collectreport(self, report) -> None:
+        if report.failed:
+            self.collection_errors += 1
+
+    def pytest_runtest_logstart(self, nodeid, location) -> None:
+        name = safe_test_name(nodeid)
+        self.current = (name, time.monotonic())
+        self.results[nodeid] = "running"
+        # A rerun replaces the earlier attempt's failure in the final summary.
+        self.failures = {entry for entry in self.failures if entry[0] != nodeid}
+        report(f"E2E [{len(self.results)}/{self.total}] START {name}")
+
+    def pytest_runtest_logreport(self, report) -> None:
+        if report.outcome == "rerun":
+            self.reruns += 1
+            self.results[report.nodeid] = "rerun"
+        elif report.failed:
+            self.results[report.nodeid] = "failed"
+            self.failures.add((report.nodeid, report.when))
+        elif self.results.get(report.nodeid) != "failed":
+            if report.skipped:
+                self.results[report.nodeid] = (
+                    "xfailed" if hasattr(report, "wasxfail") else "skipped"
+                )
+            elif report.when == "call":
+                self.results[report.nodeid] = "xpassed" if hasattr(report, "wasxfail") else "passed"
+
+    def pytest_runtest_logfinish(self, nodeid, location) -> None:
+        current = self.current
+        duration = time.monotonic() - current[1] if current else 0
+        outcome = self.results.get(nodeid, "incomplete")
+        report(
+            f"E2E {outcome.upper()} {safe_test_name(nodeid)}; elapsed={duration:.1f}s",
+            error=outcome == "failed",
+        )
+        self.current = None
+
+    def pytest_sessionfinish(self, session, exitstatus) -> None:
+        self.pytest_unconfigure()
+        counts = Counter(self.results.values())
+        detail = " ".join(f"{outcome}={count}" for outcome, count in sorted(counts.items()))
+        report(
+            f"E2E finished: exit={int(exitstatus)} {detail} reruns={self.reruns} "
+            f"collection_errors={self.collection_errors}; "
+            f"elapsed={time.monotonic() - self.started:.0f}s",
+            summary=True,
+        )
+        if self.failures:
+            write_summary("\n| Failed E2E test | Phase |\n| --- | --- |")
+            for nodeid, phase in sorted(self.failures):
+                write_summary(f"| `{safe_test_name(nodeid)}` | {phase} |")
+
+    def pytest_unconfigure(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -630,6 +630,10 @@ def pytest_configure(config):
     profile = config.getoption("--profile")
     if profile:
         _apply_profile(profile)
+    if os.environ.get("CI_E2E_PROGRESS") == "1":
+        from tests.e2e._progress import E2EProgress
+
+        config.pluginmanager.register(E2EProgress(), "ci-e2e-progress")
     try:
         _managed_bindings()
         # Validate journal policy before collection. A per-test helper reopens

--- a/tests/e2e/test_artifact_copy.py
+++ b/tests/e2e/test_artifact_copy.py
@@ -1,0 +1,29 @@
+"""Assert the managed reference copy's artifact contract as an E2E check."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ._artifact_helpers import assert_copied_reference_artifacts
+from .conftest import _managed_bindings, requires_auth
+
+
+@requires_auth
+@pytest.mark.asyncio
+@pytest.mark.readonly
+@pytest.mark.timeout(720)
+async def test_copied_reference_artifacts_become_ready(client, read_only_notebook_id):
+    if _managed_bindings() is None:
+        pytest.skip("Copied artifact contract applies only to managed CI notebooks")
+    contract = json.loads(
+        (Path(__file__).parents[1] / "fixtures" / "e2e_template_contract.json").read_text(
+            encoding="utf-8"
+        )
+    )["artifacts"]
+    await assert_copied_reference_artifacts(
+        client,
+        read_only_notebook_id,
+        required_families=set(contract["required_completed_families"]),
+        require_interactive_mind_map=contract["require_interactive_mind_map"],
+    )

--- a/tests/unit/test_aggregate_ci_e2e_outcomes.py
+++ b/tests/unit/test_aggregate_ci_e2e_outcomes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "aggregate_ci_e2e_outcomes.py"
+sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("aggregate_ci_e2e_outcomes", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 aggregate_module = importlib.util.module_from_spec(SPEC)
@@ -68,11 +69,13 @@ def test_failed_setup_requires_consumers_to_be_not_applicable() -> None:
 
 
 def test_dependency_violation_and_simultaneous_cleanup_purge_failures() -> None:
-    states = successful("rpc-health-web")
+    states = successful("nightly-readonly-windows")
     states["auth"] = "failure"
     states["cleanup"] = "failure"
     states["purge"] = "failure"
-    failures = aggregate_module.aggregate(lane="rpc-health-web", mode="rpc", states=states)
+    failures = aggregate_module.aggregate(
+        lane="nightly-readonly-windows", mode="readonly", states=states
+    )
     assert "dependency_violation:sweep" in failures
     assert "phase_failed:auth" in failures
     assert "phase_failed:cleanup" in failures
@@ -145,3 +148,26 @@ def test_cli_diagnostics_never_contain_resource_values(capsys) -> None:
     rendered = capsys.readouterr().err
     assert "phase_failed:health" in rendered
     assert "notebook_id" not in rendered
+
+
+def test_failed_prerequisite_summary_distinguishes_unrun_tests(monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    states = successful("nightly-readonly-windows")
+    states.update(
+        provision="failure",
+        preflight="not_applicable",
+        journal_policy="not_applicable",
+        primary="not_applicable",
+        lastfailed="not_applicable",
+        retry="not_applicable",
+        coverage="not_applicable",
+    )
+    args = ["--lane", "nightly-readonly-windows", "--mode", "readonly"]
+    for phase, state in states.items():
+        args.extend(["--phase", f"{phase}={state}"])
+    assert aggregate_module.main(args) == 1
+    text = summary.read_text()
+    assert "| provision | failure |" in text
+    assert "| primary | not run |" in text
+    assert "Tests/probes did not run" in text

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -28,8 +28,11 @@ import os
 import sys
 import warnings
 from collections import Counter
+from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -423,6 +426,67 @@ def test_is_transient_error_classifies_readtimeout_as_transient() -> None:
     assert is_transient_error("ConnectTimeout") is False
     assert is_transient_error("WriteTimeout") is False
     assert is_transient_error("PoolTimeout") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("created_id", ["probe-owned-notebook", None])
+async def test_full_health_runs_without_a_provisioned_fallback(monkeypatch, created_id):
+    monkeypatch.delenv("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_GENERATION_NOTEBOOK_ID", raising=False)
+    auth = SimpleNamespace(csrf_token="fake", account_route="0")
+    client = object()
+
+    @asynccontextmanager
+    async def probe_client(_auth):
+        yield client
+
+    temp = check_rpc_health.TempResources(notebook_id=created_id)
+
+    async def setup(_client, _auth, results):
+        results.append(
+            _result(
+                "CREATE_NOTEBOOK",
+                CheckStatus.OK if created_id else CheckStatus.ERROR,
+                error=None if created_id else "creation failed",
+            )
+        )
+        return temp
+
+    probe = AsyncMock(return_value=_result("READ", CheckStatus.OK))
+    cleanup = AsyncMock()
+    monkeypatch.setattr(check_rpc_health, "load_auth", AsyncMock(return_value=auth))
+    monkeypatch.setattr(check_rpc_health, "describe_cookie_scopes", lambda _auth: "fixture")
+    monkeypatch.setattr(check_rpc_health, "build_probe_client", probe_client)
+    monkeypatch.setattr(check_rpc_health, "setup_temp_resources", setup)
+    monkeypatch.setattr(check_rpc_health, "cleanup_temp_resources", cleanup)
+    monkeypatch.setattr(check_rpc_health, "check_method", probe)
+    monkeypatch.setattr(
+        check_rpc_health,
+        "check_chat_query",
+        AsyncMock(return_value=_result("CHAT", CheckStatus.OK)),
+    )
+    monkeypatch.setattr(
+        check_rpc_health,
+        "check_customization_table",
+        AsyncMock(return_value=(check_rpc_health.CustomizationStatus.UNKNOWN, "fixture")),
+    )
+    monkeypatch.setattr(
+        check_rpc_health,
+        "check_build_label",
+        AsyncMock(return_value=check_rpc_health.classify_build_label(None, "fixture")),
+    )
+    monkeypatch.setattr(check_rpc_health, "probe_rebrand_host", AsyncMock(return_value=[]))
+    monkeypatch.setattr(check_rpc_health, "CALL_DELAY", 0)
+
+    results, customization, state, build = await check_rpc_health.run_health_check(full_mode=True)
+
+    assert probe.await_count == len(list(check_rpc_health.RPCMethod))
+    assert all(call.args[3] == created_id for call in probe.await_args_list)
+    if created_id:
+        cleanup.assert_awaited_once_with(client, auth, temp, results)
+    else:
+        cleanup.assert_not_awaited()
+        assert check_rpc_health.print_summary(results, customization, state, build) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -44,7 +44,6 @@ def test_job_level_env_never_uses_step_only_runner_context() -> None:
 def test_manifest_paths_use_a_store_owned_private_child_directory() -> None:
     jobs = (
         _load("nightly.yml")["jobs"]["e2e"],
-        _load("rpc-health.yml")["jobs"]["health-check"],
         _load("verify-package.yml")["jobs"]["verify"],
     )
     for job in jobs:
@@ -403,6 +402,11 @@ def test_nightly_full_copy_journal_and_cleanup_dag_is_explicit() -> None:
     assert _step(job, "journal_policy")["if"] == "steps.preflight.outcome == 'success'"
     assert _step(job, "primary")["if"] == "steps.journal_policy.outcome == 'success'"
     assert _step(job, "cleanup")["if"] == "always()"
+
+    # A filtered read-only dispatch and its retry must still enforce the lane's
+    # marker selection, even if the requested node names a mutating test.
+    for phase in ("primary", "retry"):
+        assert '-m "${{ matrix.selection }}"' in str(_step(job, phase)["run"])
     assert _step(job, "purge")["if"] == "always()"
 
     provision = str(_step(job, "provision")["run"])
@@ -443,9 +447,13 @@ def test_rpc_and_package_lanes_have_their_designated_lifecycles() -> None:
         step = next(item for item in _steps(web) if item.get("name") == step_name)
         assert step["env"]["CHECKED_SHA"] == "${{ needs.resolve-target.outputs.sha }}"
         assert "${CHECKED_SHA}" in str(step["run"])
-    assert "--mode rpc" in str(_step(web, "provision")["run"])
-    assert _step(web, "health")["if"] == "steps.preflight.outcome == 'success'"
-    assert _step(web, "cleanup")["if"] == "always()"
+    assert not {"sweep", "provision", "preflight", "cleanup"} & {
+        step.get("id") for step in _steps(web)
+    }
+    assert "CI_E2E_MANIFEST" not in str(web)
+    assert "NOTEBOOKLM_E2E_TEMPLATE_NOTEBOOK_ID" not in str(web)
+    assert "scripts/check_rpc_health.py --full" in str(_step(web, "health")["run"])
+    assert _step(web, "health")["if"] == "steps.auth.outcome == 'success'"
     assert _step(web, "purge")["if"] == "always()"
     report_if = str(_step(web, "report")["if"])
     assert "steps.health.outcome == 'success'" in report_if
@@ -512,12 +520,6 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
     assert "Clean workspace residuals: generation/multi-source=0" in nightly_provision
     assert 'row["notebook_id"]' not in nightly_provision
     assert "Coverage floor:" in str(_step(nightly, "coverage")["run"])
-
-    rpc = _load("rpc-health.yml")["jobs"]["health-check"]
-    rpc_provision = str(_step(rpc, "provision")["run"])
-    assert "Copy outcomes: total=1" in rpc_provision
-    assert "Clean-role residuals: rpc=0" in rpc_provision
-    assert 'row["notebook_id"]' not in rpc_provision
 
     package = _load("verify-package.yml")["jobs"]["verify"]
     package_provision = str(_step(package, "provision")["run"])

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -106,6 +106,42 @@ def test_e2e_progress_handles_reruns_setup_and_teardown_failures(monkeypatch, tm
 
 
 @pytest.mark.parametrize(
+    ("lane", "test_filter", "suite"),
+    [
+        ("readonly", "tests/e2e/test_artifacts.py", "readonly"),
+        ("all", "tests/e2e/test_artifacts.py", "omitted"),
+        ("all", "", "readonly"),
+    ],
+)
+def test_account_plan_summary_matches_filtered_readonly_selection(
+    lane, test_filter, suite, tmp_path
+):
+    root = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load((root / ".github/workflows/nightly.yml").read_text())
+    command = next(
+        step["run"]
+        for step in workflow["jobs"]["plan-live-lanes"]["steps"]
+        if step.get("name") == "Summarize safe lane selection"
+    )
+    summary = tmp_path / "summary.md"
+    subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", command],
+        env={
+            **os.environ,
+            "GITHUB_STEP_SUMMARY": str(summary),
+            "E2E_LANE": lane,
+            "TEST_FILTER": test_filter,
+            "ENABLED_SLOTS": "A,B",
+            "READONLY_SLOT": "B",
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert f"| nightly-readonly-windows | Windows | web | {suite} | B |" in summary.read_text()
+
+
+@pytest.mark.parametrize(
     ("workflow", "job", "step"),
     [
         ("nightly.yml", "e2e", "verifier"),

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -1,0 +1,133 @@
+"""Failure and progress reporting must survive errors without exposing handles."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from scripts._ci_progress import report, safe_test_name
+
+from tests.e2e._progress import E2EProgress
+
+pytest_plugins = ["pytester"]
+
+
+def test_progress_plugin_runs_with_real_pytest(pytester, monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = function\n")
+    pytester.makeconftest(
+        "from tests.e2e._progress import E2EProgress\n"
+        "def pytest_configure(config):\n"
+        "    config.pluginmanager.register(E2EProgress())\n"
+    )
+    pytester.makepyfile(
+        "import pytest\n"
+        "def test_pass(): pass\n"
+        "def test_fail(): assert False, 'example failure'\n"
+        "def test_skip(): pytest.skip('example skip')\n"
+    )
+    result = pytester.runpytest("-s", "-q")
+    result.assert_outcomes(passed=1, failed=1, skipped=1)
+    result.stdout.fnmatch_lines(["*E2E finished: exit=1 failed=1 passed=1 skipped=1*"])
+    assert "failed=1 passed=1 skipped=1" in summary.read_text()
+
+
+def test_error_is_visible_in_log_annotation_and_summary(monkeypatch, tmp_path, capsys):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    report("copy readiness: 50%\nmissing audio", error=True)
+    captured = capsys.readouterr()
+    assert "missing audio" in captured.err
+    assert "::error::copy readiness: 50%25%0Amissing audio" in captured.out
+    assert "missing audio" in summary.read_text()
+
+
+def test_summary_write_failure_preserves_error_diagnostics(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path))
+    report("original verification failure", error=True)
+    assert "original verification failure" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "node_id",
+    ["secret-id", "tests/e2e/test_one.py::test_one\n::error::injected", "../secret.py::test_one"],
+)
+def test_untrusted_test_names_are_not_published(node_id):
+    assert safe_test_name(node_id) == "unavailable test name"
+
+
+def test_e2e_progress_handles_reruns_setup_and_teardown_failures(monkeypatch, tmp_path, capsys):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    progress = E2EProgress()
+    progress.pytest_collection_finish(SimpleNamespace(items=[1, 2, 3]))
+
+    def result(nodeid, when, outcome):
+        progress.pytest_runtest_logreport(
+            SimpleNamespace(
+                nodeid=nodeid,
+                when=when,
+                outcome=outcome,
+                failed=outcome == "failed",
+                skipped=outcome == "skipped",
+            )
+        )
+
+    retry = "tests/e2e/test_one.py::test_retry[private-notebook-id]"
+    progress.pytest_runtest_logstart(retry, None)
+    progress._report_current()
+    result(retry, "call", "rerun")
+    progress.pytest_runtest_logfinish(retry, None)
+    progress.pytest_runtest_logstart(retry, None)
+    result(retry, "call", "passed")
+    progress.pytest_runtest_logfinish(retry, None)
+    for name, phase in [("test_setup", "setup"), ("test_teardown", "teardown")]:
+        nodeid = f"tests/e2e/test_one.py::{name}"
+        progress.pytest_runtest_logstart(nodeid, None)
+        if phase == "teardown":
+            result(nodeid, "call", "passed")
+        result(nodeid, phase, "failed")
+        progress.pytest_runtest_logfinish(nodeid, None)
+    progress.pytest_sessionfinish(None, 1)
+
+    output = capsys.readouterr().out
+    rendered = summary.read_text()
+    assert "still running:" in output
+    assert "failed=2 passed=1 reruns=1" in rendered
+    assert "test_setup` | setup" in rendered
+    assert "test_teardown` | teardown" in rendered
+    assert "private-notebook-id" not in output + rendered
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job", "step"),
+    [
+        ("nightly.yml", "e2e", "verifier"),
+        ("nightly.yml", "e2e", "sweep"),
+        ("nightly.yml", "e2e", "cleanup"),
+    ],
+)
+def test_workflow_streams_output_and_preserves_failure(workflow, job, step, tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    data = yaml.safe_load((root / ".github" / "workflows" / workflow).read_text())
+    command = next(row["run"] for row in data["jobs"][job]["steps"] if row.get("id") == step)
+    command = command.replace("${{ steps.verifier_budget.outputs.timeout }}", "240")
+    command = command.replace("${{ matrix.backend }}", "web")
+    fake_uv = tmp_path / "uv"
+    fake_uv.write_text("#!/bin/sh\nprintf 'visible progress before failure\\n'\nexit 6\n")
+    fake_uv.chmod(0o755)
+    completed = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", command],
+        env={**os.environ, "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 6
+    assert "visible progress before failure" in completed.stdout

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,6 +16,21 @@ from scripts._ci_progress import report, safe_test_name
 from tests.e2e._progress import E2EProgress
 
 pytest_plugins = ["pytester"]
+
+
+@pytest.fixture
+def workflow_bash():
+    if sys.platform == "win32":
+        # PATH's bash.exe may be the WSL stub with no installed distribution.
+        # Actions uses the Bash bundled alongside Git for Windows.
+        git = shutil.which("git")
+        executable = Path(git).resolve().parents[1] / "bin" / "bash.exe" if git else None
+    else:
+        found = shutil.which("bash")
+        executable = Path(found) if found else None
+    if executable is None or not executable.is_file():
+        pytest.skip("workflow shell checks require Bash (Git Bash on Windows)")
+    return str(executable)
 
 
 def test_progress_plugin_runs_with_real_pytest(pytester, monkeypatch, tmp_path):
@@ -114,7 +131,7 @@ def test_e2e_progress_handles_reruns_setup_and_teardown_failures(monkeypatch, tm
     ],
 )
 def test_account_plan_summary_matches_filtered_readonly_selection(
-    lane, test_filter, suite, tmp_path
+    lane, test_filter, suite, tmp_path, workflow_bash
 ):
     root = Path(__file__).resolve().parents[2]
     workflow = yaml.safe_load((root / ".github/workflows/nightly.yml").read_text())
@@ -125,10 +142,10 @@ def test_account_plan_summary_matches_filtered_readonly_selection(
     )
     summary = tmp_path / "summary.md"
     subprocess.run(
-        ["bash", "-e", "-o", "pipefail", "-c", command],
+        [workflow_bash, "-e", "-o", "pipefail", "-c", command],
         env={
             **os.environ,
-            "GITHUB_STEP_SUMMARY": str(summary),
+            "GITHUB_STEP_SUMMARY": summary.as_posix(),
             "E2E_LANE": lane,
             "TEST_FILTER": test_filter,
             "ENABLED_SLOTS": "A,B",
@@ -137,6 +154,7 @@ def test_account_plan_summary_matches_filtered_readonly_selection(
         capture_output=True,
         text=True,
         check=True,
+        timeout=10,
     )
     assert f"| nightly-readonly-windows | Windows | web | {suite} | B |" in summary.read_text()
 
@@ -149,21 +167,19 @@ def test_account_plan_summary_matches_filtered_readonly_selection(
         ("nightly.yml", "e2e", "cleanup"),
     ],
 )
-def test_workflow_streams_output_and_preserves_failure(workflow, job, step, tmp_path):
+def test_workflow_streams_output_and_preserves_failure(workflow, job, step, workflow_bash):
     root = Path(__file__).resolve().parents[2]
     data = yaml.safe_load((root / ".github" / "workflows" / workflow).read_text())
     command = next(row["run"] for row in data["jobs"][job]["steps"] if row.get("id") == step)
     command = command.replace("${{ steps.verifier_budget.outputs.timeout }}", "240")
     command = command.replace("${{ matrix.backend }}", "web")
-    fake_uv = tmp_path / "uv"
-    fake_uv.write_text("#!/bin/sh\nprintf 'visible progress before failure\\n'\nexit 6\n")
-    fake_uv.chmod(0o755)
+    command = "uv() { printf 'visible progress before failure\\n'; return 6; }\n" + command
     completed = subprocess.run(
-        ["bash", "-e", "-o", "pipefail", "-c", command],
-        env={**os.environ, "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}"},
+        [workflow_bash, "-e", "-o", "pipefail", "-c", command],
         capture_output=True,
         text=True,
         check=False,
+        timeout=10,
     )
     assert completed.returncode == 6
     assert "visible progress before failure" in completed.stdout

--- a/tests/unit/test_ci_test_matrix.py
+++ b/tests/unit/test_ci_test_matrix.py
@@ -547,7 +547,9 @@ def test_nightly_e2e_maps_backends_and_suites_to_designated_runners() -> None:
     assert '"selection": "readonly and not variants"' in planner_run
     assert 'selected_lane in {"all", "web"}' in planner_run
     assert 'selected_lane in {"all", "android"}' in planner_run
-    assert 'selected_lane in {"all", "readonly"} and not test_filter' in planner_run
+    assert (
+        'selected_lane == "readonly" or (selected_lane == "all" and not test_filter)' in planner_run
+    )
 
     triggers = workflow.get("on", workflow.get(True))
     inputs = triggers["workflow_dispatch"]["inputs"]
@@ -595,7 +597,7 @@ def test_nightly_e2e_maps_backends_and_suites_to_designated_runners() -> None:
     primary_command = str(primary["run"])
     assert '-m "${{ matrix.selection }}"' in primary_command
     filtered_branch = primary_command.split("else", 1)[0]
-    assert "${{ matrix.selection }}" not in filtered_branch
+    assert '-m "${{ matrix.selection }}"' in filtered_branch
 
     curl_smoke = _step(job, "curl_cffi transport smoke")
     assert "matrix.lane == 'nightly-web-ubuntu'" in str(curl_smoke["if"])

--- a/tests/unit/test_copied_reference_artifacts.py
+++ b/tests/unit/test_copied_reference_artifacts.py
@@ -23,8 +23,13 @@ class Clock:
 @pytest.mark.asyncio
 async def test_reference_assertion_waits_for_late_artifacts(capsys):
     clock = Clock()
-    audio = Artifact(id="private-artifact", title="private-title", _artifact_type=1, status=3)
-    client = SimpleNamespace(artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[], [audio]])))
+    audio = Artifact(
+        id="private-artifact", title="private-title", _artifact_type=1, status=3, url="private-url"
+    )
+    client = SimpleNamespace(
+        artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[], [audio]])),
+        backends={"artifacts": "web"},
+    )
     await assert_copied_reference_artifacts(
         client,
         "private-notebook",
@@ -37,6 +42,40 @@ async def test_reference_assertion_waits_for_late_artifacts(capsys):
     output = capsys.readouterr().out
     assert "missing completed families: audio" in output
     assert "Copied reference artifacts: ready" in output
+    assert "private-" not in output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("backend", ["web", "android"])
+@pytest.mark.parametrize(("family", "type_code"), [("audio", 1), ("slide_deck", 8)])
+async def test_reference_waits_for_backend_download_payload(backend, family, type_code, capsys):
+    clock = Clock()
+    pending = Artifact(
+        id="private-artifact", title="private-title", _artifact_type=type_code, status=3
+    )
+    ready = Artifact(
+        id="private-artifact",
+        title="private-title",
+        _artifact_type=type_code,
+        status=3,
+        url="private-url",
+    )
+    client = SimpleNamespace(
+        artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[pending], [ready]])),
+        backends={"artifacts": backend},
+    )
+    await assert_copied_reference_artifacts(
+        client,
+        "private-notebook",
+        required_families={family},
+        require_interactive_mind_map=False,
+        clock=clock,
+        sleep=clock.sleep,
+    )
+    hydrate_android_slide = backend == "android" and family == "slide_deck"
+    assert clock.now == (0 if hydrate_android_slide else 30)
+    output = capsys.readouterr().out
+    assert ("missing download payload families" in output) is not hydrate_android_slide
     assert "private-" not in output
 
 

--- a/tests/unit/test_copied_reference_artifacts.py
+++ b/tests/unit/test_copied_reference_artifacts.py
@@ -1,0 +1,61 @@
+"""Copied artifacts remain a hard assertion even after setup stops waiting on them."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm import Artifact
+from tests.e2e._artifact_helpers import assert_copied_reference_artifacts
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    async def sleep(self, seconds):
+        self.now += seconds
+
+
+@pytest.mark.asyncio
+async def test_reference_assertion_waits_for_late_artifacts(capsys):
+    clock = Clock()
+    audio = Artifact(id="private-artifact", title="private-title", _artifact_type=1, status=3)
+    client = SimpleNamespace(artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[], [audio]])))
+    await assert_copied_reference_artifacts(
+        client,
+        "private-notebook",
+        required_families={"audio"},
+        require_interactive_mind_map=False,
+        clock=clock,
+        sleep=clock.sleep,
+    )
+    assert clock.now == 30
+    output = capsys.readouterr().out
+    assert "missing completed families: audio" in output
+    assert "Copied reference artifacts: ready" in output
+    assert "private-" not in output
+
+
+@pytest.mark.asyncio
+async def test_reference_assertion_fails_with_missing_families(monkeypatch, tmp_path, capsys):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    clock = Clock()
+    client = SimpleNamespace(artifacts=SimpleNamespace(list=AsyncMock(return_value=[])))
+    with pytest.raises(AssertionError, match="audio, video, interactive_mind_map"):
+        await assert_copied_reference_artifacts(
+            client,
+            "private-notebook",
+            required_families={"audio", "video"},
+            require_interactive_mind_map=True,
+            timeout=60,
+            clock=clock,
+            sleep=clock.sleep,
+        )
+    assert clock.now == 60
+    assert "missing completed families: audio, video, interactive_mind_map" in summary.read_text()
+    assert "private-notebook" not in capsys.readouterr().out

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -1598,7 +1598,7 @@ async def test_clean_copy_shape_requires_sources_but_not_inherited_artifact_comp
 
 
 @pytest.mark.asyncio
-async def test_provision_waits_for_artifacts_before_preparing_every_workspace(
+async def test_provision_leaves_artifact_completion_to_e2e_assertions(
     tmp_path: Path,
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
@@ -1607,16 +1607,90 @@ async def test_provision_waits_for_artifacts_before_preparing_every_workspace(
     validate_copy_shape = manager._validate_copy_shape
 
     async def recording_validate_copy_shape(
-        notebook_id: str, *, require_artifacts: bool = True
+        notebook_id: str,
+        *,
+        require_artifacts: bool = True,
+        require_completed_artifacts: bool = True,
     ) -> dict[str, int]:
         observed_require_artifacts.append(require_artifacts)
-        return await validate_copy_shape(notebook_id, require_artifacts=require_artifacts)
+        return await validate_copy_shape(
+            notebook_id,
+            require_artifacts=require_artifacts,
+            require_completed_artifacts=require_completed_artifacts,
+        )
 
     manager._validate_copy_shape = recording_validate_copy_shape  # type: ignore[method-assign]
 
     await _provision(manager, tmp_path, mode="full")
 
-    assert observed_require_artifacts == [True, True]
+    assert observed_require_artifacts == [False, True]
+
+
+@pytest.mark.parametrize("mode", ["full", "readonly", "rpc"])
+@pytest.mark.asyncio
+async def test_provision_succeeds_with_ready_sources_and_unfinished_copied_artifacts(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+    mode: str,
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copy = client.notebooks.copy
+
+    async def copy_with_pending_artifacts(template_id, title):
+        notebook = await copy(template_id, title)
+        for artifact in client.artifacts.by_notebook[notebook.id]:
+            artifact.is_completed = False
+        return notebook
+
+    client.notebooks.copy = copy_with_pending_artifacts
+    manifest = await _provision(manager, tmp_path, mode=mode)
+
+    assert all(row["prepared"] for row in manifest["copies"])
+    assert clock.value < 600
+    for row in manifest["copies"]:
+        if row["role"] != "reference":
+            assert client.artifacts.by_notebook[row["notebook_id"]] == []
+    assert all(artifact.is_completed for artifact in client.artifacts.by_notebook[TEMPLATE_ID])
+
+
+@pytest.mark.asyncio
+async def test_clean_copy_waits_for_late_inherited_inventory_before_quiet_window(
+    tmp_path: Path,
+    contracts: tuple[dict[str, Any], dict[str, Any]],
+) -> None:
+    manager, client, _store, clock = _manager(tmp_path, contracts)
+    copy = client.notebooks.copy
+
+    async def copy_with_late_inventory(template_id, title):
+        notebook = await copy(template_id, title)
+        client.artifacts.list_script.append([])
+        return notebook
+
+    client.notebooks.copy = copy_with_late_inventory
+    manifest = await _provision(manager, tmp_path, mode="rpc")
+
+    assert clock.value == 120  # 30s propagation, then 90s clean inventory observation
+    assert client.artifacts.by_notebook[manifest["copies"][0]["notebook_id"]] == []
+
+
+def test_cli_reports_owned_contract_reason_without_upstream_cause(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    async def fail(_args):
+        try:
+            raise RuntimeError("SID=private-cookie private-notebook-id private-title")
+        except RuntimeError as exc:
+            raise ContractError("prepared reference state did not become readable") from exc
+
+    monkeypatch.setattr(lifecycle, "_run", fail)
+    assert lifecycle.main(["validate", "--backend", "web"]) == 1
+    output = capsys.readouterr()
+    assert "prepared reference state did not become readable" in output.err
+    assert "prepared reference state did not become readable" in summary.read_text()
+    assert "private-" not in output.out + output.err + summary.read_text()
 
 
 @pytest.mark.asyncio
@@ -1635,10 +1709,17 @@ async def test_provision_dispatches_all_copies_before_settling_any_role(
         return row
 
     async def recording_validate_copy_shape(
-        notebook_id: str, *, require_artifacts: bool = True
+        notebook_id: str,
+        *,
+        require_artifacts: bool = True,
+        require_completed_artifacts: bool = True,
     ) -> dict[str, int]:
         events.append(f"settling:{notebook_id}")
-        return await validate_copy_shape(notebook_id, require_artifacts=require_artifacts)
+        return await validate_copy_shape(
+            notebook_id,
+            require_artifacts=require_artifacts,
+            require_completed_artifacts=require_completed_artifacts,
+        )
 
     manager.copy_one = recording_copy_one  # type: ignore[method-assign]
     manager._validate_copy_shape = recording_validate_copy_shape  # type: ignore[method-assign]

--- a/tests/unit/test_operation_context.py
+++ b/tests/unit/test_operation_context.py
@@ -212,15 +212,23 @@ async def test_swallowed_deadline_with_same_tick_external_cancel_stays_cancelled
     assert task.uncancel() == 0
 
 
-async def test_retired_generation_wins_when_deadline_cancellation_is_swallowed() -> None:
+async def test_retired_generation_wins_when_deadline_cancellation_is_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     supervisor = _supervisor()
-
-    with pytest.raises(asyncio.CancelledError):
-        async with supervisor.operation_scope("forced-close", timeout=0.01):
-            try:
-                await asyncio.sleep(10)
-            except asyncio.CancelledError:
-                supervisor._current = None
+    loop = asyncio.get_running_loop()
+    now = loop.time()
+    # Let the real operation timer fire, but advance its clock only after
+    # admission. A busy runner must not exhaust the deadline before this body.
+    with monkeypatch.context() as patch:
+        patch.setattr(loop, "time", lambda: now)
+        with pytest.raises(asyncio.CancelledError):
+            async with supervisor.operation_scope("forced-close", timeout=0.01):
+                try:
+                    now += 1
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    supervisor._current = None
 
     cancelling = getattr(asyncio.current_task(), "cancelling", None)
     if callable(cancelling):

--- a/tests/unit/test_verify_ci_artifacts.py
+++ b/tests/unit/test_verify_ci_artifacts.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_ci_artifacts.py"
+sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("verify_ci_artifacts", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 verify = importlib.util.module_from_spec(SPEC)
@@ -125,6 +126,35 @@ def write_journal(path: Path, rows: list[dict[str, object]]) -> None:
     path.write_text("".join(json.dumps(value) + "\n" for value in rows))
     if os.name != "nt":
         path.chmod(0o600)
+
+
+@pytest.mark.asyncio
+async def test_timeout_identifies_missing_download_url_and_producer_without_handles(
+    tmp_path, capsys
+) -> None:
+    journal = tmp_path / "journal.jsonl"
+    operation_id = str(uuid.uuid4())
+    events = [
+        row(operation_id, "started"),
+        row(operation_id, "accepted", resource_id="private-artifact-id"),
+    ]
+    for event in events:
+        event["node_id"] = "tests/e2e/test_generation.py::test_one[private-parameter]"
+    write_journal(journal, events)
+    clock = Clock()
+    with pytest.raises(verify.SettlementTimeoutError) as caught:
+        await verify.verify_journal(
+            Client([[Artifact("private-artifact-id", "audio", url=None)]]),
+            notebook_id="generation-role",
+            journal_path=journal,
+            timeout=240,
+            clock=clock,
+            sleep=clock.sleep,
+        )
+    output = capsys.readouterr().out + str(caught.value)
+    assert "audio/awaiting_download_url" in output
+    assert "tests/e2e/test_generation.py::test_one" in output
+    assert "private-" not in output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
RPC health was blocked by provisioning a second notebook even though `check_rpc_health.py --full` already creates and cleans up its own temporary resources. Nightly E2E also waited for copied artifacts to finish before running tests, while generic exceptions and captured stdout hid the reason for long waits and failures.

- Start Web RPC checking after authentication, remove the redundant copy lifecycle, and link the full diagnostic report from the job summary.
- Prepare copies once sources are ready. Clean workspaces wait for inherited artifact families to arrive, delete unfinished items, and retain the 90-second empty-inventory check. A dedicated read-only E2E assertion checks reference artifact completion and backend-specific download readiness without blocking the other tests.
- Stream safe provisioning and verifier diagnostics, including pending artifact families and producer tests. Add per-test progress, 30-second heartbeats, failure annotations, and job-summary phase/results tables.
- Advance a controlled clock after operation admission in the macOS cancellation test, eliminating the 10 ms scheduling race. Exclude the recovery probe from the queue-expiry stress scenario’s 50 ms default deadline.
- Allow a filtered read-only nightly dispatch while enforcing its marker selection on both initial tests and retries.

Validation: 594 focused tests passed (1 skipped) on Python 3.10; 105 affected tests passed after review follow-ups, with earlier focused checks also passing on Python 3.11; all 174 HTTP/gRPC stress scenarios passed; recovery-delay fault injection reproduces the old stress failure and passes with the fix; real pytest progress-plugin integration; read-only E2E collection; regression reproduction with a 30 ms admission stall; pre-commit; workflow secret-gate, permission, action-pinning, and installation-parity checks. Live E2E and RPC smoke runs will follow merge.

Investigated failures: https://github.com/teng-lin/notebooklm-py/actions/runs/34089466130 and https://github.com/teng-lin/notebooklm-py/actions/runs/34094679485.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live progress reporting, clearer failure diagnostics, and downloadable diagnostic links for automated E2E and RPC health checks.
  - Read-only test runs can now be filtered and retried while preserving the selected test scope.
  - Added checks confirming copied reference artifacts become available for E2E validation.

- **Bug Fixes**
  - Improved resilience when services respond slowly or artifacts become available asynchronously.
  - RPC health checks now use an independent temporary notebook lifecycle.

- **Documentation**
  - Updated development guidance for artifact readiness, cleanup validation, progress reporting, and RPC health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->