### PR TITLE
fix(ci): prevent E2E quota starvation and reduce live calls

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -156,6 +156,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      full_matrix: ${{ steps.plan.outputs.full_matrix }}
+      readonly_matrix: ${{ steps.plan.outputs.readonly_matrix }}
+      has_full: ${{ steps.plan.outputs.has_full }}
+      has_readonly: ${{ steps.plan.outputs.has_readonly }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -234,6 +238,11 @@ jobs:
         value = json.dumps(matrix, separators=(",", ":"))
         with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
             stream.write(f"matrix={value}\n")
+            for group, mode in (("full", "full"), ("readonly", "readonly")):
+                rows = [row for row in include if row["mode"] == mode]
+                group_matrix = json.dumps({"include": rows}, separators=(",", ":"))
+                stream.write(f"{group}_matrix={group_matrix}\n")
+                stream.write(f"has_{group}={str(bool(rows)).lower()}\n")
             stream.write(f"rotation_day={web['rotation_day']}\n")
             stream.write(f"web_slot={web['account_slot']}\n")
             stream.write(f"android_slot={android['account_slot']}\n")
@@ -273,10 +282,16 @@ jobs:
           fi
         } >> "$GITHUB_STEP_SUMMARY"
 
+  # The read-only lane still seeds a chat during provisioning. Run it before
+  # either full suite can spend the same account's quota; a concurrency group
+  # alone serializes jobs but does not establish their order.
   e2e:
     name: E2E (${{ matrix.backend }}/${{ matrix.lane }}/${{ matrix.account_slot }})
-    needs: [resolve-target, plan-live-lanes]
+    needs: [resolve-target, plan-live-lanes, e2e-readonly]
     if: >-
+      always() && !cancelled() &&
+      needs.plan-live-lanes.result == 'success' &&
+      needs.plan-live-lanes.outputs.has_full == 'true' &&
       github.repository == 'teng-lin/notebooklm-py' &&
       needs.resolve-target.outputs.is_standard == 'true'
     runs-on: ${{ matrix.os }}
@@ -284,7 +299,7 @@ jobs:
     environment: protected-readonly
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.plan-live-lanes.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.plan-live-lanes.outputs.full_matrix) }}
     concurrency:
       group: notebooklm-account-${{ matrix.account_slot }}
       queue: max
@@ -300,7 +315,7 @@ jobs:
       NOTEBOOKLM_PROFILE: ci-${{ matrix.account_slot }}-${{ matrix.lane }}
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
       E2E_COVERAGE_FLOOR_SENTINEL: ${{ github.workspace }}/.e2e-coverage-floor-failed
-    steps:
+    steps: &e2e-steps
     - uses: actions/checkout@v7
       with:
         ref: ${{ needs.resolve-target.outputs.sha }}
@@ -687,3 +702,32 @@ jobs:
         --phase coverage=${{ (steps.primary.outcome == 'success' || (steps.primary.outcome == 'failure' && (steps.lastfailed.outcome == 'failure' || (steps.lastfailed.outcome == 'success' && (steps.retry.outcome == 'success' || steps.retry.outcome == 'failure'))))) && (steps.coverage.outcome == 'success' && 'success' || 'failure') || 'not_applicable' }}
         --phase cleanup=${{ steps.cleanup.outcome == 'success' && 'success' || 'failure' }}
         --phase purge=${{ steps.purge.outcome == 'success' && 'success' || 'failure' }}
+
+  e2e-readonly:
+    name: E2E (${{ matrix.backend }}/${{ matrix.lane }}/${{ matrix.account_slot }})
+    needs: [resolve-target, plan-live-lanes]
+    if: >-
+      github.repository == 'teng-lin/notebooklm-py' &&
+      needs.resolve-target.outputs.is_standard == 'true' &&
+      needs.plan-live-lanes.outputs.has_readonly == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 360
+    environment: protected-readonly
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan-live-lanes.outputs.readonly_matrix) }}
+    concurrency:
+      group: notebooklm-account-${{ matrix.account_slot }}
+      queue: max
+      cancel-in-progress: false
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONUNBUFFERED: "1"
+      CI_E2E_PROGRESS: "1"
+      NOTEBOOKLM_BACKEND: ${{ matrix.backend }}
+      NOTEBOOKLM_PROFILE: ci-${{ matrix.account_slot }}-${{ matrix.lane }}
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+      E2E_COVERAGE_FLOOR_SENTINEL: ${{ github.workspace }}/.e2e-coverage-floor-failed
+    steps: *e2e-steps

--- a/docs/e2e-quota-efficiency.md
+++ b/docs/e2e-quota-efficiency.md
@@ -1,0 +1,105 @@
+# E2E quota investigation and optimizations
+
+## Incident: September 11, 2026
+
+[Failed run](https://github.com/teng-lin/notebooklm-py/actions/runs/34568547259)
+and [successful run](https://github.com/teng-lin/notebooklm-py/actions/runs/34443781982)
+both checked out `9adf110d96ea519475e7f505c5a9edd0f91526ce` for the candidate and
+trusted CI helpers. Installed dependencies, Python, runner image and action
+revisions matched. The installer changed from uv 0.12.12 to 0.12.13.
+
+The Windows lane failed during `prepare_reference`'s conversation-seeding ask,
+with `ERROR[QUOTA]: lifecycle provision failed: RateLimitError`. Tests never
+started. Its account B had just run the Ubuntu suite, which recorded 20
+rate-limit skips, including seven chat skips. On September 10, Windows used
+account A **before** that account's Ubuntu suite. The account concurrency group
+serializes jobs but does not specify their order.
+
+## Implemented changes
+
+### Run Windows before the full suites
+
+The planner partitions the existing lane selection into read-only and full
+matrices. `e2e-readonly` runs first; the full Web and Android jobs depend on its
+completion and can then run concurrently on distinct accounts. Both jobs retain
+the account-wide concurrency group, protected environment, pinned target and
+trusted credential-materialization steps. A shared YAML step sequence keeps
+provisioning, test execution, floors, cleanup and aggregation identical.
+
+A filtered `all` dispatch still omits Windows, an explicit `readonly` dispatch
+still applies its read-only marker filter, and Web/Android-only dispatches do not
+run Windows. Full suites still execute after a Windows failure so their results
+remain available; the Windows failure continues to fail the workflow. Cancelling
+the workflow prevents the dependent full suites from starting.
+
+This fixes within-run starvation of Windows provisioning. It does not reset an
+account's quota or guarantee capacity after unrelated account use. No quota
+failure is converted into success, and no ambiguous chat request is retried.
+
+The secret-gate scanner now expands block step aliases in each consuming job's
+own context and allows only enumerated scheduling restrictions alongside both
+mandatory trust predicates. Negative tests cover weakened alias-consumer gates,
+environment, concurrency and token selection.
+
+### Reuse live response values, preserving behavioral checks
+
+| Area | Before | After | Saving on an unthrottled run |
+| --- | --- | --- | --- |
+| Six chat answer/citation tests | Six asks and six fresh-conversation resets | One ask and one reset, shared as copied response values | Five asks and up to ten reset API calls per full backend |
+| Source-selection module, default selection | Nine source-list calls | One source-list call | Eight reads per full backend |
+| Source-selection module, variants included | Twelve source-list calls | One source-list call | Eleven reads per full backend |
+| Prepared reference validation | Preparation readback followed immediately by a duplicate validation readback | Preparation's complete readback validates the reference | Five public read calls per provisioned reference |
+
+These are public API invocation counts, not measured wire-RPC totals or claims
+about Google's quota accounting. An API method can make several wire requests.
+The two full nightly backends together save ten chat submissions and sixteen
+source-list invocations on the default path. Subsets, retries, early failures
+and throttling change the realized savings.
+
+All 237 E2E test nodes remain. In the two optimized test modules, all 28 original
+test nodes and their original assertions remain. The six shared-answer tests
+still check answer shape, conversation metadata, citation IDs, cited text,
+citation numbering and membership in the notebook's sources. Two additional
+assertions require real references and cited text, so a citation-free answer
+cannot make those checks pass without exercising the decoder.
+
+Samples are local to a test module and keyed by notebook, backend and retry
+attempt. Only successful results are retained, and each consumer gets a deep
+copy. Clients remain function-scoped; no event loop, connection or async client
+is shared across tests. Failed operations are never cached as successful samples.
+
+Distinct live request semantics remain separate: omitted versus explicit source
+selection, single sources, subsets, reordered sources, follow-ups, deletion and
+fresh conversations. Source CRUD modules retain fresh reads. Generation method,
+option and adapter coverage is unchanged; all generation journals and coverage
+floors remain active.
+
+## Further opportunities from the audit
+
+| Opportunity | Coverage constraint | Next step |
+| --- | --- | --- |
+| Repeated artifact discovery in downloads/MCP helpers | Copied artifacts arrive asynchronously; payload URLs can be absent or expire | Reuse settled candidate IDs only, with fresh download/Get calls and refresh-on-miss. Do not cache an early empty inventory. |
+| Repeated chat-history response checks | The suite exercises both limit 2 and limit 20 plus distinct history/turn APIs | Share response snapshots only among identical requests; keep both limits and every API entrypoint live. |
+| Artifact generation reused for rename/delete/readback | Cleanup, source selection, generation options and each adapter path are separate contracts | Extend lifecycle reuse only where the same generated object can satisfy all assertions without losing an entrypoint or request variant. The existing poll/rename/wait test already does this. |
+| Polling volume | Reducing polling must not reduce deadlines or skip terminal-state assertions | Record per-method request counts and observed completion times before changing intervals. Retain final completion verification. |
+| Additional account isolation | One or two enabled accounts necessarily share quota among lanes | A third enabled account separates the three nightly lanes. Scheduling still protects a small account pool. |
+
+Do not treat fewer requests as equivalent to a known daily quota reduction:
+chat submissions, Studio generation, research and ordinary reads can hit
+different upstream limits. Avoid blanket method caches, broader skip rules,
+removing live adapter tests, or reducing the nightly selection to obtain a green
+run.
+
+## Validation
+
+339 focused offline tests passed. They cover sample call counts, notebook/backend/retry isolation,
+consumer mutation, error propagation, citation coverage, provisioning readback,
+all lane/filter/account-pool combinations, alias-consumer secret gates, journals
+and execution-floor helpers. Collection still finds 237 E2E nodes. Ruff and the
+workflow secret, permission and action-pinning checks passed. No live NotebookLM
+requests were made for validation.
+
+Actionlint 1.7.12 supports the YAML aliases but does not recognize the existing
+`concurrency.queue: max` field. Validate with that specific diagnostic ignored;
+retain the repository's explicit queue checks. Live qualification remains a
+separate validation step; the offline checks spend no NotebookLM quota.

--- a/scripts/check_workflow_secret_gates.py
+++ b/scripts/check_workflow_secret_gates.py
@@ -261,12 +261,12 @@ def _flow_style_ci_bindings(line: str) -> set[str]:
 
 
 def _expression_is_ci_pool_guard(expr: str) -> bool:
-    """Return whether a job guard is the canonical two-predicate conjunction.
+    """Return whether a conjunction requires both canonical trust predicates.
 
     Pooled credentials deliberately use one narrow grammar instead of substring
-    matching.  Requiring exactly the repository and resolver predicates prevents
-    negation, disjunction, or a matching string inside another expression from
-    turning an inverted condition into an accepted gate.
+    matching. Require exactly one repository and resolver predicate, allowing
+    only enumerated scheduling restrictions as additional conjuncts. Negation,
+    disjunction and trust-looking string literals cannot satisfy either gate.
     """
 
     def strip_wrappers(value: str) -> str:
@@ -300,6 +300,14 @@ def _expression_is_ci_pool_guard(expr: str) -> bool:
 
     normalized = strip_wrappers(expr)
     parts = [strip_wrappers(part) for part in normalized.split("&&")]
+    scheduling_terms = {
+        "always()",
+        "!cancelled()",
+        "needs.plan-live-lanes.result == 'success'",
+        "needs.plan-live-lanes.outputs.has_full == 'true'",
+        "needs.plan-live-lanes.outputs.has_readonly == 'true'",
+    }
+    parts = [part for part in parts if part not in scheduling_terms]
     if len(parts) != 2:
         return False
     repository_terms = sum(bool(_REPOSITORY_GUARD_RE.fullmatch(part)) for part in parts)
@@ -410,6 +418,55 @@ def main() -> int:
     return 0
 
 
+def _workflow_lines(path: Path) -> list[tuple[int, str]]:
+    """Expand job-level block step aliases for both secret scanners.
+
+    The aliased steps must be audited inside *each consuming job's* trust and
+    concurrency envelope. Only this narrow block form is supported; unknown or
+    duplicate step anchors fail closed. Diagnostics for expanded steps point to
+    the consumer's alias line. No general YAML dependency is needed.
+    """
+    lines = path.read_text().splitlines()
+    anchors: dict[str, list[str]] = {}
+    result: list[tuple[int, str]] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        anchor = re.fullmatch(r"    steps: &([A-Za-z0-9_-]+)\s*(?:#.*)?", line)
+        alias = re.fullmatch(r"    steps: \*([A-Za-z0-9_-]+)\s*(?:#.*)?", line)
+        if anchor:
+            name = anchor.group(1)
+            if name in anchors:
+                raise ValueError(f"{path}:{index + 1}: duplicate step anchor {name}")
+            result.append((index + 1, "    steps:"))
+            index += 1
+            body: list[str] = []
+            while index < len(lines):
+                child = lines[index]
+                if (
+                    child.strip()
+                    and not _COMMENT_RE.match(child)
+                    and len(child) - len(child.lstrip()) <= 4
+                    and not child.startswith("    - ")
+                ):
+                    break
+                body.append(child)
+                result.append((index + 1, child))
+                index += 1
+            anchors[name] = body
+            continue
+        if alias:
+            name = alias.group(1)
+            if name not in anchors:
+                raise ValueError(f"{path}:{index + 1}: unknown step anchor {name}")
+            result.append((index + 1, "    steps:"))
+            result.extend((index + 1, child) for child in anchors[name])
+        else:
+            result.append((index + 1, line))
+        index += 1
+    return result
+
+
 def _scan_workflow(path: Path) -> list[str]:
     """Return a list of violation messages for ``path``.
 
@@ -425,7 +482,11 @@ def _scan_workflow(path: Path) -> list[str]:
     ``environment:`` declaration in the same job (e.g. inside a
     ``strategy: matrix`` block at the top of the job body).
     """
-    lines = path.read_text().splitlines()
+    try:
+        numbered_lines = _workflow_lines(path)
+    except ValueError as exc:
+        return [str(exc)]
+    lines = [line for _number, line in numbered_lines]
 
     # Workflow-wide state.
     jobs_section_started = False
@@ -518,7 +579,7 @@ def _scan_workflow(path: Path) -> list[str]:
         in_if_block_scalar = False
         saw_any_job = True
 
-    for i, raw_line in enumerate(lines, start=1):
+    for i, raw_line in numbered_lines:
         line = raw_line.rstrip("\r")
 
         # Detect entry into the top-level ``jobs:`` section.
@@ -731,12 +792,15 @@ def _scan_workflow(path: Path) -> list[str]:
 
 def _scan_pooled_account_jobs(path: Path) -> list[str]:
     """Enforce the pooled-token job envelope used by authenticated live CI."""
-    lines = path.read_text().splitlines()
+    try:
+        numbered_lines = _workflow_lines(path)
+    except ValueError as exc:
+        return [str(exc)]
     jobs_started = False
     violations: list[str] = []
     chunks: list[tuple[str, int, list[str]]] = []
     current: tuple[str, int, list[str]] | None = None
-    for line_number, line in enumerate(lines, 1):
+    for line_number, line in numbered_lines:
         if _JOBS_HEADER_RE.fullmatch(line):
             jobs_started = True
             continue

--- a/scripts/manage_ci_e2e_notebooks.py
+++ b/scripts/manage_ci_e2e_notebooks.py
@@ -1178,10 +1178,13 @@ class NotebookLifecycleManager:
                 )
                 self._progress("preparation", "preparing role state", summary=True)
                 if role == "reference":
+                    # prepare_reference already reads back and validates the exact
+                    # note, conversation, completed Q&A and turns before returning.
+                    # Repeating that entire snapshot here adds no coverage.
                     await self.prepare_reference(notebook_id)
                 else:
                     await self.prepare_clean_role(notebook_id, role)
-                await self.validate_prepared_role(notebook_id, role)
+                    await self.validate_prepared_role(notebook_id, role)
             except BaseException as exc:
                 report(f"Provision failed; last observation: {self._last_progress}", error=True)
                 if isinstance(exc, ContractError):

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -4,6 +4,8 @@ These tests require valid NotebookLM authentication.
 Run with: pytest tests/e2e/test_chat.py -m e2e
 """
 
+from copy import deepcopy
+
 import pytest
 
 from notebooklm import AskResult, ChatReference
@@ -15,6 +17,36 @@ from .conftest import (
 )
 
 
+@pytest.fixture(scope="module")
+def _cited_chat_samples():
+    # Store response values only, never an async client tied to another test's loop.
+    return {}
+
+
+@pytest.fixture
+async def cited_chat_sample(client, multi_source_notebook_id, _cited_chat_samples, request):
+    """One real cited answer for independent response-shape assertions.
+
+    These consumers inspect the returned value, not current conversation state.
+    Mutation/follow-up tests keep their own fresh conversations and live calls.
+    A rerun gets a fresh sample, as does a different notebook or backend.
+    """
+    key = (
+        client.backends["chat"],
+        multi_source_notebook_id,
+        getattr(request.node, "execution_count", 1),
+    )
+    if key not in _cited_chat_samples:
+        await reset_current_chat_conversation(client, multi_source_notebook_id)
+        sources = await client.sources.list(multi_source_notebook_id)
+        result = await client.chat.ask(
+            multi_source_notebook_id,
+            "Summarize the main concepts with specific citations and quote a passage from the sources.",
+        )
+        _cited_chat_samples[key] = (result, {source.id for source in sources})
+    return deepcopy(_cited_chat_samples[key])
+
+
 @pytest.mark.e2e
 @pytest.mark.live_chat_ask
 @pytest.mark.timeout(300)
@@ -23,16 +55,14 @@ class TestChatE2E:
     """E2E tests for chat API."""
 
     @pytest.fixture(autouse=True)
-    async def _start_with_fresh_conversation(self, client, multi_source_notebook_id):
-        await reset_current_chat_conversation(client, multi_source_notebook_id)
+    async def _start_with_fresh_conversation(self, client, multi_source_notebook_id, request):
+        if "cited_chat_sample" not in request.fixturenames:
+            await reset_current_chat_conversation(client, multi_source_notebook_id)
 
     @pytest.mark.asyncio
-    async def test_ask_question_returns_answer(self, client, multi_source_notebook_id):
+    async def test_ask_question_returns_answer(self, cited_chat_sample):
         """Test asking a question returns a valid answer."""
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "What is the main topic of these sources?",
-        )
+        result, _source_ids = cited_chat_sample
 
         assert isinstance(result, AskResult)
         assert result.answer
@@ -41,16 +71,13 @@ class TestChatE2E:
         assert result.turn_number >= 1
 
     @pytest.mark.asyncio
-    async def test_ask_returns_references_with_source_ids(self, client, multi_source_notebook_id):
+    async def test_ask_returns_references_with_source_ids(self, cited_chat_sample):
         """Test that ask returns references with valid source IDs."""
-        # Ask a question likely to generate citations
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "Summarize the key points with specific citations.",
-        )
+        result, _source_ids = cited_chat_sample
 
         assert isinstance(result, AskResult)
         assert result.answer
+        assert result.references, "The shared cited answer must exercise citation decoding"
 
         # If the answer contains citations [1], [2], etc., there should be references
         if "[1]" in result.answer:
@@ -65,20 +92,17 @@ class TestChatE2E:
                 assert ref.source_id.count("-") == 4
 
     @pytest.mark.asyncio
-    async def test_ask_returns_references_with_cited_text(self, client, multi_source_notebook_id):
+    async def test_ask_returns_references_with_cited_text(self, cited_chat_sample):
         """Test that references include cited text when available."""
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "Quote specific passages that explain the main concept.",
-        )
+        result, _source_ids = cited_chat_sample
 
         assert isinstance(result, AskResult)
 
         # Check if any references have cited_text
         refs_with_text = [ref for ref in result.references if ref.cited_text]
+        assert refs_with_text, "The shared quoted answer must exercise cited-text decoding"
 
-        # Note: Not all citations may have cited_text depending on the response
-        # So we just verify the structure is correct when present
+        # Individual structural citations may still omit their text.
         for ref in refs_with_text:
             assert isinstance(ref.cited_text, str)
             assert len(ref.cited_text) > 0
@@ -169,12 +193,9 @@ class TestChatE2E:
         assert result.answer
 
     @pytest.mark.asyncio
-    async def test_references_have_citation_numbers(self, client, multi_source_notebook_id):
+    async def test_references_have_citation_numbers(self, cited_chat_sample):
         """Test that references have sequential citation numbers."""
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "List the key points with citations.",
-        )
+        result, _source_ids = cited_chat_sample
 
         if result.references:
             # Citation numbers should be assigned sequentially
@@ -389,22 +410,10 @@ class TestChatHistoryE2E:
 class TestChatReferencesE2E:
     """E2E tests specifically for chat references and citations."""
 
-    @pytest.fixture(autouse=True)
-    async def _start_with_fresh_conversation(self, client, multi_source_notebook_id):
-        await reset_current_chat_conversation(client, multi_source_notebook_id)
-
     @pytest.mark.asyncio
-    async def test_reference_source_ids_exist_in_notebook(self, client, multi_source_notebook_id):
+    async def test_reference_source_ids_exist_in_notebook(self, cited_chat_sample):
         """Test that reference source IDs correspond to actual sources."""
-        # Get all sources in the notebook
-        sources = await client.sources.list(multi_source_notebook_id)
-        source_ids = {s.id for s in sources}
-
-        # Ask a question that generates citations
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "Explain the main concepts with references to sources.",
-        )
+        result, source_ids = cited_chat_sample
 
         # All reference source IDs should exist in the notebook
         for ref in result.references:
@@ -413,12 +422,9 @@ class TestChatReferencesE2E:
             )
 
     @pytest.mark.asyncio
-    async def test_cited_text_matches_source_content(self, client, multi_source_notebook_id):
+    async def test_cited_text_matches_source_content(self, cited_chat_sample):
         """Test that cited text comes from the actual source content."""
-        result = await client.chat.ask(
-            multi_source_notebook_id,
-            "Quote a specific passage from the sources.",
-        )
+        result, _source_ids = cited_chat_sample
 
         # For references with cited_text, verify it's non-empty
         for ref in result.references:

--- a/tests/e2e/test_source_selection.py
+++ b/tests/e2e/test_source_selection.py
@@ -16,6 +16,7 @@ Notebook lifecycle:
 """
 
 import random
+from copy import deepcopy
 
 import pytest
 
@@ -24,6 +25,28 @@ from .conftest import (
     requires_auth,
     reset_current_chat_conversation,
 )
+
+
+@pytest.fixture(scope="module")
+def _source_inventories():
+    return {}
+
+
+@pytest.fixture
+async def multi_source_sources(client, multi_source_notebook_id, _source_inventories, request):
+    """Read the immutable source inventory once per notebook/backend/attempt.
+
+    This module changes chat and artifacts, never sources. Keep the cache local
+    so source CRUD tests and other modules continue to make fresh reads.
+    """
+    key = (
+        client.backends["sources"],
+        multi_source_notebook_id,
+        getattr(request.node, "execution_count", 1),
+    )
+    if key not in _source_inventories:
+        _source_inventories[key] = await client.sources.list(multi_source_notebook_id)
+    return deepcopy(_source_inventories[key])
 
 
 @requires_auth
@@ -50,10 +73,12 @@ class TestChatWithSourceSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_ask_with_single_source(self, client, multi_source_notebook_id):
+    async def test_ask_with_single_source(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test asking a question using only one source."""
         # Get sources and pick just one
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 1, "Expected at least 1 source in test notebook"
 
         single_source = [sources[0].id]
@@ -69,10 +94,12 @@ class TestChatWithSourceSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_ask_with_random_subset_of_sources(self, client, multi_source_notebook_id):
+    async def test_ask_with_random_subset_of_sources(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test asking a question using a random subset of sources."""
         # Get all sources
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 2, "Expected at least 2 sources in test notebook"
 
         # Randomly pick 2 sources (if 3 available, this tests partial selection)
@@ -91,9 +118,11 @@ class TestChatWithSourceSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_ask_follow_up_with_different_sources(self, client, multi_source_notebook_id):
+    async def test_ask_follow_up_with_different_sources(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test follow-up question can use different source selection."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 2, "Expected at least 2 sources"
 
         # First question with first source
@@ -140,9 +169,11 @@ class TestArtifactGenerationWithSourceSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_generate_report_with_single_source(self, client, multi_source_notebook_id):
+    async def test_generate_report_with_single_source(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test report generation using only one source."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 1
 
         result = await client.artifacts.generate_report(
@@ -153,9 +184,11 @@ class TestArtifactGenerationWithSourceSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_generate_report_with_subset_of_sources(self, client, multi_source_notebook_id):
+    async def test_generate_report_with_subset_of_sources(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test report generation using a random subset of sources."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 2
 
         # Pick 2 random sources
@@ -171,9 +204,11 @@ class TestArtifactGenerationWithSourceSelection:
     @pytest.mark.asyncio
     @pytest.mark.e2e
     @pytest.mark.variants
-    async def test_generate_quiz_with_single_source(self, client, multi_source_notebook_id):
+    async def test_generate_quiz_with_single_source(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test quiz generation using only one source."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 1
 
         result = await client.artifacts.generate_quiz(
@@ -185,9 +220,11 @@ class TestArtifactGenerationWithSourceSelection:
     @pytest.mark.asyncio
     @pytest.mark.e2e
     @pytest.mark.variants
-    async def test_generate_flashcards_with_subset(self, client, multi_source_notebook_id):
+    async def test_generate_flashcards_with_subset(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test flashcard generation using a subset of sources."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 2
 
         selected = random.sample(sources, 2)
@@ -202,9 +239,11 @@ class TestArtifactGenerationWithSourceSelection:
     @pytest.mark.asyncio
     @pytest.mark.e2e
     @pytest.mark.variants
-    async def test_generate_audio_with_single_source(self, client, multi_source_notebook_id):
+    async def test_generate_audio_with_single_source(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test audio generation using only one source."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 1
 
         result = await client.artifacts.generate_audio(
@@ -220,9 +259,11 @@ class TestSourceListingAndSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_notebook_has_multiple_sources(self, client, multi_source_notebook_id):
+    async def test_notebook_has_multiple_sources(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Verify the test notebook has at least 3 sources."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
 
         assert len(sources) >= 3, (
             f"Expected at least 3 sources for multi-source tests, got {len(sources)}"
@@ -235,9 +276,11 @@ class TestSourceListingAndSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_source_ids_are_unique(self, client, multi_source_notebook_id):
+    async def test_source_ids_are_unique(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Verify all source IDs are unique."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
 
         source_ids = [s.id for s in sources]
         unique_ids = set(source_ids)
@@ -256,9 +299,11 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_ask_with_explicit_all_sources(self, client, multi_source_notebook_id):
+    async def test_ask_with_explicit_all_sources(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test asking with explicitly listing all source IDs (same as None)."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         all_source_ids = [s.id for s in sources]
 
         result = await client.chat.ask(
@@ -271,9 +316,11 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     @pytest.mark.e2e
-    async def test_sources_appear_in_different_order(self, client, multi_source_notebook_id):
+    async def test_sources_appear_in_different_order(
+        self, client, multi_source_notebook_id, multi_source_sources
+    ):
         """Test that source order doesn't affect results."""
-        sources = await client.sources.list(multi_source_notebook_id)
+        sources = multi_source_sources
         assert len(sources) >= 2
 
         source_ids = [s.id for s in sources[:2]]

--- a/tests/unit/test_check_workflow_secret_gates.py
+++ b/tests/unit/test_check_workflow_secret_gates.py
@@ -1480,6 +1480,89 @@ def test_ci_pool_guard_requires_exact_repository_and_standard_output(script) -> 
     )
 
 
+@pytest.mark.parametrize(
+    "restriction",
+    [
+        "always() && !cancelled()",
+        "needs.plan-live-lanes.result == 'success'",
+        "needs.plan-live-lanes.outputs.has_full == 'true'",
+        "needs.plan-live-lanes.outputs.has_readonly == 'true'",
+    ],
+)
+def test_scheduling_restrictions_never_replace_or_bypass_trust(script, restriction):
+    trust = (
+        "github.repository == 'teng-lin/notebooklm-py' && "
+        "needs.resolve-target.outputs.is_standard == 'true'"
+    )
+    assert script._expression_is_ci_pool_guard(f"{restriction} && {trust}")
+    assert not script._expression_is_ci_pool_guard(restriction)
+    assert not script._expression_is_ci_pool_guard(f"{restriction} || {trust}")
+    assert not script._expression_is_ci_pool_guard(
+        f"{restriction} && {trust.replace('==', '!=', 1)}"
+    )
+    assert not script._expression_is_ci_pool_guard(f"{restriction} && !({trust})")
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        (None, None),
+        (("is_standard == 'true'", "is_standard != 'true'"), "job gate"),
+        (("environment: protected-readonly", "environment: typo"), "Environment"),
+        (("queue: max", "queue: latest"), "queue: max"),
+        (("cancel-in-progress: false", "cancel-in-progress: true"), "concurrency cancellation"),
+        (("matrix.account_slot", "needs.plan-account.outputs.account_slot"), "selected token"),
+    ],
+)
+def test_step_alias_is_audited_in_the_consuming_jobs_envelope(
+    tmp_path, script, replacement, message
+):
+    envelope = """    if: github.repository == 'teng-lin/notebooklm-py' && needs.resolve-target.outputs.is_standard == 'true'
+    environment: protected-readonly
+    concurrency:
+      group: notebooklm-account-${{ matrix.account_slot }}
+      queue: max
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+"""
+    consumer = envelope if replacement is None else envelope.replace(*replacement)
+    path = tmp_path / "aliased.yml"
+    path.write_text(
+        "name: aliased\non: workflow_dispatch\njobs:\n  original:\n"
+        + envelope
+        + """    steps: &live-steps
+    - env:
+        NOTEBOOKLM_MASTER_TOKEN_JSON: ${{ secrets[matrix.master_token_secret_name] }}
+      run: echo ready
+  consumer:
+"""
+        + consumer
+        + "    steps: *live-steps\n"
+    )
+    errors = script._scan_workflow(path) + script._scan_pooled_account_jobs(path)
+    if message is None:
+        assert errors == []
+    else:
+        assert any("consumer" in error and message in error for error in errors), errors
+        assert not any("'original'" in error for error in errors)
+
+
+@pytest.mark.parametrize("alias", ["missing", "live-steps"])
+def test_unknown_or_duplicate_step_anchors_fail_closed(tmp_path, script, alias):
+    path = tmp_path / "invalid.yml"
+    path.write_text(
+        "jobs:\n  first:\n    steps: &live-steps\n    - run: echo first\n"
+        + "  second:\n"
+        + (
+            "    steps: *missing\n"
+            if alias == "missing"
+            else "    steps: &live-steps\n    - run: echo second\n"
+        )
+    )
+    assert script._scan_workflow(path)
+    assert script._scan_pooled_account_jobs(path)
+
+
 def test_mismatched_environment_quotes_are_not_approved(script) -> None:
     assert not script._environment_value_is_approved("'protected-readonly\"")
 

--- a/tests/unit/test_ci_account_pool_workflows.py
+++ b/tests/unit/test_ci_account_pool_workflows.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -44,6 +45,7 @@ def test_job_level_env_never_uses_step_only_runner_context() -> None:
 def test_manifest_paths_use_a_store_owned_private_child_directory() -> None:
     jobs = (
         _load("nightly.yml")["jobs"]["e2e"],
+        _load("nightly.yml")["jobs"]["e2e-readonly"],
         _load("verify-package.yml")["jobs"]["verify"],
     )
     for job in jobs:
@@ -288,6 +290,7 @@ def test_pr_qualification_keeps_account_selection_and_raw_token_consumer_trusted
 
     live_jobs = (
         workflows[0]["jobs"]["e2e"],
+        workflows[0]["jobs"]["e2e-readonly"],
         workflows[1]["jobs"]["health-check"],
         workflows[1]["jobs"]["android-grpc-health"],
     )
@@ -327,6 +330,7 @@ def test_pr_qualification_keeps_account_selection_and_raw_token_consumer_trusted
 def test_secret_bearing_jobs_have_both_literal_gates_and_exact_sha_checkout() -> None:
     jobs = [
         (_load("nightly.yml")["jobs"]["e2e"], "${{ needs.resolve-target.outputs.sha }}"),
+        (_load("nightly.yml")["jobs"]["e2e-readonly"], "${{ needs.resolve-target.outputs.sha }}"),
         (
             _load("rpc-health.yml")["jobs"]["health-check"],
             "${{ needs.resolve-target.outputs.sha }}",
@@ -350,6 +354,7 @@ def test_secret_bearing_jobs_have_both_literal_gates_and_exact_sha_checkout() ->
 def test_each_authenticated_job_queues_by_one_non_secret_slot() -> None:
     live_jobs = [
         _load("nightly.yml")["jobs"]["e2e"],
+        _load("nightly.yml")["jobs"]["e2e-readonly"],
         _load("rpc-health.yml")["jobs"]["health-check"],
         _load("rpc-health.yml")["jobs"]["android-grpc-health"],
         _load("verify-package.yml")["jobs"]["verify"],
@@ -564,3 +569,65 @@ def test_rpc_reports_do_not_stream_raw_output_and_drop_files_on_scrub_failure() 
     diagnostic = (ROOT / "scripts" / "check_rpc_health.py").read_text(encoding="utf-8")
     assert "repr(data)" not in diagnostic
     assert "WARNING: Notebook {temp.notebook_id}" not in diagnostic
+
+
+@pytest.mark.parametrize("enabled_slots", ["A", "A,B", "A,B,C"])
+@pytest.mark.parametrize("lane", ["all", "web", "android", "readonly"])
+@pytest.mark.parametrize("test_filter", ["", "tests/e2e/test_chat.py"])
+def test_nightly_planner_partitions_every_selected_lane_once(
+    enabled_slots, lane, test_filter, tmp_path
+):
+    planner = _load("nightly.yml")["jobs"]["plan-live-lanes"]
+    command = _step(planner, "plan")["run"]
+    output = tmp_path / "plan.out"
+    subprocess.run(
+        ["bash", "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        env={
+            **os.environ,
+            "ENABLED_SLOTS": enabled_slots,
+            "MANUAL_BASE": "auto",
+            "E2E_LANE": lane,
+            "TEST_FILTER": test_filter,
+            "RUNNER_TEMP": str(tmp_path),
+            "GITHUB_OUTPUT": str(output),
+        },
+    )
+    values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+    all_rows = json.loads(values["matrix"])["include"]
+    full = json.loads(values["full_matrix"])["include"]
+    readonly = json.loads(values["readonly_matrix"])["include"]
+    assert full + readonly == all_rows
+    assert all(row["mode"] == "full" for row in full)
+    assert all(row["mode"] == "readonly" for row in readonly)
+    expected_full = 2 if lane == "all" else int(lane in {"web", "android"})
+    expected_readonly = int(lane == "readonly" or (lane == "all" and not test_filter))
+    assert len(full) == expected_full
+    assert len(readonly) == expected_readonly
+    assert values["has_full"] == str(bool(expected_full)).lower()
+    assert values["has_readonly"] == str(bool(expected_readonly)).lower()
+
+
+def test_nightly_orders_readonly_before_full_without_suppressing_other_lane_failures():
+    jobs = _load("nightly.yml")["jobs"]
+    full, readonly = jobs["e2e"], jobs["e2e-readonly"]
+    assert full["needs"] == ["resolve-target", "plan-live-lanes", "e2e-readonly"]
+    assert readonly["needs"] == ["resolve-target", "plan-live-lanes"]
+    # Full lanes still execute if readonly was omitted by a filter or failed.
+    assert "always() && !cancelled()" in full["if"]
+    assert "needs.plan-live-lanes.result == 'success'" in full["if"]
+    assert "needs.plan-live-lanes.outputs.has_full == 'true'" in full["if"]
+    assert "needs.e2e-readonly.result" not in full["if"]
+    assert "needs.plan-live-lanes.outputs.has_readonly == 'true'" in readonly["if"]
+    assert readonly["strategy"]["matrix"] == (
+        "${{ fromJSON(needs.plan-live-lanes.outputs.readonly_matrix) }}"
+    )
+    # Aliases share the complete lifecycle, including cleanup and failure aggregation.
+    for key in ("steps", "env", "defaults", "concurrency"):
+        assert readonly[key] == full[key]
+    assert _step(readonly, "primary")["if"] == "steps.journal_policy.outcome == 'success'"
+    assert _step(readonly, "cleanup")["if"] == "always()"
+    assert _step(readonly, "purge")["if"] == "always()"

--- a/tests/unit/test_ci_test_matrix.py
+++ b/tests/unit/test_ci_test_matrix.py
@@ -473,7 +473,7 @@ def test_nightly_runs_full_sha_pinned_compatibility_matrix() -> None:
     assert set(triggers) == {"schedule", "workflow_dispatch"}
     assert set(triggers["workflow_dispatch"]["inputs"]) == {"custom_branch"}
     e2e = yaml.safe_load(NIGHTLY_WORKFLOW.read_text(encoding="utf-8"))
-    assert set(e2e["jobs"]) == {"resolve-target", "plan-live-lanes", "e2e"}
+    assert set(e2e["jobs"]) == {"resolve-target", "plan-live-lanes", "e2e", "e2e-readonly"}
     e2e_triggers = e2e.get("on", e2e.get(True))
     assert "run_compatibility" not in e2e_triggers["workflow_dispatch"]["inputs"]
 
@@ -619,7 +619,7 @@ def test_nightly_e2e_maps_backends_and_suites_to_designated_runners() -> None:
     job = workflow["jobs"]["e2e"]
     planner = workflow["jobs"]["plan-live-lanes"]
 
-    assert job["strategy"]["matrix"] == "${{ fromJSON(needs.plan-live-lanes.outputs.matrix) }}"
+    assert job["strategy"]["matrix"] == "${{ fromJSON(needs.plan-live-lanes.outputs.full_matrix) }}"
     assert job["env"]["NOTEBOOKLM_BACKEND"] == "${{ matrix.backend }}"
     assert job["concurrency"] == {
         "group": "notebooklm-account-${{ matrix.account_slot }}",

--- a/tests/unit/test_e2e_quota_efficiency.py
+++ b/tests/unit/test_e2e_quota_efficiency.py
@@ -1,0 +1,139 @@
+"""Offline checks for live E2E sample reuse and preserved assertions."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm import AskResult, ChatReference, RateLimitError
+from tests.e2e import test_chat as chat_tests
+from tests.e2e import test_source_selection as selection_tests
+
+SOURCE_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _client():
+    return SimpleNamespace(
+        backends={"chat": "web", "sources": "web"},
+        sources=SimpleNamespace(list=AsyncMock(return_value=[SimpleNamespace(id=SOURCE_ID)])),
+        chat=SimpleNamespace(
+            get_conversation_id=AsyncMock(return_value="old-conversation"),
+            delete_conversation=AsyncMock(),
+            ask=AsyncMock(
+                return_value=AskResult(
+                    answer="The source explains a useful concept [1].",
+                    conversation_id="new-conversation",
+                    turn_number=1,
+                    is_follow_up=False,
+                    references=[
+                        ChatReference(source_id=SOURCE_ID, citation_number=1, cited_text="concept")
+                    ],
+                )
+            ),
+        ),
+    )
+
+
+def _request(attempt=1):
+    return SimpleNamespace(node=SimpleNamespace(execution_count=attempt))
+
+
+@pytest.mark.asyncio
+async def test_six_chat_assertion_tests_share_one_live_ask_and_reset():
+    client = _client()
+    cache = {}
+    consumers = [
+        chat_tests.TestChatE2E().test_ask_question_returns_answer,
+        chat_tests.TestChatE2E().test_ask_returns_references_with_source_ids,
+        chat_tests.TestChatE2E().test_ask_returns_references_with_cited_text,
+        chat_tests.TestChatE2E().test_references_have_citation_numbers,
+        chat_tests.TestChatReferencesE2E().test_reference_source_ids_exist_in_notebook,
+        chat_tests.TestChatReferencesE2E().test_cited_text_matches_source_content,
+    ]
+    for consumer in consumers:
+        sample = await chat_tests.cited_chat_sample.__wrapped__(
+            client, "notebook", cache, _request()
+        )
+        await consumer(sample)
+    client.chat.ask.assert_awaited_once()
+    client.sources.list.assert_awaited_once_with("notebook")
+    client.chat.get_conversation_id.assert_awaited_once_with("notebook")
+    client.chat.delete_conversation.assert_awaited_once_with("notebook", "old-conversation")
+
+
+@pytest.mark.parametrize("missing", ["references", "cited_text"])
+@pytest.mark.asyncio
+async def test_shared_sample_cannot_make_citation_coverage_vacuously_pass(missing):
+    sample = await chat_tests.cited_chat_sample.__wrapped__(_client(), "notebook", {}, _request())
+    if missing == "references":
+        sample[0].references.clear()
+        consumer = chat_tests.TestChatE2E().test_ask_returns_references_with_source_ids
+    else:
+        sample[0].references[0].cited_text = None
+        consumer = chat_tests.TestChatE2E().test_ask_returns_references_with_cited_text
+    with pytest.raises(AssertionError, match="must exercise"):
+        await consumer(sample)
+
+
+@pytest.mark.parametrize("fixture_name", ["chat", "sources"])
+@pytest.mark.asyncio
+async def test_samples_are_isolated_by_notebook_backend_attempt_and_consumer(fixture_name):
+    client = _client()
+    cache = {}
+    fixture = (
+        chat_tests.cited_chat_sample
+        if fixture_name == "chat"
+        else selection_tests.multi_source_sources
+    ).__wrapped__
+    first = await fixture(client, "notebook", cache, _request())
+    if fixture_name == "chat":
+        first[0].references.clear()
+        first[1].clear()
+    else:
+        first[0].id = "mutated"
+        first.clear()
+    second = await fixture(client, "notebook", cache, _request())
+    if fixture_name == "chat":
+        assert second[0].references[0].source_id == SOURCE_ID
+        assert second[1] == {SOURCE_ID}
+    else:
+        assert second[0].id == SOURCE_ID
+    assert client.sources.list.await_count == 1
+
+    await fixture(client, "different-notebook", cache, _request())
+    client.backends = {"chat": "android", "sources": "android"}
+    await fixture(client, "notebook", cache, _request())
+    await fixture(client, "notebook", cache, _request(attempt=2))
+    assert client.sources.list.await_count == 4
+    if fixture_name == "chat":
+        assert client.chat.ask.await_count == 4
+
+
+@pytest.mark.parametrize("fixture_name", ["chat", "sources"])
+@pytest.mark.asyncio
+async def test_failed_live_reads_are_not_cached_as_success(fixture_name):
+    client = _client()
+    cache = {}
+    if fixture_name == "chat":
+        fixture = chat_tests.cited_chat_sample.__wrapped__
+        operation = client.chat.ask
+    else:
+        fixture = selection_tests.multi_source_sources.__wrapped__
+        operation = client.sources.list
+    operation.side_effect = RateLimitError("quota")
+    with pytest.raises(RateLimitError):
+        await fixture(client, "notebook", cache, _request())
+    assert not cache
+    operation.side_effect = None
+    await fixture(client, "notebook", cache, _request(attempt=2))
+    assert operation.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_only_response_consumers_bypass_per_test_conversation_reset():
+    client = _client()
+    reset = chat_tests.TestChatE2E()._start_with_fresh_conversation.__wrapped__
+    await reset(None, client, "notebook", SimpleNamespace(fixturenames=["cited_chat_sample"]))
+    client.chat.delete_conversation.assert_not_awaited()
+    await reset(None, client, "notebook", SimpleNamespace(fixturenames=["client"]))
+    client.chat.delete_conversation.assert_awaited_once_with("notebook", "old-conversation")

--- a/tests/unit/test_manage_ci_e2e_notebooks.py
+++ b/tests/unit/test_manage_ci_e2e_notebooks.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -711,9 +712,15 @@ async def test_readonly_provision_creates_only_a_managed_reference_copy(
     contracts: tuple[dict[str, Any], dict[str, Any]],
 ) -> None:
     manager, client, _store, _clock = _manager(tmp_path, contracts)
+    # Preparation's successful readback is the validation. Do not repeat the
+    # same live conversation reads immediately after it returns.
+    for name in ("get_conversation_id", "get_history", "get_conversation_turns"):
+        setattr(client.chat, name, AsyncMock(wraps=getattr(client.chat, name)))
     manifest = await _provision(manager, tmp_path, mode="readonly")
     assert [row["role"] for row in manifest["copies"]] == ["reference"]
     assert len(client.notebooks.copy_calls) == 1
+    for name in ("get_conversation_id", "get_history", "get_conversation_turns"):
+        getattr(client.chat, name).assert_awaited_once()
     lines = (tmp_path / "github-env").read_text().splitlines()
     assert lines == [
         "NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID=copy-1",


### PR DESCRIPTION
## Summary

The Windows nightly failed while seeding its reference notebook's chat after the Ubuntu suite had already hit chat limits on the same account. Both the failed and successful runs used the same commit; their account selection and lane order differed.

Run the read-only Windows lane before the full suites, and reduce redundant live requests while preserving all 237 E2E test nodes and their existing assertions.

## Related Issue

Investigation: [failed Windows job](https://github.com/teng-lin/notebooklm-py/actions/runs/34568547259/job/103165622054), [previous successful run](https://github.com/teng-lin/notebooklm-py/actions/runs/34443781982).

## Changes

- Partition the selected lanes into read-only and full matrices with an explicit dependency. Full lanes still execute after a failed or omitted Windows lane; Windows failures remain failures.
- Share the lifecycle steps through a YAML alias. Extend the secret-gate checker to audit each alias consumer's own trust, environment and concurrency boundaries.
- Reuse one live answer across six response/citation tests, with additional assertions requiring actual references and cited text. Keep follow-up, deletion and source-selection scenarios live and independent.
- Cache source inventories within the source-selection module, isolated by notebook/backend/retry and copied for each consumer. Remove the immediately repeated reference validation after preparation's complete readback.
- Document the investigation, coverage mapping and remaining optimization opportunities in `docs/e2e-quota-efficiency.md`.

Expected savings across both full nightly backends: **10 chat submissions and 16 source-list calls**, plus reset and provisioning readbacks. These are API invocation counts on the unthrottled default path, not measured wire-RPC or daily-quota totals.

## Test Plan

- [x] 339 focused offline tests passed, covering lifecycle, lane planning, sample reuse/isolation, secret gates, journals and execution-floor helpers.
- [x] E2E collection: 237 test nodes. AST comparison confirms all original assertions in both optimized modules remain.
- [x] `uv run ruff check .` and `uv run ruff format --check .` passed.
- [x] Workflow secret-gate, permission and action-pinning checks passed.
- [x] Actionlint 1.7.12 passed with only its unsupported, pre-existing `concurrency.queue` diagnostic ignored.
- [ ] Live E2E qualification remains unrun; offline validation used no NotebookLM quota.

Full pytest and mypy were not rerun; validation focused on the changed CI scripts and E2E fixtures. No library runtime code changed.

## Notes

Windows now adds its duration before the full suites start. Ordering prevents within-run quota starvation but cannot restore quota already consumed by unrelated account use. No quota failures are converted into success and no ambiguous chat submissions are retried.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Nightly end-to-end checks now run read-only scenarios separately before full test scenarios, improving execution ordering and quota efficiency.
  - Shared test responses and source inventories reduce repeated live requests while preserving validation coverage.
  - Reference setup avoids redundant conversation-read validation.

- **Documentation**
  - Added documentation covering E2E quota behavior, workflow lane partitioning, validation results, and further optimization opportunities.

- **Bug Fixes**
  - Improved workflow security-gate validation for aliased steps and scheduling conditions, with fail-closed handling for invalid or missing aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->