### PR TITLE
fix(ci): isolate live E2E runs and stream RPC diagnostics

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -1,0 +1,160 @@
+name: Nightly Code Checks
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      custom_branch:
+        description: 'Branch, tag, or commit to check (empty uses the triggering commit)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-checks-${{ github.ref }}-${{ inputs.custom_branch }}
+  cancel-in-progress: true
+
+jobs:
+  resolve-target:
+    runs-on: ubuntu-latest
+    if: github.repository == 'teng-lin/notebooklm-py'
+    outputs:
+      branch: ${{ steps.target.outputs.branch }}
+      sha: ${{ steps.target.outputs.sha }}
+      short_sha: ${{ steps.target.outputs.short_sha }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.custom_branch || github.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Resolve immutable commit
+      id: target
+      env:
+        TARGET_LABEL: ${{ inputs.custom_branch || github.ref_name }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        sha=$(git rev-parse HEAD)
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        echo "short_sha=${sha:0:12}" >> "$GITHUB_OUTPUT"
+        echo "branch=$TARGET_LABEL" >> "$GITHUB_OUTPUT"
+        printf '### Code-check target\n\nTarget: `%s@%s`\n' \
+          "$TARGET_LABEL" "$sha" >> "$GITHUB_STEP_SUMMARY"
+
+  compatibility:
+    name: Compatibility (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }}/${{ matrix.os }}/Python ${{ matrix.python-version }})
+    needs: resolve-target
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    concurrency:
+      group: nightly-compatibility-${{ needs.resolve-target.outputs.branch }}-${{ matrix.os }}-${{ matrix.python-version }}
+      cancel-in-progress: true
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+    - name: Install compatibility dependencies
+      run: >-
+        uv sync --frozen --extra browser --extra dev --extra markdown
+        --extra mcp --extra server --extra impersonate --extra cookies
+    - name: Assert native optional dependencies import
+      run: >-
+        uv run python -c "import curl_cffi, rookie_cookies;
+        assert callable(rookie_cookies.load);
+        assert callable(rookie_cookies.any_browser)"
+    - name: Run compatibility tests without coverage
+      run: >-
+        uv run pytest -n auto --dist loadgroup
+        -m "not repo_lint and not refactor_qualification and not requires_playwright and not requires_chromium"
+        --no-cov
+    - name: Run refactor qualification on every supported Python
+      if: matrix.os == 'ubuntu-latest'
+      # The exhaustive qualification runs once per supported interpreter,
+      # rather than being multiplied across all three operating systems.
+      run: >-
+        uv run pytest -n auto --dist loadgroup -m refactor_qualification
+        --timeout=180 --no-cov
+
+  coverage:
+    name: Coverage (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }})
+    needs: resolve-target
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+    - name: Install dependencies
+      run: >-
+        uv sync --frozen --extra browser --extra dev --extra markdown
+        --extra mcp --extra server --extra impersonate --extra cookies
+    - name: Install Playwright browsers
+      run: uv run playwright install chromium
+    - name: Install Playwright system dependencies (Linux)
+      run: uv run playwright install-deps chromium
+    - name: Run ordinary tests with coverage
+      run: >-
+        uv run pytest -n auto --dist loadgroup
+        -m "not repo_lint and not refactor_qualification and not requires_playwright and not requires_chromium"
+        --cov=src/notebooklm --cov-report= --cov-fail-under=0
+    - name: Append Playwright-dependent unit coverage
+      run: >-
+        uv run pytest tests/unit
+        -m "(requires_playwright or requires_chromium) and not reality and not refactor_qualification"
+        -n 0 --cov=src/notebooklm --cov-append
+        --cov-report=term-missing --cov-report=json:coverage.json
+        --cov-fail-under=90
+    - name: Assert per-file coverage floors
+      run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json
+
+  repo-lint:
+    name: Repository Lint (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }})
+    needs: resolve-target
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.resolve-target.outputs.sha }}
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Install uv
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
+    - name: Install dependencies
+      run: >-
+        uv sync --frozen --extra browser --extra dev --extra markdown
+        --extra mcp --extra server --extra impersonate --extra cookies
+    - name: Run repository lint tests
+      run: >-
+        uv run pytest -n auto --dist loadgroup
+        -m "repo_lint and not refactor_qualification"
+        --timeout=180 --no-cov

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,11 +26,6 @@ on:
         type: choice
         default: auto
         options: [auto, A, B, C]
-      run_compatibility:
-        description: 'Also run the full 3-OS by 5-Python compatibility matrix'
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -278,125 +273,6 @@ jobs:
           fi
         } >> "$GITHUB_STEP_SUMMARY"
 
-  compatibility:
-    name: Compatibility (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }}/${{ matrix.os }}/Python ${{ matrix.python-version }})
-    needs: resolve-target
-    if: >-
-      needs.resolve-target.outputs.is_standard == 'true' &&
-      (github.event_name == 'schedule' || inputs.run_compatibility)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    concurrency:
-      group: nightly-compatibility-${{ needs.resolve-target.outputs.branch }}-${{ matrix.os }}-${{ matrix.python-version }}
-      cancel-in-progress: true
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        ref: ${{ needs.resolve-target.outputs.sha }}
-        fetch-depth: 1
-        persist-credentials: false
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
-    - name: Install compatibility dependencies
-      run: >-
-        uv sync --frozen --extra browser --extra dev --extra markdown
-        --extra mcp --extra server --extra impersonate --extra cookies
-    - name: Assert native optional dependencies import
-      run: >-
-        uv run python -c "import curl_cffi, rookie_cookies;
-        assert callable(rookie_cookies.load);
-        assert callable(rookie_cookies.any_browser)"
-    - name: Run compatibility tests without coverage
-      run: >-
-        uv run pytest -n auto --dist loadgroup
-        -m "not repo_lint and not refactor_qualification and not requires_playwright and not requires_chromium"
-        --no-cov
-    - name: Run refactor qualification on every supported Python
-      if: matrix.os == 'ubuntu-latest'
-      # The exhaustive qualification runs once per supported interpreter,
-      # rather than being multiplied across all three operating systems.
-      run: >-
-        uv run pytest -n auto --dist loadgroup -m refactor_qualification
-        --timeout=180 --no-cov
-
-  coverage:
-    name: Coverage (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }})
-    needs: resolve-target
-    if: needs.resolve-target.outputs.is_standard == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        ref: ${{ needs.resolve-target.outputs.sha }}
-        fetch-depth: 1
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: "3.12"
-        cache: pip
-    - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
-    - name: Install dependencies
-      run: >-
-        uv sync --frozen --extra browser --extra dev --extra markdown
-        --extra mcp --extra server --extra impersonate --extra cookies
-    - name: Install Playwright browsers
-      run: uv run playwright install chromium
-    - name: Install Playwright system dependencies (Linux)
-      run: uv run playwright install-deps chromium
-    - name: Run ordinary tests with coverage
-      run: >-
-        uv run pytest -n auto --dist loadgroup
-        -m "not repo_lint and not refactor_qualification and not requires_playwright and not requires_chromium"
-        --cov=src/notebooklm --cov-report= --cov-fail-under=0
-    - name: Append Playwright-dependent unit coverage
-      run: >-
-        uv run pytest tests/unit
-        -m "(requires_playwright or requires_chromium) and not reality and not refactor_qualification"
-        -n 0 --cov=src/notebooklm --cov-append
-        --cov-report=term-missing --cov-report=json:coverage.json
-        --cov-fail-under=90
-    - name: Assert per-file coverage floors
-      run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json
-
-  repo-lint:
-    name: Repository Lint (${{ needs.resolve-target.outputs.branch }}@${{ needs.resolve-target.outputs.short_sha }})
-    needs: resolve-target
-    if: needs.resolve-target.outputs.is_standard == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        ref: ${{ needs.resolve-target.outputs.sha }}
-        fetch-depth: 1
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v7
-      with:
-        python-version: "3.12"
-        cache: pip
-    - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # @ v7.0.0
-    - name: Install dependencies
-      run: >-
-        uv sync --frozen --extra browser --extra dev --extra markdown
-        --extra mcp --extra server --extra impersonate --extra cookies
-    - name: Run repository lint tests
-      run: >-
-        uv run pytest -n auto --dist loadgroup
-        -m "repo_lint and not refactor_qualification"
-        --timeout=180 --no-cov
-
   e2e:
     name: E2E (${{ matrix.backend }}/${{ matrix.lane }}/${{ matrix.account_slot }})
     needs: [resolve-target, plan-live-lanes]
@@ -623,9 +499,9 @@ jobs:
         python -c 'from pathlib import Path; import os; Path(os.environ["E2E_COVERAGE_FLOOR_SENTINEL"]).unlink(missing_ok=True)'
         if [ -n "$TEST_FILTER" ]; then
           unset E2E_ENFORCE_COVERAGE_FLOOR
-          uv run pytest -m "${{ matrix.selection }}" -s -v --tb=short --reruns 1 --reruns-delay 30 -- "$TEST_FILTER"
+          uv run pytest -m "${{ matrix.selection }}" -s -v -ra --tb=short --no-cov --reruns 1 --reruns-delay 30 -- "$TEST_FILTER"
         else
-          uv run pytest tests/e2e -m "${{ matrix.selection }}" -s -v --tb=short \
+          uv run pytest tests/e2e -m "${{ matrix.selection }}" -s -v -ra --tb=short --no-cov \
             --reruns 1 --reruns-delay 30
         fi
     - name: Validate lastfailed cache
@@ -656,15 +532,15 @@ jobs:
           sleep 60
         done
         if [ -n "$TEST_FILTER" ]; then unset E2E_ENFORCE_COVERAGE_FLOOR; fi
-        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -m "${{ matrix.selection }}" -s -v --tb=short
+        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -m "${{ matrix.selection }}" -s -v -ra --tb=short --no-cov
     - name: curl_cffi transport smoke
       id: smoke
       if: steps.preflight.outcome == 'success' && matrix.lane == 'nightly-web-ubuntu'
       continue-on-error: true
       env:
         NOTEBOOKLM_TRANSPORT: curl_cffi
-      run: uv run pytest tests/e2e -m impersonate_smoke -s -v --tb=short --reruns 1 --reruns-delay 30
-    - name: Enforce coverage floors
+      run: uv run pytest tests/e2e -m impersonate_smoke -s -v -ra --tb=short --no-cov --reruns 1 --reruns-delay 30
+    - name: Enforce E2E execution floors
       id: coverage
       if: >-
         always() &&
@@ -680,9 +556,9 @@ jobs:
         sentinel="$E2E_COVERAGE_FLOOR_SENTINEL"
         if [ ! -f "$sentinel" ]; then
           if [ -n "$TEST_FILTER" ]; then
-            echo "Coverage floor: not enforced for filtered dispatch" >> "$GITHUB_STEP_SUMMARY"
+            echo "E2E execution floor: not enforced for filtered dispatch" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Coverage floor: passed; skip-only markers=0" >> "$GITHUB_STEP_SUMMARY"
+            echo "E2E execution floor: passed; skip-only markers=0" >> "$GITHUB_STEP_SUMMARY"
           fi
           exit 0
         fi
@@ -691,12 +567,12 @@ jobs:
         breach="$(comm -23 <(printf '%s\n' "$skipped" | sed '/^$/d') <(printf '%s\n' "$passed" | sed '/^$/d'))"
         if [ -n "$breach" ]; then
           breach_count=$(printf '%s\n' "$breach" | sed '/^$/d' | wc -l | tr -d ' ')
-          echo "Coverage floor: failed; skip-only markers=$breach_count" >> "$GITHUB_STEP_SUMMARY"
-          echo "::error::E2E coverage floor breached"
+          echo "E2E execution floor: failed; skip-only markers=$breach_count" >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::E2E execution floor breached"
           printf '  %s\n' "$breach"
           exit 1
         fi
-        echo "Coverage floor: passed; skip-only markers=0" >> "$GITHUB_STEP_SUMMARY"
+        echo "E2E execution floor: passed; skip-only markers=0" >> "$GITHUB_STEP_SUMMARY"
     - name: Compute verifier budget
       id: verifier_budget
       if: >-

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -351,10 +351,10 @@ jobs:
         echo "Testing branch: $TARGET_BRANCH"
         echo "Full RPC check creates and cleans up its own temporary resources."
         set +e
-        uv run python scripts/check_rpc_health.py --full \
+        uv run python scripts/check_rpc_health.py --full --progress-fd 3 \
           --rebrand-state-file rebrand-state.json \
           --rebrand-previous-state-file rebrand-state-prev.json \
-          --rebrand-run-id "${GITHUB_RUN_ID}" > health-report.txt 2>&1
+          --rebrand-run-id "${GITHUB_RUN_ID}" 3>&1 > health-report.txt 2>&1
         exit_code=$?
         echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
         exit "$exit_code"
@@ -1095,9 +1095,9 @@ jobs:
       run: |
         echo "Testing branch: $TARGET_BRANCH"
         set +e
-        uv run python scripts/android_grpc_canary.py \
+        uv run python scripts/android_grpc_canary.py --progress-fd 3 \
           --baseline tests/fixtures/android/canary_baseline.json \
-          --missing-baseline-grace-until 2026-09-14 > android-canary-report.txt 2>&1
+          --missing-baseline-grace-until 2026-09-14 3>&1 > android-canary-report.txt 2>&1
         exit_code=$?
         # Diagnostic mode is green by design, so without this annotation an
         # inert drift check would never be visible from the run list. It does

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
         # Linux carries the full supported Python range. One 3.12 cell on each
         # secondary OS preserves platform compatibility without multiplying the
         # entire suite into a 3-by-5 bottleneck on every PR; the complete
-        # 15-cell product runs nightly (`nightly.yml` → `compatibility`) and on
+        # 15-cell product runs nightly (`nightly-checks.yml` → `compatibility`) and on
         # manual nightly dispatches. Canonical Ubuntu 3.12 owns Chromium,
         # external-reality work, and the critical contract guards.
         include:

--- a/docs/development.md
+++ b/docs/development.md
@@ -582,7 +582,7 @@ lock sibling and the two invocations never contend.
    green run that never exercised the adapter surface. Add both extras
    (CI installs `--extra mcp --extra server --extra impersonate`) to run them.
 
-   CI runs the same lint gate with `uv run pre-commit run --all-files`, so local hook results should match the `quality` job. The ordinary suite then runs in a reduced 7-cell compatibility matrix on every PR: Python 3.10–3.14 on Ubuntu, plus one Python 3.12 cell each on macOS and Windows. The full 15-cell matrix (all three OSes crossed with Python 3.10–3.14) runs nightly against one resolved commit before dedicated coverage and three live-E2E jobs: full Web on Ubuntu, full Android on macOS, and read-only Web on Windows. Manual nightly dispatches also run the full compatibility matrix by default; untick `run_compatibility` for a quick E2E-only rerun.
+   CI runs the same lint gate with `uv run pre-commit run --all-files`, so local hook results should match the `quality` job. The ordinary suite then runs in a reduced 7-cell compatibility matrix on every PR: Python 3.10–3.14 on Ubuntu, plus one Python 3.12 cell each on macOS and Windows. The separate **Nightly Code Checks** workflow (`nightly-checks.yml`) runs the full 15-cell matrix, coverage, and repository lint against one resolved commit. **Nightly E2E Tests** (`nightly.yml`) runs only authenticated live lanes: full Web on Ubuntu, full Android on macOS, and read-only Web on Windows. Each workflow has its own daily schedule and manual dispatch; an E2E rerun never starts ordinary tests.
 
 2. **Authenticate:**
    ```bash
@@ -861,17 +861,27 @@ that contract. Provisioning creates and validates those on the disposable `refer
 Nightly logs show each preparation stage, per-test start/result lines, and a heartbeat every
 30 seconds while a test is running. Artifact verification reports pending families, producer
 tests, and missing download URLs during polling. The job summary retains preparation failures,
-E2E result counts and failed test names, and a table of phase outcomes even after cleanup.
+E2E result counts, failed test names, failure phases and exception types, and a table of phase
+outcomes even after cleanup. Pytest logs retain tracebacks and skip/xfail reasons (`-ra`);
+live tests explicitly disable code coverage (`--no-cov`). Execution floors only detect when
+an entire required live-test family was skipped; they are separate from code coverage.
 These reports omit notebook handles, titles, parametrized resource values, and upstream response
 bodies. To enable the same test progress locally, set `CI_E2E_PROGRESS=1` when running pytest.
 For a short workflow smoke test, dispatch nightly with `e2e_lane=readonly`, a read-only pytest
-node in `test_filter`, and `run_compatibility=false`. The filter and retries still enforce the
+node in `test_filter`. The filter and retries still enforce the
 read-only marker selection.
 
 Web RPC health does not provision an E2E copy. After authentication, `check_rpc_health.py --full`
 creates its own temporary notebook and resources, probes the RPCs, then exercises deletion RPCs
 in its cleanup block. A failed notebook-creation probe remains a reported RPC failure; account
-checks that do not need a notebook still run. The job summary links the full diagnostic report.
+checks that do not need a notebook still run. Both RPC lanes stream timestamped probe starts
+and outcomes while the complete report is captured. Web diagnostics identify the phase, method
+name and RPC ID, duration, and reason for an error or skip; the summary keeps a per-probe table
+and links the full report. An RPC-ID `OK` proves that the expected ID was observed, including
+when an operation was rejected; it does not prove feature behavior. Chat framing, customization
+enums, build-label age, and rebrand probes state their separate checks. Android diagnostics show
+the gRPC method path, ID round-trip/session checks, schema hashes, unknown-field counts, and
+baseline drift. No additional RPC requests are made just to produce progress output.
 The configured template is the public notebook titled
 `Make Your Writing More Powerful and Persuasive`. Its title cannot be changed; replacing the
 template requires updating the title contract and template-ID secret together.
@@ -1534,7 +1544,8 @@ The `RedactingFilter` preserves `record.exc_info` (the live exception object) so
 |----------|---------|---------|
 | `test.yml` | Push/PR | Reduced 7-cell compatibility matrix (Ubuntu × Python 3.10–3.14, plus macOS/Windows on 3.12), linting, type checking |
 | `fault-stress.yml` | PR, daily 5:45 AM UTC, manual dispatch | Local HTTP/gRPC fault workloads with synthetic credentials and diagnostic report artifacts |
-| `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Full compatibility/coverage plus managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E; an owner may qualify an open same-repository PR at its pinned head SHA |
+| `nightly-checks.yml` | Daily 6 AM UTC (`main`), manual dispatch with optional `custom_branch` | Full compatibility matrix, ordinary-test coverage, and repository lint; no live account credentials |
+| `nightly.yml` | Daily 6 AM UTC (`main`), manual dispatch on `main` | Managed-copy full Web/Ubuntu, full Android/macOS, and read-only Web/Windows E2E only; an owner may qualify an open same-repository PR at its pinned head SHA |
 | `rpc-health.yml` | Daily 7 AM UTC (`main`), manual dispatch on `main` | RPC monitoring on its own temporary notebook plus the template-read-only [Android gRPC canary](#android-grpc-canary); an owner may qualify an open same-repository PR at its pinned head SHA |
 | `testpypi-publish.yml` | Manual dispatch | Publish to TestPyPI |
 | `verify-package.yml` | Manual dispatch on `main` | Verify TestPyPI or PyPI install plus managed-copy E2E; artifact inventory is advisory |
@@ -1694,7 +1705,7 @@ gh workflow run rpc-health.yml --ref main \
 # If RPC passes, run only the full Web E2E lane against the same PR.
 gh workflow run nightly.yml --ref main \
   -f qualification_pr=2353 -f e2e_lane=web \
-  -f account_rotation_base=auto -f run_compatibility=false
+  -f account_rotation_base=auto
 ```
 
 Before merging, compare the run summary's resolved SHA with

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -257,11 +257,11 @@ no break against the baseline) is a CI failure, not silent cruft.
 - [ ] Go to **Actions** → **Nightly E2E Tests**
 - [ ] After the release PR is merged, dispatch the workflow on `main`; choose
       `account_rotation_base=auto` unless reproducing a slot-specific failure
-- [ ] Leave **run_compatibility** enabled (the default): the PR gate only ran
-      the reduced 7-cell matrix, so this dispatch is what proves the release
-      commit on the full 15-cell Ubuntu/macOS/Windows × Python 3.10-3.14 matrix.
-- [ ] Wait for the compatibility matrix, coverage, repository-lint, and both
-      full Windows E2E jobs (Web and Android) to pass
+- [ ] Separately dispatch **Nightly Code Checks** (`nightly-checks.yml`) on the
+      same release commit. It runs the full 15-cell compatibility matrix, coverage,
+      and repository lint. These checks are independent of the live E2E workflow.
+- [ ] Wait for code checks and the full Web/Ubuntu, full Android/macOS, and
+      read-only Web/Windows E2E jobs to pass
 - [ ] If E2E tests fail:
   1. Fix issues in a new release-fix PR against `main`
   2. Merge that PR

--- a/scripts/_ci_progress.py
+++ b/scripts/_ci_progress.py
@@ -17,9 +17,25 @@ from typing import TextIO
 
 
 @contextmanager
-def open_progress_stream(fd: int) -> Iterator[TextIO]:
-    """Own a duplicate descriptor without letting a final flush replace the verdict."""
-    stream = os.fdopen(os.dup(fd), "w", encoding="utf-8")
+def open_progress_stream(fd: int) -> Iterator[TextIO | None]:
+    """Best-effort duplicate; setup and final flush must not replace the verdict."""
+    duplicate: int | None = None
+    try:
+        duplicate = os.dup(fd)
+        stream = os.fdopen(duplicate, "w", encoding="utf-8")
+    except (OSError, ValueError):
+        if duplicate is not None:
+            try:
+                os.close(duplicate)
+            except OSError:
+                pass
+        print(
+            "WARNING: could not open CI progress stream; see normal report",
+            file=sys.stderr,
+            flush=True,
+        )
+        yield None
+        return
     try:
         yield stream
     finally:

--- a/scripts/_ci_progress.py
+++ b/scripts/_ci_progress.py
@@ -9,8 +9,24 @@ from __future__ import annotations
 import os
 import re
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TextIO
+
+
+@contextmanager
+def open_progress_stream(fd: int) -> Iterator[TextIO]:
+    """Own a duplicate descriptor without letting a final flush replace the verdict."""
+    stream = os.fdopen(os.dup(fd), "w", encoding="utf-8")
+    try:
+        yield stream
+    finally:
+        try:
+            stream.close()
+        except OSError:
+            print("WARNING: could not close CI progress stream", file=sys.stderr, flush=True)
 
 
 def safe_test_name(node_id: str) -> str:

--- a/scripts/_ci_rpc_progress.py
+++ b/scripts/_ci_rpc_progress.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import sys
 import time
@@ -15,9 +14,9 @@ from functools import wraps
 from typing import Any, ParamSpec, TextIO, TypeVar
 
 if __package__:
-    from ._ci_progress import write_summary
+    from ._ci_progress import open_progress_stream, write_summary
 else:
-    from _ci_progress import write_summary
+    from _ci_progress import open_progress_stream, write_summary
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -91,12 +90,16 @@ class RPCProgress:
         self.stream = stream
         self.phase = "initialization"
         self.rows: list[tuple[str, str, str, float, str]] = []
+        self.stream_failed = False
 
     def emit(self, message: str) -> None:
+        if self.stream_failed:
+            return
         stamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
         try:
             print(f"[{stamp}] {message}", file=self.stream, flush=True)
         except OSError:
+            self.stream_failed = True
             print("WARNING: could not write live RPC progress", file=sys.stderr, flush=True)
 
     def finish(self, label: str, status: str, started: float, reason: str) -> None:
@@ -126,7 +129,7 @@ def live_progress(fd: int | None) -> Iterator[None]:
     if fd is None:
         yield
         return
-    with os.fdopen(os.dup(fd), "w", encoding="utf-8") as stream:
+    with open_progress_stream(fd) as stream:
         progress = RPCProgress(stream)
         token = _ACTIVE.set(progress)
         try:

--- a/scripts/_ci_rpc_progress.py
+++ b/scripts/_ci_rpc_progress.py
@@ -86,20 +86,19 @@ def safe_reason(result: Any, proof: str, detail: str = "") -> str:
 
 
 class RPCProgress:
-    def __init__(self, stream: TextIO) -> None:
+    def __init__(self, stream: TextIO | None) -> None:
         self.stream = stream
         self.phase = "initialization"
         self.rows: list[tuple[str, str, str, float, str]] = []
-        self.stream_failed = False
 
     def emit(self, message: str) -> None:
-        if self.stream_failed:
+        if self.stream is None:
             return
         stamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
         try:
             print(f"[{stamp}] {message}", file=self.stream, flush=True)
         except OSError:
-            self.stream_failed = True
+            self.stream = None
             print("WARNING: could not write live RPC progress", file=sys.stderr, flush=True)
 
     def finish(self, label: str, status: str, started: float, reason: str) -> None:
@@ -176,7 +175,15 @@ def trace_probe(
                 raise
             result = value[0] if isinstance(value, tuple) else value
             status = result.value if isinstance(result, Enum) else result.status.value
-            detail = value[1] if isinstance(value, tuple) and isinstance(value[1], str) else ""
+            # Only enum probes return (status, diagnostic). RPC probes return
+            # (CheckResult, payload), whose text is neither an error nor public.
+            detail = (
+                value[1]
+                if isinstance(value, tuple)
+                and isinstance(result, Enum)
+                and isinstance(value[1], str)
+                else ""
+            )
             progress.finish(name, status, started, safe_reason(result, proof, detail))
             return value
 

--- a/scripts/_ci_rpc_progress.py
+++ b/scripts/_ci_rpc_progress.py
@@ -1,0 +1,182 @@
+"""Live RPC diagnostics on a separate stream from private response reports."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from enum import Enum
+from functools import wraps
+from typing import Any, ParamSpec, TextIO, TypeVar
+
+if __package__:
+    from ._ci_progress import write_summary
+else:
+    from _ci_progress import write_summary
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+_SKIP_REASONS = {
+    "Method always skipped (complex setup or quota)": "complex setup or quota; intentionally not probed",
+    "Duplicate method (same ID as another)": "same RPC ID is checked by another method",
+    "Requires real resource IDs (placeholder fails)": "requires real resource IDs",
+    "Tested in setup/cleanup phases": "handled in setup/cleanup; see those phase results",
+    "Requires --full mode (creates/deletes resources)": "requires full mode",
+    "No test parameters available": "no safe probe parameters available",
+    "No notebook ID provided": "notebook required for this probe",
+}
+
+
+def safe_reason(result: Any, proof: str, detail: str = "") -> str:
+    """Classify errors without publishing their bodies or resource handles."""
+    status = result.value if isinstance(result, Enum) else result.status.value
+    error = getattr(result, "error", None) or getattr(result, "detail", "") or detail
+    if status == "SKIPPED":
+        return _SKIP_REASONS.get(error, "probe prerequisites unavailable")
+    if status == "MISMATCH":
+        observed = [
+            value
+            if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9]{5,6}", value)
+            else "<unexpected ID shape>"
+            for value in result.found_ids[:10]
+        ]
+        return "expected RPC ID absent; observed IDs=" + (", ".join(observed) or "none")
+    if "ReadTimeout" in error:
+        return "RPC read timeout (transient)"
+    if any(
+        marker in error
+        for marker in (
+            "HTTP 429",
+            "RateLimitError",
+            "API rate limit",
+            "Chat rate limit",
+            "RESOURCE_EXHAUSTED",
+        )
+    ):
+        return "quota/rate limit (transient)"
+    http_status = re.search(r"\bHTTP (\d{3})\b", error)
+    if http_status:
+        return f"HTTP {int(http_status[1])}; see report"
+    for category in ("ConnectTimeout", "WriteTimeout", "PoolTimeout", "ConnectError"):
+        if category in error:
+            return category
+    if "Parse error" in error or "ParseError" in error:
+        return "response decoding failed; see report"
+    if status == "OK":
+        if error:
+            return "expected RPC ID observed, but operation rejected; see report"
+        return proof
+    return {
+        "MATCH": "option tables match the checked-in enums",
+        "DRIFT": "option-table drift; compare expected/observed values in report",
+        "PRESENT": "endpoint response framing recognized",
+        "ABSENT": "endpoint unavailable; see report",
+        "UNAUTHENTICATED": "authentication rejected",
+        "NOT_PROBED": "requires a separate authenticated capture",
+        "CURRENT": "build label is current",
+        "DRIFTED": "build label changed within the allowed age",
+        "STALE": "pinned build label is stale; see report",
+        "UNKNOWN": "probe inconclusive; see report",
+    }.get(status, "probe failed; see full diagnostic report")
+
+
+class RPCProgress:
+    def __init__(self, stream: TextIO) -> None:
+        self.stream = stream
+        self.phase = "initialization"
+        self.rows: list[tuple[str, str, str, float, str]] = []
+
+    def emit(self, message: str) -> None:
+        stamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+        try:
+            print(f"[{stamp}] {message}", file=self.stream, flush=True)
+        except OSError:
+            print("WARNING: could not write live RPC progress", file=sys.stderr, flush=True)
+
+    def finish(self, label: str, status: str, started: float, reason: str) -> None:
+        elapsed = time.monotonic() - started
+        self.rows.append((self.phase, label, status, elapsed, reason))
+        self.emit(f"{self.phase}: {status} {label}; elapsed={elapsed:.1f}s; {reason}")
+
+    def summarize(self) -> None:
+        write_summary(
+            "### RPC probe details\n\n"
+            "RPC-ID OK means the expected response ID was observed; live E2E tests check behavior. "
+            "Setup/cleanup entries report their own calls. Rebrand probes have a separate verdict.\n\n"
+            "| Phase | Probe / RPC ID | Outcome | Seconds | Diagnostic |\n"
+            "| --- | --- | --- | ---: | --- |"
+        )
+        for phase, label, status, elapsed, reason in self.rows:
+            write_summary(f"| {phase} | `{label}` | {status} | {elapsed:.1f} | {reason} |")
+        if not self.rows:
+            write_summary(f"No RPC probe completed; last phase: {self.phase}.")
+
+
+_ACTIVE: ContextVar[RPCProgress | None] = ContextVar("rpc_progress", default=None)
+
+
+@contextmanager
+def live_progress(fd: int | None) -> Iterator[None]:
+    if fd is None:
+        yield
+        return
+    with os.fdopen(os.dup(fd), "w", encoding="utf-8") as stream:
+        progress = RPCProgress(stream)
+        token = _ACTIVE.set(progress)
+        try:
+            yield
+        finally:
+            _ACTIVE.reset(token)
+            progress.summarize()
+
+
+def progress_phase(phase: str) -> None:
+    progress = _ACTIVE.get()
+    if progress is not None:
+        progress.phase = phase
+        progress.emit(f"RPC phase: {phase}")
+
+
+def progress_note(message: str) -> None:
+    progress = _ACTIVE.get()
+    if progress is not None:
+        progress.emit(message)
+
+
+def trace_probe(
+    label: str | None = None, *, proof: str = "expected RPC ID observed"
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    """Trace a checked result, including setup, inventory reads, and cleanup."""
+
+    def decorate(function: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+        @wraps(function)
+        async def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+            progress = _ACTIVE.get()
+            if progress is None:
+                return await function(*args, **kwargs)
+            name = label
+            if name is None:
+                method = kwargs.get("method", args[2] if len(args) > 2 else None)
+                name = f"RPC-ID {method.name} ({method.value})"
+            started = time.monotonic()
+            progress.emit(f"{progress.phase}: START {name}")
+            try:
+                value = await function(*args, **kwargs)
+            except BaseException:
+                progress.finish(name, "ERROR", started, "probe interrupted or raised; see report")
+                raise
+            result = value[0] if isinstance(value, tuple) else value
+            status = result.value if isinstance(result, Enum) else result.status.value
+            detail = value[1] if isinstance(value, tuple) and isinstance(value[1], str) else ""
+            progress.finish(name, status, started, safe_reason(result, proof, detail))
+            return value
+
+        return wrapped
+
+    return decorate

--- a/scripts/aggregate_ci_e2e_outcomes.py
+++ b/scripts/aggregate_ci_e2e_outcomes.py
@@ -296,7 +296,8 @@ def main(argv: list[str] | None = None) -> int:
     write_summary(f"\n### CI phases: {args.lane}\n\n| Phase | Outcome |\n| --- | --- |")
     for phase, state in states.items():
         if phase in POLICIES[args.lane].applicable and state in STATES:
-            write_summary(f"| {phase} | {state.replace('not_applicable', 'not run')} |")
+            label = "E2E execution floor" if phase == "coverage" else phase
+            write_summary(f"| {label} | {state.replace('not_applicable', 'not run')} |")
     execution_phase = "primary" if "primary" in POLICIES[args.lane].applicable else "health"
     if states.get(execution_phase) == "not_applicable":
         write_summary("\nTests/probes did not run. See the failed prerequisite above.")

--- a/scripts/android_grpc_canary.py
+++ b/scripts/android_grpc_canary.py
@@ -88,6 +88,11 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
+if __package__:
+    from ._ci_progress import open_progress_stream
+else:
+    from _ci_progress import open_progress_stream
+
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.unknown_fields import UnknownFieldSet
 
@@ -253,7 +258,15 @@ class CanaryReport:
             line = f"[{stamp}] START {step} {method}".rstrip()
             if self._redact:
                 line = line.replace(self._redact, REDACTED_NOTEBOOK_ID)
-            self._progress(line)
+            self._live_line(line)
+
+    def _live_line(self, text: str) -> None:
+        if self._progress is not None:
+            try:
+                self._progress(text)
+            except OSError:
+                self._progress = None
+                print("WARNING: could not write live Android progress", file=sys.stderr, flush=True)
 
     def _line(self, text: str, *, step: str | None = None) -> None:
         if self._redact:
@@ -264,7 +277,7 @@ class CanaryReport:
             timing = ""
             if step in self._started:
                 timing = f"; elapsed={time.monotonic() - self._started.pop(step):.1f}s"
-            self._progress(f"[{stamp}] {text}{timing}")
+            self._live_line(f"[{stamp}] {text}{timing}")
 
     def ok(self, step: str, detail: str = "") -> None:
         self._line(f"OK {step} {detail}".rstrip(), step=step)
@@ -679,7 +692,7 @@ def main(
     with ExitStack() as stack:
         progress = None
         if args.progress_fd is not None:
-            stream = stack.enter_context(os.fdopen(os.dup(args.progress_fd), "w", encoding="utf-8"))
+            stream = stack.enter_context(open_progress_stream(args.progress_fd))
             progress = functools.partial(print, file=stream, flush=True)
         return asyncio.run(
             run_canary(

--- a/scripts/android_grpc_canary.py
+++ b/scripts/android_grpc_canary.py
@@ -693,7 +693,8 @@ def main(
         progress = None
         if args.progress_fd is not None:
             stream = stack.enter_context(open_progress_stream(args.progress_fd))
-            progress = functools.partial(print, file=stream, flush=True)
+            if stream is not None:
+                progress = functools.partial(print, file=stream, flush=True)
         return asyncio.run(
             run_canary(
                 factory,

--- a/scripts/android_grpc_canary.py
+++ b/scripts/android_grpc_canary.py
@@ -80,10 +80,11 @@ import hashlib
 import json
 import os
 import sys
+import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import AbstractAsyncContextManager
+from contextlib import AbstractAsyncContextManager, ExitStack
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -234,26 +235,43 @@ class CanaryReport:
     the id into a log or step summary.
     """
 
-    def __init__(self, emit: Emit, *, redact: str = "") -> None:
+    def __init__(self, emit: Emit, *, redact: str = "", progress: Emit | None = None) -> None:
         self._emit = emit
         self._redact = redact
+        self._progress = progress
+        self._started: dict[str, float] = {}
         self.failures: list[str] = []
 
     @property
     def all_ok(self) -> bool:
         return not self.failures
 
-    def _line(self, text: str) -> None:
+    def start(self, step: str, method: str = "") -> None:
+        self._started[step] = time.monotonic()
+        if self._progress is not None:
+            stamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+            line = f"[{stamp}] START {step} {method}".rstrip()
+            if self._redact:
+                line = line.replace(self._redact, REDACTED_NOTEBOOK_ID)
+            self._progress(line)
+
+    def _line(self, text: str, *, step: str | None = None) -> None:
         if self._redact:
             text = text.replace(self._redact, REDACTED_NOTEBOOK_ID)
         self._emit(text)
+        if self._progress is not None:
+            stamp = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+            timing = ""
+            if step in self._started:
+                timing = f"; elapsed={time.monotonic() - self._started.pop(step):.1f}s"
+            self._progress(f"[{stamp}] {text}{timing}")
 
     def ok(self, step: str, detail: str = "") -> None:
-        self._line(f"OK {step} {detail}".rstrip())
+        self._line(f"OK {step} {detail}".rstrip(), step=step)
 
     def fail(self, step: str, detail: str) -> None:
         self.failures.append(step)
-        self._line(f"FAIL {step} {detail}".rstrip())
+        self._line(f"FAIL {step} {detail}".rstrip(), step=step)
 
     def shape(self, rpc: str, fingerprint: str) -> None:
         self._line(f"SHAPE {rpc} {fingerprint}")
@@ -275,6 +293,12 @@ class StepFailure(Exception):
 
 async def run_step(report: CanaryReport, step: str, work: Awaitable[str]) -> bool:
     """Await one step; any exception becomes a sanitized ``FAIL`` line."""
+    method = {
+        "bearer": "authentication refresh",
+        "get_project": GET_PROJECT_METHOD,
+        "list_chat_sessions": LIST_CHAT_SESSIONS_METHOD,
+    }.get(step, "")
+    report.start(step, method)
     try:
         detail = await work
     except asyncio.CancelledError:
@@ -496,6 +520,7 @@ async def check_schema(
         return
     for rpc, method, request, response_type in probes:
         step = f"schema {rpc}"
+        report.start(step, method)
         try:
             response = await session.unary(
                 method,
@@ -537,9 +562,10 @@ async def run_canary(
     baseline_path: Path | None = None,
     missing_baseline_grace_until: date | None = None,
     out: Emit = print,
+    progress: Emit | None = None,
 ) -> int:
     """Drive every step against one client; return the process exit code."""
-    report = CanaryReport(out, redact=notebook_id)
+    report = CanaryReport(out, redact=notebook_id, progress=progress)
     baseline = load_baseline(
         baseline_path, report, missing_grace_until=missing_baseline_grace_until
     )
@@ -550,6 +576,7 @@ async def run_canary(
         return 1
 
     entered = False
+    report.start("open", "Android authentication/session")
     try:
         async with context as client:
             entered = True
@@ -625,6 +652,12 @@ def build_parser() -> argparse.ArgumentParser:
             "FAILs, so the drift check cannot stay inert once bootstrap is over."
         ),
     )
+    parser.add_argument(
+        "--progress-fd",
+        type=int,
+        default=None,
+        help="Additional file descriptor for live canary diagnostics (CI)",
+    )
     return parser
 
 
@@ -643,15 +676,21 @@ def main(
         return 2
     factory = client_factory or _default_client_factory(args.timeout)
     emit = functools.partial(print, flush=True)
-    return asyncio.run(
-        run_canary(
-            factory,
-            notebook_id,
-            baseline_path=args.baseline,
-            missing_baseline_grace_until=args.missing_baseline_grace_until,
-            out=emit,
+    with ExitStack() as stack:
+        progress = None
+        if args.progress_fd is not None:
+            stream = stack.enter_context(os.fdopen(os.dup(args.progress_fd), "w", encoding="utf-8"))
+            progress = functools.partial(print, file=stream, flush=True)
+        return asyncio.run(
+            run_canary(
+                factory,
+                notebook_id,
+                baseline_path=args.baseline,
+                missing_baseline_grace_until=args.missing_baseline_grace_until,
+                out=emit,
+                progress=progress,
+            )
         )
-    )
 
 
 if __name__ == "__main__":

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -208,7 +208,7 @@ def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--pyproject", default="pyproject.toml")
-    ap.add_argument("--workflow", default=".github/workflows/nightly.yml")
+    ap.add_argument("--workflow", default=".github/workflows/nightly-checks.yml")
     ap.add_argument(
         "--coverage-json",
         default=None,

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -84,6 +84,11 @@ from uuid import uuid4
 
 import httpx
 
+try:
+    from scripts._ci_rpc_progress import live_progress, progress_note, progress_phase, trace_probe
+except ModuleNotFoundError:
+    from _ci_rpc_progress import live_progress, progress_note, progress_phase, trace_probe
+
 from notebooklm._auth.tokens import LoadPolicy, _load_stored_auth
 from notebooklm._env import (
     BUILD_LABEL_STALE_AFTER_DAYS,
@@ -404,6 +409,9 @@ async def load_auth(storage_path: Path | None) -> AuthTokens:
         )
         return loaded.auth
     except FileNotFoundError as e:
+        progress_note(
+            "Authentication failed: credentials missing; configure CI auth or run notebooklm login"
+        )
         # ``e`` names the storage path that was actually checked — under
         # profiles that is the only way to see which one the script resolved.
         print(
@@ -413,6 +421,9 @@ async def load_auth(storage_path: Path | None) -> AuthTokens:
         )
         sys.exit(2)
     except ValueError as e:
+        progress_note(
+            "Authentication failed: stored credentials invalid or expired; inspect auth report"
+        )
         # Name the auth source. The file branch of ``_load_storage_state``
         # re-raises a bare ``json`` error carrying no context at all, so a
         # corrupt storage_state.json would otherwise print only
@@ -423,6 +434,9 @@ async def load_auth(storage_path: Path | None) -> AuthTokens:
         )
         sys.exit(2)
     except httpx.HTTPError as e:
+        progress_note(
+            "Authentication failed: network error while fetching tokens; inspect auth report"
+        )
         # ``httpx`` exception strings can echo full request URLs including
         # ``f.sid=<session_id>`` query params, so scrub before logging.
         print(
@@ -540,6 +554,7 @@ async def make_rpc_call(
         return [], f"Parse error: {type(e).__name__}"
 
 
+@trace_probe()
 async def test_rpc_method(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -581,6 +596,7 @@ async def test_rpc_method(
     )
 
 
+@trace_probe()
 async def test_rpc_method_with_data(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -858,6 +874,7 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
     return None
 
 
+@trace_probe()
 async def check_method(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -978,6 +995,7 @@ class _ChatQueryProbe:
 CHAT_QUERY_PROBE = _ChatQueryProbe()
 
 
+@trace_probe("CHAT GENERATE_FREE_FORM_STREAMED", proof="streamed-chat framing recognized")
 async def check_chat_query(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1206,6 +1224,7 @@ async def make_raw_rpc_request(
         return None, type(e).__name__
 
 
+@trace_probe("CUSTOMIZATION GET_CUSTOMIZATION_CHOICES (sqTeoe)")
 async def check_customization_table(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1391,6 +1410,7 @@ def classify_rebrand_status(
     return RebrandProbeStatus.ABSENT, f"HTTP {status_code}"
 
 
+@trace_probe("REBRAND LIST_NOTEBOOKS (wXbhsf)")
 async def probe_rebrand_batchexecute(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1466,6 +1486,7 @@ async def probe_rebrand_batchexecute(
     )
 
 
+@trace_probe("REBRAND GENERATE_FREE_FORM_STREAMED")
 async def probe_rebrand_chat(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -1814,6 +1835,7 @@ def classify_build_label(served: str | None, detail: str) -> BuildLabelProbe:
     return BuildLabelProbe(BuildLabelStatus.DRIFTED, drift, DEFAULT_BL, served, days)
 
 
+@trace_probe("BUILD_LABEL app shell")
 async def check_build_label(client: httpx.AsyncClient) -> BuildLabelProbe:
     """Read the served build label off the app shell and score the pin against it.
 
@@ -1893,6 +1915,9 @@ async def setup_temp_resources(
     # Response format: [title, None, notebook_id, ...]
     temp.notebook_id = extract_id(data, 2)
     if not temp.notebook_id:
+        progress_note(
+            "WARNING: notebook ID not returned; dependent probes cannot run; cleanup may be needed"
+        )
         print(
             "WARNING: Notebook created but ID not found in response. May need manual cleanup.",
             file=sys.stderr,
@@ -2079,6 +2104,9 @@ async def setup_temp_resources(
                 )
     else:
         # Skip artifact tests - no source_id available
+        progress_note(
+            "setup: SKIPPED CREATE_ARTIFACT; source creation did not yield a usable source"
+        )
         print("SKIP     CREATE_ARTIFACT - No source_id available (source extraction failed)")
 
     return temp
@@ -2209,9 +2237,11 @@ async def run_health_check(
     )
     previous_state_path = rebrand_previous_state_path or rebrand_state_path
 
+    progress_phase("authentication")
     storage_path = resolve_storage_path()
     print(f"Fetching auth tokens... (source: {describe_auth_source(storage_path)})")
     auth = await load_auth(storage_path)
+    progress_note("Authentication ready; RPC-ID checks validate response IDs, not full behavior")
     print(f"Auth OK (CSRF token length: {len(auth.csrf_token)})")
     print(f"  base host:     {httpx.URL(get_base_url()).host} (from: {base_url_source})")
     print(f"  account route: {auth.account_route}")
@@ -2222,6 +2252,7 @@ async def run_health_check(
     async with build_probe_client(auth) as client:
         try:
             if full_mode:
+                progress_phase("setup")
                 print("Creating temp resources for full testing...")
                 temp_resources = await setup_temp_resources(client, auth, results)
                 if temp_resources.notebook_id:
@@ -2234,6 +2265,10 @@ async def run_health_check(
             print(f"Checking {total} RPC methods...")
             print("=" * 60)
 
+            progress_phase("method inventory")
+            progress_note(
+                f"Checking {total} registered RPC methods; skipped probes include a reason"
+            )
             for i, method in enumerate(methods, 1):
                 result = await check_method(client, auth, method, notebook_id, full_mode)
                 results.append(result)
@@ -2257,6 +2292,7 @@ async def run_health_check(
             # so it is checked separately from the method-ID loop above — but
             # its ``CheckResult`` flows through the same summary + exit-code
             # machinery so chat drift fails the canary like any other probe.
+            progress_phase("chat framing")
             chat_result = await check_chat_query(client, auth, notebook_id)
             results.append(chat_result)
             chat_icon = STATUS_ICONS[chat_result.status]
@@ -2269,6 +2305,7 @@ async def run_health_check(
             # (the id echo is already covered by the regular GET_CUSTOMIZATION_CHOICES
             # row): MATCH is the steady state, DRIFT is the loud signal that the
             # served format codes / labels no longer agree with the client enums.
+            progress_phase("customization tables")
             customization_status, customization_detail = await check_customization_table(
                 client, auth, notebook_id
             )
@@ -2282,6 +2319,7 @@ async def run_health_check(
             # only STALE is exit-coded, and it clears itself the moment the
             # constant is bumped.
             await asyncio.sleep(CALL_DELAY)
+            progress_phase("build label")
             build_label = await check_build_label(client)
             for line in format_build_label_lane(build_label):
                 print(line)
@@ -2290,6 +2328,7 @@ async def run_health_check(
             # never join ``results``, so they cannot reach ``partition_errors``
             # / ``compute_exit_code`` and cannot poison the main lane's
             # title-deduped issue.
+            progress_phase("rebrand endpoints")
             rebrand_probes = await probe_rebrand_host(client, auth, notebook_id)
             rebrand_state = build_rebrand_state(
                 rebrand_probe_host(),
@@ -2304,6 +2343,7 @@ async def run_health_check(
         finally:
             if full_mode and temp_resources.notebook_id:
                 print()
+                progress_phase("cleanup")
                 print("Testing DELETE operations during cleanup...")
                 await cleanup_temp_resources(client, auth, temp_resources, results)
 
@@ -2641,6 +2681,12 @@ def main() -> int:
             "consumer can verify the document it reads was produced by this run."
         ),
     )
+    parser.add_argument(
+        "--progress-fd",
+        type=int,
+        default=None,
+        help="Additional file descriptor for safe live probe diagnostics (CI)",
+    )
     args = parser.parse_args()
 
     source = describe_base_url_source(args.base_url is not None)
@@ -2650,28 +2696,37 @@ def main() -> int:
         except ValueError as e:
             parser.error(str(e))
 
-    mode_str = "FULL" if args.full else "QUICK"
-    print(f"RPC Health Check ({mode_str} mode)")
-    print("=" * 60)
-    print()
+    with live_progress(args.progress_fd):
+        mode_str = "FULL" if args.full else "QUICK"
+        print(f"RPC Health Check ({mode_str} mode)")
+        print("=" * 60)
+        print()
 
-    try:
-        results, customization_status, rebrand_state, build_label = asyncio.run(
-            run_health_check(
-                full_mode=args.full,
-                base_url_source=source,
-                rebrand_state_path=args.rebrand_state_file,
-                rebrand_previous_state_path=args.rebrand_previous_state_file,
-                rebrand_run_id=args.rebrand_run_id,
+        try:
+            results, customization_status, rebrand_state, build_label = asyncio.run(
+                run_health_check(
+                    full_mode=args.full,
+                    base_url_source=source,
+                    rebrand_state_path=args.rebrand_state_file,
+                    rebrand_previous_state_path=args.rebrand_previous_state_file,
+                    rebrand_run_id=args.rebrand_run_id,
+                )
             )
-        )
-        return print_summary(results, customization_status, rebrand_state, build_label)
-    except SystemExit:
-        raise
-    except Exception as e:
-        print(f"\nFATAL: RPC health check crashed: {scrub_secrets(e)}", file=sys.stderr)
-        print(scrub_secrets(traceback.format_exc()), file=sys.stderr)
-        return 2
+            exit_code = print_summary(results, customization_status, rebrand_state, build_label)
+            counts = Counter(result.status.value for result in results)
+            progress_note(
+                f"RPC health finished: exit={exit_code}; "
+                + " ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+            )
+            return exit_code
+        except SystemExit as error:
+            progress_note(f"RPC health stopped: exit={error.code}; see authentication diagnostics")
+            raise
+        except Exception as e:
+            progress_note("RPC health crashed: exit=2; see full diagnostic report")
+            print(f"\nFATAL: RPC health check crashed: {scrub_secrets(e)}", file=sys.stderr)
+            print(scrub_secrets(traceback.format_exc()), file=sys.stderr)
+            return 2
 
 
 if __name__ == "__main__":

--- a/tests/_fault_server/web_resilience_scenarios.py
+++ b/tests/_fault_server/web_resilience_scenarios.py
@@ -503,23 +503,29 @@ async def _retry_auth_operation_deadline(result: ScenarioResult) -> None:
         result,
         server,
         timeout=10.0,
-        operation_timeout=0.2,
+        # This budget tests expiration during the gated retry, not cold-start
+        # speed. Allow the three socket attempts and auth refresh to reach it
+        # while other stress scenarios share the runner.
+        operation_timeout=5.0,
         server_retries=3,
         rate_retries=3,
         retry_sleep=gated_sleep,
     ) as client:
-        task = asyncio.create_task(client.notebooks.list())
-        await asyncio.wait_for(backoff_started.wait(), 1.0)
         try:
-            await task
+            # Await the operation directly: an early timeout must remain an
+            # observed failure, rather than leaving an orphan behind a gate.
+            await client.notebooks.list()
         except BaseException as caught:
             error = caught
         attempts_before_recovery = len(_requests(server, _READ))
         release_backoff.set()
-        await asyncio.sleep(0)
-        probe = await client.notebooks.list()
+        async with client.operation(timeout=None):
+            probe = await client.notebooks.list()
     result.require("aggregate_deadline_timeout", isinstance(error, OperationTimeoutError))
-    result.require("aggregate_deadline_three_attempts", attempts_before_recovery == 3)
+    result.require(
+        "aggregate_deadline_three_attempts",
+        attempts_before_recovery == 3 and backoff_started.is_set(),
+    )
     result.require("aggregate_deadline_one_refresh", len(_requests(server, _HOME)) == 1)
     result.require("aggregate_deadline_recovery", [row.id for row in probe] == ["probe"])
     _clean(result, server)
@@ -841,7 +847,7 @@ BUDGETS["retry_auth_backoff_cancelled"].update(
 )
 BUDGETS["retry_auth_operation_deadline"].update(
     rpc_timeout_s=10.0,
-    operation_timeout_s=0.2,
+    operation_timeout_s=5.0,
     rate_limit_max_retries=3,
     server_error_max_retries=3,
     retry_clock="gated_instance",

--- a/tests/e2e/_progress.py
+++ b/tests/e2e/_progress.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 from collections import Counter
 
+import pytest
 from scripts._ci_progress import report, safe_test_name, write_summary
 
 
@@ -16,6 +18,7 @@ class E2EProgress:
         self.current: tuple[str, float] | None = None
         self.results: dict[str, str] = {}
         self.failures: set[tuple[str, str]] = set()
+        self.failure_types: dict[tuple[str, str], str] = {}
         self.reruns = 0
         self.collection_errors = 0
         self._stop = threading.Event()
@@ -51,7 +54,18 @@ class E2EProgress:
         self.results[nodeid] = "running"
         # A rerun replaces the earlier attempt's failure in the final summary.
         self.failures = {entry for entry in self.failures if entry[0] != nodeid}
+        self.failure_types = {
+            key: value for key, value in self.failure_types.items() if key[0] != nodeid
+        }
         report(f"E2E [{len(self.results)}/{self.total}] START {name}")
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        yield
+        if call.excinfo is not None:
+            name = call.excinfo.type.__name__
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,79}", name):
+                self.failure_types[(item.nodeid, call.when)] = name
 
     def pytest_runtest_logreport(self, report) -> None:
         if report.outcome == "rerun":
@@ -72,8 +86,14 @@ class E2EProgress:
         current = self.current
         duration = time.monotonic() - current[1] if current else 0
         outcome = self.results.get(nodeid, "incomplete")
+        diagnostics = "; ".join(
+            f"{phase}: {self.failure_types.get((nodeid, phase), 'failure')}"
+            for failed_node, phase in sorted(self.failures)
+            if failed_node == nodeid
+        )
         report(
-            f"E2E {outcome.upper()} {safe_test_name(nodeid)}; elapsed={duration:.1f}s",
+            f"E2E {outcome.upper()} {safe_test_name(nodeid)}; elapsed={duration:.1f}s"
+            + (f"; {diagnostics}; see pytest traceback below" if diagnostics else ""),
             error=outcome == "failed",
         )
         self.current = None
@@ -89,9 +109,10 @@ class E2EProgress:
             summary=True,
         )
         if self.failures:
-            write_summary("\n| Failed E2E test | Phase |\n| --- | --- |")
+            write_summary("\n| Failed E2E test | Phase | Exception type |\n| --- | --- | --- |")
             for nodeid, phase in sorted(self.failures):
-                write_summary(f"| `{safe_test_name(nodeid)}` | {phase} |")
+                kind = self.failure_types.get((nodeid, phase), "see pytest traceback")
+                write_summary(f"| `{safe_test_name(nodeid)}` | {phase} | {kind} |")
 
     def pytest_unconfigure(self) -> None:
         self._stop.set()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -693,7 +693,7 @@ def _rate_limit_skip_reports(terminalreporter) -> list[Any]:
 
 
 def _coverage_floor_enforced() -> bool:
-    """Whether coverage floors escalate to a suite failure.
+    """Whether execution floors escalate to a suite failure.
 
     Off by default so a shared daily-quota exhaustion can never red a release job
     (e.g. Verify Package, #1819) — the release path skips rate-limited
@@ -705,7 +705,7 @@ def _coverage_floor_enforced() -> bool:
 
 
 def _coverage_floor_failures(terminalreporter, exitstatus, marker: str) -> list[Any]:
-    """Rate-limit skips that breach the coverage floor for ``marker``.
+    """Rate-limit skips that breach the execution floor for ``marker``.
 
     Non-empty only when at least one ``marker`` test was rate-limit-skipped and no
     ``marker`` test passed — i.e. that live surface produced zero real coverage.
@@ -785,7 +785,7 @@ def pytest_sessionfinish(session, exitstatus):
     if terminalreporter is None:
         return
 
-    # Coverage floors are advisory unless the nightly opts in (see
+    # Execution floors are advisory unless the nightly opts in (see
     # _coverage_floor_enforced), so a rate-limited release job stays green (#1819).
     if not _coverage_floor_enforced():
         return
@@ -795,7 +795,7 @@ def pytest_sessionfinish(session, exitstatus):
         # Sentinel delivery (nightly). The main e2e step is ``continue-on-error`` and
         # its ``--last-failed`` retry re-runs only failures, so a ``session.exitstatus``
         # override would be masked. Instead every enforcing run (main AND retry)
-        # appends PASS/SKIP events; the "Enforce coverage floors" step breaches a
+        # appends PASS/SKIP events; the "Enforce execution floors" step breaches a
         # surface seen SKIP but never PASS across all runs. This closes the retry gap
         # (a marked test that fails on main then skips on retry) WITHOUT false-breaching
         # when coverage was achieved in another run (codex/coderabbit). Exit status is
@@ -879,13 +879,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         if not breaches:
             continue
         if enforced:
-            terminalreporter.write_sep("=", f"{label} coverage floor failed", red=True)
+            terminalreporter.write_sep("=", f"{label} execution floor failed", red=True)
             terminalreporter.write_line(
                 f"No marked {label} test completed successfully (all rate-limited)."
             )
         else:
             terminalreporter.write_sep(
-                "=", f"{label} coverage floor breached (not enforced)", yellow=True
+                "=", f"{label} execution floor breached (not enforced)", yellow=True
             )
             terminalreporter.write_line(
                 f"No marked {label} test passed; not failing (E2E_ENFORCE_COVERAGE_FLOOR unset)."

--- a/tests/unit/test_android_grpc_canary.py
+++ b/tests/unit/test_android_grpc_canary.py
@@ -353,6 +353,20 @@ async def test_progress_pipe_failure_does_not_change_canary_result(fail_on, caps
     assert capsys.readouterr().err.count("could not write live Android progress") == 1
 
 
+def test_invalid_progress_descriptor_still_runs_android_canary(capsys):
+    service = _Service()
+    code = canary.main(
+        ["--notebook-id", NOTEBOOK_ID, "--progress-fd", "-1"],
+        client_factory=_factory(service, _Bearer()),
+    )
+    assert code == 0
+    assert service.get_project_calls == 2
+    assert service.list_sessions_calls == 2
+    output = capsys.readouterr()
+    assert "OK get_project id round-trip" in output.out
+    assert "could not open CI progress stream" in output.err
+
+
 @pytest.mark.asyncio
 async def test_absent_conversation_is_still_a_pass() -> None:
     code, lines = await _run(_Service(with_session=False))

--- a/tests/unit/test_android_grpc_canary.py
+++ b/tests/unit/test_android_grpc_canary.py
@@ -235,6 +235,7 @@ async def _run(
     bearer: _Bearer | None = None,
     *,
     baseline_path: Path | None = None,
+    progress: canary.Emit | None = None,
 ) -> tuple[int, list[str]]:
     lines: list[str] = []
     code = await canary.run_canary(
@@ -242,6 +243,7 @@ async def _run(
         NOTEBOOK_ID,
         baseline_path=baseline_path,
         out=lines.append,
+        progress=progress,
     )
     return code, lines
 
@@ -281,7 +283,8 @@ def _write_baseline(tmp_path: Path, document: dict[str, Any]) -> Path:
 async def test_all_steps_pass_exits_zero() -> None:
     service = _Service()
     bearer = _Bearer()
-    code, lines = await _run(service, bearer)
+    progress: list[str] = []
+    code, lines = await _run(service, bearer, progress=progress.append)
 
     assert code == 0
     assert _line(lines, "OK open") == "OK open backends=android"
@@ -302,6 +305,15 @@ async def test_all_steps_pass_exits_zero() -> None:
     assert service.list_sessions_calls == 2
     assert bearer.invalidated == [1]
     assert bearer.generation == 2
+    live = "\n".join(progress)
+    assert f"START get_project {canary.GET_PROJECT_METHOD}" in live
+    assert f"START list_chat_sessions {canary.LIST_CHAT_SESSIONS_METHOD}" in live
+    assert "OK get_project id round-trip; elapsed=" in live
+    assert "SHAPE GetProject " in live
+    assert "UNKNOWN GetProject 0" in live
+    assert NOTEBOOK_ID not in live
+    assert "conversation-1" not in live
+    assert "fake-server-token" not in live
 
 
 @pytest.mark.asyncio
@@ -1001,6 +1013,7 @@ def test_main_prefers_the_flag_over_env_and_forwards_the_baseline(
         baseline_path: Any,
         missing_baseline_grace_until: Any = None,
         out: Any,
+        progress: Any = None,
     ) -> int:
         captured.append((notebook_id, baseline_path))
         return await original(
@@ -1009,6 +1022,7 @@ def test_main_prefers_the_flag_over_env_and_forwards_the_baseline(
             baseline_path=baseline_path,
             missing_baseline_grace_until=missing_baseline_grace_until,
             out=out,
+            progress=progress,
         )
 
     monkeypatch.setattr(canary, "run_canary", spy)

--- a/tests/unit/test_android_grpc_canary.py
+++ b/tests/unit/test_android_grpc_canary.py
@@ -335,6 +335,25 @@ async def test_output_carries_hashes_but_no_ids_or_tokens() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("fail_on", ["START", "OK open"])
+async def test_progress_pipe_failure_does_not_change_canary_result(fail_on, capsys) -> None:
+    failed = False
+
+    def broken_progress(line: str) -> None:
+        nonlocal failed
+        assert not failed, "progress writes must stop after the first pipe failure"
+        if fail_on in line:
+            failed = True
+            raise BrokenPipeError("closed diagnostic stream")
+
+    code, lines = await _run(_Service(), progress=broken_progress)
+    assert code == 0
+    assert failed
+    assert _line(lines, "OK get_project") == "OK get_project id round-trip"
+    assert capsys.readouterr().err.count("could not write live Android progress") == 1
+
+
+@pytest.mark.asyncio
 async def test_absent_conversation_is_still_a_pass() -> None:
     code, lines = await _run(_Service(with_session=False))
 

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -519,7 +519,7 @@ def test_safe_summaries_cover_selection_and_lifecycle_counts() -> None:
     assert '"full": ("reference", "generation")' in nightly_provision
     assert "Clean workspace residuals: generation/multi-source=0" in nightly_provision
     assert 'row["notebook_id"]' not in nightly_provision
-    assert "Coverage floor:" in str(_step(nightly, "coverage")["run"])
+    assert "E2E execution floor:" in str(_step(nightly, "coverage")["run"])
 
     package = _load("verify-package.yml")["jobs"]["verify"]
     package_provision = str(_step(package, "provision")["run"])

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -160,7 +160,7 @@ def test_verify_package_e2e_retry_is_scoped_to_last_failed_e2e_tests():
 
 
 def test_coverage_thresholds_passes_on_real_state():
-    """Current pyproject.toml + nightly.yml agree on the coverage threshold."""
+    """Current pyproject.toml + nightly-checks.yml agree on the coverage threshold."""
     result = _run([str(SCRIPTS / "check_coverage_thresholds.py")])
     assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
 

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 import yaml
-from scripts._ci_progress import report, safe_test_name
+from scripts._ci_progress import open_progress_stream, report, safe_test_name
 
 from tests.e2e._progress import E2EProgress
 
@@ -71,6 +71,25 @@ def test_summary_write_failure_preserves_error_diagnostics(monkeypatch, tmp_path
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path))
     report("original verification failure", error=True)
     assert "original verification failure" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("error_type", [OSError, ValueError])
+def test_progress_wrapper_setup_failure_closes_only_duplicate(monkeypatch, tmp_path, error_type):
+    duplicate = None
+
+    def cannot_wrap(fd, *args, **kwargs):
+        nonlocal duplicate
+        duplicate = fd
+        raise error_type("cannot wrap progress descriptor")
+
+    with (tmp_path / "progress.log").open("w") as original:
+        monkeypatch.setattr(os, "fdopen", cannot_wrap)
+        with open_progress_stream(original.fileno()) as progress:
+            assert progress is None
+        original.write("caller descriptor still works\n")
+        assert duplicate is not None
+        with pytest.raises(OSError):
+            os.fstat(duplicate)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -198,7 +198,8 @@ def test_rpc_workflow_keeps_live_progress_separate_and_preserves_exit(
     data = yaml.safe_load((root / ".github/workflows/rpc-health.yml").read_text())
     command = next(row["run"] for row in data["jobs"][job]["steps"] if row.get("id") == "health")
     command = (
-        "uv() { printf 'START RPC-ID visible\\n' >&3; printf 'private response\\n'; return 3; }\n"
+        "uv() { case \" $* \" in *' --progress-fd 3 '*) ;; *) return 97;; esac; "
+        "printf 'START RPC-ID visible\\n' >&3; printf 'private response\\n'; return 3; }\n"
         + command
     )
     completed = subprocess.run(

--- a/tests/unit/test_ci_progress.py
+++ b/tests/unit/test_ci_progress.py
@@ -51,7 +51,9 @@ def test_progress_plugin_runs_with_real_pytest(pytester, monkeypatch, tmp_path):
     result = pytester.runpytest("-s", "-q")
     result.assert_outcomes(passed=1, failed=1, skipped=1)
     result.stdout.fnmatch_lines(["*E2E finished: exit=1 failed=1 passed=1 skipped=1*"])
+    result.stderr.fnmatch_lines(["*E2E FAILED*call: AssertionError; see pytest traceback below*"])
     assert "failed=1 passed=1 skipped=1" in summary.read_text()
+    assert "| call | AssertionError |" in summary.read_text()
 
 
 def test_error_is_visible_in_log_annotation_and_summary(monkeypatch, tmp_path, capsys):
@@ -183,3 +185,32 @@ def test_workflow_streams_output_and_preserves_failure(workflow, job, step, work
     )
     assert completed.returncode == 6
     assert "visible progress before failure" in completed.stdout
+
+
+@pytest.mark.parametrize(
+    ("job", "report_file"),
+    [("health-check", "health-report.txt"), ("android-grpc-health", "android-canary-report.txt")],
+)
+def test_rpc_workflow_keeps_live_progress_separate_and_preserves_exit(
+    job, report_file, workflow_bash, tmp_path
+):
+    root = Path(__file__).resolve().parents[2]
+    data = yaml.safe_load((root / ".github/workflows/rpc-health.yml").read_text())
+    command = next(row["run"] for row in data["jobs"][job]["steps"] if row.get("id") == "health")
+    command = (
+        "uv() { printf 'START RPC-ID visible\\n' >&3; printf 'private response\\n'; return 3; }\n"
+        + command
+    )
+    completed = subprocess.run(
+        [workflow_bash, "-e", "-o", "pipefail", "-c", command],
+        cwd=tmp_path,
+        env={**os.environ, "GITHUB_OUTPUT": (tmp_path / "output").as_posix()},
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert completed.returncode == 3
+    assert "START RPC-ID visible" in completed.stdout
+    assert "private response" not in completed.stdout + completed.stderr
+    assert (tmp_path / report_file).read_text() == "private response\n"

--- a/tests/unit/test_ci_rpc_progress.py
+++ b/tests/unit/test_ci_rpc_progress.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 
@@ -50,6 +51,25 @@ async def test_real_probe_streams_before_response_and_keeps_payload_private(monk
     assert "private-notebook" not in output
     assert "elapsed=" in output
     assert "| method inventory |" in summary.read_text()
+
+
+@pytest.mark.asyncio
+async def test_successful_string_payload_is_not_treated_as_an_error(monkeypatch, tmp_path):
+    method = health.RPCMethod.CREATE_NOTE
+
+    async def rpc_request(*args, **kwargs):
+        return json.dumps([["wrb.fr", method.value, json.dumps("private payload")]]), None
+
+    monkeypatch.setattr(health, "make_rpc_request", rpc_request)
+    live = tmp_path / "live.log"
+    with live.open("w") as stream, live_progress(stream.fileno()):
+        result, data = await health.test_rpc_method_with_data(None, None, method, [])
+    assert result.status is health.CheckStatus.OK
+    assert data == "private payload"
+    output = live.read_text()
+    assert "expected RPC ID observed" in output
+    assert "rejected" not in output
+    assert "private payload" not in output
 
 
 @pytest.mark.parametrize(
@@ -133,7 +153,10 @@ async def test_cancelled_probe_keeps_failure_and_partial_summary(monkeypatch, tm
     assert "| ERROR |" in summary.read_text()
 
 
-def test_broken_pipe_preserves_cli_failure_and_summary(monkeypatch, tmp_path, capsys):
+@pytest.mark.parametrize("invalid_descriptor", [False, True])
+def test_unusable_progress_preserves_cli_failure_and_summary(
+    monkeypatch, tmp_path, capsys, invalid_descriptor
+):
     async def failed_call(*args, **kwargs):
         return [], "HTTP 503"
 
@@ -146,13 +169,22 @@ def test_broken_pipe_preserves_cli_failure_and_summary(monkeypatch, tmp_path, ca
     monkeypatch.setattr(health, "run_health_check", run)
     summary = tmp_path / "summary.md"
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
-    reader, writer = os.pipe()
-    os.close(reader)
+    if invalid_descriptor:
+        writer = -1
+    else:
+        reader, writer = os.pipe()
+        os.close(reader)
     try:
         monkeypatch.setattr(sys, "argv", ["check_rpc_health.py", "--progress-fd", str(writer)])
         assert health.main() == 3
     finally:
-        os.close(writer)
+        if writer >= 0:
+            os.close(writer)
     assert "| ERROR |" in summary.read_text()
     assert "HTTP 503; see report" in summary.read_text()
-    assert capsys.readouterr().err.count("could not write live RPC progress") == 1
+    warning = (
+        "could not open CI progress stream"
+        if invalid_descriptor
+        else "could not write live RPC progress"
+    )
+    assert capsys.readouterr().err.count(warning) == 1

--- a/tests/unit/test_ci_rpc_progress.py
+++ b/tests/unit/test_ci_rpc_progress.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 
 import pytest
@@ -130,3 +131,28 @@ async def test_cancelled_probe_keeps_failure_and_partial_summary(monkeypatch, tm
             await health.test_rpc_method(None, None, health.RPCMethod.DELETE_NOTEBOOK, [])
     assert "| cleanup | `RPC-ID DELETE_NOTEBOOK" in summary.read_text()
     assert "| ERROR |" in summary.read_text()
+
+
+def test_broken_pipe_preserves_cli_failure_and_summary(monkeypatch, tmp_path, capsys):
+    async def failed_call(*args, **kwargs):
+        return [], "HTTP 503"
+
+    async def run(**kwargs):
+        progress_phase("method inventory")
+        result = await health.check_method(None, None, health.RPCMethod.LIST_NOTEBOOKS, None)
+        return [result], health.CustomizationStatus.MATCH, None, None
+
+    monkeypatch.setattr(health, "make_rpc_call", failed_call)
+    monkeypatch.setattr(health, "run_health_check", run)
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    reader, writer = os.pipe()
+    os.close(reader)
+    try:
+        monkeypatch.setattr(sys, "argv", ["check_rpc_health.py", "--progress-fd", str(writer)])
+        assert health.main() == 3
+    finally:
+        os.close(writer)
+    assert "| ERROR |" in summary.read_text()
+    assert "HTTP 503; see report" in summary.read_text()
+    assert capsys.readouterr().err.count("could not write live RPC progress") == 1

--- a/tests/unit/test_ci_rpc_progress.py
+++ b/tests/unit/test_ci_rpc_progress.py
@@ -1,0 +1,132 @@
+"""Live diagnostics must precede completion and preserve the checker's verdict."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+from scripts._ci_rpc_progress import live_progress, progress_phase, safe_reason
+
+from scripts import check_rpc_health as health
+
+
+@pytest.mark.asyncio
+async def test_real_probe_streams_before_response_and_keeps_payload_private(monkeypatch, tmp_path):
+    live = tmp_path / "live.log"
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    method = health.RPCMethod.LIST_NOTEBOOKS
+
+    async def blocked_call(*args, **kwargs):
+        entered.set()
+        await release.wait()
+        return [method.value], None
+
+    monkeypatch.setattr(health, "make_rpc_call", blocked_call)
+    with live.open("w") as stream, live_progress(stream.fileno()):
+        progress_phase("method inventory")
+        task = asyncio.create_task(health.check_method(None, None, method, "private-notebook"))
+        try:
+            await asyncio.wait_for(entered.wait(), 2)
+            started = live.read_text()
+            assert f"START RPC-ID LIST_NOTEBOOKS ({method.value})" in started
+            assert " OK " not in started
+        finally:
+            release.set()
+            result = await task
+        assert result.status is health.CheckStatus.OK
+        skipped = await health.check_method(
+            None, None, health.RPCMethod.CREATE_NOTEBOOK, None, True
+        )
+        assert skipped.status is health.CheckStatus.SKIPPED
+
+    output = live.read_text() + summary.read_text()
+    assert "expected RPC ID observed" in output
+    assert "handled in setup/cleanup; see those phase results" in output
+    assert "private-notebook" not in output
+    assert "elapsed=" in output
+    assert "| method inventory |" in summary.read_text()
+
+
+@pytest.mark.parametrize(
+    ("status", "error", "reason"),
+    [
+        (health.CheckStatus.ERROR, "HTTP 429 SID=private", "quota/rate limit (transient)"),
+        (health.CheckStatus.ERROR, "ReadTimeout private", "RPC read timeout (transient)"),
+        (health.CheckStatus.ERROR, "HTTP 503 private", "HTTP 503; see report"),
+        (health.CheckStatus.ERROR, "ConnectTimeout private", "ConnectTimeout"),
+        (
+            health.CheckStatus.ERROR,
+            "Parse error: ValueError private",
+            "response decoding failed; see report",
+        ),
+        (
+            health.CheckStatus.OK,
+            "Call failed but ID found: private",
+            "expected RPC ID observed, but operation rejected; see report",
+        ),
+    ],
+)
+def test_live_error_classification_never_copies_upstream_text(status, error, reason):
+    result = health.CheckResult(health.RPCMethod.LIST_NOTEBOOKS, status, "wXbhsf", [], error)
+    assert safe_reason(result, "ID observed") == reason
+    assert "private" not in safe_reason(result, "ID observed")
+
+
+def test_mismatch_reports_only_rpc_shaped_ids():
+    result = health.CheckResult(
+        health.RPCMethod.LIST_NOTEBOOKS,
+        health.CheckStatus.MISMATCH,
+        "wXbhsf",
+        ["abcdef", "private-notebook-id", "bad|\n::error::injected"],
+    )
+    reason = safe_reason(result, "ID observed")
+    assert "observed IDs=abcdef" in reason
+    assert "<unexpected ID shape>" in reason
+    assert "private" not in reason
+    assert "::error::" not in reason
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_exit"),
+    [(health.CheckStatus.OK, 0), (health.CheckStatus.MISMATCH, 1), (health.CheckStatus.ERROR, 3)],
+)
+def test_cli_progress_preserves_verdict_and_full_report(
+    monkeypatch, tmp_path, capsys, status, expected_exit
+):
+    method = health.RPCMethod.LIST_NOTEBOOKS
+    result = health.CheckResult(method, status, method.value, [], "HTTP 503")
+
+    async def run(**kwargs):
+        return [result], health.CustomizationStatus.MATCH, None, None
+
+    monkeypatch.setattr(health, "run_health_check", run)
+    live = tmp_path / "live.log"
+    with live.open("w") as stream:
+        monkeypatch.setattr(
+            sys, "argv", ["check_rpc_health.py", "--progress-fd", str(stream.fileno())]
+        )
+        assert health.main() == expected_exit
+        # Closing the duplicate leaves the caller's descriptor usable.
+        stream.write("caller still owns descriptor\n")
+    assert "RPC health finished: exit=" in live.read_text()
+    assert "RESULT:" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_cancelled_probe_keeps_failure_and_partial_summary(monkeypatch, tmp_path):
+    async def cancelled(*args, **kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(health, "make_rpc_call", cancelled)
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    with (tmp_path / "live.log").open("w") as stream, live_progress(stream.fileno()):
+        progress_phase("cleanup")
+        with pytest.raises(asyncio.CancelledError):
+            await health.test_rpc_method(None, None, health.RPCMethod.DELETE_NOTEBOOK, [])
+    assert "| cleanup | `RPC-ID DELETE_NOTEBOOK" in summary.read_text()
+    assert "| ERROR |" in summary.read_text()

--- a/tests/unit/test_ci_test_matrix.py
+++ b/tests/unit/test_ci_test_matrix.py
@@ -14,6 +14,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "test.yml"
 AUTH_PATCH_AUDIT_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "auth-patch-audit.yml"
 NIGHTLY_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "nightly.yml"
+NIGHTLY_CHECKS_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "nightly-checks.yml"
 VERIFY_PACKAGE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "verify-package.yml"
 PYPROJECT = PROJECT_ROOT / "pyproject.toml"
 REFACTOR_QUALIFICATION_FILES = {
@@ -249,7 +250,7 @@ def test_refactor_qualification_is_out_of_prs_and_in_manual_nightly_release_lane
     assert "-m refactor_qualification" in manual_command
     assert "--no-cov" in manual_command
 
-    nightly = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    nightly = yaml.safe_load(NIGHTLY_CHECKS_WORKFLOW.read_text(encoding="utf-8"))
     compatibility = nightly["jobs"]["compatibility"]
     ordinary_nightly = str(_step(compatibility, "Run compatibility tests without coverage")["run"])
     assert "not refactor_qualification" in ordinary_nightly
@@ -363,14 +364,11 @@ def test_auth_patch_coverage_delta_is_release_gated_and_manually_dispatchable() 
 
 def test_nightly_runs_full_sha_pinned_compatibility_matrix() -> None:
     """Nightly owns the full 3-OS by 5-Python ordinary test matrix (PRs run a reduced one)."""
-    workflow = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    workflow = yaml.safe_load(NIGHTLY_CHECKS_WORKFLOW.read_text(encoding="utf-8"))
     job = workflow["jobs"]["compatibility"]
 
     assert job["needs"] == "resolve-target"
-    assert job["if"] == (
-        "needs.resolve-target.outputs.is_standard == 'true' && "
-        "(github.event_name == 'schedule' || inputs.run_compatibility)"
-    )
+    assert "if" not in job
     assert job["runs-on"] == "${{ matrix.os }}"
     assert job["strategy"] == {
         "fail-fast": False,
@@ -382,15 +380,13 @@ def test_nightly_runs_full_sha_pinned_compatibility_matrix() -> None:
     assert "environment" not in job
     assert "secrets." not in str(job)
 
-    workflow_text = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
-    # PyYAML parses a bare ``on`` key as boolean ``True``.
     triggers = workflow.get("on", workflow.get(True))
-    dispatch_inputs = triggers["workflow_dispatch"]["inputs"]
-    assert dispatch_inputs["run_compatibility"]["type"] == "boolean"
-    # Manual dispatches (release branches) default to the full matrix because the
-    # PR gate only runs the reduced 7-cell one.
-    assert dispatch_inputs["run_compatibility"]["default"] is True
-    assert "run_compatibility:" in workflow_text
+    assert set(triggers) == {"schedule", "workflow_dispatch"}
+    assert set(triggers["workflow_dispatch"]["inputs"]) == {"custom_branch"}
+    e2e = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    assert set(e2e["jobs"]) == {"resolve-target", "plan-live-lanes", "e2e"}
+    e2e_triggers = e2e.get("on", e2e.get(True))
+    assert "run_compatibility" not in e2e_triggers["workflow_dispatch"]["inputs"]
 
     checkout = next(
         step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")
@@ -426,7 +422,7 @@ def test_nightly_runs_full_sha_pinned_compatibility_matrix() -> None:
 
 def test_nightly_coverage_is_sha_pinned_secret_free_and_enforces_floors() -> None:
     """Scheduled/manual nightly owns global and per-file coverage enforcement."""
-    workflow = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    workflow = yaml.safe_load(NIGHTLY_CHECKS_WORKFLOW.read_text(encoding="utf-8"))
     triggers = workflow.get("on", workflow.get(True))
     assert set(triggers) == {"schedule", "workflow_dispatch"}
 
@@ -437,14 +433,14 @@ def test_nightly_coverage_is_sha_pinned_secret_free_and_enforces_floors() -> Non
         if str(step.get("uses", "")).startswith("actions/checkout@")
     )
     assert resolve_checkout["with"] == {
-        "ref": "${{ steps.resolve.outputs.checkout_ref }}",
+        "ref": "${{ inputs.custom_branch || github.sha }}",
         "fetch-depth": 1,
         "persist-credentials": False,
     }
 
     job = workflow["jobs"]["coverage"]
     assert job["needs"] == "resolve-target"
-    assert job["if"] == "needs.resolve-target.outputs.is_standard == 'true'"
+    assert "if" not in job
     assert job["runs-on"] == "ubuntu-latest"
     assert "environment" not in job
     assert "secrets." not in str(job)
@@ -458,13 +454,6 @@ def test_nightly_coverage_is_sha_pinned_secret_free_and_enforces_floors() -> Non
         "fetch-depth": 1,
         "persist-credentials": False,
     }
-
-    e2e_checkout = next(
-        step
-        for step in workflow["jobs"]["e2e"]["steps"]
-        if str(step.get("uses", "")).startswith("actions/checkout@")
-    )
-    assert e2e_checkout["with"] == checkout["with"]
 
     setup_python = _step(job, "Set up Python")
     assert setup_python["uses"] == "actions/setup-python@v7"
@@ -703,11 +692,11 @@ def test_repository_lint_is_a_bounded_manual_only_job() -> None:
 
 def test_repository_lint_is_scheduled_once_in_nightly() -> None:
     """AST-heavy audits run automatically once against the resolved nightly SHA."""
-    workflow = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
+    workflow = yaml.safe_load(NIGHTLY_CHECKS_WORKFLOW.read_text(encoding="utf-8"))
     job = workflow["jobs"]["repo-lint"]
 
     assert job["needs"] == "resolve-target"
-    assert job["if"] == "needs.resolve-target.outputs.is_standard == 'true'"
+    assert "if" not in job
     assert job["runs-on"] == "ubuntu-latest"
     assert "environment" not in job
     assert "secrets." not in str(job)

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -339,7 +339,7 @@ class TestRateLimitSkipSummary:
 
         assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
         assert any(
-            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            call[0] == "sep" and call[1][1] == "live chat execution floor failed"
             for call in tr._writes
         )
         assert capsys.readouterr().out == ""
@@ -358,7 +358,7 @@ class TestRateLimitSkipSummary:
 
         assert session.exitstatus == pytest.ExitCode.OK
         assert not any(
-            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            call[0] == "sep" and call[1][1] == "live chat execution floor failed"
             for call in tr._writes
         )
 
@@ -420,7 +420,7 @@ class TestRateLimitSkipSummary:
 
         assert session.exitstatus == pytest.ExitCode.USAGE_ERROR
         assert not any(
-            call[0] == "sep" and call[1][1] == "live chat coverage floor failed"
+            call[0] == "sep" and call[1][1] == "live chat execution floor failed"
             for call in tr._writes
         )
 
@@ -587,7 +587,7 @@ class TestRateLimitSkipSummary:
 
             def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 if exitstatus == pytest.ExitCode.OK and terminalreporter.stats.get("skipped"):
-                    terminalreporter.write_sep("=", "live chat coverage floor failed")
+                    terminalreporter.write_sep("=", "live chat execution floor failed")
             """
         )
         pytester.makepyfile(
@@ -603,7 +603,7 @@ class TestRateLimitSkipSummary:
         result = pytester.runpytest_subprocess("-q")
 
         assert result.ret == pytest.ExitCode.TESTS_FAILED
-        result.stdout.fnmatch_lines(["*live chat coverage floor failed*"])
+        result.stdout.fnmatch_lines(["*live chat execution floor failed*"])
 
 
 class TestAndroidArtifactOptionReadBack:


### PR DESCRIPTION
An E2E dispatch still launched ordinary coverage and repository checks, and RPC probes hid all output until their report upload. Move the existing offline matrix, coverage, and lint jobs into a separate scheduled/manual Nightly Code Checks workflow so E2E runs contain only live lanes.

Stream Web RPC phase, method name/ID, start, duration, outcome, and safe diagnostic reasons while retaining the complete report. Keep a per-probe summary and explain what RPC-ID success actually validates. Android emits gRPC method paths, semantic checks, schema hashes, unknown-field counts, and baseline differences as they happen. Reporting adds no RPC calls and preserves exit codes, including when the live progress pipe breaks during a write or final flush.

E2E explicitly disables code coverage, prints skip/xfail reasons, and includes failure phase and exception type in progress and summaries. Rename its skip-only family enforcement to “execution floors” to distinguish it from code coverage. Update release instructions and workflow audits for the split.

The required fault-stress check also exposed a pre-existing 200 ms setup race in the retry/auth deadline scenario. Give its socket/auth setup a five-second budget before the indefinitely gated backoff, await the operation directly to avoid orphan tasks, and keep the recovery read outside that intentionally expiring budget. The scenario still requires exactly three attempts, one refresh, deadline expiration in the backoff, and successful recovery.

Validation:
- 444 focused RPC, Android gRPC, E2E progress, workflow, and CI audit tests passed.
- 100 E2E option and live-workflow contract tests passed after the wording update.
- `pre-commit run --all-files` passed.
- All 174 HTTP/gRPC stress scenarios passed with the failing CI seed `34128166926`; the deadline scenario also passed with 300 ms injected before every socket request. All 50 stress-runner contract tests passed.
- 273 focused reporting and RPC tests passed after review fixes, including real broken-pipe, invalid-descriptor, wrapper setup, and Android callback failures.
- Shell regression tests verify live output/report separation and original failure codes; real fake-server gRPC tests verify unchanged request counts.

Follows #2405. After merge, rerun the quick readonly E2E dispatch and both RPC lanes to verify the final Actions presentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added nightly compatibility checks across supported operating systems and Python versions, including coverage and repository validation.
  - Added live RPC health-check progress with phase-level diagnostics and sanitized failure details.
  - Expanded E2E reports with failure phases, exception types, and per-probe diagnostics.

- **Bug Fixes**
  - Progress-reporting failures no longer interrupt RPC or Android canary checks.
  - Improved separation of live progress output from saved health-check reports.

- **Documentation**
  - Updated development and release guidance for the separate nightly code-check and authenticated E2E workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->