### PR TITLE
fix(ci): distinguish copied inventory from download payloads

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -853,6 +853,10 @@ unfinished, then prove a stable empty inventory over the existing 90-second quie
 Reference artifact completion is checked separately by
 `test_copied_reference_artifacts_become_ready`, with a ten-minute budget. Missing copied artifacts
 fail that test with the missing families listed while allowing the other E2E tests to run.
+Completed copies need not expose download payloads. Once the inventory is ready, the test reports
+each required family's completed count, list URL count, exact-read count, and payload availability.
+Android checks `GetArtifact` when `ListArtifacts` omits a URL. Missing URLs produce explicit
+warnings rather than another readiness wait; download tests report their own outcomes and skips.
 The checked-in template shape is
 `tests/fixtures/e2e_template_contract.json`. Notes and chat history are deliberately absent from
 that contract. Provisioning creates and validates those on the disposable `reference` copy using
@@ -860,7 +864,7 @@ that contract. Provisioning creates and validates those on the disposable `refer
 
 Nightly logs show each preparation stage, per-test start/result lines, and a heartbeat every
 30 seconds while a test is running. Artifact verification reports pending families, producer
-tests, and missing download URLs during polling. The job summary retains preparation failures,
+tests, and copied download payload availability. The job summary retains preparation failures,
 E2E result counts, failed test names, failure phases and exception types, and a table of phase
 outcomes even after cleanup. Pytest logs retain tracebacks and skip/xfail reasons (`-ra`);
 live tests explicitly disable code coverage (`--no-cov`). Execution floors only detect when

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -55,6 +55,50 @@ def completed_interactive_mind_maps(artifacts: list[Artifact]) -> list[Artifact]
     ]
 
 
+async def report_copied_download_payloads(
+    client: NotebookLMClient,
+    notebook_id: str,
+    completed: list[Artifact],
+    required_families: set[str],
+) -> None:
+    """Diagnose representations separately from the copied inventory contract.
+
+    Android list summaries can omit payloads present in exact GetArtifact reads.
+    Completed copied rows can also lack representations in both responses; the
+    template contract promises completed families, not downloadable copies.
+    """
+    backend = client.backends["artifacts"]
+    for family in sorted(required_families & URL_BACKED_ARTIFACT_FAMILIES):
+        candidates = [artifact for artifact in completed if artifact.kind == family]
+        list_urls = sum(bool(artifact.url) for artifact in candidates)
+        available = bool(list_urls)
+        exact_reads = 0
+        if not available and backend == "android":
+            for candidate in candidates:
+                async with client.artifacts._transport.operation_scope(
+                    "e2e copied artifact representation"
+                ) as lease:
+                    exact = await client.artifacts._get_studio_artifact(
+                        notebook_id, candidate.id, expected_epoch=lease.epoch
+                    )
+                exact_reads += 1
+                if exact is not None and exact.kind == family and exact.is_completed and exact.url:
+                    available = True
+                    break
+        report(
+            f"Copied reference payload: family={family}; completed={len(candidates)}; "
+            f"ListArtifacts_urls={list_urls}; GetArtifact_reads={exact_reads}; "
+            f"download_payload={'available' if available else 'unavailable'}",
+            summary=True,
+        )
+        if not available:
+            report(
+                f"WARNING: copied {family} inventory is complete but has no download URL; "
+                "copy readiness does not validate download coverage",
+                summary=True,
+            )
+
+
 async def assert_copied_reference_artifacts(
     client: NotebookLMClient,
     notebook_id: str,
@@ -65,7 +109,7 @@ async def assert_copied_reference_artifacts(
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> None:
-    """Keep copied-content failures visible without preventing other E2E tests."""
+    """Assert the copied inventory contract and report download payload availability."""
     deadline = clock() + timeout
     while True:
         artifacts = await client.artifacts.list(notebook_id)
@@ -74,13 +118,6 @@ async def assert_copied_reference_artifacts(
             artifact.kind.value for artifact in completed if not artifact.is_unclassified_type4
         }
         missing = sorted(required_families - families)
-        missing_payloads = sorted(
-            family
-            for family in required_families & families & URL_BACKED_ARTIFACT_FAMILIES
-            if not completed_download_candidates(
-                completed, family, backend=client.backends["artifacts"]
-            )
-        )
         if require_interactive_mind_map and not any(
             artifact.is_interactive_mind_map for artifact in completed
         ):
@@ -88,8 +125,6 @@ async def assert_copied_reference_artifacts(
         issues = []
         if missing:
             issues.append("missing completed families: " + ", ".join(missing))
-        if missing_payloads:
-            issues.append("missing download payload families: " + ", ".join(missing_payloads))
         remaining = max(0.0, deadline - clock())
         detail = "; ".join(issues) if issues else "ready"
         report(
@@ -97,6 +132,7 @@ async def assert_copied_reference_artifacts(
             summary=not issues or remaining == 0,
         )
         if not issues:
+            await report_copied_download_payloads(client, notebook_id, completed, required_families)
             return
         assert remaining > 0, "Copied reference " + detail
         await sleep(min(30, remaining))

--- a/tests/e2e/_artifact_helpers.py
+++ b/tests/e2e/_artifact_helpers.py
@@ -69,7 +69,11 @@ async def report_copied_download_payloads(
     """
     backend = client.backends["artifacts"]
     for family in sorted(required_families & URL_BACKED_ARTIFACT_FAMILIES):
-        candidates = [artifact for artifact in completed if artifact.kind == family]
+        candidates = [
+            artifact
+            for artifact in completed
+            if not artifact.is_unclassified_type4 and artifact.kind == family
+        ]
         list_urls = sum(bool(artifact.url) for artifact in candidates)
         available = bool(list_urls)
         exact_reads = 0

--- a/tests/unit/test_copied_reference_artifacts.py
+++ b/tests/unit/test_copied_reference_artifacts.py
@@ -1,5 +1,6 @@
 """Copied inventory is required; representation availability is reported separately."""
 
+import warnings
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from notebooklm import Artifact
+from notebooklm._types.common import UnknownTypeWarning
 from notebooklm.exceptions import RPCError
 from tests.e2e._artifact_helpers import assert_copied_reference_artifacts
 
@@ -28,23 +30,29 @@ async def operation_scope(_label):
 
 
 @pytest.mark.asyncio
-async def test_reference_assertion_waits_for_late_artifacts(capsys):
+@pytest.mark.parametrize("backend", ["web", "android"])
+async def test_reference_assertion_waits_for_late_artifacts(backend, capsys):
     clock = Clock()
     audio = Artifact(
         id="private-artifact", title="private-title", _artifact_type=1, status=3, url="private-url"
     )
+    legacy = Artifact(
+        id="private-legacy", title="private-title", _artifact_type=4, status=3, url="private-url"
+    )
     client = SimpleNamespace(
-        artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[], [audio]])),
-        backends={"artifacts": "web"},
+        artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[], [audio, legacy]])),
+        backends={"artifacts": backend},
     )
-    await assert_copied_reference_artifacts(
-        client,
-        "private-notebook",
-        required_families={"audio"},
-        require_interactive_mind_map=False,
-        clock=clock,
-        sleep=clock.sleep,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UnknownTypeWarning)
+        await assert_copied_reference_artifacts(
+            client,
+            "private-notebook",
+            required_families={"audio"},
+            require_interactive_mind_map=False,
+            clock=clock,
+            sleep=clock.sleep,
+        )
     assert clock.now == 30
     output = capsys.readouterr().out
     assert "missing completed families: audio" in output

--- a/tests/unit/test_copied_reference_artifacts.py
+++ b/tests/unit/test_copied_reference_artifacts.py
@@ -1,11 +1,13 @@
-"""Copied artifacts remain a hard assertion even after setup stops waiting on them."""
+"""Copied inventory is required; representation availability is reported separately."""
 
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from notebooklm import Artifact
+from notebooklm.exceptions import RPCError
 from tests.e2e._artifact_helpers import assert_copied_reference_artifacts
 
 
@@ -18,6 +20,11 @@ class Clock:
 
     async def sleep(self, seconds):
         self.now += seconds
+
+
+@asynccontextmanager
+async def operation_scope(_label):
+    yield SimpleNamespace(epoch=7)
 
 
 @pytest.mark.asyncio
@@ -42,26 +49,35 @@ async def test_reference_assertion_waits_for_late_artifacts(capsys):
     output = capsys.readouterr().out
     assert "missing completed families: audio" in output
     assert "Copied reference artifacts: ready" in output
+    assert "download_payload=available" in output
     assert "private-" not in output
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["web", "android"])
-@pytest.mark.parametrize(("family", "type_code"), [("audio", 1), ("slide_deck", 8)])
-async def test_reference_waits_for_backend_download_payload(backend, family, type_code, capsys):
+@pytest.mark.parametrize("exact_url", [None, "private-url"])
+@pytest.mark.parametrize(
+    ("family", "type_code"), [("audio", 1), ("video", 3), ("infographic", 7), ("slide_deck", 8)]
+)
+async def test_inventory_ready_diagnoses_payload_without_polling(
+    backend, family, type_code, exact_url, monkeypatch, tmp_path, capsys
+):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
     clock = Clock()
-    pending = Artifact(
+    inventory = Artifact(
         id="private-artifact", title="private-title", _artifact_type=type_code, status=3
     )
-    ready = Artifact(
-        id="private-artifact",
-        title="private-title",
-        _artifact_type=type_code,
-        status=3,
-        url="private-url",
+    exact = Artifact(
+        id=inventory.id, title=inventory.title, _artifact_type=type_code, status=3, url=exact_url
     )
+    exact_read = AsyncMock(return_value=exact)
     client = SimpleNamespace(
-        artifacts=SimpleNamespace(list=AsyncMock(side_effect=[[pending], [ready]])),
+        artifacts=SimpleNamespace(
+            list=AsyncMock(return_value=[inventory]),
+            _transport=SimpleNamespace(operation_scope=operation_scope),
+            _get_studio_artifact=exact_read,
+        ),
         backends={"artifacts": backend},
     )
     await assert_copied_reference_artifacts(
@@ -72,11 +88,38 @@ async def test_reference_waits_for_backend_download_payload(backend, family, typ
         clock=clock,
         sleep=clock.sleep,
     )
-    hydrate_android_slide = backend == "android" and family == "slide_deck"
-    assert clock.now == (0 if hydrate_android_slide else 30)
+    assert clock.now == 0
+    client.artifacts.list.assert_awaited_once()
+    if backend == "android":
+        exact_read.assert_awaited_once_with("private-notebook", inventory.id, expected_epoch=7)
+    else:
+        exact_read.assert_not_awaited()
     output = capsys.readouterr().out
-    assert ("missing download payload families" in output) is not hydrate_android_slide
-    assert "private-" not in output
+    available = backend == "android" and exact_url is not None
+    assert f"download_payload={'available' if available else 'unavailable'}" in output
+    assert f"family={family}; completed=1; ListArtifacts_urls=0" in summary.read_text()
+    assert ("does not validate download coverage" in output) is not available
+    assert "private-" not in output + summary.read_text()
+
+
+@pytest.mark.asyncio
+async def test_exact_read_failure_remains_a_failure():
+    audio = Artifact(id="private-artifact", title="private-title", _artifact_type=1, status=3)
+    client = SimpleNamespace(
+        artifacts=SimpleNamespace(
+            list=AsyncMock(return_value=[audio]),
+            _transport=SimpleNamespace(operation_scope=operation_scope),
+            _get_studio_artifact=AsyncMock(side_effect=RPCError("read failed", rpc_code=13)),
+        ),
+        backends={"artifacts": "android"},
+    )
+    with pytest.raises(RPCError):
+        await assert_copied_reference_artifacts(
+            client,
+            "private-notebook",
+            required_families={"audio"},
+            require_interactive_mind_map=False,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Android E2E run 34135410452 passed 164 tests but failed copied-reference readiness three times because completed audio, video, and infographic rows had no list URL. The readiness assertion had added a download-payload requirement beyond the template's `required_completed_families` contract, costing 30 minutes of polling plus cooldown.

Require completed copied inventory, and report download availability separately for every required URL-backed family. Android probes notebook-scoped `GetArtifact` when list summaries lack URLs. Logs and the job summary show the family, completed count, list URL count, exact-read count, and payload availability. Unavailable payloads carry an explicit warning that readiness does not validate download coverage. Missing inventory still times out and fails, exact-read errors still fail, and unclassified legacy rows are excluded from diagnostics.

Validation:
- 40 focused tests passed: `test_copied_reference_artifacts.py` and `test_e2e_managed_fixtures.py`; pre-commit passed.
- Android/macOS live PR qualification passed on slot B: readiness completed in 6.6 seconds and cleanup deleted both copies. All four required families were complete; both list summaries and exact reads lacked download URLs. This verifies inventory readiness, not copied-media download coverage.
- Slot A qualification stopped before pytest because conversation seeding hit the account's chat quota; cleanup succeeded.

Original failure: https://github.com/teng-lin/notebooklm-py/actions/runs/34135410452
Successful live qualification: https://github.com/teng-lin/notebooklm-py/actions/runs/34147561415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of copied reference artifacts by checking download payload availability separately from inventory readiness.
  * Added clearer diagnostics for completed downloads, artifact listings, and payload reads across supported platforms, including Android fallback checks.
  * Download payload retrieval failures are now surfaced directly instead of being obscured by additional polling.
  * Unclassified artifact entries are excluded from payload availability checks.

* **Documentation**
  * Clarified how copied artifact payload availability is reported in development and nightly logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->